### PR TITLE
refactor: Replace deprecated ApplicationError in remaining nodes-base nodes (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/helpers/utils.ts
@@ -1,7 +1,7 @@
 import set from 'lodash/set';
 import {
-	ApplicationError,
 	isResourceMapperValue,
+	UserError,
 	type IDataObject,
 	type NodeApiError,
 } from 'n8n-workflow';
@@ -49,7 +49,7 @@ export function findMatches(
 		});
 
 		if (!matches?.length) {
-			throw new ApplicationError('No records match provided keys', { level: 'warning' });
+			throw new UserError('No records match provided keys', { level: 'warning' });
 		}
 
 		return matches;
@@ -64,7 +64,7 @@ export function findMatches(
 		});
 
 		if (!match) {
-			throw new ApplicationError('Record matching provided keys was not found', {
+			throw new UserError('Record matching provided keys was not found', {
 				level: 'warning',
 			});
 		}

--- a/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Airtable/v2/transport/index.ts
@@ -9,7 +9,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 
 import type { IAttachment, IRecord } from '../helpers/interfaces';
 
@@ -94,7 +94,7 @@ export async function downloadRecordAttachments(
 		fieldNames = fieldNames.split(',').map((item) => item.trim());
 	}
 	if (!fieldNames.length) {
-		throw new ApplicationError("Specify field to download in 'Download Attachments' option", {
+		throw new UserError("Specify field to download in 'Download Attachments' option", {
 			level: 'warning',
 		});
 	}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/GenericFunctions.ts
@@ -7,7 +7,7 @@ import type {
 	ILoadOptionsFunctions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
-import { ApplicationError } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 
 import { getAwsCredentials } from '../GenericFunctions';
 import type { IRequestBody } from './types';
@@ -48,13 +48,13 @@ export async function awsApiRequest(
 
 		if (statusCode === 403) {
 			if (errorMessage === 'The security token included in the request is invalid.') {
-				throw new ApplicationError('The AWS credentials are not valid!', { level: 'warning' });
+				throw new UserError('The AWS credentials are not valid!', { level: 'warning' });
 			} else if (
 				errorMessage.startsWith(
 					'The request signature we calculated does not match the signature you provided',
 				)
 			) {
-				throw new ApplicationError('The AWS credentials are not valid!', { level: 'warning' });
+				throw new UserError('The AWS credentials are not valid!', { level: 'warning' });
 			}
 		}
 
@@ -64,7 +64,7 @@ export async function awsApiRequest(
 			} catch (ex) {}
 		}
 
-		throw new ApplicationError(`AWS error response [${statusCode}]: ${errorMessage}`, {
+		throw new OperationalError(`AWS error response [${statusCode}]: ${errorMessage}`, {
 			level: 'warning',
 		});
 	}

--- a/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
+++ b/packages/nodes-base/nodes/Aws/DynamoDB/utils.ts
@@ -1,5 +1,5 @@
 import type { IDataObject } from 'n8n-workflow';
-import { ApplicationError, assert } from 'n8n-workflow';
+import { assert, UserError } from 'n8n-workflow';
 
 import type {
 	AdjustedPutItem,
@@ -98,7 +98,7 @@ export function validateJSON(input: any): object {
 	try {
 		return JSON.parse(input as string);
 	} catch (error) {
-		throw new ApplicationError('Items must be a valid JSON', { level: 'warning' });
+		throw new UserError('Items must be a valid JSON', { level: 'warning' });
 	}
 }
 

--- a/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Beeminder/GenericFunctions.ts
@@ -7,7 +7,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
 const BEEMINDER_URI = 'https://www.beeminder.com/api/v1';
 
@@ -26,7 +26,7 @@ export async function beeminderApiRequest(
 	const authenticationMethod = this.getNodeParameter('authentication', 0, 'apiToken');
 
 	if (!isValidAuthenticationMethod(authenticationMethod)) {
-		throw new ApplicationError(`Invalid authentication method: ${authenticationMethod}`);
+		throw new UserError(`Invalid authentication method: ${authenticationMethod}`);
 	}
 
 	let credentialType = 'beeminderApi';

--- a/packages/nodes-base/nodes/Code/throw-execution-error.ts
+++ b/packages/nodes-base/nodes/Code/throw-execution-error.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
 
 import { isWrappableError, WrappedExecutionError } from './errors/WrappedExecutionError';
 
@@ -11,5 +11,5 @@ export function throwExecutionError(error: unknown): never {
 		throw new WrappedExecutionError(error);
 	}
 
-	throw new ApplicationError(`Unknown error: ${JSON.stringify(error)}`);
+	throw new UnexpectedError(`Unknown error: ${JSON.stringify(error)}`);
 }

--- a/packages/nodes-base/nodes/DebugHelper/DebugHelper.node.ts
+++ b/packages/nodes-base/nodes/DebugHelper/DebugHelper.node.ts
@@ -6,10 +6,10 @@ import type {
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
 	NodeApiError,
 	NodeConnectionTypes,
 	NodeOperationError,
+	UnexpectedError,
 } from 'n8n-workflow';
 
 import { generateGarbageMemory, runGarbageCollector } from './functions';
@@ -278,7 +278,7 @@ export class DebugHelper implements INodeType {
 									message: throwErrorMessage,
 								});
 							case 'Error':
-								throw new ApplicationError(throwErrorMessage);
+								throw new UnexpectedError(throwErrorMessage);
 							default:
 								break;
 						}

--- a/packages/nodes-base/nodes/FileMaker/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/FileMaker/GenericFunctions.ts
@@ -6,7 +6,7 @@ import type {
 	JsonObject,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError, NodeOperationError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 interface ScriptsOptions {
 	script?: any;
@@ -80,7 +80,7 @@ export async function getToken(this: ILoadOptionsFunctions | IExecuteFunctions):
 		} else {
 			message = error.message;
 		}
-		throw new ApplicationError(message, { level: 'warning' });
+		throw new NodeOperationError(this.getNode(), message, { level: 'warning' });
 	}
 }
 

--- a/packages/nodes-base/nodes/Formstack/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Formstack/GenericFunctions.ts
@@ -9,7 +9,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, OperationalError } from 'n8n-workflow';
 
 export interface IFormstackFieldDefinitionType {
 	id: string;
@@ -139,7 +139,7 @@ export async function getForms(this: ILoadOptionsFunctions): Promise<INodeProper
 	});
 
 	if (responseData.items === undefined) {
-		throw new ApplicationError('No data got returned', { level: 'warning' });
+		throw new OperationalError('No data got returned', { level: 'warning' });
 	}
 	const returnData: INodePropertyOptions[] = [];
 	for (const baseData of responseData.items) {
@@ -163,7 +163,7 @@ export async function getFields(
 	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {}, 'fields');
 
 	if (responseData.items === undefined) {
-		throw new ApplicationError('No form fields meta data got returned', { level: 'warning' });
+		throw new OperationalError('No form fields meta data got returned', { level: 'warning' });
 	}
 
 	const fields = responseData.items as IFormstackFieldDefinitionType[];
@@ -188,7 +188,7 @@ export async function getSubmission(
 	const responseData = await apiRequestAllItems.call(this, 'GET', endpoint, {}, 'data');
 
 	if (responseData.items === undefined) {
-		throw new ApplicationError('No form fields meta data got returned', { level: 'warning' });
+		throw new OperationalError('No form fields meta data got returned', { level: 'warning' });
 	}
 
 	return responseData.items as IFormstackSubmissionFieldContainer[];

--- a/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
+++ b/packages/nodes-base/nodes/Google/BigQuery/v2/actions/database/executeQuery.operation.ts
@@ -4,7 +4,7 @@ import type {
 	INodeExecutionData,
 	INodeProperties,
 } from 'n8n-workflow';
-import { ApplicationError, NodeOperationError, sleep } from 'n8n-workflow';
+import { NodeOperationError, sleep } from 'n8n-workflow';
 
 import { getResolvables, updateDisplayOptions } from '@utils/utilities';
 
@@ -430,7 +430,8 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				}
 				if ((response?.errors as IDataObject[])?.length) {
 					const errorMessages = (response.errors as IDataObject[]).map((error) => error.message);
-					throw new ApplicationError(
+					throw new NodeOperationError(
+						this.getNode(),
 						`Error(s) ocurring while executing query from item ${job.i.toString()}: ${errorMessages.join(
 							', ',
 						)}`,

--- a/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/helpers/GoogleSheet.ts
@@ -6,7 +6,7 @@ import type {
 	INode,
 	IPollFunctions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 import { utils as xlsxUtils } from 'xlsx';
 
 import type {
@@ -241,9 +241,11 @@ export class GoogleSheet {
 		}
 
 		if (requests.length === 0) {
-			throw new ApplicationError('Must specify at least one column or row to add', {
-				level: 'warning',
-			});
+			throw new NodeOperationError(
+				this.executeFunctions.getNode(),
+				'Must specify at least one column or row to add',
+				{ level: 'warning' },
+			);
 		}
 
 		const response = await apiRequest.call(

--- a/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HighLevel/v2/GenericFunctions.ts
@@ -16,7 +16,7 @@ import type {
 	IPollFunctions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 const VALID_EMAIL_REGEX =
 	/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -207,7 +207,10 @@ export const addNotePostReceiveAction = async function (
 
 	// Ensure there is a valid response and extract contactId and userId
 	if (!response || !response.body || !contact) {
-		throw new ApplicationError('No response data available to extract contact ID and user ID.');
+		throw new NodeOperationError(
+			this.getNode(),
+			'No response data available to extract contact ID and user ID.',
+		);
 	}
 
 	const contactId = contact.id;
@@ -405,7 +408,7 @@ export async function addCustomFieldsPreSendAction(
 						field_value: typedField.fieldValue,
 					};
 				} else {
-					throw new ApplicationError('Error processing custom fields.');
+					throw new NodeOperationError(this.getNode(), 'Error processing custom fields.');
 				}
 			});
 			requestBody.customFields = formattedCustomFields;

--- a/packages/nodes-base/nodes/ItemLists/V3/helpers/utils.ts
+++ b/packages/nodes-base/nodes/ItemLists/V3/helpers/utils.ts
@@ -4,7 +4,7 @@ import type {
 	INodeExecutionData,
 	GenericValue,
 } from 'n8n-workflow';
-import { ApplicationError, NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, UserError } from 'n8n-workflow';
 
 import { JsTaskRunnerSandbox } from '../../../Code/JsTaskRunnerSandbox';
 
@@ -18,7 +18,7 @@ export const prepareFieldsArray = (fields: string | string[], fieldName = 'Field
 	if (Array.isArray(fields)) {
 		return fields;
 	}
-	throw new ApplicationError(
+	throw new UserError(
 		`The \'${fieldName}\' parameter must be a string of fields separated by commas or an array of strings.`,
 		{ level: 'warning' },
 	);

--- a/packages/nodes-base/nodes/LoneScale/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/LoneScale/GenericFunctions.ts
@@ -1,5 +1,5 @@
 import {
-	ApplicationError,
+	OperationalError,
 	type IHttpRequestMethods,
 	type IDataObject,
 	type IExecuteFunctions,
@@ -45,7 +45,7 @@ export async function lonescaleApiRequest(
 		if (error.response) {
 			const errorMessage =
 				error.response.body.message || error.response.body.description || error.message;
-			throw new ApplicationError(
+			throw new OperationalError(
 				`Autopilot error response [${error.statusCode}]: ${errorMessage}`,
 				{ level: 'warning' },
 			);

--- a/packages/nodes-base/nodes/MQTT/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MQTT/GenericFunctions.ts
@@ -1,5 +1,5 @@
 import { connect, type IClientOptions, type MqttClient } from 'mqtt';
-import { ApplicationError, randomString } from 'n8n-workflow';
+import { OperationalError, randomString } from 'n8n-workflow';
 
 import { formatPrivateKey } from '@utils/utilities';
 
@@ -67,7 +67,7 @@ export const createClient = async (credentials: MqttCredential): Promise<MqttCli
 			// keep trying to reconnect until it succeeds unless we
 			// explicitly close the client
 			client.end();
-			reject(new ApplicationError(error.message));
+			reject(new OperationalError(error.message));
 		};
 
 		client.once('connect', onConnect);

--- a/packages/nodes-base/nodes/MQTT/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/MQTT/test/GenericFunctions.test.ts
@@ -1,6 +1,6 @@
 import { mock } from 'vitest-mock-extended';
 import { MqttClient } from 'mqtt';
-import { ApplicationError } from '@n8n/errors';
+import { OperationalError } from 'n8n-workflow';
 
 import { createClient, type MqttCredential } from '../GenericFunctions';
 
@@ -37,7 +37,7 @@ describe('createClient', () => {
 		});
 	});
 
-	it('should reject with ApplicationError on connection error and close connection', async () => {
+	it('should reject with OperationalError on connection error and close connection', async () => {
 		const mockConnect = vi.spyOn(MqttClient.prototype, 'connect').mockImplementation(function (
 			this: MqttClient,
 		) {
@@ -61,7 +61,7 @@ describe('createClient', () => {
 
 		const clientPromise = createClient(credentials);
 
-		await expect(clientPromise).rejects.toThrow(ApplicationError);
+		await expect(clientPromise).rejects.toThrow(OperationalError);
 		expect(mockConnect).toBeCalledTimes(1);
 		expect(mockEnd).toBeCalledTimes(1);
 	});

--- a/packages/nodes-base/nodes/Magento/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Magento/GenericFunctions.ts
@@ -10,7 +10,7 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, UserError } from 'n8n-workflow';
 
 import type { Filter, Address, Search, FilterGroup, ProductAttribute } from './types';
 
@@ -482,7 +482,7 @@ export function getFilterQuery(data: {
 	sort: [{ direction: string; field: string }];
 }): Search {
 	if (!data.hasOwnProperty('conditions') || data.conditions?.length === 0) {
-		throw new ApplicationError('At least one filter has to be set', { level: 'warning' });
+		throw new UserError('At least one filter has to be set', { level: 'warning' });
 	}
 
 	if (data.matchType === 'anyFilter') {

--- a/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mailcheck/GenericFunctions.ts
@@ -1,4 +1,3 @@
-import { ApplicationError } from '@n8n/errors';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -8,6 +7,7 @@ import type {
 	IRequestOptions,
 	IWebhookFunctions,
 } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
 export async function mailCheckApiRequest(
 	this: IWebhookFunctions | IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
@@ -45,7 +45,7 @@ export async function mailCheckApiRequest(
 	} catch (error) {
 		if (error.response?.body?.message) {
 			// Try to return the error prettier
-			throw new ApplicationError(
+			throw new OperationalError(
 				`Mailcheck error response [${error.statusCode}]: ${error.response.body.message}`,
 				{ level: 'warning' },
 			);

--- a/packages/nodes-base/nodes/Merge/v2/utils.ts
+++ b/packages/nodes-base/nodes/Merge/v2/utils.ts
@@ -10,7 +10,7 @@ import type {
 	INodeExecutionData,
 	IPairedItemData,
 } from 'n8n-workflow';
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 
 import { fuzzyCompare, preparePairedItemDataArray } from '@utils/utilities';
 
@@ -306,14 +306,14 @@ export function mergeMatched(
 
 export function checkMatchFieldsInput(data: IDataObject[]) {
 	if (data.length === 1 && data[0].field1 === '' && data[0].field2 === '') {
-		throw new ApplicationError(
+		throw new UserError(
 			'You need to define at least one pair of fields in "Fields to Match" to match on',
 			{ level: 'warning' },
 		);
 	}
 	for (const [index, pair] of data.entries()) {
 		if (pair.field1 === '' || pair.field2 === '') {
-			throw new ApplicationError(
+			throw new UserError(
 				`You need to define both fields in "Fields to Match" for pair ${index + 1},
 				 field 1 = '${pair.field1}'
 				 field 2 = '${pair.field2}'`,
@@ -338,10 +338,9 @@ export function checkInput(
 			return get(entry.json, field, undefined) !== undefined;
 		});
 		if (!isPresent) {
-			throw new ApplicationError(
-				`Field '${field}' is not present in any of items in '${inputLabel}'`,
-				{ level: 'warning' },
-			);
+			throw new UserError(`Field '${field}' is not present in any of items in '${inputLabel}'`, {
+				level: 'warning',
+			});
 		}
 	}
 	return input;

--- a/packages/nodes-base/nodes/Merge/v3/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Merge/v3/helpers/utils.ts
@@ -12,7 +12,7 @@ import type {
 	INodeParameters,
 	IPairedItemData,
 } from 'n8n-workflow';
-import { ApplicationError, NodeConnectionTypes, NodeHelpers } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeHelpers, UserError } from 'n8n-workflow';
 
 import { fuzzyCompare, preparePairedItemDataArray } from '@utils/utilities';
 
@@ -308,14 +308,14 @@ export function mergeMatched(
 
 export function checkMatchFieldsInput(data: IDataObject[]) {
 	if (data.length === 1 && data[0].field1 === '' && data[0].field2 === '') {
-		throw new ApplicationError(
+		throw new UserError(
 			'You need to define at least one pair of fields in "Fields to Match" to match on',
 			{ level: 'warning' },
 		);
 	}
 	for (const [index, pair] of data.entries()) {
 		if (pair.field1 === '' || pair.field2 === '') {
-			throw new ApplicationError(
+			throw new UserError(
 				`You need to define both fields in "Fields to Match" for pair ${index + 1},
 				 field 1 = '${pair.field1}'
 				 field 2 = '${pair.field2}'`,
@@ -340,10 +340,9 @@ export function checkInput(
 			return get(entry.json, field, undefined) !== undefined;
 		});
 		if (!isPresent) {
-			throw new ApplicationError(
-				`Field '${field}' is not present in any of items in '${inputLabel}'`,
-				{ level: 'warning' },
-			);
+			throw new UserError(`Field '${field}' is not present in any of items in '${inputLabel}'`, {
+				level: 'warning',
+			});
 		}
 	}
 	return input;

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
@@ -6,7 +6,7 @@ import type {
 	IPollFunctions,
 	JsonObject,
 } from 'n8n-workflow';
-import { ApplicationError, jsonParse, NodeApiError } from 'n8n-workflow';
+import { jsonParse, NodeApiError, UserError } from 'n8n-workflow';
 
 export const messageFields = [
 	'bccRecipients',
@@ -158,7 +158,7 @@ export function createMessage(fields: IDataObject) {
 			} else if (typeof value === 'string') {
 				message[key] = value.split(',').map((recipient: string) => makeRecipient(recipient.trim()));
 			} else {
-				throw new ApplicationError(`The "${key}" field must be a string or an array of strings`, {
+				throw new UserError(`The "${key}" field must be a string or an array of strings`, {
 					level: 'warning',
 				});
 			}

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -5,7 +5,7 @@ import type {
 	Sort,
 } from 'mongodb';
 import { ObjectId } from 'mongodb';
-import { ApplicationError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError, UserError } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
 	ICredentialsDecrypted,
@@ -82,7 +82,7 @@ export class MongoDb implements INodeType {
 					const { databases } = await client.db().admin().listDatabases();
 
 					if (!(databases as IDataObject[]).map((db) => db.name).includes(database)) {
-						throw new ApplicationError(`Database "${database}" does not exist`, {
+						throw new UserError(`Database "${database}" does not exist`, {
 							level: 'warning',
 						});
 					}

--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.functions.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.functions.ts
@@ -1,4 +1,3 @@
-import { ApplicationError } from '@n8n/errors';
 import type {
 	ITriggerFunctions,
 	IDataObject,
@@ -6,6 +5,7 @@ import type {
 	INodeListSearchResult,
 	INodeListSearchItems,
 } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 
 import { configurePostgres } from './transport';
 import type { PgpDatabase, PostgresNodeCredentials } from './v2/helpers/interfaces';
@@ -28,7 +28,7 @@ export function prepareNames(id: string, mode: string, additionalFields: IDataOb
 	const channelName = (additionalFields.channelName as string) || `n8n_channel_${suffix}`;
 
 	if (channelName.includes('-')) {
-		throw new ApplicationError('Channel name cannot contain hyphens (-)', { level: 'warning' });
+		throw new UserError('Channel name cannot contain hyphens (-)', { level: 'warning' });
 	}
 
 	return { functionName, triggerName, channelName };
@@ -65,7 +65,7 @@ export async function pgTriggerFunction(
 	const whichData = firesOn === 'DELETE' ? 'old' : 'new';
 
 	if (channelName.includes('-')) {
-		throw new ApplicationError('Channel name cannot contain hyphens (-)', { level: 'warning' });
+		throw new UserError('Channel name cannot contain hyphens (-)', { level: 'warning' });
 	}
 
 	const replaceIfExists = additionalFields.replaceIfExists ?? false;
@@ -80,7 +80,7 @@ export async function pgTriggerFunction(
 		await db.any(trigger, [target, functionName, firesOn, triggerName]);
 	} catch (error) {
 		if ((error as Error).message.includes('near "-"')) {
-			throw new ApplicationError('Names cannot contain hyphens (-)', { level: 'warning' });
+			throw new UserError('Names cannot contain hyphens (-)', { level: 'warning' });
 		}
 		throw error;
 	}
@@ -115,7 +115,7 @@ export async function searchTables(this: ILoadOptionsFunctions): Promise<INodeLi
 			[schema.value],
 		);
 	} catch (error) {
-		throw new ApplicationError(error as string);
+		throw new OperationalError(error as string);
 	}
 	const results: INodeListSearchItems[] = (tableList as IDataObject[]).map((s) => ({
 		name: s.table_name as string,

--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -2,8 +2,8 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import unset from 'lodash/unset';
 import {
-	ApplicationError,
 	NodeOperationError,
+	UserError,
 	deepCopy,
 	getValueDescription,
 	jsonParse,
@@ -115,7 +115,7 @@ export function composeReturnItem(
 		case INCLUDE.NONE:
 			break;
 		default:
-			throw new ApplicationError(`The include option "${options.include}" is not known!`, {
+			throw new UserError(`The include option "${options.include}" is not known!`, {
 				level: 'warning',
 			});
 	}

--- a/packages/nodes-base/nodes/TheHiveProject/helpers/utils.ts
+++ b/packages/nodes-base/nodes/TheHiveProject/helpers/utils.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
-import { ApplicationError, type IDataObject } from 'n8n-workflow';
+import { UserError, type IDataObject } from 'n8n-workflow';
 
 export function splitAndTrim(str: string | string[]) {
 	if (typeof str === 'string') {
@@ -65,7 +65,7 @@ export function prepareInputItem(item: IDataObject, schema: IDataObject[], i: nu
 			set(returnData, id, value);
 		} else {
 			if (entry.required) {
-				throw new ApplicationError(`Required field "${id}" is missing in item ${i}`, {
+				throw new UserError(`Required field "${id}" is missing in item ${i}`, {
 					level: 'warning',
 				});
 			}

--- a/packages/nodes-base/nodes/Todoist/v1/OperationHandler.ts
+++ b/packages/nodes-base/nodes/Todoist/v1/OperationHandler.ts
@@ -1,5 +1,5 @@
 import type { IDataObject } from 'n8n-workflow';
-import { ApplicationError, jsonParse } from 'n8n-workflow';
+import { jsonParse, UserError } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
 
 import type { Section, TodoistResponse } from './Service';
@@ -326,10 +326,9 @@ export class SyncHandler implements OperationHandler {
 			if (sectionId) {
 				command.args.section_id = sectionId;
 			} else {
-				throw new ApplicationError(
-					'Section ' + command.args.section + " doesn't exist on Todoist",
-					{ level: 'warning' },
-				);
+				throw new UserError('Section ' + command.args.section + " doesn't exist on Todoist", {
+					level: 'warning',
+				});
 			}
 		}
 	}

--- a/packages/nodes-base/nodes/Transform/utils/utils.ts
+++ b/packages/nodes-base/nodes/Transform/utils/utils.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 
 export const prepareFieldsArray = (fields: string | string[], fieldName = 'Fields') => {
 	if (typeof fields === 'string') {
@@ -10,7 +10,7 @@ export const prepareFieldsArray = (fields: string | string[], fieldName = 'Field
 	if (Array.isArray(fields)) {
 		return fields;
 	}
-	throw new ApplicationError(
+	throw new UserError(
 		`The \'${fieldName}\' parameter must be a string of fields separated by commas or an array of strings.`,
 		{ level: 'warning' },
 	);

--- a/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Venafi/Datacenter/GenericFunctions.ts
@@ -1,5 +1,4 @@
 import get from 'lodash/get';
-import { ApplicationError } from '@n8n/errors';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -8,6 +7,7 @@ import type {
 	IPollFunctions,
 	IRequestOptions,
 } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
 export async function venafiApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
@@ -50,7 +50,7 @@ export async function venafiApiRequest(
 
 			errors = errors.map((e: IDataObject) => e.message);
 			// Try to return the error prettier
-			throw new ApplicationError(
+			throw new OperationalError(
 				`Venafi error response [${error.statusCode}]: ${errors.join('|')}`,
 				{ level: 'warning' },
 			);

--- a/packages/nodes-base/utils/sendAndWait/configureWaitTillDate.util.ts
+++ b/packages/nodes-base/utils/sendAndWait/configureWaitTillDate.util.ts
@@ -1,4 +1,4 @@
-import { ApplicationError, NodeOperationError, WAIT_INDEFINITELY } from 'n8n-workflow';
+import { NodeOperationError, UserError, WAIT_INDEFINITELY } from 'n8n-workflow';
 import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
 
 export function configureWaitTillDate(
@@ -51,7 +51,7 @@ export function configureWaitTillDate(
 			}
 
 			if (isNaN(waitTill.getTime())) {
-				throw new ApplicationError('Invalid date format');
+				throw new UserError('Invalid date format');
 			}
 		} catch (error) {
 			throw new NodeOperationError(context.getNode(), 'Could not configure Limit Wait Time', {

--- a/packages/nodes-base/utils/utilities.ts
+++ b/packages/nodes-base/utils/utilities.ts
@@ -13,13 +13,7 @@ import type {
 	INodeProperties,
 	IPairedItemData,
 } from 'n8n-workflow';
-import {
-	ApplicationError,
-	jsonParse,
-	MYSQL_NODE_TYPE,
-	POSTGRES_NODE_TYPE,
-	randomInt,
-} from 'n8n-workflow';
+import { jsonParse, MYSQL_NODE_TYPE, POSTGRES_NODE_TYPE, randomInt, UserError } from 'n8n-workflow';
 
 /**
  * Creates an array of elements split into groups the length of `size`.
@@ -159,12 +153,12 @@ export function processJsonInput<T>(jsonData: T, inputName?: string) {
 		try {
 			values = jsonParse(jsonData);
 		} catch (error) {
-			throw new ApplicationError(`Input ${input} must contain a valid JSON`, { level: 'warning' });
+			throw new UserError(`Input ${input} must contain a valid JSON`, { level: 'warning' });
 		}
 	} else if (typeof jsonData === 'object') {
 		values = jsonData;
 	} else {
-		throw new ApplicationError(`Input ${input} must contain a valid JSON`, { level: 'warning' });
+		throw new UserError(`Input ${input} must contain a valid JSON`, { level: 'warning' });
 	}
 
 	return values;


### PR DESCRIPTION
## Summary

Continues the migration away from the deprecated `ApplicationError` (PR 1f). Replaces the remaining direct `throw new ApplicationError(...)` calls across `packages/nodes-base/nodes/` (and the few in `packages/nodes-base/utils/`) with the appropriate non-deprecated error classes from `n8n-workflow`, following the same decision guide as PR 1e:

- **User-caused / bad input or config** → `UserError`
- **Upstream API or transient failures** → `OperationalError`
- **Code invariant violations** (unknown/unreachable cases) → `UnexpectedError`
- **In-node `execute()` paths with `getNode()` available** → `NodeOperationError`

Existing error options (`{ level: 'warning' }`, `cause`) are preserved. Error subclass definitions (`WebhookAuthorizationError`, Code node errors) and the `instanceof ApplicationError` safety-net checks are intentionally left untouched — they are handled by separate PRs (2a / Phase 0).

## How to test

- `pnpm typecheck` in `packages/nodes-base` ✅
- `pnpm lint` on the changed files ✅
- `pnpm test` for the affected node suites ✅ (2088 passed)

The one test touched (`MQTT/test/GenericFunctions.test.ts`) now asserts on `OperationalError` instead of `ApplicationError`.

## Related Linear tickets

https://linear.app/n8n/issue/CAT-3248


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

