### PR TITLE
fix(MCP Client Tool Node): Reuse the MCP session across tool calls in an execution

### DIFF
--- a/packages/@n8n/config/src/configs/mcp-client.config.ts
+++ b/packages/@n8n/config/src/configs/mcp-client.config.ts
@@ -1,0 +1,23 @@
+import { Time } from '@n8n/constants';
+
+import { Config, Env } from '../decorators';
+
+/** Configuration for the MCP Client Tool node. */
+@Config
+export class McpClientConfig {
+	/**
+	 * Time in milliseconds a cached MCP client is kept alive after its last use
+	 * before being evicted. Keeping the client open lets all tool calls within a
+	 * single workflow execution share one MCP session (required for stateful MCP
+	 * servers). Default: 5 minutes.
+	 */
+	@Env('N8N_MCP_CLIENT_CACHE_TTL_MS')
+	cacheTtl: number = 5 * Time.minutes.toMilliseconds;
+
+	/**
+	 * Maximum number of MCP clients kept in the in-memory session cache. When the
+	 * cache exceeds this size, the oldest entries are evicted. Default: 500.
+	 */
+	@Env('N8N_MCP_CLIENT_CACHE_MAX_SIZE')
+	cacheMaxSize: number = 500;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -28,6 +28,7 @@ import { InstanceAiConfig } from './configs/instance-ai.config';
 import { InstanceSettingsLoaderConfig } from './configs/instance-settings-loader.config';
 import { LicenseConfig } from './configs/license.config';
 import { LoggingConfig } from './configs/logging.config';
+import { McpClientConfig } from './configs/mcp-client.config';
 import { MfaConfig } from './configs/mfa.config';
 import { MultiMainSetupConfig } from './configs/multi-main-setup.config';
 import { NodesConfig } from './configs/nodes.config';
@@ -69,6 +70,7 @@ export type { LogScope } from './configs/logging.config';
 export { WorkflowsConfig } from './configs/workflows.config';
 export * from './custom-types';
 export { DeploymentConfig } from './configs/deployment.config';
+export { McpClientConfig } from './configs/mcp-client.config';
 export { MfaConfig } from './configs/mfa.config';
 export { HiringBannerConfig } from './configs/hiring-banner.config';
 export { HttpRequestConfig } from './configs/http-request.config';
@@ -269,6 +271,9 @@ export class GlobalConfig {
 
 	@Nested
 	compressionNode: CompressionNodeConfig;
+
+	@Nested
+	mcpClient: McpClientConfig;
 
 	@Nested
 	instanceAi: InstanceAiConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -286,6 +286,10 @@ describe('GlobalConfig', () => {
 			maxDecompressedSize: 2 * 1024 * 1024 * 1024,
 			maxZipEntries: 5000,
 		},
+		mcpClient: {
+			cacheTtl: 300000,
+			cacheMaxSize: 500,
+		},
 		chatHub: {
 			executionContextTtl: 3600,
 			maxBufferedChunks: 1000,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -58,8 +58,8 @@ export class McpClientTool implements INodeType {
 			dark: 'file:../mcp.dark.svg',
 		},
 		group: ['output'],
-		version: [1, 1.1, 1.2, 1.3],
-		defaultVersion: 1.3,
+		version: [1, 1.1, 1.2, 1.3, 1.4],
+		defaultVersion: 1.4,
 		description: 'Connect tools from an MCP Server',
 		defaults: {
 			name: 'MCP Client',
@@ -289,8 +289,11 @@ export class McpClientTool implements INodeType {
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return await executeMcpTool(this, (itemIndex) =>
-			resolveConfigFromNodeParameters(this, itemIndex),
+		return await executeMcpTool(
+			this,
+			(itemIndex) => resolveConfigFromNodeParameters(this, itemIndex),
+			// v1.4+ reuses one MCP session across tool calls within an execution.
+			{ enableSessionCache: this.getNode().typeVersion >= 1.4 },
 		);
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -2,6 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { McpError, ErrorCode, CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { proxyFetch } from '@n8n/ai-utilities';
+import { Container } from '@n8n/di';
 import { StructuredToolkit } from 'n8n-core';
 import {
 	type IExecuteFunctions,
@@ -17,6 +18,7 @@ import { mock, mockDeep } from 'vitest-mock-extended';
 import { getTools } from '../loadOptions';
 import { McpClientTool } from '../McpClientTool.node';
 import { buildMcpToolName } from '../utils';
+import { McpClientsManager } from '../../shared/McpClientsManager';
 import type { MockedFunction } from 'vitest';
 
 vi.mock('@modelcontextprotocol/sdk/client/sse.js');
@@ -2066,6 +2068,82 @@ describe('McpClientTool', () => {
 			});
 
 			await expect(getTools.call(ctx)).rejects.toThrow(/Domain not allowed.*allowed\.example/);
+		});
+	});
+
+	describe('execute: session cache version gating', () => {
+		let manager: McpClientsManager;
+
+		function createCtx(typeVersion: number) {
+			const mockNode = mock<INode>({ typeVersion, type: 'mcpClientTool', name: 'MCP Client' });
+			return mock<any>({
+				getNode: vi.fn(() => mockNode),
+				logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+				getExecutionId: vi.fn(() => 'exec-gating'),
+				getExecutionCancelSignal: vi.fn(() => undefined),
+				onExecutionCancellation: vi.fn(),
+				getInputData: vi.fn(() => [
+					{ json: { tool: buildMcpToolName('MCP Client', 'get_weather'), location: 'Berlin' } },
+				]),
+				getNodeParameter: vi.fn((key) => {
+					const params: Record<string, any> = {
+						include: 'all',
+						includeTools: [],
+						excludeTools: [],
+						authentication: 'none',
+						serverTransport: 'httpStreamable',
+						endpointUrl: 'https://test.com/mcp',
+						'options.timeout': 60000,
+					};
+					return params[key];
+				}),
+			});
+		}
+
+		beforeEach(() => {
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				content: [{ type: 'text', text: 'Sunny' }],
+			});
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'get_weather',
+						description: 'Gets the weather',
+						inputSchema: { type: 'object', properties: { location: { type: 'string' } } },
+					},
+				],
+			});
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
+			manager = new McpClientsManager({
+				cacheTtl: 300_000,
+				cacheMaxSize: 500,
+			} as never);
+			vi.mocked(Container.get).mockReturnValue(manager as never);
+		});
+
+		afterEach(() => {
+			manager.shutdown();
+		});
+
+		it('reuses one MCP session across tool calls for v1.4 nodes', async () => {
+			const ctx = createCtx(1.4);
+			await new McpClientTool().execute.call(ctx);
+			await new McpClientTool().execute.call(ctx);
+
+			expect(Client.prototype.connect).toHaveBeenCalledTimes(1);
+			expect(Client.prototype.close).not.toHaveBeenCalled();
+			expect(manager.size).toBe(1);
+		});
+
+		it('opens a fresh MCP session per tool call for v1.3 nodes', async () => {
+			const ctx = createCtx(1.3);
+			await new McpClientTool().execute.call(ctx);
+			await new McpClientTool().execute.call(ctx);
+
+			expect(Client.prototype.connect).toHaveBeenCalledTimes(2);
+			expect(Client.prototype.close).toHaveBeenCalledTimes(2);
+			expect(manager.size).toBe(0);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
@@ -215,20 +215,27 @@ describe('McpRegistryClientTool', () => {
 
 	describe('execute', () => {
 		it('passes a per-item resolveConfig callback to executeMcpTool', async () => {
-			const ctx = createExecuteCtx({
-				serverTransport: 'httpStreamable',
-				endpointUrl: 'https://mcp.notion.com/mcp',
-				'options.timeout': 60000,
-				include: 'all',
-				includeTools: [],
-				excludeTools: [],
-			});
+			const ctx = createExecuteCtx(
+				{
+					serverTransport: 'httpStreamable',
+					endpointUrl: 'https://mcp.notion.com/mcp',
+					'options.timeout': 60000,
+					include: 'all',
+					includeTools: [],
+					excludeTools: [],
+				},
+				{ typeVersion: 1.1 },
+			);
 			executeMcpToolMock.mockResolvedValue([[]]);
 
 			const node = new McpRegistryClientTool();
 			await node.execute.call(ctx);
 
-			expect(executeMcpToolMock).toHaveBeenCalledWith(ctx, expect.any(Function));
+			expect(executeMcpToolMock).toHaveBeenCalledWith(
+				ctx,
+				expect.any(Function),
+				expect.objectContaining({ enableSessionCache: true }),
+			);
 
 			const resolve = executeMcpToolMock.mock.calls[0][1];
 			expect(resolve(0)).toEqual({
@@ -238,6 +245,29 @@ describe('McpRegistryClientTool', () => {
 				timeout: 60000,
 				toolFilter: { mode: 'all', includeTools: [], excludeTools: [] },
 			});
+		});
+
+		it('does not enable the session cache for v1 nodes', async () => {
+			const ctx = createExecuteCtx(
+				{
+					serverTransport: 'httpStreamable',
+					endpointUrl: 'https://mcp.notion.com/mcp',
+					'options.timeout': 60000,
+					include: 'all',
+					includeTools: [],
+					excludeTools: [],
+				},
+				{ typeVersion: 1 },
+			);
+			executeMcpToolMock.mockResolvedValue([[]]);
+
+			await new McpRegistryClientTool().execute.call(ctx);
+
+			expect(executeMcpToolMock).toHaveBeenCalledWith(
+				ctx,
+				expect.any(Function),
+				expect.objectContaining({ enableSessionCache: false }),
+			);
 		});
 
 		it('throws an error when no OAuth2 credentials are defined on the node', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
@@ -35,7 +35,8 @@ export class McpRegistryClientTool implements INodeType {
 		name: 'mcpRegistryClientTool',
 		hidden: true,
 		group: ['output'],
-		version: 1,
+		version: [1, 1.1],
+		defaultVersion: 1.1,
 		description: 'Runtime backing for MCP registry-derived nodes',
 		defaults: {
 			name: 'MCP Registry Client',
@@ -166,7 +167,10 @@ export class McpRegistryClientTool implements INodeType {
 	}
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-		return await executeMcpTool(this, (itemIndex) => resolveConfig(this, itemIndex));
+		return await executeMcpTool(this, (itemIndex) => resolveConfig(this, itemIndex), {
+			// v1.1+ reuses one MCP session across tool calls within an execution.
+			enableSessionCache: this.getNode().typeVersion >= 1.1,
+		});
 	}
 }
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
@@ -186,7 +186,19 @@ export class McpClientsManager {
 				cacheKey: key,
 				error,
 			});
-			evictIfCurrent();
+			if (this.activeClients.get(key)?.client === client) {
+				// `remove` deletes the entry and closes the client.
+				this.remove(key, logger);
+			} else {
+				// Entry already replaced by a reconnect — close just this orphaned
+				// client without disturbing the live replacement.
+				void client.close().catch((closeError: unknown) => {
+					logger?.warn('McpClientsManager: failed to close errored client', {
+						cacheKey: key,
+						error: closeError,
+					});
+				});
+			}
 			try {
 				prevOnError?.(error);
 			} catch (chained: unknown) {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/McpClientsManager.ts
@@ -1,0 +1,205 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { McpClientConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+
+import type { McpTool } from './types';
+
+const EVICTION_INTERVAL_MS = 30_000;
+
+export interface McpCacheLogger {
+	warn(message: string, meta?: object): void;
+	debug(message: string, meta?: object): void;
+}
+
+interface CachedClient {
+	client: Client;
+	mcpTools: McpTool[];
+	lastUsedAt: number;
+}
+
+interface GetOrConnectOpts {
+	logger?: McpCacheLogger;
+	onExecutionCancellation?: (handler: () => void) => void;
+}
+
+/**
+ * Cache of live MCP clients across tool calls within a single execution.
+ * Required for stateful MCP servers (e.g. Playwright) — keeping the
+ * transport open between Agent V3 tool calls preserves the server-side
+ * session that would otherwise be torn down per call.
+ *
+ * Lifecycle:
+ *   - `getOrConnect` returns a cached entry or runs the factory once
+ *     (with concurrent-miss dedup via in-flight Promise map).
+ *   - Transport `onclose`/`onerror` evict the entry automatically.
+ *   - Idle entries (older than TTL on `lastUsedAt`) are swept periodically, and
+ *     the cache is capped at max size (oldest evicted) on insert and on sweep.
+ *   - On process exit, cached clients are dropped (close is best-effort only,
+ *     since async work cannot complete during the `exit` event).
+ */
+@Service()
+export class McpClientsManager {
+	private readonly activeClients = new Map<string, CachedClient>();
+
+	private readonly pendingConnections = new Map<
+		string,
+		Promise<{ client: Client; mcpTools: McpTool[] }>
+	>();
+
+	private readonly cleanupTimer: NodeJS.Timeout;
+
+	private readonly exitHandler = () => this.shutdown();
+
+	constructor(private readonly config: McpClientConfig) {
+		this.cleanupTimer = setInterval(() => this.evictStale(), EVICTION_INTERVAL_MS);
+		this.cleanupTimer.unref();
+		process.on('exit', this.exitHandler);
+	}
+
+	/** Test-only: total entries currently held. */
+	get size(): number {
+		return this.activeClients.size;
+	}
+
+	/** Test-only: peek a cached entry. */
+	getEntry(key: string): CachedClient | undefined {
+		return this.activeClients.get(key);
+	}
+
+	async getOrConnect(
+		key: string,
+		factory: () => Promise<{ client: Client; mcpTools: McpTool[] }>,
+		opts: GetOrConnectOpts = {},
+	): Promise<{ client: Client; mcpTools: McpTool[] }> {
+		const cached = this.activeClients.get(key);
+		if (cached) {
+			opts.logger?.debug('McpClientsManager: cache hit', { cacheKey: key });
+			cached.lastUsedAt = Date.now();
+			return { client: cached.client, mcpTools: cached.mcpTools };
+		}
+
+		const inFlight = this.pendingConnections.get(key);
+		if (inFlight) {
+			opts.logger?.debug('McpClientsManager: awaiting in-flight connection', { cacheKey: key });
+			return await inFlight;
+		}
+
+		opts.logger?.debug('McpClientsManager: cache miss, connecting', { cacheKey: key });
+		const pending = factory();
+		this.pendingConnections.set(key, pending);
+		try {
+			const result = await pending;
+			this.activeClients.set(key, {
+				client: result.client,
+				mcpTools: result.mcpTools,
+				lastUsedAt: Date.now(),
+			});
+			this.enforceMaxSize();
+			this.attachTransportLifecycle(result.client, key, opts.logger);
+			// Close on cancellation, but only if this entry still holds the client we
+			// just connected — a later reconnect under the same key (after eviction)
+			// registers its own handler and owns cleanup of its own client.
+			opts.onExecutionCancellation?.(() => {
+				if (this.activeClients.get(key)?.client === result.client) {
+					this.remove(key, opts.logger);
+				}
+			});
+			return result;
+		} finally {
+			this.pendingConnections.delete(key);
+		}
+	}
+
+	/** Refresh idle timer for an entry — call after long-running tool calls. */
+	refresh(key: string): void {
+		const entry = this.activeClients.get(key);
+		if (entry) entry.lastUsedAt = Date.now();
+	}
+
+	/** Close + remove cache entry. Safe to call multiple times. */
+	remove(key: string, logger?: McpCacheLogger): void {
+		const entry = this.activeClients.get(key);
+		if (!entry) return;
+
+		this.activeClients.delete(key);
+		void entry.client.close().catch((error: unknown) => {
+			logger?.warn('McpClientsManager: failed to close cached client', { cacheKey: key, error });
+		});
+	}
+
+	/** Evict idle entries (TTL on lastUsedAt) and enforce max cache size. */
+	evictStale(): void {
+		if (this.activeClients.size === 0) return;
+		const now = Date.now();
+
+		for (const [key, entry] of this.activeClients) {
+			if (now - entry.lastUsedAt > this.config.cacheTtl) {
+				this.remove(key);
+			}
+		}
+
+		this.enforceMaxSize();
+	}
+
+	/** Evict oldest entries until the cache is within `cacheMaxSize`. */
+	private enforceMaxSize(): void {
+		// Map iteration follows insertion order, so the oldest entries come first.
+		let excess = this.activeClients.size - this.config.cacheMaxSize;
+		for (const [key] of this.activeClients) {
+			if (excess <= 0) break;
+			this.remove(key);
+			excess--;
+		}
+	}
+
+	/**
+	 * Wire transport-level lifecycle so cache evicts when the server drops
+	 * the connection or transport errors out — prevents handing dead clients
+	 * back to subsequent tool calls. The MCP SDK's Protocol class exposes
+	 * `onclose`/`onerror` as plain assignable fields (no setter side effects),
+	 * so chaining via captured `prev*` is safe.
+	 */
+	private attachTransportLifecycle(client: Client, key: string, logger?: McpCacheLogger): void {
+		// Only evict if this entry still holds `client`; a late-firing handler from a
+		// client already replaced by a reconnect under the same key must not drop the
+		// live replacement.
+		const evictIfCurrent = () => {
+			if (this.activeClients.get(key)?.client === client) {
+				this.activeClients.delete(key);
+			}
+		};
+
+		const prevOnClose = client.onclose;
+		client.onclose = () => {
+			logger?.debug('McpClientsManager: transport closed, evicting cache entry', { cacheKey: key });
+			evictIfCurrent();
+			try {
+				prevOnClose?.();
+			} catch (error: unknown) {
+				logger?.warn('McpClientsManager: chained onclose threw', { error });
+			}
+		};
+
+		const prevOnError = client.onerror;
+		client.onerror = (error: Error) => {
+			logger?.warn('McpClientsManager: transport error, evicting cache entry', {
+				cacheKey: key,
+				error,
+			});
+			evictIfCurrent();
+			try {
+				prevOnError?.(error);
+			} catch (chained: unknown) {
+				logger?.warn('McpClientsManager: chained onerror threw', { error: chained });
+			}
+		};
+	}
+
+	shutdown(): void {
+		clearInterval(this.cleanupTimer);
+		process.off('exit', this.exitHandler);
+		for (const key of [...this.activeClients.keys()]) {
+			this.remove(key);
+		}
+	}
+}

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
@@ -1,0 +1,222 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+import { McpClientsManager } from '../McpClientsManager';
+
+type FakeClient = Client & {
+	close: ReturnType<typeof vi.fn>;
+	onclose?: (() => void) | null;
+	onerror?: ((error: Error) => void) | null;
+};
+
+function fakeClient(): FakeClient {
+	return {
+		close: vi.fn().mockResolvedValue(undefined),
+		onclose: null,
+		onerror: null,
+	} as unknown as FakeClient;
+}
+
+function makeManager(
+	overrides: Partial<{ cacheTtl: number; cacheMaxSize: number }> = {},
+): McpClientsManager {
+	const config = { cacheTtl: 300_000, cacheMaxSize: 500, ...overrides };
+	return new McpClientsManager(config as never);
+}
+
+describe('McpClientsManager', () => {
+	let manager: McpClientsManager;
+
+	afterEach(() => {
+		manager?.shutdown();
+	});
+
+	it('runs the factory once and caches the client', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		const factory = vi.fn().mockResolvedValue({ client, mcpTools: [] });
+
+		const a = await manager.getOrConnect('k', factory);
+		const b = await manager.getOrConnect('k', factory);
+
+		expect(factory).toHaveBeenCalledTimes(1);
+		expect(a.client).toBe(client);
+		expect(b.client).toBe(client);
+		expect(manager.size).toBe(1);
+	});
+
+	it('dedups concurrent cache misses', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		let resolveFactory: (value: { client: FakeClient; mcpTools: [] }) => void = () => {};
+		const factory = vi.fn().mockReturnValue(
+			new Promise((resolve) => {
+				resolveFactory = resolve;
+			}),
+		);
+
+		const p1 = manager.getOrConnect('k', factory);
+		const p2 = manager.getOrConnect('k', factory);
+		resolveFactory({ client, mcpTools: [] });
+		await Promise.all([p1, p2]);
+
+		expect(factory).toHaveBeenCalledTimes(1);
+		expect(manager.size).toBe(1);
+	});
+
+	it('registers a cancellation handler that closes and evicts the client', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		let handler: () => void = () => {};
+
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }), {
+			onExecutionCancellation: (h) => {
+				handler = h;
+			},
+		});
+
+		handler();
+		expect(client.close).toHaveBeenCalledTimes(1);
+		expect(manager.size).toBe(0);
+	});
+
+	it('cancellation handler does not close a client that replaced it under the same key', async () => {
+		manager = makeManager();
+		const client1 = fakeClient();
+		const client2 = fakeClient();
+		let handler1: () => void = () => {};
+		let handler2: () => void = () => {};
+
+		await manager.getOrConnect('k', async () => ({ client: client1, mcpTools: [] }), {
+			onExecutionCancellation: (h) => {
+				handler1 = h;
+			},
+		});
+
+		// Transport drop evicts client1's entry, then a reconnect stores client2.
+		client1.onclose?.();
+		expect(manager.size).toBe(0);
+
+		await manager.getOrConnect('k', async () => ({ client: client2, mcpTools: [] }), {
+			onExecutionCancellation: (h) => {
+				handler2 = h;
+			},
+		});
+		expect(manager.size).toBe(1);
+
+		// The stale handler must not touch the replacement client.
+		handler1();
+		expect(client2.close).not.toHaveBeenCalled();
+		expect(manager.size).toBe(1);
+
+		// The current handler still closes the current client.
+		handler2();
+		expect(client2.close).toHaveBeenCalledTimes(1);
+		expect(manager.size).toBe(0);
+	});
+
+	it('remove() closes the client and is idempotent', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+
+		manager.remove('k');
+		manager.remove('k');
+
+		expect(client.close).toHaveBeenCalledTimes(1);
+		expect(manager.size).toBe(0);
+	});
+
+	it('evicts idle entries past the TTL', async () => {
+		manager = makeManager({ cacheTtl: 50 });
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+
+		// Backdate last use so the entry is considered idle.
+		manager.getEntry('k')!.lastUsedAt = Date.now() - 10_000;
+		manager.evictStale();
+
+		expect(manager.size).toBe(0);
+		expect(client.close).toHaveBeenCalled();
+	});
+
+	it('keeps recently-used entries during eviction', async () => {
+		manager = makeManager({ cacheTtl: 10_000 });
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+
+		manager.evictStale();
+
+		expect(manager.size).toBe(1);
+		expect(client.close).not.toHaveBeenCalled();
+	});
+
+	it('enforces the max cache size on insert, evicting the oldest entries', async () => {
+		manager = makeManager({ cacheTtl: 10_000_000, cacheMaxSize: 2 });
+		const clients = [fakeClient(), fakeClient(), fakeClient()];
+		await manager.getOrConnect('a', async () => ({ client: clients[0], mcpTools: [] }));
+		await manager.getOrConnect('b', async () => ({ client: clients[1], mcpTools: [] }));
+		// Cap enforced on insert — no periodic sweep needed.
+		await manager.getOrConnect('c', async () => ({ client: clients[2], mcpTools: [] }));
+
+		expect(manager.size).toBe(2);
+		expect(clients[0].close).toHaveBeenCalled(); // oldest evicted
+		expect(manager.getEntry('a')).toBeUndefined();
+		expect(manager.getEntry('c')).toBeDefined();
+	});
+
+	it('evicts the entry when the transport closes', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+		expect(manager.size).toBe(1);
+
+		client.onclose?.();
+
+		expect(manager.size).toBe(0);
+	});
+
+	it('transport close handler does not evict a client that replaced it under the same key', async () => {
+		manager = makeManager();
+		const client1 = fakeClient();
+		const client2 = fakeClient();
+
+		await manager.getOrConnect('k', async () => ({ client: client1, mcpTools: [] }));
+		client1.onclose?.();
+		expect(manager.size).toBe(0);
+
+		await manager.getOrConnect('k', async () => ({ client: client2, mcpTools: [] }));
+		expect(manager.size).toBe(1);
+
+		// A late/duplicate close from the replaced client must not drop client2.
+		client1.onclose?.();
+		expect(manager.size).toBe(1);
+		expect(manager.getEntry('k')?.client).toBe(client2);
+
+		// The current client's own close still evicts.
+		client2.onclose?.();
+		expect(manager.size).toBe(0);
+	});
+
+	it('evicts the entry when the transport errors', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+		expect(manager.size).toBe(1);
+
+		client.onerror?.(new Error('boom'));
+
+		expect(manager.size).toBe(0);
+	});
+
+	it('refresh() updates lastUsedAt', async () => {
+		manager = makeManager();
+		const client = fakeClient();
+		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
+		const before = manager.getEntry('k')!.lastUsedAt;
+
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		manager.refresh('k');
+
+		expect(manager.getEntry('k')!.lastUsedAt).toBeGreaterThan(before);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/McpClientsManager.test.ts
@@ -197,7 +197,7 @@ describe('McpClientsManager', () => {
 		expect(manager.size).toBe(0);
 	});
 
-	it('evicts the entry when the transport errors', async () => {
+	it('evicts and closes the client when the transport errors', async () => {
 		manager = makeManager();
 		const client = fakeClient();
 		await manager.getOrConnect('k', async () => ({ client, mcpTools: [] }));
@@ -206,6 +206,28 @@ describe('McpClientsManager', () => {
 		client.onerror?.(new Error('boom'));
 
 		expect(manager.size).toBe(0);
+		// The SDK does not close the transport on error, so the cache must.
+		expect(client.close).toHaveBeenCalledTimes(1);
+	});
+
+	it('transport error closes only the errored client, not a replacement under the same key', async () => {
+		manager = makeManager();
+		const client1 = fakeClient();
+		const client2 = fakeClient();
+
+		await manager.getOrConnect('k', async () => ({ client: client1, mcpTools: [] }));
+		client1.onclose?.();
+		expect(manager.size).toBe(0);
+
+		await manager.getOrConnect('k', async () => ({ client: client2, mcpTools: [] }));
+		expect(manager.size).toBe(1);
+
+		// A late error from the replaced client closes the orphan but leaves client2 live.
+		client1.onerror?.(new Error('boom'));
+		expect(client1.close).toHaveBeenCalledTimes(1);
+		expect(client2.close).not.toHaveBeenCalled();
+		expect(manager.size).toBe(1);
+		expect(manager.getEntry('k')?.client).toBe(client2);
 	});
 
 	it('refresh() updates lastUsedAt', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -1,4 +1,5 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { StructuredToolkit } from 'n8n-core';
 import {
@@ -10,6 +11,7 @@ import {
 	type ISupplyDataFunctions,
 } from 'n8n-workflow';
 
+import { McpClientsManager } from './McpClientsManager';
 import { buildMcpToolkit, executeMcpTool, loadMcpToolOptions } from './runtime';
 import type { ResolvedMcpConfig, McpConnectionConfig } from './runtime';
 import { buildMcpToolName } from '../McpClientTool/utils';
@@ -398,6 +400,117 @@ describe('runtime', () => {
 
 			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow('network');
 			expect(closeSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('executeMcpTool session cache', () => {
+		let manager: McpClientsManager;
+
+		function createCachedCtx(executionId: string, overrides: Record<string, unknown> = {}) {
+			return mock<IExecuteFunctions>({
+				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP', type: 'mcp' })),
+				logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+				getInputData: jest.fn(() => [{ json: { tool: buildMcpToolName('MCP', 'search') } }]),
+				getExecutionId: jest.fn(() => executionId),
+				getExecutionCancelSignal: jest.fn(() => undefined),
+				onExecutionCancellation: jest.fn(),
+				...overrides,
+			} as Partial<IExecuteFunctions>);
+		}
+
+		beforeEach(() => {
+			manager = new McpClientsManager({
+				cacheTtl: 300_000,
+				cacheMaxSize: 500,
+			} as never);
+			vi.mocked(Container.get).mockReturnValue(manager as never);
+		});
+
+		afterEach(() => {
+			manager.shutdown();
+		});
+
+		it('reuses one client across execute calls within the same execution', async () => {
+			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedCtx('exec-1');
+			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
+			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
+
+			expect(connect).toHaveBeenCalledTimes(1);
+			expect(Client.prototype.callTool).toHaveBeenCalledTimes(2);
+			expect(close).not.toHaveBeenCalled();
+			expect(manager.size).toBe(1);
+		});
+
+		it('opens a fresh client per call when the cache is disabled', async () => {
+			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedCtx('exec-1');
+			await executeMcpTool(ctx, () => baseConfig);
+			await executeMcpTool(ctx, () => baseConfig);
+
+			expect(connect).toHaveBeenCalledTimes(2);
+			expect(close).toHaveBeenCalledTimes(2);
+		});
+
+		it('bypasses the cache when there is no execution id', async () => {
+			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createCachedCtx('');
+			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
+			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
+
+			expect(connect).toHaveBeenCalledTimes(2);
+			expect(close).toHaveBeenCalledTimes(2);
+			expect(manager.size).toBe(0);
+		});
+
+		it('does not share the cache across different executions', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			await executeMcpTool(createCachedCtx('exec-1'), () => baseConfig, {
+				enableSessionCache: true,
+			});
+			await executeMcpTool(createCachedCtx('exec-2'), () => baseConfig, {
+				enableSessionCache: true,
+			});
+
+			expect(Client.prototype.connect).toHaveBeenCalledTimes(2);
+			expect(manager.size).toBe(2);
+		});
+
+		it('closes and evicts the cached client on execution cancellation', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			let cancel: () => void = () => {};
+			const ctx = createCachedCtx('exec-1', {
+				onExecutionCancellation: jest.fn((handler: () => void) => {
+					cancel = handler;
+				}),
+			});
+
+			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
+			expect(manager.size).toBe(1);
+
+			cancel();
+			expect(close).toHaveBeenCalledTimes(1);
+			expect(manager.size).toBe(0);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
@@ -1,5 +1,7 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { logWrapper } from '@n8n/ai-utilities';
+import { Container } from '@n8n/di';
 import type { JSONSchema7 } from 'json-schema';
 import pick from 'lodash/pick';
 import { StructuredToolkit } from 'n8n-core';
@@ -7,6 +9,7 @@ import {
 	type IDataObject,
 	type IExecuteFunctions,
 	type ILoadOptionsFunctions,
+	type INode,
 	type INodeExecutionData,
 	type INodePropertyOptions,
 	NodeConnectionTypes,
@@ -15,6 +18,15 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
+import { McpClientsManager } from './McpClientsManager';
+import type { McpAuthenticationOption, McpServerTransport, McpTool } from './types';
+import {
+	connectMcpClientForCredential,
+	getAllTools,
+	isStructuredContent,
+	mapToNodeOperationError,
+} from './utils';
+import type { McpToolIncludeMode } from '../McpClientTool/types';
 import {
 	buildMcpToolName,
 	createCallTool,
@@ -22,14 +34,6 @@ import {
 	getSelectedTools,
 	mcpToolToDynamicTool,
 } from '../McpClientTool/utils';
-import type { McpToolIncludeMode } from '../McpClientTool/types';
-import type { McpAuthenticationOption, McpServerTransport } from './types';
-import {
-	connectMcpClientForCredential,
-	getAllTools,
-	isStructuredContent,
-	mapToNodeOperationError,
-} from './utils';
 
 /**
  * Connection config used to open an MCP client. Shared across `supplyData`,
@@ -179,82 +183,179 @@ export async function buildMcpToolkit(
 }
 
 /**
+ * Connect to the MCP server and return the client + filtered tools, or throw a
+ * `NodeOperationError` on connection failure or an empty tool list. The
+ * `connectOrThrow` counterpart to {@link connectAndGetTools}.
+ */
+async function connectOrThrow(
+	ctx: IExecuteFunctions,
+	config: ResolvedMcpConfig,
+	itemIndex: number,
+): Promise<{ client: Client; mcpTools: McpTool[] }> {
+	const node = ctx.getNode();
+	const { client, mcpTools, error } = await connectAndGetTools(ctx, config);
+
+	if (error) {
+		throw new NodeOperationError(node, error.error, { itemIndex });
+	}
+	if (!mcpTools?.length) {
+		await client.close();
+		throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
+	}
+
+	return { client, mcpTools };
+}
+
+/**
+ * Run the tool named in `item.json.tool` against the connected client and push
+ * the result onto `returnData`. Shared by the cached and non-cached execute paths.
+ */
+async function runToolCall(opts: {
+	ctx: IExecuteFunctions;
+	node: INode;
+	item: INodeExecutionData;
+	mcpTools: McpTool[];
+	client: Client;
+	timeout: number;
+	itemIndex: number;
+	returnData: INodeExecutionData[];
+}): Promise<void> {
+	const { ctx, node, item, mcpTools, client, timeout, itemIndex, returnData } = opts;
+
+	if (!item.json.tool || typeof item.json.tool !== 'string') {
+		throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
+			itemIndex,
+		});
+	}
+
+	const toolName = item.json.tool;
+	for (const tool of mcpTools) {
+		const prefixedName = buildMcpToolName(node.name, tool.name);
+		if (toolName !== prefixedName) continue;
+
+		const { tool: _, ...toolArguments } = item.json;
+		const schema: JSONSchema7 = tool.inputSchema;
+		const sanitizedToolArguments: IDataObject =
+			schema.additionalProperties !== true
+				? pick(toolArguments, Object.keys(schema.properties ?? {}))
+				: toolArguments;
+
+		const result = await client.callTool(
+			{ name: tool.name, arguments: sanitizedToolArguments },
+			CallToolResultSchema,
+			{
+				timeout,
+				signal: ctx.getExecutionCancelSignal(),
+			},
+		);
+
+		if (node.typeVersion >= 1.3 && result.isError) {
+			const errorMessage =
+				getErrorDescriptionFromToolCall(result) ?? `Tool "${tool.name}" returned an error`;
+			throw new NodeOperationError(node, errorMessage, { itemIndex });
+		}
+
+		returnData.push({
+			json: {
+				response: result.content as IDataObject,
+				...(isStructuredContent(result.structuredContent) && {
+					structuredContent: result.structuredContent,
+				}),
+			},
+			pairedItem: { item: itemIndex },
+		});
+	}
+}
+
+/**
  * Execute a single MCP tool call from an agent toolkit invocation.
  *
  * The agent passes `item.json.tool` (the prefixed tool name) and the tool arguments
  * inline on `item.json`. We sanitize the arguments against the tool's input schema
  * and forward the call to the MCP server.
+ *
+ * When `enableSessionCache` is set, the connected client is kept alive in
+ * {@link McpClientsManager} and reused across tool calls within the same execution,
+ * so stateful MCP servers keep their session between Agent V3 tool calls. Otherwise
+ * a fresh connection is opened and closed per call (legacy behaviour).
  */
 export async function executeMcpTool(
 	ctx: IExecuteFunctions,
 	resolveConfig: (itemIndex: number) => ResolvedMcpConfig | Promise<ResolvedMcpConfig>,
+	options: { enableSessionCache?: boolean } = {},
 ): Promise<INodeExecutionData[][]> {
 	const node = ctx.getNode();
 	const items = ctx.getInputData();
 	const returnData: INodeExecutionData[] = [];
 
-	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-		const signal = ctx.getExecutionCancelSignal();
-		if (signal?.aborted) {
+	const assertNotCancelled = (itemIndex: number): void => {
+		if (ctx.getExecutionCancelSignal()?.aborted) {
 			throw new NodeOperationError(node, 'Execution was cancelled', { itemIndex });
 		}
+	};
 
-		const item = items[itemIndex];
-		const config = await resolveConfig(itemIndex);
-		const { client, mcpTools, error } = await connectAndGetTools(ctx, config);
+	// Require a real execution id: without one the cache key would collide across
+	// concurrent executions (e.g. `undefined:NodeName`) and leak a session between
+	// them. Fall back to the per-call connection in that case.
+	const executionId = ctx.getExecutionId();
 
-		if (error) {
-			throw new NodeOperationError(node, error.error, { itemIndex });
+	if (options.enableSessionCache && executionId) {
+		assertNotCancelled(0);
+
+		const manager = Container.get(McpClientsManager);
+		const cacheKey = `${executionId}:${node.name}`;
+		// One cached client per execution+node, connected with the first item's
+		// config. Agent tool dispatch always sends a single item, so per-item
+		// connection config does not apply here (only per-item `timeout` below).
+		const firstConfig = await resolveConfig(0);
+
+		const { client, mcpTools } = await manager.getOrConnect(
+			cacheKey,
+			async () => await connectOrThrow(ctx, firstConfig, 0),
+			{
+				logger: ctx.logger,
+				onExecutionCancellation: ctx.onExecutionCancellation?.bind(ctx),
+			},
+		);
+
+		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+			assertNotCancelled(itemIndex);
+			const config = await resolveConfig(itemIndex);
+			await runToolCall({
+				ctx,
+				node,
+				item: items[itemIndex],
+				mcpTools,
+				client,
+				timeout: config.timeout,
+				itemIndex,
+				returnData,
+			});
 		}
 
+		// Bump the entry's idle timer at the end so the session survives the gap
+		// until the next tool call (e.g. agent/LLM latency) without being evicted.
+		manager.refresh(cacheKey);
+		return [returnData];
+	}
+
+	for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+		assertNotCancelled(itemIndex);
+
+		const config = await resolveConfig(itemIndex);
+		const { client, mcpTools } = await connectOrThrow(ctx, config, itemIndex);
+
 		try {
-			if (!mcpTools?.length) {
-				throw new NodeOperationError(node, 'MCP Server returned no tools', { itemIndex });
-			}
-
-			if (!item.json.tool || typeof item.json.tool !== 'string') {
-				throw new NodeOperationError(node, 'Tool name not found in item.json.tool or item.tool', {
-					itemIndex,
-				});
-			}
-
-			const toolName = item.json.tool;
-			for (const tool of mcpTools) {
-				const prefixedName = buildMcpToolName(node.name, tool.name);
-				if (toolName !== prefixedName) continue;
-
-				const { tool: _, ...toolArguments } = item.json;
-				const schema: JSONSchema7 = tool.inputSchema;
-				const sanitizedToolArguments: IDataObject =
-					schema.additionalProperties !== true
-						? pick(toolArguments, Object.keys(schema.properties ?? {}))
-						: toolArguments;
-
-				const result = await client.callTool(
-					{ name: tool.name, arguments: sanitizedToolArguments },
-					CallToolResultSchema,
-					{
-						timeout: config.timeout,
-						signal: ctx.getExecutionCancelSignal(),
-					},
-				);
-
-				if (node.typeVersion >= 1.3 && result.isError) {
-					const errorMessage =
-						getErrorDescriptionFromToolCall(result) ?? `Tool "${tool.name}" returned an error`;
-					throw new NodeOperationError(node, errorMessage, { itemIndex });
-				}
-
-				returnData.push({
-					json: {
-						response: result.content as IDataObject,
-						...(isStructuredContent(result.structuredContent) && {
-							structuredContent: result.structuredContent,
-						}),
-					},
-					pairedItem: { item: itemIndex },
-				});
-			}
+			await runToolCall({
+				ctx,
+				node,
+				item: items[itemIndex],
+				mcpTools,
+				client,
+				timeout: config.timeout,
+				itemIndex,
+				returnData,
+			});
 		} finally {
 			await client.close();
 		}


### PR DESCRIPTION
## Summary

In **Agent node v3**, every MCP tool call is dispatched as an independent `execute()` on the MCP Client Tool node, and the previous implementation opened **and closed** a fresh connection per call. Stateful MCP servers (e.g. Playwright MCP, DB cursors, terminal sessions) therefore lost their server-side session **between tool calls** — `browser_navigate` ran in one session, then `browser_click` landed on a fresh `about:blank` in another. This is a regression from Agent v2, where the toolkit was built once and all tools shared a single connection.

This PR keeps **one live MCP client per workflow execution + node**, reused across all tool calls in that execution, so the server session survives. A new session is created only on the next execution.

**How it works**
- New DI-managed `McpClientsManager` caches live `Client` instances keyed by `executionId:nodeName`, with single-flight dedup of concurrent connects.
- Cleanup: per-entry TTL + max-size cap (enforced on insert and on a periodic sweep), transport `onclose`/`onerror` auto-eviction, and execution-cancellation cleanup. The cache is bypassed when there is no execution id (prevents cross-execution key collisions).
- Gated behind **MCP Client Tool `v1.4`** and **MCP Registry Client `v1.1`** — older node versions keep the previous per-call behaviour, so existing workflows are unaffected until upgraded.
- Cache knobs live in a new `McpClientConfig` (`N8N_MCP_CLIENT_CACHE_TTL_MS`, default 5 min; `N8N_MCP_CLIENT_CACHE_MAX_SIZE`, default 500).

**Known limitation:** with a Human-in-the-Loop tool in queue/scaling mode, a resume can land on a different worker (empty cache) and start a fresh session. This was already broken before and is out of scope; the fallback is a graceful reconnect.

## How to test

Unit tests cover the cache mechanics, version gating, eviction, and cancellation cleanup:

```bash
cd packages/@n8n/nodes-langchain && pnpm vitest run nodes/mcp
```

For an end-to-end check there's a tiny **stateful** mock MCP server below — it makes the bug/fix observable in seconds without Playwright/Docker, and lets you A/B the same instance.

<details>
<summary>Mock stateful MCP server — save as <code>server.mjs</code> and run with <code>node server.mjs</code></summary>

Run it from the repo root so `@modelcontextprotocol/sdk` and `zod` resolve from the monorepo (or `npm i @modelcontextprotocol/sdk zod` in a scratch folder).

```js
// Mock STATEFUL MCP server.
//   - store_note({ note })  -> saves `note` into the CURRENT session
//   - read_note()           -> returns the note saved earlier in THIS session
// State is keyed by the transport's MCP session id, so:
//   * same session reused  -> read_note returns the note  (fixed)
//   * fresh session per call -> read_note returns "(no note...)"  (bug)
// Every request logs its session id so you can watch it stay constant (fix) vs change (bug).
// Point an n8n MCP Client Tool at:  http://localhost:8931/mcp  (HTTP Streamable, no auth)

import { randomUUID } from 'node:crypto';
import { createServer } from 'node:http';

import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
import { z } from 'zod';

const PORT = Number(process.env.MOCK_MCP_PORT ?? 8931);

const sessionState = new Map(); // sessionId -> { note }
const transports = new Map(); // sessionId -> transport

function log(...args) {
	console.log(`[mock-mcp ${new Date().toISOString()}]`, ...args);
}

function buildServer(getSessionId) {
	const server = new McpServer({ name: 'mock-stateful-mcp', version: '1.0.0' });

	server.registerTool(
		'store_note',
		{
			description: 'Store a note in the current MCP session so it can be read back later.',
			inputSchema: { note: z.string().describe('The note to remember for this session') },
		},
		async ({ note }) => {
			const sid = getSessionId() ?? 'unknown';
			sessionState.set(sid, { note });
			log(`store_note  session=${sid}  note=${JSON.stringify(note)}`);
			return { content: [{ type: 'text', text: `Saved "${note}" to session ${sid}.` }] };
		},
	);

	server.registerTool(
		'read_note',
		{
			description: 'Read the note stored earlier in THIS MCP session.',
			inputSchema: {},
		},
		async () => {
			const sid = getSessionId() ?? 'unknown';
			const entry = sessionState.get(sid);
			const text = entry ? entry.note : '(no note in this session)';
			log(`read_note   session=${sid}  -> ${JSON.stringify(text)}`);
			return { content: [{ type: 'text', text: `[session ${sid}] ${text}` }] };
		},
	);

	return server;
}

const httpServer = createServer(async (req, res) => {
	try {
		if (!req.url?.startsWith('/mcp')) {
			res.writeHead(404).end('Not found');
			return;
		}

		const sessionId = req.headers['mcp-session-id'];

		let body;
		if (req.method === 'POST') {
			const chunks = [];
			for await (const chunk of req) chunks.push(chunk);
			const raw = Buffer.concat(chunks).toString('utf8');
			body = raw ? JSON.parse(raw) : undefined;
		}

		let transport;
		if (sessionId && transports.has(sessionId)) {
			transport = transports.get(sessionId);
		} else if (!sessionId && req.method === 'POST' && isInitializeRequest(body)) {
			transport = new StreamableHTTPServerTransport({
				sessionIdGenerator: () => randomUUID(),
				onsessioninitialized: (sid) => {
					transports.set(sid, transport);
					log(`session INITIALIZED  session=${sid}`);
				},
			});
			transport.onclose = () => {
				const sid = transport.sessionId;
				if (sid) {
					log(`session CLOSED       session=${sid}`);
					transports.delete(sid);
					sessionState.delete(sid);
				}
			};
			const server = buildServer(() => transport.sessionId);
			await server.connect(transport);
		} else {
			res.writeHead(400, { 'Content-Type': 'application/json' }).end(
				JSON.stringify({
					jsonrpc: '2.0',
					error: { code: -32000, message: 'Bad Request: no valid session id' },
					id: null,
				}),
			);
			return;
		}

		log(`${req.method} /mcp  session=${sessionId ?? '(initializing)'}`);
		await transport.handleRequest(req, res, body);
	} catch (error) {
		log('request error:', error?.message ?? error);
		if (!res.headersSent) {
			res.writeHead(500, { 'Content-Type': 'application/json' }).end(
				JSON.stringify({
					jsonrpc: '2.0',
					error: { code: -32603, message: 'Internal server error' },
					id: null,
				}),
			);
		}
	}
});

httpServer.listen(PORT, () => {
	log(`Mock stateful MCP server listening on http://localhost:${PORT}/mcp`);
	log('Tools: store_note({ note }), read_note()');
});
```

</details>

**Steps**
1. `node server.mjs` (separate terminal).
2. Build a workflow: **Chat Trigger → Agent (v3) →** MCP Client Tool (**v1.4**), pointed at `http://localhost:8931/mcp` (HTTP Streamable, no auth, all tools).
3. Prompt the agent: *"Store the note 'banana', wait for 5 seconds, then read the note back."*

**Expected**
- **v1.4 (fixed):** `read_note` returns `banana`, and the server log shows the **same** session id for both calls. Run the chat again → a **new** session id (one session per execution).
- **v1.3 / older (control):** `read_note` returns `(no note in this session)` and the log shows a **different** session id per tool call — the original bug.

Optionally verify against a real Playwright MCP server: `browser_navigate` → `browser_click` now act on the same page.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4274

closes #21642

Supersedes the earlier drafts of this fix: #28145 (builds on the `McpClientsManager` design from @krisn0x's draft) and #25350 (@elsmr).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32476">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
