### PR TITLE
refactor(core): Expose DI-free transport subpath and transport-agnostic request errors (no-changelog)

### DIFF
--- a/packages/@n8n/backend-network/package.json
+++ b/packages/@n8n/backend-network/package.json
@@ -29,12 +29,20 @@
       "types": "./dist/testing.d.ts",
       "import": "./src/testing.ts",
       "require": "./dist/testing.js"
+    },
+    "./transport": {
+      "types": "./dist/transport.d.ts",
+      "import": "./src/transport.ts",
+      "require": "./dist/transport.js"
     }
   },
   "typesVersions": {
     "*": {
       "testing": [
         "dist/testing.d.ts"
+      ],
+      "transport": [
+        "dist/transport.d.ts"
       ]
     }
   },

--- a/packages/@n8n/backend-network/src/http/__tests__/client-request-error.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/client-request-error.test.ts
@@ -1,4 +1,70 @@
-import { httpStatusFromError, isConnectionRefusedError } from '../client-request-error';
+import {
+	httpStatusFromError,
+	isConnectionRefusedError,
+	isHttpRequestError,
+	markHttpRequestError,
+} from '../client-request-error';
+
+describe('isHttpRequestError', () => {
+	const transportError = (props: Record<string, unknown>) =>
+		markHttpRequestError(Object.assign(new Error('request failed'), props));
+
+	it('is true for errors tagged by the request client', () => {
+		expect(isHttpRequestError(transportError({ response: { status: 400, data: {} } }))).toBe(true);
+		expect(isHttpRequestError(transportError({ code: 'ECONNREFUSED' }))).toBe(true);
+	});
+
+	it('is false for untagged errors (incl. raw transport errors) and non-errors', () => {
+		expect(isHttpRequestError(new Error('boom'))).toBe(false);
+		// An axios-shaped error that did NOT come through the client is not tagged.
+		expect(isHttpRequestError(Object.assign(new Error('x'), { isAxiosError: true }))).toBe(false);
+		expect(isHttpRequestError({})).toBe(false);
+		expect(isHttpRequestError(undefined)).toBe(false);
+		expect(isHttpRequestError('nope')).toBe(false);
+	});
+
+	it('narrows to the response body so callers can read it', () => {
+		const error: unknown = transportError({
+			response: { status: 409, data: { message: 'taken' } },
+		});
+
+		expect(isHttpRequestError(error)).toBe(true);
+		if (isHttpRequestError(error)) {
+			const data = error.response?.data as { message?: string } | undefined;
+			expect(data?.message).toBe('taken');
+		}
+	});
+});
+
+describe('markHttpRequestError', () => {
+	it('returns the same error instance and is recognized by the guard', () => {
+		const error = new Error('boom');
+		expect(markHttpRequestError(error)).toBe(error);
+		expect(isHttpRequestError(error)).toBe(true);
+	});
+
+	it('adds a non-enumerable marker that does not leak into logs/serialization', () => {
+		const error = markHttpRequestError(Object.assign(new Error('boom'), { code: 'X' }));
+		const marker = Symbol.for('n8n.backend-network.http-request-error');
+
+		expect(Object.keys(error)).toEqual(['code']);
+		expect(Object.getOwnPropertyDescriptor(error, marker)?.enumerable).toBe(false);
+	});
+
+	it('uses a global-registry symbol shared across module instances', () => {
+		// A separately-resolved symbol with the same key must read the marker —
+		// this is what makes the guard survive src/dist module duplication.
+		const error = markHttpRequestError(new Error('boom'));
+		const sharedSymbol = Symbol.for('n8n.backend-network.http-request-error');
+
+		expect((error as unknown as Record<symbol, unknown>)[sharedSymbol]).toBe(true);
+	});
+
+	it('is a no-op for non-objects', () => {
+		expect(markHttpRequestError('nope')).toBe('nope');
+		expect(markHttpRequestError(undefined)).toBeUndefined();
+	});
+});
 
 describe('isConnectionRefusedError', () => {
 	it('is true for an error carrying ECONNREFUSED', () => {

--- a/packages/@n8n/backend-network/src/http/__tests__/outbound-http.error-tagging.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/outbound-http.error-tagging.test.ts
@@ -1,0 +1,57 @@
+import type { Logger } from '@n8n/backend-common';
+import { mock } from 'vitest-mock-extended';
+
+import type { SsrfProtectionService } from '../../ssrf';
+import {
+	httpStatusFromError,
+	isConnectionRefusedError,
+	isHttpRequestError,
+} from '../client-request-error';
+import { startServer, type LocalServer } from '../local-server';
+import { OutboundHttp } from '../outbound-http';
+
+const client = () =>
+	new OutboundHttp(mock<SsrfProtectionService>(), mock<Logger>()).requests({ ssrf: 'disabled' });
+
+describe('OutboundHttp error tagging', () => {
+	let server: LocalServer;
+
+	afterEach(async () => {
+		await server?.close();
+	});
+
+	it('tags a non-2xx rejection so isHttpRequestError recognizes it', async () => {
+		server = await startServer((_req, res) => {
+			res.statusCode = 409;
+			res.setHeader('content-type', 'application/json');
+			res.end(JSON.stringify({ message: 'already exists' }));
+		});
+
+		expect.assertions(3);
+		try {
+			await client().request({ url: server.url, method: 'POST', body: { a: 1 }, json: true });
+		} catch (error) {
+			expect(isHttpRequestError(error)).toBe(true);
+			expect(httpStatusFromError(error)).toBe(409);
+			if (isHttpRequestError(error)) {
+				const data = error.response?.data as { message?: string } | undefined;
+				expect(data?.message).toBe('already exists');
+			}
+		}
+	});
+
+	it('tags a connection failure (and isConnectionRefusedError still reads it)', async () => {
+		server = await startServer(() => {});
+		const url = server.url;
+		await server.close();
+		server = undefined as unknown as LocalServer;
+
+		expect.assertions(2);
+		try {
+			await client().request({ url, method: 'GET' });
+		} catch (error) {
+			expect(isHttpRequestError(error)).toBe(true);
+			expect(isConnectionRefusedError(error)).toBe(true);
+		}
+	});
+});

--- a/packages/@n8n/backend-network/src/http/__tests__/transport-subpath-purity.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/transport-subpath-purity.test.ts
@@ -1,0 +1,100 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+// Guards the task-runner bundle: the `@n8n/backend-network/transport` subpath
+// must stay free of DI / config / backend-common at runtime, so DI-less callers
+// (e.g. `@n8n/ai-utilities` in the runner) can build transport without dragging
+// the full `OutboundHttp` service and its backend dependencies into their bundle.
+//
+// This walks the *runtime* import graph from `src/transport.ts` (following only
+// relative, non-type imports/exports — `import type` / `export type` are erased
+// by tsc) and asserts no forbidden package is reachable.
+
+const FORBIDDEN_PACKAGES = ['@n8n/di', '@n8n/backend-common', '@n8n/config', 'cache-manager'];
+
+const ENTRY = resolve(__dirname, '../../transport.ts');
+
+interface ImportRef {
+	specifier: string;
+	typeOnly: boolean;
+}
+
+/** Extract `import`/`export ... from` specifiers from a source file. */
+function parseImports(source: string): ImportRef[] {
+	const refs: ImportRef[] = [];
+
+	// `import ... from '<s>'` / `export ... from '<s>'`. Requiring `from` (and
+	// disallowing `;` before it) avoids matching value expressions like
+	// `?? 'env'` inside a function body.
+	const fromRe = /(?:^|\n)\s*(import|export)(\s+type)?\b[^;]*?\bfrom\s*['"]([^'"]+)['"]/g;
+	let match: RegExpExecArray | null;
+	while ((match = fromRe.exec(source)) !== null) {
+		const [, , typeKeyword, specifier] = match;
+		refs.push({ specifier, typeOnly: Boolean(typeKeyword) });
+	}
+
+	// Bare side-effect imports: `import '<s>';` (always runtime).
+	const bareRe = /(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g;
+	while ((match = bareRe.exec(source)) !== null) {
+		refs.push({ specifier: match[1], typeOnly: false });
+	}
+
+	return refs;
+}
+
+function resolveRelative(fromFile: string, specifier: string): string | undefined {
+	const base = resolve(dirname(fromFile), specifier);
+	const candidates = [base, `${base}.ts`, resolve(base, 'index.ts')];
+	return candidates.find((candidate) => existsSync(candidate) && candidate.endsWith('.ts'));
+}
+
+/** All bare (non-relative) specifiers reachable at runtime from the entry file. */
+function collectRuntimeExternals(entry: string): Set<string> {
+	const externals = new Set<string>();
+	const visited = new Set<string>();
+
+	const visit = (file: string) => {
+		if (visited.has(file)) return;
+		visited.add(file);
+
+		const source = readFileSync(file, 'utf8');
+		for (const { specifier, typeOnly } of parseImports(source)) {
+			if (typeOnly) continue; // erased at compile time — no runtime dependency
+			if (specifier.startsWith('.')) {
+				const resolved = resolveRelative(file, specifier);
+				if (resolved) visit(resolved);
+				continue;
+			}
+			externals.add(specifier);
+		}
+	};
+
+	visit(entry);
+	return externals;
+}
+
+describe('@n8n/backend-network/transport subpath purity', () => {
+	it('has a resolvable entry file', () => {
+		expect(existsSync(ENTRY)).toBe(true);
+	});
+
+	it('does not pull DI / config / backend-common into the runtime graph', () => {
+		const externals = collectRuntimeExternals(ENTRY);
+
+		for (const forbidden of FORBIDDEN_PACKAGES) {
+			const leaked = [...externals].some(
+				(specifier) => specifier === forbidden || specifier.startsWith(`${forbidden}/`),
+			);
+			expect(
+				leaked,
+				`forbidden runtime dependency reachable from transport subpath: ${forbidden}`,
+			).toBe(false);
+		}
+	});
+
+	it('only depends on undici and n8n-workflow at runtime', () => {
+		const externals = collectRuntimeExternals(ENTRY);
+
+		expect([...externals].sort()).toEqual(['n8n-workflow', 'undici']);
+	});
+});

--- a/packages/@n8n/backend-network/src/http/__tests__/transport-subpath-purity.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/transport-subpath-purity.test.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-// Guards the task-runner bundle: the `@n8n/backend-network/transport` subpath
+// Guards the DI-less bundle: the `@n8n/backend-network/transport` subpath
 // must stay free of DI / config / backend-common at runtime, so DI-less callers
-// (e.g. `@n8n/ai-utilities` in the runner) can build transport without dragging
-// the full `OutboundHttp` service and its backend dependencies into their bundle.
+// can build transport without dragging the full `OutboundHttp` service and its
+// backend dependencies into their bundle.
 //
 // This walks the *runtime* import graph from `src/transport.ts` (following only
 // relative, non-type imports/exports — `import type` / `export type` are erased

--- a/packages/@n8n/backend-network/src/http/__tests__/transport-timeouts.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/transport-timeouts.test.ts
@@ -1,0 +1,51 @@
+import { type LocalServer, startServer } from '../local-server';
+import { buildDispatcher, createDispatcherTransport } from '../undici/transport';
+
+// Proves the undici timeout knobs added for long-running outbound calls (e.g.
+// LLM completions) actually reach the dispatcher. A local server delays its
+// response well past a tight `headersTimeout`: with the knob applied the request
+// aborts, and with undici's default (5 min) the same slow response succeeds.
+
+const RESPONSE_DELAY_MS = 1000;
+const TIGHT_TIMEOUT_MS = 50;
+
+describe('transport timeouts', () => {
+	let slow: LocalServer;
+
+	beforeAll(async () => {
+		slow = await startServer((_req, res) => {
+			setTimeout(() => {
+				res.setHeader('Content-Type', 'text/plain');
+				res.end('late');
+			}, RESPONSE_DELAY_MS);
+		});
+	});
+
+	afterAll(async () => {
+		await slow.close();
+	});
+
+	it('applies headersTimeout to the dispatcher so a slow response aborts', async () => {
+		const transport = createDispatcherTransport({
+			proxy: false,
+			ssrf: 'disabled',
+			timeouts: { headersTimeout: TIGHT_TIMEOUT_MS, bodyTimeout: TIGHT_TIMEOUT_MS },
+		});
+
+		await expect(transport.asCustomFetch()(`${slow.url}/x`)).rejects.toThrow();
+	});
+
+	it('keeps undici defaults when no timeout is set so the slow response succeeds', async () => {
+		const transport = createDispatcherTransport({ proxy: false, ssrf: 'disabled' });
+
+		const response = await transport.asCustomFetch()(`${slow.url}/x`);
+
+		expect(await response.text()).toBe('late');
+	});
+
+	it('builds a dispatcher without timeouts when none are provided', () => {
+		// Smoke check that the optional argument path stays valid.
+		expect(() => buildDispatcher(false, 'disabled')).not.toThrow();
+		expect(() => buildDispatcher('env', 'disabled', { bodyTimeout: 1000 })).not.toThrow();
+	});
+});

--- a/packages/@n8n/backend-network/src/http/client-request-error.ts
+++ b/packages/@n8n/backend-network/src/http/client-request-error.ts
@@ -31,3 +31,47 @@ export function httpStatusFromError(error: unknown): number | undefined {
 	}
 	return undefined;
 }
+
+/**
+ * The shape of an error rejected by the {@link HttpRequestClient}
+ * It carries the transport's `code` and, when a response was received, its `status` and parsed `data`.
+ */
+export interface HttpRequestError extends Error {
+	code?: string;
+	response?: { status?: number; data?: unknown };
+}
+
+/**
+ * Process-global marker tagged onto every error the {@link HttpRequestClient} rejects with.
+ * Uses `Symbol.for` (the global registry), not a module-local `Symbol()`,
+ * so the tag still matches when this package is loaded as more than one module instance (src + dist).
+ */
+const HTTP_REQUEST_ERROR = Symbol.for('n8n.backend-network.http-request-error');
+
+/**
+ * Tags an error as rejected by the {@link HttpRequestClient}.
+ * Called by the client on its reject path so {@link isHttpRequestError} can recognize it
+ * without coupling to the transport library.
+ */
+export function markHttpRequestError<E>(error: E): E {
+	if (typeof error === 'object' && error !== null) {
+		Object.defineProperty(error, HTTP_REQUEST_ERROR, {
+			value: true,
+			enumerable: false, // it never leaks into logs, `JSON.stringify`, or `Object.keys`.
+			configurable: true,
+		});
+	}
+	return error;
+}
+
+/**
+ * Whether the error was rejected by the {@link HttpRequestClient} (a transport
+ * failure or a non-2xx response) rather than being an unrelated runtime error.
+ * Lets callers read `response.data` without coupling to a specific HTTP library.
+ */
+export function isHttpRequestError(error: unknown): error is HttpRequestError {
+	return (
+		error instanceof Error &&
+		(error as unknown as Record<symbol, unknown>)[HTTP_REQUEST_ERROR] === true
+	);
+}

--- a/packages/@n8n/backend-network/src/http/index.ts
+++ b/packages/@n8n/backend-network/src/http/index.ts
@@ -18,7 +18,13 @@ export {
 	type HttpTransport,
 	type HttpTransportOptions,
 } from './outbound-http';
-export { httpStatusFromError, isConnectionRefusedError } from './client-request-error';
+export {
+	httpStatusFromError,
+	isConnectionRefusedError,
+	isHttpRequestError,
+	markHttpRequestError,
+	type HttpRequestError,
+} from './client-request-error';
 export type { HttpRequestDefaultHeaders } from './client-default-headers';
 export type { HttpRequestClientOptions } from './client-options';
 export type { LegacyRequestCallbacks } from './legacy-request';

--- a/packages/@n8n/backend-network/src/http/outbound-http.ts
+++ b/packages/@n8n/backend-network/src/http/outbound-http.ts
@@ -148,15 +148,26 @@ export class OutboundHttp {
 		const applyDefaults = (requestOptions: IHttpRequestOptions): IHttpRequestOptions =>
 			withClientDefaults(requestOptions, options?.baseURL, options?.headers);
 
+		function request(
+			requestOptions: IHttpRequestOptions & { returnFullResponse: true },
+		): Promise<IN8nHttpFullResponse>;
+		function request(
+			requestOptions: IHttpRequestOptions & { returnFullResponse?: false },
+		): Promise<IN8nHttpResponse>;
+		function request(
+			requestOptions: IHttpRequestOptions,
+		): Promise<IN8nHttpFullResponse | IN8nHttpResponse>;
+		async function request(requestOptions: IHttpRequestOptions) {
+			try {
+				return await httpRequest(applyDefaults(requestOptions), ssrfBridge);
+			} catch (error) {
+				// Tag so callers can recognize a client-rejected error transport-agnostically.
+				throw markHttpRequestError(error);
+			}
+		}
+
 		return {
-			request: (async (requestOptions: IHttpRequestOptions) => {
-				try {
-					return await httpRequest(applyDefaults(requestOptions), ssrfBridge);
-				} catch (error) {
-					// Tag so callers can recognize a client-rejected error transport-agnostically.
-					throw markHttpRequestError(error);
-				}
-			}) as HttpRequestClient['request'],
+			request,
 			requestLegacy: async (requestOptions, callbacks) => {
 				try {
 					return await executeLegacyRequest(requestOptions, ssrfBridge, this.logger, callbacks);

--- a/packages/@n8n/backend-network/src/http/outbound-http.ts
+++ b/packages/@n8n/backend-network/src/http/outbound-http.ts
@@ -14,10 +14,15 @@ import { SsrfProtectionService } from '../ssrf';
 import { httpRequest } from './axios/request';
 import { withClientDefaults } from './client-default-headers';
 import { HttpRequestClientOptions } from './client-options';
+import { markHttpRequestError } from './client-request-error';
 import { executeLegacyRequest, type LegacyRequestCallbacks } from './legacy-request';
 import type { NodeAgentOptions, ProxyOption, SsrfOption } from './node-agents';
 import { buildNodeAgents } from './node-agents';
-import { buildDispatcher, dispatchedFetch, type CustomFetch } from './undici/transport';
+import {
+	createDispatcherTransport,
+	type CustomFetch,
+	type TransportTimeoutOptions,
+} from './undici/transport';
 
 export interface HttpTransportOptions {
 	/**
@@ -33,6 +38,12 @@ export interface HttpTransportOptions {
 	 * Pass `'disabled'` to explicitly opt out.
 	 */
 	ssrf?: SsrfOption;
+	/**
+	 * Undici agent timeout overrides (ms). Unset fields keep undici's defaults.
+	 * Used for long-running outbound calls (e.g. LLM completions) that would
+	 * otherwise hit undici's 5-minute `headersTimeout` / `bodyTimeout`.
+	 */
+	timeouts?: TransportTimeoutOptions;
 }
 
 /**
@@ -138,13 +149,21 @@ export class OutboundHttp {
 			withClientDefaults(requestOptions, options?.baseURL, options?.headers);
 
 		return {
-			request: (async (requestOptions: IHttpRequestOptions) =>
-				await httpRequest(
-					applyDefaults(requestOptions),
-					ssrfBridge,
-				)) as HttpRequestClient['request'],
-			requestLegacy: async (requestOptions, callbacks) =>
-				await executeLegacyRequest(requestOptions, ssrfBridge, this.logger, callbacks),
+			request: (async (requestOptions: IHttpRequestOptions) => {
+				try {
+					return await httpRequest(applyDefaults(requestOptions), ssrfBridge);
+				} catch (error) {
+					// Tag so callers can recognize a client-rejected error transport-agnostically.
+					throw markHttpRequestError(error);
+				}
+			}) as HttpRequestClient['request'],
+			requestLegacy: async (requestOptions, callbacks) => {
+				try {
+					return await executeLegacyRequest(requestOptions, ssrfBridge, this.logger, callbacks);
+				} catch (error) {
+					throw markHttpRequestError(error);
+				}
+			},
 		};
 	}
 
@@ -154,14 +173,17 @@ export class OutboundHttp {
 	transport(options?: HttpTransportOptions): HttpTransport {
 		const proxy = options?.proxy ?? 'env';
 		const ssrf = options?.ssrf ?? this.ssrfProtection;
+		const timeouts = options?.timeouts;
 
-		const lazyDispatcher = lazy(() => buildDispatcher(proxy, ssrf));
+		// The dispatcher/fetch half is the DI-free core shared with the
+		// `@n8n/backend-network/transport` subpath. Only `getNodeAgent` stays here,
+		// because Node agent construction is not yet dependency-free.
+		const dispatcherTransport = createDispatcherTransport({ proxy, ssrf, timeouts });
 		const lazyNodeAgents = lazy(() => buildNodeAgents(proxy, ssrf));
 
 		return {
-			asCustomFetch: () => async (input, init) =>
-				await dispatchedFetch(lazyDispatcher(), input, init),
-			getDispatcher: () => lazyDispatcher(),
+			asCustomFetch: () => dispatcherTransport.asCustomFetch(),
+			getDispatcher: () => dispatcherTransport.getDispatcher(),
 			getNodeAgent: (agentOptions) =>
 				agentOptions !== undefined ? buildNodeAgents(proxy, ssrf, agentOptions) : lazyNodeAgents(),
 		};

--- a/packages/@n8n/backend-network/src/http/undici/transport.ts
+++ b/packages/@n8n/backend-network/src/http/undici/transport.ts
@@ -11,24 +11,112 @@ import type { ProxyOption, SsrfOption } from '../node-agents';
 export type CustomFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 /**
- * Builds the undici dispatcher for a given proxy + SSRF policy — the transport
- * plumbing behind `OutboundHttp.transport()`. When SSRF is active the dispatcher
- * is composed with {@link createSsrfInterceptor} so every dispatched request,
- * including each redirect hop, is validated.
+ * Undici agent timeout overrides for a transport, in milliseconds.
+ *
+ * undici defaults `headersTimeout` / `bodyTimeout` to 5 minutes, which is too
+ * short for long-running outbound calls (e.g. LLM completions).
+ * Callers pass their own values here (the value itself, e.g. aligned to the execution
+ * timeout, is owned by the caller, not this transport core).
+ *
+ * Kept as plain data so the pure transport core (`@n8n/backend-network/transport`)
+ * carries no config or DI dependency.
  */
-export function buildDispatcher(proxy: ProxyOption, ssrf: SsrfOption): Dispatcher {
-	const dispatcher = buildDispatcherFromProxy(proxy);
+export interface TransportTimeoutOptions {
+	headersTimeout?: number;
+	bodyTimeout?: number;
+	connectTimeout?: number;
+}
+
+/** Options for {@link createDispatcherTransport}. */
+export interface CreateDispatcherTransportOptions {
+	/** Proxy routing. Defaults to `'env'` (HTTP(S)_PROXY / NO_PROXY). */
+	proxy?: ProxyOption;
+	/** SSRF policy. Defaults to `'disabled'`. */
+	ssrf?: SsrfOption;
+	/** Undici agent timeout overrides. */
+	timeouts?: TransportTimeoutOptions;
+}
+
+/**
+ * The dispatcher/fetch half of an `HttpTransport`: it hands out a pure undici
+ * `Dispatcher` (and a `fetch` bound to it), with no Node `http.Agent` construction.
+ * This is the part of the transport that has no DI dependency,
+ * so DI-less callers (e.g. task-runner code) can build it via the `@n8n/backend-network/transport` subpath.
+ */
+export interface DispatcherTransport {
+	asCustomFetch(): CustomFetch;
+	getDispatcher(): Dispatcher;
+}
+
+/**
+ * Builds the undici dispatcher for a given proxy + SSRF policy,
+ * The transport plumbing behind `OutboundHttp.transport()`.
+ * When SSRF is active the dispatcher is composed with {@link createSsrfInterceptor},
+ * so every dispatched request, including each redirect hop, is validated.
+ */
+export function buildDispatcher(
+	proxy: ProxyOption,
+	ssrf: SsrfOption,
+	timeouts?: TransportTimeoutOptions,
+): Dispatcher {
+	const dispatcher = buildDispatcherFromProxy(proxy, timeouts);
 	return ssrf === 'disabled' ? dispatcher : dispatcher.compose(createSsrfInterceptor(ssrf));
 }
 
-function buildDispatcherFromProxy(proxy: ProxyOption): Dispatcher {
+function buildDispatcherFromProxy(
+	proxy: ProxyOption,
+	timeouts?: TransportTimeoutOptions,
+): Dispatcher {
+	const agentOptions = toAgentTimeoutOptions(timeouts);
 	if (proxy === false) {
-		return new Agent();
+		return new Agent(agentOptions);
 	}
 	if (proxy === 'env') {
-		return new EnvHttpProxyAgent();
+		return new EnvHttpProxyAgent(agentOptions);
 	}
-	return new ProxyAgent(proxy);
+	return new ProxyAgent({ uri: proxy, ...agentOptions });
+}
+
+/**
+ * Maps {@link TransportTimeoutOptions} onto the undici agent option subset,
+ * omitting unset keys so undici keeps its own default for each one.
+ */
+function toAgentTimeoutOptions(timeouts?: TransportTimeoutOptions): TransportTimeoutOptions {
+	if (!timeouts) {
+		return {};
+	}
+	return {
+		...(timeouts.headersTimeout !== undefined && { headersTimeout: timeouts.headersTimeout }),
+		...(timeouts.bodyTimeout !== undefined && { bodyTimeout: timeouts.bodyTimeout }),
+		...(timeouts.connectTimeout !== undefined && { connectTimeout: timeouts.connectTimeout }),
+	};
+}
+
+/**
+ * Builds a {@link DispatcherTransport} from plain options, the DI-free core
+ * shared by `OutboundHttp.transport()` and the `@n8n/backend-network/transport`
+ * subpath. A single dispatcher instance is built lazily and shared by
+ * `getDispatcher()` and `asCustomFetch()` so they use one connection pool.
+ */
+export function createDispatcherTransport(
+	options?: CreateDispatcherTransportOptions,
+): DispatcherTransport {
+	const proxy = options?.proxy ?? 'env';
+	const ssrf = options?.ssrf ?? 'disabled';
+	const timeouts = options?.timeouts;
+
+	const lazyDispatcher = lazyValue(() => buildDispatcher(proxy, ssrf, timeouts));
+
+	return {
+		asCustomFetch: () => async (input, init) =>
+			await dispatchedFetch(lazyDispatcher(), input, init),
+		getDispatcher: () => lazyDispatcher(),
+	};
+}
+
+function lazyValue<T>(factory: () => T): () => T {
+	let cached: { value: T } | undefined;
+	return () => (cached ??= { value: factory() }).value;
 }
 
 /**

--- a/packages/@n8n/backend-network/src/transport.ts
+++ b/packages/@n8n/backend-network/src/transport.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure transport entry point (`@n8n/backend-network/transport`).
+ *
+ * Exposes the dispatcher/fetch core of the outbound HTTP transport with no DI,
+ * `@n8n/config` or `@n8n/backend-common` dependency: its only runtime imports
+ * are `undici` and `n8n-workflow`. This is the construction path for DI-less
+ * callers (e.g. task-runner code) that must build a proxy/SSRF-aware transport
+ * without dragging the full `OutboundHttp` service — and its backend
+ * dependencies — into their bundle.
+ *
+ * `OutboundHttp` (the `@n8n/di` service) wraps this same core, so there is a
+ * single implementer of transport construction across the codebase.
+ *
+ * The Node `http.Agent` path (`getNodeAgent` / `buildNodeAgents`) is
+ * intentionally NOT re-exported here: it is not yet dependency-free.
+ */
+export {
+	buildDispatcher,
+	createSsrfInterceptor,
+	createDispatcherTransport,
+	dispatchedFetch,
+} from './http/undici/transport';
+export type {
+	CustomFetch,
+	DispatcherTransport,
+	CreateDispatcherTransportOptions,
+	TransportTimeoutOptions,
+} from './http/undici/transport';
+export type { ProxyOption, ProxyUrl, SsrfOption } from './http/node-agents';
+export type { SsrfBridge } from './ssrf/ssrf-protection.service';


### PR DESCRIPTION
## Summary

Prepares `@n8n/backend-network` for two upcoming consumers:
- a lightweight transport for DI-less callers
- and the eventual axios replacements

by adding the export surface and contracts they need. 

No service callsites are migrated and no axios is removed here.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3506

Parent: https://linear.app/n8n/issue/CAT-3365

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32566">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
