### PR TITLE
feat(core): Add Prometheus metrics for Instance AI runs

### DIFF
--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -511,6 +511,7 @@ export type {
 	ResumableStreamSource,
 } from './runtime/resumable-stream-executor';
 export type { WorkSummary } from './stream/work-summary-accumulator';
+export type { RunTokenUsage } from './stream/usage-accumulator';
 export const resumeAgentRun: typeof StreamRunnerMod.resumeAgentRun = lazyFunction(
 	() => loadStreamRunner().resumeAgentRun,
 );

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -5,6 +5,7 @@ import type { InstanceAiEventBus } from '../event-bus';
 import type { Logger } from '../logger';
 import { mapAgentChunkToEvent } from '../stream/map-chunk';
 import { OutputRedactor } from '../stream/output-redaction';
+import { UsageAccumulator, type RunTokenUsage } from '../stream/usage-accumulator';
 import { WorkSummaryAccumulator, type WorkSummary } from '../stream/work-summary-accumulator';
 import { parseSuspension, resumeAgentStream } from '../utils/stream-helpers';
 import type { SuspensionInfo } from '../utils/stream-helpers';
@@ -73,6 +74,8 @@ export interface ExecuteResumableStreamResult {
 	confirmationEvent?: ConfirmationRequestEvent;
 	/** Accumulated tool call outcomes observed during stream consumption. */
 	workSummary: WorkSummary;
+	/** Accumulated token usage and cost, when the stream emitted usage. */
+	usage?: RunTokenUsage;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -193,6 +196,7 @@ export async function executeResumableStream(
 	let activeAgentRunId = options.stream.runId ?? options.initialAgentRunId ?? '';
 	let text = options.stream.text;
 	const workSummaryAccumulator = new WorkSummaryAccumulator();
+	const usageAccumulator = new UsageAccumulator();
 	const outputRedactor = new OutputRedactor({
 		logger: options.context.logger,
 		threadId: options.context.threadId,
@@ -218,10 +222,12 @@ export async function executeResumableStream(
 					agentRunId: activeAgentRunId,
 					text,
 					workSummary: workSummaryAccumulator.toSummary(),
+					usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 				};
 			}
 
 			options.context.onActivity?.();
+			usageAccumulator.observe(chunk);
 
 			if (isRecord(chunk) && chunk.type === 'start-step') {
 				nativeStepIndex += 1;
@@ -314,6 +320,7 @@ export async function executeResumableStream(
 				agentRunId: activeAgentRunId,
 				text,
 				workSummary: workSummaryAccumulator.toSummary(),
+				usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 			};
 		}
 
@@ -323,6 +330,7 @@ export async function executeResumableStream(
 				agentRunId: activeAgentRunId,
 				text,
 				workSummary: workSummaryAccumulator.toSummary(),
+				usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 			};
 		}
 
@@ -333,6 +341,7 @@ export async function executeResumableStream(
 				text,
 				suspension,
 				workSummary: workSummaryAccumulator.toSummary(),
+				usage: usageAccumulator.hasUsage() ? usageAccumulator.toUsage() : undefined,
 				...(confirmationEvent ? { confirmationEvent } : {}),
 			};
 		}

--- a/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
+++ b/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
@@ -218,6 +218,11 @@ export class RunStateRegistry<TUser = unknown> {
 		return this.activeRuns.get(threadId)?.runId;
 	}
 
+	/** Number of runs currently executing (excludes suspended/pending runs). */
+	activeRunCount(): number {
+		return this.activeRuns.size;
+	}
+
 	getActiveRun(threadId: string): ActiveRunState | undefined {
 		return this.activeRuns.get(threadId);
 	}

--- a/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
+++ b/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
@@ -9,6 +9,7 @@ import {
 	type ResumableStreamSource,
 	type TraceStatus,
 } from './resumable-stream-executor';
+import type { RunTokenUsage } from '../stream/usage-accumulator';
 import type { WorkSummary } from '../stream/work-summary-accumulator';
 import { resumeAgentStream } from '../utils/stream-helpers';
 import type { SuspensionInfo } from '../utils/stream-helpers';
@@ -34,6 +35,7 @@ export interface StreamRunResult {
 	agentRunId: string;
 	text?: Promise<string>;
 	workSummary: WorkSummary;
+	usage?: RunTokenUsage;
 	suspension?: SuspensionInfo;
 	confirmationEvent?: Extract<InstanceAiEvent, { type: 'confirmation-request' }>;
 }
@@ -90,6 +92,7 @@ async function consumeStream(
 			agentRunId: result.agentRunId,
 			text: result.text,
 			workSummary: result.workSummary,
+			usage: result.usage,
 			suspension: result.suspension,
 			...(result.confirmationEvent ? { confirmationEvent: result.confirmationEvent } : {}),
 		};
@@ -105,5 +108,6 @@ async function consumeStream(
 		agentRunId: result.agentRunId,
 		text: result.text,
 		workSummary: result.workSummary,
+		usage: result.usage,
 	};
 }

--- a/packages/@n8n/instance-ai/src/stream/__tests__/usage-accumulator.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/usage-accumulator.test.ts
@@ -1,0 +1,78 @@
+import { UsageAccumulator } from '../usage-accumulator';
+
+describe('UsageAccumulator', () => {
+	it('reports no usage and zeroes before any finish chunk', () => {
+		const acc = new UsageAccumulator();
+
+		expect(acc.hasUsage()).toBe(false);
+		expect(acc.toUsage()).toEqual({
+			promptTokens: 0,
+			completionTokens: 0,
+			totalTokens: 0,
+			costUsd: 0,
+		});
+	});
+
+	it('captures usage and cost from a finish chunk', () => {
+		const acc = new UsageAccumulator();
+
+		acc.observe({
+			type: 'finish',
+			usage: { promptTokens: 100, completionTokens: 40, totalTokens: 140, cost: 0.02 },
+		});
+
+		expect(acc.hasUsage()).toBe(true);
+		expect(acc.toUsage()).toEqual({
+			promptTokens: 100,
+			completionTokens: 40,
+			totalTokens: 140,
+			costUsd: 0.02,
+		});
+	});
+
+	it('sums usage across multiple finish chunks (e.g. resumed runs)', () => {
+		const acc = new UsageAccumulator();
+
+		acc.observe({
+			type: 'finish',
+			usage: { promptTokens: 100, completionTokens: 40, totalTokens: 140, cost: 0.02 },
+		});
+		acc.observe({
+			type: 'finish',
+			usage: { promptTokens: 50, completionTokens: 10, totalTokens: 60, cost: 0.01 },
+		});
+
+		expect(acc.toUsage()).toEqual({
+			promptTokens: 150,
+			completionTokens: 50,
+			totalTokens: 200,
+			costUsd: 0.03,
+		});
+	});
+
+	it('ignores non-finish chunks and finish chunks without usage', () => {
+		const acc = new UsageAccumulator();
+
+		acc.observe({ type: 'text-delta', textDelta: 'hi' });
+		acc.observe({ type: 'finish', finishReason: 'stop' });
+		acc.observe('not even an object');
+		acc.observe(undefined);
+
+		expect(acc.hasUsage()).toBe(false);
+		expect(acc.toUsage().totalTokens).toBe(0);
+	});
+
+	it('treats missing usage fields as zero', () => {
+		const acc = new UsageAccumulator();
+
+		acc.observe({ type: 'finish', usage: { totalTokens: 10 } });
+
+		expect(acc.hasUsage()).toBe(true);
+		expect(acc.toUsage()).toEqual({
+			promptTokens: 0,
+			completionTokens: 0,
+			totalTokens: 10,
+			costUsd: 0,
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/stream/usage-accumulator.ts
+++ b/packages/@n8n/instance-ai/src/stream/usage-accumulator.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+// ── Schema (source of truth) ────────────────────────────────────────────────
+
+export const runTokenUsageSchema = z.object({
+	promptTokens: z.number().int().min(0),
+	completionTokens: z.number().int().min(0),
+	totalTokens: z.number().int().min(0),
+	/** Estimated cost in USD, summed from per-step `usage.cost` (models.dev pricing). */
+	costUsd: z.number().min(0),
+});
+
+export type RunTokenUsage = z.infer<typeof runTokenUsageSchema>;
+
+/** Shape of the `usage` field on the agent SDK's `finish` stream chunk. */
+const finishChunkSchema = z.object({
+	type: z.literal('finish'),
+	usage: z
+		.object({
+			promptTokens: z.number().optional(),
+			completionTokens: z.number().optional(),
+			totalTokens: z.number().optional(),
+			cost: z.number().optional(),
+		})
+		.optional(),
+});
+
+// ── Accumulator ─────────────────────────────────────────────────────────────
+
+/**
+ * Accumulates token usage and cost from the agent SDK's `finish` stream chunks.
+ * Mirrors {@link WorkSummaryAccumulator}: instantiated per-stream, fed each raw
+ * chunk, and drained at the end. A run emits one `finish` chunk per agent
+ * segment (one extra per resume), so usage is summed across segments.
+ */
+export class UsageAccumulator {
+	private promptTokens = 0;
+	private completionTokens = 0;
+	private totalTokens = 0;
+	private costUsd = 0;
+	private seen = false;
+
+	/** Feed a raw stream chunk. Only `finish` chunks carry usage; others are ignored. */
+	observe(chunk: unknown): void {
+		const parsed = finishChunkSchema.safeParse(chunk);
+		if (!parsed.success || !parsed.data.usage) return;
+		const { promptTokens, completionTokens, totalTokens, cost } = parsed.data.usage;
+		this.promptTokens += promptTokens ?? 0;
+		this.completionTokens += completionTokens ?? 0;
+		this.totalTokens += totalTokens ?? 0;
+		this.costUsd += cost ?? 0;
+		this.seen = true;
+	}
+
+	/** Whether any usage was observed. */
+	hasUsage(): boolean {
+		return this.seen;
+	}
+
+	/** Produce a usage summary. Safe to call multiple times (idempotent). */
+	toUsage(): RunTokenUsage {
+		return {
+			promptTokens: this.promptTokens,
+			completionTokens: this.completionTokens,
+			totalTokens: this.totalTokens,
+			costUsd: this.costUsd,
+		};
+	}
+}

--- a/packages/cli/src/events/event.service.ts
+++ b/packages/cli/src/events/event.service.ts
@@ -3,10 +3,15 @@ import { Service } from '@n8n/di';
 
 import type { AiEventMap } from './maps/ai.event-map';
 import type { ExecutionDataEventMap } from './maps/execution-data.event-map';
+import type { InstanceAiEventMap } from './maps/instance-ai.event-map';
 import type { QueueMetricsEventMap } from './maps/queue-metrics.event-map';
 import type { RelayEventMap } from './maps/relay.event-map';
 
-type EventMap = RelayEventMap & QueueMetricsEventMap & AiEventMap & ExecutionDataEventMap;
+type EventMap = RelayEventMap &
+	QueueMetricsEventMap &
+	AiEventMap &
+	ExecutionDataEventMap &
+	InstanceAiEventMap;
 
 @Service()
 export class EventService extends TypedEmitter<EventMap> {}

--- a/packages/cli/src/events/maps/instance-ai.event-map.ts
+++ b/packages/cli/src/events/maps/instance-ai.event-map.ts
@@ -1,0 +1,18 @@
+export type InstanceAiEventMap = {
+	'instance-ai-run-finished': {
+		status: 'completed' | 'cancelled' | 'error';
+		/** Wall-clock duration of the run, or undefined when the start time is unknown. */
+		durationMs?: number;
+		/** Model identifier for built-in providers; 'custom' for OpenAI-compatible/native instances. */
+		model: string;
+		toolCalls: number;
+		toolErrors: number;
+		/** Token usage and estimated USD cost, when the run reported usage. */
+		usage?: {
+			promptTokens: number;
+			completionTokens: number;
+			totalTokens: number;
+			costUsd: number;
+		};
+	};
+};

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -10,6 +10,7 @@ import type { PrometheusDefaultMetricsService } from '../prometheus/default-metr
 import type { PrometheusDnsCacheMetricsService } from '../prometheus/dns-cache-metrics.service';
 import type { PrometheusEventBusMetricsService } from '../prometheus/event-bus-metrics.service';
 import type { PrometheusExecutionDataMetricsService } from '../prometheus/execution-data-metrics.service';
+import type { PrometheusInstanceAiMetricsService } from '../prometheus/instance-ai-metrics.service';
 import type { PrometheusInstanceRoleMetricsService } from '../prometheus/instance-role-metrics.service';
 import { PrometheusMetricsService } from '../prometheus/prometheus.service';
 import type { PrometheusPssMetricsService } from '../prometheus/pss-metrics.service';
@@ -46,6 +47,7 @@ describe('PrometheusMetricsService', () => {
 	let dnsCache: jest.Mocked<PrometheusDnsCacheMetricsService>;
 	let webhook: jest.Mocked<PrometheusWebhookAndFormMetricsService>;
 	let workflowInfo: jest.Mocked<PrometheusWorkflowInfoMetricsService>;
+	let instanceAi: jest.Mocked<PrometheusInstanceAiMetricsService>;
 
 	let service: PrometheusMetricsService;
 
@@ -69,6 +71,7 @@ describe('PrometheusMetricsService', () => {
 			dnsCache,
 			webhook,
 			workflowInfo,
+			instanceAi,
 		);
 
 	beforeEach(() => {
@@ -99,6 +102,7 @@ describe('PrometheusMetricsService', () => {
 		dnsCache = mock<PrometheusDnsCacheMetricsService>({ enabled: true });
 		webhook = mock<PrometheusWebhookAndFormMetricsService>({ enabled: true });
 		workflowInfo = mock<PrometheusWorkflowInfoMetricsService>({ enabled: true });
+		instanceAi = mock<PrometheusInstanceAiMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -128,6 +132,7 @@ describe('PrometheusMetricsService', () => {
 			expect(dnsCache.init).toHaveBeenCalledWith(app);
 			expect(webhook.init).toHaveBeenCalledWith(app);
 			expect(workflowInfo.init).toHaveBeenCalledWith(app);
+			expect(instanceAi.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/instance-ai-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/instance-ai-metrics.service.test.ts
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/unbound-method -- jest mocks */
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import promClient from 'prom-client';
+
+import type { EventService } from '@/events/event.service';
+import type { InstanceAiRunProbe } from '@/modules/instance-ai/instance-ai-run-probe';
+
+import { DURATION_BUCKETS_SECONDS } from '../constant';
+import { PrometheusInstanceAiMetricsService } from '../instance-ai-metrics.service';
+
+jest.mock('prom-client');
+
+describe('PrometheusInstanceAiMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+	});
+	const eventService = mock<EventService>();
+	const runProbe = mock<InstanceAiRunProbe>();
+	let service: PrometheusInstanceAiMetricsService;
+	let mockCounterInc: jest.Mock;
+	let mockHistogramObserve: jest.Mock;
+	let mockGaugeSet: jest.Mock;
+
+	function getEventHandler(eventName: string) {
+		return eventService.on.mock.calls.find((c) => c[0] === eventName)?.[1];
+	}
+
+	beforeEach(() => {
+		Object.assign(config, { prefix: 'n8n_' });
+		service = new PrometheusInstanceAiMetricsService(config, eventService, runProbe);
+		mockCounterInc = jest.fn();
+		promClient.Counter.prototype.inc = mockCounterInc;
+		mockHistogramObserve = jest.fn();
+		promClient.Histogram.prototype.observe = mockHistogramObserve;
+		mockGaugeSet = jest.fn();
+		promClient.Gauge.prototype.set = mockGaugeSet;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('enabled', () => {
+		it('is always on (gated by N8N_METRICS via init)', () => {
+			expect(service.enabled).toBe(true);
+		});
+	});
+
+	describe('init', () => {
+		it('should create instance_ai_runs_total counter with status and model labels', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_instance_ai_runs_total',
+				help: 'Total number of Instance AI runs.',
+				labelNames: ['status', 'model'],
+			});
+		});
+
+		it('should create instance_ai_run_duration_seconds histogram with DURATION_BUCKETS_SECONDS', () => {
+			service.init();
+
+			expect(promClient.Histogram).toHaveBeenCalledWith({
+				name: 'n8n_instance_ai_run_duration_seconds',
+				help: 'Instance AI run duration in seconds.',
+				labelNames: ['status'],
+				buckets: DURATION_BUCKETS_SECONDS,
+			});
+		});
+
+		it('should create instance_ai_tokens_total counter with a type label', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_instance_ai_tokens_total',
+				help: 'Total number of tokens used by Instance AI runs.',
+				labelNames: ['type'],
+			});
+		});
+
+		it('should create instance_ai_cost_usd_total counter', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_instance_ai_cost_usd_total',
+				help: 'Total estimated cost in USD of Instance AI runs (models.dev pricing).',
+			});
+		});
+
+		it('should create instance_ai_active_runs gauge that reads the run probe on collect', () => {
+			runProbe.activeRunCount.mockReturnValue(3);
+			service.init();
+
+			const gaugeOptions = (promClient.Gauge as unknown as jest.Mock).mock.calls.find(
+				(c) => c[0]?.name === 'n8n_instance_ai_active_runs',
+			)?.[0];
+			expect(gaugeOptions).toBeDefined();
+			expect(gaugeOptions.help).toBe('Number of Instance AI runs currently executing.');
+
+			// Invoke the collect() hook with a gauge-like `this` to verify it reads the probe.
+			gaugeOptions.collect.call({ set: mockGaugeSet });
+			expect(runProbe.activeRunCount).toHaveBeenCalled();
+			expect(mockGaugeSet).toHaveBeenCalledWith(3);
+		});
+	});
+
+	describe('instance-ai-run-finished event handler', () => {
+		it('should increment runs counter with status and model labels', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+			expect(handler).toBeDefined();
+
+			handler!({
+				status: 'completed',
+				durationMs: 4200,
+				model: 'claude-opus-4',
+				toolCalls: 3,
+				toolErrors: 1,
+			});
+
+			expect(mockCounterInc).toHaveBeenCalledWith(
+				{ status: 'completed', model: 'claude-opus-4' },
+				1,
+			);
+		});
+
+		it('should observe duration histogram in seconds when durationMs is present', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+
+			handler!({ status: 'error', durationMs: 4200, model: 'custom', toolCalls: 0, toolErrors: 0 });
+
+			expect(mockHistogramObserve).toHaveBeenCalledWith({ status: 'error' }, 4.2);
+		});
+
+		it('should not observe duration histogram when durationMs is undefined', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+
+			handler!({ status: 'cancelled', model: 'custom', toolCalls: 0, toolErrors: 0 });
+
+			expect(mockHistogramObserve).not.toHaveBeenCalled();
+		});
+
+		it('should increment tool call and error counters by their counts', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+
+			handler!({
+				status: 'completed',
+				durationMs: 1000,
+				model: 'custom',
+				toolCalls: 5,
+				toolErrors: 2,
+			});
+
+			expect(mockCounterInc).toHaveBeenCalledWith(5);
+			expect(mockCounterInc).toHaveBeenCalledWith(2);
+		});
+
+		it('should not increment tool counters when counts are zero', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+			mockCounterInc.mockClear();
+
+			handler!({
+				status: 'completed',
+				durationMs: 1000,
+				model: 'custom',
+				toolCalls: 0,
+				toolErrors: 0,
+			});
+
+			expect(mockCounterInc).not.toHaveBeenCalledWith(0);
+		});
+
+		it('should increment token counters by type and cost when usage is present', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+
+			handler!({
+				status: 'completed',
+				durationMs: 1000,
+				model: 'custom',
+				toolCalls: 0,
+				toolErrors: 0,
+				usage: {
+					promptTokens: 1200,
+					completionTokens: 300,
+					totalTokens: 1500,
+					costUsd: 0.0123,
+				},
+			});
+
+			expect(mockCounterInc).toHaveBeenCalledWith({ type: 'input' }, 1200);
+			expect(mockCounterInc).toHaveBeenCalledWith({ type: 'output' }, 300);
+			expect(mockCounterInc).toHaveBeenCalledWith(0.0123);
+		});
+
+		it('should not increment token or cost counters when usage is absent', () => {
+			service.init();
+			const handler = getEventHandler('instance-ai-run-finished');
+			mockCounterInc.mockClear();
+
+			handler!({
+				status: 'completed',
+				durationMs: 1000,
+				model: 'custom',
+				toolCalls: 0,
+				toolErrors: 0,
+			});
+
+			expect(mockCounterInc).not.toHaveBeenCalledWith({ type: 'input' }, expect.any(Number));
+			expect(mockCounterInc).not.toHaveBeenCalledWith({ type: 'output' }, expect.any(Number));
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
@@ -1,0 +1,96 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import promClient from 'prom-client';
+
+import { EventService } from '@/events/event.service';
+import { InstanceAiRunProbe } from '@/modules/instance-ai/instance-ai-run-probe';
+
+import type { PrometheusMetricsCollector } from './base';
+import { DURATION_BUCKETS_SECONDS } from './constant';
+
+/**
+ * Tracks Instance AI run counts, durations, and tool-call outcomes, driven off the
+ * `instance-ai-run-finished` event emitted when a run is finalized.
+ */
+@Service()
+export class PrometheusInstanceAiMetricsService implements PrometheusMetricsCollector {
+	constructor(
+		private readonly config: PrometheusMetricsConfig,
+		private readonly eventService: EventService,
+		private readonly runProbe: InstanceAiRunProbe,
+	) {}
+
+	get enabled(): boolean {
+		// Always on when Prometheus metrics are enabled (N8N_METRICS); no separate flag.
+		return true;
+	}
+
+	init() {
+		const runsTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_runs_total`,
+			help: 'Total number of Instance AI runs.',
+			labelNames: ['status', 'model'],
+		});
+
+		const runDurationHistogram = new promClient.Histogram({
+			name: `${this.config.prefix}instance_ai_run_duration_seconds`,
+			help: 'Instance AI run duration in seconds.',
+			labelNames: ['status'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		const toolCallsTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_tool_calls_total`,
+			help: 'Total number of tool calls made during Instance AI runs.',
+		});
+		toolCallsTotal.inc(0);
+
+		const toolErrorsTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_tool_errors_total`,
+			help: 'Total number of failed tool calls during Instance AI runs.',
+		});
+		toolErrorsTotal.inc(0);
+
+		const tokensTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_tokens_total`,
+			help: 'Total number of tokens used by Instance AI runs.',
+			labelNames: ['type'],
+		});
+		tokensTotal.inc({ type: 'input' }, 0);
+		tokensTotal.inc({ type: 'output' }, 0);
+
+		const costTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_cost_usd_total`,
+			help: 'Total estimated cost in USD of Instance AI runs (models.dev pricing).',
+		});
+		costTotal.inc(0);
+
+		const runProbe = this.runProbe;
+		new promClient.Gauge({
+			name: `${this.config.prefix}instance_ai_active_runs`,
+			help: 'Number of Instance AI runs currently executing.',
+			collect() {
+				this.set(runProbe.activeRunCount());
+			},
+		});
+
+		this.eventService.on(
+			'instance-ai-run-finished',
+			({ status, durationMs, model, toolCalls, toolErrors, usage }) => {
+				runsTotal.inc({ status, model }, 1);
+				if (durationMs !== undefined) {
+					runDurationHistogram.observe({ status }, durationMs / 1000);
+				}
+				if (toolCalls > 0) toolCallsTotal.inc(toolCalls);
+				if (toolErrors > 0) toolErrorsTotal.inc(toolErrors);
+				if (usage) {
+					if (usage.promptTokens > 0) tokensTotal.inc({ type: 'input' }, usage.promptTokens);
+					if (usage.completionTokens > 0) {
+						tokensTotal.inc({ type: 'output' }, usage.completionTokens);
+					}
+					if (usage.costUsd > 0) costTotal.inc(usage.costUsd);
+				}
+			},
+		);
+	}
+}

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -10,6 +10,7 @@ import { PrometheusDefaultMetricsService } from './default-metrics.service';
 import { PrometheusDnsCacheMetricsService } from './dns-cache-metrics.service';
 import { PrometheusEventBusMetricsService } from './event-bus-metrics.service';
 import { PrometheusExecutionDataMetricsService } from './execution-data-metrics.service';
+import { PrometheusInstanceAiMetricsService } from './instance-ai-metrics.service';
 import { PrometheusInstanceRoleMetricsService } from './instance-role-metrics.service';
 import { PrometheusPssMetricsService } from './pss-metrics.service';
 import { PrometheusQueueMetricsService } from './queue-metrics.service';
@@ -47,6 +48,7 @@ export class PrometheusMetricsService {
 		dnsCache: PrometheusDnsCacheMetricsService,
 		webhook: PrometheusWebhookAndFormMetricsService,
 		workflowInfo: PrometheusWorkflowInfoMetricsService,
+		instanceAi: PrometheusInstanceAiMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -67,6 +69,7 @@ export class PrometheusMetricsService {
 			dnsCache,
 			webhook,
 			workflowInfo,
+			instanceAi,
 		];
 	}
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-run-probe.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-run-probe.test.ts
@@ -1,0 +1,17 @@
+import { InstanceAiRunProbe } from '../instance-ai-run-probe';
+
+describe('InstanceAiRunProbe', () => {
+	it('defaults to 0 when no provider is registered', () => {
+		expect(new InstanceAiRunProbe().activeRunCount()).toBe(0);
+	});
+
+	it('reads from the registered provider', () => {
+		const probe = new InstanceAiRunProbe();
+		let count = 2;
+		probe.registerActiveRunCountProvider(() => count);
+
+		expect(probe.activeRunCount()).toBe(2);
+		count = 5;
+		expect(probe.activeRunCount()).toBe(5);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -595,7 +595,9 @@ type TerminalGuardOrderServiceInternals = {
 		cancelThread: jest.Mock;
 		clearActiveRun: jest.Mock;
 		hasSuspendedRun: jest.Mock;
+		getActiveRun: jest.Mock;
 	};
+	eventService: { emit: jest.Mock };
 	eventBus: {
 		events: InstanceAiEvent[];
 		getEventsForRun: jest.Mock;
@@ -674,7 +676,9 @@ function createTerminalGuardOrderService(): TerminalGuardOrderServiceInternals {
 		cancelThread: jest.fn(),
 		clearActiveRun: jest.fn(),
 		hasSuspendedRun: jest.fn(() => true),
+		getActiveRun: jest.fn(() => undefined),
 	};
+	service.eventService = { emit: jest.fn() };
 	service.eventBus = {
 		events,
 		getEventsForRun: jest.fn(() => events),

--- a/packages/cli/src/modules/instance-ai/instance-ai-run-probe.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-run-probe.ts
@@ -1,0 +1,22 @@
+import { Service } from '@n8n/di';
+
+/**
+ * Lightweight bridge so the Prometheus collector can read the live active-run
+ * count without depending on the heavy (lazily-registered) InstanceAiService.
+ *
+ * InstanceAiService registers a pull provider; the gauge reads it at scrape
+ * time. Pull (not push) keeps the count drift-free across suspend/resume.
+ * Defaults to 0 when Instance AI is disabled and no provider is registered.
+ */
+@Service()
+export class InstanceAiRunProbe {
+	private activeRunCountProvider: () => number = () => 0;
+
+	registerActiveRunCountProvider(provider: () => number): void {
+		this.activeRunCountProvider = provider;
+	}
+
+	activeRunCount(): number {
+		return this.activeRunCountProvider();
+	}
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -80,6 +80,7 @@ import {
 	type WorkflowTaskService,
 	type WorkflowVerificationObligation,
 	type WorkSummary,
+	type RunTokenUsage,
 	type RunDebugRecord,
 	WorkflowTaskCoordinator,
 	WorkflowLoopStorage,
@@ -95,6 +96,7 @@ import { v5 as uuidv5 } from 'uuid';
 import { InProcessEventBus } from './event-bus/in-process-event-bus';
 import { InstanceAiGatewayService } from './instance-ai-gateway.service';
 import { InstanceAiMemoryService } from './instance-ai-memory.service';
+import { InstanceAiRunProbe } from './instance-ai-run-probe';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiTemporaryWorkflowService } from './instance-ai-temporary-workflow.service';
 import { InstanceAiAdapterService } from './instance-ai.adapter.service';
@@ -574,8 +576,10 @@ export class InstanceAiService {
 		ssrfProtectionConfig: SsrfProtectionConfig,
 		ssrfProtectionService: SsrfProtectionService,
 		private readonly eventService: EventService,
+		runProbe: InstanceAiRunProbe,
 	) {
 		this.logger = logger.scoped('instance-ai');
+		runProbe.registerActiveRunCountProvider(() => this.runState.activeRunCount());
 		this.workflowObligations = new WorkflowVerificationObligationService(this.agentMemory);
 		this.taskProjector = new WorkflowVerificationTaskProjector(
 			this.agentMemory,
@@ -3993,6 +3997,8 @@ export class InstanceAiService {
 				userId: user.id,
 				modelId,
 				archivedWorkflowIds,
+				workSummary: result.workSummary,
+				usage: result.usage,
 			});
 
 			// Count credits on first completed run per thread
@@ -4864,6 +4870,8 @@ export class InstanceAiService {
 			);
 			await this.finalizeRun(opts.threadId, opts.runId, result.status, opts.snapshotStorage, {
 				archivedWorkflowIds,
+				workSummary: result.workSummary,
+				usage: result.usage,
 			});
 
 			if (result.status === 'completed') {
@@ -5360,13 +5368,37 @@ export class InstanceAiService {
 		runId: string,
 		status: 'completed' | 'cancelled' | 'errored',
 		snapshotStorage: DbSnapshotStorage,
-		options?: { userId?: string; modelId?: ModelConfig; archivedWorkflowIds?: string[] },
+		options?: {
+			userId?: string;
+			modelId?: ModelConfig;
+			archivedWorkflowIds?: string[];
+			workSummary?: WorkSummary;
+			usage?: RunTokenUsage;
+		},
 	): Promise<void> {
 		this.publishRunFinish(threadId, runId, status, undefined, options?.archivedWorkflowIds);
+		this.emitRunMetrics(threadId, status, options);
 		await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);
 		if (status === 'completed' && options?.userId && options?.modelId) {
 			void this.refineTitleIfNeeded(threadId, options.userId, options.modelId);
 		}
+	}
+
+	/** Emit a typed event consumed by the Prometheus Instance AI metrics collector. */
+	private emitRunMetrics(
+		threadId: string,
+		status: 'completed' | 'cancelled' | 'errored',
+		options?: { modelId?: ModelConfig; workSummary?: WorkSummary; usage?: RunTokenUsage },
+	): void {
+		const startedAt = this.runState.getActiveRun(threadId)?.startedAt;
+		this.eventService.emit('instance-ai-run-finished', {
+			status: status === 'errored' ? 'error' : status,
+			durationMs: startedAt !== undefined ? Date.now() - startedAt : undefined,
+			model: typeof options?.modelId === 'string' ? options.modelId : 'custom',
+			toolCalls: options?.workSummary?.totalToolCalls ?? 0,
+			toolErrors: options?.workSummary?.totalToolErrors ?? 0,
+			...(options?.usage ? { usage: options.usage } : {}),
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Phase 2 of [INS-550](https://linear.app/n8n/issue/INS-550) (observability): adds Prometheus metrics for Instance AI runs. Until now Instance AI had zero metrics on `/metrics` — run counts, latency, cost, concurrency and tool failure rates were invisible to Grafana.

A new `PrometheusInstanceAiMetricsService` collector follows the existing collector pattern. It is **always on when `N8N_METRICS` is enabled** (no dedicated include flag — the collector only initializes when the metrics endpoint is mounted). It is driven off a single typed `instance-ai-run-finished` event emitted from `finalizeRun`, the terminal funnel for every run.

Metrics exposed (with the `N8N_METRICS_PREFIX`, default `n8n_`):

- `instance_ai_runs_total{status, model}` — counter
- `instance_ai_run_duration_seconds{status}` — histogram (duration from the run-state registry's `startedAt`)
- `instance_ai_tool_calls_total` / `instance_ai_tool_errors_total` — counters (from the run's work summary)
- `instance_ai_tokens_total{type=input|output}` — counter
- `instance_ai_cost_usd_total` — counter (estimated USD, from models.dev pricing)
- `instance_ai_active_runs` — gauge (live concurrency)

**The Grafana dashboard is intentionally out of scope here** (will be a separate change).

### Token usage and cost

The `@n8n/agents` SDK emits a `finish` stream chunk carrying a typed `usage` (prompt/completion/total tokens) with `cost` already computed from models.dev pricing. A small `UsageAccumulator` (mirroring the existing `WorkSummaryAccumulator`) sums it across the run's segments and threads it through the same `finalizeRun` path as tool counts — no LangSmith round-trip, no extra request. So Grafana gets **cost-per-run and tokens-per-run** directly.

### Active-run concurrency

`instance_ai_active_runs` is a pull-based `collect()` gauge that reads the live `RunStateRegistry.activeRunCount()` at scrape time (bridged via a tiny `InstanceAiRunProbe` so the collector doesn't depend on the lazily-registered `InstanceAiService`). Pull, not inc/dec, so it never drifts across suspend/resume/shutdown.

## How to test

1. Start n8n with `N8N_METRICS=true`.
2. Run an Instance AI build that calls at least one tool.
3. `curl localhost:5678/metrics | grep instance_ai` — counters/histogram/gauge appear and update per run, including `instance_ai_tokens_total`, `instance_ai_cost_usd_total` and `instance_ai_active_runs`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-550

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
