### PR TITLE
fix(editor): Prevent autosave failure loop after AI builder modifies a workflow

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -3449,7 +3449,6 @@ describe('AI Builder store', () => {
 
 			saveCurrentWorkflowMock.mockClear();
 
-			// Builder edits the workflow, then the stream errors
 			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, _onDone, onError) => {
 				onMessage({
 					messages: [
@@ -3470,7 +3469,6 @@ describe('AI Builder store', () => {
 				expect(saveCurrentWorkflowMock).toHaveBeenCalledWith({}, false, true);
 			});
 
-			// No version card on the error path
 			expect(builderStore.chatMessages.some((m) => m.type === 'custom')).toBe(false);
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -3425,6 +3425,57 @@ describe('AI Builder store', () => {
 			});
 		});
 
+		it('should reconcile the stale checksum on the error path without appending a version card', async () => {
+			const builderStore = useBuilderStore();
+			workflowsStore.setWorkflowId('test-workflow-123');
+			workflowsStore.isNewWorkflow = false;
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
+			workflowDocumentStore.setVersionData({
+				versionId: 'version-1',
+				name: null,
+				description: null,
+			});
+			workflowDocumentStore.setUpdatedAt('2024-01-01T00:00:00Z');
+
+			const workflowHistoryModule = await import('@n8n/rest-api-client/api/workflowHistory');
+			vi.mocked(workflowHistoryModule.getWorkflowVersionsByIds)
+				.mockResolvedValueOnce({
+					versions: [{ versionId: 'version-1', createdAt: '2024-01-01T00:00:00Z' }],
+				})
+				.mockResolvedValueOnce({
+					versions: [{ versionId: 'version-1', createdAt: '2024-01-01T00:00:00Z' }],
+				});
+
+			saveCurrentWorkflowMock.mockClear();
+
+			// Builder modifies the workflow server-side, then the stream errors
+			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, _onDone, onError) => {
+				onMessage({
+					messages: [
+						{
+							type: 'workflow-updated',
+							role: 'assistant',
+							codeSnippet: '{"nodes":[],"connections":{}}',
+						},
+					],
+					sessionId: 'test-session',
+				});
+				onError(new Error('stream failed'));
+			});
+
+			await builderStore.sendChatMessage({ text: 'Build a workflow' });
+
+			// Token is still reconciled via force-save so autosave cannot loop
+			await vi.waitFor(() => {
+				expect(saveCurrentWorkflowMock).toHaveBeenCalledWith({}, false, true);
+			});
+
+			// No version card is appended on the error path
+			expect(builderStore.chatMessages.some((m) => m.type === 'custom')).toBe(false);
+		});
+
 		it('should not add revertVersion to user message after streaming when workflow was not modified', async () => {
 			const builderStore = useBuilderStore();
 			workflowsStore.setWorkflowId('test-workflow-123');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -3419,7 +3419,6 @@ describe('AI Builder store', () => {
 				capturedDoneCallback();
 			}
 
-			// Post-modification save must force-save (3rd arg) to overwrite the stale checksum
 			await vi.waitFor(() => {
 				expect(saveCurrentWorkflowMock).toHaveBeenCalledWith({}, false, true);
 			});
@@ -3450,7 +3449,7 @@ describe('AI Builder store', () => {
 
 			saveCurrentWorkflowMock.mockClear();
 
-			// Builder modifies the workflow server-side, then the stream errors
+			// Builder edits the workflow, then the stream errors
 			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, _onDone, onError) => {
 				onMessage({
 					messages: [
@@ -3467,12 +3466,11 @@ describe('AI Builder store', () => {
 
 			await builderStore.sendChatMessage({ text: 'Build a workflow' });
 
-			// Token is still reconciled via force-save so autosave cannot loop
 			await vi.waitFor(() => {
 				expect(saveCurrentWorkflowMock).toHaveBeenCalledWith({}, false, true);
 			});
 
-			// No version card is appended on the error path
+			// No version card on the error path
 			expect(builderStore.chatMessages.some((m) => m.type === 'custom')).toBe(false);
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -3375,6 +3375,56 @@ describe('AI Builder store', () => {
 			});
 		});
 
+		it('should force-save the post-modification version so a stale checksum cannot loop autosave', async () => {
+			const builderStore = useBuilderStore();
+			workflowsStore.setWorkflowId('test-workflow-123');
+			workflowsStore.isNewWorkflow = false;
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
+			workflowDocumentStore.setVersionData({
+				versionId: 'version-1',
+				name: null,
+				description: null,
+			});
+			workflowDocumentStore.setUpdatedAt('2024-01-01T00:00:00Z');
+
+			const workflowHistoryModule = await import('@n8n/rest-api-client/api/workflowHistory');
+			vi.mocked(workflowHistoryModule.getWorkflowVersionsByIds)
+				.mockResolvedValueOnce({
+					versions: [{ versionId: 'version-1', createdAt: '2024-01-01T00:00:00Z' }],
+				})
+				.mockResolvedValueOnce({
+					versions: [{ versionId: 'version-1', createdAt: '2024-01-01T00:00:00Z' }],
+				});
+
+			saveCurrentWorkflowMock.mockClear();
+
+			await builderStore.sendChatMessage({ text: 'Build a workflow' });
+
+			if (capturedOnMessageCallback) {
+				capturedOnMessageCallback({
+					messages: [
+						{
+							type: 'workflow-updated',
+							role: 'assistant',
+							codeSnippet: '{"nodes":[],"connections":{}}',
+						},
+					],
+					sessionId: 'test-session',
+				});
+			}
+
+			if (capturedDoneCallback) {
+				capturedDoneCallback();
+			}
+
+			// Post-modification save must force-save (3rd arg) to overwrite the stale checksum
+			await vi.waitFor(() => {
+				expect(saveCurrentWorkflowMock).toHaveBeenCalledWith({}, false, true);
+			});
+		});
+
 		it('should not add revertVersion to user message after streaming when workflow was not modified', async () => {
 			const builderStore = useBuilderStore();
 			workflowsStore.setWorkflowId('test-workflow-123');

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -589,7 +589,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			resetWizardState();
 		}
 
-		// Reconcile the stale checksum on every path the builder edited the workflow, else autosave loops
 		const hasWorkflowUpdate = !!userMessageId && hasWorkflowUpdateInCurrentBatch(userMessageId);
 		const postModVersion = hasWorkflowUpdate ? await savePostModificationVersion() : undefined;
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -589,19 +589,12 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			resetWizardState();
 		}
 
-		// Only show "Restore version" on user messages that triggered a workflow modification.
-		// During planning or question phases no workflow changes happen, so skip it.
-		// Skip on error/abort paths — the caller handles chatMessages directly and a
-		// late-resolving savePostModificationVersion() would race with those writes.
-		if (
-			!payload &&
-			userMessageId &&
-			revertVersion &&
-			hasWorkflowUpdateInCurrentBatch(userMessageId)
-		) {
-			// Save the post-modification state to create a new version entry.
-			// Falls back to the pre-modification revertVersion if the save fails.
-			const postModVersion = await savePostModificationVersion();
+		// Reconcile the now-stale local checksum whenever the builder modified the workflow server-side, including abort/error paths, so autosave doesn't loop on a stale token
+		const hasWorkflowUpdate = !!userMessageId && hasWorkflowUpdateInCurrentBatch(userMessageId);
+		const postModVersion = hasWorkflowUpdate ? await savePostModificationVersion() : undefined;
+
+		// Show the "Restore version" card only on success; on error/abort the caller mutates chatMessages directly, so appending here would race with those writes
+		if (!payload && userMessageId && revertVersion && hasWorkflowUpdate) {
 			const versionForCard = postModVersion ?? revertVersion;
 
 			chatMessages.value = [

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -589,11 +589,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			resetWizardState();
 		}
 
-		// Reconcile the now-stale local checksum whenever the builder modified the workflow server-side, including abort/error paths, so autosave doesn't loop on a stale token
+		// Reconcile the stale checksum on every path the builder edited the workflow, else autosave loops
 		const hasWorkflowUpdate = !!userMessageId && hasWorkflowUpdateInCurrentBatch(userMessageId);
 		const postModVersion = hasWorkflowUpdate ? await savePostModificationVersion() : undefined;
 
-		// Show the "Restore version" card only on success; on error/abort the caller mutates chatMessages directly, so appending here would race with those writes
+		// Card only on success; on error/abort the caller writes chatMessages and would race
 		if (!payload && userMessageId && revertVersion && hasWorkflowUpdate) {
 			const versionForCard = postModVersion ?? revertVersion;
 
@@ -859,7 +859,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		{ id: string; createdAt: string } | undefined
 	> {
 		try {
-			// Force-save: builder already persisted server-side so the local checksum is stale; a normal save would 409 and leave autosave looping
+			// Force-save: builder already persisted server-side, so the local checksum is stale and a normal save would 409
 			const saved = await workflowSaver.saveCurrentWorkflow({}, false, true);
 			if (!saved) return undefined;
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -866,7 +866,8 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		{ id: string; createdAt: string } | undefined
 	> {
 		try {
-			const saved = await workflowSaver.saveCurrentWorkflow();
+			// Force-save: builder already persisted server-side so the local checksum is stale; a normal save would 409 and leave autosave looping
+			const saved = await workflowSaver.saveCurrentWorkflow({}, false, true);
 			if (!saved) return undefined;
 
 			const versionId = workflowDocumentStore.value.versionId;


### PR DESCRIPTION
## Summary

After the AI builder modifies a workflow, the editor would show a continuous stream of "Autosave failed: someone else just updated this workflow" toasts.

Root cause: the builder persists its edits **server-side**, which advances the workflow's content checksum in the DB. The editor's post-modification save (`savePostModificationVersion`) still sent the **pre-build** checksum, so the backend conflict check (`_detectConflicts`) returned a 409. That error was swallowed by the function's `try/catch`, leaving the canvas dirty with a stale checksum. Autosave then retried the same stale checksum on every cycle, looping forever (the autosave 409 branch only reschedules + toasts, it never re-syncs the token).

The "someone else" is the AI builder itself.

Fix: force-save the post-modification version. The builder owns its own edit and the canvas already mirrors the server state, so overwriting the conflict refreshes the local checksum/versionId and clears the dirty flag, which breaks the loop.

This also covers the **abort/error paths**: if the builder modified the workflow server-side and the stream was then aborted or errored, the token was previously left stale (the whole block was skipped), so autosave could loop the same way. The reconciliation save now runs on those paths too; the "Restore version" card stays success-only to avoid racing with the caller's `chatMessages` writes.

## How to test

1. Open the AI builder and ask it to build a simple workflow.
2. Once built, manually run the workflow.
3. Before: a continuous stream of "Autosave failed" error toasts appears.
4. After: no autosave errors; the workflow stays saved and clean.
5. Also verify aborting/erroring a build mid-way (after nodes were added) does not produce the autosave loop.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-547

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)