### PR TITLE
fix(editor): Enable ungroup shortcut for selected collapsed group (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -397,7 +397,7 @@ const {
 	canUngroup: canUngroupSelection,
 	groupSelection,
 	selectedGroupIds,
-} = useCanvasNodeGroupActions(selectedNodes, {
+} = useCanvasNodeGroupActions(selectedNodesAndGroups, {
 	readOnly: () => props.readOnly || props.suppressInteraction,
 });
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { computed } from 'vue';
-import type { GraphNode } from '@vue-flow/core';
 
 import { useCanvasNodeGroupActions } from './useCanvasNodeGroupActions';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import {
+	createCanvasGraphNode,
+	createCanvasGraphGroupNode,
+} from '@/features/workflows/canvas/__tests__/utils';
 
 const isSelectionGroupableMock = vi.fn();
 const expandSelectionWithSubNodesMock = vi.fn((nodeIds: string[]) => nodeIds);
@@ -29,10 +32,6 @@ vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
 	};
 });
 
-function makeNode(id: string): GraphNode {
-	return { id, position: { x: 0, y: 0 } } as unknown as GraphNode;
-}
-
 describe('useCanvasNodeGroupActions', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
@@ -47,7 +46,7 @@ describe('useCanvasNodeGroupActions', () => {
 	describe('canGroup', () => {
 		it('is false in read-only mode', () => {
 			const { canGroup } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('b')]),
+				computed(() => [createCanvasGraphNode({ id: 'a' }), createCanvasGraphNode({ id: 'b' })]),
 				{
 					readOnly: () => true,
 				},
@@ -57,7 +56,7 @@ describe('useCanvasNodeGroupActions', () => {
 
 		it('is true when validation succeeds and no node is grouped', () => {
 			const { canGroup } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('b')]),
+				computed(() => [createCanvasGraphNode({ id: 'a' }), createCanvasGraphNode({ id: 'b' })]),
 			);
 			expect(canGroup.value).toBe(true);
 		});
@@ -69,7 +68,7 @@ describe('useCanvasNodeGroupActions', () => {
 				nodeIds: ['a'],
 			});
 			const { canGroup } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('b')]),
+				computed(() => [createCanvasGraphNode({ id: 'a' }), createCanvasGraphNode({ id: 'b' })]),
 			);
 			expect(canGroup.value).toBe(false);
 		});
@@ -77,7 +76,7 @@ describe('useCanvasNodeGroupActions', () => {
 		it('is false when validation rejects the selection', () => {
 			isSelectionGroupableMock.mockReturnValue({ valid: false, reason: 'invalid-subgraph' });
 			const { canGroup } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('b')]),
+				computed(() => [createCanvasGraphNode({ id: 'a' }), createCanvasGraphNode({ id: 'b' })]),
 			);
 			expect(canGroup.value).toBe(false);
 		});
@@ -87,7 +86,10 @@ describe('useCanvasNodeGroupActions', () => {
 		it('creates a group from the expanded selection', () => {
 			expandSelectionWithSubNodesMock.mockImplementation((ids: string[]) => [...ids, 'memory']);
 			const { groupSelection } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('agent')]),
+				computed(() => [
+					createCanvasGraphNode({ id: 'a' }),
+					createCanvasGraphNode({ id: 'agent' }),
+				]),
 			);
 			const group = groupSelection();
 			expect(group?.nodeIds).toEqual(['a', 'agent', 'memory']);
@@ -96,7 +98,9 @@ describe('useCanvasNodeGroupActions', () => {
 
 		it('returns null when canGroup is false', () => {
 			isSelectionGroupableMock.mockReturnValue({ valid: false, reason: 'invalid-subgraph' });
-			const { groupSelection } = useCanvasNodeGroupActions(computed(() => [makeNode('a')]));
+			const { groupSelection } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphNode({ id: 'a' })]),
+			);
 			expect(groupSelection()).toBeNull();
 		});
 	});
@@ -104,19 +108,31 @@ describe('useCanvasNodeGroupActions', () => {
 	describe('canUngroup', () => {
 		it('is true when any selected node belongs to a group', () => {
 			workflowDocumentStore.createGroup(['a', 'b'], 'Group');
-			const { canUngroup } = useCanvasNodeGroupActions(computed(() => [makeNode('a')]));
+			const { canUngroup } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphNode({ id: 'a' })]),
+			);
+			expect(canUngroup.value).toBe(true);
+		});
+
+		it('is true when a collapsed group node is directly selected', () => {
+			const group = workflowDocumentStore.createGroup(['a', 'b'], 'Group');
+			const { canUngroup } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphGroupNode({ id: group.id })]),
+			);
 			expect(canUngroup.value).toBe(true);
 		});
 
 		it('is false when no selected node belongs to a group', () => {
-			const { canUngroup } = useCanvasNodeGroupActions(computed(() => [makeNode('a')]));
+			const { canUngroup } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphNode({ id: 'a' })]),
+			);
 			expect(canUngroup.value).toBe(false);
 		});
 
 		it('is false in read-only mode', () => {
 			workflowDocumentStore.createGroup(['a', 'b'], 'Group');
 			const { canUngroup } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a')]),
+				computed(() => [createCanvasGraphNode({ id: 'a' })]),
 				{
 					readOnly: () => true,
 				},
@@ -132,15 +148,29 @@ describe('useCanvasNodeGroupActions', () => {
 			workflowDocumentStore.createGroup(['e', 'f'], 'Group C');
 
 			const { selectedGroupIds } = useCanvasNodeGroupActions(
-				computed(() => [makeNode('a'), makeNode('b'), makeNode('c')]),
+				computed(() => [
+					createCanvasGraphNode({ id: 'a' }),
+					createCanvasGraphNode({ id: 'b' }),
+					createCanvasGraphNode({ id: 'c' }),
+				]),
 			);
 
 			expect(selectedGroupIds.value).toEqual(expect.arrayContaining([groupA.id, groupB.id]));
 			expect(selectedGroupIds.value).toHaveLength(2);
 		});
 
+		it('resolves the group id from a directly selected collapsed group node', () => {
+			const group = workflowDocumentStore.createGroup(['a', 'b'], 'Group');
+			const { selectedGroupIds } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphGroupNode({ id: group.id })]),
+			);
+			expect(selectedGroupIds.value).toEqual([group.id]);
+		});
+
 		it('is empty when no selected node belongs to a group', () => {
-			const { selectedGroupIds } = useCanvasNodeGroupActions(computed(() => [makeNode('a')]));
+			const { selectedGroupIds } = useCanvasNodeGroupActions(
+				computed(() => [createCanvasGraphNode({ id: 'a' })]),
+			);
 			expect(selectedGroupIds.value).toEqual([]);
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
@@ -6,6 +6,10 @@ import { computed, toValue } from 'vue';
 
 import { useSelectionValidation } from '@/app/composables/useSelectionValidation';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	isCanvasGroupNode,
+	parseCanvasGroupNodeId,
+} from '@/features/workflows/canvas/canvas.types';
 
 export function useCanvasNodeGroupActions(
 	selectedNodes: MaybeRefOrGetter<GraphNode[]>,
@@ -18,7 +22,11 @@ export function useCanvasNodeGroupActions(
 	const isReadOnly = computed(() => toValue(options?.readOnly) ?? false);
 
 	const expandedSelectionIds = computed(() => {
-		return expandSelectionWithSubNodes(toValue(selectedNodes).map((n) => n.id));
+		return expandSelectionWithSubNodes(
+			toValue(selectedNodes)
+				.filter((n) => !isCanvasGroupNode(n))
+				.map((n) => n.id),
+		);
 	});
 
 	const canGroup = computed(() => {
@@ -30,8 +38,17 @@ export function useCanvasNodeGroupActions(
 		if (isReadOnly.value) return [];
 		const ids = new Set<string>();
 		for (const node of toValue(selectedNodes)) {
+			// Collapsed group: selectable as one group node whose id carries the group id
+			const directGroupId = parseCanvasGroupNodeId(node.id);
+			if (directGroupId) {
+				ids.add(directGroupId);
+				continue;
+			}
+			// Expanded group: the group node isn't selectable, so map a selected member back to it
 			const group = workflowDocumentStore.value.getGroupForNode(node.id);
-			if (group) ids.add(group.id);
+			if (group) {
+				ids.add(group.id);
+			}
 		}
 		return Array.from(ids);
 	});


### PR DESCRIPTION
## Summary

The ungroup keyboard shortcut (Ctrl/Cmd+Shift+G) did nothing when a collapsed group was selected on the canvas — the shortcut stayed disabled, so there was no way to ungroup a group from the keyboard while it was collapsed.

This enables the shortcut for a directly-selected collapsed group, so it behaves the same as ungrouping while the group is expanded (member nodes selected).

## How to test

1. Create a group of nodes on the canvas
2. Collapse the group
3. Select the collapsed group (click its title bar)
4. Press the ungroup shortcut (Ctrl/Cmd+Shift+G)
5. The group is ungrouped

Also verify the existing expanded-group flow still works: expand a group, select its member nodes, press the shortcut, and confirm it ungroups.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5454

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32567">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
