### PR TITLE
feat(core): Add workflow-publish-wake-up pubsub event (no-changelog)

### DIFF
--- a/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
+++ b/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
@@ -10,6 +10,7 @@ export type PubSubEventName =
 	| 'display-workflow-activation'
 	| 'display-workflow-deactivation'
 	| 'display-workflow-activation-error'
+	| 'workflow-publish-wake-up'
 	| 'community-package-install'
 	| 'community-package-uninstall'
 	| 'community-package-update'

--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -19,6 +19,8 @@ export const MCP_RELAY_PUBSUB_CHANNEL = 'n8n.mcp-relay';
 export const SELF_SEND_COMMANDS = new Set<PubSub.Command['command']>([
 	'add-webhooks-triggers-and-pollers',
 	'remove-triggers-and-pollers',
+	// The leader may itself enqueue an outbox record, so it must receive its own wake-up.
+	'workflow-publish-wake-up',
 ]);
 
 /**
@@ -36,4 +38,5 @@ export const IMMEDIATE_COMMANDS = new Set<PubSub.Command['command']>([
 	'display-workflow-activation',
 	'display-workflow-deactivation',
 	'display-workflow-activation-error',
+	'workflow-publish-wake-up',
 ]);

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -100,12 +100,8 @@ export type PubSubCommandMap = {
 		workflowId: string;
 	};
 
-	/**
-	 * Wake the leader's workflow publication outbox consumer so it drains pending
-	 * records immediately instead of waiting for the next poll cycle. Published by
-	 * the main that enqueued an outbox record (which may be any main, including the
-	 * leader itself, hence it is a self-send command). Only the leader consumes the
-	 * outbox, so the event is filtered to the leader on the listening side.
+	/** Wake the leader's publication outbox consumer to drain pending records now.
+	 * The consumer polls as a backup, but this lets publication feel fast without frequent polling.
 	 */
 	'workflow-publish-wake-up': never;
 

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -100,6 +100,15 @@ export type PubSubCommandMap = {
 		workflowId: string;
 	};
 
+	/**
+	 * Wake the leader's workflow publication outbox consumer so it drains pending
+	 * records immediately instead of waiting for the next poll cycle. Published by
+	 * the main that enqueued an outbox record (which may be any main, including the
+	 * leader itself, hence it is a self-send command). Only the leader consumes the
+	 * outbox, so the event is filtered to the leader on the listening side.
+	 */
+	'workflow-publish-wake-up': never;
+
 	'display-workflow-activation-error': {
 		workflowId: string;
 		errorMessage: string;

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -56,6 +56,7 @@ export namespace PubSub {
 		export type DisplayWorkflowActivation = ToCommand<'display-workflow-activation'>;
 		export type DisplayWorkflowDeactivation = ToCommand<'display-workflow-deactivation'>;
 		export type DisplayWorkflowActivationError = ToCommand<'display-workflow-activation-error'>;
+		export type WorkflowPublishWakeUp = ToCommand<'workflow-publish-wake-up'>;
 		export type RelayExecutionLifecycleEvent = ToCommand<'relay-execution-lifecycle-event'>;
 		export type RelayChatStreamEvent = ToCommand<'relay-chat-stream-event'>;
 		export type RelayChatHumanMessage = ToCommand<'relay-chat-human-message'>;
@@ -91,6 +92,7 @@ export namespace PubSub {
 		| Commands.DisplayWorkflowActivation
 		| Commands.DisplayWorkflowDeactivation
 		| Commands.DisplayWorkflowActivationError
+		| Commands.WorkflowPublishWakeUp
 		| Commands.RelayExecutionLifecycleEvent
 		| Commands.RelayChatStreamEvent
 		| Commands.RelayChatHumanMessage

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -191,6 +191,32 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 		});
 	});
 
+	describe('wakeUp', () => {
+		test('starts polling and drains all pending records', async () => {
+			const first = makeRecord({ id: 1 });
+			const second = makeRecord({ id: 2 });
+			outboxRepository.claimNextPendingRecord
+				.mockResolvedValueOnce(first)
+				.mockResolvedValueOnce(second)
+				.mockResolvedValue(null);
+
+			await consumer.wakeUp();
+
+			expect(applier.apply).toHaveBeenCalledTimes(2);
+			expect(reporter.report).toHaveBeenCalledTimes(2);
+			expect(jest.getTimerCount()).toBe(1);
+		});
+
+		test('does nothing when the feature flag is off', async () => {
+			consumer = createConsumer(false);
+
+			await consumer.wakeUp();
+
+			expect(outboxRepository.claimNextPendingRecord).not.toHaveBeenCalled();
+			expect(jest.getTimerCount()).toBe(0);
+		});
+	});
+
 	describe('poll cycle', () => {
 		test('drains all pending records through apply + report', async () => {
 			const first = makeRecord({ id: 1 });

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -75,9 +75,8 @@ export class WorkflowPublicationOutboxConsumer {
 	/**
 	 * Wake the consumer in response to a `workflow-publish-wake-up` pubsub event so
 	 * it drains the outbox immediately instead of waiting for the next poll cycle.
-	 * The event is filtered to the leader, but we still guard the feature flag and
-	 * ensure polling is running (both idempotent) since the handler is wired
-	 * independently of the startup path.
+	 *
+	 * Also start polling - this is idempotent, so harmless if we're already polling.
 	 */
 	@OnPubSubEvent('workflow-publish-wake-up', { instanceType: 'main', instanceRole: 'leader' })
 	async wakeUp(): Promise<void> {

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { WorkflowsConfig } from '@n8n/config';
 import { WorkflowPublicationOutbox, WorkflowPublicationOutboxRepository } from '@n8n/db';
-import { OnShutdown } from '@n8n/decorators';
+import { OnPubSubEvent, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import { UnexpectedError, ensureError } from 'n8n-workflow';
@@ -72,8 +72,24 @@ export class WorkflowPublicationOutboxConsumer {
 		this.stopPolling();
 	}
 
-	// We will rely on the `workflow-publish-wake-up` event in the future, but
-	// will keep the poller as a fallback since pubsub delivery is not ensured.
+	/**
+	 * Wake the consumer in response to a `workflow-publish-wake-up` pubsub event so
+	 * it drains the outbox immediately instead of waiting for the next poll cycle.
+	 * The event is filtered to the leader, but we still guard the feature flag and
+	 * ensure polling is running (both idempotent) since the handler is wired
+	 * independently of the startup path.
+	 */
+	@OnPubSubEvent('workflow-publish-wake-up', { instanceType: 'main', instanceRole: 'leader' })
+	async wakeUp(): Promise<void> {
+		if (!this.workflowsConfig.useWorkflowPublicationService) return;
+
+		this.startPolling();
+		await this.drainPending();
+	}
+
+	// The `workflow-publish-wake-up` event drains the outbox promptly (see
+	// `wakeUp`); the poller is kept as a fallback since pubsub delivery is not
+	// ensured.
 	private schedulePollCycle() {
 		clearTimeout(this.pollTimeout);
 		if (!this.shouldKeepPolling()) return;


### PR DESCRIPTION
## Summary

Introduces a new `workflow-publish-wake-up` pubsub command as part of the [Workflow Publication Service](https://linear.app/n8n/issue/CAT-2195) project.

The leader's workflow publication outbox consumer now listens for this event and drains the outbox immediately, rather than waiting for the next scheduled poll cycle. The periodic poller is retained as a fallback since pubsub delivery is not guaranteed.

## Changes

- Add `workflow-publish-wake-up` to `PubSubCommandMap` (no payload) and to the `PubSub.Command` union / `PubSubEventName`.
- Register a leader-only `@OnPubSubEvent('workflow-publish-wake-up')` handler on `WorkflowPublicationOutboxConsumer` that starts polling (idempotent) and drains pending records.
- Add the command to `SELF_SEND_COMMANDS` (the leader may itself enqueue an outbox record, so it must receive its own wake-up) and to `IMMEDIATE_COMMANDS` (not debounced).
- Unit tests for `wakeUp` (drains all pending records; no-op when the feature flag is off).

The publishing side (emitting the event on activation) lands in a follow-up (CAT-2196). All behavior is gated behind the existing `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` flag and is a no-op when off.

## Related

https://linear.app/n8n/issue/CAT-2195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

