### PR TITLE
feat(core): Enable creation of custom instance (global) roles

### DIFF
--- a/packages/@n8n/api-types/src/dto/roles/create-role.dto.ts
+++ b/packages/@n8n/api-types/src/dto/roles/create-role.dto.ts
@@ -6,6 +6,6 @@ import { Z } from '../../zod-class';
 export class CreateRoleDto extends Z.class({
 	displayName: z.string().min(2).max(100),
 	description: z.string().max(500).optional(),
-	roleType: z.enum(['project']),
+	roleType: z.enum(['project', 'global']),
 	scopes: z.array(scopeSchema),
 }) {}

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -21,6 +21,7 @@ import type {
 	Scope,
 	Role as RoleDTO,
 	AssignableProjectRole,
+	AssignableGlobalRole,
 	RoleNamespace,
 } from '@n8n/permissions';
 import {
@@ -352,7 +353,7 @@ export class RoleService {
 		return await this.roleCacheService.getRolesWithAllScopes(namespace, scopes, trx);
 	}
 
-	isRoleLicensed(role: AssignableProjectRole) {
+	isRoleLicensed(role: AssignableProjectRole | AssignableGlobalRole) {
 		// TODO: move this info into FrontendSettings
 
 		if (!isBuiltInRole(role)) {

--- a/packages/cli/test/integration/controllers/role.controller.test.ts
+++ b/packages/cli/test/integration/controllers/role.controller.test.ts
@@ -809,6 +809,41 @@ describe('RoleController', () => {
 			expect(roleService.createCustomRole).toHaveBeenCalledWith(createRoleDto);
 		});
 
+		it('should create a global custom role with valid data as owner', async () => {
+			//
+			// ARRANGE
+			//
+			const createRoleDto: CreateRoleDto = {
+				displayName: 'Custom Global Role',
+				description: 'A custom global role',
+				roleType: 'global',
+				scopes: ['workflow:read'],
+			};
+
+			const mockCreatedRole: Role = {
+				slug: 'global:custom-global-role',
+				displayName: createRoleDto.displayName,
+				description: createRoleDto.description ?? null,
+				systemRole: false,
+				roleType: createRoleDto.roleType,
+				scopes: createRoleDto.scopes,
+				licensed: true,
+			};
+
+			roleService.createCustomRole.mockResolvedValue(mockCreatedRole);
+
+			//
+			// ACT
+			//
+			const response = await ownerAgent.post('/roles').send(createRoleDto).expect(200);
+
+			//
+			// ASSERT
+			//
+			expect(response.body).toEqual({ data: mockCreatedRole });
+			expect(roleService.createCustomRole).toHaveBeenCalledWith(createRoleDto);
+		});
+
 		it('should create role without description', async () => {
 			//
 			// ARRANGE

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -820,6 +820,45 @@ describe('RoleService', () => {
 			expect(savedRole?.displayName).toBe(createRoleDto.displayName);
 		});
 
+		it('should create a global custom role with valid data', async () => {
+			//
+			// ARRANGE
+			//
+			const testScopes = await createTestScopes();
+			const createRoleDto: CreateRoleDto = {
+				displayName: 'Test Global Role',
+				description: 'A test global custom role',
+				roleType: 'global',
+				scopes: [testScopes.readScope.slug, testScopes.writeScope.slug],
+			};
+
+			//
+			// ACT
+			//
+			const result = await roleService.createCustomRole(createRoleDto);
+
+			//
+			// ASSERT
+			//
+			expect(result).toMatchObject({
+				displayName: createRoleDto.displayName,
+				description: createRoleDto.description,
+				systemRole: false,
+				roleType: 'global',
+				scopes: expect.arrayContaining(createRoleDto.scopes),
+				licensed: expect.any(Boolean),
+			});
+
+			// Verify slug was generated with the global namespace
+			expect(result.slug).toMatch(/^global:test-global-role-[a-z0-9]{6}$/);
+
+			// Verify role was saved to database
+			const savedRole = await roleRepository.findBySlug(result.slug);
+			expect(savedRole).toBeDefined();
+			expect(savedRole?.roleType).toBe('global');
+			expect(savedRole?.systemRole).toBe(false);
+		});
+
 		it('should create custom role without description', async () => {
 			//
 			// ARRANGE
@@ -969,6 +1008,68 @@ describe('RoleService', () => {
 			expect(updatedRole?.description).toBe(updateRoleDto.description);
 		});
 
+		it('should update a global custom role with valid data', async () => {
+			//
+			// ARRANGE
+			//
+			const testScopes = await createTestScopes();
+			const existingRole = await createCustomRoleWithScopes([testScopes.readScope], {
+				displayName: 'Original Global Role',
+				description: 'Original description',
+				roleType: 'global',
+			});
+
+			const updateRoleDto: UpdateRoleDto = {
+				displayName: 'Updated Global Role',
+				description: 'Updated description',
+				scopes: [testScopes.writeScope.slug],
+			};
+
+			//
+			// ACT
+			//
+			const result = await roleService.updateCustomRole(existingRole.slug, updateRoleDto);
+
+			//
+			// ASSERT
+			//
+			expect(result).toMatchObject({
+				slug: existingRole.slug,
+				displayName: updateRoleDto.displayName,
+				description: updateRoleDto.description,
+				roleType: 'global',
+				scopes: expect.arrayContaining(updateRoleDto.scopes as string[]),
+			});
+
+			const updatedRole = await roleRepository.findBySlug(existingRole.slug);
+			expect(updatedRole?.roleType).toBe('global');
+			expect(updatedRole?.displayName).toBe(updateRoleDto.displayName);
+		});
+
+		it('should throw BadRequestError when trying to update a system role', async () => {
+			//
+			// ARRANGE
+			//
+			const systemRole = await createSystemRole({
+				displayName: 'System Global Role',
+				roleType: 'global',
+			});
+
+			const updateRoleDto: UpdateRoleDto = {
+				displayName: 'Updated System Role',
+			};
+
+			//
+			// ACT & ASSERT
+			//
+			await expect(roleService.updateCustomRole(systemRole.slug, updateRoleDto)).rejects.toThrow(
+				BadRequestError,
+			);
+			await expect(roleService.updateCustomRole(systemRole.slug, updateRoleDto)).rejects.toThrow(
+				'Cannot update system roles',
+			);
+		});
+
 		it('should update displayName when provided', async () => {
 			//
 			// ARRANGE
@@ -1098,6 +1199,35 @@ describe('RoleService', () => {
 			});
 
 			// Verify role was deleted from database
+			const deletedRole = await roleRepository.findBySlug(customRole.slug);
+			expect(deletedRole).toBeNull();
+		});
+
+		it('should remove a global custom role successfully', async () => {
+			//
+			// ARRANGE
+			//
+			const customRole = await createRole({
+				displayName: 'Global Role to Delete',
+				systemRole: false,
+				roleType: 'global',
+			});
+
+			//
+			// ACT
+			//
+			const result = await roleService.removeCustomRole(customRole.slug);
+
+			//
+			// ASSERT
+			//
+			expect(result).toMatchObject({
+				slug: customRole.slug,
+				displayName: customRole.displayName,
+				roleType: 'global',
+				systemRole: false,
+			});
+
 			const deletedRole = await roleRepository.findBySlug(customRole.slug);
 			expect(deletedRole).toBeNull();
 		});


### PR DESCRIPTION
## Summary

Lifts the project-only restriction on the role CRUD path so custom **global** roles can be created, previously only `project` custom roles were accepted.

- `CreateRoleDto.roleType` now accepts `'global'` in addition to `'project'`.
- `RoleService.createCustomRole` already derives the slug from `roleType`, so a `global` type yields a `global:<slug>-<suffix>` slug with `systemRole: false` — no logic change needed there.
- `RoleService.isRoleLicensed` param type widened to also accept assignable global roles; custom roles still route through `license.isCustomRolesLicensed()`.
- Controller authorization is unchanged: POST/PATCH/DELETE remain gated by `@GlobalScope('role:manage')` + `@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)`, which fire before the body is parsed and are therefore `roleType`-agnostic.

##  Related Linear tickets

https://linear.app/n8n/issue/IAM-828

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32590">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

