### PR TITLE
feat(core): Add feature flag for custom instance roles

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -213,6 +213,9 @@ export interface FrontendSettings {
 	folders: {
 		enabled: boolean;
 	};
+	customInstanceRoles: {
+		enabled: boolean;
+	};
 	banners: {
 		dismissed: string[];
 	};

--- a/packages/@n8n/config/src/configs/__tests__/roles.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/roles.config.test.ts
@@ -1,0 +1,28 @@
+import { Container } from '@n8n/di';
+
+import { GlobalConfig } from '../../index';
+
+describe('RolesConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		vi.unstubAllEnvs();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should default the custom instance roles flag to off', () => {
+		const { roles } = Container.get(GlobalConfig);
+
+		expect(roles.customInstanceRolesEnabled).toBe(false);
+	});
+
+	it('should enable the custom instance roles flag from env', () => {
+		vi.stubEnv('N8N_CUSTOM_INSTANCE_ROLES_ENABLED', 'true');
+
+		const { roles } = Container.get(GlobalConfig);
+
+		expect(roles.customInstanceRolesEnabled).toBe(true);
+	});
+});

--- a/packages/@n8n/config/src/configs/roles.config.ts
+++ b/packages/@n8n/config/src/configs/roles.config.ts
@@ -1,0 +1,11 @@
+import { Config, Env } from '../decorators';
+
+@Config
+export class RolesConfig {
+	/**
+	 * Dark-launch flag for the custom instance roles UI. When off, the
+	 * instance-roles surface is not exposed in the frontend.
+	 */
+	@Env('N8N_CUSTOM_INSTANCE_ROLES_ENABLED')
+	customInstanceRolesEnabled: boolean = false;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -34,6 +34,7 @@ import { NodesConfig } from './configs/nodes.config';
 import { PersonalizationConfig } from './configs/personalization.config';
 import { PublicApiConfig } from './configs/public-api.config';
 import { RedisConfig } from './configs/redis.config';
+import { RolesConfig } from './configs/roles.config';
 import { TaskRunnersConfig } from './configs/runners.config';
 import { ScalingModeConfig } from './configs/scaling-mode.config';
 import { SecurityConfig } from './configs/security.config';
@@ -84,6 +85,7 @@ export { PasswordConfig } from './configs/password.config';
 export { AgentsConfig } from './configs/agents.config';
 export { CompressionNodeConfig } from './configs/compression.config';
 export { RedisConfig } from './configs/redis.config';
+export { RolesConfig } from './configs/roles.config';
 export { EndpointsConfig, PrometheusMetricsConfig };
 
 const protocolSchema = z.enum(['http', 'https']);
@@ -284,4 +286,7 @@ export class GlobalConfig {
 
 	@Nested
 	instanceSettingsLoader: InstanceSettingsLoaderConfig;
+
+	@Nested
+	roles: RolesConfig;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -597,6 +597,9 @@ describe('GlobalConfig', () => {
 			daytonaApiUrl: '',
 			daytonaApiKey: '',
 		},
+		roles: {
+			customInstanceRolesEnabled: false,
+		},
 	} satisfies GlobalConfigShape;
 
 	it('should use all default values when no env variables are defined', () => {

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -35,6 +35,7 @@ describe('FrontendService', () => {
 		tags: { disabled: false },
 		logging: { level: 'info' },
 		hiringBanner: { enabled: false },
+		roles: { customInstanceRolesEnabled: false },
 		versionNotifications: {
 			enabled: false,
 			endpoint: '',

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -399,6 +399,9 @@ export class FrontendService {
 			folders: {
 				enabled: false,
 			},
+			customInstanceRoles: {
+				enabled: this.globalConfig.roles.customInstanceRolesEnabled,
+			},
 			evaluation: {
 				quota: this.licenseState.getMaxWorkflowsWithEvaluations(),
 			},

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -176,6 +176,9 @@ export const defaultSettings: FrontendSettings = {
 	folders: {
 		enabled: false,
 	},
+	customInstanceRoles: {
+		enabled: false,
+	},
 	evaluation: {
 		quota: 0,
 	},

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
@@ -312,4 +312,56 @@ describe('settings.store', () => {
 			expect(settingsStore.isOtelCustomSpanAttributesEnabled).toBe(true);
 		});
 	});
+
+	describe('isCustomInstanceRolesEnabled', () => {
+		it('should return true when the dark-launch flag is on', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				customInstanceRoles: { enabled: true },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCustomInstanceRolesEnabled).toBe(true);
+		});
+
+		it('should return false when the dark-launch flag is off', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				customInstanceRoles: { enabled: false },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCustomInstanceRolesEnabled).toBe(false);
+		});
+
+		it('should return false when the setting is absent', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				customInstanceRoles: undefined,
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCustomInstanceRolesEnabled).toBe(false);
+		});
+
+		it('should stay off when the customRoles license is on but the flag is off (gates are independent)', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				enterprise: { customRoles: true },
+				customInstanceRoles: { enabled: false },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCustomRolesFeatureEnabled).toBe(true);
+			expect(settingsStore.isCustomInstanceRolesEnabled).toBe(false);
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -201,6 +201,10 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		() => settings.value.enterprise?.customRoles ?? false,
 	);
 
+	const isCustomInstanceRolesEnabled = computed(
+		() => settings.value.customInstanceRoles?.enabled ?? false,
+	);
+
 	const areTagsEnabled = computed(() =>
 		settings.value.workflowTagsDisabled !== undefined ? !settings.value.workflowTagsDisabled : true,
 	);
@@ -440,6 +444,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		isFoldersFeatureEnabled,
 		isAiAssistantEnabled,
 		isCustomRolesFeatureEnabled,
+		isCustomInstanceRolesEnabled,
 		areTagsEnabled,
 		isAutosaveEnabled,
 		isHiringBannerEnabled,


### PR DESCRIPTION
## Summary

Adds a dark-launch flag (`N8N_CUSTOM_INSTANCE_ROLES_ENABLED`, default **off**) so the custom instance roles feature can be merged to master incrementally without exposing partial UI to users, then enabled for everyone in a single change once complete.

This PR is the flag mechanism only — it does not add any instance-roles UI. The upcoming instance-roles PRs consume the isCustomInstanceRolesEnabled getter to gate the tab, routes, "Add role" action, and assignments tab.

**This flag is UX-only and is not a security boundary.** Backend endpoints stay open and remain gated by the `customRoles` license feature, as today. The flag controls frontend exposure during rollout only.

### Changes

- **`@n8n/config`** — new `RolesConfig` exposing `N8N_CUSTOM_INSTANCE_ROLES_ENABLED`
  (default `false`), registered on `GlobalConfig` as `roles`.
- **`@n8n/api-types`** — `customInstanceRoles: { enabled: boolean }` added to
  `FrontendSettings`.
- **`cli`** — `frontend.service.ts` populates the setting from the config flag.
- **`editor-ui`** — `settings.store.ts` exposes the `isCustomInstanceRolesEnabled` getter
  (independent of the existing `isCustomRolesFeatureEnabled` license getter).

## Related Linear tickets

https://linear.app/n8n/issue/IAM-848

A follow-up cleanup ticket will remove the flag once the feature is stable and on by default.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32582">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

