### PR TITLE
feat(Google contacts): Add URL fields to contacts

### DIFF
--- a/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
@@ -600,7 +600,7 @@ export const contactFields: INodeProperties[] = [
 						],
 					},
 				],
-			}
+			},
 		],
 	},
 	/* -------------------------------------------------------------------------- */
@@ -1677,7 +1677,7 @@ export const contactFields: INodeProperties[] = [
 						],
 					},
 				],
-			}
+			},
 		],
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/ContactDescription.ts
@@ -534,6 +534,73 @@ export const contactFields: INodeProperties[] = [
 					},
 				],
 			},
+			{
+				displayName: 'URLs',
+				name: 'urlsUi',
+				type: 'fixedCollection',
+				default: {},
+				placeholder: 'Add URL',
+				typeOptions: {
+					multipleValues: true,
+				},
+				options: [
+					{
+						name: 'urlsValues',
+						displayName: 'URL',
+						values: [
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								options: [
+									{
+										name: 'Home',
+										value: 'home',
+									},
+									{
+										name: 'Work',
+										value: 'work',
+									},
+									{
+										name: 'Blog',
+										value: 'blog',
+									},
+									{
+										name: 'Profile',
+										value: 'profile',
+									},
+									{
+										name: 'Home Page',
+										value: 'homePage',
+									},
+									{
+										name: 'FTP',
+										value: 'ftp',
+									},
+									{
+										name: 'Reservations',
+										value: 'reservations',
+									},
+									{
+										name: 'Other',
+										value: 'other',
+									},
+								],
+								default: '',
+								description:
+									'The type of the URL. The type can be custom or one of these predefined values.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The URL',
+							},
+						],
+					},
+				],
+			}
 		],
 	},
 	/* -------------------------------------------------------------------------- */
@@ -1544,6 +1611,73 @@ export const contactFields: INodeProperties[] = [
 					},
 				],
 			},
+			{
+				displayName: 'URLs',
+				name: 'urlsUi',
+				type: 'fixedCollection',
+				default: {},
+				placeholder: 'Add URL',
+				typeOptions: {
+					multipleValues: true,
+				},
+				options: [
+					{
+						name: 'urlsValues',
+						displayName: 'URL',
+						values: [
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								options: [
+									{
+										name: 'Home',
+										value: 'home',
+									},
+									{
+										name: 'Work',
+										value: 'work',
+									},
+									{
+										name: 'Blog',
+										value: 'blog',
+									},
+									{
+										name: 'Profile',
+										value: 'profile',
+									},
+									{
+										name: 'Home Page',
+										value: 'homePage',
+									},
+									{
+										name: 'FTP',
+										value: 'ftp',
+									},
+									{
+										name: 'Reservations',
+										value: 'reservations',
+									},
+									{
+										name: 'Other',
+										value: 'other',
+									},
+								],
+								default: '',
+								description:
+									'The type of the URL. The type can be custom or one of these predefined values.',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The URL',
+							},
+						],
+					},
+				],
+			}
 		],
 	},
 ];

--- a/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
+++ b/packages/nodes-base/nodes/Google/Contacts/GoogleContacts.node.ts
@@ -214,6 +214,12 @@ export class GoogleContacts implements INodeType {
 							];
 						}
 
+						if (additionalFields.urlsUi) {
+							const urlsValues = (additionalFields.urlsUi as IDataObject)
+								.urlsValues as IDataObject[];
+							body.urls = urlsValues;
+						}
+
 						if (additionalFields.customFieldsUi) {
 							const customFieldsValues = (additionalFields.customFieldsUi as IDataObject)
 								.customFieldsValues as IDataObject[];
@@ -477,6 +483,13 @@ export class GoogleContacts implements INodeType {
 								},
 							];
 							updatePersonFields.push('biographies');
+						}
+
+						if (updateFields.urlsUi) {
+							const urlsValues = (updateFields.urlsUi as IDataObject)
+								.urlsValues as IDataObject[];
+							body.urls = urlsValues;
+							updatePersonFields.push('urls');
 						}
 
 						if (updateFields.customFieldsUi) {

--- a/packages/nodes-base/nodes/Google/Contacts/test/contact-create-full.workflow.json
+++ b/packages/nodes-base/nodes/Google/Contacts/test/contact-create-full.workflow.json
@@ -75,6 +75,18 @@
 							}
 						]
 					},
+					"urlsUi": {
+						"urlsValues": [
+							{
+								"value": "https://example.com",
+								"type": "work"
+							},
+							{
+								"value": "https://linkedin.com/in/janesmith",
+								"type": "profile"
+							}
+						]
+					},
 					"customFieldsUi": {
 						"customFieldsValues": [
 							{


### PR DESCRIPTION
## Summary

Adds support for URL fields in the Google Contacts node.

Adds a new URLs fixed collection field to Google Contacts contact create and update operations. Users can now provide one or more contact URLs, including predefined Google Contacts URL types such as work, home, blog, profile, home page, FTP, reservations, and other.

## How to test

Add additonal fields to Google Contacts node when making request.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

