### PR TITLE
feat(Microsoft Outlook Node): Accept the generic Microsoft OAuth2 (Graph) credential

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
@@ -61,8 +61,6 @@ export class MicrosoftOutlookTrigger implements INodeType {
 					{
 						name: 'Microsoft OAuth2 (Graph)',
 						value: 'microsoftOAuth2Api',
-						description:
-							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Mail.ReadWrite) on the credential.',
 					},
 				],
 				default: 'microsoftOutlookOAuth2Api',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/MicrosoftOutlookTrigger.node.ts
@@ -28,12 +28,45 @@ export class MicrosoftOutlookTrigger implements INodeType {
 			{
 				name: 'microsoftOutlookOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOutlookOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		polling: true,
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Outlook OAuth2',
+						value: 'microsoftOutlookOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Mail.ReadWrite) on the credential.',
+					},
+				],
+				default: 'microsoftOutlookOAuth2Api',
+			},
 			{
 				displayName: 'Trigger On',
 				name: 'event',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
@@ -1,8 +1,8 @@
-import { mockDeep } from 'vitest-mock-extended';
-import type { ILoadOptionsFunctions } from 'n8n-workflow';
-
-import { getSubfolders } from '../../../v2/transport';
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { getOutlookCredentialType, getSubfolders } from '../../../v2/transport';
 
 describe('MicrosoftOutlookV2 - getSubfolders', () => {
 	let mockLoadOptionsFunctions: Mocked<ILoadOptionsFunctions>;
@@ -89,5 +89,37 @@ describe('MicrosoftOutlookV2 - getSubfolders', () => {
 			{ id: 'inbox', displayName: 'Inbox', childFolderCount: 1 },
 			{ id: 'work', displayName: 'Work', childFolderCount: 0 },
 		]);
+	});
+});
+
+describe('MicrosoftOutlookV2 - getOutlookCredentialType', () => {
+	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+	});
+
+	it('should return the selected credential when authentication is set to the generic credential', () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+		const result = getOutlookCredentialType.call(mockExecuteFunctions);
+
+		expect(result).toBe('microsoftOAuth2Api');
+	});
+
+	it('should fall back to microsoftOutlookOAuth2Api when authentication is not set', () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+		const result = getOutlookCredentialType.call(mockExecuteFunctions);
+
+		expect(result).toBe('microsoftOutlookOAuth2Api');
+	});
+
+	it('should fall back to microsoftOutlookOAuth2Api when authentication is an empty string', () => {
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('');
+
+		const result = getOutlookCredentialType.call(mockExecuteFunctions);
+
+		expect(result).toBe('microsoftOutlookOAuth2Api');
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/node.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/node.description.ts
@@ -30,11 +30,42 @@ export const description: INodeTypeDescription = {
 		{
 			name: 'microsoftOutlookOAuth2Api',
 			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['microsoftOutlookOAuth2Api'],
+				},
+			},
+		},
+		{
+			name: 'microsoftOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['microsoftOAuth2Api'],
+				},
+			},
 		},
 	],
 	waitingNodeTooltip: SEND_AND_WAIT_WAITING_TOOLTIP,
 	webhooks: sendAndWaitWebhooksDescription,
 	properties: [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			noDataExpression: true,
+			options: [
+				{
+					name: 'Outlook OAuth2',
+					value: 'microsoftOutlookOAuth2Api',
+				},
+				{
+					name: 'Microsoft OAuth2 (Graph)',
+					value: 'microsoftOAuth2Api',
+				},
+			],
+			default: 'microsoftOutlookOAuth2Api',
+		},
 		{
 			displayName: 'Resource',
 			name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/test/transport/index.test.ts
@@ -207,5 +207,37 @@ describe('Microsoft Outlook Transport', () => {
 				);
 			});
 		});
+
+		describe('credential type resolution', () => {
+			it('should use microsoftOutlookOAuth2Api when authentication is not set (backward compatibility)', async () => {
+				mockRequestWithAuthentication.mockResolvedValue({ data: 'test' });
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+				mockExecuteFunctions.getCredentials.mockResolvedValue({});
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/messages');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+					'microsoftOutlookOAuth2Api',
+				);
+				expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+					'microsoftOutlookOAuth2Api',
+					expect.anything(),
+				);
+			});
+
+			it('should route through microsoftOAuth2Api when the generic credential is selected', async () => {
+				mockRequestWithAuthentication.mockResolvedValue({ data: 'test' });
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+				mockExecuteFunctions.getCredentials.mockResolvedValue({});
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/messages');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+				expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+					'microsoftOAuth2Api',
+					expect.anything(),
+				);
+			});
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/transport/index.ts
@@ -11,6 +11,22 @@ import type {
 
 import { prepareApiError } from '../helpers/utils';
 
+export type OutlookCredentialType = 'microsoftOutlookOAuth2Api' | 'microsoftOAuth2Api';
+
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftOutlookOAuth2Api` so existing workflows (and nodes
+ * without the `authentication` selector) keep working unchanged, while allowing
+ * the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ */
+export function getOutlookCredentialType(
+	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IPollFunctions,
+): OutlookCredentialType {
+	return this.getNodeParameter('authentication', 0) === 'microsoftOAuth2Api'
+		? 'microsoftOAuth2Api'
+		: 'microsoftOutlookOAuth2Api';
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -21,7 +37,8 @@ export async function microsoftApiRequest(
 	headers: IDataObject = {},
 	option: IDataObject = { json: true },
 ) {
-	const credentials = await this.getCredentials('microsoftOutlookOAuth2Api');
+	const credentialType = getOutlookCredentialType.call(this);
+	const credentials = await this.getCredentials(credentialType);
 
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
@@ -55,11 +72,7 @@ export async function microsoftApiRequest(
 			delete options.body;
 		}
 
-		return await this.helpers.requestWithAuthentication.call(
-			this,
-			'microsoftOutlookOAuth2Api',
-			options,
-		);
+		return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 	} catch (error) {
 		if (
 			((error.message || '').toLowerCase().includes('bad request') ||


### PR DESCRIPTION
## Summary

Adds the generic `microsoftOAuth2Api` (Microsoft Graph) credential as a selectable authentication option on the Microsoft Outlook **v2** action node and the **Outlook Trigger** node, alongside the existing `microsoftOutlookOAuth2Api`.

The change is **additive and non-breaking**: existing workflows continue to authenticate with the Outlook-specific credential. The `authentication` selector defaults to `microsoftOutlookOAuth2Api`, and saved nodes (which have no stored `authentication` parameter) are default-backfilled to it, so they resolve to the same credential as before.

Implementation follows the pattern already shipped for OneDrive and Excel — the option values are the credential names themselves, so the resolver passes the selected value straight through:

- **Transport** (`v2/transport/index.ts`): new `getOutlookCredentialType()` resolves the credential type at runtime and is used in both `getCredentials` and `requestWithAuthentication`. A single transport change covers the v2 action node, the Outlook Trigger (its poll path reuses the v2 transport), and the v2 `listSearch`/`loadOptions` methods.
- **Descriptors**: the v2 action node and the Trigger each gain an `authentication` selector and split their single `credentials[]` entry into two `displayOptions`-gated entries.
- Sovereign-cloud `graphApiBaseUrl` continues to flow through unchanged.

> Note: because `authentication` is the node's main auth field, n8n hides it from the node settings and merges both credential types into the single **Credential** picker (the standard "mixed credentials" UX, same as OneDrive/Excel). There is no separate visible "Authentication" dropdown.

Out of scope (per ticket): Outlook v1, reducing baked scopes, replacing the Outlook-specific credential. Documentation updates are tracked separately in `n8n-io/n8n-docs`.

## How to test

1. Create a generic **Microsoft OAuth2 API** credential with the Outlook Graph scopes:
   `openid offline_access Contacts.Read Contacts.ReadWrite Calendars.Read Calendars.Read.Shared Calendars.ReadWrite Mail.ReadWrite Mail.ReadWrite.Shared Mail.Send Mail.Send.Shared MailboxSettings.Read`
2. Add a **Microsoft Outlook** node — the Credential picker now lists generic `microsoftOAuth2Api` credentials alongside any `microsoftOutlookOAuth2Api` ones. Run e.g. **Message → Get Many** and confirm it succeeds.
3. Confirm an existing workflow using a `microsoftOutlookOAuth2Api` credential still runs unchanged (backward compatibility).
4. Repeat with the **Microsoft Outlook Trigger** (Message Received), including the sovereign-cloud base URL flowing through when set on the generic credential.

Successful execution:

https://github.com/user-attachments/assets/89df9dc3-b951-4288-8bb4-08d5828bf6eb



## Related tickets

https://linear.app/n8n/issue/ENT-57

docs: https://github.com/n8n-io/n8n-docs/pull/4839/changes

## Review / Merge checklist

- [ ] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md).
- [x] Tests included. (Backward-compat + generic-routing tests added under `v2/test/transport` and `test/v2/transport`.)
- [x] Docs updated — tracked separately in `n8n-io/n8n-docs`.



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32531">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->