### PR TITLE
fix(core): Propagate execution context to sub-workflow tools

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -19,6 +19,7 @@ import { UnexpectedError, NodeHelpers, WAIT_INDEFINITELY } from 'n8n-workflow';
 import { captor, mock, type MockProxy } from 'vitest-mock-extended';
 
 import { BinaryDataService } from '@/binary-data/binary-data.service';
+import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
 
 import type { BaseExecuteContext } from '../base-execute-context';
 
@@ -302,6 +303,100 @@ export const describeCommonTests = (
 			expect(additionalData.setExecutionStatus).toHaveBeenCalledWith('waiting');
 			expect(runExecutionData.waitTill).toEqual(WAIT_INDEFINITELY);
 			expect(result.waitTill).toBe(waitTill);
+		});
+
+		describe('execution context propagation to sub-workflows', () => {
+			const executionContext: IExecutionContext = {
+				version: 1,
+				establishedAt: 123,
+				source: 'webhook',
+				credentials: 'encrypted-credential-data',
+			};
+
+			afterEach(() => {
+				vi.restoreAllMocks();
+			});
+
+			it('should inject the current execution context when the parent id matches', async () => {
+				additionalData.executeWorkflow.mockResolvedValue(executeWorkflowData);
+				vi.spyOn(context, 'getExecutionId').mockReturnValue('current_execution_id');
+				vi.spyOn(context, 'getExecutionContext').mockReturnValue(executionContext);
+
+				const childParentExecution: RelatedExecution = {
+					executionId: 'current_execution_id',
+					workflowId: 'parent_workflow_id',
+				};
+
+				await context.executeWorkflow(workflowInfo, undefined, undefined, {
+					parentExecution: childParentExecution,
+				});
+
+				expect(childParentExecution.executionContext).toBe(executionContext);
+				expect(additionalData.executeWorkflow).toHaveBeenCalledWith(
+					workflowInfo,
+					additionalData,
+					expect.objectContaining({
+						parentExecution: expect.objectContaining({ executionContext }),
+					}),
+				);
+			});
+
+			// Regression for IAM-857: during a trigger's webhook phase (e.g. an MCP
+			// Trigger tool call) there is no execution id yet, so `getExecutionId()` is
+			// `undefined` while the parent id is the placeholder. Context must still propagate.
+			it('should inject the execution context when no execution id is assigned yet', async () => {
+				additionalData.executeWorkflow.mockResolvedValue(executeWorkflowData);
+				vi.spyOn(context, 'getExecutionId').mockReturnValue(undefined as unknown as string);
+				vi.spyOn(context, 'getExecutionContext').mockReturnValue(executionContext);
+
+				const childParentExecution: RelatedExecution = {
+					executionId: PLACEHOLDER_EMPTY_EXECUTION_ID,
+					workflowId: 'parent_workflow_id',
+				};
+
+				await context.executeWorkflow(workflowInfo, undefined, undefined, {
+					parentExecution: childParentExecution,
+				});
+
+				expect(childParentExecution.executionContext).toBe(executionContext);
+			});
+
+			it('should not overwrite an execution context already set on the parent', async () => {
+				additionalData.executeWorkflow.mockResolvedValue(executeWorkflowData);
+				const existingContext: IExecutionContext = { ...executionContext, establishedAt: 999 };
+				vi.spyOn(context, 'getExecutionId').mockReturnValue('current_execution_id');
+				const getExecutionContextSpy = vi.spyOn(context, 'getExecutionContext');
+
+				const childParentExecution: RelatedExecution = {
+					executionId: 'current_execution_id',
+					workflowId: 'parent_workflow_id',
+					executionContext: existingContext,
+				};
+
+				await context.executeWorkflow(workflowInfo, undefined, undefined, {
+					parentExecution: childParentExecution,
+				});
+
+				expect(childParentExecution.executionContext).toBe(existingContext);
+				expect(getExecutionContextSpy).not.toHaveBeenCalled();
+			});
+
+			it('should not inject context when the parent id refers to a different execution', async () => {
+				additionalData.executeWorkflow.mockResolvedValue(executeWorkflowData);
+				vi.spyOn(context, 'getExecutionId').mockReturnValue('current_execution_id');
+				vi.spyOn(context, 'getExecutionContext').mockReturnValue(executionContext);
+
+				const childParentExecution: RelatedExecution = {
+					executionId: 'some_other_execution_id',
+					workflowId: 'parent_workflow_id',
+				};
+
+				await context.executeWorkflow(workflowInfo, undefined, undefined, {
+					parentExecution: childParentExecution,
+				});
+
+				expect(childParentExecution.executionContext).toBeUndefined();
+			});
 		});
 	});
 };

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -35,6 +35,8 @@ import {
 	createEnvProviderState,
 } from 'n8n-workflow';
 
+import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
+
 import { NodeExecutionContext } from './node-execution-context';
 
 export class BaseExecuteContext extends NodeExecutionContext {
@@ -126,14 +128,15 @@ export class BaseExecuteContext extends NodeExecutionContext {
 		},
 	): Promise<ExecuteWorkflowData> {
 		if (options?.parentExecution) {
-			// We inject the execution context of the current execution
-			// to the sub-workflow so that it can be accessed there
-			// this should only happen for the direct parent execution
-			// if a workflow starts a sub-workflow for a workflow that is not itself
-			// then the context should not be passed down
+			// Inject the current execution context into the direct parent's
+			// sub-workflow only. Normalize against the placeholder id: during a
+			// trigger's webhook phase (e.g. an MCP Trigger tool call) no execution id
+			// exists yet, so `getExecutionId()` is `undefined` while the proxied
+			// `parentExecution.executionId` is `PLACEHOLDER_EMPTY_EXECUTION_ID`.
 			if (
 				!options.parentExecution.executionContext &&
-				options.parentExecution.executionId === this.getExecutionId()
+				options.parentExecution.executionId ===
+					(this.getExecutionId() ?? PLACEHOLDER_EMPTY_EXECUTION_ID)
 			) {
 				options.parentExecution.executionContext = this.getExecutionContext();
 			}


### PR DESCRIPTION
## Summary

When a sub-workflow tool runs during a trigger's webhook phase (e.g. an MCP Trigger tool call), no execution id is assigned yet, so `getExecutionId()` is `undefined` while the proxied `parentExecution.executionId` resolves to `PLACEHOLDER_EMPTY_EXECUTION_ID`. That mismatch silently skipped execution-context injection, so the spawned sub-workflow inherited no credential context and failed dynamic/private credential resolution with `Cannot resolve dynamic credentials without execution context for "<credential>"`. This normalizes the comparison against the placeholder so the established context (including the caller's private-credential identity) still propagates to the direct child. Behavior is unchanged whenever a real execution id exists, and the existing guards (don't overwrite an already-set context; don't inject for a different execution) are preserved.

## How to test

1. Configure private/dynamic credentials and an MCP Trigger that exposes a **Call n8n Workflow Tool** whose sub-workflow uses a node with a private credential (e.g. Linear).
2. Call that tool from an MCP client.
3. Before: the sub-workflow fails with `Cannot resolve dynamic credentials without execution context for "Linear account"`. After: the caller's credential context propagates and the sub-workflow resolves the credential.

Unit coverage added in `shared-tests.ts` (`executeWorkflow › execution context propagation to sub-workflows`), verified to fail without the fix.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-857

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32577">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

