### PR TITLE
fix(core): Check sub-workflow dynamic credentials status (no-changelog)

### DIFF
--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -2,7 +2,7 @@ import type { CredentialsRepository, WorkflowRepository } from '@n8n/db';
 import { CredentialsEntity, WorkflowEntity } from '@n8n/db';
 import type { ICredentialResolver } from '@n8n/decorators';
 import type { Cipher } from 'n8n-core';
-import type { INode } from 'n8n-workflow';
+import type { INode, NodeParameterValueType } from 'n8n-workflow';
 
 import type { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -310,12 +310,6 @@ describe('CredentialResolverWorkflowService', () => {
 				resolverId: 'resolver-2',
 			});
 
-			const mockResolver1 = createMockResolver({
-				id: 'resolver-1',
-				type: 'test.resolver',
-				config: 'encrypted-config-1',
-			});
-
 			const mockResolver2 = createMockResolver({
 				id: 'resolver-2',
 				type: 'test.resolver',
@@ -324,13 +318,10 @@ describe('CredentialResolverWorkflowService', () => {
 
 			mockWorkflowRepository.get.mockResolvedValue(mockWorkflow);
 			mockCredentialRepository.find.mockResolvedValue([mockCredential]);
-			mockResolverRepository.findOneBy
-				.mockResolvedValueOnce(mockResolver1)
-				.mockResolvedValueOnce(mockResolver2);
+			// Only the credential's own resolver is fetched; the unused workflow resolver is not.
+			mockResolverRepository.findOneBy.mockResolvedValue(mockResolver2);
 			mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
-			mockCipher.decryptV2
-				.mockResolvedValueOnce(JSON.stringify({ prefix: 'test-1' }))
-				.mockResolvedValueOnce(JSON.stringify({ prefix: 'test-2' }));
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test-2' }));
 			mockResolverImplementation.getSecret.mockResolvedValue('secret-value' as any);
 
 			const credentialContext = {
@@ -500,6 +491,339 @@ describe('CredentialResolverWorkflowService', () => {
 			expect(result).toHaveLength(2);
 			expect(result[0].status).toBe('configured');
 			expect(result[1].status).toBe('missing');
+		});
+
+		describe('sub-workflows', () => {
+			const credentialContext = {
+				identity: 'token-123',
+				version: 1 as const,
+				metadata: {},
+			};
+
+			const createExecuteWorkflowNode = (subWorkflowId: unknown, overrides: Partial<INode> = {}) =>
+				createMockNode({
+					id: 'exec-node',
+					name: 'Execute Workflow',
+					type: 'n8n-nodes-base.executeWorkflow',
+					parameters: { source: 'database', workflowId: subWorkflowId as NodeParameterValueType },
+					...overrides,
+				});
+
+			const nodeWithCredential = (credentialId: string, overrides: Partial<INode> = {}) =>
+				createMockNode({
+					credentials: { oauth2Api: { id: credentialId, name: credentialId } },
+					...overrides,
+				});
+
+			// Resolve credentials by the ids requested via the In() operator so dedup is exercised.
+			const mockFindReturning = (credentials: CredentialsEntity[]) => {
+				mockCredentialRepository.find.mockImplementation(async (options) => {
+					const requestedIds = (options?.where as { id?: { value?: string[] } })?.id?.value ?? [];
+					return credentials.filter((c) => requestedIds.includes(c.id) && c.isResolvable);
+				});
+			};
+
+			const mockWorkflowsById = (workflows: Record<string, WorkflowEntity | null>) => {
+				mockWorkflowRepository.get.mockImplementation(async ({ id }: { id: string }) =>
+					workflows[id] === undefined ? null : workflows[id],
+				);
+			};
+
+			beforeEach(() => {
+				mockResolverRepository.findOneBy.mockResolvedValue(
+					createMockResolver({ id: 'resolver-1', type: 'test.resolver' }),
+				);
+				mockResolverRegistry.getResolverByTypename.mockReturnValue(mockResolverImplementation);
+				mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ prefix: 'test' }));
+				mockResolverImplementation.getSecret.mockResolvedValue('secret' as any);
+			});
+
+			it('collects resolvable credentials from referenced sub-workflows', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [nodeWithCredential('cred-root'), createExecuteWorkflowNode({ value: 'sub-1' })],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-sub')],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([
+					createMockCredential({ id: 'cred-root' }),
+					createMockCredential({ id: 'cred-sub' }),
+				]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId).sort()).toEqual(['cred-root', 'cred-sub']);
+			});
+
+			it('follows AI Workflow Tool (toolWorkflow) references', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							createExecuteWorkflowNode(
+								{ value: 'sub-1' },
+								{ type: '@n8n/n8n-nodes-langchain.toolWorkflow' },
+							),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-sub')],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-sub' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-sub']);
+			});
+
+			it('handles cycles and self-references without re-processing workflows', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-root'),
+							createExecuteWorkflowNode({ value: 'workflow-1' }, { id: 'self-ref' }),
+							createExecuteWorkflowNode({ value: 'sub-1' }, { id: 'to-sub' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [
+							nodeWithCredential('cred-sub'),
+							createExecuteWorkflowNode({ value: 'workflow-1' }, { id: 'back-ref' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([
+					createMockCredential({ id: 'cred-root' }),
+					createMockCredential({ id: 'cred-sub' }),
+				]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId).sort()).toEqual(['cred-root', 'cred-sub']);
+				// Each workflow is loaded exactly once despite the cycle.
+				expect(mockWorkflowRepository.get).toHaveBeenCalledTimes(2);
+			});
+
+			it('deduplicates a credential shared between parent and sub-workflow', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-shared'),
+							createExecuteWorkflowNode({ value: 'sub-1' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-shared')],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-shared' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].credentialId).toBe('cred-shared');
+			});
+
+			it('deduplicates a credential used by multiple nodes in the same workflow', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-shared', { id: 'node-a', name: 'A' }),
+							nodeWithCredential('cred-shared', { id: 'node-b', name: 'B' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-shared' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].credentialId).toBe('cred-shared');
+			});
+
+			it('throws when the sub-workflow tree exceeds the traversal limit', async () => {
+				const subCount = 150;
+				const workflows: Record<string, WorkflowEntity | null> = {
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: Array.from({ length: subCount }, (_, i) =>
+							createExecuteWorkflowNode({ value: `sub-${i}` }, { id: `exec-${i}` }),
+						),
+						settings: {},
+					}),
+				};
+				for (let i = 0; i < subCount; i++) {
+					workflows[`sub-${i}`] = createMockWorkflow({ id: `sub-${i}`, nodes: [], settings: {} });
+				}
+				mockWorkflowsById(workflows);
+				mockFindReturning([]);
+
+				await expect(service.getWorkflowStatus('workflow-1', credentialContext)).rejects.toThrow(
+					/too many sub-workflows/i,
+				);
+			});
+
+			it('skips disabled sub-workflow nodes', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-root'),
+							createExecuteWorkflowNode({ value: 'sub-1' }, { disabled: true }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-sub')],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([
+					createMockCredential({ id: 'cred-root' }),
+					createMockCredential({ id: 'cred-sub' }),
+				]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-root']);
+				expect(mockWorkflowRepository.get).not.toHaveBeenCalledWith({ id: 'sub-1' });
+			});
+
+			it('skips non-database sub-workflow sources', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-root'),
+							createExecuteWorkflowNode(undefined, { parameters: { source: 'parameter' } }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-root' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-root']);
+				expect(mockWorkflowRepository.get).toHaveBeenCalledTimes(1);
+			});
+
+			it('ignores expression-based sub-workflow ids that cannot be resolved statically', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-root'),
+							createExecuteWorkflowNode({ value: '={{ $json.workflowId }}' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-root' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-root']);
+				expect(mockWorkflowRepository.get).toHaveBeenCalledTimes(1);
+			});
+
+			it('tolerates a deleted sub-workflow without failing the check', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-root'),
+							createExecuteWorkflowNode({ value: 'missing' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					missing: null,
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-root' })]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result.map((s) => s.credentialId)).toEqual(['cred-root']);
+			});
+
+			it('uses each sub-workflow own effective resolver as the fallback', async () => {
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [createExecuteWorkflowNode({ value: 'sub-1' })],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-sub')],
+						settings: { credentialResolverId: 'resolver-2' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-sub', resolverId: null })]);
+				mockResolverRepository.findOneBy.mockResolvedValue(
+					createMockResolver({ id: 'resolver-2', type: 'test.resolver' }),
+				);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toHaveLength(1);
+				expect(result[0].resolverId).toBe('resolver-2');
+			});
+
+			it('enforces user access on the root but resolves sub-workflows by id', async () => {
+				const user = { id: 'user-1' } as unknown as Parameters<typeof service.getWorkflowStatus>[2];
+				mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(
+					createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [nodeWithCredential('cred-root'), createExecuteWorkflowNode({ value: 'sub-1' })],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				);
+				mockWorkflowsById({
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-sub')],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+				});
+				mockFindReturning([
+					createMockCredential({ id: 'cred-root' }),
+					createMockCredential({ id: 'cred-sub' }),
+				]);
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext, user);
+
+				expect(result.map((s) => s.credentialId).sort()).toEqual(['cred-root', 'cred-sub']);
+				expect(mockWorkflowFinderService.findWorkflowForUser).toHaveBeenCalledWith(
+					'workflow-1',
+					user,
+					['workflow:read'],
+				);
+				// Sub-workflow loaded by id, not through the user-scoped finder.
+				expect(mockWorkflowRepository.get).toHaveBeenCalledWith({ id: 'sub-1' });
+				expect(mockWorkflowFinderService.findWorkflowForUser).toHaveBeenCalledTimes(1);
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-resolver-workflow.service.test.ts
@@ -791,6 +791,56 @@ describe('CredentialResolverWorkflowService', () => {
 				expect(result[0].resolverId).toBe('resolver-2');
 			});
 
+			it('checks a shared resolver-less credential under each workflow effective resolver', async () => {
+				// Same credential (no own resolverId) used in a parent and a sub-workflow that
+				// override the resolver differently: it must be checked under both, since at
+				// execution time each workflow resolves it with its own effective resolver.
+				mockWorkflowsById({
+					'workflow-1': createMockWorkflow({
+						id: 'workflow-1',
+						nodes: [
+							nodeWithCredential('cred-shared'),
+							createExecuteWorkflowNode({ value: 'sub-1' }),
+						],
+						settings: { credentialResolverId: 'resolver-1' },
+					}),
+					'sub-1': createMockWorkflow({
+						id: 'sub-1',
+						nodes: [nodeWithCredential('cred-shared')],
+						settings: { credentialResolverId: 'resolver-2' },
+					}),
+				});
+				mockFindReturning([createMockCredential({ id: 'cred-shared', resolverId: null })]);
+				mockResolverRepository.findOneBy.mockImplementation(async ({ id }: { id: string }) =>
+					createMockResolver({ id, type: 'test.resolver' }),
+				);
+				// Configured under resolver-1, missing under resolver-2.
+				mockResolverImplementation.getSecret.mockImplementation(async (_id, _ctx, opts) => {
+					if (opts.resolverId === 'resolver-2') {
+						throw new Error('Secret not found');
+					}
+					return 'secret' as any;
+				});
+
+				const result = await service.getWorkflowStatus('workflow-1', credentialContext);
+
+				expect(result).toHaveLength(2);
+				expect(result).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							credentialId: 'cred-shared',
+							resolverId: 'resolver-1',
+							status: 'configured',
+						}),
+						expect.objectContaining({
+							credentialId: 'cred-shared',
+							resolverId: 'resolver-2',
+							status: 'missing',
+						}),
+					]),
+				);
+			});
+
 			it('enforces user access on the root but resolves sub-workflows by id', async () => {
 				const user = { id: 'user-1' } as unknown as Parameters<typeof service.getWorkflowStatus>[2];
 				mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -96,9 +96,11 @@ export class CredentialResolverWorkflowService {
 		user?: User,
 	): Promise<CredentialStatus[]> {
 		const visited = new Set<string>();
-		// credentialId -> effective resolverId of the workflow it was first found in (fallback only;
-		// a credential-level resolverId still takes priority during the status check).
-		const credentialFallbackResolvers = new Map<string, string | null>();
+		// credentialId -> set of distinct effective resolverIds of the workflows it appears in
+		// (fallback only; a credential-level resolverId still takes priority during the status
+		// check). A credential without its own resolverId resolves under the resolver of whichever
+		// workflow contains it, so it must be checked once per distinct fallback.
+		const credentialFallbackResolvers = new Map<string, Set<string | null>>();
 
 		await this.collectResolvableCredentials(
 			workflowId,
@@ -122,10 +124,20 @@ export class CredentialResolverWorkflowService {
 		// Fetch/decrypt each distinct resolver at most once across the whole tree.
 		const resolverCache = new Map<string, ResolvedResolver>();
 
-		const credentialStatusPromises = credentials.map(
-			async (credential) =>
+		// A credential with its own resolverId always resolves the same way, so check it once.
+		// Otherwise check it once per distinct fallback resolver, since the same credential can
+		// resolve differently in a parent vs a sub-workflow that override the resolver.
+		const credentialChecks = credentials.flatMap((credential) => {
+			const fallbacks = credential.resolverId
+				? [null]
+				: [...(credentialFallbackResolvers.get(credential.id) ?? [null])];
+			return fallbacks.map((fallbackResolverId) => ({ credential, fallbackResolverId }));
+		});
+
+		const credentialStatusPromises = credentialChecks.map(
+			async ({ credential, fallbackResolverId }) =>
 				await this.checkCredentialStatus(credential, {
-					fallbackResolverId: credentialFallbackResolvers.get(credential.id) ?? null,
+					fallbackResolverId,
 					credentialContext,
 					resolverCache,
 				}),
@@ -141,7 +153,7 @@ export class CredentialResolverWorkflowService {
 	 */
 	private async collectResolvableCredentials(
 		workflowId: string,
-		acc: Map<string, string | null>,
+		acc: Map<string, Set<string | null>>,
 		visited: Set<string>,
 		user: User | undefined,
 		isRoot: boolean,
@@ -178,9 +190,12 @@ export class CredentialResolverWorkflowService {
 		for (const node of workflow.nodes ?? []) {
 			for (const credentialName in node.credentials ?? {}) {
 				const credentialId = node.credentials?.[credentialName]?.id;
-				if (credentialId && !acc.has(credentialId)) {
-					acc.set(credentialId, resolverId);
+				if (!credentialId) {
+					continue;
 				}
+				const fallbacks = acc.get(credentialId) ?? new Set<string | null>();
+				fallbacks.add(resolverId);
+				acc.set(credentialId, fallbacks);
 			}
 		}
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-resolver-workflow.service.ts
@@ -2,14 +2,20 @@ import { CredentialsEntity, CredentialsRepository, In, User, WorkflowRepository 
 import { ICredentialResolver } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
-import { ICredentialContext, jsonParse } from 'n8n-workflow';
+import { ICredentialContext, INode, isNodeWithWorkflowSelector, jsonParse } from 'n8n-workflow';
 
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { DynamicCredentialResolverRegistry } from './credential-resolver-registry.service';
 import { DynamicCredentialResolverRepository } from '../database/repositories/credential-resolver.repository';
+
+// Upper bound on distinct workflows traversed per status check. Bounds the number of sequential
+// DB loads on the unauthenticated execution-status endpoint regardless of tree shape (deep chains
+// or wide fan-out), and is far above any realistic sub-workflow tree.
+const MAX_TRAVERSED_WORKFLOWS = 100;
 
 type CredentialStatus = {
 	credentialId: string;
@@ -17,6 +23,11 @@ type CredentialStatus = {
 	resolverId?: string;
 	credentialType: string;
 	status: 'missing' | 'configured' | 'resolver_missing';
+};
+
+type ResolvedResolver = {
+	resolverInstance: ICredentialResolver;
+	resolverConfig: Record<string, unknown>;
 };
 
 function isCredentialStatus(obj: unknown): obj is CredentialStatus {
@@ -45,10 +56,7 @@ export class CredentialResolverWorkflowService {
 		private readonly workflowFinderService: WorkflowFinderService,
 	) {}
 
-	private async getResolver(resolverId: string): Promise<{
-		resolverInstance: ICredentialResolver;
-		resolverConfig: Record<string, unknown>;
-	}> {
+	private async getResolver(resolverId: string): Promise<ResolvedResolver> {
 		const resolver = await this.resolverRepository.findOneBy({ id: resolverId });
 		if (!resolver) {
 			throw new Error('Credential resolver not found');
@@ -71,89 +79,184 @@ export class CredentialResolverWorkflowService {
 	}
 
 	/**
-	 * Checks the status of all resolvable credentials in a workflow.
-	 * Tests credential availability by attempting to retrieve secrets using the provided identity token.
+	 * Checks the status of all resolvable credentials in a workflow and its sub-workflows.
+	 * Traverses Execute Sub-workflow and AI Workflow Tool references recursively, deduplicating
+	 * both workflows (cycles / self-references / diamond references) and credentials, then tests
+	 * credential availability by attempting to retrieve secrets using the provided identity token.
 	 *
-	 * @param workflowId - The workflow ID to check
-	 * @param identityToken - Bearer token for credential authorization
+	 * @param workflowId - The (root) workflow ID to check
+	 * @param credentialContext - Identity context used for credential authorization
+	 * @param user - Optional n8n session user whose access is enforced on the root workflow
 	 * @returns Array of credential statuses (configured/missing) with resolver info
-	 * @throws {Error} When workflow is not found or resolver configuration is invalid
+	 * @throws {Error} When the root workflow is not found or resolver configuration is invalid
 	 */
 	async getWorkflowStatus(
 		workflowId: string,
 		credentialContext: ICredentialContext,
 		user?: User,
 	): Promise<CredentialStatus[]> {
-		// When the request carries an n8n session user, enforce that user's access
-		// to the workflow. Execution-time/external callers have no user and resolve
-		// by id (their identity is validated via the credential context).
-		const workflow = user
-			? await this.workflowFinderService.findWorkflowForUser(workflowId, user, ['workflow:read'])
-			: await this.workflowRepository.get({ id: workflowId });
+		const visited = new Set<string>();
+		// credentialId -> effective resolverId of the workflow it was first found in (fallback only;
+		// a credential-level resolverId still takes priority during the status check).
+		const credentialFallbackResolvers = new Map<string, string | null>();
 
-		if (!workflow) {
-			throw new NotFoundError('Workflow not found');
-		}
+		await this.collectResolvableCredentials(
+			workflowId,
+			credentialFallbackResolvers,
+			visited,
+			user,
+			true,
+		);
 
-		const resolverId = this.dynamicCredentialsProxy.getEffectiveResolverId(workflow.settings);
-
-		let workflowResolverInstance: ICredentialResolver | null = null;
-		let workflowResolverConfig: Record<string, unknown> | null = null;
-
-		if (resolverId) {
-			const { resolverInstance, resolverConfig } = await this.getResolver(resolverId);
-			workflowResolverInstance = resolverInstance;
-			workflowResolverConfig = resolverConfig;
-		}
-
-		const credentialsToCheck: string[] = [];
-
-		for (const node of workflow.nodes ?? []) {
-			for (const credentialName in node.credentials ?? {}) {
-				const credentialData = node.credentials?.[credentialName];
-				// Fetch credentials from the DB using the credentialData.id
-				if (credentialData?.id) {
-					credentialsToCheck.push(credentialData.id);
-				}
-			}
-		}
-
-		if (credentialsToCheck.length === 0) {
+		if (credentialFallbackResolvers.size === 0) {
 			return [];
 		}
 
 		const credentials = await this.credentialRepository.find({
 			where: {
-				id: In(credentialsToCheck),
+				id: In([...credentialFallbackResolvers.keys()]),
 				isResolvable: true,
 			},
 		});
-		// Get all credentials from the DB based on the ids collected above and resolvable being true
 
-		const credentialStatusPromises = credentials.map(async (credential) => {
-			return await this.checkCredentialStatus(credential, {
-				workflowResolverInstance,
-				workflowResolverConfig,
-				resolverId,
-				credentialContext,
-			});
-		});
+		// Fetch/decrypt each distinct resolver at most once across the whole tree.
+		const resolverCache = new Map<string, ResolvedResolver>();
+
+		const credentialStatusPromises = credentials.map(
+			async (credential) =>
+				await this.checkCredentialStatus(credential, {
+					fallbackResolverId: credentialFallbackResolvers.get(credential.id) ?? null,
+					credentialContext,
+					resolverCache,
+				}),
+		);
 
 		return (await Promise.all(credentialStatusPromises)).filter(isCredentialStatus);
+	}
+
+	/**
+	 * Recursively walks a workflow and its sub-workflows, recording every resolvable-credential id
+	 * mapped to the effective resolver of the workflow it was first found in. The `visited` set
+	 * prevents processing the same workflow twice (cycles, self-references, diamond references).
+	 */
+	private async collectResolvableCredentials(
+		workflowId: string,
+		acc: Map<string, string | null>,
+		visited: Set<string>,
+		user: User | undefined,
+		isRoot: boolean,
+	): Promise<void> {
+		if (visited.has(workflowId)) {
+			return;
+		}
+		// Fail closed: erroring is safer than silently stopping traversal, which could report a
+		// workflow as ready while unvisited sub-workflows are still missing credentials.
+		if (visited.size >= MAX_TRAVERSED_WORKFLOWS) {
+			throw new BadRequestError(
+				`Workflow references too many sub-workflows to check (limit ${MAX_TRAVERSED_WORKFLOWS})`,
+			);
+		}
+		visited.add(workflowId);
+
+		// Enforce the session user's access on the root workflow only. Sub-workflows resolve by id
+		// to match execution-time semantics (a sub-workflow runs regardless of who can read it).
+		const workflow =
+			isRoot && user
+				? await this.workflowFinderService.findWorkflowForUser(workflowId, user, ['workflow:read'])
+				: await this.workflowRepository.get({ id: workflowId });
+
+		if (!workflow) {
+			if (isRoot) {
+				throw new NotFoundError('Workflow not found');
+			}
+			// A referenced sub-workflow may have been deleted; skip it rather than failing the check.
+			return;
+		}
+
+		const resolverId = this.dynamicCredentialsProxy.getEffectiveResolverId(workflow.settings);
+
+		for (const node of workflow.nodes ?? []) {
+			for (const credentialName in node.credentials ?? {}) {
+				const credentialId = node.credentials?.[credentialName]?.id;
+				if (credentialId && !acc.has(credentialId)) {
+					acc.set(credentialId, resolverId);
+				}
+			}
+		}
+
+		for (const subWorkflowId of this.extractSubWorkflowIds(workflow.nodes ?? [])) {
+			await this.collectResolvableCredentials(subWorkflowId, acc, visited, user, false);
+		}
+	}
+
+	/**
+	 * Extracts statically-resolvable sub-workflow ids from a workflow's nodes. Considers Execute
+	 * Sub-workflow and AI Workflow Tool nodes that reference a stored workflow by id; skips disabled
+	 * nodes, non-database sources, and expression-based ids that can't be resolved statically.
+	 */
+	private extractSubWorkflowIds(nodes: INode[]): string[] {
+		const ids = new Set<string>();
+
+		for (const node of nodes) {
+			if (node.disabled || !isNodeWithWorkflowSelector(node)) {
+				continue;
+			}
+
+			const source = node.parameters?.source;
+			if (source === 'parameter' || source === 'localFile' || source === 'url') {
+				continue;
+			}
+
+			const subWorkflowId = this.extractWorkflowId(node.parameters?.workflowId);
+			if (subWorkflowId && !subWorkflowId.includes('{')) {
+				ids.add(subWorkflowId);
+			}
+		}
+
+		return [...ids];
+	}
+
+	/**
+	 * Reads a workflow id from a node's `workflowId` parameter, handling both the plain-string and
+	 * the resource-locator (`{ value }`) shapes.
+	 */
+	private extractWorkflowId(workflowIdParam: unknown): string | undefined {
+		if (typeof workflowIdParam === 'string') {
+			return workflowIdParam;
+		}
+		if (
+			typeof workflowIdParam === 'object' &&
+			workflowIdParam !== null &&
+			'value' in workflowIdParam &&
+			typeof workflowIdParam.value === 'string'
+		) {
+			return workflowIdParam.value;
+		}
+		return undefined;
+	}
+
+	private async getCachedResolver(
+		resolverId: string,
+		cache: Map<string, ResolvedResolver>,
+	): Promise<ResolvedResolver> {
+		const cached = cache.get(resolverId);
+		if (cached) {
+			return cached;
+		}
+		const resolved = await this.getResolver(resolverId);
+		cache.set(resolverId, resolved);
+		return resolved;
 	}
 
 	private async checkCredentialStatus(
 		credential: CredentialsEntity,
 		options: {
-			workflowResolverInstance: ICredentialResolver | null;
-			workflowResolverConfig: Record<string, unknown> | null;
-			resolverId: string | null;
+			fallbackResolverId: string | null;
 			credentialContext: ICredentialContext;
+			resolverCache: Map<string, ResolvedResolver>;
 		},
-	): Promise<CredentialStatus | null> {
-		let resolverInstance: ICredentialResolver | null = options.workflowResolverInstance;
-		let resolverConfig: Record<string, unknown> | null = options.workflowResolverConfig;
-		const credentialResolverId = credential.resolverId ?? options.resolverId;
+	): Promise<CredentialStatus> {
+		const credentialResolverId = credential.resolverId ?? options.fallbackResolverId;
 		if (!credentialResolverId) {
 			return {
 				credentialId: credential.id,
@@ -162,40 +265,33 @@ export class CredentialResolverWorkflowService {
 				credentialType: credential.type,
 			};
 		}
-		if (credentialResolverId !== options.resolverId) {
-			const {
-				resolverInstance: credentialResolverInstance,
-				resolverConfig: credentialResolverConfig,
-			} = await this.getResolver(credentialResolverId);
-			resolverInstance = credentialResolverInstance;
-			resolverConfig = credentialResolverConfig;
-		}
 
-		if (resolverConfig && resolverInstance) {
-			try {
-				await resolverInstance.getSecret(credential.id, options.credentialContext, {
-					configuration: resolverConfig,
-					resolverName: resolverInstance.metadata.name,
-					resolverId: credentialResolverId,
-				});
-				return {
-					credentialId: credential.id,
-					resolverId: credentialResolverId,
-					credentialName: credential.name,
-					status: 'configured',
-					credentialType: credential.type,
-				};
-			} catch (error) {
-				// Handle error (e.g., log it, collect status, etc.
-				return {
-					credentialId: credential.id,
-					resolverId: credentialResolverId,
-					credentialName: credential.name,
-					status: 'missing',
-					credentialType: credential.type,
-				};
-			}
+		const { resolverInstance, resolverConfig } = await this.getCachedResolver(
+			credentialResolverId,
+			options.resolverCache,
+		);
+
+		try {
+			await resolverInstance.getSecret(credential.id, options.credentialContext, {
+				configuration: resolverConfig,
+				resolverName: resolverInstance.metadata.name,
+				resolverId: credentialResolverId,
+			});
+			return {
+				credentialId: credential.id,
+				resolverId: credentialResolverId,
+				credentialName: credential.name,
+				status: 'configured',
+				credentialType: credential.type,
+			};
+		} catch (error) {
+			return {
+				credentialId: credential.id,
+				resolverId: credentialResolverId,
+				credentialName: credential.name,
+				status: 'missing',
+				credentialType: credential.type,
+			};
 		}
-		return null;
 	}
 }


### PR DESCRIPTION
## Summary

`getWorkflowStatus` previously checked only the root workflow's own nodes, so the dynamic-credential readiness check (the `execution-status` endpoint / MCP-trigger auth guard and the runtime credential-check proxy) could report a workflow as ready while a referenced sub-workflow was still missing credentials. It now recursively traverses **Execute Sub-workflow** and **AI Workflow Tool** references, deduplicating both workflows (cycles / self-references / diamond references) and credentials, resolving sub-workflows by id to match execution-time semantics, and capping the number of workflows visited per check (fail-closed). Both callers benefit with no caller-side changes.

## How to test

1. Create workflow B that uses a resolvable (dynamic) credential, and workflow A that calls B via an Execute Sub-workflow node (and/or an AI Workflow Tool node).
2. Call `GET /rest/workflows/<A-id>/execution-status` with a valid identity token.
3. The response now includes B's resolvable credentials; `readyToExecute` is `false` when any sub-workflow credential is missing. Cycles/self-references are handled without looping, and a credential shared by multiple nodes/workflows appears once.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-859

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32586">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

