### PR TITLE
feat(editor): Expand/collapse canvas group by double-clicking (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3952,7 +3952,7 @@
 	"workflowProductionChecklist.timeSaved.title": "Track time saved",
 	"workflowProductionChecklist.timeSaved.description": "Configure the time saved on each run to track the manual work it saves.",
 	"canvas.selection.toolbar.group": "Group nodes",
-	"canvas.selection.toolbar.ungroup": "Ungroup",
+	"canvas.selection.toolbar.ungroup": "Ungroup nodes",
 	"canvas.nodeGroup.defaultTitle": "Group",
 	"canvas.nodeGroup.connectionAddBlocked.title": "Connection not added",
 	"canvas.nodeGroup.connectionRemoveBlocked.title": "Connection not removed",

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -3530,7 +3530,7 @@ describe('useCanvasOperations', () => {
 				throw new Error('Expected ungroup action to be a vnode');
 			}
 
-			expect(ungroupAction.children).toBe('Ungroup');
+			expect(ungroupAction.children).toBe('Ungroup nodes');
 			expect(ungroupAction.props).toEqual(
 				expect.objectContaining({ href: '#', class: 'primary-color' }),
 			);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.test.ts
@@ -93,6 +93,28 @@ describe('CanvasNodeGroupTitleBar', () => {
 		});
 	});
 
+	describe('double-click to toggle collapse', () => {
+		it('emits toggle when the group body is double-clicked', async () => {
+			const wrapper = render();
+			await fireEvent.dblClick(wrapper.getByTestId('canvas-node-group-header'));
+			expect(wrapper.emitted().toggle).toEqual([['g1']]);
+		});
+
+		it('does not emit toggle when the title is double-clicked', async () => {
+			const wrapper = render();
+			const titleArea = wrapper.getByTestId('canvas-node-group-title');
+			const titleEdit = titleArea.querySelector('.nodrag') as HTMLElement;
+			await fireEvent.dblClick(titleEdit);
+			expect(wrapper.emitted().toggle).toBeUndefined();
+		});
+
+		it('does not emit toggle when the ungroup button is double-clicked', async () => {
+			const wrapper = render();
+			await fireEvent.dblClick(wrapper.getByTestId('canvas-node-group-ungroup'));
+			expect(wrapper.emitted().toggle).toBeUndefined();
+		});
+	});
+
 	describe('height invariant; nodrag on interactive children', () => {
 		it('has the fixed header height when collapsed', () => {
 			const wrapper = render({ data: makeData({ isCollapsed: true }) });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -112,6 +112,15 @@ function onToggleClick() {
 	emit('toggle', group.value.id);
 }
 
+// Toggle collapse on double clicking
+function onWrapperDblClick(event: MouseEvent) {
+	const target = event.target as HTMLElement | null;
+	// if happened inside an element with its own click behavior, do nothing
+	if (target?.closest('.nodrag')) return;
+
+	emit('toggle', group.value.id);
+}
+
 async function focusTitleEdit() {
 	if (props.autofocusGroupId !== group.value.id || props.readOnly || !isAutofocusReady.value)
 		return;
@@ -175,6 +184,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 		data-test-id="canvas-node-group"
 		:data-group-id="group.id"
 		@pointerdown="onWrapperPointerDown"
+		@dblclick.stop="onWrapperDblClick"
 	>
 		<div :class="$style.titleBar">
 			<Handle

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -247,7 +247,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 						<div ref="titleText" :class="$style.titleText">
 							<N8nInlineTextEdit
 								ref="titleEdit"
-								class="nodrag"
+								:class="['nodrag', $style.titleEdit]"
 								:model-value="group.name"
 								:read-only="readOnly"
 								:min-width="0"
@@ -381,6 +381,13 @@ function onWrapperPointerDown(event: PointerEvent) {
 	max-width: 100%;
 	overflow: clip;
 	overflow-clip-margin: var(--spacing--2xs);
+}
+
+/* Keep the rename (nodrag) hit area as narrow as the name
+so the empty space beside it stays draggable. */
+.titleEdit {
+	width: fit-content;
+	max-width: 100%;
 }
 
 .statusIcons {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -247,7 +247,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 						<div ref="titleText" :class="$style.titleText">
 							<N8nInlineTextEdit
 								ref="titleEdit"
-								:class="['nodrag', $style.titleEdit]"
+								class="nodrag"
 								:model-value="group.name"
 								:read-only="readOnly"
 								:min-width="0"
@@ -381,13 +381,6 @@ function onWrapperPointerDown(event: PointerEvent) {
 	max-width: 100%;
 	overflow: clip;
 	overflow-clip-margin: var(--spacing--2xs);
-}
-
-/* Keep the rename (nodrag) hit area as narrow as the name
-so the empty space beside it stays draggable. */
-.titleEdit {
-	width: fit-content;
-	max-width: 100%;
 }
 
 .statusIcons {


### PR DESCRIPTION
## Summary

Three improvements to canvas group interactions on the title bar:

**Feature (ADO-5412) — Expand/collapse by double-clicking**
- Double-clicking the group body now toggles collapse/expand, reusing the existing chevron toggle path.
- Single-click on the name still renames; the chevron and ungroup buttons keep their own click behavior (the handler ignores double-clicks that land on `.nodrag` elements). Click + drag still moves the group.

**Copy (ADO-5455) — Rename "Ungroup" to "Ungroup nodes"**
- Renames the ungroup action label for parity with the existing "Group nodes" label. Applies to the toolbar tooltip, aria-label, and the ungroup-confirmation notification action.

## How to test

1. Create a group of nodes on the canvas.
2. **Double-click toggle:** double-click the group title bar (not on the name) → the group collapses/expands. Verify the chevron still toggles, single-click on the name still renames, and double-clicking the name does **not** toggle.
3. **Label:** the ungroup action reads "Ungroup nodes" (tooltip, aria-label, and the ungroup-confirmation toast).

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/ADO-5412/feature-expandcollapse-group-by-double-clicking
Closes https://linear.app/n8n/issue/ADO-5455/feature-rename-ungroup-label-to-ungroup-nodes

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
