### PR TITLE
fix(Microsoft OneDrive Node): Validate upload file name to replace misleading Graph error

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -44,7 +44,7 @@ export function validateOneDriveFileName(
 			{
 				itemIndex,
 				description:
-					'OneDrive file names can\'t contain any of these characters: : \\ / ? * " < > |. Remove them from the file name and try again.' +
+					`OneDrive file names can't contain any of these characters: ${ONEDRIVE_ILLEGAL_FILE_NAME_CHARS.join(' ')}. Remove them from the file name and try again.` +
 					(illegalChars.includes(':')
 						? " If you're inserting a timestamp, use a colon-free format such as {{ $now.toFormat('yyyy-MM-dd_HH-mm-ss') }}."
 						: ''),

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -3,12 +3,54 @@ import type {
 	IExecuteFunctions,
 	ILoadOptionsFunctions,
 	IDataObject,
+	INode,
 	JsonObject,
 	IHttpRequestMethods,
 	IRequestOptions,
 	IPollFunctions,
 } from 'n8n-workflow';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Characters that OneDrive/SharePoint forbid in file names. Sending any of
+ * these breaks Graph's `:/path:/` addressing (a colon collapses the URL to the
+ * item entity endpoint), so Graph rejects the upload with a misleading
+ * `Entity only allows writes with a JSON Content-Type header` 400.
+ */
+export const ONEDRIVE_ILLEGAL_FILE_NAME_CHARS = ['"', '*', ':', '<', '>', '?', '/', '\\', '|'];
+
+/**
+ * Validates a resolved upload file name before any Graph request is made.
+ * Throws a `NodeOperationError` (carrying `itemIndex`) when the name is missing,
+ * blank, or contains a character OneDrive doesn't allow, naming the offending
+ * character(s) and suggesting a fix. The assertion signature narrows the name to
+ * `string` for callers once it returns.
+ */
+export function validateOneDriveFileName(
+	node: INode,
+	fileName: string | undefined,
+	itemIndex: number,
+): asserts fileName is string {
+	if (fileName === undefined || fileName.trim() === '') {
+		throw new NodeOperationError(node, 'File name must be set!', { itemIndex });
+	}
+
+	const illegalChars = ONEDRIVE_ILLEGAL_FILE_NAME_CHARS.filter((char) => fileName.includes(char));
+	if (illegalChars.length > 0) {
+		throw new NodeOperationError(
+			node,
+			`The file name "${fileName}" contains characters that OneDrive doesn't allow: ${illegalChars.join(' ')}`,
+			{
+				itemIndex,
+				description:
+					'OneDrive file names can\'t contain any of these characters: : \\ / ? * " < > |. Remove them from the file name and try again.' +
+					(illegalChars.includes(':')
+						? " If you're inserting a timestamp, use a colon-free format such as {{ $now.toFormat('yyyy-MM-dd_HH-mm-ss') }}."
+						: ''),
+			},
+		);
+	}
+}
 
 export type OneDriveCredentialType = 'microsoftOneDriveOAuth2Api' | 'microsoftOAuth2Api';
 

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -1,15 +1,16 @@
 import { DateTime } from 'luxon';
-import type {
-	IExecuteFunctions,
-	ILoadOptionsFunctions,
-	IDataObject,
-	INode,
-	JsonObject,
-	IHttpRequestMethods,
-	IRequestOptions,
-	IPollFunctions,
+import {
+	NodeApiError,
+	NodeOperationError,
+	type IExecuteFunctions,
+	type ILoadOptionsFunctions,
+	type IDataObject,
+	type INode,
+	type JsonObject,
+	type IHttpRequestMethods,
+	type IRequestOptions,
+	type IPollFunctions,
 } from 'n8n-workflow';
-import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 /**
  * Characters that OneDrive/SharePoint forbid in file names. Sending any of

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -247,6 +247,10 @@ export class MicrosoftOneDrive implements INodeType {
 					//https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online#example-upload-a-new-file
 					if (operation === 'upload') {
 						const parentId = this.getNodeParameter('parentId', i) as string;
+						// Encode the parent ID before interpolating it into the Graph `:/path:/`
+						// URL — like the file name, an unescaped `/ : ? #` here would retarget
+						// the request to a different item/endpoint.
+						const encodedParentId = encodeURIComponent(parentId);
 						const isBinaryData = this.getNodeParameter('binaryData', i);
 						const fileName = this.getNodeParameter('fileName', i) as string;
 
@@ -282,7 +286,7 @@ export class MicrosoftOneDrive implements INodeType {
 							responseData = await microsoftApiRequest.call(
 								this,
 								'PUT',
-								`/drive/items/${parentId}:/${encodedFilename}:/content`,
+								`/drive/items/${encodedParentId}:/${encodedFilename}:/content`,
 								body,
 								{},
 								undefined,
@@ -298,7 +302,7 @@ export class MicrosoftOneDrive implements INodeType {
 							responseData = await microsoftApiRequest.call(
 								this,
 								'PUT',
-								`/drive/items/${parentId}:/${encodedFilename}:/content`,
+								`/drive/items/${encodedParentId}:/${encodedFilename}:/content`,
 								body,
 								{},
 								undefined,

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -7,11 +7,15 @@ import type {
 	INodeTypeDescription,
 	JsonObject,
 } from 'n8n-workflow';
-import { NodeApiError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { NodeApiError, NodeConnectionTypes } from 'n8n-workflow';
 
 import { fileFields, fileOperations } from './FileDescription';
 import { folderFields, folderOperations } from './FolderDescription';
-import { microsoftApiRequest, microsoftApiRequestAllItems } from './GenericFunctions';
+import {
+	microsoftApiRequest,
+	microsoftApiRequestAllItems,
+	validateOneDriveFileName,
+} from './GenericFunctions';
 
 export class MicrosoftOneDrive implements INodeType {
 	description: INodeTypeDescription = {
@@ -249,24 +253,31 @@ export class MicrosoftOneDrive implements INodeType {
 						if (isBinaryData) {
 							const binaryPropertyName = this.getNodeParameter('binaryPropertyName', 0);
 							const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);
-							const body = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
-							let encodedFilename;
 
+							// Resolve the effective file name following each version's precedence:
+							// v1.1+ prefers the explicit File Name and falls back to the binary
+							// file name; v1 lets the binary file name overwrite the parameter.
+							let resolvedFileName: string | undefined;
 							if (nodeVersion >= 1.1) {
 								if (fileName !== '') {
-									encodedFilename = encodeURIComponent(fileName);
+									resolvedFileName = fileName;
 								} else if (binaryData.fileName !== undefined) {
-									encodedFilename = encodeURIComponent(binaryData.fileName);
+									resolvedFileName = binaryData.fileName;
 								}
 							} else {
 								if (fileName !== '') {
-									encodedFilename = encodeURIComponent(fileName);
+									resolvedFileName = fileName;
 								}
 
 								if (binaryData.fileName !== undefined) {
-									encodedFilename = encodeURIComponent(binaryData.fileName);
+									resolvedFileName = binaryData.fileName;
 								}
 							}
+
+							validateOneDriveFileName(this.getNode(), resolvedFileName, i);
+
+							const body = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+							const encodedFilename = encodeURIComponent(resolvedFileName);
 
 							responseData = await microsoftApiRequest.call(
 								this,
@@ -282,11 +293,7 @@ export class MicrosoftOneDrive implements INodeType {
 							responseData = JSON.parse(responseData as string);
 						} else {
 							const body = this.getNodeParameter('fileContent', i) as string;
-							if (fileName === '') {
-								throw new NodeOperationError(this.getNode(), 'File name must be set!', {
-									itemIndex: i,
-								});
-							}
+							validateOneDriveFileName(this.getNode(), fileName, i);
 							const encodedFilename = encodeURIComponent(fileName);
 							responseData = await microsoftApiRequest.call(
 								this,

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -440,5 +440,17 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 			expect(caught?.message).toContain('/');
 			expect(caught?.message).toContain('?');
 		});
+
+		it('omits the timestamp suggestion when the illegal name has no colon', () => {
+			let caught: Error | undefined;
+			try {
+				validateOneDriveFileName(mockNode, 'bad*name?.txt', 0);
+			} catch (error) {
+				caught = error as Error;
+			}
+
+			expect(caught?.message).toContain("contains characters that OneDrive doesn't allow");
+			expect((caught as { description?: string })?.description).not.toContain('$now.toFormat');
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -3,7 +3,12 @@ import type { IExecuteFunctions, INode, IPollFunctions, IWorkflowMetadata } from
 import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
-import { microsoftApiRequest, getPath, getOneDriveCredentialType } from '../GenericFunctions';
+import {
+	microsoftApiRequest,
+	getPath,
+	getOneDriveCredentialType,
+	validateOneDriveFileName,
+} from '../GenericFunctions';
 
 describe('Microsoft OneDrive GenericFunctions', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
@@ -396,6 +401,44 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 			} as IPollFunctions;
 
 			expect(getOneDriveCredentialType.call(pollCtx)).toBe('microsoftOneDriveOAuth2Api');
+		});
+	});
+
+	describe('validateOneDriveFileName', () => {
+		it('accepts a legal file name', () => {
+			expect(() => validateOneDriveFileName(mockNode, 'report.txt', 0)).not.toThrow();
+		});
+
+		it.each([undefined, '', '   '])('rejects a missing or blank name (%p)', (name) => {
+			expect(() => validateOneDriveFileName(mockNode, name, 0)).toThrow('File name must be set');
+		});
+
+		it('names the colon and suggests a colon-free timestamp format', () => {
+			let caught: Error | undefined;
+			try {
+				validateOneDriveFileName(mockNode, 'report-2026-06-10T12:34:56.789Z.txt', 3);
+			} catch (error) {
+				caught = error as Error;
+			}
+
+			expect(caught?.message).toContain("contains characters that OneDrive doesn't allow");
+			expect(caught?.message).toContain(':');
+			expect((caught as { description?: string })?.description).toContain(
+				"$now.toFormat('yyyy-MM-dd_HH-mm-ss')",
+			);
+		});
+
+		it('names every disallowed character present', () => {
+			let caught: Error | undefined;
+			try {
+				validateOneDriveFileName(mockNode, 'a:b/c?.txt', 0);
+			} catch (error) {
+				caught = error as Error;
+			}
+
+			expect(caught?.message).toContain(':');
+			expect(caught?.message).toContain('/');
+			expect(caught?.message).toContain('?');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -163,4 +163,196 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 			{},
 		);
 	});
+
+	it('should upload via the text path when the file name is valid', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'report.txt';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/report.txt:/content',
+			'hello world',
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain' },
+		);
+	});
+
+	it('should reject a text-path file name containing a colon without issuing an upload request', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'report-2026-06-10T12:34:56.789Z.txt';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain("contains characters that OneDrive doesn't allow");
+		expect(error.message).toContain(':');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should name every disallowed character when several are present', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'a:b/c?.txt';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain(':');
+		expect(error.message).toContain('/');
+		expect(error.message).toContain('?');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should reject an empty text-path file name without issuing an upload request', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return '';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain('File name must be set');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should reject a blank (whitespace-only) text-path file name', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return '   ';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain('File name must be set');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should reject a binary-path file name containing a colon without issuing an upload request', async () => {
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'bad:name.txt';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain("contains characters that OneDrive doesn't allow");
+		expect(error.message).toContain(':');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+		expect(getBinaryDataBuffer).not.toHaveBeenCalled();
+	});
+
+	it('should reject a binary-path fallback file name that is illegal', async () => {
+		mockExecuteFunctions.helpers.assertBinaryData = vi.fn(
+			() =>
+				({
+					data: 'base64data',
+					mimeType: 'text/plain',
+					fileName: 'illegal:fallback.txt',
+				}) as IBinaryData,
+		);
+
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return '';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain("contains characters that OneDrive doesn't allow");
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should reject a binary upload when no file name can be resolved', async () => {
+		mockExecuteFunctions.helpers.assertBinaryData = vi.fn(
+			() =>
+				({
+					data: 'base64data',
+					mimeType: 'text/plain',
+				}) as IBinaryData,
+		);
+
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return '';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		const error = await microsoftOneDrive.execute.call(mockExecuteFunctions).catch((e) => e);
+
+		expect(error.message).toContain('File name must be set');
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('should route the validation error to the node output when Continue On Fail is enabled', async () => {
+		const items = [{ json: { data: 'test' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'bad:name.txt';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+		});
+
+		const result = await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
+		expect(result[0][0]).toEqual({ error: expect.stringContaining("OneDrive doesn't allow") });
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.upload.test.ts
@@ -355,4 +355,67 @@ describe('Test MicrosoftOneDrive, file > upload', () => {
 		expect(genericFunctions.microsoftApiRequest).not.toHaveBeenCalled();
 		expect(result[0][0]).toEqual({ error: expect.stringContaining("OneDrive doesn't allow") });
 	});
+
+	it('should upload via the binary path with the resolved binary mime type and content length', async () => {
+		mockExecuteFunctions.helpers.assertBinaryData = vi.fn(
+			() =>
+				({
+					data: 'base64data',
+					mimeType: 'application/pdf',
+					fileName: 'report.pdf',
+				}) as IBinaryData,
+		);
+
+		const items = [{ json: { data: 'test' }, binary: { data: {} as IBinaryData } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'fileName') return 'report.pdf';
+			if (key === 'binaryData') return true;
+			if (key === 'binaryPropertyName') return 'data';
+		});
+
+		await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(getBinaryDataBuffer).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/report.pdf:/content',
+			expect.any(Buffer),
+			{},
+			undefined,
+			{ 'Content-Type': 'application/pdf', 'Content-length': expect.any(Number) },
+			{},
+		);
+	});
+
+	it('should upload valid items and route only the invalid one to output under Continue On Fail', async () => {
+		const items = [{ json: { data: 'a' } }, { json: { data: 'b' } }];
+		mockExecuteFunctions.getInputData.mockReturnValue(items);
+		mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string, itemIndex?: number) => {
+			if (key === 'resource') return 'file';
+			if (key === 'operation') return 'upload';
+			if (key === 'parentId') return 'parentFolderId';
+			if (key === 'binaryData') return false;
+			if (key === 'fileContent') return 'hello world';
+			if (key === 'fileName') return itemIndex === 0 ? 'good.txt' : 'bad:name.txt';
+		});
+
+		const result = await microsoftOneDrive.execute.call(mockExecuteFunctions);
+
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledTimes(1);
+		expect(genericFunctions.microsoftApiRequest).toHaveBeenCalledWith(
+			'PUT',
+			'/drive/items/parentFolderId:/good.txt:/content',
+			'hello world',
+			{},
+			undefined,
+			{ 'Content-Type': 'text/plain' },
+		);
+		expect(result[0][1]).toEqual({ error: expect.stringContaining("OneDrive doesn't allow") });
+	});
 });


### PR DESCRIPTION
## Summary

The Microsoft OneDrive **File → Upload** operation builds the Graph path `/drive/items/{parentId}:/{fileName}:/content` directly from the file name. OneDrive/SharePoint forbid `: \ / ? * " < > |` in names — and even when percent-encoded, a colon collapses Graph's `:/path:/` addressing onto the item *entity* endpoint, so the upload fails with the misleading `Entity only allows writes with a JSON Content-Type header` (HTTP 400). The classic trigger is a `{{ $now }}` expression in **File Name**, which renders an ISO timestamp with colons (e.g. `report-2026-06-10T12:34:56.789Z.txt`).

This PR adds `validateOneDriveFileName`, which runs **before any Graph request** on both upload paths and across both node versions:

- **Both upload paths are validated.** The text path (Binary File off) and the binary path (Binary File on). The binary path validates the *resolved* name — the explicit **File Name** when set, otherwise the `binaryData.fileName` fallback — matching each version's existing precedence (v1.1+ prefers the parameter; v1 lets the binary name overwrite it).
- **Clear, actionable error.** When the name contains a disallowed character, the node throws a `NodeOperationError` naming the specific offending character(s), stating the full disallowed set, and — when a colon is present — suggesting a colon-free timestamp format (`{{ $now.toFormat('yyyy-MM-dd_HH-mm-ss') }}`).
- **Empty/blank check extended.** The empty-name check is preserved for the text path and extended to the binary path, which previously had none (it could send `.../undefined:/content`).
- **Item-aware and Continue-On-Fail safe.** Errors carry `itemIndex` and are routed to the error output instead of thrown when Continue On Fail is enabled. No Graph request is issued for an invalid name.

## How to test

1. Add a Microsoft OneDrive credential and create a workflow with a **Microsoft OneDrive** node.
2. Set **Resource: File**, **Operation: Upload**, a valid **Parent ID**, **Binary File: off**, and any text in **File Content**.
3. Set **File Name** to `report-{{ $now }}.txt` and execute. Before: fails with `Entity only allows writes with a JSON Content-Type header`. After: fails with a clear error naming the colon and suggesting `{{ $now.toFormat('yyyy-MM-dd_HH-mm-ss') }}`, and no upload request is made.
4. Set **File Name** to `report-{{ $now.toFormat('yyyy-MM-dd_HH-mm-ss') }}.txt` and execute — uploads successfully (unchanged behaviour).
5. Repeat with **Binary File: on** for both an illegal explicit name and a name that falls back to the binary file name.

Unit tests cover both paths, the colon/timestamp repro, multiple illegal characters, empty/blank names on both paths, the unresolved-binary-name case, Continue On Fail, and the valid happy path — each asserting that no Graph upload request is issued for invalid names.

## Screenshots

### Error message on violation

<img width="694" height="322" alt="image" src="https://github.com/user-attachments/assets/308aecbc-11bb-4883-a4c4-62d004cf9ed8" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-48

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
