### PR TITLE
fix(core): Upgrade @n8n_io/license-sdk to v3 and resolve node-rsa to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,8 @@
       "@opentelemetry/exporter-prometheus@<=0.217.0": "0.217.0",
       "@opentelemetry/sdk-node@<=0.217.0": "0.217.0",
       "langsmith": "0.6.0",
-      "hono": "4.12.25"
+      "hono": "4.12.25",
+      "node-rsa": "2.0.0"
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -138,7 +138,7 @@
     "@n8n/utils": "workspace:*",
     "@n8n/workflow-sdk": "workspace:*",
     "@n8n_io/ai-assistant-sdk": "catalog:",
-    "@n8n_io/license-sdk": "2.25.0",
+    "@n8n_io/license-sdk": "3.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.217.0",
     "@opentelemetry/instrumentation": "^0.217.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,7 @@ overrides:
   '@opentelemetry/sdk-node@<=0.217.0': 0.217.0
   langsmith: 0.6.0
   hono: 4.12.25
+  node-rsa: 2.0.0
 
 patchedDependencies:
   '@lezer/highlight':
@@ -3201,8 +3202,8 @@ importers:
         specifier: 'catalog:'
         version: 1.21.1
       '@n8n_io/license-sdk':
-        specifier: 2.25.0
-        version: 2.25.0
+        specifier: 3.0.0
+        version: 3.0.0
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
@@ -8561,9 +8562,9 @@ packages:
     resolution: {integrity: sha512-Bb18Cv6VeX3eqPF1DLN48ZqjTzUoWuskO0opVOwCrDESZUAQWWhG54enKsggXzhAdYh8XnqmO7RphN4t8ZwxHQ==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
 
-  '@n8n_io/license-sdk@2.25.0':
-    resolution: {integrity: sha512-6pNo09XHhBb+igaHfpuvLez+IxcerzRWMFUH1eqAOOE0Uf5orQp8j5p5RE7ohNZYtxlMoL/PcsQIXK5uHBycwg==}
-    engines: {node: '>=18.12.1'}
+  '@n8n_io/license-sdk@3.0.0':
+    resolution: {integrity: sha512-JJjpbzFfWHfZ2aOIEWd/s23xU4ZKcPYxXd1ByGXmFz7SHXSqk+h11zUoEU9wR1AsN3SY308eQRoJ5RAKLjpH2Q==}
+    engines: {node: '>=20'}
 
   '@napi-rs/canvas-android-arm64@0.1.80':
     resolution: {integrity: sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==}
@@ -8742,6 +8743,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -17434,8 +17439,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  node-rsa@1.1.1:
-    resolution: {integrity: sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==}
+  node-rsa@2.0.0:
+    resolution: {integrity: sha512-7yfzccmBd5rm7pALJf709tPwLL987WvdT7LC/QK5Oxa5S2aabdBPjxRDxhWKkbfCc9/FiC82lwSc+ulGZHH44g==}
+    engines: {node: '>=20'}
 
   node-screenshots-darwin-arm64@0.2.8:
     resolution: {integrity: sha512-CEJE47gG2ceTc1fQRE3T/8lBwCGFJ+0iJiP+CQgCUAll4kKd32DQ7lCANqUseo96/xi6HuDOlrjLkAp7x2TzFw==}
@@ -25857,11 +25863,11 @@ snapshots:
 
   '@n8n_io/ai-assistant-sdk@1.21.1': {}
 
-  '@n8n_io/license-sdk@2.25.0':
+  '@n8n_io/license-sdk@3.0.0':
     dependencies:
       crypto-js: 4.2.0
       node-machine-id: 1.1.12
-      node-rsa: 1.1.1
+      node-rsa: 2.0.0
       undici: 7.27.2
 
   '@napi-rs/canvas-android-arm64@0.1.80':
@@ -25990,6 +25996,8 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.1.0': {}
 
@@ -36403,9 +36411,9 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  node-rsa@1.1.1:
+  node-rsa@2.0.0:
     dependencies:
-      asn1: 0.2.6
+      '@noble/hashes': 2.2.0
 
   node-screenshots-darwin-arm64@0.2.8:
     optional: true
@@ -38354,7 +38362,7 @@ snapshots:
     dependencies:
       '@authenio/xml-encryption': 2.0.2
       '@xmldom/xmldom': 0.8.13
-      node-rsa: 1.1.1
+      node-rsa: 2.0.0
       xml: 1.0.1
       xml-crypto: 6.1.2
       xml-escape: 1.1.0


### PR DESCRIPTION
## Summary

Upgrades `@n8n_io/license-sdk` (`2.25.0` → `3.0.0`) and pins `node-rsa` to `2.0.0` in `pnpm.overrides`. Together these remove `node-rsa@1.1.1` — an unmaintained major — from the dependency closure, so the workspace resolves a single, current `node-rsa@2.0.0`.

**Why both changes?** `node-rsa` is only reached transitively, through two consumers:

- `@n8n_io/license-sdk@3.0.0` — already ships `node-rsa@^2.0.0` and handles the upgrade itself.
- `samlify@2.13.0` — still declares `node-rsa@^1.1.1` (so does the latest, `2.13.1`), so the `overrides` pin is the only way to move it onto v2 without waiting for an upstream release.

**Is the pin safe for samlify?** Yes. node-rsa v2 changes its default `signingScheme` (PKCS#1 v1.5 → PSS), but samlify never relies on that default — it passes an explicit `signingScheme` (from the SAML `SigAlg`) on every signing and verification call. It also uses node-rsa only for redirect-binding signatures; SAML XML encryption runs through `@authenio/xml-encryption`. So the signature wire format is unchanged.

This supersedes an earlier attempt that pinned node-rsa on its own — moving the license SDK to v3 first lets that consumer own its upgrade, leaving the override to cover only samlify.

## How to test

- Run `pnpm install` and confirm no `node-rsa@1.1.1` remains in `pnpm-lock.yaml` (a single `2.0.0`).
- Exercise SAML SSO end-to-end against a real IdP — sign-in and the redirect-binding flow through samlify's `constructMessageSignature` / `verifyMessageSignature`. node-rsa v2 is a rewrite on a new crypto backend; the explicit scheme is preserved, but real-IdP signature interop is the gate that unit tests cannot cover.
- Exercise license activation/renewal against the license server to confirm `LicenseManager` verification still accepts a real signed payload.

## Related Linear tickets, Github issues, and Community forum posts

<!-- none referenced publicly -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

🤖 PR Summary generated by AI
