### PR TITLE
test(core): Stabilize flaky task runner process connect waits (no-changelog)

### DIFF
--- a/packages/cli/test/integration/task-runners/task-runner-process.test.ts
+++ b/packages/cli/test/integration/task-runners/task-runner-process.test.ts
@@ -13,6 +13,11 @@ describe('TaskRunnerProcess', () => {
 	// per-test timeout, so give this spawn-heavy suite extra headroom.
 	jest.setTimeout(30_000);
 
+	// Every `start()` spawns a `node` child process and waits for the WebSocket
+	// handshake to complete. Under CI load that can comfortably exceed the default
+	// 5s `retryUntil` window, so allow a longer window for all connect waits.
+	const CONNECT_TIMEOUT_MS = 15_000;
+
 	const { config, server: taskRunnerServer } = setupBrokerTestServer({
 		mode: 'internal',
 	});
@@ -45,7 +50,9 @@ describe('TaskRunnerProcess', () => {
 		expect(runnerProcess.isRunning).toBeTruthy();
 
 		// Wait until the runner has connected
-		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1));
+		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), {
+			timeoutMs: CONNECT_TIMEOUT_MS,
+		});
 		expect(getNumRegisteredRunners()).toBe(1);
 	});
 
@@ -54,7 +61,9 @@ describe('TaskRunnerProcess', () => {
 		await runnerProcess.start();
 
 		// Wait until the runner has connected
-		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1));
+		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), {
+			timeoutMs: CONNECT_TIMEOUT_MS,
+		});
 		expect(getNumRegisteredRunners()).toBe(1);
 
 		// Act
@@ -73,7 +82,9 @@ describe('TaskRunnerProcess', () => {
 		await runnerProcess.start();
 
 		// Wait until the runner has connected
-		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1));
+		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), {
+			timeoutMs: CONNECT_TIMEOUT_MS,
+		});
 		const processId = runnerProcess.pid;
 
 		// Act
@@ -87,7 +98,9 @@ describe('TaskRunnerProcess', () => {
 		// Wait until the runner has connected again. Restarting spawns a fresh
 		// child process and re-runs the WebSocket handshake, which is slower and
 		// more load-sensitive than the initial connect, so allow a longer window.
-		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), { timeoutMs: 15_000 });
+		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), {
+			timeoutMs: CONNECT_TIMEOUT_MS,
+		});
 		expect(getNumConnectedRunners()).toBe(1);
 		expect(getNumRegisteredRunners()).toBe(1);
 		expect(runnerProcess.pid).not.toBe(processId);


### PR DESCRIPTION
## Summary

The `TaskRunnerProcess › should restart the task runner if it exits` integration test flakes on CI at the *initial* connect wait (line 76). Each `runnerProcess.start()` spawns a `node` child process and waits for a full WebSocket handshake, which under CI contention can exceed the default 5s `retryUntil` window, leaving `getNumConnectedRunners()` at `0`. A prior fix only widened the post-restart connect; this change hoists a shared `CONNECT_TIMEOUT_MS = 15_000` and applies it to all four spawn-and-connect waits so the whole spawn-heavy suite gets consistent headroom. The longer ceiling only affects the failure path — the happy path still resolves as soon as the runner connects.

## How to test

Run the suite locally and confirm all 4 tests pass:

```
cd packages/cli && pnpm test test/integration/task-runners/task-runner-process.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

N/A — CI flakiness follow-up to #32184.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32514">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

