### PR TITLE
feat(Microsoft To Do Node): Allow custom OAuth2 scopes

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftToDoOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftToDoOAuth2Api.credentials.ts
@@ -1,5 +1,8 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
+//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
+const defaultScopes = ['openid', 'offline_access', 'Tasks.ReadWrite'];
+
 export class MicrosoftToDoOAuth2Api implements ICredentialType {
 	name = 'microsoftToDoOAuth2Api';
 
@@ -10,12 +13,43 @@ export class MicrosoftToDoOAuth2Api implements ICredentialType {
 	documentationUrl = 'microsoft';
 
 	properties: INodeProperties[] = [
-		//https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
+		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
 		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: 'openid offline_access Tasks.ReadWrite',
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/test/MicrosoftToDoOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftToDoOAuth2Api.credentials.test.ts
@@ -1,0 +1,153 @@
+import { ClientOAuth2 } from '@n8n/client-oauth2';
+import nock from 'nock';
+
+import { MicrosoftToDoOAuth2Api } from '../MicrosoftToDoOAuth2Api.credentials';
+
+describe('MicrosoftToDoOAuth2Api Credential', () => {
+	const microsoftToDoOAuth2Api = new MicrosoftToDoOAuth2Api();
+	const defaultScopes = ['openid', 'offline_access', 'Tasks.ReadWrite'];
+
+	// Shared OAuth2 configuration
+	const baseUrl = 'https://login.microsoftonline.com';
+	const authorizationUri = `${baseUrl}/common/oauth2/v2.0/authorize`;
+	const accessTokenUri = `${baseUrl}/common/oauth2/v2.0/token`;
+	const redirectUri = 'http://localhost:5678/rest/oauth2-credential/callback';
+	const clientId = 'test-client-id';
+	const clientSecret = 'test-client-secret';
+
+	const createOAuthClient = (scopes: string[]) =>
+		new ClientOAuth2({
+			clientId,
+			clientSecret,
+			accessTokenUri,
+			authorizationUri,
+			redirectUri,
+			scopes,
+		});
+
+	const mockTokenEndpoint = (code: string, responseScopes: string[]) => {
+		nock(baseUrl)
+			.post('/common/oauth2/v2.0/token', (body: Record<string, unknown>) => {
+				return (
+					body.code === code &&
+					body.grant_type === 'authorization_code' &&
+					body.redirect_uri === redirectUri
+				);
+			})
+			.reply(200, {
+				access_token: 'test-access-token',
+				token_type: 'Bearer',
+				expires_in: 3600,
+				scope: responseScopes.join(' '),
+			});
+	};
+
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
+	it('should have correct credential metadata', () => {
+		expect(microsoftToDoOAuth2Api.name).toBe('microsoftToDoOAuth2Api');
+		expect(microsoftToDoOAuth2Api.extends).toEqual(['microsoftOAuth2Api']);
+
+		// Verify default scopes are correctly defined
+		const enabledScopesProperty = microsoftToDoOAuth2Api.properties.find(
+			(p) => p.name === 'enabledScopes',
+		);
+		expect(enabledScopesProperty?.default).toBe('openid offline_access Tasks.ReadWrite');
+	});
+
+	it('should keep the scope hidden and default to the standard scopes when custom scopes are off', () => {
+		const scopeProperty = microsoftToDoOAuth2Api.properties.find((p) => p.name === 'scope');
+		expect(scopeProperty?.type).toBe('hidden');
+		expect(scopeProperty?.default).toBe(
+			'={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access Tasks.ReadWrite"}}',
+		);
+	});
+
+	describe('OAuth2 flow with default scopes', () => {
+		it('should include default scopes in authorization URI', () => {
+			const oauthClient = createOAuthClient(defaultScopes);
+			const authUri = oauthClient.code.getUri();
+
+			// Verify the authorization URI contains the correct scopes
+			// Scopes can be encoded with either %20 or + for spaces
+			expect(authUri).toMatch(/scope=(openid[+%20]offline_access[+%20]Tasks\.ReadWrite)/);
+			expect(authUri).toContain(`client_id=${clientId}`);
+			expect(authUri).toContain('response_type=code');
+		});
+
+		it('should retrieve token successfully with default scopes', async () => {
+			const code = 'test-auth-code';
+			mockTokenEndpoint(code, defaultScopes);
+
+			const oauthClient = createOAuthClient(defaultScopes);
+			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
+
+			expect(token.data.scope).toBe('openid offline_access Tasks.ReadWrite');
+		});
+	});
+
+	describe('OAuth2 flow with custom scopes', () => {
+		const customScopes = [
+			'openid',
+			'offline_access',
+			'Tasks.ReadWrite',
+			'Tasks.ReadWrite.Shared',
+			'User.Read',
+		];
+
+		it('should include custom scopes in authorization URI', () => {
+			const oauthClient = createOAuthClient(customScopes);
+			const authUri = oauthClient.code.getUri();
+
+			expect(authUri).toContain('scope=');
+			expect(authUri).toContain('openid');
+			expect(authUri).toContain('Tasks.ReadWrite.Shared');
+			expect(authUri).toContain('User.Read');
+		});
+
+		it('should retrieve token successfully with custom scopes', async () => {
+			const code = 'test-auth-code';
+			mockTokenEndpoint(code, customScopes);
+
+			const oauthClient = createOAuthClient(customScopes);
+			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
+
+			expect(token.data.scope).toContain('openid');
+			expect(token.data.scope).toContain('offline_access');
+			expect(token.data.scope).toContain('Tasks.ReadWrite');
+			expect(token.data.scope).toContain('Tasks.ReadWrite.Shared');
+			expect(token.data.scope).toContain('User.Read');
+		});
+
+		it('should handle completely different custom scopes', async () => {
+			const differentScopes = ['openid', 'offline_access', 'Calendars.Read', 'Mail.Send'];
+			const code = 'test-auth-code';
+			mockTokenEndpoint(code, differentScopes);
+
+			const oauthClient = createOAuthClient(differentScopes);
+			const authUri = oauthClient.code.getUri();
+
+			// Verify authorization URI has the different scopes
+			expect(authUri).toContain('Calendars.Read');
+			expect(authUri).toContain('Mail.Send');
+			expect(authUri).not.toContain('Tasks.ReadWrite');
+
+			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
+
+			// Verify token response has the different scopes
+			expect(token.data.scope).toContain('Calendars.Read');
+			expect(token.data.scope).toContain('Mail.Send');
+			expect(token.data.scope).not.toContain('Tasks.ReadWrite');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The **Microsoft To Do** OAuth2 credential previously had its scopes hardcoded and hidden (`openid offline_access Tasks.ReadWrite`), so users had no way to request additional Microsoft Graph permissions.

This adds a **Custom Scopes** toggle to the credential. When enabled, an editable **Enabled Scopes** field appears (pre-filled with the current defaults) and drives the OAuth `scope`. When the toggle is off — the default — behaviour is completely unchanged, so existing saved credentials keep working.

Mirrors the existing pattern in the **Microsoft Excel 365** and **Microsoft Teams** credentials (same project: "Add custom scopes to all OAuth based nodes that support them").

### What changed

- `packages/nodes-base/credentials/MicrosoftToDoOAuth2Api.credentials.ts` — added `customScopes` (boolean), a notice, an `enabledScopes` string field shown when `customScopes` is on, and changed the hidden `scope` default to `={{$self["customScopes"] ? $self["enabledScopes"] : "openid offline_access Tasks.ReadWrite"}}`.
- `packages/nodes-base/credentials/test/MicrosoftToDoOAuth2Api.credentials.test.ts` — new test covering the default-scope flow, the custom-scope flow, and the hidden-scope expression.

No node or transport change is needed — the node references the credential by name and the scope is resolved at the credential/OAuth layer.

## How to test

1. Add or edit a **Microsoft To Do** credential.
2. With **Custom Scopes** off → connect; OAuth uses the default scopes exactly as before.
3. Toggle **Custom Scopes** on → an **Enabled Scopes** field appears pre-filled with `openid offline_access Tasks.ReadWrite`. Add an extra scope (e.g. `Tasks.ReadWrite.Shared`), connect, and confirm the Microsoft consent screen requests the additional permission.
4. Existing saved To Do credentials continue to authenticate unchanged.

Unit tests:

```bash
cd packages/nodes-base && pnpm test MicrosoftToDoOAuth2Api
```

## Screenshots

### Custom scopes available on ToDo

<img width="1847" height="935" alt="image" src="https://github.com/user-attachments/assets/1bbfbe65-5b6f-4f25-bdd0-59e0f89e3674" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-79

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32538">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

