### PR TITLE
fix(core): Handle workflow unpublish in publication outbox (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -13,6 +13,7 @@ import type { ErrorReporter } from 'n8n-core';
 
 import type { ActivationErrorsService } from '@/activation-errors.service';
 import type { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { WORKFLOW_UNPUBLISH_SENTINEL } from '@/workflows/workflow-publication-outbox.constants';
 import { WorkflowPublicationOutboxConsumer } from '@/workflows/workflow-publication-outbox-consumer';
 
 describe('WorkflowPublicationOutboxConsumer', () => {
@@ -82,6 +83,7 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		outboxRepository.claimNextPendingRecord.mockResolvedValue(null);
 		outboxRepository.markCompleted.mockResolvedValue(undefined);
 		outboxRepository.markFailed.mockResolvedValue(undefined);
+		entityManager.delete.mockResolvedValue({} as never);
 		entityManager.upsert.mockResolvedValue({} as never);
 		Object.defineProperty(outboxRepository, 'manager', {
 			value: entityManager,
@@ -240,6 +242,22 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1);
 			expect(activeWorkflowManager.clearWebhooks).not.toHaveBeenCalled();
 			expect(activeWorkflowManager.removeNonWebhookTriggers).not.toHaveBeenCalled();
+		});
+
+		test('removes published version when processing an unpublish sentinel record', async () => {
+			const record = makeRecord({ publishedVersionId: WORKFLOW_UNPUBLISH_SENTINEL });
+
+			await consumer.processRecord(record);
+
+			expect(workflowRepository.findById).not.toHaveBeenCalled();
+			expect(entityManager.delete).toHaveBeenCalledWith(WorkflowPublishedVersion, {
+				workflowId: 'wf-1',
+			});
+			expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1);
+			expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
+			expect(activeWorkflowManager.clearWebhooks).not.toHaveBeenCalled();
+			expect(activeWorkflowManager.removeNonWebhookTriggers).not.toHaveBeenCalled();
+			expect(activeWorkflowManager.add).not.toHaveBeenCalled();
 		});
 
 		test('finalizes without trigger reapply when version already matches', async () => {

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -66,6 +66,7 @@ describe('WorkflowService', () => {
 				mock(), // folderRepository
 				mock(), // workflowFinderService
 				mock(), // workflowPublishedVersionRepository
+				mock(), // workflowPublicationOutboxRepository
 				mock(), // workflowPublishHistoryRepository
 				Object.assign(mock<WorkflowValidationService>(), {
 					validateCredentialNodeRestrictions: () => ({ isValid: true }),
@@ -217,6 +218,7 @@ describe('WorkflowService', () => {
 				mock(), // folderRepository
 				workflowFinderServiceMock, // workflowFinderService
 				mock(), // workflowPublishedVersionRepository
+				mock(), // workflowPublicationOutboxRepository
 				mock(), // workflowPublishHistoryRepository
 				Object.assign(mock<WorkflowValidationService>(), {
 					validateCredentialNodeRestrictions: () => ({ isValid: true }),
@@ -847,6 +849,7 @@ describe('WorkflowService', () => {
 				mock(), // folderRepository
 				workflowFinderServiceMock, // workflowFinderService
 				mock(), // workflowPublishedVersionRepository
+				mock(), // workflowPublicationOutboxRepository
 				workflowPublishHistoryRepositoryMock, // workflowPublishHistoryRepository
 				Object.assign(mock<WorkflowValidationService>(), {
 					validateCredentialNodeRestrictions: () => ({ isValid: true }),

--- a/packages/cli/src/workflows/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/workflow-publication-outbox-consumer.ts
@@ -13,6 +13,7 @@ import { ensureError } from 'n8n-workflow';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
+import { isWorkflowUnpublishSentinel } from '@/workflows/workflow-publication-outbox.constants';
 
 /**
  * Consumes the workflow publication outbox on the leader instance. It polls for
@@ -126,6 +127,12 @@ export class WorkflowPublicationOutboxConsumer {
 	async processRecord(record: WorkflowPublicationOutbox) {
 		const { workflowId, publishedVersionId } = record;
 
+		if (isWorkflowUnpublishSentinel(publishedVersionId)) {
+			await this.removePublishedVersion(record);
+			await this.finalizePublication(record);
+			return;
+		}
+
 		const workflow = await this.workflowRepository.findById(workflowId);
 		if (!workflow) {
 			this.logger.warn('Workflow not found, marking outbox record as completed', {
@@ -218,6 +225,12 @@ export class WorkflowPublicationOutboxConsumer {
 			{ workflowId: record.workflowId, publishedVersionId: record.publishedVersionId },
 			['workflowId'],
 		);
+	}
+
+	private async removePublishedVersion(record: WorkflowPublicationOutbox) {
+		await this.outboxRepository.manager.delete(WorkflowPublishedVersion, {
+			workflowId: record.workflowId,
+		});
 	}
 
 	/**

--- a/packages/cli/src/workflows/workflow-publication-outbox.constants.ts
+++ b/packages/cli/src/workflows/workflow-publication-outbox.constants.ts
@@ -1,0 +1,5 @@
+export const WORKFLOW_UNPUBLISH_SENTINEL = '__workflow_unpublish__';
+
+export function isWorkflowUnpublishSentinel(versionId: string): boolean {
+	return versionId === WORKFLOW_UNPUBLISH_SENTINEL;
+}

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -15,6 +15,7 @@ import {
 	WorkflowTagMappingRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
+	WorkflowPublicationOutboxRepository,
 	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	ProjectRepository,
@@ -43,6 +44,7 @@ import { v4 as uuid } from 'uuid';
 
 import { getErrorDescription, getErrorNodeId, getRequiredRedactionScopes } from './utils';
 import { WorkflowFinderService } from './workflow-finder.service';
+import { WORKFLOW_UNPUBLISH_SENTINEL } from './workflow-publication-outbox.constants';
 import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
 
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
@@ -93,6 +95,7 @@ export class WorkflowService {
 		private readonly folderRepository: FolderRepository,
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
+		private readonly workflowPublicationOutboxRepository: WorkflowPublicationOutboxRepository,
 		private readonly workflowPublishHistoryRepository: WorkflowPublishHistoryRepository,
 		private readonly workflowValidationService: WorkflowValidationService,
 		private readonly nodeTypes: NodeTypes,
@@ -895,9 +898,14 @@ export class WorkflowService {
 
 		const deactivatedVersionId = workflow.activeVersionId;
 
-		// Temporary: will be removed when the workflow publication service manages this.
+		// Temporary: publish still updates workflow_published_version directly.
+		// Unpublish goes through the outbox so the consumer removes the mapping
+		// after the workflow has been deactivated.
 		if (this.globalConfig.workflows.useWorkflowPublicationService) {
-			await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+			await this.workflowPublicationOutboxRepository.enqueue(
+				workflowId,
+				WORKFLOW_UNPUBLISH_SENTINEL,
+			);
 		}
 
 		await this.workflowPublishHistoryRepository.addRecord({
@@ -997,9 +1005,14 @@ export class WorkflowService {
 		if (workflow.activeVersionId !== null) {
 			await this.activeWorkflowManager.remove(workflowId);
 
-			// Temporary: will be removed when the workflow publication service manages this.
+			// Temporary: publish still updates workflow_published_version directly.
+			// Unpublish goes through the outbox so the consumer removes the mapping
+			// after the workflow has been deactivated.
 			if (this.globalConfig.workflows.useWorkflowPublicationService) {
-				await this.workflowPublishedVersionRepository.removePublishedVersion(workflowId);
+				await this.workflowPublicationOutboxRepository.enqueue(
+					workflowId,
+					WORKFLOW_UNPUBLISH_SENTINEL,
+				);
 			}
 
 			await this.workflowPublishHistoryRepository.addRecord({

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -11,6 +11,7 @@ import { GlobalConfig } from '@n8n/config';
 import {
 	SharedWorkflowRepository,
 	type WorkflowEntity,
+	WorkflowPublicationOutboxRepository,
 	WorkflowPublishedVersionRepository,
 	WorkflowPublishHistoryRepository,
 	WorkflowRepository,
@@ -27,6 +28,7 @@ import { NodeTypes } from '@/node-types';
 import { Telemetry } from '@/telemetry';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
+import { WORKFLOW_UNPUBLISH_SENTINEL } from '@/workflows/workflow-publication-outbox.constants';
 import { WorkflowValidationService } from '@/workflows/workflow-validation.service';
 import { WorkflowService } from '@/workflows/workflow.service';
 import { OwnershipService } from '@/services/ownership.service';
@@ -41,6 +43,7 @@ import { WebhookService } from '@/webhooks/webhook.service';
 let globalConfig: GlobalConfig;
 let workflowRepository: WorkflowRepository;
 let workflowService: WorkflowService;
+let workflowPublicationOutboxRepository: WorkflowPublicationOutboxRepository;
 let workflowPublishedVersionRepository: WorkflowPublishedVersionRepository;
 let workflowPublishHistoryRepository: WorkflowPublishHistoryRepository;
 let workflowHistoryService: WorkflowHistoryService;
@@ -56,6 +59,7 @@ beforeAll(async () => {
 
 	globalConfig = Container.get(GlobalConfig);
 	workflowRepository = Container.get(WorkflowRepository);
+	workflowPublicationOutboxRepository = Container.get(WorkflowPublicationOutboxRepository);
 	workflowPublishedVersionRepository = Container.get(WorkflowPublishedVersionRepository);
 	workflowPublishHistoryRepository = Container.get(WorkflowPublishHistoryRepository);
 	workflowHistoryService = Container.get(WorkflowHistoryService);
@@ -78,6 +82,7 @@ beforeAll(async () => {
 		mock(),
 		Container.get(WorkflowFinderService),
 		workflowPublishedVersionRepository,
+		workflowPublicationOutboxRepository,
 		workflowPublishHistoryRepository,
 		workflowValidationService,
 		nodeTypes,
@@ -102,6 +107,7 @@ afterEach(async () => {
 		'SharedWorkflow',
 		'ProjectRelation',
 		'WorkflowPublishedVersion',
+		'WorkflowPublicationOutbox',
 		'WorkflowEntity',
 		'WorkflowHistory',
 		'WorkflowPublishHistory',
@@ -554,7 +560,7 @@ describe('workflow_published_version table population', () => {
 			expect(publishedVersion?.publishedVersionId).toBe(newVersionId);
 		});
 
-		test('should remove workflow_published_version on deactivation', async () => {
+		test('should enqueue an unpublish sentinel on deactivation', async () => {
 			const owner = await createOwner();
 			const workflow = await createWorkflowWithHistory({}, owner);
 
@@ -565,10 +571,16 @@ describe('workflow_published_version table population', () => {
 			const publishedVersion = await workflowPublishedVersionRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(publishedVersion).toBeNull();
+			expect(publishedVersion?.publishedVersionId).toBe(workflow.versionId);
+
+			const outboxRecord = await workflowPublicationOutboxRepository.findOneByOrFail({
+				workflowId: workflow.id,
+				status: 'pending',
+			});
+			expect(outboxRecord.publishedVersionId).toBe(WORKFLOW_UNPUBLISH_SENTINEL);
 		});
 
-		test('should remove workflow_published_version on archive', async () => {
+		test('should enqueue an unpublish sentinel on archive', async () => {
 			const owner = await createOwner();
 			const workflow = await createWorkflowWithHistory({}, owner);
 
@@ -584,7 +596,13 @@ describe('workflow_published_version table population', () => {
 			const publishedVersionAfter = await workflowPublishedVersionRepository.findOne({
 				where: { workflowId: workflow.id },
 			});
-			expect(publishedVersionAfter).toBeNull();
+			expect(publishedVersionAfter?.publishedVersionId).toBe(workflow.versionId);
+
+			const outboxRecord = await workflowPublicationOutboxRepository.findOneByOrFail({
+				workflowId: workflow.id,
+				status: 'pending',
+			});
+			expect(outboxRecord.publishedVersionId).toBe(WORKFLOW_UNPUBLISH_SENTINEL);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Handle workflow unpublishing via the outbox.

We use a magic string for the "new" workflow version id. This feels a bit hacky but actually works fairly well, and has the nice bonus that the `workflow_published_version` table DOES restrict the version id to be a real history version; so we can't accidentally try to publish it.

## How to test

Un-publish a workflow via the UI, verify that its triggers get torn down.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3344

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

