### PR TITLE
feat(core): Enable scheduled execution deduplication by default

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -154,8 +154,4 @@ export class ExecutionsConfig {
 	/** Whether to save execution data for manual executions. This default can be overridden at a workflow level. */
 	@Env('EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS')
 	saveDataManualExecutions: boolean = true;
-
-	/** Whether scheduled executions receive a deduplication key enforced by a unique DB index. */
-	@Env('N8N_SCHEDULED_EXECUTION_DEDUPLICATION_ENABLED')
-	scheduledExecutionDeduplicationEnabled: boolean = false;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type { DatabaseConfig } from '../src/index';
-import { ExecutionsConfig, GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
+import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
 const { readFileSyncMock } = vi.hoisted(() => ({
 	readFileSyncMock: vi.fn(),
@@ -470,7 +470,6 @@ describe('GlobalConfig', () => {
 			saveDataOnSuccess: 'all',
 			saveExecutionProgress: false,
 			saveDataManualExecutions: true,
-			scheduledExecutionDeduplicationEnabled: false,
 		},
 		diagnostics: {
 			enabled: true,
@@ -866,22 +865,6 @@ describe('GlobalConfig', () => {
 
 			const config = Container.get(GlobalConfig);
 			expect(config.endpoints.health).toEqual('/api/v1/health');
-		});
-	});
-
-	describe('ExecutionsConfig', () => {
-		it('should default scheduledExecutionDeduplicationEnabled to false', () => {
-			process.env = {};
-			const config = Container.get(ExecutionsConfig);
-			expect(config.scheduledExecutionDeduplicationEnabled).toBe(false);
-		});
-
-		it('should enable scheduledExecutionDeduplicationEnabled when env var is set to true', () => {
-			process.env = {
-				N8N_SCHEDULED_EXECUTION_DEDUPLICATION_ENABLED: 'true',
-			};
-			const config = Container.get(ExecutionsConfig);
-			expect(config.scheduledExecutionDeduplicationEnabled).toBe(true);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -1,5 +1,3 @@
-import { ExecutionsConfig } from '@n8n/config';
-import { Container } from '@n8n/di';
 import { sendAt } from 'cron';
 import moment from 'moment-timezone';
 import type {
@@ -446,12 +444,6 @@ export class ScheduleTrigger implements INodeType {
 		const workflowId = this.getWorkflow().id;
 		const nodeId = this.getNode().id;
 
-		const configDedupEnabled =
-			Container.get(ExecutionsConfig).scheduledExecutionDeduplicationEnabled;
-		// The workflowId should always be defined, but if it isn't we skip
-		// the deduplication key.
-		const dedupEnabled = configDedupEnabled && Boolean(workflowId);
-
 		const executeTrigger = (
 			recurrence: IRecurrenceRule,
 			skipRecurrenceCheck = false,
@@ -477,8 +469,10 @@ export class ScheduleTrigger implements INodeType {
 				Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
 			};
 
+			// The workflowId should always be defined, but if it isn't we skip
+			// the deduplication key.
 			const deduplicationKey =
-				dedupEnabled && scheduledTime
+				workflowId && scheduledTime
 					? `${workflowId}:${nodeId}:${scheduledTime.toISOString()}`
 					: undefined;
 

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -1,5 +1,3 @@
-import { ExecutionsConfig } from '@n8n/config';
-import { Container } from '@n8n/di';
 import * as n8nWorkflow from 'n8n-workflow';
 
 import { testTriggerNode } from '@test/nodes/TriggerHelpers';
@@ -222,19 +220,7 @@ describe('ScheduleTrigger', () => {
 		});
 
 		describe('deduplication key', () => {
-			const executionsConfig = Container.get(ExecutionsConfig);
-
-			beforeEach(() => {
-				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
-			});
-
-			afterEach(() => {
-				executionsConfig.scheduledExecutionDeduplicationEnabled = false;
-			});
-
-			it('should emit a deduplication key when the feature flag is enabled', async () => {
-				executionsConfig.scheduledExecutionDeduplicationEnabled = true;
-
+			it('should emit a deduplication key for scheduled executions', async () => {
 				const workflowId = 'wf-123';
 				const nodeId = 'node-456';
 				const { emit } = await testTriggerNode(ScheduleTrigger, {
@@ -269,8 +255,6 @@ describe('ScheduleTrigger', () => {
 			});
 
 			it('should not emit a deduplication key for manual executions', async () => {
-				executionsConfig.scheduledExecutionDeduplicationEnabled = true;
-
 				const { emit, manualTriggerFunction } = await testTriggerNode(ScheduleTrigger, {
 					mode: 'manual',
 					timezone,


### PR DESCRIPTION
## Summary

Remove the feature flag gating scheduled execution deduplication.

It's been running on internal for a week, so it seems stable.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32533">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

