### PR TITLE
refactor(core): Route workflow URL import through the shared HTTP client (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -1,13 +1,11 @@
 import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
-import type { SsrfProtectionService } from '@n8n/backend-network';
+import type { HttpRequestClient, OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { SsrfBlockedIpError } from '@n8n/backend-network';
 import type { SsrfProtectionConfig } from '@n8n/config';
 import type { AuthenticatedRequest, IExecutionResponse } from '@n8n/db';
-import axios from 'axios';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
-import { createResultError, createResultOk } from 'n8n-workflow';
 
 import { WorkflowsController } from '../workflows.controller';
 
@@ -16,25 +14,27 @@ import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ExecutionService } from '@/executions/execution.service';
 import type { ProjectService } from '@/services/project.service.ee';
 
-jest.mock('axios');
-
 describe('WorkflowsController', () => {
 	const controller = Object.create(WorkflowsController.prototype);
-	const axiosMock = axios.get as jest.Mock;
 	const req = mock<AuthenticatedRequest>();
 	const res = mock<Response>();
 	const projectService = mock<ProjectService>();
 	const logger = mock<Logger>();
 	const ssrfConfig = { enabled: false } as SsrfProtectionConfig;
 	const ssrfProtectionService = mock<SsrfProtectionService>();
+	const httpClient = mock<HttpRequestClient>();
+	const outboundHttp = mock<OutboundHttp>();
+	const requestMock = httpClient.request as jest.Mock;
 
 	beforeEach(() => {
 		controller.projectService = projectService;
 		controller.logger = logger;
 		controller.ssrfConfig = ssrfConfig;
 		controller.ssrfProtectionService = ssrfProtectionService;
+		controller.outboundHttp = outboundHttp;
 		ssrfConfig.enabled = false;
 		jest.clearAllMocks();
+		outboundHttp.requests.mockReturnValue(httpClient);
 	});
 
 	describe('getFromUrl', () => {
@@ -48,7 +48,7 @@ describe('WorkflowsController', () => {
 				};
 
 				projectService.getProjectWithScope.mockResolvedValue({} as any);
-				axiosMock.mockResolvedValue({ data: mockWorkflowData });
+				requestMock.mockResolvedValue(mockWorkflowData);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/workflow.json',
@@ -60,7 +60,7 @@ describe('WorkflowsController', () => {
 				expect(projectService.getProjectWithScope).toHaveBeenCalledWith(req.user, projectId, [
 					'workflow:create',
 				]);
-				expect(axiosMock).toHaveBeenCalledWith(query.url);
+				expect(requestMock).toHaveBeenCalledWith({ method: 'GET', url: query.url });
 			});
 		});
 
@@ -77,7 +77,7 @@ describe('WorkflowsController', () => {
 				expect(projectService.getProjectWithScope).toHaveBeenCalledWith(req.user, projectId, [
 					'workflow:create',
 				]);
-				expect(axiosMock).not.toHaveBeenCalled();
+				expect(requestMock).not.toHaveBeenCalled();
 			});
 		});
 
@@ -87,7 +87,7 @@ describe('WorkflowsController', () => {
 			});
 
 			it('when the URL does not point to a valid JSON file', async () => {
-				axiosMock.mockRejectedValue(new Error('Network Error'));
+				requestMock.mockRejectedValue(new Error('Network Error'));
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/invalid.json',
@@ -95,7 +95,7 @@ describe('WorkflowsController', () => {
 				};
 
 				await expect(controller.getFromUrl(req, res, query)).rejects.toThrow(BadRequestError);
-				expect(axiosMock).toHaveBeenCalledWith(query.url);
+				expect(requestMock).toHaveBeenCalledWith({ method: 'GET', url: query.url });
 			});
 
 			it('when the data is not a valid n8n workflow JSON', async () => {
@@ -104,7 +104,7 @@ describe('WorkflowsController', () => {
 					connections: 'not an object',
 				};
 
-				axiosMock.mockResolvedValue({ data: invalidWorkflowData });
+				requestMock.mockResolvedValue(invalidWorkflowData);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/invalid.json',
@@ -112,7 +112,7 @@ describe('WorkflowsController', () => {
 				};
 
 				await expect(controller.getFromUrl(req, res, query)).rejects.toThrow(BadRequestError);
-				expect(axiosMock).toHaveBeenCalledWith(query.url);
+				expect(requestMock).toHaveBeenCalledWith({ method: 'GET', url: query.url });
 			});
 
 			it('when the data is missing required fields', async () => {
@@ -121,7 +121,7 @@ describe('WorkflowsController', () => {
 					// Missing connections field
 				};
 
-				axiosMock.mockResolvedValue({ data: incompleteWorkflowData });
+				requestMock.mockResolvedValue(incompleteWorkflowData);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/workflow.json',
@@ -129,23 +129,19 @@ describe('WorkflowsController', () => {
 				};
 
 				await expect(controller.getFromUrl(req, res, query)).rejects.toThrow(BadRequestError);
-				expect(axiosMock).toHaveBeenCalledWith(query.url);
+				expect(requestMock).toHaveBeenCalledWith({ method: 'GET', url: query.url });
 			});
 		});
 
 		describe('when URL protection is enabled', () => {
-			const mockLookup = jest.fn();
-
 			beforeEach(() => {
 				ssrfConfig.enabled = true;
 				projectService.getProjectWithScope.mockResolvedValue({} as any);
-				ssrfProtectionService.validateUrl.mockResolvedValue(createResultOk(undefined));
-				ssrfProtectionService.createSecureLookup.mockReturnValue(mockLookup);
 			});
 
-			it('should validate URL before fetching', async () => {
+			it('should create the client with the SSRF protection service', async () => {
 				const mockWorkflowData = { nodes: [], connections: {} };
-				axiosMock.mockResolvedValue({ data: mockWorkflowData });
+				requestMock.mockResolvedValue(mockWorkflowData);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/workflow.json',
@@ -153,21 +149,12 @@ describe('WorkflowsController', () => {
 				};
 				await controller.getFromUrl(req, res, query);
 
-				expect(ssrfProtectionService.validateUrl).toHaveBeenCalledWith(query.url);
-				expect(ssrfProtectionService.createSecureLookup).toHaveBeenCalled();
-				expect(axiosMock).toHaveBeenCalledWith(
-					query.url,
-					expect.objectContaining({
-						lookup: mockLookup,
-						beforeRedirect: expect.any(Function),
-					}),
-				);
+				expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: ssrfProtectionService });
+				expect(requestMock).toHaveBeenCalledWith({ method: 'GET', url: query.url });
 			});
 
-			it('should reject requests to restricted addresses', async () => {
-				ssrfProtectionService.validateUrl.mockResolvedValue(
-					createResultError(new SsrfBlockedIpError('127.0.0.1')),
-				);
+			it('should propagate blocked errors surfaced by the client', async () => {
+				requestMock.mockRejectedValue(new SsrfBlockedIpError('127.0.0.1'));
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'http://127.0.0.1/workflow.json',
@@ -175,15 +162,14 @@ describe('WorkflowsController', () => {
 				};
 
 				await expect(controller.getFromUrl(req, res, query)).rejects.toThrow(SsrfBlockedIpError);
-				expect(axiosMock).not.toHaveBeenCalled();
 			});
 
-			it('should propagate blocked errors from redirects', async () => {
+			it('should propagate blocked errors buried in a redirect cause chain', async () => {
 				const ssrfError = new SsrfBlockedIpError('10.0.0.1');
 				const axiosError = new Error('Request failed', {
 					cause: new Error('Redirected request failed', { cause: ssrfError }),
 				});
-				axiosMock.mockRejectedValue(axiosError);
+				requestMock.mockRejectedValue(axiosError);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/workflow.json',
@@ -195,11 +181,11 @@ describe('WorkflowsController', () => {
 		});
 
 		describe('when URL protection is disabled', () => {
-			it('should not validate URL', async () => {
+			it('should create the client with SSRF disabled', async () => {
 				ssrfConfig.enabled = false;
 				projectService.getProjectWithScope.mockResolvedValue({} as any);
 				const mockWorkflowData = { nodes: [], connections: {} };
-				axiosMock.mockResolvedValue({ data: mockWorkflowData });
+				requestMock.mockResolvedValue(mockWorkflowData);
 
 				const query: ImportWorkflowFromUrlDto = {
 					url: 'https://example.com/workflow.json',
@@ -207,8 +193,7 @@ describe('WorkflowsController', () => {
 				};
 				await controller.getFromUrl(req, res, query);
 
-				expect(ssrfProtectionService.validateUrl).not.toHaveBeenCalled();
-				expect(ssrfProtectionService.createSecureLookup).not.toHaveBeenCalled();
+				expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
 			});
 		});
 	});

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -35,7 +35,6 @@ import {
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type FindOptionsRelations } from '@n8n/typeorm';
-import axios, { type AxiosRequestConfig } from 'axios';
 import express from 'express';
 import { calculateWorkflowChecksum, ensureError } from 'n8n-workflow';
 import { CollaborationService } from '../collaboration/collaboration.service';
@@ -62,7 +61,7 @@ import { NamingService } from '@/services/naming.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
-import { SsrfBlockedIpError, SsrfProtectionService } from '@n8n/backend-network';
+import { OutboundHttp, SsrfBlockedIpError, SsrfProtectionService } from '@n8n/backend-network';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -87,6 +86,7 @@ export class WorkflowsController {
 		private readonly collaborationService: CollaborationService,
 		private readonly ssrfConfig: SsrfProtectionConfig,
 		private readonly ssrfProtectionService: SsrfProtectionService,
+		private readonly outboundHttp: OutboundHttp,
 	) {}
 
 	@Post('/')
@@ -695,25 +695,12 @@ export class WorkflowsController {
 	}
 
 	private async fetchWorkflowFromUrl(url: string) {
+		const client = this.outboundHttp.requests({
+			ssrf: this.ssrfConfig.enabled ? this.ssrfProtectionService : 'disabled',
+		});
+
 		try {
-			if (!this.ssrfConfig.enabled) {
-				const { data } = await axios.get<IWorkflowResponse>(url);
-
-				return data;
-			}
-
-			const result = await this.ssrfProtectionService.validateUrl(url);
-			if (!result.ok) throw result.error;
-
-			const config: AxiosRequestConfig = {
-				lookup: this.ssrfProtectionService.createSecureLookup() as AxiosRequestConfig['lookup'],
-				beforeRedirect: (redirectedRequest: Record<string, string>) => {
-					this.ssrfProtectionService.validateRedirectSync(redirectedRequest.href);
-				},
-			};
-
-			const { data } = await axios.get<IWorkflowResponse>(url, config);
-			return data;
+			return (await client.request({ method: 'GET', url })) as IWorkflowResponse;
 		} catch (error) {
 			const blockedError = this.findSsrfBlockedError(error);
 			if (blockedError) throw blockedError;


### PR DESCRIPTION
## Summary

The workflow-import endpoint (`GET /workflows/from-url`) previously called `axios` directly and hand-rolled its own URL validation, secure DNS lookup and redirect handling.

It now fetches through the shared `OutboundHttp` client, so the import path goes through the same outbound HTTP contract as the rest of the service layer (consistent URL validation + proxy handling, applied inside the request pipeline).

SSRF is enabled based on configuration.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3378

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [w] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32602">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->