### PR TITLE
test(MCP Client Tool Node): Cover error-result handling in executeMcpTool (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -399,6 +399,48 @@ describe('runtime', () => {
 			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow('network');
 			expect(closeSpy).toHaveBeenCalled();
 		});
+
+		// A tool result flagged `isError` must throw rather than be returned as node
+		// output. Only a thrown error reaches the execution engine's node-failure
+		// handling, which is what routes the error back to the calling agent.
+		it('throws with the tool error text when the tool result is flagged isError (v1.3+)', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				isError: true,
+				content: [{ type: 'text', text: 'MCP error -32602: bad arguments' }],
+			});
+
+			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }], {
+				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.3, name: 'MCP', type: 'mcp' })),
+			});
+
+			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow(
+				'MCP error -32602: bad arguments',
+			);
+		});
+
+		// Throwing on isError only applies to typeVersion >= 1.3; older nodes
+		// pass the flagged result through as normal output.
+		it('returns the flagged result without throwing for nodes before v1.3', async () => {
+			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+				isError: true,
+				content: [{ type: 'text', text: 'some error' }],
+			});
+			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+
+			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }], {
+				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.2, name: 'MCP', type: 'mcp' })),
+			});
+
+			const result = await executeMcpTool(ctx, () => baseConfig);
+
+			expect(result[0][0].json).toEqual({
+				response: [{ type: 'text', text: 'some error' }],
+			});
+		});
 	});
 
 	describe('loadMcpToolOptions', () => {


### PR DESCRIPTION
## Summary

CAT-3230 reported that when the MCP Client tool node errors, the whole AI Agent execution fails instead of the error being passed back to the agent for recovery.

Tracing the code path, this is **already fixed on master** (2.24.0+):

- The MCP Client tool runs engine-mediated: when the agent calls an MCP tool, the engine executes the MCP Client node as an ordinary node (`rewireOutputLogTo = ai_tool`). It is not a path that escapes the engine's error handling.
- `executeMcpTool` throws on failure (transport errors propagate; for node typeVersion >= 1.3, an `isError` tool result is also turned into a thrown `NodeOperationError`). That throw reaches the engine's central node-failure branch.
- PR #31225 (`863dfc340c`) made AI tools continue-on-error by default at that branch: the failing tool's error is returned to the agent on the `ai_tool` channel and the run continues, unless the node sets `onError: stopWorkflow`.

So no code change is needed. The engine behaviour is already covered by a test (`workflow-execute.test.ts`), but the MCP-specific case — an `isError` tool result — was not. This PR adds regression tests for `executeMcpTool`:

- typeVersion >= 1.3: an `isError` result throws with the tool's error text (so the engine routes it back to the agent).
- before v1.3: the flagged result is passed through as normal output (unchanged legacy behaviour).

## How to test

```
cd packages/@n8n/nodes-langchain
pnpm test runtime.test.ts
```

All `executeMcpTool` tests pass. The two new tests turn red if the `typeVersion >= 1.3 && result.isError` throw in `nodes/mcp/shared/runtime.ts` is removed, confirming they guard the behaviour.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3230

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32583">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

