### PR TITLE
fix(editor): Preserve existing node IDs when AI edits a workflow

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
@@ -190,8 +190,17 @@ export class ParseValidateHandler {
 			this.logger?.debug('Parsing WorkflowCode', { codeLength: codeToParse.length });
 			const builder = parseWorkflowCodeToBuilder(codeToParse);
 
-			// Regenerate node IDs deterministically to ensure stable IDs across re-parses
-			builder.regenerateNodeIds();
+			// Regenerate node IDs deterministically to ensure stable IDs across re-parses,
+			// but preserve the IDs of nodes that already exist (matched by name) so editing a
+			// hand-built workflow doesn't rewrite every node's ID and skew the version diff.
+			const existingIdsByName = currentWorkflow
+				? new Map(
+						currentWorkflow.nodes
+							.filter((node): node is typeof node & { name: string } => Boolean(node.name))
+							.map((node) => [node.name, node.id]),
+					)
+				: undefined;
+			builder.regenerateNodeIds(existingIdsByName);
 
 			// Run graph + JSON validation
 			const allWarnings: ValidationWarning[] = [];

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
@@ -190,16 +190,12 @@ export class ParseValidateHandler {
 			this.logger?.debug('Parsing WorkflowCode', { codeLength: codeToParse.length });
 			const builder = parseWorkflowCodeToBuilder(codeToParse);
 
-			// Regenerate node IDs deterministically to ensure stable IDs across re-parses,
-			// but preserve the IDs of nodes that already exist (matched by name) so editing a
-			// hand-built workflow doesn't rewrite every node's ID and skew the version diff.
-			const existingIdsByName = currentWorkflow
-				? new Map(
-						currentWorkflow.nodes
-							.filter((node): node is typeof node & { name: string } => Boolean(node.name))
-							.map((node) => [node.name, node.id]),
-					)
-				: undefined;
+			// Preserve IDs of nodes that already exist (by name) so editing a workflow doesn't skew the diff.
+			const existingIdsByName = new Map(
+				(currentWorkflow?.nodes ?? [])
+					.filter((node): node is typeof node & { name: string } => Boolean(node.name))
+					.map((node) => [node.name, node.id]),
+			);
 			builder.regenerateNodeIds(existingIdsByName);
 
 			// Run graph + JSON validation

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
@@ -229,6 +229,53 @@ describe('ParseValidateHandler', () => {
 			expect(mockBuilder.generatePinData).toHaveBeenCalledWith({ beforeWorkflow: currentWorkflow });
 		});
 
+		it('should preserve existing node IDs (matched by name) when regenerating', async () => {
+			const currentWorkflow = {
+				id: 'current',
+				name: 'Current',
+				nodes: [
+					{ id: 'manual-id-1', name: 'Set A', type: 'n8n-nodes-base.set' },
+					{ id: 'manual-id-2', name: 'Set B', type: 'n8n-nodes-base.set' },
+				],
+				connections: {},
+			} as unknown as WorkflowJSON;
+
+			const mockBuilder = {
+				regenerateNodeIds: vi.fn(),
+				validate: vi.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+				generatePinData: vi.fn(),
+				toJSON: vi.fn().mockReturnValue({ id: 'test', name: 'Test', nodes: [], connections: {} }),
+			};
+
+			mockParseWorkflowCodeToBuilder.mockReturnValue(mockBuilder);
+			mockValidateWorkflow.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+			await handler.parseAndValidate('code', currentWorkflow);
+
+			expect(mockBuilder.regenerateNodeIds).toHaveBeenCalledWith(
+				new Map([
+					['Set A', 'manual-id-1'],
+					['Set B', 'manual-id-2'],
+				]),
+			);
+		});
+
+		it('should regenerate without a name map when no currentWorkflow is provided', async () => {
+			const mockBuilder = {
+				regenerateNodeIds: vi.fn(),
+				validate: vi.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
+				generatePinData: vi.fn(),
+				toJSON: vi.fn().mockReturnValue({ id: 'test', name: 'Test', nodes: [], connections: {} }),
+			};
+
+			mockParseWorkflowCodeToBuilder.mockReturnValue(mockBuilder);
+			mockValidateWorkflow.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+			await handler.parseAndValidate('code');
+
+			expect(mockBuilder.regenerateNodeIds).toHaveBeenCalledWith(undefined);
+		});
+
 		it('should throw on parse error', async () => {
 			mockParseWorkflowCodeToBuilder.mockImplementation(() => {
 				throw new Error('Syntax error at line 5');

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/test/parse-validate-handler.test.ts
@@ -260,7 +260,7 @@ describe('ParseValidateHandler', () => {
 			);
 		});
 
-		it('should regenerate without a name map when no currentWorkflow is provided', async () => {
+		it('should regenerate with an empty name map when no currentWorkflow is provided', async () => {
 			const mockBuilder = {
 				regenerateNodeIds: vi.fn(),
 				validate: vi.fn().mockReturnValue({ valid: true, errors: [], warnings: [] }),
@@ -273,7 +273,7 @@ describe('ParseValidateHandler', () => {
 
 			await handler.parseAndValidate('code');
 
-			expect(mockBuilder.regenerateNodeIds).toHaveBeenCalledWith(undefined);
+			expect(mockBuilder.regenerateNodeIds).toHaveBeenCalledWith(new Map());
 		});
 
 		it('should throw on parse error', async () => {

--- a/packages/@n8n/workflow-sdk/src/deterministic-ids.test.ts
+++ b/packages/@n8n/workflow-sdk/src/deterministic-ids.test.ts
@@ -384,6 +384,29 @@ export default wf.add(start);
 			expect(jsonAfter.nodes[0].id).toBe(expectedId);
 			expect(jsonAfter.nodes[0].id).not.toBe(originalId);
 		});
+
+		it('should preserve existing node IDs matched by name and only generate IDs for new nodes', () => {
+			const wf = workflow('test-workflow-id', 'Test Workflow').add(
+				trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: { name: 'Start' } })
+					.to(node({ type: 'n8n-nodes-base.set', version: 3.4, config: { name: 'Set A' } }))
+					.to(node({ type: 'n8n-nodes-base.set', version: 3.4, config: { name: 'Set B' } })),
+			);
+
+			// Start and Set A already exist with hand-built IDs; Set B is new.
+			const existingIdsByName = new Map([
+				['Start', 'manual-start'],
+				['Set A', 'manual-set-a'],
+			]);
+			wf.regenerateNodeIds(existingIdsByName);
+			const json = wf.toJSON();
+
+			expect(json.nodes.find((n) => n.name === 'Start')?.id).toBe('manual-start');
+			expect(json.nodes.find((n) => n.name === 'Set A')?.id).toBe('manual-set-a');
+			// The new node falls back to a deterministic ID.
+			expect(json.nodes.find((n) => n.name === 'Set B')?.id).toBe(
+				generateDeterministicNodeId('test-workflow-id', 'n8n-nodes-base.set', 'Set B'),
+			);
+		});
 	});
 
 	describe('Roundtrip with deterministic IDs', () => {

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1109,9 +1109,7 @@ export interface WorkflowBuilder {
 	 * Node IDs are generated using SHA-256 hash of `${workflowId}:${nodeType}:${nodeName}`,
 	 * formatted as a valid UUID v4 structure.
 	 *
-	 * Pass `existingIdsByName` to preserve the IDs of nodes that already exist (matched by
-	 * name) instead of regenerating them, so editing a hand-built workflow doesn't rewrite
-	 * every node's ID and produce a misleading version diff.
+	 * @param existingIdsByName - reuse these IDs (keyed by node name) instead of regenerating.
 	 */
 	regenerateNodeIds(existingIdsByName?: Map<string, string>): void;
 }

--- a/packages/@n8n/workflow-sdk/src/types/base.ts
+++ b/packages/@n8n/workflow-sdk/src/types/base.ts
@@ -1108,8 +1108,12 @@ export interface WorkflowBuilder {
 	 *
 	 * Node IDs are generated using SHA-256 hash of `${workflowId}:${nodeType}:${nodeName}`,
 	 * formatted as a valid UUID v4 structure.
+	 *
+	 * Pass `existingIdsByName` to preserve the IDs of nodes that already exist (matched by
+	 * name) instead of regenerating them, so editing a hand-built workflow doesn't rewrite
+	 * every node's ID and produce a misleading version diff.
 	 */
-	regenerateNodeIds(): void;
+	regenerateNodeIds(existingIdsByName?: Map<string, string>): void;
 }
 
 /**

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -602,8 +602,12 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	 *
 	 * Node IDs are generated using SHA-256 hash of `${workflowId}:${nodeType}:${nodeName}`,
 	 * formatted as a valid UUID v4 structure.
+	 *
+	 * Pass `existingIdsByName` to preserve the IDs of nodes that already exist (matched by
+	 * name) instead of regenerating them, so editing a hand-built workflow doesn't rewrite
+	 * every node's ID and produce a misleading version diff.
 	 */
-	regenerateNodeIds(): void {
+	regenerateNodeIds(existingIdsByName?: Map<string, string>): void {
 		const newNodes = new Map<string, GraphNode>();
 		// Build mapping from old instance IDs to map keys BEFORE cloning.
 		// Cloned instances' _connections still reference original target instances
@@ -614,7 +618,9 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 		for (const [mapKey, graphNode] of this._nodes) {
 			const instance = graphNode.instance;
 			staleIdToKeyMap.set(instance.id, mapKey);
-			const newId = generateDeterministicNodeId(this.id, instance.type, mapKey);
+			const newId =
+				existingIdsByName?.get(mapKey) ??
+				generateDeterministicNodeId(this.id, instance.type, mapKey);
 
 			// Clone the instance with the new deterministic ID
 			const newInstance = cloneNodeWithId(instance, newId);

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -603,9 +603,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 	 * Node IDs are generated using SHA-256 hash of `${workflowId}:${nodeType}:${nodeName}`,
 	 * formatted as a valid UUID v4 structure.
 	 *
-	 * Pass `existingIdsByName` to preserve the IDs of nodes that already exist (matched by
-	 * name) instead of regenerating them, so editing a hand-built workflow doesn't rewrite
-	 * every node's ID and produce a misleading version diff.
+	 * @param existingIdsByName - reuse these IDs (keyed by node name) instead of regenerating.
 	 */
 	regenerateNodeIds(existingIdsByName?: Map<string, string>): void {
 		const newNodes = new Map<string, GraphNode>();
@@ -622,7 +620,7 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 				existingIdsByName?.get(mapKey) ??
 				generateDeterministicNodeId(this.id, instance.type, mapKey);
 
-			// Clone the instance with the new deterministic ID
+			// Clone the instance with the new ID
 			const newInstance = cloneNodeWithId(instance, newId);
 
 			newNodes.set(mapKey, {


### PR DESCRIPTION
## Summary

When Instance AI edited a hand-built workflow for the first time, it rewrote **every** node's `id`. The parse step ran `regenerateNodeIds()` unconditionally, so all of the workflow's original (random) node IDs were replaced with deterministic hashes in one go. The workflow-history diff then showed every node as deleted-and-re-added instead of just the one node that actually changed.

The fix preserves the IDs of nodes that already exist (matched by name) and only generates IDs for genuinely new nodes.

- `@n8n/workflow-sdk`: `regenerateNodeIds()` takes an optional `existingIdsByName` map and reuses those IDs instead of regenerating them (interface updated to match).
- `@n8n/ai-workflow-builder.ee`: `parse-validate-handler` builds a name→id map from the current workflow (which it already had on hand) and passes it in.

Renamed nodes still surface as add/remove in the diff, which is correct: a rename is a different node.

## How to test

1. Manually create a workflow with 2 Set nodes.
2. Ask Instance AI to add a 3rd Set node.
3. Open the workflow history and view the diff for the latest version.
4. Only the new node should appear as added; the two original nodes should be unchanged.

Automated coverage:
- `packages/@n8n/workflow-sdk` → `pnpm test deterministic-ids`
- `packages/@n8n/ai-workflow-builder.ee` → `pnpm test parse-validate-handler`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-590

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->