### PR TITLE
chore(core): Add debug logs to publication outbox processing (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -7,6 +7,7 @@ import type {
 	WorkflowHistoryRepository,
 	WorkflowRepository,
 } from '@n8n/db';
+import type { Logger } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 import type { INode } from 'n8n-workflow';
 import { WebhookPathTakenError } from 'n8n-workflow';
@@ -15,12 +16,15 @@ import { WorkflowPublicationApplier } from '@/workflows/publication/workflow-pub
 import type { WorkflowTriggerActivator } from '@/workflows/triggers/workflow-trigger-activator';
 
 describe('WorkflowPublicationApplier', () => {
+	const logger = mock<Logger>();
+	logger.scoped.mockReturnValue(logger);
 	const workflowRepository = mock<WorkflowRepository>();
 	const workflowHistoryRepository = mock<WorkflowHistoryRepository>();
 	const workflowPublishedVersionRepository = mock<WorkflowPublishedVersionRepository>();
 	const workflowTriggerActivator = mock<WorkflowTriggerActivator>();
 
 	const applier = new WorkflowPublicationApplier(
+		logger,
 		workflowRepository,
 		workflowHistoryRepository,
 		workflowPublishedVersionRepository,

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import {
 	WorkflowEntity,
 	WorkflowHistory,
@@ -30,11 +31,14 @@ import {
 @Service()
 export class WorkflowPublicationApplier {
 	constructor(
+		private readonly logger: Logger,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly workflowHistoryRepository: WorkflowHistoryRepository,
 		private readonly workflowPublishedVersionRepository: WorkflowPublishedVersionRepository,
 		private readonly workflowTriggerActivator: WorkflowTriggerActivator,
-	) {}
+	) {
+		this.logger = this.logger.scoped('workflow-publication');
+	}
 
 	/**
 	 * Reconciles the workflow's triggers to the version requested by `record`. It
@@ -77,6 +81,13 @@ export class WorkflowPublicationApplier {
 		const desiredTriggerNodes = this.workflowTriggerActivator.getEnabledTriggerNodes(newVersion);
 
 		const { toAdd, toRemove } = computeTriggerDiff(oldTriggerNodes, desiredTriggerNodes);
+
+		this.logger.debug('Calculated trigger diff for workflow publication', {
+			workflowId: record.workflowId,
+			publishedVersionId: record.publishedVersionId,
+			toAdd: Array.from(toAdd),
+			toRemove: Array.from(toRemove),
+		});
 
 		// We also register triggers that are in our desired state that aren't
 		// present locally, even if they aren't in this version diff. This is

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -131,6 +131,12 @@ export class WorkflowPublicationOutboxConsumer {
 	 * for a later poll cycle to retry.
 	 */
 	async processRecord(record: WorkflowPublicationOutbox): Promise<void> {
+		this.logger.debug('Started processing workflow publication outbox record', {
+			outboxId: record.id,
+			workflowId: record.workflowId,
+			publishedVersionId: record.publishedVersionId,
+		});
+
 		let result: PublicationResult;
 
 		try {
@@ -148,5 +154,11 @@ export class WorkflowPublicationOutboxConsumer {
 		} catch (reportError) {
 			this.errorReporter.error(reportError, { shouldBeLogged: true });
 		}
+
+		this.logger.debug('Finished processing workflow publication outbox record', {
+			outboxId: record.id,
+			workflowId: record.workflowId,
+			result: result.type,
+		});
 	}
 }

--- a/packages/cli/src/workflows/triggers/non-webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/non-webhook-trigger-registrar.ts
@@ -47,7 +47,7 @@ export class NonWebhookTriggerRegistrar {
 		private readonly activeWorkflowTriggers: ActiveWorkflowTriggers,
 		private readonly triggerExecutionContextFactory: TriggerExecutionContextFactory,
 	) {
-		this.logger = this.logger.scoped(['workflow-activation']);
+		this.logger = this.logger.scoped('workflow-publication');
 	}
 
 	/**
@@ -141,5 +141,7 @@ export class NonWebhookTriggerRegistrar {
 	 */
 	async deregister(workflowId: WorkflowId, nodeId: INode['id']) {
 		await this.activeWorkflowTriggers.removeTriggers(workflowId, new Set([nodeId]));
+
+		this.logger.debug(`Deactivating non-webhook trigger "${nodeId}" for workflow "${workflowId}"`);
 	}
 }

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -49,7 +49,7 @@ export class WebhookTriggerRegistrar {
 		private readonly webhookService: WebhookService,
 		private readonly workflowStaticDataService: WorkflowStaticDataService,
 	) {
-		this.logger = this.logger.scoped(['workflow-activation']);
+		this.logger = this.logger.scoped('workflow-publication');
 	}
 
 	/**
@@ -112,6 +112,11 @@ export class WebhookTriggerRegistrar {
 	 */
 	async deregister({ workflow, webhookData }: WebhookTriggerDeregistrationOptions) {
 		await this.webhookService.deleteWebhook(workflow, webhookData, 'internal', 'update');
+
+		this.logger.debug(
+			`Deactivating webhook trigger "${webhookData.node}" for workflow "${workflow.name}"`,
+			{ workflowId: workflow.id, nodeName: webhookData.node },
+		);
 
 		return webhookData.node;
 	}


### PR DESCRIPTION
## Summary

Adds debug-level logging across the workflow publication outbox flow so a single record's lifecycle can be traced end-to-end. The consumer now logs when it starts and finishes processing a record (with the outcome type), the applier logs the computed trigger diff (node IDs to add/remove), and the webhook / non-webhook registrars log when a trigger is deactivated — mirroring the existing "Added …" activation logs. Both registrars' logger scope was moved from `workflow-activation` to `workflow-publication` so all publication trigger operations group under one scope.

## How to test

Run the instance with `N8N_LOG_LEVEL=debug` and the publication service enabled, then publish a workflow that adds and removes a trigger. Confirm the log sequence: `Started processing…` → `Calculated trigger diff…` → `Deactivating … trigger…` → `Added … trigger…` → `Finished processing… { result: 'completed' }`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3486

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

