### PR TITLE
feat(core): Recover from runtime trigger failures in-process (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -496,6 +496,7 @@ describe('WorkflowTriggerActivator', () => {
 			triggerExecutionContextFactory?: TriggerExecutionContextFactory;
 			activationErrorsService?: ActivationErrorsService;
 			errorReporter?: ErrorReporter;
+			workflowStaticDataService?: WorkflowStaticDataService;
 		}) {
 			jest.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
 			jest.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
@@ -551,14 +552,20 @@ describe('WorkflowTriggerActivator', () => {
 			activationErrorsService.deregister.mockImplementation(async () => {
 				callOrder.push('clear-error');
 			});
+			const workflowStaticDataService = mock<WorkflowStaticDataService>();
+			workflowStaticDataService.saveStaticData.mockImplementation(async () => {
+				callOrder.push('save-static');
+			});
 
 			const onTriggerFailure = await activateAndCaptureFailureHandler({
 				nonWebhookTriggerRegistrar,
 				triggerExecutionContextFactory,
 				activationErrorsService,
+				workflowStaticDataService,
 			});
 			// Drop the bookkeeping from the initial activation; only track the recovery.
 			callOrder.length = 0;
+			workflowStaticDataService.saveStaticData.mockClear();
 
 			onTriggerFailure(failure);
 			await flushPromises();
@@ -568,9 +575,11 @@ describe('WorkflowTriggerActivator', () => {
 				'register-error',
 				'error-workflow',
 				'reactivate',
+				'save-static',
 				'clear-error',
 			]);
 			expect(nonWebhookTriggerRegistrar.deregister).toHaveBeenCalledWith('wf-1', 't');
+			expect(workflowStaticDataService.saveStaticData).toHaveBeenCalledTimes(1);
 			expect(activationErrorsService.register).toHaveBeenCalledWith('wf-1', 'trigger crashed');
 			expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
 		});

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { WorkflowsConfig } from '@n8n/config';
-import type { WorkflowEntity, WorkflowRepository } from '@n8n/db';
-import { mock } from 'jest-mock-extended';
+import type { IWorkflowDb, WorkflowEntity, WorkflowRepository } from '@n8n/db';
+import { mock, type MockProxy } from 'jest-mock-extended';
 import type { ErrorReporter } from 'n8n-core';
 import type { IWebhookData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
-import { WebhookPathTakenError, WorkflowExpression } from 'n8n-workflow';
+import { WebhookPathTakenError, WorkflowActivationError, WorkflowExpression } from 'n8n-workflow';
 
+import type { ActivationErrorsService } from '@/activation-errors.service';
 import { TRIGGER_ACTIVATION_MAX_ATTEMPTS } from '@/constants';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import type {
@@ -27,47 +28,53 @@ jest.mock('n8n-workflow', () => ({
 
 const MAX_ATTEMPTS = TRIGGER_ACTIVATION_MAX_ATTEMPTS;
 
+const flushPromises = async () => await new Promise((resolve) => setImmediate(resolve));
+
+type ActivatorOverrides = {
+	errorReporter?: ErrorReporter;
+	nodeTypes?: ReturnType<typeof createNodeTypes>;
+	workflowRepository?: WorkflowRepository;
+	workflowStaticDataService?: WorkflowStaticDataService;
+	workflowsConfig?: WorkflowsConfig;
+	triggerExecutionContextFactory?: TriggerExecutionContextFactory;
+	webhookTriggerRegistrar?: WebhookTriggerRegistrar;
+	nonWebhookTriggerRegistrar?: NonWebhookTriggerRegistrar;
+	triggerCountService?: TriggerCountService;
+	activationErrorsService?: ActivationErrorsService;
+};
+
+function buildActivator(overrides: ActivatorOverrides = {}) {
+	return new WorkflowTriggerActivator(
+		logger,
+		overrides.errorReporter ?? mock<ErrorReporter>(),
+		overrides.nodeTypes ?? createNodeTypes(),
+		overrides.workflowRepository ?? mock<WorkflowRepository>(),
+		overrides.workflowStaticDataService ?? mock<WorkflowStaticDataService>(),
+		overrides.workflowsConfig ?? mock<WorkflowsConfig>({ useWorkflowPublicationService: true }),
+		overrides.triggerExecutionContextFactory ?? mock<TriggerExecutionContextFactory>(),
+		overrides.webhookTriggerRegistrar ?? mock<WebhookTriggerRegistrar>(),
+		overrides.nonWebhookTriggerRegistrar ?? mock<NonWebhookTriggerRegistrar>(),
+		overrides.triggerCountService ?? mock<TriggerCountService>(),
+		overrides.activationErrorsService ?? mock<ActivationErrorsService>(),
+	);
+}
+
 describe('WorkflowTriggerActivator', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.restoreAllMocks();
 	});
 
-	function enabledWorkflowsConfig() {
-		return mock<WorkflowsConfig>({ useWorkflowPublicationService: true });
-	}
-
 	test('requires workflow publication service to be enabled', () => {
-		expect(
-			() =>
-				new WorkflowTriggerActivator(
-					logger,
-					mock<ErrorReporter>(),
-					createNodeTypes(),
-					mock<WorkflowRepository>(),
-					mock<WorkflowStaticDataService>(),
-					mock<WorkflowsConfig>({ useWorkflowPublicationService: false }),
-					mock<TriggerExecutionContextFactory>(),
-					mock<WebhookTriggerRegistrar>(),
-					mock<NonWebhookTriggerRegistrar>(),
-					mock<TriggerCountService>(),
-				),
+		expect(() =>
+			buildActivator({
+				workflowsConfig: mock<WorkflowsConfig>({ useWorkflowPublicationService: false }),
+			}),
 		).toThrow('WorkflowTriggerActivator requires workflow publication service to be enabled');
 	});
 
 	test('returns enabled trigger, poll and webhook nodes, excluding regular and disabled nodes', () => {
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			mock<WebhookTriggerRegistrar>(),
-			mock<NonWebhookTriggerRegistrar>(),
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator();
 
 		const result = activator.getEnabledTriggerNodes({
 			nodes: [
@@ -85,25 +92,10 @@ describe('WorkflowTriggerActivator', () => {
 	});
 
 	describe('getUnregisteredNonWebhookTriggerNodeIds', () => {
-		function activatorWith(nonWebhookTriggerRegistrar: NonWebhookTriggerRegistrar) {
-			return new WorkflowTriggerActivator(
-				logger,
-				mock<ErrorReporter>(),
-				createNodeTypes(),
-				mock<WorkflowRepository>(),
-				mock<WorkflowStaticDataService>(),
-				enabledWorkflowsConfig(),
-				mock<TriggerExecutionContextFactory>(),
-				mock<WebhookTriggerRegistrar>(),
-				nonWebhookTriggerRegistrar,
-				mock<TriggerCountService>(),
-			);
-		}
-
 		test('returns desired non-webhook triggers not registered in memory', () => {
 			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t']));
-			const activator = activatorWith(nonWebhookTriggerRegistrar);
+			const activator = buildActivator({ nonWebhookTriggerRegistrar });
 
 			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
@@ -117,7 +109,7 @@ describe('WorkflowTriggerActivator', () => {
 		test('excludes webhook nodes since they are not tracked in memory', () => {
 			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set());
-			const activator = activatorWith(nonWebhookTriggerRegistrar);
+			const activator = buildActivator({ nonWebhookTriggerRegistrar });
 
 			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
@@ -130,7 +122,7 @@ describe('WorkflowTriggerActivator', () => {
 		test('returns empty when all desired non-webhook triggers are registered', () => {
 			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t', 'p']));
-			const activator = activatorWith(nonWebhookTriggerRegistrar);
+			const activator = buildActivator({ nonWebhookTriggerRegistrar });
 
 			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
@@ -183,18 +175,13 @@ describe('WorkflowTriggerActivator', () => {
 			return 2;
 		});
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
+		const activator = buildActivator({
 			workflowRepository,
 			workflowStaticDataService,
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
 			webhookTriggerRegistrar,
 			nonWebhookTriggerRegistrar,
 			triggerCountService,
-		);
+		});
 
 		await activator.activate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -244,18 +231,7 @@ describe('WorkflowTriggerActivator', () => {
 			callOrder.push(`deregister-non-webhook:${nodeId}`);
 		});
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		await activator.deactivate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -292,18 +268,7 @@ describe('WorkflowTriggerActivator', () => {
 		const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 		nonWebhookTriggerRegistrar.getTriggerNodeIds.mockReturnValue([]);
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({
@@ -353,18 +318,7 @@ describe('WorkflowTriggerActivator', () => {
 		const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 		nonWebhookTriggerRegistrar.getTriggerNodeIds.mockReturnValue([]);
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -393,18 +347,7 @@ describe('WorkflowTriggerActivator', () => {
 		const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 		nonWebhookTriggerRegistrar.getTriggerNodeIds.mockReturnValue([]);
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -431,7 +374,6 @@ describe('WorkflowTriggerActivator', () => {
 			.mockResolvedValue(mock<IWorkflowExecuteAdditionalData>());
 
 		const workflowRepository = mock<WorkflowRepository>();
-		const workflowStaticDataService = mock<WorkflowStaticDataService>();
 		const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
 		const webhookA = mock<IWebhookData>({ node: 'Webhook A' });
 		const webhookB = mock<IWebhookData>({ node: 'Webhook B' });
@@ -443,18 +385,11 @@ describe('WorkflowTriggerActivator', () => {
 		const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 		nonWebhookTriggerRegistrar.getTriggerNodeIds.mockReturnValue([]);
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
+		const activator = buildActivator({
 			workflowRepository,
-			workflowStaticDataService,
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
 			webhookTriggerRegistrar,
 			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		});
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({
@@ -501,18 +436,7 @@ describe('WorkflowTriggerActivator', () => {
 			if (id === 'p') throw new Error('poll failed');
 		});
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -549,18 +473,7 @@ describe('WorkflowTriggerActivator', () => {
 			.mockRejectedValueOnce(new Error('poll failed'))
 			.mockResolvedValueOnce(undefined);
 
-		const activator = new WorkflowTriggerActivator(
-			logger,
-			mock<ErrorReporter>(),
-			createNodeTypes(),
-			mock<WorkflowRepository>(),
-			mock<WorkflowStaticDataService>(),
-			enabledWorkflowsConfig(),
-			mock<TriggerExecutionContextFactory>(),
-			webhookTriggerRegistrar,
-			nonWebhookTriggerRegistrar,
-			mock<TriggerCountService>(),
-		);
+		const activator = buildActivator({ webhookTriggerRegistrar, nonWebhookTriggerRegistrar });
 
 		const outcome = await activator.activate(
 			mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
@@ -570,5 +483,148 @@ describe('WorkflowTriggerActivator', () => {
 
 		expect(outcome).toEqual({ activated: ['p'], failures: [] });
 		expect(nonWebhookTriggerRegistrar.register).toHaveBeenCalledTimes(2);
+	});
+
+	describe('runtime trigger failure recovery', () => {
+		/**
+		 * Activates a single active trigger node and returns the `onTriggerFailure`
+		 * handler the activator wired into the registration, so a runtime failure
+		 * can be simulated by invoking it directly.
+		 */
+		async function activateAndCaptureFailureHandler(deps: {
+			nonWebhookTriggerRegistrar: MockProxy<NonWebhookTriggerRegistrar>;
+			triggerExecutionContextFactory?: TriggerExecutionContextFactory;
+			activationErrorsService?: ActivationErrorsService;
+			errorReporter?: ErrorReporter;
+		}) {
+			jest.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			jest.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
+			jest
+				.spyOn(WorkflowExecuteAdditionalData, 'getBase')
+				.mockResolvedValue(mock<IWorkflowExecuteAdditionalData>());
+
+			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
+			webhookTriggerRegistrar.getWebhookTriggers.mockReturnValue([]);
+
+			deps.nonWebhookTriggerRegistrar.createRegistrationContext.mockReturnValue(
+				mock<PreparedNonWebhookTriggerRegistration>(),
+			);
+			deps.nonWebhookTriggerRegistrar.getTriggerNodeIds.mockReturnValue(['t']);
+
+			const activator = buildActivator({ webhookTriggerRegistrar, ...deps });
+
+			await activator.activate(
+				mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
+				{ nodes: [node('t', 'trigger')], connections: {} },
+				new Set(['t']),
+			);
+
+			const context = deps.nonWebhookTriggerRegistrar.createRegistrationContext.mock.calls[0][1];
+			return context.onTriggerFailure;
+		}
+
+		const failure = {
+			error: new Error('trigger crashed'),
+			node: node('t', 'trigger'),
+			workflowData: mock<IWorkflowDb>({ id: 'wf-1', name: 'Test workflow' }),
+			mode: 'trigger' as const,
+			activation: 'update' as const,
+		};
+
+		test('tears the node down, surfaces the error, runs the error workflow, then reactivates and clears the error', async () => {
+			const callOrder: string[] = [];
+			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
+			nonWebhookTriggerRegistrar.deregister.mockImplementation(async () => {
+				callOrder.push('teardown');
+			});
+			nonWebhookTriggerRegistrar.register.mockImplementation(async () => {
+				callOrder.push('reactivate');
+			});
+			const triggerExecutionContextFactory = mock<TriggerExecutionContextFactory>();
+			triggerExecutionContextFactory.executeErrorWorkflow.mockImplementation(() => {
+				callOrder.push('error-workflow');
+			});
+			const activationErrorsService = mock<ActivationErrorsService>();
+			activationErrorsService.register.mockImplementation(async () => {
+				callOrder.push('register-error');
+			});
+			activationErrorsService.deregister.mockImplementation(async () => {
+				callOrder.push('clear-error');
+			});
+
+			const onTriggerFailure = await activateAndCaptureFailureHandler({
+				nonWebhookTriggerRegistrar,
+				triggerExecutionContextFactory,
+				activationErrorsService,
+			});
+			// Drop the bookkeeping from the initial activation; only track the recovery.
+			callOrder.length = 0;
+
+			onTriggerFailure(failure);
+			await flushPromises();
+
+			expect(callOrder).toEqual([
+				'teardown',
+				'register-error',
+				'error-workflow',
+				'reactivate',
+				'clear-error',
+			]);
+			expect(nonWebhookTriggerRegistrar.deregister).toHaveBeenCalledWith('wf-1', 't');
+			expect(activationErrorsService.register).toHaveBeenCalledWith('wf-1', 'trigger crashed');
+			expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
+		});
+
+		test('runs the error workflow with a workflow activation error wrapping the cause', async () => {
+			const triggerExecutionContextFactory = mock<TriggerExecutionContextFactory>();
+
+			const onTriggerFailure = await activateAndCaptureFailureHandler({
+				nonWebhookTriggerRegistrar: mock<NonWebhookTriggerRegistrar>(),
+				triggerExecutionContextFactory,
+			});
+
+			onTriggerFailure(failure);
+			await flushPromises();
+
+			expect(triggerExecutionContextFactory.executeErrorWorkflow).toHaveBeenCalledTimes(1);
+			const [passedError, passedWorkflowData, passedMode] =
+				triggerExecutionContextFactory.executeErrorWorkflow.mock.calls[0];
+			expect(passedError).toBeInstanceOf(WorkflowActivationError);
+			expect((passedError as WorkflowActivationError).node).toBe(failure.node);
+			expect(passedError.message).toContain('"t"');
+			expect(passedWorkflowData).toBe(failure.workflowData);
+			expect(passedMode).toBe('trigger');
+		});
+
+		test('leaves the surfaced error in place when reactivation exhausts its retry budget', async () => {
+			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
+			const errorReporter = mock<ErrorReporter>();
+			const activationErrorsService = mock<ActivationErrorsService>();
+
+			const onTriggerFailure = await activateAndCaptureFailureHandler({
+				nonWebhookTriggerRegistrar,
+				activationErrorsService,
+				errorReporter,
+			});
+
+			// Reactivation fails transiently on every attempt, exhausting the budget.
+			// Reset first so we only count the reactivation calls, not the initial activation.
+			nonWebhookTriggerRegistrar.register.mockReset();
+			nonWebhookTriggerRegistrar.register.mockRejectedValue(new Error('still broken'));
+
+			onTriggerFailure(failure);
+			await flushPromises();
+
+			// One register call per attempt, all during reactivation.
+			expect(nonWebhookTriggerRegistrar.register).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+			// The node stays down: the surfaced error is registered but never cleared.
+			expect(activationErrorsService.register).toHaveBeenCalledWith('wf-1', 'trigger crashed');
+			expect(activationErrorsService.deregister).not.toHaveBeenCalled();
+			// The reactivation failure is reported (once for the runtime error, once for the giveup).
+			expect(errorReporter.error).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'still broken' }),
+				expect.anything(),
+			);
+		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -487,7 +487,7 @@ export class WorkflowTriggerActivator {
 
 		const activationError = new WorkflowActivationError(
 			`The trigger node "${node.name}" failed at runtime and was deactivated`,
-			{ cause: error, node },
+			{ cause: error, node, level: 'warning' },
 		);
 		this.errorReporter.warn(activationError, {
 			extra: { workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
@@ -495,16 +495,12 @@ export class WorkflowTriggerActivator {
 		});
 
 		try {
-			// Tear down the failed trigger.
 			await this.nonWebhookTriggerRegistrar.deregister(workflowId, node.id);
 
-			// Register and surface the activation error so the UI reflects the failure.
 			await this.activationErrorsService.register(workflowId, error.message);
 
-			// Run the error workflow, matching the legacy runtime-failure path.
 			this.triggerExecutionContextFactory.executeErrorWorkflow(activationError, workflowData, mode);
 
-			// Re-activate the node in-process, retrying transient failures with backoff.
 			// `addTriggers` does not own the expression isolate, so acquire it per attempt.
 			await retryTriggerActivation(async () => {
 				await workflow.expression.acquireIsolate();
@@ -517,7 +513,6 @@ export class WorkflowTriggerActivator {
 
 			await this.workflowStaticDataService.saveStaticData(workflow);
 
-			// The node is running again, so clear the surfaced error.
 			await this.activationErrorsService.deregister(workflowId);
 		} catch (e) {
 			const reactivationError = ensureError(e);

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -460,14 +460,11 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
-	 * Recovers from a runtime failure of an already-active trigger node (its
-	 * `emitError` callback firing). Mirrors the legacy in-process recovery loop,
-	 * scoped to the single failed node: tear the trigger down, surface the
-	 * activation error, run the error workflow, then re-activate the node with the
-	 * same backoff used at activation time. The error is cleared once the node is
-	 * running again; if reactivation exhausts its budget the node stays down and
-	 * the error stays surfaced. Fired with `void` from the trigger callback, so it
-	 * owns its error handling and never rejects to the caller.
+	 * Recovers in-process from a runtime failure of an active trigger node, scoped
+	 * to the single failed node: tear it down, surface the activation error, run
+	 * the error workflow, then re-activate it with the activation backoff. The
+	 * error is cleared once the node is running again, or left surfaced if
+	 * reactivation gives up. Fired with `void`, so it owns its error handling.
 	 */
 	private async recoverFromRuntimeTriggerFailure({
 		error,
@@ -488,18 +485,14 @@ export class WorkflowTriggerActivator {
 	}): Promise<void> {
 		const workflowId = workflow.id;
 
-		this.logger.warn(
-			`The trigger node "${node.name}" of workflow "${workflowData.name}" failed at runtime: "${error.message}". Tearing it down and reactivating in-process.`,
-			{ workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
-		);
-		this.errorReporter.error(error, {
-			extra: { workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
-		});
-
 		const activationError = new WorkflowActivationError(
-			`There was a problem with the trigger node "${node.name}", for that reason did the workflow had to be deactivated`,
+			`The trigger node "${node.name}" failed at runtime and was deactivated`,
 			{ cause: error, node },
 		);
+		this.errorReporter.warn(activationError, {
+			extra: { workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
+			shouldBeLogged: true,
+		});
 
 		try {
 			// Tear down the failed trigger.
@@ -521,6 +514,8 @@ export class WorkflowTriggerActivator {
 					await workflow.expression.releaseIsolate();
 				}
 			}, TRIGGER_ACTIVATION_MAX_ATTEMPTS);
+
+			await this.workflowStaticDataService.saveStaticData(workflow);
 
 			// The node is running again, so clear the surfaced error.
 			await this.activationErrorsService.deregister(workflowId);

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 
 import { Logger } from '@n8n/backend-common';
 import { WorkflowsConfig } from '@n8n/config';
-import type { WorkflowEntity } from '@n8n/db';
+import type { IWorkflowDb, WorkflowEntity } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ErrorReporter } from 'n8n-core';
@@ -12,13 +12,17 @@ import type {
 	IWebhookData,
 	IWorkflowBase,
 	IWorkflowExecuteAdditionalData,
+	WorkflowActivateMode,
+	WorkflowExecuteMode,
 	WorkflowId,
 } from 'n8n-workflow';
-import { Workflow, ensureError } from 'n8n-workflow';
+import { Workflow, WorkflowActivationError, ensureError } from 'n8n-workflow';
 
+import { ActivationErrorsService } from '@/activation-errors.service';
 import { TRIGGER_ACTIVATION_MAX_ATTEMPTS } from '@/constants';
 import { NodeTypes } from '@/node-types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import type { PreparedNonWebhookTriggerRegistration } from '@/workflows/triggers/non-webhook-trigger-registrar';
 import { NonWebhookTriggerRegistrar } from '@/workflows/triggers/non-webhook-trigger-registrar';
 import { retryTriggerActivation } from '@/workflows/triggers/trigger-activation-retry';
 import { TriggerCountService } from '@/workflows/triggers/trigger-count.service';
@@ -64,6 +68,7 @@ export class WorkflowTriggerActivator {
 		private readonly webhookTriggerRegistrar: WebhookTriggerRegistrar,
 		private readonly nonWebhookTriggerRegistrar: NonWebhookTriggerRegistrar,
 		private readonly triggerCountService: TriggerCountService,
+		private readonly activationErrorsService: ActivationErrorsService,
 	) {
 		assert(
 			this.workflowsConfig.useWorkflowPublicationService,
@@ -393,7 +398,15 @@ export class WorkflowTriggerActivator {
 			additionalData,
 			resolveWorkflowData,
 			onTriggerFailure: ({ error, node, workflowData, mode, activation }) => {
-				this.reportRuntimeTriggerFailure(error, node, workflowData.id, mode, activation);
+				void this.recoverFromRuntimeTriggerFailure({
+					error,
+					node,
+					workflow,
+					workflowData,
+					registration,
+					mode,
+					activation,
+				});
 			},
 		});
 
@@ -446,23 +459,80 @@ export class WorkflowTriggerActivator {
 			await this.triggerExecutionContextFactory.loadPublishedWorkflowData(dbWorkflow);
 	}
 
-	private reportRuntimeTriggerFailure(
-		error: Error,
-		node: INode,
-		workflowId: WorkflowId,
-		mode: string,
-		activation: string,
-	) {
-		this.logger.warn('Publication trigger node reported a runtime error', {
-			error,
-			workflowId,
-			nodeId: node.id,
-			nodeName: node.name,
-			mode,
-			activation,
-		});
+	/**
+	 * Recovers from a runtime failure of an already-active trigger node (its
+	 * `emitError` callback firing). Mirrors the legacy in-process recovery loop,
+	 * scoped to the single failed node: tear the trigger down, surface the
+	 * activation error, run the error workflow, then re-activate the node with the
+	 * same backoff used at activation time. The error is cleared once the node is
+	 * running again; if reactivation exhausts its budget the node stays down and
+	 * the error stays surfaced. Fired with `void` from the trigger callback, so it
+	 * owns its error handling and never rejects to the caller.
+	 */
+	private async recoverFromRuntimeTriggerFailure({
+		error,
+		node,
+		workflow,
+		workflowData,
+		registration,
+		mode,
+		activation,
+	}: {
+		error: Error;
+		node: INode;
+		workflow: Workflow;
+		workflowData: IWorkflowDb;
+		registration: PreparedNonWebhookTriggerRegistration;
+		mode: WorkflowExecuteMode;
+		activation: WorkflowActivateMode;
+	}): Promise<void> {
+		const workflowId = workflow.id;
+
+		this.logger.warn(
+			`The trigger node "${node.name}" of workflow "${workflowData.name}" failed at runtime: "${error.message}". Tearing it down and reactivating in-process.`,
+			{ workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
+		);
 		this.errorReporter.error(error, {
 			extra: { workflowId, nodeId: node.id, nodeName: node.name, mode, activation },
 		});
+
+		const activationError = new WorkflowActivationError(
+			`There was a problem with the trigger node "${node.name}", for that reason did the workflow had to be deactivated`,
+			{ cause: error, node },
+		);
+
+		try {
+			// Tear down the failed trigger.
+			await this.nonWebhookTriggerRegistrar.deregister(workflowId, node.id);
+
+			// Register and surface the activation error so the UI reflects the failure.
+			await this.activationErrorsService.register(workflowId, error.message);
+
+			// Run the error workflow, matching the legacy runtime-failure path.
+			this.triggerExecutionContextFactory.executeErrorWorkflow(activationError, workflowData, mode);
+
+			// Re-activate the node in-process, retrying transient failures with backoff.
+			// `addTriggers` does not own the expression isolate, so acquire it per attempt.
+			await retryTriggerActivation(async () => {
+				await workflow.expression.acquireIsolate();
+				try {
+					await this.nonWebhookTriggerRegistrar.register(workflow, registration, node.id);
+				} finally {
+					await workflow.expression.releaseIsolate();
+				}
+			}, TRIGGER_ACTIVATION_MAX_ATTEMPTS);
+
+			// The node is running again, so clear the surfaced error.
+			await this.activationErrorsService.deregister(workflowId);
+		} catch (e) {
+			const reactivationError = ensureError(e);
+			this.logger.error(
+				`Failed to reactivate trigger node "${node.name}" of workflow "${workflowData.name}" after a runtime failure`,
+				{ workflowId, nodeId: node.id, nodeName: node.name, error: reactivationError },
+			);
+			this.errorReporter.error(reactivationError, {
+				extra: { workflowId, nodeId: node.id, nodeName: node.name },
+			});
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Tear down and reactivate non-webhook triggers that fail during runtime.

Also created a followup:
https://linear.app/n8n/issue/CAT-3507/runtime-trigger-recovery-clears-partial-activation-status

## How to test

Run the unit tests: `pnpm --filter n8n test workflow-trigger-activator` (covers teardown → surface → error-workflow → reactivate, error-workflow parity, and the retry-exhaustion path). End-to-end: with `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`, activate a workflow whose active trigger emits a runtime error and confirm the node is torn down, surfaced as an activation error, the error workflow runs, and the node automatically re-activates.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3424

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [x] Tests included


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

