### PR TITLE
feat(Microsoft To Do Node): Accept the generic Microsoft OAuth2 (Graph) credential

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -8,6 +8,25 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+export type ToDoCredentialType = 'microsoftToDoOAuth2Api' | 'microsoftOAuth2Api';
+
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftToDoOAuth2Api` so existing workflows (and nodes saved
+ * before the `authentication` selector existed) keep working unchanged, while
+ * allowing the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ */
+export function getToDoCredentialType(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+): ToDoCredentialType {
+	// `0` is the execute item index; in load-options getNodeParameter has no itemIndex
+	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form. Anything
+	// other than the generic value (incl. legacy nodes) resolves to the To Do credential.
+	return this.getNodeParameter('authentication', 0) === 'microsoftOAuth2Api'
+		? 'microsoftOAuth2Api'
+		: 'microsoftToDoOAuth2Api';
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -18,7 +37,8 @@ export async function microsoftApiRequest(
 	_headers: IDataObject = {},
 	option: IDataObject = { json: true },
 ) {
-	const credentials = await this.getCredentials('microsoftToDoOAuth2Api');
+	const credentialType = getToDoCredentialType.call(this);
+	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl
@@ -41,7 +61,7 @@ export async function microsoftApiRequest(
 		if (Object.keys(body).length === 0) {
 			delete options.body;
 		}
-		return await this.helpers.requestOAuth2.call(this, 'microsoftToDoOAuth2Api', options);
+		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}

--- a/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
@@ -35,9 +35,42 @@ export class MicrosoftToDo implements INodeType {
 			{
 				name: 'microsoftToDoOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftToDoOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'To Do OAuth2',
+						value: 'microsoftToDoOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Tasks.ReadWrite) on the credential.',
+					},
+				],
+				default: 'microsoftToDoOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -1,8 +1,9 @@
-import { mockDeep } from 'vitest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
-
-import { microsoftApiRequest } from '../GenericFunctions';
+import type { IExecuteFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { getToDoCredentialType, microsoftApiRequest } from '../GenericFunctions';
+import { MicrosoftToDo } from '../MicrosoftToDo.node';
 
 describe('Microsoft ToDo GenericFunctions', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
@@ -23,6 +24,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			parameters: {},
 		};
 		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
 		vi.clearAllMocks();
 	});
 
@@ -206,6 +208,119 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					}),
 				);
 			});
+		});
+	});
+
+	describe('authentication credential resolution', () => {
+		beforeEach(() => {
+			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				graphApiBaseUrl: 'https://graph.microsoft.us',
+			});
+		});
+
+		it('should use microsoftToDoOAuth2Api when authentication is not set (backward compatibility)', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
+			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
+		});
+
+		it('should use microsoftToDoOAuth2Api when explicitly selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
+			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
+		});
+
+		it('should use microsoftOAuth2Api when the generic credential is selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+		});
+
+		it('should resolve the credential name from the authentication parameter at index 0', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('authentication', 0);
+		});
+
+		it('should honor graphApiBaseUrl from the generic credential (sovereign cloud)', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOAuth2Api',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.us/v1.0/me/todo/lists',
+				}),
+			);
+		});
+	});
+
+	describe('getToDoCredentialType', () => {
+		it('should default to microsoftToDoOAuth2Api when authentication is undefined', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			expect(getToDoCredentialType.call(mockExecuteFunctions)).toBe('microsoftToDoOAuth2Api');
+		});
+
+		it('should return microsoftToDoOAuth2Api when explicitly selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
+
+			expect(getToDoCredentialType.call(mockExecuteFunctions)).toBe('microsoftToDoOAuth2Api');
+		});
+
+		it('should return microsoftOAuth2Api when the generic credential is selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			expect(getToDoCredentialType.call(mockExecuteFunctions)).toBe('microsoftOAuth2Api');
+		});
+	});
+
+	describe('loadOptions credential routing', () => {
+		let mockLoadOptions: Mocked<ILoadOptionsFunctions>;
+		let loadOptionsRequestOAuth2: Mock;
+
+		beforeEach(() => {
+			mockLoadOptions = mockDeep<ILoadOptionsFunctions>();
+			loadOptionsRequestOAuth2 = vi.fn().mockResolvedValue({ value: [] });
+			mockLoadOptions.helpers.requestOAuth2 = loadOptionsRequestOAuth2;
+			mockLoadOptions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+		});
+
+		it('should route getTaskLists through the selected generic credential', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await new MicrosoftToDo().methods.loadOptions.getTaskLists.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOAuth2Api',
+				expect.anything(),
+			);
+		});
+
+		it('should default getTaskLists to the To Do credential', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(undefined);
+
+			await new MicrosoftToDo().methods.loadOptions.getTaskLists.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftToDoOAuth2Api',
+				expect.anything(),
+			);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
@@ -1,0 +1,38 @@
+import type { INodePropertyOptions } from 'n8n-workflow';
+
+import { MicrosoftToDo } from '../MicrosoftToDo.node';
+
+describe('MicrosoftToDo authentication descriptor', () => {
+	const node = new MicrosoftToDo();
+	const { properties, credentials } = node.description;
+
+	const authentication = properties.find((property) => property.name === 'authentication');
+	const toDoCredential = credentials?.find((cred) => cred.name === 'microsoftToDoOAuth2Api');
+	const genericCredential = credentials?.find((cred) => cred.name === 'microsoftOAuth2Api');
+
+	it('exposes an authentication selector offering both credentials', () => {
+		expect(authentication).toBeDefined();
+		expect(authentication?.type).toBe('options');
+		expect(authentication?.noDataExpression).toBe(true);
+
+		const optionValues = (authentication?.options as INodePropertyOptions[]).map(
+			(option) => option.value,
+		);
+		expect(optionValues).toEqual(['microsoftToDoOAuth2Api', 'microsoftOAuth2Api']);
+	});
+
+	it('defaults to the To Do credential and gates it on that value (backward compatibility)', () => {
+		// A node saved before the selector existed has no `authentication` parameter; it keeps
+		// working only because the backfilled default equals the value gating the To Do credential.
+		expect(authentication?.default).toBe('microsoftToDoOAuth2Api');
+		expect(toDoCredential?.required).toBe(true);
+		expect(toDoCredential?.displayOptions?.show?.authentication).toEqual([
+			'microsoftToDoOAuth2Api',
+		]);
+	});
+
+	it('gates the generic credential behind the generic option', () => {
+		expect(genericCredential?.required).toBe(true);
+		expect(genericCredential?.displayOptions?.show?.authentication).toEqual(['microsoftOAuth2Api']);
+	});
+});


### PR DESCRIPTION
## Summary

Lets the **Microsoft To Do** node authenticate with **either** the existing node-specific `microsoftToDoOAuth2Api` credential (default) **or** the generic `microsoftOAuth2Api` ("Microsoft OAuth2 API", Graph) credential, selected via a new **Authentication** dropdown.

This is **additive and non-breaking**: `microsoftToDoOAuth2Api` stays the default, so every already-saved To Do workflow keeps working unchanged. The generic credential lets Entra-managed / enterprise tenants drive To Do from a single, centrally-administered Graph app registration with an explicitly-entered delegated scope (`Tasks.ReadWrite`, which is user-consentable — no admin consent required).

Mirrors the pattern already merged for **Microsoft Excel 365** (ENT-56, #32434) and **Microsoft OneDrive** (ENT-53), and in-flight for **Microsoft Teams** (ENT-58).

### What changed

- **`GenericFunctions.ts`** — added a `getToDoCredentialType()` helper that resolves the credential name from the `authentication` node parameter, defaulting to `microsoftToDoOAuth2Api`. Both auth sites in `microsoftApiRequest` (`getCredentials` and `requestOAuth2`) now use the single resolved value. Because the `getTaskLists` loadOptions method and both paged helpers all funnel through `microsoftApiRequest`, parameterizing this one function covers the `execute` and `loadOptions` paths alike — it's the node's sole auth chokepoint.
- **`MicrosoftToDo.node.ts`** — split the single `credentials[]` entry into two `displayOptions`-gated entries and added a top-level `authentication` options property (`default: 'microsoftToDoOAuth2Api'`).

### Backward compatibility (the critical bit)

Saved To Do nodes have no stored `authentication` parameter and there is no DB migration for node parameters. They keep working because `options`-type properties are default-backfilled when the workflow is built — **and** because the new property's default (`microsoftToDoOAuth2Api`) equals the value that gates the existing To Do credential entry. `getToDoCredentialType` is defensive: anything other than the exact generic value (including a legacy/undefined value) resolves to `microsoftToDoOAuth2Api`. This contract is pinned by a dedicated descriptor test plus transport tests.

> **Sovereign cloud:** the To Do transport already honors `credentials.graphApiBaseUrl`, so selecting the generic credential picks up US Gov / DOD / China endpoints automatically (covered by the existing base-URL tests, which stay green).

## How to test

1. Open a **Microsoft To Do** node. The new **Authentication** dropdown shows **To Do OAuth2** (default) and **Microsoft OAuth2 (Graph)**; the matching credential field renders for each choice.
2. With **To Do OAuth2**, behaviour is unchanged.
3. With **Microsoft OAuth2 (Graph)**, create a generic `microsoftOAuth2Api` credential whose Scope field contains `openid offline_access Tasks.ReadWrite`, and add the delegated `Tasks.ReadWrite` permission to the Entra app registration (no admin consent needed).
4. Verify one operation per resource (e.g. Task → Create, List → Create, Linked Resource → Create) and the task-list picker (loadOptions) all succeed via the selected credential.
5. **Backward compat:** a To Do workflow saved before this change executes unchanged (resolves to `microsoftToDoOAuth2Api`).

Automated coverage (`packages/nodes-base`, all green — 21 tests):
- `nodes/Microsoft/ToDo/test/GenericFunctions.test.ts` — credential resolution (default / explicit / generic), `getNodeParameter('authentication', 0)`, sovereign base URL via the generic credential, the 8 existing base-URL tests, and `getTaskLists` (loadOptions) routing.
- `nodes/Microsoft/ToDo/test/authentication.test.ts` — descriptor contract: selector exists with both options, default equals the To Do credential's gate value (backward compat), both credentials gated and required.

## Screenshots

### ToDo lists get many responses:

<img width="1806" height="899" alt="image" src="https://github.com/user-attachments/assets/ea96f9f1-f8c8-48b8-8ae3-5272e018cbd8" />

### Credential config

<img width="1806" height="899" alt="image" src="https://github.com/user-attachments/assets/52e74563-4848-46b7-89a0-93091572ec84" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-54

## Follow-ups (not in this PR)

- **Docs** (`n8n-io/n8n-docs`): document the new Authentication option and the `Tasks.ReadWrite` scope string on the To Do and generic-credential pages — companion to the Excel/OneDrive docs PR (#4827).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. *(docs follow-up noted above)*
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (not needed — additive feature).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

