### PR TITLE
fix: Prevent text selection and native context menu on canvas in Safari

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -181,5 +181,7 @@ defineExpose({
 	align-items: stretch;
 	justify-content: stretch;
 	background-color: var(--canvas--color--background);
+	user-select: none;
+	-webkit-user-select: none;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -157,6 +157,7 @@ watch(viewport, () => {
 });
 
 function openContextMenu(event: MouseEvent) {
+	event.preventDefault();
 	emit('open:contextmenu', event);
 }
 


### PR DESCRIPTION
Two Safari-specific issues on the canvas:

1. Drag-selecting triggered browser text selection instead of n8n's selection rectangle. Added `user-select: none` + `-webkit-user-select: none` to the `.canvas` container in `WorkflowCanvas.vue`.

2. Right-clicking a node showed Safari's native context menu on top of n8n's custom one. The pane-level `contextmenu` event already called `preventDefault`, but the node-level handler in `CanvasNodeDefault.vue` didn't. Added it there.

Closes #32521

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32574">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

