### PR TITLE
refactor(core): Re-parent task runner error subclasses (no-changelog)

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/errors/task-cancelled-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/task-cancelled-error.ts
@@ -1,6 +1,6 @@
-import { ApplicationError } from '@n8n/errors';
+import { OperationalError } from 'n8n-workflow';
 
-export class TaskCancelledError extends ApplicationError {
+export class TaskCancelledError extends OperationalError {
 	constructor(reason: string) {
 		super(`Task cancelled: ${reason}`, { level: 'warning' });
 	}

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/timeout-error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/timeout-error.ts
@@ -1,13 +1,7 @@
-import { ApplicationError } from '@n8n/errors';
+import { OperationalError } from 'n8n-workflow';
 
-export class TimeoutError extends ApplicationError {
-	description: string;
-
+export class TimeoutError extends OperationalError {
 	constructor(taskTimeout: number) {
-		super(
-			`Task execution timed out after ${taskTimeout} ${taskTimeout === 1 ? 'second' : 'seconds'}`,
-		);
-
 		const subtitle = 'The task runner was taking too long on this task, so the task was aborted.';
 
 		const fixes = {
@@ -25,6 +19,9 @@ export class TimeoutError extends ApplicationError {
 
 		const description = `${subtitle} You can try the following:<br/><br/>${suggestionsText}`;
 
-		this.description = description;
+		super(
+			`Task execution timed out after ${taskTimeout} ${taskTimeout === 1 ? 'second' : 'seconds'}`,
+			{ description },
+		);
 	}
 }

--- a/packages/@n8n/task-runner/src/js-task-runner/errors/unsupported-function.error.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/errors/unsupported-function.error.ts
@@ -1,13 +1,11 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 
 /**
  * Error that indicates that a specific function is not available in the
  * Code Node.
  */
-export class UnsupportedFunctionError extends ApplicationError {
+export class UnsupportedFunctionError extends UserError {
 	constructor(functionName: string) {
-		super(`The function "${functionName}" is not supported in the Code Node`, {
-			level: 'info',
-		});
+		super(`The function "${functionName}" is not supported in the Code Node`);
 	}
 }


### PR DESCRIPTION
## Summary

Re-parents three error subclasses in `packages/@n8n/task-runner/` away from the deprecated `ApplicationError`:

- `UnsupportedFunctionError` → `UserError` (keeps the `info` level, which is `UserError`'s default)
- `TimeoutError` → `OperationalError` (the `description` is now passed via the constructor options)
- `TaskCancelledError` → `OperationalError` (keeps the explicit `warning` level)

Part of the effort to migrate away from deprecated `ApplicationError`.

## How to test

- `pnpm typecheck` in `packages/@n8n/task-runner`
- `pnpm test` in `packages/@n8n/task-runner`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3254

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. (existing tests cover these errors)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32543">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

