### PR TITLE
refactor(editor): Resolve workflow id from document store and route (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -569,13 +569,13 @@ export function useCanvasOperations() {
 
 		if (node.type === STICKY_NODE_TYPE) {
 			telemetry.track('User deleted workflow note', {
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 			});
 		} else {
 			void externalHooks.run('node.deleteNode', { node });
 			telemetry.track('User deleted node', {
 				node_type: node.type,
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 			});
 		}
 	}
@@ -1178,7 +1178,7 @@ export function useCanvasOperations() {
 
 	function trackAddStickyNoteNode() {
 		telemetry.track('User inserted workflow note', {
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 	}
 
@@ -1199,7 +1199,7 @@ export function useCanvasOperations() {
 			node_type: nodeData.type,
 			node_version: nodeData.typeVersion,
 			is_auto_add: options.isAutoAdd,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			drag_and_drop: options.dragAndDrop,
 			input_node_type: lastInteractedWithNode.value?.type,
 			resource,
@@ -2850,18 +2850,18 @@ export function useCanvasOperations() {
 
 					if (source === 'paste') {
 						telemetry.track('User pasted nodes', {
-							workflow_id: workflowsStore.workflowId,
+							workflow_id: workflowDocumentStore.value.workflowId,
 							node_graph_string: nodeGraph,
 						});
 					} else if (source === 'duplicate') {
 						telemetry.track('User duplicated nodes', {
-							workflow_id: workflowsStore.workflowId,
+							workflow_id: workflowDocumentStore.value.workflowId,
 							node_graph_string: nodeGraph,
 						});
 					} else {
 						telemetry.track('User imported workflow', {
 							source,
-							workflow_id: workflowsStore.workflowId,
+							workflow_id: workflowDocumentStore.value.workflowId,
 							node_graph_string: nodeGraph,
 						});
 					}
@@ -3149,7 +3149,7 @@ export function useCanvasOperations() {
 
 		telemetry.track('User copied nodes', {
 			node_types: workflowData.nodes.map((node) => node.type),
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -70,6 +70,7 @@ const {
 		confirm: vi.fn(),
 	},
 	mockWorkflowDocumentStore: {
+		workflowId: '123',
 		updateNodeProperties: vi.fn(),
 		getNodeByName: vi.fn(),
 		getStartNode: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -265,7 +265,7 @@ export function useNodeExecution(
 
 	async function stopWaitingForWebhook() {
 		try {
-			await workflowsStore.removeTestWebhook(workflowsStore.workflowId);
+			await workflowsStore.removeTestWebhook(workflowDocumentStore.value.workflowId);
 		} catch (error) {
 			toast.showError(error, 'Error stopping webhook');
 		}
@@ -419,7 +419,7 @@ export function useNodeExecution(
 			// Normal execution
 			const telemetryPayload = {
 				node_type: nodeType.value ? nodeType.value.name : null,
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 				source: telemetrySource,
 				push_ref: ndvStore.value.pushRef,
 			};

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -778,7 +778,7 @@ export function useNodeHelpers() {
 			telemetry.track('User set node enabled status', {
 				node_type: node.type,
 				is_enabled: node.disabled,
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 			});
 
 			workflowDocumentStore.value.updateNodeProperties(updateInformation);

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
@@ -15,7 +15,6 @@ import {
 	PIN_DATA_NODE_TYPES_DENYLIST,
 } from '@/app/constants';
 import { stringSizeInBytes, toMegaBytes } from '@/app/utils/typesUtils';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import {
 	injectWorkflowDocumentStore,
@@ -56,7 +55,6 @@ export function usePinnedData(
 	} = {},
 ) {
 	const rootStore = useRootStore();
-	const workflowsStore = useWorkflowsStore();
 	const uiStore = useUIStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const toast = useToast();
@@ -235,7 +233,7 @@ export function usePinnedData(
 			data_size: stringSizeInBytes(data.value),
 			view: displayMode,
 			run_index: runIndex,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			node_id: targetNode?.id,
 		};
 

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -601,7 +601,7 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 
 	async function stopWaitingForWebhook() {
 		try {
-			await workflowsStore.removeTestWebhook(workflowsStore.workflowId);
+			await workflowsStore.removeTestWebhook(workflowDocumentStore.value.workflowId);
 		} catch (error) {
 			toast.showError(error, i18n.baseText('nodeView.showError.stopWaitingForWebhook.title'));
 			return;

--- a/packages/frontend/editor-ui/src/app/composables/useToast.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToast.ts
@@ -3,7 +3,7 @@ import type { NotificationHandle, MessageBoxState } from 'element-plus';
 import type { NotificationOptions } from '@/Interface';
 import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useI18n } from '@n8n/i18n';
 import { useExternalHooks } from './useExternalHooks';
@@ -14,7 +14,7 @@ const stickyNotificationQueue: NotificationHandle[] = [];
 
 export function useToast() {
 	const telemetry = useTelemetry();
-	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const uiStore = useUIStore();
 	const externalHooks = useExternalHooks();
 	const i18n = useI18n();
@@ -83,7 +83,7 @@ export function useToast() {
 				error_title: params.title,
 				error_message: messageForTelemetry,
 				caused_by_credential: causedByCredential(messageForTelemetry),
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 			});
 		}
 
@@ -179,7 +179,7 @@ export function useToast() {
 			error_description: message,
 			error_message: error.message,
 			caused_by_credential: causedByCredential(error.message),
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowActivate.ts
@@ -11,6 +11,7 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { useI18n } from '@n8n/i18n';
 import { ref } from 'vue';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
@@ -28,6 +29,7 @@ export function useWorkflowActivate() {
 	const activationErrorNodeId = ref<string | undefined>();
 
 	const workflowsStore = useWorkflowsStore();
+	const currentWorkflowId = useWorkflowId();
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const telemetry = useTelemetry();
@@ -108,7 +110,7 @@ export function useWorkflowActivate() {
 
 		try {
 			const expectedChecksum =
-				workflowId === workflowsStore.workflowId ? workflowDocumentStore.checksum : undefined;
+				workflowId === currentWorkflowId.value ? workflowDocumentStore.checksum : undefined;
 
 			const updatedWorkflow = await workflowsStore.publishWorkflow(workflowId, {
 				versionId,
@@ -126,7 +128,7 @@ export function useWorkflowActivate() {
 				activeVersion: updatedWorkflow.activeVersion,
 			});
 
-			if (workflowId === workflowsStore.workflowId) {
+			if (workflowId === currentWorkflowId.value) {
 				workflowDocumentStore.setVersionData({
 					versionId: updatedWorkflow.versionId,
 					name: workflowDocumentStore.versionData?.name ?? null,
@@ -195,7 +197,7 @@ export function useWorkflowActivate() {
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 		try {
 			const expectedChecksum =
-				workflowId === workflowsStore.workflowId ? workflowDocumentStore.checksum : undefined;
+				workflowId === currentWorkflowId.value ? workflowDocumentStore.checksum : undefined;
 
 			await workflowsStore.deactivateWorkflow(workflowId, expectedChecksum);
 			workflowDocumentStore.setActiveState({

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.test.ts
@@ -20,6 +20,17 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 
+// The current workflow id is resolved via the route/document store. These tests
+// drive it through `workflowsStore.workflowId`, so resolve it from there.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 describe('useWorkflowHelpers', () => {
 	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
 	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -56,6 +56,7 @@ import {
 	injectWorkflowDocumentStore,
 	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 
@@ -489,6 +490,7 @@ export function useWorkflowHelpers() {
 	const i18n = useI18n();
 
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const currentWorkflowId = useWorkflowId();
 
 	function getNodeTypesMaxCount() {
 		const nodes = workflowDocumentStore.value.allNodes;
@@ -574,7 +576,7 @@ export function useWorkflowHelpers() {
 			},
 		} as const;
 		const baseUrl = baseUrls[showUrlFor][nodeType ?? 'webhook'];
-		const workflowId = workflowsStore.workflowId;
+		const workflowId = currentWorkflowId.value;
 		const path = (await getWebhookExpressionValue(webhookData, 'path', true, node.name)) ?? '';
 		const isFullPath =
 			((await getWebhookExpressionValue(
@@ -663,7 +665,7 @@ export function useWorkflowHelpers() {
 		let data: WorkflowDataUpdate = {};
 
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		const isCurrentWorkflow = workflowId === workflowsStore.workflowId;
+		const isCurrentWorkflow = workflowId === currentWorkflowId.value;
 		if (isCurrentWorkflow) {
 			data = partialData
 				? { versionId: workflowDocumentStore.versionId }
@@ -873,7 +875,7 @@ export function useWorkflowHelpers() {
 		let data;
 		if (uiStore.stateIsDirty) {
 			const workflowDocumentStore = useWorkflowDocumentStore(
-				createWorkflowDocumentId(workflowsStore.workflowId),
+				createWorkflowDocumentId(currentWorkflowId.value),
 			);
 			data = workflowDocumentStore.serialize();
 		} else {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowId.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowId.test.ts
@@ -1,5 +1,5 @@
 import { VIEWS } from '@/app/constants';
-import { useWorkflowId } from '@/app/composables/useWorkflowId';
+import { useRouteWorkflowId, useWorkflowId } from '@/app/composables/useWorkflowId';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { render } from '@testing-library/vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -62,5 +62,56 @@ describe('useWorkflowId', () => {
 		});
 
 		expect(getByTestId('workflow-id')).toHaveTextContent('injected-workflow-id');
+	});
+});
+
+describe('useRouteWorkflowId', () => {
+	beforeEach(() => {
+		route.name = VIEWS.WORKFLOW;
+		route.params = {};
+	});
+
+	it('uses the workflow route workflowId parameter', () => {
+		route.params = { workflowId: 'workflow-123' };
+
+		expect(useRouteWorkflowId().value).toBe('workflow-123');
+	});
+
+	it('uses the first workflow route workflowId parameter when it is an array', () => {
+		route.params = { workflowId: ['workflow-123', 'node-456'] };
+
+		expect(useRouteWorkflowId().value).toBe('workflow-123');
+	});
+
+	it('returns an empty string when the workflow route workflowId parameter is missing', () => {
+		expect(useRouteWorkflowId().value).toBe('');
+	});
+
+	it.each([VIEWS.DEMO, VIEWS.DEMO_DIFF])('uses demo for %s routes', (routeName) => {
+		route.name = routeName;
+		route.params = { workflowId: 'workflow-123' };
+
+		expect(useRouteWorkflowId().value).toBe('demo');
+	});
+
+	it('ignores an injected workflow ID and always uses the route', () => {
+		route.params = { workflowId: 'route-workflow-id' };
+
+		const TestComponent = defineComponent({
+			setup() {
+				const workflowId = useRouteWorkflowId();
+				return () => h('span', { 'data-test-id': 'workflow-id' }, workflowId.value);
+			},
+		});
+
+		const { getByTestId } = render(TestComponent, {
+			global: {
+				provide: {
+					[WorkflowIdKey as symbol]: computed(() => 'injected-workflow-id'),
+				},
+			},
+		});
+
+		expect(getByTestId('workflow-id')).toHaveTextContent('route-workflow-id');
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowId.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowId.ts
@@ -1,12 +1,20 @@
-import { computed, hasInjectionContext, inject } from 'vue';
+import { computed, hasInjectionContext, inject, type ComputedRef } from 'vue';
 import { useRoute } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 
-export function useWorkflowId() {
-	const injectedWorkflowId = hasInjectionContext() ? inject(WorkflowIdKey, null) : null;
-	if (injectedWorkflowId) return injectedWorkflowId;
-
+/**
+ * Resolves the current workflow id from the route only, ignoring any injected
+ * `WorkflowIdKey`.
+ *
+ * Use this in out-of-tree Pinia stores. A setup store captures `inject()` once,
+ * at first instantiation, so resolving via `useWorkflowId()` there risks
+ * freezing a shadowed id (e.g. the prop-derived id `WorkflowCanvasHost` provides
+ * for an embedded canvas). Reading the route directly keeps the value global and
+ * reactive — matching the semantics of the deprecated global
+ * `workflowsStore.workflowId` it replaces.
+ */
+export function useRouteWorkflowId(): ComputedRef<string> {
 	const route = useRoute();
 
 	return computed(() => {
@@ -15,4 +23,19 @@ export function useWorkflowId() {
 		const workflowId = route.params.workflowId;
 		return (Array.isArray(workflowId) ? workflowId[0] : workflowId) ?? '';
 	});
+}
+
+/**
+ * Resolves the current workflow id, preferring an injected `WorkflowIdKey`
+ * (provided globally by `App.vue`, shadowed by `WorkflowCanvasHost` for embedded
+ * canvases) and falling back to the route.
+ *
+ * Use this in components and in-tree composables, which should honor the
+ * injected/shadowed id. Out-of-tree stores should use `useRouteWorkflowId()`.
+ */
+export function useWorkflowId(): ComputedRef<string> {
+	const injectedWorkflowId = hasInjectionContext() ? inject(WorkflowIdKey, null) : null;
+	if (injectedWorkflowId) return injectedWorkflowId;
+
+	return useRouteWorkflowId();
 }

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -171,7 +171,7 @@ export function useWorkflowInitialization() {
 
 		// Create document store for template workflow (empty tags initially)
 		// The workflow ID was set during the template import
-		const currentWorkflowId = workflowsStore.workflowId;
+		const currentWorkflowId = workflowId.value;
 		if (currentWorkflowId) {
 			const workflowDocumentId = createWorkflowDocumentId(currentWorkflowId);
 			currentWorkflowDocumentStore.value = useWorkflowDocumentStore(workflowDocumentId);
@@ -191,7 +191,7 @@ export function useWorkflowInitialization() {
 		documentTitle.setDocumentTitle(currentWorkflowDocumentStore.value?.name ?? '', 'DEBUG');
 
 		const executionStateStore = useWorkflowExecutionStateStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(workflowId.value),
 		);
 		if (!executionStateStore.isInDebugMode) {
 			const executionId = route.params.executionId;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -234,6 +234,7 @@ describe('useWorkflowSaving', () => {
 			const MOCK_ID = 'existing-workflow-id';
 			const existingWorkflow = createTestWorkflow({ id: MOCK_ID });
 			workflowStore.setWorkflowId(MOCK_ID);
+			mockRoute.params = { workflowId: MOCK_ID };
 			// Populate workflowsById to mark workflow as existing (not new)
 			workflowListStore.workflowsById = { [MOCK_ID]: existingWorkflow };
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -79,7 +79,7 @@ export function useWorkflowSaving({
 		} = {},
 	) {
 		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(workflowId.value),
 		);
 
 		if (
@@ -126,7 +126,7 @@ export function useWorkflowSaving({
 				return;
 			case MODAL_CLOSE:
 				// For new workflows that are not saved yet, don't do anything, only close modal
-				if (workflowsStore.isWorkflowSaved[workflowsStore.workflowId]) {
+				if (workflowsStore.isWorkflowSaved[workflowId.value]) {
 					stayOnCurrentWorkflow(next);
 				}
 
@@ -139,7 +139,7 @@ export function useWorkflowSaving({
 		next(
 			router.resolve({
 				name: VIEWS.WORKFLOW,
-				params: { workflowId: workflowsStore.workflowId },
+				params: { workflowId: workflowId.value },
 			}),
 		);
 	}
@@ -389,7 +389,7 @@ export function useWorkflowSaving({
 			const dirtyCountBeforeSave = uiStore.dirtyStateSetCount;
 
 			const currentDocumentStore = useWorkflowDocumentStore(
-				createWorkflowDocumentId(workflowsStore.workflowId),
+				createWorkflowDocumentId(workflowId.value),
 			);
 			const workflowDataRequest: WorkflowDataCreate = data || currentDocumentStore.serialize();
 			const changedNodes = {} as IDataObject;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', () => ({
 // Mock workflowDocumentStore - using hoisted for proper initialization
 const mockDocumentStore = vi.hoisted(() => ({
 	allNodes: [] as INodeUi[],
+	workflowId: 'test-workflow',
 	name: '',
 	setName: vi.fn(),
 	setNodes: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.ts
@@ -5,12 +5,7 @@
  */
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
 import type { INodeUi } from '@/Interface';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-	injectWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
@@ -42,7 +37,6 @@ export type UpdateWorkflowResult =
 	  };
 
 export function useWorkflowUpdate() {
-	const workflowsStore = useWorkflowsStore();
 	const credentialsStore = useCredentialsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const builderStore = useBuilderStore();
@@ -317,13 +311,10 @@ export function useWorkflowUpdate() {
 	 * Update workflow name if initial generation and name starts with default
 	 */
 	function updateWorkflowNameIfNeeded(name?: string, isInitialGeneration?: boolean): void {
-		if (!name || !isInitialGeneration || !workflowsStore.workflowId) return;
+		if (!name || !isInitialGeneration || !workflowDocumentStore.value.workflowId) return;
 
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
-		if (workflowDocumentStore.name.startsWith(DEFAULT_NEW_WORKFLOW_NAME)) {
-			workflowDocumentStore.setName(name);
+		if (workflowDocumentStore.value.name.startsWith(DEFAULT_NEW_WORKFLOW_NAME)) {
+			workflowDocumentStore.value.setName(name);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Replaces usages of the deprecated global `workflowsStore.workflowId` across editor-ui composables with the workflow document store's `workflowId` and a route-based resolver. Adds a new `useRouteWorkflowId()` that resolves the current workflow id from the route only — for use in out-of-tree Pinia stores, which would otherwise freeze a shadowed injected id captured at first instantiation — while `useWorkflowId()` continues to prefer an injected `WorkflowIdKey` for components and in-tree composables. Telemetry tracking, webhook teardown, workflow saving/activation, and pinned-data flows now read the id from the correct source, and tests are updated accordingly.

## How to test

Open a workflow in the editor and exercise saving, activation/publish, node add/delete/copy/paste telemetry, pinned data, and webhook-based execution; verify behavior is unchanged and telemetry `workflow_id` is populated. Run the editor-ui unit tests for the touched composables (`useWorkflowId`, `useWorkflowHelpers`, `useWorkflowSaving`, `useWorkflowUpdate`, `useNodeExecution`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3482

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI