### PR TITLE
feat(editor): Render workflow history and template previews natively

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
@@ -1,0 +1,154 @@
+<script lang="ts" setup>
+import { computed, nextTick, onBeforeUnmount, provide, shallowRef, watch } from 'vue';
+import { N8nIcon } from '@n8n/design-system';
+import NodeView from '@/app/views/NodeView.vue';
+import type { IWorkflowDb, INodeUi } from '@/Interface';
+import type { IWorkflowTemplate } from '@n8n/rest-api-client/api/templates';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowDocumentStoreKey,
+	WorkflowIdKey,
+	type EditorEnabledFeatures,
+} from '@/app/constants/injectionKeys';
+import { useWorkflowNormalization } from '@/app/composables/useWorkflowNormalization';
+import { assignNodeId } from '@/app/utils/nodes/nodeTransforms';
+import {
+	disposeWorkflowDocumentStore,
+	useWorkflowDocumentStore,
+	type WorkflowDocumentId,
+	type WorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import {
+	disposeWorkflowExecutionStateStore,
+	useWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
+import { disposeNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
+
+const props = defineProps<{
+	/**
+	 * Synthetic document id this preview is keyed by — never `{id}@latest`,
+	 * so the preview can never collide with the editor's document store.
+	 * Construct via `createWorkflowDocumentId(workflowId, <version token>)`.
+	 */
+	documentId: WorkflowDocumentId;
+	workflow: IWorkflowDb | IWorkflowTemplate['workflow'];
+}>();
+
+const { normalizeWorkflowData } = useWorkflowNormalization();
+
+const documentStore = shallowRef<WorkflowDocumentStore | null>(null);
+
+// Scope every injection-aware consumer in this subtree (NodeView/canvas
+// render data, NDV) to the preview's stores. Nothing in this setup injects
+// these keys, so providing and rendering live in one component.
+const workflowId = computed(() => documentStore.value?.workflowId ?? '');
+provide(WorkflowIdKey, workflowId);
+provide(WorkflowDocumentStoreKey, documentStore);
+provide(
+	EditorEnabledFeaturesKey,
+	computed<EditorEnabledFeatures>(() => ({
+		readOnly: true,
+		aiAssistant: false,
+		aiBuilder: false,
+		askAi: false,
+		executionSuccessToasts: false,
+		executionErrorToasts: false,
+	})),
+);
+
+function disposePreviewStores() {
+	const scopedDocumentStore = documentStore.value;
+	if (!scopedDocumentStore) {
+		return;
+	}
+	const documentId = scopedDocumentStore.documentId;
+	documentStore.value = null;
+	// NDV store first: its setup instantiates the document and execution-state
+	// stores for its id, so disposing it afterwards would re-create what was
+	// just removed.
+	disposeNDVStore(useNDVStore(documentId));
+	disposeWorkflowExecutionStateStore(useWorkflowExecutionStateStore(documentId));
+	disposeWorkflowDocumentStore(scopedDocumentStore);
+}
+
+async function hydratePreview() {
+	if (documentStore.value && documentStore.value.documentId !== props.documentId) {
+		disposePreviewStores();
+	}
+
+	const [workflowIdFromDocumentId, version] = props.documentId.split('@');
+	const scopedDocumentStore = useWorkflowDocumentStore(props.documentId);
+	// Template workflow nodes have no canvas node ids — assign them, same as
+	// the workflow import path does. The cast is safe once an id is ensured;
+	// remaining template-node differences (e.g. legacy credential format) are
+	// handled gracefully by normalization.
+	const previewNodes = (props.workflow.nodes ?? []).map((node) => {
+		const previewNode = { ...node } as INodeUi;
+		if (!previewNode.id) {
+			assignNodeId(previewNode);
+		}
+		return previewNode;
+	});
+	const { nodes, connections } = normalizeWorkflowData({
+		nodes: previewNodes,
+		connections: props.workflow.connections ?? {},
+	});
+
+	scopedDocumentStore.hydrate({
+		name: '',
+		active: false,
+		isArchived: false,
+		createdAt: '',
+		updatedAt: '',
+		...props.workflow,
+		id: workflowIdFromDocumentId,
+		versionId: version,
+		nodes,
+		connections,
+	} as IWorkflowDb);
+
+	documentStore.value = scopedDocumentStore;
+
+	// Wait for NodeView/canvas to mount (first hydrate) before requesting fit.
+	await nextTick();
+	canvasEventBus.emit('fitView');
+}
+
+watch(() => [props.documentId, props.workflow] as const, hydratePreview, { immediate: true });
+
+onBeforeUnmount(() => {
+	disposePreviewStores();
+});
+
+const isReady = computed(() => documentStore.value !== null);
+</script>
+
+<template>
+	<div :class="$style.host" data-test-id="workflow-preview-host">
+		<NodeView v-if="isReady" />
+		<div v-else :class="$style.centerState">
+			<N8nIcon icon="loader-circle" :size="80" spin />
+		</div>
+	</div>
+</template>
+
+<style lang="scss" module>
+.host {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	min-height: 0;
+}
+
+.centerState {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing--xs);
+	flex: 1;
+	min-height: 0;
+}
+</style>

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
@@ -73,7 +73,10 @@ function disposePreviewStores() {
 }
 
 async function hydratePreview() {
-	if (documentStore.value && documentStore.value.documentId !== props.documentId) {
+	// Tear down any previously hydrated scope before (re)hydrating, so a new
+	// workflow never renders over a prior preview's NDV/execution-state stores —
+	// including when the document id is unchanged.
+	if (documentStore.value) {
 		disposePreviewStores();
 	}
 

--- a/packages/frontend/editor-ui/src/features/workflows/templates/views/TemplatesWorkflowView.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/views/TemplatesWorkflowView.vue
@@ -8,7 +8,8 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useI18n } from '@n8n/i18n';
-import WorkflowPreview from '@/app/components/WorkflowPreview.vue';
+import WorkflowPreviewHost from '@/app/components/WorkflowPreviewHost.vue';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import TemplatesView from './TemplatesView.vue';
 import RecommendedTemplateCard from '../recommendations/components/RecommendedTemplateCard.vue';
 
@@ -49,10 +50,6 @@ const openTemplateSetup = async (id: string, e: PointerEvent) => {
 		templatesStore,
 		source: 'template_preview',
 	});
-};
-
-const onHidePreview = () => {
-	showPreview.value = false;
 };
 
 const scrollToTop = () => {
@@ -102,6 +99,13 @@ watch(
 onMounted(async () => {
 	scrollToTop();
 
+	// The native preview canvas renders node icons/shapes from the node types
+	// store; community nodes used by templates resolve through previews.
+	if (nodeTypesStore.allNodeTypes.length === 0) {
+		void nodeTypesStore.getNodeTypes();
+	}
+	void nodeTypesStore.fetchCommunityNodePreviews();
+
 	if (template.value?.full) {
 		loading.value = false;
 		return;
@@ -133,6 +137,12 @@ const strippedWorkflow = computed<IWorkflowTemplate['workflow'] | undefined>(() 
 		pinData: {},
 	};
 });
+
+// Synthetic preview document id — template workflows have no instance
+// workflow id, so key by the template id.
+const previewDocumentId = computed(() =>
+	createWorkflowDocumentId(`template-${templateId.value}`, 'preview'),
+);
 </script>
 
 <template>
@@ -145,11 +155,10 @@ const strippedWorkflow = computed<IWorkflowTemplate['workflow'] | undefined>(() 
 		<template v-if="!notFoundError" #content>
 			<div :class="$style.previewWrapper">
 				<div :class="$style.image">
-					<WorkflowPreview
-						v-if="showPreview"
-						:loading="loading"
+					<WorkflowPreviewHost
+						v-if="showPreview && !loading && strippedWorkflow"
+						:document-id="previewDocumentId"
 						:workflow="strippedWorkflow"
-						@close="onHidePreview"
 					/>
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.test.ts
@@ -1,5 +1,4 @@
 import { vi } from 'vitest';
-import type { MockInstance } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
@@ -11,6 +10,17 @@ import { workflowVersionDataFactory } from '../__tests__/utils';
 import type { IWorkflowDb } from '@/Interface';
 import type { IUser } from 'n8n-workflow';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+
+vi.mock('@/app/views/NodeView.vue', () => ({
+	default: {
+		name: 'NodeViewStub',
+		template: '<div data-test-id="node-view-stub" />',
+	},
+}));
 
 const actionTypes: WorkflowHistoryActionTypes = ['restore', 'clone', 'open', 'download'];
 const actions: Array<UserAction<IUser>> = actionTypes.map((value) => ({
@@ -23,7 +33,6 @@ const renderComponent = createComponentRenderer(WorkflowHistoryContent);
 
 let pinia: ReturnType<typeof createPinia>;
 let projectsStore: ReturnType<typeof useProjectsStore>;
-let postMessageSpy: MockInstance;
 
 describe('WorkflowHistoryContent', () => {
 	beforeEach(() => {
@@ -33,14 +42,6 @@ describe('WorkflowHistoryContent', () => {
 
 		// Mock currentProjectId for all tests
 		vi.spyOn(projectsStore, 'currentProjectId', 'get').mockReturnValue('test-project-id');
-
-		postMessageSpy = vi.fn();
-		Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
-			writable: true,
-			value: {
-				postMessage: postMessageSpy,
-			},
-		});
 	});
 
 	it('should render version data with action toggle', () => {
@@ -88,10 +89,13 @@ describe('WorkflowHistoryContent', () => {
 		]);
 	});
 
-	it('should pass proper workflow data to WorkflowPreview component', async () => {
+	it('should hydrate the scoped preview document from the version, without pin data', async () => {
 		const workflowVersion = workflowVersionDataFactory();
-		const workflow = { pinData: {} } as IWorkflowDb;
-		renderComponent({
+		const workflow = {
+			id: 'history-workflow',
+			pinData: { 'Some Node': [{ json: { pinned: true } }] },
+		} as unknown as IWorkflowDb;
+		const { getByTestId } = renderComponent({
 			pinia,
 			props: {
 				workflow,
@@ -100,9 +104,14 @@ describe('WorkflowHistoryContent', () => {
 			},
 		});
 
-		window.postMessage('{"command":"n8nReady"}', '*');
-		await waitFor(() => {
-			expect(postMessageSpy).toHaveBeenCalledWith(expect.not.stringContaining('pinData'), '*');
-		});
+		await waitFor(() => expect(getByTestId('node-view-stub')).toBeInTheDocument());
+
+		const previewDocumentStore = useWorkflowDocumentStore(
+			createWorkflowDocumentId('history-workflow', `history-preview-${workflowVersion.versionId}`),
+		);
+		expect(previewDocumentStore.getPinDataSnapshot()).toEqual({});
+		expect(previewDocumentStore.allNodes.map((node) => node.name)).toEqual(
+			workflowVersion.nodes.map((node) => node.name),
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/components/WorkflowHistoryContent.vue
@@ -5,7 +5,8 @@ import type {
 	WorkflowVersion,
 	WorkflowHistoryActionTypes,
 } from '@n8n/rest-api-client/api/workflowHistory';
-import WorkflowPreview from '@/app/components/WorkflowPreview.vue';
+import WorkflowPreviewHost from '@/app/components/WorkflowPreviewHost.vue';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useI18n } from '@n8n/i18n';
 import type { IUser } from 'n8n-workflow';
 
@@ -48,6 +49,15 @@ const workflowVersionPreview = computed<IWorkflowDb | undefined>(() => {
 		connections: props.workflowVersion.connections,
 	};
 });
+
+// Synthetic preview document id, distinct from the editor's `{id}@latest` and
+// from the history diff's `{id}@{versionId}` stores.
+const previewDocumentId = computed(() =>
+	createWorkflowDocumentId(
+		props.workflow?.id ?? '',
+		`history-preview-${props.workflowVersion?.versionId ?? ''}`,
+	),
+);
 
 const formattedCreatedAt = computed<string>(() => {
 	if (!props.workflowVersion) {
@@ -126,11 +136,10 @@ watch(
 
 <template>
 	<div :class="$style.content">
-		<WorkflowPreview
-			v-if="props.workflowVersion"
+		<WorkflowPreviewHost
+			v-if="workflowVersionPreview && !props.isListLoading"
+			:document-id="previewDocumentId"
 			:workflow="workflowVersionPreview"
-			:loading="props.isListLoading"
-			loader-type="spinner"
 		/>
 		<div v-if="props.workflowVersion" :class="$style.info">
 			<div :class="$style.card">


### PR DESCRIPTION
## Summary

Replaces the iframe-based `WorkflowPreview` with a native `WorkflowPreviewHost` that renders `NodeView` directly against a scoped, synthetic workflow document store. Both the template detail page and the workflow history panel now use this host, so previews render natively (no iframe `postMessage` handshake) with read-only feature flags and pin data stripped. Each preview is keyed by a synthetic document id (`template-<id>@preview`, `<id>@history-preview-<versionId>`) so it can never collide with the editor's `{id}@latest` store or the history diff store. Template community node icons/shapes are resolved by prefetching node types and community node previews.

## How to test

1. Open a template detail page (`/templates/:id`) — the workflow preview canvas should render natively and fit to view.
2. Open a workflow's history panel and select a version — the version preview should render natively with no pin data.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3419

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32468">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

