### PR TITLE
fix(core): Coalesce outbox drains and wait for in-flight processing on shutdown

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -147,11 +147,79 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(jest.getTimerCount()).toBe(0);
 		});
 
-		test('shutdown stops polling', () => {
+		test('shutdown stops polling', async () => {
 			consumer.startPolling();
-			consumer.shutdown();
+			await consumer.shutdown();
 
 			expect(jest.getTimerCount()).toBe(0);
+		});
+	});
+
+	describe('concurrent drains', () => {
+		test('coalesces overlapping drainPending calls onto a single pass', async () => {
+			const record = makeRecord({ id: 1 });
+			let releaseClaim!: () => void;
+			const claimGate = new Promise<void>((resolve) => {
+				releaseClaim = resolve;
+			});
+			outboxRepository.claimNextPendingRecord
+				.mockImplementationOnce(async () => {
+					await claimGate;
+					return record;
+				})
+				.mockResolvedValue(null);
+			consumer.startPolling();
+
+			const first = consumer.drainPending();
+			const second = consumer.drainPending();
+
+			releaseClaim();
+			const [firstProcessed, secondProcessed] = await Promise.all([first, second]);
+
+			// Both callers share the one in-flight pass, so the record is claimed and
+			// applied exactly once even though drainPending was invoked twice.
+			expect(applier.apply).toHaveBeenCalledTimes(1);
+			expect(reporter.report).toHaveBeenCalledTimes(1);
+			expect(firstProcessed).toBe(1);
+			expect(secondProcessed).toBe(1);
+		});
+	});
+
+	describe('shutdown', () => {
+		test('waits for an in-flight record to finish before resolving', async () => {
+			const record = makeRecord({ id: 1 });
+			outboxRepository.claimNextPendingRecord.mockResolvedValueOnce(record).mockResolvedValue(null);
+
+			let releaseApply!: () => void;
+			let applyStarted = false;
+			applier.apply.mockImplementationOnce(async () => {
+				applyStarted = true;
+				await new Promise<void>((resolve) => {
+					releaseApply = resolve;
+				});
+				return { type: 'completed' };
+			});
+
+			consumer.startPolling();
+			const drain = consumer.drainPending();
+			await Promise.resolve();
+			expect(applyStarted).toBe(true);
+
+			let shutdownResolved = false;
+			const shutdown = consumer.shutdown().then(() => {
+				shutdownResolved = true;
+			});
+
+			// Shutdown must not resolve while the record is still being applied.
+			await Promise.resolve();
+			expect(shutdownResolved).toBe(false);
+
+			releaseApply();
+			await shutdown;
+			await drain;
+
+			expect(shutdownResolved).toBe(true);
+			expect(reporter.report).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -27,6 +27,8 @@ export class WorkflowPublicationOutboxConsumer {
 
 	private isShuttingDown = false;
 
+	private activeDrain: Promise<number> | null = null;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly workflowsConfig: WorkflowsConfig,
@@ -67,9 +69,11 @@ export class WorkflowPublicationOutboxConsumer {
 	}
 
 	@OnShutdown()
-	shutdown() {
+	async shutdown() {
 		this.isShuttingDown = true;
 		this.stopPolling();
+		// Wait for any in-flight drain to finish so triggers aren't left half-activated.
+		await this.activeDrain;
 	}
 
 	// We will rely on the `workflow-publish-wake-up` event in the future, but
@@ -101,10 +105,24 @@ export class WorkflowPublicationOutboxConsumer {
 	 * Claim and process every currently pending record in a single pass, returning
 	 * the number processed. Used both by the scheduled poll cycle and at leader
 	 * startup for an immediate drain. The loop stops if the instance steps down or
-	 * shuts down mid-drain. Claiming is atomic, so an extra concurrent drain never
-	 * double-processes a record.
+	 * shuts down mid-drain; claiming is atomic, so an extra concurrent drain never
+	 * double-processes a record. Concurrent callers coalesce onto the same in-flight
+	 * pass rather than running an overlapping drain, which also lets shutdown wait
+	 * for the active pass to settle.
 	 */
 	async drainPending(): Promise<number> {
+		if (this.activeDrain) return await this.activeDrain;
+
+		const drain = this.runDrain();
+		this.activeDrain = drain;
+		try {
+			return await drain;
+		} finally {
+			this.activeDrain = null;
+		}
+	}
+
+	private async runDrain(): Promise<number> {
 		let processed = 0;
 		while (this.shouldKeepPolling()) {
 			const record = await this.outboxRepository.claimNextPendingRecord();


### PR DESCRIPTION
## Summary

The workflow-publication outbox consumer started its poll loop and an immediate drain separately, so a long-running drain could overlap with a scheduled poll-cycle drain, and shutdown returned without waiting for an in-flight drain (potentially exiting mid trigger-activation). This PR coalesces concurrent `drainPending()` calls onto a single in-flight pass via a tracked `activeDrain` promise, and makes the `@OnShutdown` handler `async` so it stops polling and awaits that in-flight pass before the process exits.

## How to test

Run the consumer unit tests: `cd packages/cli && pnpm test src/workflows/publication`. New cases cover (1) overlapping `drainPending()` calls claiming/applying each record exactly once, and (2) `shutdown()` not resolving until an in-flight `processRecord` completes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3497

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32548">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

