### PR TITLE
feat(editor): Hide AI Transform node when Instance AI is enabled (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -10,6 +10,7 @@ import {
 	HTTP_REQUEST_NODE_TYPE,
 	CREDENTIAL_ONLY_HTTP_NODE_VERSION,
 	MODULE_ENABLED_NODES,
+	AI_TRANSFORM_NODE_TYPE,
 } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import type { NodeTypesByTypeNameAndVersion } from '@/Interface';
@@ -220,10 +221,18 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	});
 
 	const visibleNodeTypes = computed(() => {
+		// Instance AI replaces the legacy "AI Transform" node; hide it from the
+		// creator/search when the instance has Instance AI on.
+		const instanceAiActive =
+			settingsStore.isModuleActive('instance-ai') &&
+			settingsStore.moduleSettings['instance-ai']?.enabled !== false;
 		return allLatestNodeTypes.value
 			.concat(officialCommunityNodeTypes.value)
 			.concat(moduleEnabledNodeTypes.value)
-			.filter((nodeType) => !nodeType.hidden);
+			.filter(
+				(nodeType) =>
+					!nodeType.hidden && !(instanceAiActive && nodeType.name === AI_TRANSFORM_NODE_TYPE),
+			);
 	});
 
 	const nativelyNumberSuffixedDefaults = computed(() => {


### PR DESCRIPTION
## Summary

The Instance AI assistant supersedes the legacy **AI Transform** node (`n8n-nodes-base.aiTransform`) as the AI code-generation surface. When the `instance-ai` module is active and not admin-disabled, this filters AI Transform out of the node creator / search / command bar so users aren't offered two competing entry points.

Single predicate added to `visibleNodeTypes` in `nodeTypes.store.ts` — the existing chokepoint that already strips `hidden` nodes and feeds the creator panel:

```ts
.filter(
  (nodeType) =>
    !nodeType.hidden && !(instanceAiActive && nodeType.name === AI_TRANSFORM_NODE_TYPE),
);
```

The gate uses the **instance-level** signal (`isModuleActive('instance-ai') && moduleSettings['instance-ai']?.enabled !== false`), not per-user RBAC — node-panel contents shouldn't differ between an admin and a member on the same instance.

**Scope:** this only removes AI Transform from the creator/search. Existing `aiTransform` nodes already on a canvas resolve independently via `getNodeType`, so old workflows still open and run unchanged.

## How to test

1. Enable the `instance-ai` module on the instance.
2. Open the node creator (Tab / "+") and search "AI Transform" → it should not appear.
3. Disable / don't enable `instance-ai` → AI Transform appears as before.
4. Open an existing workflow containing an AI Transform node → it still loads and executes.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. Tagged `(no-changelog)` — behavior is gated behind the in-development Instance AI module.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with backport labels (if needed).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32603">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

