### PR TITLE
fix(core): Preserve trace identifiers through Instance AI telemetry redaction (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tracing/__tests__/redact-structural-ids.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/redact-structural-ids.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+import { redactLangSmithTelemetrySpan } from '../trace-payloads';
+
+describe('redactLangSmithTelemetrySpan structural id preservation', () => {
+	it('does not corrupt langsmith.span.parent_id (zero-prefixed UUID)', () => {
+		const parentId = '00000000-0000-0000-1d18-3fc2f08b306f';
+		const span = {
+			name: 'agent: orchestrator',
+			attributes: {
+				'langsmith.span.parent_id': parentId,
+				'langsmith.span.id': '00000000-0000-0000-7c26-0de606834ec1',
+				'langsmith.trace.id': '00000000-0000-0000-936e-8d716ec46f0c',
+				'langsmith.traceable': 'true',
+			},
+		};
+
+		const redacted = redactLangSmithTelemetrySpan(span) as {
+			attributes: Record<string, unknown>;
+		};
+
+		expect(redacted.attributes['langsmith.span.parent_id']).toBe(parentId);
+		expect(redacted.attributes['langsmith.span.id']).toBe('00000000-0000-0000-7c26-0de606834ec1');
+		expect(redacted.attributes['langsmith.trace.id']).toBe('00000000-0000-0000-936e-8d716ec46f0c');
+	});
+
+	it('does not corrupt zero-prefixed run IDs carried in trace metadata', () => {
+		const span = {
+			name: 'llm: orchestrator',
+			attributes: {
+				langsmith_root_run_id: '00000000-0000-0000-b505-a974af202164',
+				langsmith_actor_run_id: '00000000-0000-0000-7f35-9c91c43d63bf',
+				'langsmith.metadata.langsmith_root_run_id': '00000000-0000-0000-b505-a974af202164',
+				'langsmith.metadata.continued_from_run_id': '00000000-0000-0000-1d18-3fc2f08b306f',
+				'langsmith.metadata.spawned_by_span_id': '00000000-0000-0000-7c26-0de606834ec1',
+				'langsmith.traceable': 'true',
+			},
+		};
+
+		const redacted = redactLangSmithTelemetrySpan(span) as {
+			attributes: Record<string, unknown>;
+		};
+
+		expect(redacted.attributes.langsmith_root_run_id).toBe('00000000-0000-0000-b505-a974af202164');
+		expect(redacted.attributes.langsmith_actor_run_id).toBe('00000000-0000-0000-7f35-9c91c43d63bf');
+		expect(redacted.attributes['langsmith.metadata.langsmith_root_run_id']).toBe(
+			'00000000-0000-0000-b505-a974af202164',
+		);
+		expect(redacted.attributes['langsmith.metadata.continued_from_run_id']).toBe(
+			'00000000-0000-0000-1d18-3fc2f08b306f',
+		);
+		expect(redacted.attributes['langsmith.metadata.spawned_by_span_id']).toBe(
+			'00000000-0000-0000-7c26-0de606834ec1',
+		);
+	});
+
+	it('still scrubs secrets in non-structural attributes', () => {
+		const span = {
+			name: 'llm: orchestrator',
+			attributes: {
+				'langsmith.span.parent_id': '00000000-0000-0000-1d18-3fc2f08b306f',
+				authorization: 'Bearer sk-secret-value',
+			},
+		};
+
+		const redacted = redactLangSmithTelemetrySpan(span) as {
+			attributes: Record<string, unknown>;
+		};
+
+		expect(redacted.attributes['langsmith.span.parent_id']).toBe(
+			'00000000-0000-0000-1d18-3fc2f08b306f',
+		);
+		expect(redacted.attributes.authorization).toBe('[redacted]');
+	});
+});

--- a/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
+++ b/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
@@ -28,6 +28,37 @@ const SENSITIVE_TELEMETRY_KEY_PATTERN =
 	/(api[_-]?key|authorization|bearer|cookie|credentials?|password|secret|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token|(?:^|[._-])token$)/i;
 
 /**
+ * LangSmith structural identifier attributes. These carry the run/trace/span IDs
+ * and dotted-order path used to reconstruct the trace hierarchy — never user
+ * content. They must bypass PII/secret scrubbing: the redactor otherwise mangles
+ * the zero-prefixed UUIDs (e.g. `00000000-0000-0000-...`) into `[REDACTED]-...`,
+ * which LangSmith rejects with HTTP 422 ("invalid UUID received for
+ * parent_run_id"), silently dropping every child span.
+ */
+const STRUCTURAL_TELEMETRY_ID_KEYS = new Set<string>([
+	'langsmith.span.id',
+	'langsmith.span.parent_id',
+	'langsmith.trace.id',
+	'langsmith.span.dotted_order',
+	'langsmith.traceable_parent_otel_span_id',
+]);
+
+/**
+ * Correlation identifiers carried in trace metadata, e.g. `langsmith_root_run_id`,
+ * `langsmith_actor_run_id`, `continued_from_run_id`, `spawned_by_span_id` — and
+ * their `langsmith.metadata.`-prefixed attribute forms. Like the structural keys
+ * above these are internally generated run/trace/span IDs, several of which are
+ * zero-prefixed UUIDs that the scrubber would otherwise corrupt into
+ * `[REDACTED]-...`.
+ */
+const CORRELATION_ID_KEY_PATTERN = /(?:^|[._])(?:run|trace|span|activation)_id$/;
+
+/** True for run/trace/span identifier attributes that must skip content scrubbing. */
+function isStructuralTelemetryIdKey(key: string): boolean {
+	return STRUCTURAL_TELEMETRY_ID_KEYS.has(key) || CORRELATION_ID_KEY_PATTERN.test(key);
+}
+
+/**
  * Telemetry/tracing redaction policy. Deliberately stricter than the
  * user-facing output policy `DEFAULT_OUTPUT_REDACTION_OPTIONS`.
  */
@@ -187,6 +218,12 @@ function maxRedactionDepthForAttribute(key: string): number {
 }
 
 function redactTelemetryAttribute(key: string, value: unknown): unknown {
+	// Structural run/trace/span identifiers must pass through untouched — scrubbing
+	// them corrupts the IDs, breaking LangSmith ingestion (422) and run correlation.
+	if (isStructuralTelemetryIdKey(key)) {
+		return value;
+	}
+
 	if (SENSITIVE_TELEMETRY_KEY_PATTERN.test(key)) {
 		return '[redacted]';
 	}


### PR DESCRIPTION
## Summary

Instance AI traces stopped showing nested LLM calls, token usage, and tool spans
in LangSmith — only the top-level `turn` span survived. Every child span was
silently dropped.

**Root cause:** the telemetry PII/secret scrubber was being applied to *every*
exported span attribute, including LangSmith's structural identifiers. The
LangSmith OTel→run bridge encodes run IDs from the OTel span ID as a
zero-prefixed UUID, e.g. `00000000-0000-0000-1d18-3fc2f08b306f`. The 16-zero
prefix matches the scrubber's numeric-PII detector, so `parent_run_id` was
rewritten to `[REDACTED]-1d18-3fc2f08b306f` before egress. LangSmith then
rejected the export with `HTTP 422 invalid UUID received for parent_run_id` and
dropped the child runs.

```text
"00000000-0000-0000-1d18-3fc2f08b306f"  ->  "[REDACTED]-1d18-3fc2f08b306f"   (corrupted)
"936e8d71-6ec4-4f0c-8abc-1d183fc2f08b"  ->  "936e8d71-6ec4-4f0c-8abc-..."     (normal UUID untouched)
```

Only children carried a `parent_run_id`, which is why the root `turn` kept
landing while everything nested under it disappeared.

**Fix:** never run PII/secret scrubbing on LangSmith's run/trace/span identifiers:

- the structural attributes (`langsmith.span.id`, `langsmith.span.parent_id`,
  `langsmith.trace.id`, `langsmith.span.dotted_order`,
  `langsmith.traceable_parent_otel_span_id`), which carry the trace hierarchy, and
- correlation IDs in trace metadata (`langsmith_root_run_id`,
  `langsmith_actor_run_id`, `continued_from_run_id`, `spawned_by_span_id`, … and
  their `langsmith.metadata.`-prefixed forms) — matched by key suffix
  `(run|trace|span|activation)_id`.

These are internally generated identifiers, never user content. Prompts, tool
args, tool results, and all other metadata are still scrubbed exactly as before
(`thread_id`, `user_id`, `agent_id`, etc. remain scrubbed).

## How to test

1. Configure Instance AI with LangSmith tracing (direct or via the AI proxy).
2. Send any message (e.g. "Hello") and open the resulting trace in LangSmith.
3. Confirm the `turn` span now nests `agent: orchestrator`, `prepare: prompt`,
   `llm: orchestrator` (with token usage), and tool spans — instead of a lone
   `turn`.

Automated coverage: `packages/@n8n/instance-ai/src/tracing/__tests__/redact-structural-ids.test.ts`
asserts that structural IDs pass through untouched while secret-bearing
attributes are still redacted.

```bash
cd packages/@n8n/instance-ai
pnpm vitest run src/tracing/__tests__/redact-structural-ids.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add the Instance AI Agent Linear ticket here if one is filed. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. (no-changelog — internal observability fix)
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with backport labels (if applicable).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

