### PR TITLE
fix(OpenAI Node): Send assistant messages as output text in Message a Model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/responses.test.ts
@@ -85,7 +85,29 @@ describe('OpenAI Responses Helper Functions', () => {
 			const executeFunctions = createExecuteFunctionsMock({});
 			const messages = [
 				{
+					role: 'user',
+					content: 'How are you?',
+				},
+			];
+
+			const result = await formatInputMessages.call(executeFunctions, 0, messages);
+
+			expect(result).toEqual([
+				{
+					role: 'user',
+					content: [{ type: 'input_text', text: 'How are you?' }],
+				},
+			]);
+		});
+
+		it('should format assistant text messages as string content, not input_text', async () => {
+			// The Responses API rejects `input_text` parts for assistant messages
+			// (expects `output_text`/`refusal`). A plain string is valid for assistant.
+			const executeFunctions = createExecuteFunctionsMock({});
+			const messages = [
+				{
 					role: 'assistant',
+					type: 'text',
 					content: 'I am doing well, thank you!',
 				},
 			];
@@ -95,7 +117,7 @@ describe('OpenAI Responses Helper Functions', () => {
 			expect(result).toEqual([
 				{
 					role: 'assistant',
-					content: [{ type: 'input_text', text: 'I am doing well, thank you!' }],
+					content: 'I am doing well, thank you!',
 				},
 			]);
 		});
@@ -364,7 +386,7 @@ describe('OpenAI Responses Helper Functions', () => {
 				},
 				{
 					role: 'assistant',
-					content: [{ type: 'input_text', text: 'I can see the image you shared.' }],
+					content: 'I can see the image you shared.',
 				},
 			]);
 		});
@@ -913,6 +935,53 @@ describe('OpenAI Responses Helper Functions', () => {
 				},
 				background: false,
 			});
+		});
+
+		it('should not send assistant messages as input_text with JSON object output', async () => {
+			// Regression: a workflow with User + System + Assistant roles and JSON
+			// output previously crashed with a 400 "Invalid value: 'input_text'".
+			const executeFunctions = createExecuteFunctionsMock({});
+			const options = {
+				model: 'gpt-4',
+				messages: [
+					{ role: 'system', type: 'text', content: 'You are a helpful assistant.' },
+					{ role: 'user', type: 'text', content: 'Hello' },
+					{ role: 'assistant', type: 'text', content: 'Hi there!' },
+				],
+				options: {
+					textFormat: {
+						textOptions: {
+							type: 'json_object',
+							verbosity: 'medium',
+						},
+					},
+				},
+				builtInTools: undefined,
+				tools: undefined,
+			};
+
+			const result = await createRequest.call(executeFunctions, 0, options);
+
+			expect(result.input).toEqual([
+				{
+					role: 'system',
+					content: [
+						{ type: 'input_text', text: 'You are a helpful assistant designed to output JSON.' },
+					],
+				},
+				{
+					role: 'system',
+					content: [{ type: 'input_text', text: 'You are a helpful assistant.' }],
+				},
+				{
+					role: 'user',
+					content: [{ type: 'input_text', text: 'Hello' }],
+				},
+				{
+					role: 'assistant',
+					content: 'Hi there!',
+				},
+			]);
 		});
 
 		it('should handle text format configuration with text type', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/text/helpers/responses.ts
@@ -2,14 +2,13 @@ import type { OpenAIClient } from '@langchain/openai';
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 import { isObjectEmpty, jsonParse, type IDataObject, type IExecuteFunctions } from 'n8n-workflow';
-import type { ResponseInputImage } from 'openai/resources/responses/responses';
+import type {
+	ResponseInputImage,
+	ResponseInputItem,
+} from 'openai/resources/responses/responses';
 
 import { getBinaryDataFile } from '../../../../helpers/binary-data';
-import type {
-	ChatContent,
-	ChatInputItem,
-	ChatResponseRequest,
-} from '../../../../helpers/interfaces';
+import type { ChatContent, ChatResponseRequest } from '../../../../helpers/interfaces';
 
 const toArray = (str: string) => str.split(',').map((e) => e.trim());
 
@@ -28,12 +27,23 @@ export async function formatInputMessages(
 	messages: IDataObject[],
 ) {
 	return await Promise.all(
-		messages.map<Promise<ChatInputItem>>(async (message) => {
-			const role = message.role as ChatInputItem['role'];
-			let content: ChatContent = [];
+		messages.map<Promise<ResponseInputItem>>(async (message) => {
+			const role = message.role as 'user' | 'assistant' | 'system' | 'developer';
+
 			if (message.type === 'text' || !message.type) {
-				content = [{ type: 'input_text', text: message.content as string }];
-			} else if (message.type === 'image') {
+				// The Responses API rejects `input_text` content parts for assistant
+				// messages — it only accepts `output_text`/`refusal` there. Passing the
+				// text as a plain string is valid for every role and is treated as
+				// assistant output text, so it avoids the 400 "Invalid value:
+				// 'input_text'" error when an assistant message is included.
+				if (role === 'assistant') {
+					return { role, content: message.content as string };
+				}
+				return { role, content: [{ type: 'input_text', text: message.content as string }] };
+			}
+
+			let content: ChatContent = [];
+			if (message.type === 'image') {
 				const detail = (message.imageDetail as ResponseInputImage['detail']) || ('auto' as const);
 
 				if (message.imageType === 'base64') {


### PR DESCRIPTION
## Summary

The v2 **Message a Model** operation (Responses API) built every text
message with an `input_text` content part, regardless of role. OpenAI's
Responses API only accepts `output_text`/`refusal` for **assistant**-role
messages, so including an Assistant message made the request fail with a 400:

> Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.

The bug was hidden by a type cast — `formatInputMessages` typed its result as
`ChatInputItem`, whose `role` is only `'user' | 'system' | 'developer'`, and
cast `message.role` to it, so the `assistant` case was never modeled.

This change sends assistant text messages as plain string content
(`{ role: 'assistant', content: '…' }`), which the Responses API accepts for
any role and treats as assistant output text. User/system/developer messages
are unchanged. The map return type is widened to `ResponseInputItem` so
`assistant` is properly represented instead of cast away.

The Output Format (JSON Schema / JSON Object) in the report was incidental —
the trigger is the Assistant-role message. The legacy 1.4 node works because
it targets the older `chat/completions` endpoint.

## How to test

1. Add an **OpenAI** node (v2.x) → Resource: **Text** → Operation: **Message a Model**.
2. Add three messages: a **System**, a **User**, and an **Assistant** message.
3. Set **Output Format** to **JSON Object** (or JSON Schema).
4. Execute the node.
   - **Before:** 400 `Invalid value: 'input_text'…`
   - **After:** the request succeeds and returns the model output.

Automated coverage: `packages/@n8n/nodes-langchain` →
`test/v2/actions/text/responses.test.ts` (assistant-as-string assertion +
a `createRequest` test mirroring the System+User+Assistant+JSON-object repro).

## Related Linear tickets, Github issues, and Community forum posts

Fixes #32433

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (if urgent).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

