### PR TITLE
fix(editor): Prevent NDV panels from collapsing before the container is measured

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.test.ts
@@ -38,6 +38,32 @@ describe('useNdvLayout', () => {
 		).toBeCloseTo(100);
 	});
 
+	it('keeps finite full-width defaults when container has not been measured yet', async () => {
+		// `useElementSize` reports 0 until its `ResizeObserver` fires.
+		containerWidth.value = 0;
+
+		const { panelWidthPercentage } = useNdvLayout({ container, hasInputPanel, paneType });
+
+		const total =
+			panelWidthPercentage.value.left +
+			panelWidthPercentage.value.main +
+			panelWidthPercentage.value.right;
+		expect(Number.isFinite(total)).toBe(true);
+		expect(total).toBeCloseTo(100);
+
+		// Once a real measurement arrives, sizes are computed normally.
+		containerWidth.value = 1000;
+		await nextTick();
+		await nextTick();
+
+		expect(panelWidthPercentage.value.main).toBeGreaterThan(0);
+		expect(
+			panelWidthPercentage.value.left +
+				panelWidthPercentage.value.main +
+				panelWidthPercentage.value.right,
+		).toBeCloseTo(100);
+	});
+
 	it('loads and uses stored values from localStorage', () => {
 		const key = `${LOCAL_STORAGE_NDV_PANEL_WIDTH}_REGULAR`;
 		localStorage.setItem(key, JSON.stringify({ left: 30, main: 40, right: 30 }));

--- a/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/composables/useNdvLayout.ts
@@ -104,6 +104,13 @@ export function useNdvLayout(options: UseNdvLayoutOptions) {
 	};
 
 	const loadPanelSize = () => {
+		// Skip until the container has a real measurement. `useElementSize` reports
+		// 0 until its `ResizeObserver` fires, and computing sizes against a 0 width
+		// yields non-finite percentages (Infinity/NaN) that collapse the panels to
+		// the left. The sane default ref is kept until a valid width arrives, and
+		// the `containerWidth` watcher re-runs this once it does.
+		if (containerWidth.value <= 0) return;
+
 		const storedPanelSizeString = localStorage.getItem(localStorageKey.value);
 		const defaultSize = defaultPanelSize.value;
 		if (storedPanelSizeString) {


### PR DESCRIPTION
## Summary

When opening a node, the Node Detail View could render with its input /
parameters / output panels crushed into the left of the modal, leaving the
rest empty (canvas showing through the backdrop).

`useNdvLayout` derives panel widths from the container width measured by
`useElementSize`, which reports `0` until its `ResizeObserver` fires. The
`paneType` watcher runs `loadPanelSize()` **immediately on mount**, while the
width is still `0`, so the size math divides by zero and produces non-finite
percentages (`Infinity` / `NaN`). Those bind to invalid `width:` styles and
the columns fall back to their `min-width`, bunching to the left. It normally
self-heals once the observer fires, but that correction is timing-fragile
inside the native `<dialog>` shown via `.show()`.

The fix makes `loadPanelSize()` wait for a real measurement (`containerWidth > 0`),
keeping the sane `40/20/40` default (which sums to 100% and fills the modal)
until a valid width arrives — at which point the existing `containerWidth`
watcher re-runs it normally.

## How to test

1. Open any workflow and open a node's detail view several times.
2. Panels should always fill the modal width (input / parameters / output),
   with no empty gap on the right.
3. Resizing/dragging panels and browser zoom continue to behave as before.

Automated coverage: `packages/frontend/editor-ui` →
`features/ndv/panel/composables/useNdvLayout.test.ts` (new test asserting
finite, full-width defaults when the container is unmeasured, then correct
sizing once a width arrives).

> Note: reported on n8n Cloud 2.25.7; reproduction is timing/state-dependent,
> so this addresses the underlying non-finite-measurement defect rather than a
> deterministic repro.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #32435

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (if urgent).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32465">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

