### PR TITLE
feat(editor): Surface execution data size in the executions view

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/typesUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/typesUtils.test.ts
@@ -1,4 +1,4 @@
-import { isEmpty, intersection, isValidDate } from '@/app/utils/typesUtils';
+import { isEmpty, intersection, isValidDate, formatBytes } from '@/app/utils/typesUtils';
 
 describe('Types Utils', () => {
 	describe('isEmpty', () => {
@@ -38,6 +38,22 @@ describe('Types Utils', () => {
 			expect(
 				intersection([1, 2, 2, 3, 4], [2, 3, 3, 4], [2, 1, 5, 4, 4, 1], [2, 4, 5, 5, 6, 7]),
 			).toEqual([2, 4]);
+		});
+	});
+
+	describe('formatBytes', () => {
+		test.each([
+			[0, '0B'],
+			[512, '512B'],
+			[1023, '1023B'],
+			[1024, '1KB'],
+			[1536, '2KB'],
+			[100 * 1024 + 44 * 1024, '144KB'],
+			[1024 * 1024 - 1, '1024KB'],
+			[1024 * 1024, '1MB'],
+			[5 * 1024 * 1024, '5MB'],
+		])('formats %i bytes as %s', (input, expected) => {
+			expect(formatBytes(input)).toBe(expected);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/utils/typesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/typesUtils.ts
@@ -68,6 +68,12 @@ export function toMegaBytes(bytes: number, decimalPlaces: number = 2): number {
 	return parseFloat(megabytes.toFixed(decimalPlaces));
 }
 
+export function formatBytes(sizeInBytes: number): string {
+	if (sizeInBytes < 1024) return `${sizeInBytes}B`;
+	if (sizeInBytes < 1024 * 1024) return `${Math.round(sizeInBytes / 1024)}KB`;
+	return `${Math.round(sizeInBytes / (1024 * 1024))}MB`;
+}
+
 export function shorten(s: string, limit: number, keep: number) {
 	if (s.length <= limit) {
 		return s;

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
@@ -388,6 +388,40 @@ describe('WorkflowExecutionsPreview.vue', () => {
 		expect(queryByTestId('execution-preview-ellipsis-button')).not.toBeInTheDocument();
 	});
 
+	describe('execution data size', () => {
+		it('shows the combined json + binary size in human-readable form', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					execution: {
+						...executionData,
+						status: 'success',
+						jsonSizeBytes: 100 * 1024,
+						binaryDataSizeBytes: 44 * 1024,
+					},
+				},
+			});
+
+			await nextTick();
+
+			expect(getByTestId('execution-preview-id').textContent).toContain('144KB');
+		});
+
+		it('omits the size segment when both sizes are zero/undefined', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					execution: { ...executionData, status: 'success' },
+				},
+			});
+
+			await nextTick();
+
+			const header = getByTestId('execution-preview-id').textContent ?? '';
+			expect(header).toContain('ID#');
+			expect(header).not.toContain('KB');
+			expect(header).not.toContain('MB');
+		});
+	});
+
 	describe('workflow version link', () => {
 		const makeVersion = (overrides: Partial<WorkflowVersion> = {}): WorkflowVersion => ({
 			versionId: faker.string.uuid(),

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -11,6 +11,7 @@ import { useToast } from '@/app/composables/useToast';
 import { useMessage } from '@/app/composables/useMessage';
 import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
+import { formatBytes } from '@/app/utils/typesUtils';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -167,6 +168,12 @@ const executionMetaText = computed(() => {
 	return null;
 });
 
+const executionDataSize = computed(() => {
+	if (!props.execution) return null;
+	const total = (props.execution.jsonSizeBytes ?? 0) + (props.execution.binaryDataSizeBytes ?? 0);
+	return total > 0 ? formatBytes(total) : null;
+});
+
 watch(
 	() => props.execution?.workflowVersionId,
 	async (versionId) => {
@@ -316,6 +323,7 @@ const onVoteClick = async (voteValue: AnnotationVote) => {
 						color="text-base"
 						size="medium"
 					>
+						<template v-if="executionDataSize">| {{ executionDataSize }}</template>
 						| ID#{{ execution.id }}
 						<template v-if="workflowVersionLabel && workflowVersionRoute">
 							|
@@ -339,6 +347,7 @@ const onVoteClick = async (voteValue: AnnotationVote) => {
 						data-test-id="execution-preview-id"
 					>
 						{{ executionMetaText }}
+						<template v-if="executionDataSize">| {{ executionDataSize }}</template>
 						| ID#{{ execution.id }}
 						<template v-if="workflowVersionLabel && workflowVersionRoute">
 							|


### PR DESCRIPTION
## Summary

Surfaces the execution data size as a human-readable value in the execution detail header in the Executions view, next to the running time and execution ID (e.g. `Succeeded in 114ms | 144KB | ID#26 | Autosave`).

The displayed value is the **combined** `jsonSizeBytes + binaryDataSizeBytes` already stored on the execution row (added in CAT-3382 and CAT-3445) and already served by both the list and detail execution endpoints — so this is a frontend-only change. The segment is hidden when the total is `0`/undefined.

Formatting reuses the existing B/KB/MB convention used elsewhere in the editor UI (1024-based division, decimal-style labels) for consistency.

## How to test

1. Run any workflow so an execution is saved.
2. Open the workflow's **Executions** tab and select an execution.
3. The header should show the data size between the running time and `ID#`, e.g. `Succeeded in 114ms | 144KB | ID#26`.
4. Executions with no recorded size (0 bytes) show no size segment.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3448

Follows up on CAT-3382 and CAT-3445.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32505">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

