### PR TITLE
refactor(editor): Make injectNDVStore resolve strictly from document store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/render.ts
+++ b/packages/frontend/editor-ui/src/__tests__/render.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from 'vue';
+import { computed, type Plugin } from 'vue';
 import { render, type RenderOptions as TestingLibraryRenderOptions } from '@testing-library/vue';
 import { i18nInstance } from '@n8n/i18n';
 import { GlobalDirectivesPlugin } from '@/app/plugins/directives';
@@ -9,6 +9,12 @@ import type { Telemetry } from '@/app/plugins/telemetry';
 import vueJsonPretty from 'vue-json-pretty';
 import merge from 'lodash/merge';
 import type { TestingPinia } from '@pinia/testing';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 export type RenderOptions<T> = Omit<TestingLibraryRenderOptions<T>, 'props'> & {
 	pinia?: TestingPinia | Pinia;
@@ -51,6 +57,17 @@ export function renderComponent<T>(component: T, options: RenderOptions<T> = {})
 				...(renderOptions.global?.plugins ?? []),
 				...(pinia ? [pinia] : []),
 			],
+			provide: {
+				// Mirror App.vue, which always provides the workflow document store.
+				// injectNDVStore()/injectWorkflowDocumentStore() resolve strictly from
+				// this key, so a default keeps components that don't set up their own
+				// scope working (replicates the former workflowId-based fallback).
+				// Tests override it by passing their own `global.provide`.
+				[WorkflowDocumentStoreKey as symbol]: computed(() =>
+					useWorkflowDocumentStore(createWorkflowDocumentId(useWorkflowsStore().workflowId)),
+				),
+				...(renderOptions.global?.provide ?? {}),
+			},
 		},
 	} as TestingLibraryRenderOptions<T>);
 }

--- a/packages/frontend/editor-ui/src/app/App.vue
+++ b/packages/frontend/editor-ui/src/app/App.vue
@@ -12,7 +12,7 @@ import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
 import { useTelemetryInitializer } from '@/app/composables/useTelemetryInitializer';
 import { useWorkflowDiffRouting } from '@/app/composables/useWorkflowDiffRouting';
 import { CODEMIRROR_TOOLTIP_CONTAINER_ELEMENT_ID, HIRING_BANNER, VIEWS } from '@/app/constants';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import LoadingView from '@/app/views/LoadingView.vue';
 import { locale } from '@n8n/design-system';
@@ -27,18 +27,35 @@ import { useExposeCssVar } from '@/app/composables/useExposeCssVar';
 import { useFloatingUiOffsets } from '@/app/composables/useFloatingUiOffsets';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
-import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import type {
+	WorkflowDocumentId,
+	WorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 
 const route = useRoute();
 const rootStore = useRootStore();
 const settingsStore = useSettingsStore();
-const ndvStore = injectNDVStore();
+
+const workflowId = useWorkflowId();
+const currentWorkflowDocumentStore = shallowRef<WorkflowDocumentStore | null>(null);
+
+provide(WorkflowIdKey, workflowId);
+provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
+
+// App.vue provides WorkflowDocumentStoreKey, so it cannot inject it. Expose the
+// current workflow document id (null when no workflow is loaded, e.g.
+// settings/credentials views); consumers derive their own scoped NDV store from
+// it via useNDVStore() as needed.
+const workflowDocumentId = computed<WorkflowDocumentId | null>(
+	() => currentWorkflowDocumentStore.value?.documentId ?? null,
+);
+
 const { setAppZIndexes } = useStyles();
 const { toastBottomOffset, toastRightOffset, askAiFloatingButtonBottomOffset } =
-	useFloatingUiOffsets();
+	useFloatingUiOffsets(workflowDocumentId);
 
 // Initialize undo/redo
-useHistoryHelper(route);
+useHistoryHelper(route, workflowDocumentId);
 
 // Initialize workflow diff routing management
 useWorkflowDiffRouting();
@@ -52,13 +69,14 @@ const loading = ref(true);
 const defaultLocale = computed(() => rootStore.defaultLocale);
 const isDemoMode = computed(() => route.name === VIEWS.DEMO);
 const hasContentFooter = ref(false);
-const workflowId = useWorkflowId();
-const currentWorkflowDocumentStore = shallowRef<WorkflowDocumentStore | null>(null);
 
-provide(WorkflowIdKey, workflowId);
-provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
-
-useTelemetryContext({ ndv_source: computed(() => ndvStore.value.lastSetActiveNodeSource) });
+useTelemetryContext({
+	ndv_source: computed(() =>
+		workflowDocumentId.value
+			? useNDVStore(workflowDocumentId.value).lastSetActiveNodeSource
+			: undefined,
+	),
+});
 
 onMounted(async () => {
 	setAppZIndexes();

--- a/packages/frontend/editor-ui/src/app/components/app/AppChatPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/app/AppChatPanel.vue
@@ -3,11 +3,19 @@ import AssistantsHub from '@/features/ai/assistant/components/AssistantsHub.vue'
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useChatHubPanelStore } from '@/features/ai/chatHub/chatHubPanel.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { provideWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { computed, nextTick, onBeforeUnmount, onMounted, watch } from 'vue';
 
 const props = defineProps<{
 	layoutRef: Element | null;
 }>();
+
+// The assistant/builder chat is mounted globally (App.vue #aside) and renders
+// NDV-store consumers (setup cards, node issues, node execution) that may
+// outlive the workflow editor (e.g. after navigating to a settings route).
+// Re-provide the resolved workflow document store so those components resolve a
+// scoped NDV store via injectNDVStore() even when no workflow is loaded.
+provideWorkflowDocumentStore();
 
 const chatPanelStore = useChatPanelStore();
 const chatHubPanelStore = useChatHubPanelStore();

--- a/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.ts
@@ -2,7 +2,8 @@ import { type MaybeRefOrGetter, computed, toValue, watchEffect } from 'vue';
 import { ExpressionExtensions } from 'n8n-workflow';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useTelemetry } from '../composables/useTelemetry';
 import type { Compartment } from '@codemirror/state';
@@ -17,7 +18,8 @@ export const useAutocompleteTelemetry = ({
 	parameterPath: MaybeRefOrGetter<string>;
 	compartment: MaybeRefOrGetter<Compartment>;
 }) => {
-	const ndvStore = injectNDVStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const rootStore = useRootStore();
 	const telemetry = useTelemetry();
 

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -55,7 +55,7 @@ import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -190,7 +190,6 @@ export function useCanvasOperations() {
 	const credentialsStore = useCredentialsStore();
 	const historyStore = useHistoryStore();
 	const uiStore = useUIStore();
-	const ndvStore = injectNDVStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const canvasStore = useCanvasStore();
 	const settingsStore = useSettingsStore();
@@ -204,6 +203,10 @@ export function useCanvasOperations() {
 	const focusPanelStore = useFocusPanelStore();
 	const setupPanelStore = useSetupPanelStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	// `useCanvasOperations` runs in out-of-tree contexts (push/socket handlers,
+	// router guards) as well as inside the editor, so derive the NDV store from
+	// the document store (which keeps a fallback) rather than injectNDVStore().
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 
 	const i18n = useI18n();
 	const toast = useToast();

--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
@@ -6,16 +6,19 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { useChatPanelStateStore } from '@/features/ai/assistant/chatPanelState.store';
 import { setActivePinia } from 'pinia';
 import { useFloatingUiOffsets } from './useFloatingUiOffsets';
-import { reactive } from 'vue';
+import { reactive, shallowRef, type ShallowRef } from 'vue';
 import { EDITABLE_CANVAS_VIEWS } from '@/app/constants';
 import { createTestNode } from '@/__tests__/mocks';
 import { createTestingPinia } from '@pinia/testing';
 
 let currentRouteName = '';
+// App.vue passes in the current workflow document id; mirror that here.
+let workflowDocumentIdRef: ShallowRef<WorkflowDocumentId | null>;
 
 vi.mock('vue-router', () => ({
 	useRoute: vi.fn(() =>
@@ -39,6 +42,7 @@ describe(useFloatingUiOffsets, () => {
 			createWorkflowDocumentId(workflowsStore.workflowId),
 		);
 		workflowDocumentStore.setNodes([createTestNode({ name: 'n0' })]);
+		workflowDocumentIdRef = shallowRef(createWorkflowDocumentId(workflowsStore.workflowId));
 	});
 
 	describe('toastBottomOffset', () => {
@@ -46,7 +50,7 @@ describe(useFloatingUiOffsets, () => {
 			useLogsStore().setHeight(3);
 			useNDVStore(createWorkflowDocumentId('test-workflow')).setActiveNodeName('n0', 'other'); // set NDV to be opened
 
-			const { toastBottomOffset } = useFloatingUiOffsets();
+			const { toastBottomOffset } = useFloatingUiOffsets(workflowDocumentIdRef);
 
 			expect(toastBottomOffset.value).toBe('0px');
 
@@ -58,7 +62,7 @@ describe(useFloatingUiOffsets, () => {
 		it('should not account for the height of log view when chat panel is open', () => {
 			useLogsStore().setHeight(300);
 
-			const { toastBottomOffset } = useFloatingUiOffsets();
+			const { toastBottomOffset } = useFloatingUiOffsets(workflowDocumentIdRef);
 
 			expect(toastBottomOffset.value).toBe('300px');
 
@@ -76,7 +80,7 @@ describe(useFloatingUiOffsets, () => {
 					aiAssistant: { enabled: true, setup: true },
 				});
 
-				const { toastBottomOffset } = useFloatingUiOffsets();
+				const { toastBottomOffset } = useFloatingUiOffsets(workflowDocumentIdRef);
 
 				expect(toastBottomOffset.value).toBe('0px');
 

--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
@@ -1,25 +1,35 @@
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useLogsStore } from '@/app/stores/logs.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
-import { computed } from 'vue';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import type { WorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import { computed, type Ref } from 'vue';
 
 const ASSISTANT_FLOATING_BUTTON_SIZE = 42;
 
-export function useFloatingUiOffsets() {
+/**
+ * Called from `App.vue`, which sits above the workflow document provide tree
+ * and therefore cannot use `injectNDVStore()`. The current workflow document id
+ * is passed in (null when no workflow is loaded); the scoped NDV store is
+ * derived from it here.
+ */
+export function useFloatingUiOffsets(workflowDocumentId: Readonly<Ref<WorkflowDocumentId | null>>) {
 	const assistantStore = useAssistantStore();
 	const chatPanelStore = useChatPanelStore();
-	const ndvStore = injectNDVStore();
 	const logsStore = useLogsStore();
 
+	const ndvStore = computed(() =>
+		workflowDocumentId.value ? useNDVStore(workflowDocumentId.value) : null,
+	);
+
 	const isNDVV2 = computed(() => true);
-	const askAiOffset = computed(() => (ndvStore.value.isNDVOpen && !isNDVV2.value ? 48 : 16));
+	const askAiOffset = computed(() => (ndvStore.value?.isNDVOpen && !isNDVV2.value ? 48 : 16));
 
 	return {
 		askAiFloatingButtonBottomOffset: computed(() => `${askAiOffset.value}px`),
 		toastBottomOffset: computed(() => {
 			const logsPanelOffset =
-				ndvStore.value.isNDVOpen || chatPanelStore.isOpen ? 0 : logsStore.height;
+				ndvStore.value?.isNDVOpen || chatPanelStore.isOpen ? 0 : logsStore.height;
 			const assistantOffset = assistantStore.isFloatingButtonShown
 				? ASSISTANT_FLOATING_BUTTON_SIZE + askAiOffset.value
 				: 0;

--- a/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.test.ts
@@ -3,7 +3,7 @@ import { MAIN_HEADER_TABS } from '@/app/constants';
 import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { useHistoryHelper } from './useHistoryHelper';
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent, ref, type PropType } from 'vue';
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
 import { mock } from 'vitest-mock-extended';
 import { Command, BulkCommand } from '@/app/models/history';
@@ -69,7 +69,10 @@ const TestComponent = defineComponent({
 		},
 	},
 	setup(props) {
-		useHistoryHelper(props.route);
+		useHistoryHelper(
+			props.route,
+			ref('wf@latest') as unknown as Parameters<typeof useHistoryHelper>[1],
+		);
 		return {};
 	},
 	template: '<div />',

--- a/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.ts
@@ -1,11 +1,12 @@
 import { MAIN_HEADER_TABS } from '@/app/constants';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import type { WorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import type { Undoable } from '@/app/models/history';
 import { BulkCommand, Command } from '@/app/models/history';
 import { useHistoryStore } from '@/app/stores/history.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
-import { onMounted, onUnmounted, nextTick } from 'vue';
+import { onMounted, onUnmounted, nextTick, computed, type Ref } from 'vue';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { getNodeViewTab } from '@/app/utils/nodeViewUtils';
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
@@ -14,10 +15,15 @@ import { shouldIgnoreCanvasShortcut } from '@/features/workflows/canvas/canvas.u
 
 const ELEMENT_UI_OVERLAY_SELECTOR = '.el-overlay';
 
-export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
+export function useHistoryHelper(
+	activeRoute: RouteLocationNormalizedLoaded,
+	workflowDocumentId: Readonly<Ref<WorkflowDocumentId | null>>,
+) {
 	const telemetry = useTelemetry();
 
-	const ndvStore = injectNDVStore();
+	const ndvStore = computed(() =>
+		workflowDocumentId.value ? useNDVStore(workflowDocumentId.value) : null,
+	);
 	const historyStore = useHistoryStore();
 	const uiStore = useUIStore();
 
@@ -91,7 +97,7 @@ export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
 	}
 
 	function trackUndoAttempt() {
-		const activeNode = ndvStore.value.activeNode;
+		const activeNode = ndvStore.value?.activeNode;
 		if (activeNode) {
 			telemetry?.track('User hit undo in NDV', { node_type: activeNode.type });
 		}
@@ -110,7 +116,7 @@ export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
 
 	function handleKeyDown(event: KeyboardEvent) {
 		const currentNodeViewTab = getNodeViewTab(activeRoute);
-		const isNDVOpen = ndvStore.value.isNDVOpen;
+		const isNDVOpen = ndvStore.value?.isNDVOpen;
 		const isAnyModalOpen = uiStore.isAnyModalOpen || isMessageDialogOpen();
 		const undoKeysPressed = isCtrlKeyPressed(event) && event.key.toLowerCase() === 'z';
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeDirtiness.test.ts
@@ -47,7 +47,10 @@ describe(useNodeDirtiness, () => {
 				nodeTypeStore = useNodeTypesStore();
 				workflowsStore = useWorkflowsStore();
 				workflowsStore.setWorkflowId(TEST_WORKFLOW_ID);
-				historyHelper = useHistoryHelper({} as RouteLocationNormalizedLoaded);
+				historyHelper = useHistoryHelper(
+					{} as RouteLocationNormalizedLoaded,
+					shallowRef(null) as Parameters<typeof useHistoryHelper>[1],
+				);
 
 				workflowDocumentStore = useWorkflowDocumentStore(TEST_DOCUMENT_ID);
 				provide(WorkflowDocumentStoreKey, shallowRef(workflowDocumentStore));

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -14,7 +14,7 @@ import type { INodeUi, IUpdateInformation } from '@/Interface';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
@@ -98,10 +98,10 @@ export function useNodeExecution(
 
 	const workflowsStore = useWorkflowsStore();
 	const nodeTypesStore = useNodeTypesStore();
-	const ndvStore = injectNDVStore();
 	const uiStore = useUIStore();
 
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 
 	const { runWorkflow, stopCurrentExecution } = useRunWorkflow({ router });

--- a/packages/frontend/editor-ui/src/app/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useResolvedExpression.ts
@@ -1,4 +1,4 @@
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import {
 	isExpression as isExpressionUtil,
@@ -35,9 +35,9 @@ export function useResolvedExpression({
 	stringifyObject?: MaybeRefOrGetter<boolean>;
 	contextNodeName?: MaybeRefOrGetter<string>;
 }) {
-	const ndvStore = injectNDVStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 
 	const { resolveExpression } = useWorkflowHelpers();
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -15,7 +15,12 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
+	provideWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { injectNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
 import { DEFAULT_SETTINGS } from '@/app/constants/workflows';
 import { useUIStore } from '@/app/stores/ui.store';
 import { createTestNode } from '@/__tests__/mocks';
@@ -681,5 +686,34 @@ describe('workflowDocument.store orchestration', () => {
 			expect(store.allGroups).toEqual([]);
 			expect(store.viewport).toBeNull();
 		});
+	});
+});
+
+describe('provideWorkflowDocumentStore', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('re-provides a resolved store so a descendant injectNDVStore() resolves with no workflow loaded', () => {
+		useWorkflowsStore().setWorkflowId('wf-host');
+
+		let childNdvStore: ReturnType<typeof useNDVStore> | undefined;
+		const Child = defineComponent({
+			setup() {
+				childNdvStore = injectNDVStore().value;
+				return () => null;
+			},
+		});
+		const Host = defineComponent({
+			setup() {
+				// No WorkflowDocumentStoreKey is provided above Host, so this resolves
+				// via the document-store workflowId fallback and re-provides it to Child.
+				provideWorkflowDocumentStore();
+				return () => h(Child);
+			},
+		});
+
+		expect(() => mount(Host)).not.toThrow();
+		expect(childNdvStore).toBe(useNDVStore(createWorkflowDocumentId('wf-host')));
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -1,6 +1,6 @@
 import { defineStore, getActivePinia } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { computed, inject, type ShallowRef } from 'vue';
+import { computed, inject, provide, shallowRef, watchEffect, type ShallowRef } from 'vue';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { useWorkflowDocumentActive } from './workflowDocument/useWorkflowDocumentActive';
 import { useWorkflowDocumentHomeProject } from './workflowDocument/useWorkflowDocumentHomeProject';
@@ -473,4 +473,31 @@ export function injectWorkflowDocumentStore(): ShallowRef<WorkflowDocumentStore>
 	const injected = inject(WorkflowDocumentStoreKey, null);
 
 	return computed(() => injected?.value ?? fallback.value);
+}
+
+/**
+ * Re-provides the resolved workflow document store to the current component's
+ * subtree.
+ *
+ * Use this in hosts that render workflow-editor components (e.g. NDV parameter
+ * inputs, which call `injectNDVStore()`/`injectWorkflowDocumentStore()`)
+ * outside the normal workflow editor tree — such as the credential edit modal
+ * or the log-streaming settings modal. Those components are descendants of
+ * `App.vue` but may mount while no workflow document is loaded; re-providing
+ * here guarantees they resolve a valid scoped store instead of throwing.
+ *
+ * Returns the resolved (non-null) document store so the host can derive its own
+ * scoped stores from `documentId` (the host cannot inject what it provides).
+ */
+export function provideWorkflowDocumentStore(): ShallowRef<WorkflowDocumentStore> {
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const provided = shallowRef<WorkflowDocumentStore | null>(workflowDocumentStore.value);
+
+	watchEffect(() => {
+		provided.value = workflowDocumentStore.value;
+	});
+
+	provide(WorkflowDocumentStoreKey, provided);
+
+	return workflowDocumentStore;
 }

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -29,6 +29,7 @@ import type { INodeUi } from '@/Interface';
 
 const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 	mockWorkflowDocumentStore: {
+		documentId: 'test-id',
 		allNodes: [] as INodeUi[],
 		workflowTriggerNodes: [] as INodeUi[],
 		name: '',

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -16,8 +16,9 @@ import type {
 	NodeOperationError,
 	NodeParameterValueType,
 } from 'n8n-workflow';
+import { computed } from 'vue';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import {
 	executionDataToJson,
@@ -28,6 +29,7 @@ import type { AssistantProcessOptions, ChatRequest } from '../assistant.types';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import { useDataSchema } from '@/app/composables/useDataSchema';
 import { AI_ASSISTANT_MAX_CONTENT_LENGTH, VIEWS } from '@/app/constants';
@@ -41,7 +43,8 @@ const WORKFLOW_LIST_VIEWS = [VIEWS.WORKFLOWS, VIEWS.PROJECTS_WORKFLOWS];
 const CREDENTIALS_LIST_VIEWS = [VIEWS.CREDENTIALS, VIEWS.PROJECTS_CREDENTIALS];
 
 export const useAIAssistantHelpers = () => {
-	const ndvStore = injectNDVStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const nodeTypesStore = useNodeTypesStore();
 
 	const workflowHelpers = useWorkflowHelpers();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
@@ -1,4 +1,4 @@
-import { ref, h } from 'vue';
+import { computed, ref, h } from 'vue';
 import type { Ref } from 'vue';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
 import type { INodeParameters } from 'n8n-workflow';
@@ -9,8 +9,9 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { codeNodeEditorEventBus } from '@/app/event-bus';
@@ -26,7 +27,8 @@ export interface UseCodeDiffOptions {
 
 export function useCodeDiff(options: UseCodeDiffOptions) {
 	const rootStore = useRootStore();
-	const ndvStore = injectNDVStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const locale = useI18n();
 
 	const suggestions = ref<{

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.disposal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.disposal.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for the per-section store disposal in WorkflowSetupSectionBody.
+ *
+ * The component provides a workflow-document store keyed by `${workflowId}@${section.id}`
+ * and its descendants materialize an NDV store for the same id. Pinia stores are
+ * not freed on unmount, so the component must dispose both on teardown. Without
+ * the dispose hooks these entries accumulate in `pinia.state` per section visited.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setActivePinia, createPinia, getActivePinia } from 'pinia';
+import { computed, ref } from 'vue';
+import { renderComponent } from '@/__tests__/render';
+import { createTestNode } from '@/__tests__/mocks';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import type { INodeUi } from '@/Interface';
+
+const displayNode = createTestNode({ name: 'Target', type: 'n8n-nodes-base.set' }) as INodeUi;
+
+const mockContext = {
+	workflowId: computed(() => 'wf-setup'),
+	projectId: computed(() => undefined),
+	credentialSelections: ref({}),
+	getDisplayNode: vi.fn(() => displayNode),
+	setCredential: vi.fn(),
+	setParameterValue: vi.fn(),
+};
+
+vi.mock('../composables/useWorkflowSetupContext', () => ({
+	useWorkflowSetupContext: () => mockContext,
+}));
+
+// Import after the mock is registered.
+import WorkflowSetupSectionBody from './WorkflowSetupSectionBody.vue';
+
+// A section with no credential type and no parameters so the heavy child
+// components (NodeCredentials, ParameterInputList) are not rendered.
+const section = {
+	id: 'sec-1',
+	targetNodeName: 'Target',
+	credentialType: undefined,
+	credentialTargetNodes: [],
+	parameterNames: [],
+	node: { type: 'n8n-nodes-base.set', typeVersion: 1 },
+} as unknown as InstanceType<typeof WorkflowSetupSectionBody>['$props']['section'];
+
+describe('WorkflowSetupSectionBody store disposal', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+	});
+
+	it('disposes the scoped document and NDV stores on unmount', () => {
+		const documentId = createWorkflowDocumentId('wf-setup', 'sec-1');
+
+		const { unmount } = renderComponent(WorkflowSetupSectionBody, { props: { section } });
+
+		// The host created the document store; simulate a descendant materializing
+		// the NDV store for the same id.
+		const documentStore = useWorkflowDocumentStore(documentId);
+		const ndvStore = useNDVStore(documentId);
+		ndvStore.setActiveNodeName('Target', 'other');
+
+		const documentStoreId = documentStore.$id;
+		const ndvStoreId = ndvStore.$id;
+		const pinia = getActivePinia();
+
+		expect(pinia?.state.value[documentStoreId]).toBeDefined();
+		expect(pinia?.state.value[ndvStoreId]).toBeDefined();
+
+		unmount();
+
+		expect(pinia?.state.value[documentStoreId]).toBeUndefined();
+		expect(pinia?.state.value[ndvStoreId]).toBeUndefined();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupSectionBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, provide, ref, watch } from 'vue';
+import { computed, onScopeDispose, provide, ref, watch } from 'vue';
 import { N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import NodeCredentials from '@/features/credentials/components/NodeCredentials.vue';
@@ -10,8 +10,11 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { ExpressionLocalResolveContextSymbol, WorkflowDocumentStoreKey } from '@/app/constants';
 import {
 	createWorkflowDocumentId,
+	disposeWorkflowDocumentStore,
 	useWorkflowDocumentStore,
+	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { disposeNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { INodeProperties } from 'n8n-workflow';
 import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
 import type { INodeUi, INodeUpdatePropertiesInformation, IUpdateInformation } from '@/Interface';
@@ -99,14 +102,11 @@ const displayNode = computed<INodeUi>(() => {
 	} as INodeUi;
 });
 
-const workflowDocumentStore = computed(() =>
-	useWorkflowDocumentStore(
-		createWorkflowDocumentId(
-			ctx.workflowId.value ?? 'instance-ai-workflow-setup',
-			props.section.id,
-		),
-	),
+const documentId = computed(() =>
+	createWorkflowDocumentId(ctx.workflowId.value ?? 'instance-ai-workflow-setup', props.section.id),
 );
+
+const workflowDocumentStore = computed(() => useWorkflowDocumentStore(documentId.value));
 
 watch(
 	displayNode,
@@ -115,6 +115,24 @@ watch(
 	},
 	{ immediate: true, deep: true },
 );
+
+// The provided document store — and the NDV store its descendants
+// (NodeCredentials, ParameterInputList) materialize via injectNDVStore() — are
+// keyed by a per-section document id. Pinia stores are not freed when this
+// component unmounts, so dispose the previous id whenever it changes and the
+// final id on scope teardown.
+function disposeStores(id: WorkflowDocumentId) {
+	disposeNDVStore(useNDVStore(id));
+	disposeWorkflowDocumentStore(useWorkflowDocumentStore(id));
+}
+
+watch(documentId, (_newId, oldId) => {
+	if (oldId) disposeStores(oldId);
+});
+
+onScopeDispose(() => {
+	disposeStores(documentId.value);
+});
 
 const expressionContext = computed<ExpressionLocalResolveContext | undefined>(() => ({
 	localResolve: true,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -28,11 +28,11 @@ import { CREDENTIAL_EDIT_MODAL_KEY } from '../../credentials.constants';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import { useCredentialsStore } from '../../credentials.store';
 import { getTrustedOAuthOrigins, parseOAuthCallbackMessage } from '../../composables/oauthCallback';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { provideWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { Project, ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { getResourcePermissions } from '@n8n/permissions';
 import { assert } from '@n8n/utils/assert';
@@ -87,7 +87,6 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), { mode: 'new', activeId: undefined });
 
 const credentialsStore = useCredentialsStore();
-const ndvStore = injectNDVStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const nodeTypesStore = useNodeTypesStore();
@@ -155,7 +154,13 @@ const useCustomOAuth = ref(false);
 const pendingAuthType = ref<string | null>(null);
 const credentialDataCache = ref<Record<string, ICredentialDataDecryptedObject>>({});
 
-const workflowDocumentStore = injectWorkflowDocumentStore();
+// The credential editor can open outside the workflow editor (e.g. the
+// Credentials view), where no workflow document is provided. Re-provide the
+// resolved document store so the reused NDV parameter components rendered below
+// resolve a valid scoped store, and derive this modal's own NDV store from it
+// (it cannot inject what it provides).
+const workflowDocumentStore = provideWorkflowDocumentStore();
+const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 
 const contextNode = computed<INode | null>(() => {
 	if (ndvStore.value.activeNode) return ndvStore.value.activeNode;

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
@@ -43,6 +43,7 @@ const { mockDocumentStore } = vi.hoisted(() => ({
 			getChildNodes: vi.fn().mockReturnValue([]),
 			getParentNodesByDepth: vi.fn().mockReturnValue([]),
 		}),
+		documentId: 'test-workflow-id@latest',
 		connectionsBySourceNode: {},
 		pinnedDataByNodeName: {},
 		incomingConnectionsByNodeName: vi.fn().mockReturnValue({}),

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.test.ts
@@ -6,8 +6,12 @@ import {
 } from '@/__tests__/mocks';
 import { createTestLogEntry } from '../__test__/mocks';
 import { fireEvent, render, waitFor } from '@testing-library/vue';
-import { computed } from 'vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { computed, shallowRef } from 'vue';
+import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import userEvent from '@testing-library/user-event';
 import LogsViewRunData from './LogsViewRunData.vue';
 import { createTestingPinia, type TestingPinia } from '@pinia/testing';
@@ -45,7 +49,12 @@ describe('LogsViewRunData', () => {
 	it('should display item count', async () => {
 		const rendered = render(LogsViewRunData, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [pinia],
 			},
 			props: { title: '', logEntry, collapsingTableColumnName: null, paneType: 'output' },
@@ -57,7 +66,12 @@ describe('LogsViewRunData', () => {
 	it('should display matched and total item count unless display mode is schema', async () => {
 		const rendered = render(LogsViewRunData, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [pinia],
 			},
 			props: { title: '', logEntry, collapsingTableColumnName: null, paneType: 'output' },
@@ -110,7 +124,12 @@ describe('LogsViewRunData', () => {
 		});
 		const rendered = render(LogsViewRunData, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [pinia],
 			},
 			props: {

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
@@ -28,8 +28,8 @@ import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 
 import { useLogStreamingStore } from '../logStreaming.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { provideWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import ParameterInputList from '@/features/ndv/parameters/components/ParameterInputList.vue';
 import type { IMenuItem, IUpdateInformation, ModalKey } from '@/Interface';
 import { LOG_STREAM_MODAL_KEY, MODAL_CONFIRM } from '@/app/constants';
@@ -83,8 +83,12 @@ const i18n = useI18n();
 const { confirm } = useMessage();
 const telemetry = useTelemetry();
 const logStreamingStore = useLogStreamingStore();
-const ndvStore = injectNDVStore();
-const workflowDocumentStore = injectWorkflowDocumentStore();
+// The log-streaming settings modal can open outside the workflow editor, where
+// no workflow document is provided. Re-provide the resolved document store so
+// the reused NDV parameter components resolve a valid scoped store, and derive
+// this modal's own NDV store from it (it cannot inject what it provides).
+const workflowDocumentStore = provideWorkflowDocumentStore();
+const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 const uiStore = useUIStore();
 
 const unchanged = ref(!isNew);

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import { computed, shallowRef } from 'vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
 
 import {
 	injectWorkflowDocumentStore,
@@ -118,6 +118,7 @@ const render = (props: Partial<Props> = {}, pinData?: INodeExecutionData[], runD
 		global: {
 			provide: {
 				[WorkflowIdKey as unknown as string]: computed(() => workflow.id),
+				[WorkflowDocumentStoreKey as symbol]: shallowRef(workflowDocumentStore),
 			},
 			stubs: {
 				InputPanelPinButton: { template: '<button data-test-id="ndv-pin-data"></button>' },

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.test.ts
@@ -12,6 +12,7 @@ import {
 	injectWorkflowDocumentStore,
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 
 const nodeType: INodeTypeDescription = {
 	displayName: 'OpenAI',
@@ -86,6 +87,11 @@ describe('NDVSubConnections', () => {
 				rootNode: node,
 			},
 			global: {
+				provide: {
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('wf0')),
+					),
+				},
 				stubs: {
 					N8nButton: true,
 				},
@@ -103,6 +109,13 @@ describe('NDVSubConnections', () => {
 		const component = render(NDVSubConnections, {
 			props: {
 				rootNode: node,
+			},
+			global: {
+				provide: {
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('wf0')),
+					),
+				},
 			},
 		});
 		vi.advanceTimersByTime(1000); // Event debounce time
@@ -175,6 +188,13 @@ describe('NDVSubConnections', () => {
 		const { getByTestId } = render(NDVSubConnections, {
 			props: {
 				rootNode: multiConnectionNode,
+			},
+			global: {
+				provide: {
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('wf0')),
+					),
+				},
 			},
 		});
 		vi.advanceTimersByTime(1);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
@@ -6,7 +6,7 @@ import DraggableTarget from '@/app/components/DraggableTarget.vue';
 import ExpressionFunctionIcon from './ExpressionFunctionIcon.vue';
 import InlineExpressionEditorInput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorInput.vue';
 import InlineExpressionEditorOutput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { createExpressionTelemetryPayload } from '@/app/utils/telemetryUtils';
 
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -58,13 +58,13 @@ const emit = defineEmits<{
 }>();
 
 const telemetry = useTelemetry();
-const ndvStore = injectNDVStore();
+const ndvStore = injectNDVStoreIfProvided();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const canvas = inject(CanvasKey, undefined);
 const isInExperimentalNdv = useIsInExperimentalNdv();
 
-const isDragging = computed(() => ndvStore.value.isDraggableDragging);
+const isDragging = computed(() => ndvStore.value?.isDraggableDragging ?? false);
 const isOutputPopoverVisible = computed(
 	() => isFocused.value && (!isInExperimentalNdv.value || !canvas?.isPaneMoving.value),
 );
@@ -117,8 +117,8 @@ function onBlur(event?: FocusEvent | KeyboardEvent) {
 			segments.value,
 			props.modelValue,
 			workflowDocumentStore.value.workflowId,
-			ndvStore.value.pushRef,
-			ndvStore.value.activeNode?.type ?? '',
+			ndvStore.value?.pushRef ?? '',
+			ndvStore.value?.activeNode?.type ?? '',
 		);
 
 		telemetry.track('User closed Expression Editor', telemetryPayload);
@@ -153,9 +153,9 @@ async function onDrop(value: string, event: MouseEvent) {
 
 	const droppedSelection = await dropInExpressionEditor(toRaw(editor), event, value);
 
-	if (!ndvStore.value.isMappingOnboarded) ndvStore.value.setMappingOnboarded();
+	if (ndvStore.value && !ndvStore.value.isMappingOnboarded) ndvStore.value.setMappingOnboarded();
 
-	if (!ndvStore.value.isAutocompleteOnboarded) {
+	if (!ndvStore.value?.isAutocompleteOnboarded) {
 		setCursorPosition((droppedSelection.ranges.at(0)?.head ?? 3) - 3);
 		setTimeout(() => {
 			startCompletion(editor);
@@ -169,7 +169,7 @@ async function onDropOnFixedInput() {
 	if (!inlineInput.value) return;
 	const { editor, setCursorPosition } = inlineInput.value;
 
-	if (!editor || ndvStore.value.isAutocompleteOnboarded) return;
+	if (!editor || ndvStore.value?.isAutocompleteOnboarded) return;
 
 	setCursorPosition('lastExpression');
 	setTimeout(() => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -76,6 +76,7 @@ vi.mock('@/features/ndv/shared/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
 		injectNDVStore: vi.fn(() => ({ value: mockNdvState })),
+		injectNDVStoreIfProvided: vi.fn(() => ({ value: mockNdvState })),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -74,7 +74,7 @@ import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useNodeSettingsParameters } from '@/features/ndv/settings/composables/useNodeSettingsParameters';
 import { htmlEditorEventBus } from '@/app/event-bus';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
@@ -173,7 +173,7 @@ const nodeSettingsParameters = useNodeSettingsParameters();
 const telemetry = useTelemetry();
 
 const credentialsStore = useCredentialsStore();
-const ndvStore = injectNDVStore();
+const ndvStore = injectNDVStoreIfProvided();
 const workflowsListStore = useWorkflowsListStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const settingsStore = useSettingsStore();
@@ -239,7 +239,7 @@ const node = computed(() => {
 	const contextNode =
 		expressionLocalResolveCtx?.value &&
 		workflowDocumentStore.value.getNodeByName(expressionLocalResolveCtx.value.nodeName);
-	return contextNode ?? ndvStore.value.activeNode ?? undefined;
+	return contextNode ?? ndvStore.value?.activeNode ?? undefined;
 });
 const nodeType = computed(
 	() => node.value && nodeTypesStore.getNodeType(node.value.type, node.value.typeVersion),
@@ -315,7 +315,7 @@ const parameterOptions = computed(() => {
 	const options = hasRemoteMethod.value ? remoteParameterOptions.value : props.parameter.options;
 	const safeOptions = (options ?? []).filter(isValidParameterOption);
 
-	return getParameterDisplayableOptions(safeOptions, ndvStore.value.activeNode);
+	return getParameterDisplayableOptions(safeOptions, ndvStore.value?.activeNode ?? null);
 });
 
 const modelValueString = computed<string>(() => {
@@ -479,7 +479,7 @@ const expressionDisplayValue = computed(() => {
 
 const dependentParametersValues = computedAsync(async () => {
 	// Reference dependencies to ensure reactivity tracking
-	void ndvStore.value.activeNode?.parameters;
+	void ndvStore.value?.activeNode?.parameters;
 	void props.parameter;
 	void props.path;
 
@@ -717,7 +717,7 @@ const isHtmlNode = computed(() => !!node.value && node.value.type === HTML_NODE_
 const isInputTypeString = computed(() => props.parameter.type === 'string');
 const isInputTypeNumber = computed(() => props.parameter.type === 'number');
 
-const isInputDataEmpty = computed(() => ndvStore.value.isInputPanelEmpty);
+const isInputDataEmpty = computed(() => ndvStore.value?.isInputPanelEmpty ?? true);
 const isDropDisabled = computed(
 	() =>
 		props.parameter.noDataExpression === true ||
@@ -731,9 +731,9 @@ const showDragnDropTip = computed(
 		(isInputTypeString.value || isInputTypeNumber.value) &&
 		!isModelValueExpression.value &&
 		!isDropDisabled.value &&
-		(!ndvStore.value.hasInputData || !isInputDataEmpty.value) &&
-		!ndvStore.value.isMappingOnboarded &&
-		ndvStore.value.isInputParentOfActiveNode &&
+		(!(ndvStore.value?.hasInputData ?? false) || !isInputDataEmpty.value) &&
+		!(ndvStore.value?.isMappingOnboarded ?? true) &&
+		(ndvStore.value?.isInputParentOfActiveNode ?? false) &&
 		!props.isForCredential,
 );
 
@@ -777,14 +777,14 @@ function getPlaceholder(): string {
 
 	return props.isForCredential
 		? i18n.credText(uiStore.activeCredentialType).placeholder(props.parameter)
-		: i18n.nodeText(ndvStore.value.activeNode?.type).placeholder(props.parameter, props.path);
+		: i18n.nodeText(ndvStore.value?.activeNode?.type).placeholder(props.parameter, props.path);
 }
 
 function getOptionsOptionDisplayName(option: INodePropertyOptions): string {
 	return props.isForCredential
 		? i18n.credText(uiStore.activeCredentialType).optionsOptionDisplayName(props.parameter, option)
 		: i18n
-				.nodeText(ndvStore.value.activeNode?.type)
+				.nodeText(ndvStore.value?.activeNode?.type)
 				.optionsOptionDisplayName(props.parameter, option, props.path);
 }
 
@@ -792,7 +792,7 @@ function getOptionsOptionDescription(option: INodePropertyOptions): string {
 	return props.isForCredential
 		? i18n.credText(uiStore.activeCredentialType).optionsOptionDescription(props.parameter, option)
 		: i18n
-				.nodeText(ndvStore.value.activeNode?.type)
+				.nodeText(ndvStore.value?.activeNode?.type)
 				.optionsOptionDescription(props.parameter, option, props.path);
 }
 
@@ -874,7 +874,7 @@ function trackExpressionEditOpen() {
 			parameter_field_type: props.parameter.type,
 			new_expression: !isModelValueExpression.value,
 			workflow_id: workflowDocumentStore.value.workflowId,
-			push_ref: ndvStore.value.pushRef,
+			push_ref: ndvStore.value?.pushRef ?? '',
 			source: props.eventSource ?? 'ndv',
 		});
 	}
@@ -1083,7 +1083,7 @@ function valueChanged(untypedValue: unknown) {
 			node_type: node.value?.type,
 			resource: node.value?.parameters.resource,
 			is_custom: value === CUSTOM_API_CALL_KEY,
-			push_ref: ndvStore.value.pushRef,
+			push_ref: ndvStore.value?.pushRef ?? '',
 			parameter: props.parameter.name,
 			value: value as string,
 		});
@@ -1536,7 +1536,7 @@ onUpdated(async () => {
 					:model-value="codeEditDialogVisible"
 					:append-to="`#${APP_MODALS_ELEMENT_ID}`"
 					:title="`${i18n.baseText('codeEdit.edit')} ${i18n
-						.nodeText(ndvStore.activeNode?.type)
+						.nodeText(ndvStore?.activeNode?.type)
 						.inputLabelDisplayName(parameter, path)}`"
 					:before-close="closeCodeEditDialog"
 					data-test-id="code-editor-fullscreen"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
@@ -55,6 +55,7 @@ vi.mock('@/features/ndv/shared/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
 		injectNDVStore: vi.fn(() => ({ value: mockNdvState })),
+		injectNDVStoreIfProvided: vi.fn(() => ({ value: mockNdvState })),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
@@ -14,7 +14,7 @@ import {
 import { useResolvedExpression } from '@/app/composables/useResolvedExpression';
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import { useExternalSecretsStore } from '@/features/integrations/externalSecrets.ee/externalSecrets.ee.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { useBinaryDataAccessTooltip } from '@/features/ndv/shared/composables/useBinaryDataAccessTooltip';
 import { isValueExpression, parseResourceMapperFieldName } from '@/app/utils/nodeTypesUtils';
 import type { EventBus } from '@n8n/utils/event-bus';
@@ -62,7 +62,7 @@ const emit = defineEmits<{
 	textInput: [value: IUpdateInformation];
 }>();
 
-const ndvStore = injectNDVStore();
+const ndvStore = injectNDVStoreIfProvided();
 const externalSecretsStore = useExternalSecretsStore();
 const environmentsStore = useEnvironmentsStore();
 const { binaryDataAccessTooltip } = useBinaryDataAccessTooltip();
@@ -99,9 +99,11 @@ const parameterHint = computed(() => {
 	return props.hint;
 });
 
-const targetItem = computed(() => ndvStore.value.expressionTargetItem);
+const targetItem = computed(() => ndvStore.value?.expressionTargetItem ?? null);
 
-const isInputParentOfActiveNode = computed(() => ndvStore.value.isInputParentOfActiveNode);
+const isInputParentOfActiveNode = computed(
+	() => ndvStore.value?.isInputParentOfActiveNode ?? false,
+);
 
 const expression = computed(() => {
 	if (!isExpression.value) return '';

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
@@ -8,7 +8,7 @@ import {
 import { isValueExpression } from '@/app/utils/nodeTypesUtils';
 import { computed, inject } from 'vue';
 import { ChatHubToolContextKey } from '@/app/constants';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { AI_TRANSFORM_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { getParameterTypeOption } from '@/features/ndv/shared/ndv.utils';
 import { useIsInExperimentalNdv } from '@/features/workflows/canvas/experimental/composables/useIsInExperimentalNdv';
@@ -56,9 +56,9 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const ndvStore = injectNDVStore();
+const ndvStore = injectNDVStoreIfProvided();
 
-const activeNode = computed(() => ndvStore.value.activeNode);
+const activeNode = computed(() => ndvStore.value?.activeNode ?? null);
 const isDefault = computed(() => props.parameter.default === props.value);
 const isValueAnExpression = computed(() => isValueExpression(props.parameter, props.value));
 const editor = computed(() => getParameterTypeOption(props.parameter, 'editor'));

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -492,6 +492,7 @@ describe('ResourceLocator', () => {
 		});
 
 		const mockWorkflowDocumentStore = shallowRef({
+			documentId: 'test-workflow@latest',
 			homeProject: { id: 'home-project-456', name: 'Test Project', type: 'team' },
 		});
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
@@ -5,12 +5,14 @@ import { VIEWS } from '@/app/constants';
 
 import type { IWorkflowDb, WorkflowListResource } from '@/Interface';
 import type { NodeParameterValue } from 'n8n-workflow';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export function useWorkflowResourcesLocator(router: Router) {
 	const workflowsListStore = useWorkflowsListStore();
-	const ndvStore = injectNDVStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const { renameNode } = useCanvasOperations();
 
 	const workflowsResources = ref<

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
-import { type Ref } from 'vue';
+import { computed, type Ref } from 'vue';
 import {
 	type INode,
 	type INodeParameters,
@@ -23,7 +23,7 @@ import {
 } from '@/features/ndv/shared/ndv.utils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { CHAT_TRIGGER_NODE_TYPE, KEEP_AUTH_IN_NDV_FOR_NODES } from '@/app/constants';
 import {
 	getMainAuthField,
@@ -55,6 +55,7 @@ const stripPublicDisplayCondition = (parameter: INodeProperties): INodePropertie
 
 export function useNodeSettingsParameters() {
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const nodeTypesStore = useNodeTypesStore();
 	const settingsStore = useSettingsStore();
 	const telemetry = useTelemetry();
@@ -168,7 +169,6 @@ export function useNodeSettingsParameters() {
 	function handleFocus(node: INodeUi | undefined, path: string, parameter: INodeProperties) {
 		if (!node) return;
 
-		const ndvStore = injectNDVStore();
 		const focusPanelStore = useFocusPanelStore();
 
 		focusPanelStore.openWithFocusedNodeParameter({

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setActivePinia, createPinia, getActivePinia } from 'pinia';
-import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
-import { disposeNDVStore, useNDVStore } from './ndv.store';
+import { defineComponent, shallowRef, type ShallowRef } from 'vue';
+import { mount } from '@vue/test-utils';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+	type WorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { disposeNDVStore, injectNDVStore, useNDVStore } from './ndv.store';
 
 describe('ndv.store', () => {
 	beforeEach(() => {
@@ -27,5 +34,55 @@ describe('ndv.store', () => {
 
 		expect(recreatedNDVStore).not.toBe(ndvStore);
 		expect(recreatedNDVStore.activeNodeName).toBeNull();
+	});
+
+	it('keeps NDV state isolated per workflow document id', () => {
+		const storeA = useNDVStore(createWorkflowDocumentId('wf-a'));
+		const storeB = useNDVStore(createWorkflowDocumentId('wf-b'));
+
+		expect(storeA).not.toBe(storeB);
+
+		storeA.setActiveNodeName('Node A', 'other');
+
+		expect(storeA.activeNodeName).toBe('Node A');
+		expect(storeB.activeNodeName).toBeNull();
+		// Re-deriving by the same id returns the same scoped instance.
+		expect(useNDVStore(createWorkflowDocumentId('wf-a')).activeNodeName).toBe('Node A');
+	});
+
+	describe('injectNDVStore', () => {
+		function renderWithProvidedStore(provided?: ShallowRef<WorkflowDocumentStore | null>) {
+			let injected!: ReturnType<typeof injectNDVStore>;
+			const comp = defineComponent({
+				setup() {
+					injected = injectNDVStore();
+					return () => null;
+				},
+			});
+			const wrapper = mount(comp, {
+				global: {
+					provide: provided ? { [WorkflowDocumentStoreKey as symbol]: provided } : {},
+				},
+			});
+			return { injected, unmount: () => wrapper.unmount() };
+		}
+
+		it('resolves the workflow-scoped NDV store from the provided document store', () => {
+			const documentStore = useWorkflowDocumentStore(createWorkflowDocumentId('wf-1'));
+
+			const { injected } = renderWithProvidedStore(shallowRef(documentStore));
+
+			expect(injected.value).toBe(useNDVStore(createWorkflowDocumentId('wf-1')));
+		});
+
+		it('throws when accessed with no workflow document loaded', () => {
+			const { injected } = renderWithProvidedStore(shallowRef(null));
+
+			expect(() => injected.value).toThrowError(/without an active workflow document store/);
+		});
+
+		it('throws when no workflow document store is provided at all', () => {
+			expect(() => renderWithProvidedStore()).toThrowError(/Could not resolve/);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -25,7 +25,7 @@ import {
 	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
-import { computed, ref, type ShallowRef } from 'vue';
+import { computed, inject, ref, type ShallowRef } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { injectStrict } from '@/app/utils/injectStrict';
@@ -508,5 +508,25 @@ export function injectNDVStore(): ShallowRef<NDVStore> {
 			);
 		}
 		return useNDVStore(documentStore.documentId);
+	});
+}
+
+/**
+ * Non-throwing variant of {@link injectNDVStore} for parameter-input components
+ * that are reused outside a loaded workflow document (e.g. the credential and
+ * external-secrets settings modals). Resolves the workflow-scoped NDV store when
+ * a workflow document store is provided, and `null` otherwise — so consumers must
+ * guard accesses (`ndvStore.value?.x`). Editor-only components should keep the
+ * strict {@link injectNDVStore}.
+ *
+ * Returns a `ShallowRef` so consumers re-derive when the active workflow document
+ * changes.
+ */
+export function injectNDVStoreIfProvided(): ShallowRef<NDVStore | null> {
+	const workflowDocumentStore = inject(WorkflowDocumentStoreKey, null);
+
+	return computed(() => {
+		const documentStore = workflowDocumentStore?.value;
+		return documentStore ? useNDVStore(documentStore.documentId) : null;
 	});
 }

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -20,16 +20,15 @@ import type { INodeIssues } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { defineStore, getActivePinia, type Pinia } from 'pinia';
 import { v4 as uuid } from 'uuid';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
 	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
-import { computed, inject, ref, type ShallowRef } from 'vue';
+import { computed, ref, type ShallowRef } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { injectStrict } from '@/app/utils/injectStrict';
 
 export type NDVStoreId = WorkflowDocumentId;
 
@@ -484,18 +483,30 @@ export function disposeNDVStore(store: NDVStore) {
 /**
  * Injects the NDV store for the current workflow document.
  *
- * Resolves to a workflow-scoped NDV store derived from the injected
- * `WorkflowDocumentStoreKey` when available, falling back to a store keyed by
- * the current `workflowsStore.workflowId` for callers outside the provide tree
- * (App.vue header etc.). Returns a `ShallowRef` so consumers re-derive when
- * the active workflow document changes.
+ * Resolves a workflow-scoped NDV store strictly from the injected
+ * `WorkflowDocumentStoreKey`, so it must be called from within the provide
+ * tree below `App.vue` (i.e. inside a component `setup()` whose ancestor
+ * provides the workflow document store). There is intentionally no
+ * `workflowsStore.workflowId` fallback: callers that may run outside the
+ * provide tree (socket/push handlers, router guards, `App.vue` itself) or
+ * before a workflow is loaded must derive the NDV store from
+ * `injectWorkflowDocumentStore().value.documentId` instead.
+ *
+ * Returns a `ShallowRef` so consumers re-derive when the active workflow
+ * document changes.
  */
 export function injectNDVStore(): ShallowRef<NDVStore> {
-	const workflowsStore = useWorkflowsStore();
-	const fallback = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
-	const injected = inject(WorkflowDocumentStoreKey, null);
+	const workflowDocumentStore = injectStrict(WorkflowDocumentStoreKey);
 
-	return computed(() =>
-		injected?.value?.documentId ? useNDVStore(injected.value.documentId) : fallback.value,
-	);
+	return computed(() => {
+		const documentStore = workflowDocumentStore.value;
+		if (!documentStore) {
+			throw new Error(
+				'injectNDVStore() was accessed without an active workflow document store. ' +
+					'Derive the NDV store from injectWorkflowDocumentStore().value.documentId in contexts ' +
+					'that can run without a loaded workflow.',
+			);
+		}
+		return useNDVStore(documentStore.documentId);
+	});
 }

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -21,7 +21,7 @@ import {
 	EXPRESSION_EDITOR_PARSER_TIMEOUT,
 	ExpressionLocalResolveContextSymbol,
 } from '@/app/constants';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 
 import type { TargetItem, TargetNodeParameterContext } from '@/Interface';
 import {
@@ -81,8 +81,8 @@ export const useExpressionEditor = ({
 	initialCursorPosition?: number | 'lastExpression' | 'end';
 	onChange?: (viewUpdate: ViewUpdate) => void;
 }) => {
-	const ndvStore = injectNDVStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const workflowHelpers = useWorkflowHelpers();
 	const { isMacOs } = useDeviceSupport();

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
@@ -3,7 +3,7 @@ import { useDebounce } from '@/app/composables/useDebounce';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { autocompletableNodeNames } from '@/features/shared/editors/plugins/codemirror/completions/utils';
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { injectWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { forceParse } from '@/app/utils/forceParse';
@@ -15,7 +15,7 @@ import { Text, type Extension } from '@codemirror/state';
 import { EditorView, hoverTooltip } from '@codemirror/view';
 import * as Comlink from 'comlink';
 import { NodeConnectionTypes, type CodeExecutionMode, type INodeExecutionData } from 'n8n-workflow';
-import { onBeforeUnmount, ref, toRef, toValue, watch, type MaybeRefOrGetter } from 'vue';
+import { computed, onBeforeUnmount, ref, toRef, toValue, watch, type MaybeRefOrGetter } from 'vue';
 import type { LanguageServiceWorker, RemoteLanguageServiceWorkerInit } from '../types';
 import { typescriptCompletionSource } from './completions';
 import { typescriptWorkerFacet } from './facet';
@@ -32,9 +32,9 @@ export function useTypescript(
 	targetNodeParameterContext?: MaybeRefOrGetter<TargetNodeParameterContext | undefined>,
 ) {
 	const { getInputDataWithPinned, getSchemaForExecutionData } = useDataSchema();
-	const ndvStore = injectNDVStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const { debounce } = useDebounce();
 	const activeNodeName =
 		toValue(targetNodeParameterContext)?.nodeName ?? ndvStore.value.activeNodeName;

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
@@ -36,8 +36,10 @@ import useEnvironmentsStore from '@/features/settings/environments.ee/environmen
 import { useSettingsStore } from '@/app/stores/settings.store';
 import {
 	createWorkflowDocumentId,
+	disposeWorkflowDocumentStore,
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { disposeNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
 
 const props = defineProps<{
 	initialNode: INode;
@@ -366,6 +368,13 @@ onMounted(async () => {
 onBeforeUnmount(() => {
 	// Clear current project to avoid side effects
 	projectsStore.setCurrentProject(null);
+
+	// Dispose the scoped document store and the NDV store its descendants
+	// materialize — Pinia stores are not freed on unmount. The doc id is a
+	// constant and only one tool-config host is mounted at a time.
+	const documentStore = workflowDocumentStore.value;
+	disposeNDVStore(useNDVStore(documentStore.documentId));
+	disposeWorkflowDocumentStore(documentStore);
 });
 
 defineExpose({ node, isValid, nodeTypeDescription, handleChangeName });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.test.ts
@@ -1,21 +1,35 @@
 import { createTestNode } from '@/__tests__/mocks';
 import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
 import userEvent from '@testing-library/user-event';
 import { render, waitFor } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
-import { computed, nextTick } from 'vue';
-import { WorkflowIdKey } from '@/app/constants/injectionKeys';
+import { computed, nextTick, shallowRef } from 'vue';
+import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import ExperimentalEmbeddedNdvMapper from './ExperimentalEmbeddedNdvMapper.vue';
 import { useExperimentalNdvStore } from '../experimentalNdv.store';
 
 describe('ExperimentalEmbeddedNdvMapper', () => {
 	const node = createTestNode({ name: 'n1' });
 
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ stubActions: false }));
+	});
+
 	it('should open the popover on hover if visibleOnHover is true', async () => {
 		const reference = document.createElement('div');
 		const rendered = render(ExperimentalEmbeddedNdvMapper, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [createTestingPinia({ stubActions: false })],
 			},
 			props: {
@@ -35,7 +49,12 @@ describe('ExperimentalEmbeddedNdvMapper', () => {
 		const reference = document.createElement('div');
 		const rendered = render(ExperimentalEmbeddedNdvMapper, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [createTestingPinia({ stubActions: false })],
 			},
 			props: {
@@ -57,7 +76,12 @@ describe('ExperimentalEmbeddedNdvMapper', () => {
 		const reference = document.createElement('div');
 		const rendered = render(ExperimentalEmbeddedNdvMapper, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [pinia],
 			},
 			props: {
@@ -79,7 +103,12 @@ describe('ExperimentalEmbeddedNdvMapper', () => {
 		const reference = document.createElement('div');
 		const rendered = render(ExperimentalEmbeddedNdvMapper, {
 			global: {
-				provide: { [WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id') },
+				provide: {
+					[WorkflowIdKey as unknown as string]: computed(() => 'test-workflow-id'),
+					[WorkflowDocumentStoreKey as symbol]: shallowRef(
+						useWorkflowDocumentStore(createWorkflowDocumentId('test-workflow-id')),
+					),
+				},
 				plugins: [createTestingPinia({ stubActions: false })],
 			},
 			props: {


### PR DESCRIPTION
## Summary

Completes the NDV keyed-store migration by removing the legacy `workflowsStore.workflowId` fallback from `injectNDVStore()`. It now resolves a workflow-scoped NDV store strictly from the injected `WorkflowDocumentStoreKey` and throws a clear error if accessed outside the provide tree, forcing callers that can run without a loaded workflow to derive the store from `injectWorkflowDocumentStore().value.documentId`. A new `provideWorkflowDocumentStore()` helper re-provides the resolved document store to modal hosts (credential edit, log-streaming settings, tool config) that render workflow-editor components outside the normal editor tree. Consumers across NDV, AI assistant, canvas operations, and expression editors were updated to the new pattern, with tests added/updated to cover store disposal and scoped resolution.

## How to test

Open a workflow, edit nodes via NDV, open the credential edit modal and log-streaming destination settings modal — verify parameter inputs and resource locators resolve correctly. Run `pnpm --filter n8n-editor-ui test`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3484

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


