### PR TITLE
fix(core): Stop sending feature flags on telemetry events (no-changelog)

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -78,7 +78,6 @@ describe('PostHog', () => {
 			distinctId: userId,
 			event,
 			properties,
-			sendFeatureFlags: true,
 		});
 	});
 
@@ -119,7 +118,6 @@ describe('PostHog', () => {
 		expect(PostHog.prototype.capture).toHaveBeenCalledWith({
 			distinctId: `${instanceId}#user-1`,
 			event: '$groupidentify',
-			sendFeatureFlags: true,
 			properties: {
 				$group_type: 'company',
 				$group_key: instanceId,
@@ -140,7 +138,6 @@ describe('PostHog', () => {
 		expect(PostHog.prototype.capture).toHaveBeenCalledWith({
 			distinctId: `company_${instanceId}`,
 			event: '$groupidentify',
-			sendFeatureFlags: true,
 			properties: {
 				$group_type: 'company',
 				$group_key: instanceId,

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -56,7 +56,6 @@ export class PostHogClient {
 		this.postHog?.capture({
 			event: payload.event,
 			distinctId: payload.userId,
-			sendFeatureFlags: true,
 			properties: payload.properties,
 			...(typeof instanceId === 'string' && {
 				groups: { [POSTHOG_GROUP_TYPE_INSTANCE]: instanceId },
@@ -78,7 +77,6 @@ export class PostHogClient {
 		this.postHog?.capture({
 			distinctId: distinctId ?? `${POSTHOG_GROUP_TYPE_INSTANCE}_${instanceId}`,
 			event: '$groupidentify',
-			sendFeatureFlags: true,
 			properties: {
 				$group_type: POSTHOG_GROUP_TYPE_INSTANCE,
 				$group_key: instanceId,


### PR DESCRIPTION
## Summary

I'm an engineer on the Feature Flags team at PostHog. I've been working with Christophe Eynius Tranberg (@ceyniustranberg) and Leonhard Prinz (@leonhardprinz) to figure out why n8n sends such a high volume of `$feature_flag_called` events to PostHog. This PR fixes one of the bigger contributors on the server side.
  
`PostHogClient.track()` and `PostHogClient.groupIdentify()` both pass `sendFeatureFlags: true` on every `capture()` call (`packages/cli/src/posthog/index.ts`). That flag tells the posthog-node SDK to fetch `/flags` once for every event it sends. So every telemetry event and every group identify triggers a flag evaluation, which is where the `$feature_flag_called` volume comes from.

It adds up fast. There are around 88 distinct telemetry event types, plus the `pulse` flush that runs every 6 hours and emits a separate event per workflow, per agent, and per user. Run that across a lot of self-hosted instances and you get a steady stream of flag requests that nobody is actually reading.

These are diagnostic events. They don't branch on flag values, so they don't need flags attached. This PR drops `sendFeatureFlags: true` from both calls.

`sendFeatureFlags: true` used to be required for the old experiments engine, which evaluated flags and attached them to events server-side at capture time. The new experiments engine no longer works that way, so telemetry events don't need flags attached for experiments to function.

The real flag read path is untouched. `getFeatureFlags()` already does the right thing: one batched `evaluateFlags()` call with a 10 minute in-memory cache keyed by `instanceId#userId`. That's the path that should be making flag requests, and it still does.

## How to test

This only touches telemetry, so there's no workflow behavior to exercise.

- Unit tests: `pnpm --filter n8n test src/posthog`. The existing `PostHogClient` tests now assert `capture()` is called without `sendFeatureFlags`.
- Manual: with diagnostics enabled, do something that gets tracked (create a credential, say) and confirm no `/flags` request fires for that event.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32515">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

