### PR TITLE
refactor(core): Replace deprecated ApplicationError in nodes-langchain (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
@@ -8,7 +8,7 @@ import type {
 	IWorkflowDataProxyData,
 	NodeConnectionType,
 } from 'n8n-workflow';
-import { ApplicationError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError, UnexpectedError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 import type { MockProxy } from 'vitest-mock-extended';
 
@@ -41,14 +41,14 @@ describe('OutputParserAutofixing', () => {
 			if (type === NodeConnectionTypes.AiLanguageModel) return mockModel;
 			if (type === NodeConnectionTypes.AiOutputParser) return mockStructuredOutputParser;
 
-			throw new ApplicationError('Unexpected connection type');
+			throw new UnexpectedError('Unexpected connection type');
 		});
 		thisArg.getNodeParameter.mockReset();
 		thisArg.getNodeParameter.mockImplementation((parameterName) => {
 			if (parameterName === 'options.prompt') {
 				return NAIVE_FIX_PROMPT;
 			}
-			throw new ApplicationError('Not implemented');
+			throw new UnexpectedError('Not implemented');
 		});
 	});
 
@@ -70,7 +70,7 @@ describe('OutputParserAutofixing', () => {
 				if (parameterName === 'options.prompt') {
 					return 'Invalid prompt without error placeholder';
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			await expect(outputParser.supplyData.call(thisArg, 0)).rejects.toBeInstanceOf(
@@ -86,7 +86,7 @@ describe('OutputParserAutofixing', () => {
 				if (parameterName === 'options.prompt') {
 					return '';
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const execution = outputParser.supplyData.call(thisArg, 0);
@@ -102,7 +102,7 @@ describe('OutputParserAutofixing', () => {
 				if (parameterName === 'options.prompt') {
 					return NAIVE_FIX_PROMPT;
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = (await outputParser.supplyData.call(thisArg, 0)) as {

--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserItemList/test/OutputParserItemList.node.test.ts
@@ -1,6 +1,6 @@
 import { normalizeItems } from 'n8n-core';
 import {
-	ApplicationError,
+	UnexpectedError,
 	type ISupplyDataFunctions,
 	type IWorkflowDataProxyData,
 } from 'n8n-workflow';
@@ -31,7 +31,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return {};
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -44,7 +44,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return { numberOfItems: 5 };
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -58,7 +58,7 @@ describe('OutputParserItemList', () => {
 					return { numberOfItems: -1 };
 				}
 
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -71,7 +71,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return { separator: ',' };
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -86,7 +86,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return {};
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -99,7 +99,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return { separator: ',' };
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -112,7 +112,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return { numberOfItems: 2 };
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);
@@ -127,7 +127,7 @@ describe('OutputParserItemList', () => {
 				if (parameterName === 'options') {
 					return { numberOfItems: 5 };
 				}
-				throw new ApplicationError('Not implemented');
+				throw new UnexpectedError('Not implemented');
 			});
 
 			const { response } = await outputParser.supplyData.call(thisArg, 0);

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -1,5 +1,5 @@
 import { DynamicTool } from '@langchain/core/tools';
-import { ApplicationError, NodeOperationError, sleepWithAbort } from 'n8n-workflow';
+import { NodeOperationError, sleepWithAbort, UnexpectedError } from 'n8n-workflow';
 import type {
 	ISupplyDataFunctions,
 	INodeExecutionData,
@@ -912,7 +912,7 @@ describe('WorkflowTool::WorkflowToolService', () => {
 			const executeWorkflowMock = vi.fn().mockImplementation(() => {
 				// Simulate abort during execution
 				abortController.abort();
-				throw new ApplicationError('Workflow execution failed');
+				throw new UnexpectedError('Workflow execution failed');
 			});
 
 			const contextWithRetryNode = createAbortSignalContext(

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/error.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/error.ts
@@ -1,6 +1,6 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 
-export class ChatTriggerAuthorizationError extends ApplicationError {
+export class ChatTriggerAuthorizationError extends UserError {
 	constructor(
 		readonly responseCode: number,
 		message?: string,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreChromaDB/VectorStoreChromaDB.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreChromaDB/VectorStoreChromaDB.node.ts
@@ -9,7 +9,7 @@ import {
 	type ILoadOptionsFunctions,
 	type ISupplyDataFunctions,
 	NodeApiError,
-	ApplicationError,
+	OperationalError,
 } from 'n8n-workflow';
 
 import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
@@ -219,12 +219,12 @@ class ExtendedChroma extends Chroma {
 				});
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				throw new ApplicationError(`Chroma getOrCreateCollection error: ${message}`);
+				throw new OperationalError(`Chroma getOrCreateCollection error: ${message}`);
 			}
 		}
 
 		if (!this.collection) {
-			throw new ApplicationError('Failed to initialize Chroma collection');
+			throw new OperationalError('Failed to initialize Chroma collection');
 		}
 
 		return this.collection;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -8,7 +8,7 @@ import {
 	type NodeParameterValueType,
 	type IExecuteFunctions,
 	type ISupplyDataFunctions,
-	ApplicationError,
+	UnexpectedError,
 } from 'n8n-workflow';
 
 import { createVectorStoreNode, MemoryVectorStoreManager } from '@n8n/ai-utilities';
@@ -163,7 +163,7 @@ export class VectorStoreInMemory extends createVectorStoreNode<MemoryVectorStore
 				payload: string | IDataObject | undefined,
 			): Promise<NodeParameterValueType> {
 				if (!payload || typeof payload === 'string') {
-					throw new ApplicationError('Invalid payload type');
+					throw new UnexpectedError('Invalid payload type');
 				}
 
 				const { name } = payload;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreInMemory/VectorStoreInMemory.node.ts
@@ -8,7 +8,7 @@ import {
 	type NodeParameterValueType,
 	type IExecuteFunctions,
 	type ISupplyDataFunctions,
-	UnexpectedError,
+	UserError,
 } from 'n8n-workflow';
 
 import { createVectorStoreNode, MemoryVectorStoreManager } from '@n8n/ai-utilities';
@@ -163,7 +163,7 @@ export class VectorStoreInMemory extends createVectorStoreNode<MemoryVectorStore
 				payload: string | IDataObject | undefined,
 			): Promise<NodeParameterValueType> {
 				if (!payload || typeof payload === 'string') {
-					throw new UnexpectedError('Invalid payload type');
+					throw new UserError('Invalid payload type');
 				}
 
 				const { name } = payload;

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -3,7 +3,7 @@ import type { Embeddings } from '@langchain/core/embeddings';
 import type { WeaviateLibArgs as OriginalWeaviateLibArgs } from '@langchain/weaviate';
 import { WeaviateStore } from '@langchain/weaviate';
 import {
-	ApplicationError,
+	UnexpectedError,
 	type IDataObject,
 	type INodeProperties,
 	type INodePropertyCollection,
@@ -41,7 +41,7 @@ class ExtendedWeaviateVectorStore extends WeaviateStore {
 		const baseCandidate = await ctor.fromExistingIndex(embeddings, args);
 
 		if (!(baseCandidate instanceof ExtendedWeaviateVectorStore)) {
-			throw new ApplicationError(
+			throw new UnexpectedError(
 				'Weaviate store factory did not return an ExtendedWeaviateVectorStore instance',
 			);
 		}
@@ -79,7 +79,7 @@ class ExtendedWeaviateVectorStore extends WeaviateStore {
 			return content.map((doc) => {
 				const { score, ...metadata } = doc.metadata;
 				if (typeof score !== 'number') {
-					throw new ApplicationError(`Unexpected score type: ${typeof score}`);
+					throw new UnexpectedError(`Unexpected score type: ${typeof score}`);
 				}
 				return [
 					new Document({

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
@@ -1,6 +1,6 @@
 import { Pinecone } from '@pinecone-database/pinecone';
 import { MilvusClient } from '@zilliz/milvus2-sdk-node';
-import { ApplicationError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
+import { OperationalError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
 
 import type { QdrantCredential } from '../../VectorStoreQdrant/Qdrant.utils';
 import { createQdrantClient } from '../../VectorStoreQdrant/Qdrant.utils';
@@ -30,7 +30,7 @@ export async function supabaseTableNameSearch(this: ILoadOptionsFunctions) {
 	const results = [];
 
 	if (typeof credentials.host !== 'string') {
-		throw new ApplicationError('Expected Supabase credentials host to be a string');
+		throw new OperationalError('Expected Supabase credentials host to be a string');
 	}
 
 	const { paths } = (await this.helpers.requestWithAuthentication.call(this, 'supabaseApi', {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/shared/methods/listSearch.ts
@@ -1,6 +1,6 @@
 import { Pinecone } from '@pinecone-database/pinecone';
 import { MilvusClient } from '@zilliz/milvus2-sdk-node';
-import { OperationalError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
+import { UserError, type IDataObject, type ILoadOptionsFunctions } from 'n8n-workflow';
 
 import type { QdrantCredential } from '../../VectorStoreQdrant/Qdrant.utils';
 import { createQdrantClient } from '../../VectorStoreQdrant/Qdrant.utils';
@@ -30,7 +30,7 @@ export async function supabaseTableNameSearch(this: ILoadOptionsFunctions) {
 	const results = [];
 
 	if (typeof credentials.host !== 'string') {
-		throw new OperationalError('Expected Supabase credentials host to be a string');
+		throw new UserError('Expected Supabase credentials host to be a string');
 	}
 
 	const { paths } = (await this.helpers.requestWithAuthentication.call(this, 'supabaseApi', {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts
@@ -11,7 +11,6 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
 	assertCredentialAllowsUrl,
 	BaseError,
 	NodeConnectionTypes,
@@ -316,7 +315,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		// Remove configuration properties and runId added by Langchain that are not relevant to the user
 		filteredResponse = omit(response, ['signal', 'timeout', 'content', 'runId']) as IDataObject;
 	} catch (error) {
-		if (!(error instanceof ApplicationError) && !(error instanceof BaseError)) {
+		if (!(error instanceof BaseError)) {
 			throw new NodeOperationError(this.getNode(), error.message, { itemIndex: i });
 		}
 	}

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/update.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/update.operation.ts
@@ -4,7 +4,7 @@ import type {
 	INodeExecutionData,
 	IDataObject,
 } from 'n8n-workflow';
-import { ApplicationError, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
+import { NodeOperationError, UnexpectedError, updateDisplayOptions } from 'n8n-workflow';
 
 import { apiRequest } from '../../../transport';
 import { assistantRLC, modelRLC } from '../descriptions';
@@ -126,7 +126,7 @@ function getFileIds(file_ids: unknown): string[] {
 		return file_ids.split(',').map((file_id) => file_id.trim());
 	}
 
-	throw new ApplicationError('Invalid file_ids type');
+	throw new UnexpectedError('Invalid file_ids type');
 }
 
 export async function execute(this: IExecuteFunctions, i: number): Promise<INodeExecutionData[]> {


### PR DESCRIPTION
## Summary

Replaces all deprecated `ApplicationError` usages in `packages/@n8n/nodes-langchain/` with the modern `UserError` / `OperationalError` / `UnexpectedError` errors from `n8n-workflow`.

Error type chosen per case:
- **Vector store external/transient failures** (Chroma `getOrCreateCollection` and init) → `OperationalError`
- **User-triggered errors** (Supabase credentials host check, InMemory payload type) → `UserError`
- **Internal invariants** (Weaviate factory/score-type checks, OpenAI `file_ids` type) → `UnexpectedError`
- **ChatTrigger authorization error** now extends `UserError` instead of `ApplicationError`
- **OpenAI assistant message** error guard now keys off `BaseError` only — `ApplicationError` does not extend `BaseError`, and the modern n8n errors do, so the redundant branch was dropped
- Test mocks throwing placeholder errors migrated to `UnexpectedError`

No behavior change to user-facing flows.

## How to test

`pnpm typecheck`, `pnpm test`, and `pnpm lint` all pass in `packages/@n8n/nodes-langchain`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3249

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. 




---


<a href="https://stagereview.app/n8n-io/n8n/pull/32471" rel="nofollow noreferrer noopener" target="_blank">
  
    
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  
</a>





<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32471?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>

