### PR TITLE
fix(AI Agent Node): Preserve parallel tool call structure in chat memory

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -55,7 +55,11 @@ export function extractToolCallId(
 
 /**
  * Converts ToolCallData array into LangChain message sequence.
- * Creates alternating AIMessage (with tool_calls) and ToolMessage pairs.
+ * For sequential tool calls this produces alternating AIMessage (with tool_calls)
+ * and ToolMessage pairs. For parallel tool calls, the shared AIMessage is emitted
+ * once for the batch followed by one ToolMessage per call
+ * (e.g. [AIMessage, ToolMessage, ToolMessage, …]), to avoid splitting a single
+ * model turn into several consecutive AI messages.
  *
  * @param steps - Array of tool call data with actions and observations
  * @returns Array of BaseMessage objects (AIMessage and ToolMessage pairs)

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -88,31 +88,37 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 		const toolCallId =
 			existingToolCallId ?? extractToolCallId(step.action.toolCallId, step.action.tool);
 
-		// Use existing AIMessage or create a synthetic one
-		const aiMessage =
-			existingAIMessage ??
-			new AIMessage({
-				content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
-				tool_calls: [
-					{
-						id: toolCallId,
-						name: step.action.tool,
-						args: step.action.toolInput,
-						type: 'tool_call',
-					},
-				],
-			});
+		// Parallel tool calls share one AIMessage on the first step (with all tool_calls)
+		// and leave an empty messageLog on the rest. Emit the AIMessage when present;
+		// continuation steps (empty messageLog, i > 0) get only a ToolMessage to avoid
+		// splitting one model turn into several consecutive AI messages. Synthesize an
+		// AIMessage only for a first step lacking one, so its ToolMessage isn't orphaned.
+		if (existingAIMessage) {
+			messages.push(existingAIMessage);
+		} else if (i === 0) {
+			messages.push(
+				new AIMessage({
+					content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
+					tool_calls: [
+						{
+							id: toolCallId,
+							name: step.action.tool,
+							args: step.action.toolInput,
+							type: 'tool_call',
+						},
+					],
+				}),
+			);
+		}
 
 		// Create ToolMessage with the observation result
-		const toolMessage = new ToolMessage({
-			content: step.observation,
-			tool_call_id: toolCallId,
-			name: step.action.tool,
-		});
-
-		// Add both messages
-		messages.push(aiMessage);
-		messages.push(toolMessage);
+		messages.push(
+			new ToolMessage({
+				content: step.observation,
+				tool_call_id: toolCallId,
+				name: step.action.tool,
+			}),
+		);
 	}
 
 	return messages;

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -434,6 +434,66 @@ describe('memoryManagement', () => {
 			expect(result[3]).toBeInstanceOf(ToolMessage);
 		});
 
+		it('should not fabricate an AIMessage for parallel tool calls with an empty messageLog', () => {
+			// Parallel Gemini calls: a single shared AIMessage (with all tool_calls and the
+			// thought signature) on the first step, empty messageLog on the rest.
+			const sharedAIMessage = new AIMessage({
+				content: 'Calling tools: tool_a, tool_b',
+				tool_calls: [
+					{ id: 'call-a', name: 'tool_a', args: { input: 'test' }, type: 'tool_call' },
+					{ id: 'call-b', name: 'tool_b', args: { input: 'test' }, type: 'tool_call' },
+				],
+				additional_kwargs: {
+					signatures: ['', 'sig-a', ''],
+					__gemini_function_call_thought_signatures__: { 'call-a': 'sig-a' },
+				},
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'tool_a',
+						toolInput: { input: 'test' },
+						log: 'Calling tools: tool_a, tool_b',
+						messageLog: [sharedAIMessage],
+						toolCallId: 'call-a',
+						type: 'tool_call',
+					},
+					observation: 'tool_a executed',
+				},
+				{
+					action: {
+						tool: 'tool_b',
+						toolInput: { input: 'test' },
+						log: 'Calling tool_b',
+						messageLog: [],
+						toolCallId: 'call-b',
+						type: 'tool_call',
+					},
+					observation: 'tool_b executed',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps);
+
+			// Expected: [sharedAIMessage, ToolMessage(tool_a), ToolMessage(tool_b)]
+			// NOT a spurious second AIMessage for tool_b.
+			expect(result).toHaveLength(3);
+			expect(result[0]).toBe(sharedAIMessage);
+			expect(result[1]).toBeInstanceOf(ToolMessage);
+			expect((result[1] as ToolMessage).tool_call_id).toBe('call-a');
+			expect((result[1] as ToolMessage).name).toBe('tool_a');
+			expect(result[2]).toBeInstanceOf(ToolMessage);
+			expect((result[2] as ToolMessage).tool_call_id).toBe('call-b');
+			expect((result[2] as ToolMessage).name).toBe('tool_b');
+
+			// The shared message retains its thought signatures untouched.
+			expect((result[0] as AIMessage).additional_kwargs).toEqual({
+				signatures: ['', 'sig-a', ''],
+				__gemini_function_call_thought_signatures__: { 'call-a': 'sig-a' },
+			});
+		});
+
 		it('should return empty array for empty steps', () => {
 			const result = buildMessagesFromSteps([]);
 			expect(result).toHaveLength(0);
@@ -489,6 +549,65 @@ describe('memoryManagement', () => {
 			expect(savedMessages[2]).toBeInstanceOf(ToolMessage);
 			expect(savedMessages[3]).toBeInstanceOf(AIMessage);
 			expect(savedMessages[3].content).toBe('The answer is 4');
+		});
+
+		it('should save parallel tool calls as a single AI tool-call message (no spurious AIMessage)', async () => {
+			const sharedAIMessage = new AIMessage({
+				content: 'Calling tools: tool_a, tool_b',
+				tool_calls: [
+					{ id: 'call-a', name: 'tool_a', args: { input: 'test' }, type: 'tool_call' },
+					{ id: 'call-b', name: 'tool_b', args: { input: 'test' }, type: 'tool_call' },
+				],
+				additional_kwargs: {
+					signatures: ['', 'sig-a', ''],
+					__gemini_function_call_thought_signatures__: { 'call-a': 'sig-a' },
+				},
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'tool_a',
+						toolInput: { input: 'test' },
+						log: 'Calling tools: tool_a, tool_b',
+						messageLog: [sharedAIMessage],
+						toolCallId: 'call-a',
+						type: 'tool_call',
+					},
+					observation: 'tool_a executed',
+				},
+				{
+					action: {
+						tool: 'tool_b',
+						toolInput: { input: 'test' },
+						log: 'Calling tool_b',
+						messageLog: [],
+						toolCallId: 'call-b',
+						type: 'tool_call',
+					},
+					observation: 'tool_b executed',
+				},
+			];
+
+			await saveToMemory('Hello', 'done', mockMemory, steps);
+
+			expect(mockChatHistory.addMessages).toHaveBeenCalledTimes(1);
+			const savedMessages = mockChatHistory.addMessages.mock.calls[0][0];
+
+			// Human, sharedAIMessage, ToolMessage(tool_a), ToolMessage(tool_b), final AIMessage
+			expect(savedMessages).toHaveLength(5);
+			expect(savedMessages[0]).toBeInstanceOf(HumanMessage);
+			expect(savedMessages[1]).toBe(sharedAIMessage);
+			expect(savedMessages[2]).toBeInstanceOf(ToolMessage);
+			expect(savedMessages[3]).toBeInstanceOf(ToolMessage);
+			expect(savedMessages[4]).toBeInstanceOf(AIMessage);
+			expect(savedMessages[4].content).toBe('done');
+
+			// Exactly one AI tool-call message — no consecutive AIMessages.
+			const aiToolCallMessages = savedMessages.filter(
+				(m: AIMessage) => m instanceof AIMessage && (m.tool_calls?.length ?? 0) > 0,
+			);
+			expect(aiToolCallMessages).toHaveLength(1);
 		});
 
 		it('should fall back to string format when addMessages is not available', async () => {


### PR DESCRIPTION
## Summary

When the AI Agent makes **parallel tool calls** and persists the turn to chat memory (e.g. Postgres Chat Memory), the saved message history was structurally malformed, causing the model to reject the replayed history on the next turn (Gemini/Vertex returns **HTTP 400**).

**Root cause.** `buildSteps()` encodes parallel tool calls as a single shared `AIMessage` on the first step — carrying *all* `tool_calls` and the Gemini `thought_signature` — with an **empty `messageLog`** on every continuation step. This contract is honored on the live execution path by LangChain's `formatToToolMessages`. But the memory-save path, `buildMessagesFromSteps()`, iterated per step and **fabricated a synthetic single-tool `AIMessage`** for each empty-`messageLog` step. That split one model turn into several consecutive `AIMessage`s and dropped the thought signature on the synthesized rows:

```
AI:   "Calling tools: tool_a, tool_b"   (tool_calls: [a,b], signatures ✓)   ← correct
Tool: tool_a result
AI:   "Calling tool_b with input: ..."  (additional_kwargs: {})            ← SPURIOUS
Tool: tool_b result
AI:   "done"
```

The spurious second `AIMessage` is a structure the model never emitted, and the consecutive-AI-message sequence violates Gemini's protocol → 400 on the next turn.

**Fix.** In `buildMessagesFromSteps()`, emit the shared `AIMessage` once and write **only** a `ToolMessage` for continuation steps (empty `messageLog`, `i > 0`). The synthetic-`AIMessage` fallback is retained for a genuinely-first step that lacks a `messageLog`, so non-parallel data is unaffected. The resulting history is faithful to the model response:

```
Human → AI("Calling tools: tool_a, tool_b", signatures ✓) → Tool(a) → Tool(b) → AI("done")
```

Since the spurious row is eliminated and the shared message's `additional_kwargs` are preserved verbatim, the reported thought-signature loss is resolved as a side effect (it lived entirely on the now-removed row).

## How to test

1. Build a workflow: Chat Trigger → AI Agent (V3) → Google Vertex Chat Model (`gemini-3-flash-preview`) → Postgres Chat Memory, plus two trivial tools `tool_a` and `tool_b`.
2. System prompt forces parallel calls: *"For EVERY user message you MUST call BOTH tools `tool_a` AND `tool_b` together in the SAME step, then reply with the single word: done."*
3. Turn 1 (`"Hello"`, fixed `sessionId`) succeeds with a parallel tool call.
4. Turn 2 (`"How are you?"`, same session) — **before:** HTTP 400; **after:** succeeds.

Automated coverage added in `memoryManagement.test.ts`:
- `buildMessagesFromSteps` parallel case → `[sharedAIMessage, ToolMessage(a), ToolMessage(b)]`, no fabricated `AIMessage`, signatures intact.
- `saveToMemory` parallel case → exactly one AI tool-call message between the Human input and the final AI response.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2572
fixes #32271

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

