### PR TITLE
refactor(core): Migrate OAuth2 identifier metadata fetch to outbound HTTP factory

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.integration.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.integration.test.ts
@@ -1,0 +1,134 @@
+import {
+	DnsResolver,
+	InMemoryDnsCache,
+	OutboundHttp,
+	SsrfProtectionService,
+} from '@n8n/backend-network';
+import { startServer, type LocalServer } from '@n8n/backend-network/testing';
+import { mockLogger } from '@n8n/backend-test-utils';
+import { SsrfProtectionConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import type { IncomingHttpHeaders } from 'node:http';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2TokenIntrospectionIdentifier } from '../oauth2-introspection-identifier';
+import { OAuth2MetadataHttpClient } from '../oauth2-metadata-http-client';
+
+interface CapturedRequest {
+	url: string;
+	method: string;
+	headers: IncomingHttpHeaders;
+	body: string;
+}
+
+/**
+ * Real-socket coverage for the metadata → introspection sequence. Drives the
+ * actual `OutboundHttp` factory (no mocks) so we exercise the SSRF-guarded
+ * client, the form-urlencoded request body, and JSON response parsing end to end.
+ */
+describe('OAuth2TokenIntrospectionIdentifier (integration)', () => {
+	let server: LocalServer;
+	let baseUrl = '';
+	let received: CapturedRequest[];
+
+	const mockContext = { identity: 'mock-access-token', version: 1 as const };
+
+	const validOptions = () => ({
+		metadataUri: `${baseUrl}/.well-known/oauth-authorization-server`,
+		clientId: 'test-client',
+		clientSecret: 'test-secret',
+		subjectClaim: 'sub',
+		validation: 'oauth2-introspection' as const,
+	});
+
+	const buildIdentifier = (configOverrides: Partial<SsrfProtectionConfig>) => {
+		const config = new SsrfProtectionConfig();
+		Object.assign(config, configOverrides);
+		const ssrfService = new SsrfProtectionService(
+			config,
+			new DnsResolver(new InMemoryDnsCache(config)),
+			mockLogger(),
+		);
+		const outboundHttp = new OutboundHttp(ssrfService, mockLogger());
+		const cache = mock<CacheService>();
+		cache.get.mockResolvedValue(undefined);
+		cache.set.mockResolvedValue();
+		const httpClient = new OAuth2MetadataHttpClient(
+			mockLogger(),
+			cache,
+			outboundHttp,
+			ssrfService,
+			config,
+		);
+		return new OAuth2TokenIntrospectionIdentifier(mockLogger(), cache, httpClient);
+	};
+
+	beforeEach(async () => {
+		received = [];
+		server = await startServer((req, res) => {
+			let body = '';
+			req.on('data', (chunk) => (body += chunk));
+			req.on('end', () => {
+				received.push({
+					url: req.url ?? '',
+					method: req.method ?? '',
+					headers: req.headers,
+					body,
+				});
+				res.writeHead(200, { 'content-type': 'application/json' });
+				if (req.url === '/introspect') {
+					res.end(JSON.stringify({ active: true, sub: 'user-123' }));
+				} else {
+					// Discovery: the server itself dictates the second-hop endpoint.
+					res.end(
+						JSON.stringify({
+							issuer: baseUrl,
+							introspection_endpoint: `${baseUrl}/introspect`,
+							introspection_endpoint_auth_methods_supported: ['client_secret_basic'],
+						}),
+					);
+				}
+			});
+		});
+		baseUrl = server.url;
+	});
+
+	afterEach(async () => {
+		await server.close();
+	});
+
+	test('resolves the subject over a real socket through the SSRF-guarded client', async () => {
+		// Loopback is blocked by default; an internal target is reached via the
+		// allowlist (mirroring a self-hosted IdP), not by disabling the guard.
+		const identifier = buildIdentifier({ enabled: true, allowedIpRanges: ['127.0.0.0/8'] });
+
+		const subject = await identifier.resolve(mockContext, validOptions());
+
+		expect(subject).toBe('user-123');
+		expect(received).toHaveLength(2);
+
+		const [metadataReq, introspectReq] = received;
+		expect(metadataReq.method).toBe('GET');
+		expect(metadataReq.url).toBe('/.well-known/oauth-authorization-server');
+
+		expect(introspectReq.method).toBe('POST');
+		expect(introspectReq.url).toBe('/introspect');
+		expect(introspectReq.headers['content-type']).toBe('application/x-www-form-urlencoded');
+		expect(introspectReq.headers.authorization).toMatch(/^Basic /);
+		// Form-urlencoded body carries the caller token.
+		expect(new URLSearchParams(introspectReq.body).get('token')).toBe('mock-access-token');
+	});
+
+	test('surfaces a blocked metadataUri as the normal "Could not reach metadata URL" path', async () => {
+		// SSRF enabled, loopback NOT allowlisted → the metadata fetch is blocked.
+		const identifier = buildIdentifier({ enabled: true });
+
+		const error = await identifier.validateOptions(validOptions()).catch((e) => e);
+
+		expect(error).toBeInstanceOf(IdentifierValidationError);
+		expect(error.message).toContain('Could not reach metadata URL');
+		expect(received).toHaveLength(0);
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -1,19 +1,21 @@
+import type { HttpRequestClient, OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { mockLogger } from '@n8n/backend-test-utils';
+import type { SsrfProtectionConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import axios from 'axios';
 import { mock } from 'jest-mock-extended';
+import type { IHttpRequestOptions } from 'n8n-workflow';
 
 import type { CacheService } from '@/services/cache/cache.service';
 
 import { IdentifierValidationError } from '../identifier-interface';
 import { OAuth2TokenIntrospectionIdentifier } from '../oauth2-introspection-identifier';
-
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
+import { OAuth2MetadataHttpClient } from '../oauth2-metadata-http-client';
 
 describe('OAuth2TokenIntrospectionIdentifier', () => {
 	const logger = mockLogger();
 	const cache = mock<CacheService>();
+	const request = jest.fn();
+	const outboundHttp = mock<OutboundHttp>();
 	let identifier: OAuth2TokenIntrospectionIdentifier;
 
 	const validOptions = {
@@ -43,26 +45,38 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		version: 1 as const,
 	};
 
+	/**
+	 * Branch the single `request` mock on HTTP method so tests can invoke
+	 * `resolve` more than once without exhausting a `mockResolvedValueOnce` chain.
+	 */
+	const stubFlow = (metadata: unknown, introspection: unknown) => {
+		request.mockImplementation(async (options: IHttpRequestOptions) =>
+			options.method === 'POST'
+				? { statusCode: 200, body: introspection }
+				: { statusCode: 200, body: metadata },
+		);
+	};
+
 	beforeEach(() => {
 		jest.clearAllMocks();
-		identifier = new OAuth2TokenIntrospectionIdentifier(logger, cache);
+		outboundHttp.requests.mockReturnValue(mock<HttpRequestClient>({ request }));
+		const httpClient = new OAuth2MetadataHttpClient(
+			logger,
+			cache,
+			outboundHttp,
+			mock<SsrfProtectionService>(),
+			mock<SsrfProtectionConfig>({ enabled: true }),
+		);
+		identifier = new OAuth2TokenIntrospectionIdentifier(logger, cache, httpClient);
 		cache.get.mockResolvedValue(undefined);
 		cache.set.mockResolvedValue();
 	});
 
 	describe('Happy Path', () => {
 		test('should resolve subject successfully with client_secret_basic', async () => {
-			// Mock metadata endpoint
-			mockedAxios.get.mockResolvedValueOnce({
-				status: 200,
-				data: validMetadata,
-			});
-
-			// Mock introspection endpoint
-			mockedAxios.post.mockResolvedValueOnce({
-				status: 200,
-				data: validIntrospectionResponse,
-			});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: validIntrospectionResponse });
 
 			const result = await identifier.resolve(mockContext, validOptions);
 
@@ -72,15 +86,41 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 				'user-123',
 				expect.any(Number),
 			);
-			expect(mockedAxios.post).toHaveBeenCalledWith(
-				'https://auth.example.com/oauth/introspect',
-				expect.any(URLSearchParams),
+			// Introspection POST: form-urlencoded body, JSON response, Basic auth header.
+			expect(request).toHaveBeenNthCalledWith(
+				2,
 				expect.objectContaining({
+					url: 'https://auth.example.com/oauth/introspect',
+					method: 'POST',
+					body: expect.any(URLSearchParams),
+					json: true,
+					returnFullResponse: true,
+					ignoreHttpStatusErrors: true,
 					headers: expect.objectContaining({
+						'Content-Type': 'application/x-www-form-urlencoded',
 						Authorization: expect.stringMatching(/^Basic /),
 					}),
 				}),
 			);
+		});
+
+		test('should use client_secret_post auth params in the body', async () => {
+			const metadataPostOnly = {
+				...validMetadata,
+				introspection_endpoint_auth_methods_supported: ['client_secret_post'],
+			};
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: metadataPostOnly })
+				.mockResolvedValueOnce({ statusCode: 200, body: validIntrospectionResponse });
+
+			await identifier.resolve(mockContext, validOptions);
+
+			const postCall = request.mock.calls[1][0] as IHttpRequestOptions;
+			expect(postCall.headers).not.toHaveProperty('Authorization');
+			const body = postCall.body as URLSearchParams;
+			expect(body.get('client_id')).toBe('test-client');
+			expect(body.get('client_secret')).toBe('test-secret');
+			expect(body.get('token')).toBe('mock-access-token');
 		});
 
 		test('should return cached result on subsequent calls', async () => {
@@ -88,30 +128,23 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 			// Second cache.get call is for subject (returns cached value)
 			cache.get.mockResolvedValueOnce(undefined).mockResolvedValueOnce('cached-user-123');
 
-			mockedAxios.get.mockResolvedValueOnce({
-				status: 200,
-				data: validMetadata,
-			});
+			request.mockResolvedValueOnce({ statusCode: 200, body: validMetadata });
 
 			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('cached-user-123');
-			expect(mockedAxios.post).not.toHaveBeenCalled(); // Should not call introspection
+			// Only the metadata GET — never the introspection POST.
+			expect(request).toHaveBeenCalledTimes(1);
+			expect(request.mock.calls.every((call) => call[0].method === 'GET')).toBe(true);
 		});
 
 		test('should extract subject from custom claim', async () => {
 			const customOptions = { ...validOptions, subjectClaim: 'username' };
 			const customResponse = { ...validIntrospectionResponse, username: 'john.doe' };
 
-			mockedAxios.get.mockResolvedValueOnce({
-				status: 200,
-				data: validMetadata,
-			});
-
-			mockedAxios.post.mockResolvedValueOnce({
-				status: 200,
-				data: customResponse,
-			});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: customResponse });
 
 			const result = await identifier.resolve(mockContext, customOptions);
 
@@ -129,15 +162,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError when token is not active', async () => {
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadata,
-			});
-
-			mockedAxios.post.mockResolvedValue({
-				status: 200,
-				data: { ...validIntrospectionResponse, active: false },
-			});
+			stubFlow(validMetadata, { ...validIntrospectionResponse, active: false });
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -148,30 +173,19 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError when metadata fetch fails', async () => {
-			mockedAxios.get.mockResolvedValue({
-				status: 404,
-				data: {},
-			});
+			request.mockResolvedValue({ statusCode: 404, body: {} });
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
 			);
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
-				'Failed to fetch OAuth2 metadata',
+				'Failed to fetch OAuth2 metadata, status code: 404',
 			);
 		});
 
 		test('should throw IdentifierValidationError when subject claim is missing', async () => {
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadata,
-			});
-
 			const responseWithoutSub = { active: true, exp: validIntrospectionResponse.exp };
-			mockedAxios.post.mockResolvedValue({
-				status: 200,
-				data: responseWithoutSub,
-			});
+			stubFlow(validMetadata, responseWithoutSub);
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -216,7 +230,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError when metadata URL is unreachable', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
+			request.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -224,7 +238,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError on DNS resolution failure', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
+			request.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -232,7 +246,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError on request timeout', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
+			request.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -247,23 +261,18 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 				introspection_endpoint: 'https://auth.example.com/oauth/introspect',
 			};
 
-			mockedAxios.get.mockResolvedValueOnce({
-				status: 200,
-				data: metadataWithoutAuthMethods,
-			});
-
-			mockedAxios.post.mockResolvedValueOnce({
-				status: 200,
-				data: validIntrospectionResponse,
-			});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: metadataWithoutAuthMethods })
+				.mockResolvedValueOnce({ statusCode: 200, body: validIntrospectionResponse });
 
 			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('user-123');
-			expect(mockedAxios.post).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.any(URLSearchParams),
+			expect(request).toHaveBeenNthCalledWith(
+				2,
 				expect.objectContaining({
+					method: 'POST',
+					body: expect.any(URLSearchParams),
 					headers: expect.objectContaining({
 						Authorization: expect.stringMatching(/^Basic /),
 					}),
@@ -277,15 +286,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 				exp: Math.floor(Date.now() / 1000) + 7200, // 2 hours from now
 			};
 
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadata,
-			});
-
-			mockedAxios.post.mockResolvedValue({
-				status: 200,
-				data: longLivedResponse,
-			});
+			stubFlow(validMetadata, longLivedResponse);
 
 			await identifier.resolve(mockContext, validOptions);
 
@@ -303,15 +304,7 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 				exp: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
 			};
 
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadata,
-			});
-
-			mockedAxios.post.mockResolvedValue({
-				status: 200,
-				data: expiredButActiveResponse,
-			});
+			stubFlow(validMetadata, expiredButActiveResponse);
 
 			await identifier.resolve(mockContext, validOptions);
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-metadata-http-client.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-metadata-http-client.test.ts
@@ -1,0 +1,106 @@
+import type { HttpRequestClient, OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { SsrfProtectionConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import { z } from 'zod';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2MetadataHttpClient } from '../oauth2-metadata-http-client';
+
+describe('OAuth2MetadataHttpClient', () => {
+	const logger = mockLogger();
+	const cache = mock<CacheService>();
+	const request = jest.fn();
+	const outboundHttp = mock<OutboundHttp>();
+
+	const buildClient = (
+		configOverrides: Partial<SsrfProtectionConfig>,
+		ssrfService = mock<SsrfProtectionService>(),
+	) =>
+		new OAuth2MetadataHttpClient(
+			logger,
+			cache,
+			outboundHttp,
+			ssrfService,
+			mock<SsrfProtectionConfig>(configOverrides),
+		);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		outboundHttp.requests.mockReturnValue(mock<HttpRequestClient>({ request }));
+		cache.get.mockResolvedValue(undefined);
+		cache.set.mockResolvedValue();
+	});
+
+	describe('Client construction', () => {
+		test('builds the client with SSRF disabled when protection is off', () => {
+			buildClient({ enabled: false });
+
+			expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+		});
+
+		test('builds the client with the SSRF service when protection is on', () => {
+			const ssrfProtectionService = mock<SsrfProtectionService>();
+
+			buildClient({ enabled: true }, ssrfProtectionService);
+
+			expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: ssrfProtectionService });
+		});
+	});
+
+	describe('requestFull', () => {
+		test('returns the full response without throwing on non-2xx', async () => {
+			request.mockResolvedValue({ statusCode: 404, body: { error: 'nope' } });
+			const client = buildClient({ enabled: true });
+
+			const response = await client.requestFull({ url: 'https://auth.example.com', method: 'GET' });
+
+			expect(response).toEqual({ statusCode: 404, body: { error: 'nope' } });
+			expect(request).toHaveBeenCalledWith(
+				expect.objectContaining({
+					url: 'https://auth.example.com',
+					method: 'GET',
+					returnFullResponse: true,
+					ignoreHttpStatusErrors: true,
+				}),
+			);
+		});
+	});
+
+	describe('fetchMetadata', () => {
+		const schema = z.object({ issuer: z.string().url() });
+
+		test('fetches, validates, and caches the metadata', async () => {
+			request.mockResolvedValue({ statusCode: 200, body: { issuer: 'https://auth.example.com' } });
+			const client = buildClient({ enabled: true });
+
+			const metadata = await client.fetchMetadata(schema, {
+				metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+				cachePrefix: 'test-prefix',
+				skipCache: false,
+			});
+
+			expect(metadata).toEqual({ issuer: 'https://auth.example.com' });
+			expect(cache.set).toHaveBeenCalledWith(
+				expect.stringContaining('test-prefix:metadata:'),
+				metadata,
+				expect.any(Number),
+			);
+		});
+
+		test('throws IdentifierValidationError when the metadata fetch fails', async () => {
+			request.mockResolvedValue({ statusCode: 500, body: {} });
+			const client = buildClient({ enabled: true });
+
+			await expect(
+				client.fetchMetadata(schema, {
+					metadataUri: 'https://auth.example.com/.well-known/openid-configuration',
+					cachePrefix: 'test-prefix',
+					skipCache: true,
+				}),
+			).rejects.toThrow(IdentifierValidationError);
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.integration.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.integration.test.ts
@@ -1,0 +1,119 @@
+import {
+	DnsResolver,
+	InMemoryDnsCache,
+	OutboundHttp,
+	SsrfProtectionService,
+} from '@n8n/backend-network';
+import { startServer, type LocalServer } from '@n8n/backend-network/testing';
+import { mockLogger } from '@n8n/backend-test-utils';
+import { SsrfProtectionConfig } from '@n8n/config';
+import { mock } from 'jest-mock-extended';
+import type { IncomingHttpHeaders } from 'node:http';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2MetadataHttpClient } from '../oauth2-metadata-http-client';
+import { OAuth2UserInfoIdentifier } from '../oauth2-userinfo-identifier';
+
+interface CapturedRequest {
+	url: string;
+	method: string;
+	headers: IncomingHttpHeaders;
+}
+
+/**
+ * Real-socket coverage for the metadata → userinfo sequence. Drives the actual
+ * `OutboundHttp` factory (no mocks) so we exercise the SSRF-guarded client,
+ * request mapping, and JSON parsing end to end.
+ */
+describe('OAuth2UserInfoIdentifier (integration)', () => {
+	let server: LocalServer;
+	let baseUrl = '';
+	let received: CapturedRequest[];
+
+	const mockContext = { identity: 'mock-access-token', version: 1 as const };
+
+	const buildIdentifier = (configOverrides: Partial<SsrfProtectionConfig>) => {
+		const config = new SsrfProtectionConfig();
+		Object.assign(config, configOverrides);
+		const ssrfService = new SsrfProtectionService(
+			config,
+			new DnsResolver(new InMemoryDnsCache(config)),
+			mockLogger(),
+		);
+		const outboundHttp = new OutboundHttp(ssrfService, mockLogger());
+		const cache = mock<CacheService>();
+		cache.get.mockResolvedValue(undefined);
+		cache.set.mockResolvedValue();
+		const httpClient = new OAuth2MetadataHttpClient(
+			mockLogger(),
+			cache,
+			outboundHttp,
+			ssrfService,
+			config,
+		);
+		return new OAuth2UserInfoIdentifier(mockLogger(), cache, httpClient);
+	};
+
+	beforeEach(async () => {
+		received = [];
+		server = await startServer((req, res) => {
+			received.push({ url: req.url ?? '', method: req.method ?? '', headers: req.headers });
+			res.writeHead(200, { 'content-type': 'application/json' });
+			if (req.url === '/userinfo') {
+				res.end(JSON.stringify({ sub: 'user-123' }));
+			} else {
+				// Discovery: the server itself dictates the second-hop endpoint.
+				res.end(JSON.stringify({ issuer: baseUrl, userinfo_endpoint: `${baseUrl}/userinfo` }));
+			}
+		});
+		baseUrl = server.url;
+	});
+
+	afterEach(async () => {
+		await server.close();
+	});
+
+	test('resolves the subject over a real socket through the SSRF-guarded client', async () => {
+		// Loopback is blocked by default; an internal target is reached via the
+		// allowlist (mirroring a self-hosted IdP), not by disabling the guard.
+		const identifier = buildIdentifier({ enabled: true, allowedIpRanges: ['127.0.0.0/8'] });
+
+		const subject = await identifier.resolve(mockContext, {
+			metadataUri: `${baseUrl}/.well-known/openid-configuration`,
+			subjectClaim: 'sub',
+			validation: 'oauth2-userinfo',
+		});
+
+		expect(subject).toBe('user-123');
+		expect(received).toHaveLength(2);
+
+		const [metadataReq, userInfoReq] = received;
+		expect(metadataReq.method).toBe('GET');
+		expect(metadataReq.url).toBe('/.well-known/openid-configuration');
+		expect(metadataReq.headers.accept).toContain('application/json');
+
+		expect(userInfoReq.method).toBe('GET');
+		expect(userInfoReq.url).toBe('/userinfo');
+		expect(userInfoReq.headers.authorization).toBe('Bearer mock-access-token');
+	});
+
+	test('surfaces a blocked metadataUri as the normal "Could not reach metadata URL" path', async () => {
+		// SSRF enabled, loopback NOT allowlisted → the metadata fetch is blocked.
+		const identifier = buildIdentifier({ enabled: true });
+
+		const error = await identifier
+			.validateOptions({
+				metadataUri: `${baseUrl}/.well-known/openid-configuration`,
+				subjectClaim: 'sub',
+				validation: 'oauth2-userinfo',
+			})
+			.catch((e) => e);
+
+		expect(error).toBeInstanceOf(IdentifierValidationError);
+		expect(error.message).toContain('Could not reach metadata URL');
+		// The request never left the process.
+		expect(received).toHaveLength(0);
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
@@ -1,19 +1,20 @@
+import type { HttpRequestClient, OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { mockLogger } from '@n8n/backend-test-utils';
+import type { SsrfProtectionConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import axios from 'axios';
 import { mock } from 'jest-mock-extended';
 
 import type { CacheService } from '@/services/cache/cache.service';
 
 import { IdentifierValidationError } from '../identifier-interface';
+import { OAuth2MetadataHttpClient } from '../oauth2-metadata-http-client';
 import { OAuth2UserInfoIdentifier } from '../oauth2-userinfo-identifier';
-
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('OAuth2UserInfoIdentifier', () => {
 	const logger = mockLogger();
 	const cache = mock<CacheService>();
+	const request = jest.fn();
+	const outboundHttp = mock<OutboundHttp>();
 	let identifier: OAuth2UserInfoIdentifier;
 
 	const validOptions = {
@@ -40,22 +41,24 @@ describe('OAuth2UserInfoIdentifier', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		identifier = new OAuth2UserInfoIdentifier(logger, cache);
+		outboundHttp.requests.mockReturnValue(mock<HttpRequestClient>({ request }));
+		const httpClient = new OAuth2MetadataHttpClient(
+			logger,
+			cache,
+			outboundHttp,
+			mock<SsrfProtectionService>(),
+			mock<SsrfProtectionConfig>({ enabled: true }),
+		);
+		identifier = new OAuth2UserInfoIdentifier(logger, cache, httpClient);
 		cache.get.mockResolvedValue(undefined);
 		cache.set.mockResolvedValue();
 	});
 
 	describe('Happy Path', () => {
 		test('should resolve subject successfully', async () => {
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validUserInfoResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: validUserInfoResponse });
 
 			const result = await identifier.resolve(mockContext, validOptions);
 
@@ -65,10 +68,25 @@ describe('OAuth2UserInfoIdentifier', () => {
 				'user-123',
 				expect.any(Number),
 			);
-			expect(mockedAxios.get).toHaveBeenCalledWith(
-				'https://auth.example.com/oauth/userinfo',
+			// Metadata call is mapped to a plain JSON GET.
+			expect(request).toHaveBeenNthCalledWith(
+				1,
 				expect.objectContaining({
+					url: validOptions.metadataUri,
+					method: 'GET',
+					json: true,
+					returnFullResponse: true,
+					ignoreHttpStatusErrors: true,
+				}),
+			);
+			// UserInfo call carries the caller's bearer token.
+			expect(request).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining({
+					url: 'https://auth.example.com/oauth/userinfo',
+					method: 'GET',
 					headers: { authorization: 'Bearer mock-access-token' },
+					json: true,
 				}),
 			);
 		});
@@ -76,30 +94,21 @@ describe('OAuth2UserInfoIdentifier', () => {
 		test('should return cached result on subsequent calls', async () => {
 			cache.get.mockResolvedValueOnce(undefined).mockResolvedValueOnce('cached-user-123');
 
-			mockedAxios.get.mockResolvedValueOnce({
-				status: 200,
-				data: validMetadata,
-			});
+			request.mockResolvedValueOnce({ statusCode: 200, body: validMetadata });
 
 			const result = await identifier.resolve(mockContext, validOptions);
 
 			expect(result).toBe('cached-user-123');
-			expect(mockedAxios.get).toHaveBeenCalledTimes(1); // Only metadata call, no userinfo call
+			expect(request).toHaveBeenCalledTimes(1); // Only metadata call, no userinfo call
 		});
 
 		test('should extract subject from custom claim', async () => {
 			const customOptions = { ...validOptions, subjectClaim: 'email' };
 			const customResponse = { ...validUserInfoResponse, email: 'john.doe@example.com' };
 
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: customResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: customResponse });
 
 			const result = await identifier.resolve(mockContext, customOptions);
 
@@ -109,10 +118,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 
 	describe('Validation', () => {
 		test('should validate successfully with valid options', async () => {
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadata,
-			});
+			request.mockResolvedValue({ statusCode: 200, body: validMetadata });
 
 			await expect(identifier.validateOptions(validOptions)).resolves.toBeUndefined();
 		});
@@ -122,10 +128,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 				issuer: 'https://auth.example.com',
 			};
 
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: metadataWithoutUserInfo,
-			});
+			request.mockResolvedValue({ statusCode: 200, body: metadataWithoutUserInfo });
 
 			await expect(identifier.validateOptions(validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -138,7 +141,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 
 	describe('Network Errors', () => {
 		test('should throw IdentifierValidationError when metadata URL is unreachable', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
+			request.mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:443'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -146,7 +149,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError on DNS resolution failure', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
+			request.mockRejectedValue(new Error('getaddrinfo ENOTFOUND auth.example.com'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -154,7 +157,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError on request timeout', async () => {
-			mockedAxios.get.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
+			request.mockRejectedValue(new Error('timeout of 10000ms exceeded'));
 
 			const error = await identifier.validateOptions(validOptions).catch((e) => e);
 			expect(error).toBeInstanceOf(IdentifierValidationError);
@@ -172,10 +175,7 @@ describe('OAuth2UserInfoIdentifier', () => {
 		});
 
 		test('should throw IdentifierValidationError when metadata fetch fails', async () => {
-			mockedAxios.get.mockResolvedValue({
-				status: 404,
-				data: {},
-			});
+			request.mockResolvedValue({ statusCode: 404, body: {} });
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -183,18 +183,15 @@ describe('OAuth2UserInfoIdentifier', () => {
 			expect(logger.error).toHaveBeenCalledWith(
 				expect.stringContaining('Failed to fetch OAuth2 metadata'),
 			);
+			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
+				'Failed to fetch OAuth2 metadata, status code: 404',
+			);
 		});
 
 		test('should throw IdentifierValidationError when userinfo call fails', async () => {
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 401,
-					data: { error: 'invalid_token' },
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 401, body: { error: 'invalid_token' } });
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -208,15 +205,9 @@ describe('OAuth2UserInfoIdentifier', () => {
 				name: 'Test User',
 			};
 
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: responseWithoutSub,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: responseWithoutSub });
 
 			await expect(identifier.resolve(mockContext, validOptions)).rejects.toThrow(
 				IdentifierValidationError,
@@ -227,15 +218,9 @@ describe('OAuth2UserInfoIdentifier', () => {
 
 	describe('TTL Handling', () => {
 		test('should use default TTL when exp not provided', async () => {
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validUserInfoResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: validUserInfoResponse });
 
 			await identifier.resolve(mockContext, validOptions);
 
@@ -250,15 +235,9 @@ describe('OAuth2UserInfoIdentifier', () => {
 				exp: Math.floor(Date.now() / 1000) + 7200, // 2 hours from now
 			};
 
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: longLivedResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: longLivedResponse });
 
 			await identifier.resolve(mockContext, validOptions);
 
@@ -273,15 +252,9 @@ describe('OAuth2UserInfoIdentifier', () => {
 				exp: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
 			};
 
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: expiredResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: expiredResponse });
 
 			await identifier.resolve(mockContext, validOptions);
 
@@ -296,15 +269,9 @@ describe('OAuth2UserInfoIdentifier', () => {
 				exp: Math.floor(Date.now() / 1000) + 120, // 2 minutes from now
 			};
 
-			mockedAxios.get
-				.mockResolvedValueOnce({
-					status: 200,
-					data: validMetadata,
-				})
-				.mockResolvedValueOnce({
-					status: 200,
-					data: expiringResponse,
-				});
+			request
+				.mockResolvedValueOnce({ statusCode: 200, body: validMetadata })
+				.mockResolvedValueOnce({ statusCode: 200, body: expiringResponse });
 
 			await identifier.resolve(mockContext, validOptions);
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -1,21 +1,20 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import axios from 'axios';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
 
-import { CacheService } from '@/services/cache/cache.service';
-
 import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
+import { OAuth2MetadataHttpClient, REQUEST_TIMEOUT } from './oauth2-metadata-http-client';
 import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
+
+import { CacheService } from '@/services/cache/cache.service';
 
 // Use minimum of 30 seconds to avoid cache thrashing
 // Cap at 5 minutes to ensure periodic revalidation
 const MIN_TOKEN_CACHE_TIMEOUT = 30 * Time.seconds.toMilliseconds;
 const MAX_TOKEN_CACHE_TIMEOUT = 5 * Time.minutes.toMilliseconds;
 const DEFAULT_CACHE_TIMEOUT = 60 * Time.seconds.toMilliseconds; // 60 seconds
-const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
 
 export const OAuth2IntrospectionOptionsSchema = z.object({
 	...OAuth2OptionsSchema.shape,
@@ -65,6 +64,7 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 	constructor(
 		private readonly logger: Logger,
 		private readonly cache: CacheService,
+		private readonly http: OAuth2MetadataHttpClient,
 	) {}
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
@@ -150,38 +150,11 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 		options: OAuth2IntrospectionOptions,
 		skipCache: boolean = false,
 	): Promise<OAuth2Metadata> {
-		const cacheKey = `${CACHE_PREFIX}:metadata:${options.metadataUri}`;
-		if (!skipCache) {
-			const cached = await this.cache.get<OAuth2Metadata>(cacheKey);
-			if (cached) {
-				return cached;
-			}
-		}
-
-		const response = await axios.get(options.metadataUri, {
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
+		return await this.http.fetchMetadata(OAuth2MetadataSchema, {
+			metadataUri: options.metadataUri,
+			cachePrefix: CACHE_PREFIX,
+			skipCache,
 		});
-
-		if (response.status !== 200) {
-			this.logger.error(
-				`Failed to fetch OAuth2 metadata from ${options.metadataUri}, status code: ${response.status}`,
-			);
-			throw new IdentifierValidationError(
-				`Failed to fetch OAuth2 metadata, status code: ${response.status}`,
-			);
-		}
-
-		try {
-			const metadata = OAuth2MetadataSchema.parse(response.data);
-			if (!skipCache) {
-				await this.cache.set(cacheKey, metadata, METADATA_CACHE_TIMEOUT);
-			}
-			return metadata;
-		} catch (error) {
-			this.logger.error('Invalid OAuth2 metadata format', { error });
-			throw new IdentifierValidationError('Invalid OAuth2 metadata format', { cause: error });
-		}
 	}
 
 	private buildClientBasicRequest(options: OAuth2IntrospectionOptions): {
@@ -254,21 +227,24 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 			...authParams,
 		});
 
-		const response = await axios.post(metadata.introspection_endpoint, params, {
+		const response = await this.http.requestFull({
+			url: metadata.introspection_endpoint,
+			method: 'POST',
+			body: params,
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeaders },
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
+			json: true,
+			timeout: REQUEST_TIMEOUT,
 		});
 
-		if (response.status !== 200) {
+		if (response.statusCode !== 200) {
 			this.logger.error('Token introspection failed', {
-				status: response.status,
-				data: response.data,
+				status: response.statusCode,
+				data: response.body,
 			});
 			throw new IdentifierValidationError('Token introspection failed');
 		}
 
-		const introspectionData = this.parseIntrospectionResponse(response.data);
+		const introspectionData = this.parseIntrospectionResponse(response.body);
 
 		if (!introspectionData.active) {
 			this.logger.error('Token is not active according to introspection response');

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-metadata-http-client.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-metadata-http-client.ts
@@ -1,0 +1,102 @@
+import { Logger } from '@n8n/backend-common';
+import { OutboundHttp, SsrfProtectionService, type HttpRequestClient } from '@n8n/backend-network';
+import { SsrfProtectionConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { Service } from '@n8n/di';
+import type { IHttpRequestOptions, IN8nHttpFullResponse } from 'n8n-workflow';
+import type { z } from 'zod';
+
+import { IdentifierValidationError } from './identifier-interface';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+export const REQUEST_TIMEOUT = 10 * Time.seconds.toMilliseconds;
+const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
+
+interface FetchMetadataParams {
+	metadataUri: string;
+	/** Cache-key namespace for the calling identifier (e.g. `oauth2-userinfo-identifier`). */
+	cachePrefix: string;
+	/** Skip reading/writing the metadata cache — used on the validation path. */
+	skipCache: boolean;
+}
+
+/**
+ * Shared HTTP entrypoint for the OAuth2 token identifiers.
+ */
+@Service()
+export class OAuth2MetadataHttpClient {
+	private readonly http: HttpRequestClient;
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly cache: CacheService,
+		outboundHttp: OutboundHttp,
+		ssrfProtectionService: SsrfProtectionService,
+		ssrfProtectionConfig: SsrfProtectionConfig,
+	) {
+		// We opt into SSRF protection (when the environment enables it) because the attack risk is higher here.
+		// This matters for the second hop too: the introspection/userinfo endpoints come from
+		// the remote metadata server, so they are fully third-party-controlled.
+		// Self-hosted users pointing the resolver at an internal IdP can allowlist via SsrfProtectionConfig.
+		this.http = outboundHttp.requests({
+			ssrf: ssrfProtectionConfig.enabled ? ssrfProtectionService : 'disabled',
+		});
+	}
+
+	/**
+	 * @returns the full response without throwing on non-2xx.
+	 */
+	async requestFull(options: IHttpRequestOptions): Promise<IN8nHttpFullResponse> {
+		return await this.http.request({
+			...options,
+			returnFullResponse: true,
+			ignoreHttpStatusErrors: true,
+		});
+	}
+
+	/**
+	 * Fetches an OAuth2 server's discovery metadata through the SSRF-guarded
+	 * client, validates it against the caller's `schema`, and read-through caches
+	 * the result.
+	 */
+	async fetchMetadata<T>(
+		schema: z.ZodType<T>,
+		{ metadataUri, cachePrefix, skipCache }: FetchMetadataParams,
+	): Promise<T> {
+		const cacheKey = `${cachePrefix}:metadata:${metadataUri}`;
+		if (!skipCache) {
+			const cached = await this.cache.get<T>(cacheKey);
+			if (cached) {
+				return cached;
+			}
+		}
+
+		const response = await this.requestFull({
+			url: metadataUri,
+			method: 'GET',
+			json: true,
+			timeout: REQUEST_TIMEOUT,
+		});
+
+		if (response.statusCode !== 200) {
+			this.logger.error(
+				`Failed to fetch OAuth2 metadata from ${metadataUri}, status code: ${response.statusCode}`,
+			);
+			throw new IdentifierValidationError(
+				`Failed to fetch OAuth2 metadata, status code: ${response.statusCode}`,
+			);
+		}
+
+		try {
+			const metadata = schema.parse(response.body);
+			if (!skipCache) {
+				await this.cache.set(cacheKey, metadata, METADATA_CACHE_TIMEOUT);
+			}
+			return metadata;
+		} catch (error) {
+			this.logger.error('Invalid OAuth2 metadata format', { error });
+			throw new IdentifierValidationError('Invalid OAuth2 metadata format', { cause: error });
+		}
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -1,13 +1,13 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import axios from 'axios';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { CacheService } from '@/services/cache/cache.service';
 
 import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
+import { OAuth2MetadataHttpClient, REQUEST_TIMEOUT } from './oauth2-metadata-http-client';
 import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
 
 // Use minimum of 30 seconds to avoid cache thrashing
@@ -15,7 +15,6 @@ import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
 const MIN_TOKEN_CACHE_TIMEOUT = 30 * Time.seconds.toMilliseconds;
 const MAX_TOKEN_CACHE_TIMEOUT = 5 * Time.minutes.toMilliseconds;
 const DEFAULT_CACHE_TIMEOUT = 60 * Time.seconds.toMilliseconds; // 60 seconds
-const METADATA_CACHE_TIMEOUT = 1 * Time.hours.toMilliseconds; // 1 hour
 
 export const OAuth2UserInfoOptionsSchema = z.object({
 	...OAuth2OptionsSchema.shape,
@@ -47,6 +46,7 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 	constructor(
 		private readonly logger: Logger,
 		private readonly cache: CacheService,
+		private readonly http: OAuth2MetadataHttpClient,
 	) {}
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
@@ -118,38 +118,11 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 		options: OAuth2UserInfoOptions,
 		skipCache: boolean = false,
 	): Promise<OAuth2Metadata> {
-		const cacheKey = `${CACHE_PREFIX}:metadata:${options.metadataUri}`;
-		if (!skipCache) {
-			const cached = await this.cache.get<OAuth2Metadata>(cacheKey);
-			if (cached) {
-				return cached;
-			}
-		}
-
-		const response = await axios.get(options.metadataUri, {
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
+		return await this.http.fetchMetadata(OAuth2MetadataSchema, {
+			metadataUri: options.metadataUri,
+			cachePrefix: CACHE_PREFIX,
+			skipCache,
 		});
-
-		if (response.status !== 200) {
-			this.logger.error(
-				`Failed to fetch OAuth2 metadata from ${options.metadataUri}, status code: ${response.status}`,
-			);
-			throw new IdentifierValidationError(
-				`Failed to fetch OAuth2 metadata, status code: ${response.status}`,
-			);
-		}
-
-		try {
-			const metadata = OAuth2MetadataSchema.parse(response.data);
-			if (!skipCache) {
-				await this.cache.set(cacheKey, metadata, METADATA_CACHE_TIMEOUT);
-			}
-			return metadata;
-		} catch (error) {
-			this.logger.error('Invalid OAuth2 metadata format', { error });
-			throw new IdentifierValidationError('Invalid OAuth2 metadata format', { cause: error });
-		}
 	}
 
 	private parseUserInfoResponse(data: unknown): UserInfoResponse {
@@ -166,22 +139,24 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 		options: OAuth2UserInfoOptions,
 		context: ICredentialContext,
 	): Promise<{ subject: string; ttl?: number }> {
-		const response = await axios.get(metadata.userinfo_endpoint, {
+		const response = await this.http.requestFull({
+			url: metadata.userinfo_endpoint,
+			method: 'GET',
 			headers: { authorization: `Bearer ${context.identity}` },
-			validateStatus: () => true,
-			timeout: 10 * Time.seconds.toMilliseconds,
+			json: true,
+			timeout: REQUEST_TIMEOUT,
 		});
 
-		if (response.status !== 200) {
+		if (response.statusCode !== 200) {
 			this.logger.error('UserInfo failed', {
-				status: response.status,
-				data: response.data,
+				status: response.statusCode,
+				data: response.body,
 			});
 			throw new IdentifierValidationError('UserInfo query failed');
 		}
 
 		// TODO: Add support for JWT responses in addition to JSON
-		const userData = this.parseUserInfoResponse(response.data);
+		const userData = this.parseUserInfoResponse(response.body);
 		const subject = userData[options.subjectClaim];
 		if (!subject) {
 			this.logger.error(`UserInfo response missing subject claim (${options.subjectClaim})`);


### PR DESCRIPTION
## Summary

Re-points the dynamic-credentials OAuth2 identifiers (`OAuth2UserInfoIdentifier` and `OAuth2TokenIntrospectionIdentifier`) at the `OutboundHttp` facade from `@n8n/backend-network` instead of calling `axios` directly. 

All HTTP now flows through `OutboundHttp.requests().request(...)`, with SSRF protection active on every call (gated on `N8N_SSRF_PROTECTION_ENABLED`).

This closes a previously-open SSRF gap: these identifiers had no network-level guard before. The only validation was zod `z.string().url()`. The guard matters especially for the second hop (`userinfo_endpoint` / `introspection_endpoint`), which is dictated by the remote metadata server and is fully third-party-controlled. 

`axios` is gone from both identifier files.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3375

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32535">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->