### PR TITLE
fix(core): Reduce Sentry tracing noise from auto-instrumentation spans (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/sentry.config.ts
+++ b/packages/@n8n/config/src/configs/sentry.config.ts
@@ -36,6 +36,16 @@ export class SentryConfig {
 	profilesSampleRate: number = 0;
 
 	/**
+	 * Spans (`db`, `http.client`) shorter than this and not errored are dropped
+	 * before being sent to Sentry, to cut auto-instrumentation trace volume
+	 * while keeping slow/failed operations. In milliseconds.
+	 *
+	 * @default 1000
+	 */
+	@Env('N8N_SENTRY_TRACES_SLOW_SPAN_THRESHOLD_MS', z.number({ coerce: true }).int().positive())
+	tracesSlowSpanThresholdMs: number = 1000;
+
+	/**
 	 * Whether Sentry's native event-loop-block detection is enabled. When on, a
 	 * native watchdog (`@sentry/node-native`) captures the main thread's stack
 	 * whenever the event loop is blocked beyond the threshold below.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -385,6 +385,7 @@ describe('GlobalConfig', () => {
 			deploymentName: '',
 			profilesSampleRate: 0,
 			tracesSampleRate: 0,
+			tracesSlowSpanThresholdMs: 1000,
 			eventLoopBlockDetectionEnabled: false,
 			eventLoopBlockThreshold: 500,
 			eventLoopBlockMaxEventsPerHour: 5,

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -95,6 +95,7 @@ export abstract class BaseCommand<F = never> {
 			deploymentName,
 			profilesSampleRate,
 			tracesSampleRate,
+			tracesSlowSpanThresholdMs,
 			eventLoopBlockThreshold,
 			eventLoopBlockMaxEventsPerHour,
 			eventLoopBlockDetectionEnabled,
@@ -110,6 +111,7 @@ export abstract class BaseCommand<F = never> {
 			eventLoopBlockThreshold,
 			eventLoopBlockMaxEventsPerHour,
 			tracesSampleRate,
+			slowSpanThresholdMs: tracesSlowSpanThresholdMs,
 			profilesSampleRate,
 			healthEndpoint: resolveBackendHealthEndpointPath(this.globalConfig),
 			eligibleIntegrations: {

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -8,7 +8,13 @@ import { AxiosError } from 'axios';
 import { ApplicationError, ExecutionCancelledError, BaseError } from 'n8n-workflow';
 import { createHash } from 'node:crypto';
 
-import { Tracing, SentryTracing } from '@/observability';
+import {
+	Tracing,
+	SentryTracing,
+	buildBeforeSendTransaction,
+	buildTracesSampler,
+	DEFAULT_SLOW_SPAN_THRESHOLD_MS,
+} from '@/observability';
 
 type SentryIntegration = 'Redis' | 'Postgres' | 'Http' | 'Express';
 
@@ -31,6 +37,9 @@ type ErrorReporterInitOptions = {
 
 	/** Sample rate for Sentry traces (0.0 to 1.0). 0 means disabled */
 	tracesSampleRate: number;
+
+	/** Threshold in ms below which non-errored `db`/`http.client` spans are dropped. */
+	slowSpanThresholdMs?: number;
 
 	/** Sample rate for Sentry profiling (0.0 to 1.0). 0 means disabled */
 	profilesSampleRate: number;
@@ -139,6 +148,7 @@ export class ErrorReporter {
 		eventLoopBlockMaxEventsPerHour,
 		profilesSampleRate,
 		tracesSampleRate,
+		slowSpanThresholdMs = DEFAULT_SLOW_SPAN_THRESHOLD_MS,
 		eligibleIntegrations = {},
 		healthEndpoint = '/healthz',
 	}: ErrorReporterInitOptions) {
@@ -229,7 +239,12 @@ export class ErrorReporter {
 			environment,
 			serverName,
 			maxValueLength: SENTRY_MAX_VALUE_LENGTH,
-			...(isTracingEnabled ? { tracesSampleRate } : {}),
+			...(isTracingEnabled
+				? {
+						tracesSampler: buildTracesSampler(tracesSampleRate),
+						beforeSendTransaction: buildBeforeSendTransaction(slowSpanThresholdMs),
+					}
+				: {}),
 			...(isProfilingEnabled ? { profilesSampleRate, profileLifecycle: 'trace' } : {}),
 			beforeSend: this.beforeSend.bind(this) as NodeOptions['beforeSend'],
 			ignoreTransactions: [`GET ${healthEndpoint}`, 'GET /metrics', 'SET search_path TO'],

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -6,3 +6,8 @@ export {
 	type Span,
 } from './tracing/tracing';
 export { SentryTracing } from './tracing/sentry-tracing';
+export {
+	buildBeforeSendTransaction,
+	buildTracesSampler,
+	DEFAULT_SLOW_SPAN_THRESHOLD_MS,
+} from './tracing/span-sampling';

--- a/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
@@ -1,0 +1,142 @@
+import type { SpanJSON, TracesSamplerSamplingContext, TransactionEvent } from '@sentry/core';
+
+import { buildBeforeSendTransaction, buildTracesSampler } from '../span-sampling';
+
+const THRESHOLD_MS = 1000;
+
+/** Builds a minimal child SpanJSON with a duration of `durationMs`. */
+function span(overrides: Partial<SpanJSON> & { op?: string; durationMs?: number }): SpanJSON {
+	const { durationMs = 0, ...rest } = overrides;
+	const startTimestamp = 1000;
+	return {
+		span_id: 'span-id',
+		trace_id: 'trace-id',
+		start_timestamp: startTimestamp,
+		timestamp: startTimestamp + durationMs / 1000,
+		data: {},
+		...rest,
+	};
+}
+
+/** Runs the filter and returns the surviving child spans. */
+function filterSpans(spans: SpanJSON[]): SpanJSON[] {
+	const event = { type: 'transaction', spans } as TransactionEvent;
+	return buildBeforeSendTransaction(THRESHOLD_MS)(event).spans ?? [];
+}
+
+describe('buildBeforeSendTransaction', () => {
+	it.each(['middleware.express', 'router.express', 'request_handler.express'])(
+		'drops %s spans wholesale',
+		(op) => {
+			expect(filterSpans([span({ op, durationMs: 5000 })])).toEqual([]);
+		},
+	);
+
+	it.each(['db', 'http.client'])('drops fast, non-errored %s spans', (op) => {
+		expect(filterSpans([span({ op, durationMs: THRESHOLD_MS - 1, status: 'ok' })])).toEqual([]);
+	});
+
+	it.each(['db', 'http.client'])('keeps slow %s spans', (op) => {
+		const slow = span({ op, durationMs: THRESHOLD_MS, status: 'ok' });
+		expect(filterSpans([slow])).toEqual([slow]);
+	});
+
+	it.each(['db', 'http.client'])('keeps errored fast %s spans', (op) => {
+		const errored = span({ op, durationMs: 1, status: 'internal_error' });
+		expect(filterSpans([errored])).toEqual([errored]);
+	});
+
+	it('keeps http.server, custom n8n, and op-less spans', () => {
+		const kept = [
+			span({ op: 'http.server', durationMs: 1, status: 'ok' }),
+			span({ op: 'trigger.poll', durationMs: 1 }),
+			span({ durationMs: 1 }),
+		];
+		expect(filterSpans(kept)).toEqual(kept);
+	});
+
+	it('keeps unfinished spans (no end timestamp)', () => {
+		const unfinished = span({ op: 'db', timestamp: undefined });
+		expect(filterSpans([unfinished])).toEqual([unfinished]);
+	});
+
+	it('filters a mixed span tree, keeping only signal-bearing spans', () => {
+		const slowDb = span({ op: 'db', durationMs: 2000, status: 'ok' });
+		const httpServer = span({ op: 'http.server', durationMs: 50, status: 'ok' });
+		const result = filterSpans([
+			span({ op: 'middleware.express', durationMs: 40 }),
+			span({ op: 'db', durationMs: 2, status: 'ok' }),
+			slowDb,
+			httpServer,
+		]);
+		expect(result).toEqual([slowDb, httpServer]);
+	});
+
+	it('reparents surviving children of dropped spans', () => {
+		const slowDb = span({
+			span_id: 'db-span',
+			parent_span_id: 'express-span',
+			op: 'db',
+			durationMs: 2000,
+			status: 'ok',
+		});
+
+		const result = filterSpans([
+			span({
+				span_id: 'express-span',
+				parent_span_id: 'root-span',
+				op: 'middleware.express',
+				durationMs: 40,
+			}),
+			slowDb,
+		]);
+
+		expect(result).toEqual([{ ...slowDb, parent_span_id: 'root-span' }]);
+	});
+
+	it('returns the event unchanged when it has no spans', () => {
+		const event = { type: 'transaction' } as TransactionEvent;
+		expect(buildBeforeSendTransaction(THRESHOLD_MS)(event)).toBe(event);
+	});
+});
+
+describe('buildTracesSampler', () => {
+	const BASE_RATE = 0.05;
+	const tracesSampler = buildTracesSampler(BASE_RATE);
+
+	function ctx(
+		attributes?: TracesSamplerSamplingContext['attributes'],
+		inheritedRate?: number,
+	): TracesSamplerSamplingContext {
+		return {
+			name: 'tx',
+			attributes,
+			inheritOrSampleWith: (fallbackRate) => inheritedRate ?? fallbackRate,
+		};
+	}
+
+	it('returns a near-zero rate for poll-trigger transactions', () => {
+		expect(tracesSampler(ctx({ 'sentry.op': 'trigger.poll' }))).toBeLessThan(BASE_RATE);
+	});
+
+	it('does not raise poll-trigger transactions above the base rate', () => {
+		const lowBaseRateSampler = buildTracesSampler(0.0005);
+		expect(lowBaseRateSampler(ctx({ 'sentry.op': 'trigger.poll' }))).toBe(0.0005);
+	});
+
+	it('does not raise poll-trigger transactions above an inherited rate', () => {
+		expect(tracesSampler(ctx({ 'sentry.op': 'trigger.poll' }, 0.0005))).toBe(0.0005);
+	});
+
+	it('returns the base rate for other transactions', () => {
+		expect(tracesSampler(ctx({ 'sentry.op': 'http.server' }))).toBe(BASE_RATE);
+	});
+
+	it('inherits upstream sampling decisions for other transactions', () => {
+		expect(tracesSampler(ctx({ 'sentry.op': 'http.server' }, 1))).toBe(1);
+	});
+
+	it('returns the base rate when attributes are missing', () => {
+		expect(tracesSampler(ctx())).toBe(BASE_RATE);
+	});
+});

--- a/packages/core/src/observability/tracing/span-sampling.ts
+++ b/packages/core/src/observability/tracing/span-sampling.ts
@@ -1,0 +1,90 @@
+import type { SpanJSON, TracesSamplerSamplingContext, TransactionEvent } from '@sentry/core';
+
+/**
+ * Express auto-instrumentation span ops whose duration only mirrors the
+ * handler, so they carry no independent signal. Dropped wholesale.
+ */
+const DROPPED_EXPRESS_OPS = new Set([
+	'middleware.express',
+	'router.express',
+	'request_handler.express',
+]);
+
+/** High-volume auto-instrumentation ops kept only when slow or errored. */
+const DURATION_FILTERED_OPS = new Set(['db', 'http.client']);
+
+/** Near-zero sample rate for high-frequency, low-value poll-trigger transactions. */
+const POLL_TRIGGER_SAMPLE_RATE = 0.001;
+
+/** Fallback slow-span threshold (ms) when a caller doesn't configure one. */
+export const DEFAULT_SLOW_SPAN_THRESHOLD_MS = 1000;
+
+/** A span errored unless Sentry explicitly marked it ok. */
+function isErrored(status: SpanJSON['status']): boolean {
+	return status !== undefined && status !== 'ok';
+}
+
+/** Whether a child span should survive filtering. */
+function shouldKeepSpan(span: SpanJSON, slowSpanThresholdMs: number): boolean {
+	const { op, timestamp, start_timestamp: startTimestamp } = span;
+
+	if (op && DROPPED_EXPRESS_OPS.has(op)) return false;
+
+	if (op && DURATION_FILTERED_OPS.has(op) && timestamp !== undefined) {
+		const durationMs = (timestamp - startTimestamp) * 1000;
+		if (durationMs < slowSpanThresholdMs && !isErrored(span.status)) return false;
+	}
+
+	return true;
+}
+
+function reparentChildSpans(
+	spans: SpanJSON[],
+	droppedSpan: SpanJSON,
+	fallbackParentSpanId?: string,
+): void {
+	const parentSpanId = droppedSpan.parent_span_id ?? fallbackParentSpanId;
+	if (!parentSpanId) return;
+
+	for (const span of spans) {
+		if (span.parent_span_id === droppedSpan.span_id) {
+			span.parent_span_id = parentSpanId;
+		}
+	}
+}
+
+/**
+ * Filters noisy auto-instrumentation child spans before Sentry sends a transaction:
+ * - Express middleware/router/handler spans wholesale.
+ * - Fast, non-errored `db`/`http.client` spans (below `slowSpanThresholdMs`).
+ *
+ * Kept descendants of dropped spans are reparented.
+ */
+export function buildBeforeSendTransaction(slowSpanThresholdMs: number) {
+	return (event: TransactionEvent): TransactionEvent => {
+		if (event.spans) {
+			const spans = event.spans;
+			event.spans = spans.filter((span) => {
+				const keep = shouldKeepSpan(span, slowSpanThresholdMs);
+				if (!keep) reparentChildSpans(spans, span, event.contexts?.trace?.span_id);
+				return keep;
+			});
+		}
+		return event;
+	};
+}
+
+/**
+ * Builds a Sentry `tracesSampler` that head-samples by transaction type:
+ * `baseRate` for meaningful transactions, near-zero for high-frequency
+ * poll-trigger transactions.
+ */
+export function buildTracesSampler(baseRate: number) {
+	return (samplingContext: TracesSamplerSamplingContext): number => {
+		const effectiveBaseRate = samplingContext.inheritOrSampleWith(baseRate);
+		if (samplingContext.attributes?.['sentry.op'] === 'trigger.poll') {
+			return Math.min(effectiveBaseRate, POLL_TRIGGER_SAMPLE_RATE);
+		}
+		return effectiveBaseRate;
+	};
+}


### PR DESCRIPTION
## Summary

When Sentry trace sampling is enabled, ~95% of span volume is auto-instrumentation noise (`db` ~71%, Express middleware/router/handler ~24%), which burns the trace quota in days. This adds a `beforeSendTransaction` filter that drops Express middleware/router/handler child spans wholesale and keeps `db`/`http.client` spans only when slow (above a configurable threshold, env `N8N_SENTRY_TRACES_SLOW_SPAN_THRESHOLD_MS`, default 1000ms) or errored — reparenting surviving children of dropped spans so trace trees stay coherent. It also replaces the flat `tracesSampleRate` with a `tracesSampler` that head-samples poll-trigger transactions near-zero while honoring upstream sampling decisions. The default sample rate stays `0`, so there is no behavior change unless tracing is explicitly turned on.

> Note: the ticket assumed `beforeSendSpan` returning `null`, but in `@sentry/node` v10 that callback can no longer drop spans, so the equivalent filtering is done in `beforeSendTransaction` (the root transaction lives in `event.contexts.trace` and is never droppable there).

## How to test

Set `N8N_SENTRY_DSN` and `N8N_SENTRY_TRACES_SAMPLE_RATE=1` against a test DSN, drive a few API/webhook requests and a poll trigger, then confirm in Sentry that fast `db`/`http.client` and Express middleware/router spans are gone while slow/errored ones and `http.server` remain, and poll-trigger transactions are rare. Unit tests: `cd packages/core && pnpm test span-sampling`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3509

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

