### PR TITLE
feat(core): Send push messages after publication outbox record is processed (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
@@ -54,6 +54,10 @@ describe('PublicationStatusReporter', () => {
 		expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1);
 		expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
 		expect(outboxRepository.markFailed).not.toHaveBeenCalled();
+		expect(push.broadcast).toHaveBeenCalledWith({
+			type: 'workflowActivated',
+			data: { workflowId: 'wf-1', activeVersionId: 'v-2' },
+		});
 	});
 
 	test.each([['workflow-not-found'], ['workflow-inactive']] as const)(
@@ -64,6 +68,7 @@ describe('PublicationStatusReporter', () => {
 			expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1);
 			expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
 			expect(outboxRepository.markFailed).not.toHaveBeenCalled();
+			expect(push.broadcast).not.toHaveBeenCalled();
 		},
 	);
 
@@ -73,6 +78,10 @@ describe('PublicationStatusReporter', () => {
 		expect(outboxRepository.markFailed).toHaveBeenCalledWith(1, 'Published version not found');
 		expect(errorReporter.error).not.toHaveBeenCalled();
 		expect(activationErrorsService.deregister).not.toHaveBeenCalled();
+		expect(push.broadcast).toHaveBeenCalledWith({
+			type: 'workflowFailedToActivate',
+			data: { workflowId: 'wf-1', errorMessage: 'Published version not found' },
+		});
 	});
 
 	test('failed reports the error and marks the record failed with its message', async () => {
@@ -83,6 +92,10 @@ describe('PublicationStatusReporter', () => {
 		expect(errorReporter.error).toHaveBeenCalledWith(error, { shouldBeLogged: true });
 		expect(outboxRepository.markFailed).toHaveBeenCalledWith(1, 'registration failed');
 		expect(outboxRepository.markCompleted).not.toHaveBeenCalled();
+		expect(push.broadcast).toHaveBeenCalledWith({
+			type: 'workflowFailedToActivate',
+			data: { workflowId: 'wf-1', errorMessage: 'registration failed' },
+		});
 	});
 
 	test('partial marks partial_success, registers per-node detail, and pushes the failures', async () => {

--- a/packages/cli/src/workflows/publication/publication-status-reporter.ts
+++ b/packages/cli/src/workflows/publication/publication-status-reporter.ts
@@ -33,6 +33,10 @@ export class PublicationStatusReporter {
 		switch (result.type) {
 			case 'completed': {
 				await this.complete(record);
+				this.push.broadcast({
+					type: 'workflowActivated',
+					data: { workflowId: record.workflowId, activeVersionId: record.publishedVersionId },
+				});
 				return;
 			}
 
@@ -43,18 +47,21 @@ export class PublicationStatusReporter {
 			}
 
 			case 'version-missing': {
+				const errorMessage = 'Published version not found';
 				this.logger.warn('Published version not found, marking outbox record as failed', {
 					workflowId: record.workflowId,
 					publishedVersionId: record.publishedVersionId,
 					outboxId: record.id,
 				});
-				await this.outboxRepository.markFailed(record.id, 'Published version not found');
+				await this.outboxRepository.markFailed(record.id, errorMessage);
+				this.pushFailedToActivate(record.workflowId, errorMessage);
 				return;
 			}
 
 			case 'failed': {
 				this.errorReporter.error(result.error, { shouldBeLogged: true });
 				await this.outboxRepository.markFailed(record.id, result.error.message);
+				this.pushFailedToActivate(record.workflowId, result.error.message);
 				return;
 			}
 
@@ -111,6 +118,14 @@ export class PublicationStatusReporter {
 			.join('; ');
 
 		return `Some triggers failed to activate: ${detail}`;
+	}
+
+	/** Broadcasts a failed-to-activate status to connected clients (leader-local). */
+	private pushFailedToActivate(workflowId: string, errorMessage: string): void {
+		this.push.broadcast({
+			type: 'workflowFailedToActivate',
+			data: { workflowId, errorMessage },
+		});
 	}
 
 	/** Marks the record completed and clears any activation errors for the workflow. */


### PR DESCRIPTION
## Summary

Send push messages when reporting workflow publication outbox record processing result.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3487

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<details>
<summary>Implementation plan</summary>

# CAT-3487: Send push messages after outbox record has been processed

## Context

The workflow publication outbox pipeline is split into a consumer (claims pending records), an applier (reconciles triggers and returns a `PublicationResult`), and a reporter (`PublicationStatusReporter`) that turns the result into terminal state and side effects. Today the reporter pushes to the UI only for the `partial` case (`workflowPartiallyActivated`). The success and failure cases write DB status and activation errors but send **no push**, so a connected editor doesn't learn the outcome of a publish until it reloads. This ticket closes that gap.

## Result → push mapping

| `PublicationResult.type` | Existing behavior | New push |
|---|---|---|
| `completed` | mark completed + deregister errors | **`workflowActivated`** |
| `failed` | report error + mark failed | **`workflowFailedToActivate`** |
| `version-missing` | warn + mark failed | **`workflowFailedToActivate`** (terminal failure) |
| `skipped` | log + mark completed | **none** (no triggers were activated) |
| `partial` | mark partial + register + push | unchanged |

Payloads (types already exist in `@n8n/api-types`):
- `workflowActivated`: `{ workflowId, activeVersionId: record.publishedVersionId }`
- `workflowFailedToActivate`: `{ workflowId, errorMessage }`

Both broadcasts are leader-local via `this.push.broadcast(...)`, consistent with the existing `reportPartial` push; multi-main pubsub routing remains follow-up work.

## Changes

- `publication-status-reporter.ts`: broadcast `workflowActivated` in the `completed` case; broadcast `workflowFailedToActivate` in the `failed` and `version-missing` cases via a shared private `pushFailedToActivate(workflowId, errorMessage)` helper. `skipped` stays silent.
- `__tests__/publication-status-reporter.test.ts`: assert the broadcast is present (completed/failed/version-missing) or absent (skipped).

</details>


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32483">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

