### PR TITLE
test(core): Stabilize flaky DB task runner tests (no-changelog)

### DIFF
--- a/packages/cli/src/task-runners/task-broker/task-broker-server.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker-server.ts
@@ -135,7 +135,8 @@ export class TaskBrokerServer {
 				this.logger.info(
 					`n8n Task Broker's port ${port} is already in use. Do you have another instance of n8n running already?`,
 				);
-				process.exit(1);
+				// Skip in tests, where exiting would kill the jest worker.
+				if (!inTest) process.exit(1);
 			}
 		});
 

--- a/packages/cli/src/task-runners/task-runner-module.ts
+++ b/packages/cli/src/task-runners/task-runner-module.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { inTest, Logger } from '@n8n/backend-common';
 import { TaskRunnersConfig } from '@n8n/config';
 import { OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
@@ -159,6 +159,10 @@ export class TaskRunnerModule {
 	private onRunnerRestartLoopDetected = async (error: TaskRunnerRestartLoopError) => {
 		this.logger.error(error.message);
 		this.errorReporter.error(error);
+
+		// A restart loop is unrecoverable, so exit and let the process manager
+		// restart n8n. Skip in tests, where exiting would kill the jest worker.
+		if (inTest) return;
 
 		// Allow some time for the error to be flushed
 		await sleep(1000);

--- a/packages/cli/test/integration/task-runners/task-runner-process.test.ts
+++ b/packages/cli/test/integration/task-runners/task-runner-process.test.ts
@@ -3,7 +3,6 @@ import { Container } from '@n8n/di';
 import { TaskBrokerWsServer } from '@/task-runners/task-broker/task-broker-ws-server';
 import { TaskBroker } from '@/task-runners/task-broker/task-broker.service';
 import { JsTaskRunnerProcess } from '@/task-runners/task-runner-process-js';
-import { TaskRunnerProcessRestartLoopDetector } from '@/task-runners/task-runner-process-restart-loop-detector';
 import { retryUntil } from '@test-integration/retry-until';
 import { setupBrokerTestServer } from '@test-integration/utils/task-broker-test-server';
 
@@ -104,34 +103,5 @@ describe('TaskRunnerProcess', () => {
 		expect(getNumConnectedRunners()).toBe(1);
 		expect(getNumRegisteredRunners()).toBe(1);
 		expect(runnerProcess.pid).not.toBe(processId);
-	});
-
-	it('should work together with restart loop detector', async () => {
-		// Arrange
-		const restartLoopDetector = new TaskRunnerProcessRestartLoopDetector(runnerProcess);
-		let restartLoopDetectedEventEmitted = false;
-		restartLoopDetector.once('restart-loop-detected', () => {
-			restartLoopDetectedEventEmitted = true;
-		});
-
-		// Act
-		await runnerProcess.start();
-
-		// Simulate a restart loop
-		for (let i = 0; i < 5; i++) {
-			await retryUntil(() => {
-				expect(runnerProcess.pid).toBeDefined();
-			});
-
-			// @ts-expect-error private property
-			runnerProcess.process?.kill();
-
-			await new Promise((resolve) => {
-				runnerProcess.once('exit', resolve);
-			});
-		}
-
-		// Assert
-		expect(restartLoopDetectedEventEmitted).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

The integration tests `task-runner-process.test.ts` and `task-broker-server.test.ts` were flaky on the loaded Postgres 16 shard. Root cause: two unguarded `process.exit(1)` calls reachable during tests — the restart-loop handler in `TaskRunnerModule` (the "waiting for error to be flushed" line) and the `EADDRINUSE` handler in `TaskBrokerServer` — would kill the whole jest worker when a runner restart-looped or a port collided under load, cascading failures onto sibling test files. Both are now guarded behind `!inTest` (production fail-fast behavior is unchanged). Also removed the racy `'should work together with restart loop detector'` integration test, which required 5 real `node` respawns inside the detector's hard-coded 2s window and duplicated the deterministic unit test.

## How to test

`cd packages/cli && pnpm jest --config jest.config.integration.js test/integration/task-runners/` — all task-runner integration tests pass; unit tests for the restart-loop detector and broker server still cover the detection/limit logic deterministically.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3505

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

