### PR TITLE
fix(editor): Show a rejection screen when the OAuth consent target is unavailable

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2435,6 +2435,7 @@
 	"oauth.consentView.error.deny": "Error denying access",
 	"oauth.consentView.error.allow": "Error allowing access",
 	"oauth.consentView.error.fetchDetails": "Error fetching client details",
+	"oauth.consentView.error.heading": "Authorization unavailable",
 	"oauth.consentView.error.resourceUnavailable": "This authorization can no longer be completed because the target is no longer available.",
 	"oauth.consentView.success.title": "Success",
 	"oauth.consentView.success.description": "You will soon be redirected back to the client.",

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -65,7 +65,24 @@ describe('OAuthConsentView', () => {
 		expect(getByText('Get a list of your workflows')).toBeVisible();
 	});
 
-	it('should show the dedicated error and disable the buttons when the resource is unavailable', async () => {
+	it('should show the dedicated error and a Close action when the resource is unavailable', async () => {
+		consentStore.error = 'Authorization target is no longer available';
+		consentStore.errorCode = 'resource_unavailable';
+		consentStore.fetchConsentDetails.mockResolvedValue(consentStore.consentDetails!);
+
+		const { getByTestId, queryByTestId } = renderComponent();
+		await waitAllPromises();
+
+		expect(getByTestId('consent-error-notice')).toHaveTextContent(
+			'This authorization can no longer be completed because the target is no longer available.',
+		);
+		// No grant controls on a rejected request — only a way out.
+		expect(queryByTestId('consent-deny-button')).toBeNull();
+		expect(queryByTestId('consent-allow-button')).toBeNull();
+		expect(getByTestId('consent-close-button')).toBeVisible();
+	});
+
+	it('should redirect to home page when Close is clicked on the error screen', async () => {
 		consentStore.error = 'Authorization target is no longer available';
 		consentStore.errorCode = 'resource_unavailable';
 		consentStore.fetchConsentDetails.mockResolvedValue(consentStore.consentDetails!);
@@ -73,11 +90,24 @@ describe('OAuthConsentView', () => {
 		const { getByTestId } = renderComponent();
 		await waitAllPromises();
 
-		expect(getByTestId('consent-error-notice')).toHaveTextContent(
-			'This authorization can no longer be completed because the target is no longer available.',
-		);
-		expect(getByTestId('consent-deny-button')).toBeDisabled();
-		expect(getByTestId('consent-allow-button')).toBeDisabled();
+		await userEvent.click(getByTestId('consent-close-button'));
+		await waitAllPromises();
+
+		expect(consentStore.approveConsent).not.toHaveBeenCalled();
+		expect(window.location.href).toBe(window.BASE_PATH ?? '/');
+	});
+
+	it('should not render the instance consent layout when the resource is unavailable', async () => {
+		consentStore.error = 'Authorization target is no longer available';
+		consentStore.errorCode = 'resource_unavailable';
+		consentStore.fetchConsentDetails.mockResolvedValue(consentStore.consentDetails!);
+
+		const { queryByText } = renderComponent();
+		await waitAllPromises();
+
+		// A rejected request must not present the broad instance permission grant.
+		expect(queryByText('Test MCP Client wants access to your n8n instance')).toBeNull();
+		expect(queryByText('Get a list of your workflows')).toBeNull();
 	});
 
 	it('should redirect to home page when deny is clicked', async () => {

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -49,6 +49,12 @@ const handleDeny = async () => {
 	}
 };
 
+// On a failed details fetch the session is already gone (the server clears it,
+// e.g. on resource_unavailable), so there's nothing to approve/deny — just leave.
+const handleClose = () => {
+	window.location.href = window.BASE_PATH ?? '/';
+};
+
 onMounted(async () => {
 	documentTitle.set(i18n.baseText('oauth.consentView.title'));
 	try {
@@ -81,6 +87,18 @@ onMounted(async () => {
 				<N8nText color="text-base">
 					{{ i18n.baseText('oauth.consentView.success.description') }}
 				</N8nText>
+			</div>
+			<!-- Rejection state: the details fetch failed (e.g. the requested resource
+				is no longer available), so we must not present a consent grant. -->
+			<div v-else-if="error" :class="$style.content" data-test-id="consent-error">
+				<N8nHeading tag="h2" size="large" :bold="true">
+					{{ i18n.baseText('oauth.consentView.error.heading') }}
+				</N8nHeading>
+				<N8nNotice
+					theme="danger"
+					:data-test-id="'consent-error-notice'"
+					:content="errorMessage ?? ''"
+				></N8nNotice>
 			</div>
 			<!-- Default content -->
 			<div v-else :class="$style.content" data-test-id="consent-content">
@@ -136,33 +154,38 @@ onMounted(async () => {
 				</div>
 			</div>
 			<footer v-if="!waitingForRedirect" :class="$style.footer">
-				<N8nNotice
-					v-if="errorMessage"
-					theme="danger"
-					:data-test-id="'consent-error-notice'"
-					:content="errorMessage"
-				></N8nNotice>
 				<div :class="$style['button-group']">
 					<N8nButton
-						variant="subtle"
-						:data-test-id="'consent-deny-button'"
-						:size="'large'"
-						:loading="loading"
-						:disabled="loading || error !== null"
-						@click="handleDeny"
-					>
-						{{ i18n.baseText('generic.deny') }}
-					</N8nButton>
-					<N8nButton
+						v-if="error"
 						variant="solid"
-						:data-test-id="'consent-allow-button'"
+						:data-test-id="'consent-close-button'"
 						:size="'large'"
-						:loading="loading"
-						:disabled="loading || error !== null"
-						@click="handleAllow"
+						@click="handleClose"
 					>
-						{{ i18n.baseText('generic.allow') }}
+						{{ i18n.baseText('generic.close') }}
 					</N8nButton>
+					<template v-else>
+						<N8nButton
+							variant="subtle"
+							:data-test-id="'consent-deny-button'"
+							:size="'large'"
+							:loading="loading"
+							:disabled="loading"
+							@click="handleDeny"
+						>
+							{{ i18n.baseText('generic.deny') }}
+						</N8nButton>
+						<N8nButton
+							variant="solid"
+							:data-test-id="'consent-allow-button'"
+							:size="'large'"
+							:loading="loading"
+							:disabled="loading"
+							@click="handleAllow"
+						>
+							{{ i18n.baseText('generic.allow') }}
+						</N8nButton>
+					</template>
 				</div>
 			</footer>
 		</div>


### PR DESCRIPTION
## Summary

When a user authorizes an MCP **trigger** over OAuth, the consent screen could
fall back to the generic **instance MCP** consent layout (the broad "wants
access to your n8n instance" heading plus the full permission list) instead of
showing a proper rejection.

The backend already behaves correctly per the RFC 8707 resource-indicator rules:

- `resource` present and resolvable → trigger-specific consent screen.
- `resource` present but **not** resolvable (e.g. the trigger's test listener
  expired and the audience is gone) → **rejected** with `422 resource_unavailable`,
  and the session is cleared.
- `resource` absent → instance consent screen (intended backwards-compat for
  pre-8707 instance-MCP tokens that carry no resource).

The defect was purely on the frontend: `OAuthConsentView` chose its layout based
only on whether a `resourceName` was present. On the rejected (`422`) path
`resourceName` is empty, so the view still rendered the full instance consent
layout behind an error notice — the same layout shown for a legitimate
instance-MCP flow. To the user this looked like "the wrong consent screen", and
it presented a broad permission grant for a request the server had already
rejected.

This PR makes the frontend honour the rejection: when the consent-details fetch
fails for any reason, it renders a dedicated rejection state instead of the
consent-grant UI.

### Why

The consent screen is the user's only window into *what* they are granting. A
rejected authorization must not present a permission-grant UI — especially one
implying instance-wide access — because the request can no longer be completed
and the user could otherwise be misled about scope. The backend was already
secure; this aligns the UI with it.

### What changed

`packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue`:

- Added a third top-level body state. The dialog is now: success
  (`waitingForRedirect`) → **rejection (`error`)** → consent content. The
  consent-grant block (heading, description, permission list, docs link) and the
  Allow/Deny buttons are gated on `v-if="!error"`.
- The rejection state shows a short heading ("Authorization unavailable") plus
  the existing error message (`resource_unavailable` maps to the dedicated copy;
  other load failures fall back to the generic error), and a single **Close**
  action.
- Added `handleClose()` that simply redirects to n8n (`window.BASE_PATH ?? '/'`).
  It deliberately does **not** route through `handleDeny`/the approve API,
  because the server clears the session on the rejected path so there is nothing
  to approve or deny.
- New i18n key `oauth.consentView.error.heading`.

Cases C1 (named resource → workflow screen) and C3 (absent resource → instance
screen) are unchanged, since both have `error === null`.

### How to test manually

Prerequisites: an MCP Trigger node configured with `n8nOAuth2` authentication,
and an MCP client (or any OAuth client) that performs the discovery +
authorization handshake.

1. Open the workflow with the MCP Trigger and click **Test** (this registers a
   ~120s test listener and exposes the trigger's protected resource).
2. From the MCP client, start the OAuth connection so it discovers the trigger
   resource, then let the ~120s test listener lapse before the consent screen is
   reached (so the client re-sends a now-stale `resource`). The server returns
   `422 resource_unavailable`.
3. **Before this change:** the consent screen shows the generic "…wants access
   to your n8n instance" heading and the full permission list (Allow/Deny
   disabled).
   **After this change:** the screen shows "Authorization unavailable" with the
   explanatory notice and a single **Close** button that returns you to n8n.
4. Sanity-check the unaffected paths: a still-valid trigger authorization shows
   the workflow-specific screen (C1); an instance-MCP authorization with no
   resource still shows the instance consent screen (C3).

Because the timing window above is fiddly to hit by hand, the deterministic
coverage lives in the component tests below.

### Tests

`packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts`:

- New: on `resource_unavailable`, the instance permission grant is **not**
  rendered (the original failing/red test that proved the bug — now green).
- New: clicking **Close** redirects home and does not call `approveConsent`.
- Updated the existing "resource unavailable" test: the Allow/Deny buttons are
  gone (replaced by Close), so it now asserts the rejection notice + Close action
  instead of disabled grant buttons.

Run: `cd packages/frontend/editor-ui && pnpm test src/app/views/OAuthConsentView.test.ts`
(7/7 green). `pnpm typecheck` passes after building `@n8n/i18n` so the generated
`BaseTextKey` type picks up the new key.

### Key implementation decisions

- **Frontend-only.** The backend already enforces the spec (rejects an
  unresolvable resource with `422`, keeps the no-resource instance path for
  backwards compatibility). No backend change was needed or made.
- **Gate on any load error, not just `resource_unavailable`.** Any failed
  details fetch (422, an invalid/expired session 400, or 500) should hide the
  grant UI — none of them should present a consent screen. This is simpler and
  more robust than special-casing one error code, and keeps C1/C3 untouched.
- **Close is a plain redirect.** The session is already cleared on the rejected
  path, so reusing the deny handler (which hits the approve API) would fail; a
  direct redirect is the only correct exit.

## Related Links

closes https://linear.app/n8n/issue/IAM-858

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32594">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

