### PR TITLE
fix(core): Fix error path schema mismatch in mcp tools

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -776,16 +776,46 @@ describe('create-workflow-from-code MCP tool', () => {
 			};
 
 			const envelopeShape = tool.config.outputSchema as z.ZodRawShape;
-			const itemsField = envelopeShape.autoAssignedCredentials as z.ZodArray<
-				z.ZodObject<z.ZodRawShape>
-			>;
+			// `autoAssignedCredentials` is optional in the schema, so unwrap the
+			// ZodOptional to reach the inner array before tightening its items.
+			const itemsField = (
+				envelopeShape.autoAssignedCredentials as z.ZodOptional<
+					z.ZodArray<z.ZodObject<z.ZodRawShape>>
+				>
+			).unwrap();
 			const strictSchema = z
 				.object({
 					...envelopeShape,
-					autoAssignedCredentials: z.array(itemsField.element.strict()),
+					autoAssignedCredentials: z.array(itemsField.element.strict()).optional(),
 				})
 				.strict();
 
+			expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
+		});
+
+		test('error-path structuredContent conforms to declared outputSchema', async () => {
+			// Regression for ADO-5448 / GH #32503: a thrown handler error returned
+			// `structuredContent: { error }`, which violated the declared
+			// outputSchema (additionalProperties: false + required success fields)
+			// and made strict MCP clients reject the response with an opaque
+			// `-32602` schema mismatch that masked the real error.
+			mockParseAndValidate.mockRejectedValue(new Error('boom: invalid SDK code'));
+
+			const tool = createTool();
+			const result = (await tool.handler({ code: 'const wf = ...' } as never, {} as never)) as {
+				isError?: boolean;
+				structuredContent: unknown;
+			};
+
+			// The real, previously-masked error is now surfaced...
+			expect(result.isError).toBe(true);
+			const structured = result.structuredContent as { error?: string };
+			expect(structured.error).toContain('boom: invalid SDK code');
+			expect(createWorkflowMock).not.toHaveBeenCalled();
+
+			// ...and the error envelope validates against the published schema,
+			// so strict clients no longer reject it with -32602.
+			const strictSchema = z.object(tool.config.outputSchema as z.ZodRawShape).strict();
 			expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
 		});
 	});

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -2,6 +2,7 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { SharedWorkflowRepository, User, WorkflowEntity } from '@n8n/db';
 import { NodeConnectionTypes, type IConnections, type INode } from 'n8n-workflow';
+import { z } from 'zod';
 
 import { createUpdateWorkflowTool } from '../tools/workflow-builder/update-workflow.tool';
 
@@ -188,6 +189,65 @@ describe('update-workflow MCP tool', () => {
 				}),
 			);
 			expect(typeof tool.handler).toBe('function');
+		});
+	});
+
+	describe('output schema conformance', () => {
+		// Regression for ADO-5448 / GH #32503: the error path returned
+		// `structuredContent: { error }`, which failed validation against the
+		// declared outputSchema (the MCP SDK publishes it with
+		// additionalProperties: false and required success fields). Strict MCP
+		// clients then rejected the response with an opaque `-32602` schema
+		// mismatch that masked the real error. Both the error and success
+		// envelopes must validate against the published schema.
+		const buildStrictOutputSchema = (tool: ReturnType<typeof createTool>) =>
+			z.object(tool.config.outputSchema as z.ZodRawShape).strict();
+
+		test('error-path structuredContent conforms to declared outputSchema', async () => {
+			// A JSON Pointer path without a leading "/" passes input validation but
+			// fails at apply time — the exact repro from the ticket.
+			const tool = createTool();
+			const result = (await callHandler(
+				{
+					workflowId: 'wf-1',
+					operations: [
+						{
+							type: 'setNodeParameter',
+							nodeName: 'B',
+							path: 'parameters.url',
+							value: 'https://new',
+						},
+					],
+				},
+				tool,
+			)) as { isError?: boolean; structuredContent: unknown };
+
+			// The real, previously-masked error is now surfaced...
+			expect(result.isError).toBe(true);
+			const structured = result.structuredContent as { error?: string };
+			expect(structured.error).toContain('Operation 0 failed');
+			expect(structured.error).toContain('is invalid or contains unsafe segments');
+
+			// ...and the error envelope validates against the published schema,
+			// so strict clients no longer reject it with -32602.
+			expect(() => buildStrictOutputSchema(tool).parse(result.structuredContent)).not.toThrow();
+			expect(workflowService.update).not.toHaveBeenCalled();
+		});
+
+		test('success-path structuredContent conforms to declared outputSchema', async () => {
+			const tool = createTool();
+			const result = (await callHandler(
+				{
+					workflowId: 'wf-1',
+					operations: [
+						{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+					],
+				},
+				tool,
+			)) as { isError?: boolean; structuredContent: unknown };
+
+			expect(result.isError).toBeUndefined();
+			expect(() => buildStrictOutputSchema(tool).parse(result.structuredContent)).not.toThrow();
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -70,11 +70,18 @@ const inputSchema = {
 		),
 } satisfies z.ZodRawShape;
 
+// The MCP SDK publishes this schema with `additionalProperties: false` and
+// validates `structuredContent` against it on every response. Success returns
+// the full payload below; the error path returns only `{ error }` (optionally
+// with `hint`). To keep both shapes valid under strict clients, the success
+// fields are optional and `error` is a declared, optional property — otherwise
+// a thrown handler error surfaces as an opaque `-32602` schema mismatch
+// instead of the real message.
 const outputSchema = {
-	workflowId: z.string().describe('The ID of the created workflow'),
-	name: z.string().describe('The name of the created workflow'),
-	nodeCount: z.number().describe('The number of nodes in the workflow'),
-	url: z.string().describe('The URL to open the workflow in n8n'),
+	workflowId: z.string().optional().describe('The ID of the created workflow'),
+	name: z.string().optional().describe('The name of the created workflow'),
+	nodeCount: z.number().optional().describe('The number of nodes in the workflow'),
+	url: z.string().optional().describe('The URL to open the workflow in n8n'),
 	autoAssignedCredentials: z
 		.array(
 			z.object({
@@ -83,6 +90,7 @@ const outputSchema = {
 				credentialType: z.string().describe('The credential type that was auto-assigned'),
 			}),
 		)
+		.optional()
 		.describe('List of credentials that were automatically assigned to nodes'),
 	targetProject: z
 		.object({
@@ -92,6 +100,7 @@ const outputSchema = {
 				.enum(['personal', 'team'])
 				.describe('Whether the workflow landed in a personal or team project'),
 		})
+		.optional()
 		.describe('The project the workflow was actually created in.'),
 	note: z
 		.string()
@@ -105,6 +114,10 @@ const outputSchema = {
 		.describe(
 			'Actionable hint for recovering from the error. When present, follow the suggested action before retrying.',
 		),
+	error: z
+		.string()
+		.optional()
+		.describe('Error message explaining why the creation failed. Present only on failure.'),
 } satisfies z.ZodRawShape;
 
 /**

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -184,12 +184,18 @@ const inputSchema: z.ZodRawShape = {
 		),
 };
 
+// The MCP SDK publishes this schema with `additionalProperties: false` and
+// validates `structuredContent` against it on every response. Success returns
+// the full payload below; the error path returns only `{ error }`. To keep
+// both shapes valid under strict clients, the success fields are optional and
+// `error` is a declared, optional property — otherwise a thrown handler error
+// surfaces as an opaque `-32602` schema mismatch instead of the real message.
 const outputSchema = {
-	workflowId: z.string(),
-	name: z.string(),
-	nodeCount: z.number(),
-	url: z.string(),
-	appliedOperations: z.number().describe('Number of operations applied.'),
+	workflowId: z.string().optional(),
+	name: z.string().optional(),
+	nodeCount: z.number().optional(),
+	url: z.string().optional(),
+	appliedOperations: z.number().optional().describe('Number of operations applied.'),
 	autoAssignedCredentials: z
 		.array(
 			z.object({
@@ -198,6 +204,7 @@ const outputSchema = {
 				credentialType: z.string(),
 			}),
 		)
+		.optional()
 		.describe('Credentials auto-assigned to nodes that were added in this update.'),
 	validationWarnings: z
 		.array(
@@ -207,10 +214,15 @@ const outputSchema = {
 				nodeName: z.string().optional(),
 			}),
 		)
+		.optional()
 		.describe(
 			'Graph and JSON validation warnings on the resulting workflow. Use these to self-correct on the next call.',
 		),
 	note: z.string().optional(),
+	error: z
+		.string()
+		.optional()
+		.describe('Error message explaining why the update failed. Present only on failure.'),
 } satisfies z.ZodRawShape;
 
 /**


### PR DESCRIPTION
## Summary
Fixes output schema mismatch in the error path of `update_workflow` and `create_workflow_from_code` MCP tools.

## How to test
The easiest way is to point an MCP Client that enforces strict schema validation, like OpenCode, to related Linear issue and ask it to call update tool with the parameters that the OP was trying to pass. On `master` this should fail with schema issue, on this branch, the real error should surface:

```json
{ "error": "Operation 0 failed: path 'parameters.subject' is invalid or contains unsafe segments" }
```

## Related Linear tickets, Github issues, and Community forum posts
Fixes ADO-5448
Fixes [32503](https://github.com/n8n-io/n8n/issues/32503)


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32560">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

