### PR TITLE
feat(editor): Improve tidy-up behavior for collapsed node groups (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
@@ -19,6 +19,10 @@ import {
 	CanvasNodeRenderType,
 } from '@/features/workflows/canvas/canvas.types';
 import type { NodeExecutionSnapshot } from '@/features/workflows/canvas/canvas.types';
+import {
+	GROUP_HEADER_HEIGHT,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+} from '@/features/workflows/canvas/stores/canvasNodeGroups.constants';
 import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { GraphEdge, GraphNode, ViewportTransform } from '@vue-flow/core';
@@ -96,6 +100,32 @@ export function createCanvasGroupElement({
 			nodesRect,
 			isCollapsed,
 		},
+	};
+}
+
+/**
+ * Graph-node form of a group chip (the runtime VueFlow node), as opposed to the
+ * plain input element from {@link createCanvasGroupElement}.
+ */
+export function createCanvasGraphGroupNode(
+	options: Parameters<typeof createCanvasGroupElement>[0] = {},
+): GraphNode<CanvasGroupNodeData> {
+	const element = createCanvasGroupElement(options);
+	const data = element.data!; // createCanvasGroupElement always populates data
+	return {
+		id: element.id,
+		type: CANVAS_NODE_GROUP_TYPE,
+		label: data.group.name,
+		position: element.position,
+		computedPosition: { ...element.position, z: 0 },
+		dimensions: { width: GROUP_HEADER_WIDTH_COLLAPSED, height: GROUP_HEADER_HEIGHT },
+		dragging: false,
+		isParent: false,
+		selected: false,
+		resizing: false,
+		handleBounds: { source: null, target: null },
+		events: {},
+		data,
 	};
 }
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -406,6 +406,28 @@ describe('useCanvasLayout', () => {
 			expect(after.x).toBeGreaterThan(rm2.x);
 		});
 
+		test('keeps a top-left collapsed group anchored in place', () => {
+			// Group owns the top-left corner, where the chip box (944, 908) and the
+			// member box (1008, 1008) disagree — the anchor must not absorb that gap.
+			const m1 = createCanvasGraphNode({ id: 'm1', position: { x: 1008, y: 1008 } });
+			const m2 = createCanvasGraphNode({ id: 'm2', position: { x: 1104, y: 1008 } });
+			const group = createCanvasGraphGroupNode({
+				id: groupId,
+				nodeIds: ['m1', 'm2'],
+				isCollapsed: true,
+				nodesRect: { x: 1008, y: 1008, width: 192, height: 96 },
+				position: { x: 944, y: 908 },
+			});
+
+			const { layout } = createTestSetup([m1, m2, group], []);
+			const result = layout('all');
+
+			const rm1 = result.nodes.find((n) => n.id === 'm1');
+			assert(rm1);
+			// A lone group has nothing to re-flow, so its members stay put.
+			expect(rm1).toMatchObject({ x: 1008, y: 1008 });
+		});
+
 		test('lays out expanded group members individually and excludes the chip', () => {
 			const m1 = createCanvasGraphNode({ id: 'm1' });
 			const m2 = createCanvasGraphNode({ id: 'm2' });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -6,9 +6,14 @@ import {
 } from '@/features/workflows/canvas/canvas.utils';
 import {
 	createCanvasGraphEdge,
+	createCanvasGraphGroupNode,
 	createCanvasGraphNode,
 } from '@/features/workflows/canvas/__tests__/utils';
-import { CanvasNodeRenderType, type CanvasNodeData } from '../canvas.types';
+import {
+	CanvasNodeRenderType,
+	type CanvasGroupNodeData,
+	type CanvasNodeData,
+} from '../canvas.types';
 import { useCanvasLayout, type CanvasLayoutResult } from './useCanvasLayout';
 import { STICKY_NODE_TYPE } from '@/app/constants';
 import { GRID_SIZE } from '@/app/utils/nodeViewUtils';
@@ -21,7 +26,7 @@ function matchesGrid(result: CanvasLayoutResult) {
 
 describe('useCanvasLayout', () => {
 	function createTestSetup(
-		nodes: Array<GraphNode<CanvasNodeData>>,
+		nodes: Array<GraphNode<CanvasNodeData> | GraphNode<CanvasGroupNodeData>>,
 		connections: Array<[string, string]>,
 		selectedNodeIds?: string[],
 	) {
@@ -334,5 +339,100 @@ describe('useCanvasLayout', () => {
 		assert(node2);
 
 		expect(node2.x).toBeGreaterThan(node1.x);
+	});
+
+	describe('collapsed node groups', () => {
+		const groupId = 'g1';
+		const chipId = `group:${groupId}`;
+
+		function createCollapsedGroupSetup() {
+			// Use a grid-aligned gap so snap-to-grid preserves the relative spacing
+			const m1 = createCanvasGraphNode({ id: 'm1', position: { x: 1008, y: 1008 } });
+			const m2 = createCanvasGraphNode({ id: 'm2', position: { x: 1104, y: 1008 } });
+			const before = createCanvasGraphNode({ id: 'before', position: { x: 0, y: 0 } });
+			const after = createCanvasGraphNode({ id: 'after', position: { x: 2000, y: 0 } });
+			const group = createCanvasGraphGroupNode({
+				id: groupId,
+				nodeIds: ['m1', 'm2'],
+				isCollapsed: true,
+				nodesRect: { x: 1008, y: 1008, width: 192, height: 96 },
+				position: { x: 944, y: 908 },
+			});
+
+			const nodes = [before, m1, m2, after, group];
+			const connections: Array<[string, string]> = [
+				['before', chipId],
+				[chipId, 'after'],
+			];
+
+			return createTestSetup(nodes, connections);
+		}
+
+		test('lays out a collapsed group as a unit, preserving member offsets and dropping the chip', () => {
+			const { layout } = createCollapsedGroupSetup();
+			const result = layout('all');
+
+			const ids = result.nodes.map((n) => n.id);
+			expect(ids).toContain('m1');
+			expect(ids).toContain('m2');
+			// Chip is placed from its members, never emitted as a node.
+			expect(ids).not.toContain(chipId);
+
+			const rm1 = result.nodes.find((n) => n.id === 'm1');
+			const rm2 = result.nodes.find((n) => n.id === 'm2');
+			assert(rm1);
+			assert(rm2);
+
+			// Members move as a block, keeping their relative offset.
+			expect(rm2.x - rm1.x).toBe(96);
+			expect(rm2.y - rm1.y).toBe(0);
+			expect(matchesGrid(result)).toBe(true);
+		});
+
+		test('keeps a collapsed group clustered between its external neighbours', () => {
+			const { layout } = createCollapsedGroupSetup();
+			const result = layout('all');
+
+			const before = result.nodes.find((n) => n.id === 'before');
+			const after = result.nodes.find((n) => n.id === 'after');
+			const rm1 = result.nodes.find((n) => n.id === 'm1');
+			const rm2 = result.nodes.find((n) => n.id === 'm2');
+			assert(before);
+			assert(after);
+			assert(rm1);
+			assert(rm2);
+
+			expect(before.x).toBeLessThan(rm1.x);
+			expect(after.x).toBeGreaterThan(rm2.x);
+		});
+
+		test('lays out expanded group members individually and excludes the chip', () => {
+			const m1 = createCanvasGraphNode({ id: 'm1' });
+			const m2 = createCanvasGraphNode({ id: 'm2' });
+			const group = createCanvasGraphGroupNode({
+				id: groupId,
+				nodeIds: ['m1', 'm2'],
+				isCollapsed: false,
+				nodesRect: { x: 96, y: 96, width: 192, height: 96 },
+			});
+
+			// Expanded: members are visible and connected normally.
+			const nodes = [m1, m2, group];
+			const connections: Array<[string, string]> = [['m1', 'm2']];
+
+			const { layout } = createTestSetup(nodes, connections);
+			const result = layout('all');
+
+			const ids = result.nodes.map((n) => n.id);
+			expect(ids).toContain('m1');
+			expect(ids).toContain('m2');
+			expect(ids).not.toContain(chipId);
+
+			const rm1 = result.nodes.find((n) => n.id === 'm1');
+			const rm2 = result.nodes.find((n) => n.id === 'm2');
+			assert(rm1);
+			assert(rm2);
+			expect(rm2.x).toBeGreaterThan(rm1.x);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
@@ -7,10 +7,15 @@ import {
 	isCanvasGroupNode,
 	type BoundingBox,
 	type CanvasConnection,
+	type CanvasGroupNode,
 	type CanvasNodeData,
 } from '../canvas.types';
 import { isPresent } from '@/app/utils/typesUtils';
 import { DEFAULT_NODE_SIZE, GRID_SIZE } from '@/app/utils/nodeViewUtils';
+import {
+	GROUP_HEADER_HEIGHT,
+	GROUP_HEADER_WIDTH_COLLAPSED,
+} from '../stores/canvasNodeGroups.constants';
 import type { ComputedRef, Ref } from 'vue';
 import { computeNodeDisplaySize, type CanvasRenderData } from '../canvas.utils';
 
@@ -25,6 +30,7 @@ export type CanvasLayoutSource =
 export type CanvasLayoutTargetData = {
 	nodes: Array<GraphNode<CanvasNodeData>>;
 	edges: CanvasConnection[];
+	collapsedGroups: CanvasGroupNode[];
 };
 
 export type NodeLayoutResult = {
@@ -64,12 +70,26 @@ export function useCanvasLayout(
 		nodes: allNodes,
 	} = useVueFlow(canvasId);
 
+	function getSourceNodes(target: CanvasLayoutTarget) {
+		return target === 'selection' ? getSelectedNodes.value : allNodes.value;
+	}
+
 	function getTargetData(target: CanvasLayoutTarget): CanvasLayoutTargetData {
-		// Group title-bar nodes are positioned from their nodes' bounding rect, not by dagre.
-		const source = target === 'selection' ? getSelectedNodes.value : allNodes.value;
+		const source = getSourceNodes(target);
+
+		const collapsedGroups = source
+			.filter(isCanvasGroupNode)
+			.filter((node) => node.data.isCollapsed);
+
+		// Collapsed groups: keep the chip as one unit, discard its hidden members
+		// Expanded groups: discard the chip, keep the members
+		const belongsInGraph = (node: GraphNode<CanvasNodeData>) =>
+			isCanvasGroupNode(node) ? node.data.isCollapsed : !node.hidden;
+
 		return {
-			nodes: source.filter((node) => !isCanvasGroupNode(node)),
+			nodes: source.filter(belongsInGraph),
 			edges: allEdges.value,
+			collapsedGroups,
 		};
 	}
 
@@ -96,6 +116,14 @@ export function useCanvasLayout(
 	}
 
 	function getNodeDimensions(node: GraphNode<CanvasNodeData>): { width: number; height: number } {
+		// A collapsed group enters the graph as its fixed-size chip
+		if (isCanvasGroupNode(node)) {
+			return {
+				width: node.dimensions?.width || GROUP_HEADER_WIDTH_COLLAPSED,
+				height: node.dimensions?.height || GROUP_HEADER_HEIGHT,
+			};
+		}
+
 		// Check if dimensions exist and have valid values
 		if (
 			node.dimensions &&
@@ -121,7 +149,7 @@ export function useCanvasLayout(
 		return { width: DEFAULT_NODE_SIZE[0], height: DEFAULT_NODE_SIZE[1] };
 	}
 
-	function createDagreGraph({ nodes, edges }: CanvasLayoutTargetData) {
+	function createDagreGraph({ nodes, edges }: Pick<CanvasLayoutTargetData, 'nodes' | 'edges'>) {
 		const graph = new dagre.graphlib.Graph();
 		graph.setDefaultEdgeLabel(() => ({}));
 
@@ -328,14 +356,14 @@ export function useCanvasLayout(
 
 	function isAiParentNode(node: CanvasNodeData) {
 		return (
-			node.render.type === CanvasNodeRenderType.Default &&
+			node.render?.type === CanvasNodeRenderType.Default &&
 			node.render.options.configurable &&
 			!node.render.options.configuration
 		);
 	}
 
 	function isAiConfigNode(node: CanvasNodeData) {
-		return node.render.type === CanvasNodeRenderType.Default && node.render.options.configuration;
+		return node.render?.type === CanvasNodeRenderType.Default && node.render.options.configuration;
 	}
 
 	function getAllConnectedAiConfigNodes({
@@ -357,7 +385,9 @@ export function useCanvasLayout(
 	}
 
 	function layout(target: CanvasLayoutTarget): CanvasLayoutResult {
-		const { nodes, edges } = getTargetData(target);
+		// Collapsed groups are laid out as single chips — afterwards we translate
+		// their members so each chip lands where dagre placed it
+		const { nodes, edges, collapsedGroups } = getTargetData(target);
 
 		const nonStickyNodes = nodes
 			.filter((node) => node.data.type !== STICKY_NODE_TYPE)
@@ -509,6 +539,32 @@ export function useCanvasLayout(
 					}
 				}
 			});
+
+		// Move hidden nodes by the same offset as their collapsed group chip,
+		// then remove the chip since its position is derived from the nodes
+		for (const groupNode of collapsedGroups) {
+			const chipBox = boundingBoxByNodeId[groupNode.id];
+			if (!chipBox || !groupNode.data) continue;
+
+			const delta = {
+				x: chipBox.x - groupNode.position.x,
+				y: chipBox.y - groupNode.position.y,
+			};
+
+			for (const memberId of groupNode.data.group.nodeIds) {
+				const member = findNode<CanvasNodeData>(memberId);
+				if (!member) continue;
+				const box = boundingBoxFromCanvasNode(member);
+				boundingBoxByNodeId[memberId] = {
+					x: box.x + delta.x,
+					y: box.y + delta.y,
+					width: box.width,
+					height: box.height,
+				};
+			}
+
+			delete boundingBoxByNodeId[groupNode.id];
+		}
 
 		const positionedNodes = Object.entries(boundingBoxByNodeId).map(([id, boundingBox]) => ({
 			id,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
@@ -540,6 +540,9 @@ export function useCanvasLayout(
 				}
 			});
 
+		// Measure while groups are still chips, to match boundingBoxBefore
+		const boundingBoxAfter = compositeBoundingBox(Object.values(boundingBoxByNodeId));
+
 		// Move hidden nodes by the same offset as their collapsed group chip,
 		// then remove the chip since its position is derived from the nodes
 		for (const groupNode of collapsedGroups) {
@@ -570,7 +573,6 @@ export function useCanvasLayout(
 			id,
 			boundingBox,
 		}));
-		const boundingBoxAfter = compositeBoundingBox(positionedNodes.map((node) => node.boundingBox));
 
 		const anchor = {
 			x: boundingBoxAfter.x - boundingBoxBefore.x,


### PR DESCRIPTION
## Summary

Tidy up (Shift+Alt+T / context menu / canvas button) produced messy layouts when the canvas contained **collapsed node groups** - members scattered and the group chip landed in an arbitrary spot.

### Why it happened

Collapsed-group members remain in the graph as hidden nodes, but their edges are remapped to the group's chip. `useCanvasLayout` still passed those hidden members to dagre, which then treated them as disconnected nodes and spread them into separate subgraphs, scattering the group across the canvas.

### The fix

Treat a collapsed group as a single node during layout:
- Keep the group chip in the dagre graph and exclude its hidden members.
- Layout the chip using its collapsed dimensions and existing `group:*` edges.
- After layout, apply the chip's movement to all hidden members so they move as a block and preserve their internal arrangement.
- Do not emit a position for the chip itself; its position is derived from its members.

Expanded groups are unchanged and continue to be laid out node-by-node.

## How to test

1. Build a workflow with a few nodes, group some of them and collapse the group.
2. Add nodes before/after the group and scatter everything.
3. Run tidy up - the collapsed group should stay intact and sit sensibly inline with the rest of the flow; expanding it afterwards shows the members in their original relative arrangement.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5409](https://linear.app/n8n/issue/ADO-5409/feature-make-tidy-up-behavior-work-for-node-groups)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

