### PR TITLE
feat(core): OpenAI Responses API support for agent pdf passthrough

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
@@ -80,7 +80,7 @@ export async function executeBatch(
 
 		checkMaxIterations(response, maxIterations, ctx.getNode());
 
-		const itemContext = await prepareItemContext(ctx, itemIndex, processedResponse);
+		const itemContext = await prepareItemContext(ctx, itemIndex, processedResponse, model);
 
 		const { tools, prompt, options, outputParser } = itemContext;
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/prepareItemContext.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/prepareItemContext.ts
@@ -1,3 +1,4 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { ChatPromptTemplate } from '@langchain/core/prompts';
 import type { DynamicStructuredTool, Tool } from '@langchain/classic/tools';
 import { NodeOperationError } from 'n8n-workflow';
@@ -41,6 +42,7 @@ export async function prepareItemContext(
 	ctx: IExecuteFunctions | ISupplyDataFunctions,
 	itemIndex: number,
 	response?: EngineResponse<RequestResponseMetadata>,
+	model?: BaseChatModel,
 ): Promise<ItemContext> {
 	const steps = buildSteps(response, itemIndex);
 
@@ -68,6 +70,7 @@ export async function prepareItemContext(
 		passthroughBinaryImages: options.passthroughBinaryImages ?? true,
 		passthroughBinaryPdfs: options.passthroughBinaryPdfs ?? false,
 		outputParser,
+		model,
 	});
 	const prompt: ChatPromptTemplate = preparePrompt(messages);
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -83,6 +83,44 @@ function shouldPassthroughBinary(data: IBinaryData, options: BinaryPassthroughOp
 	return false;
 }
 
+// How a file (PDF) attachment must be encoded for the connected model.
+// - 'standard': LangChain standard data content block (Gemini, Anthropic, OpenAI Completions)
+// - 'openai-responses': OpenAI Responses API native part, which rejects the standard block
+type BinaryContentFormat = 'standard' | 'openai-responses';
+
+/**
+ * OpenAI's Responses API rejects the standard `file` content block (it expects an
+ * `input_file` part), so when the connected model talks to that API we must emit a
+ * provider-native block instead. Gemini, Anthropic, and OpenAI's Completions API all
+ * consume the standard block.
+ *
+ * Detection relies on ChatOpenAI's `_useResponsesApi()` because LangChain exposes no
+ * public API for it; `_useResponsesApi()` (unlike the `useResponsesApi` flag alone)
+ * also covers models that auto-select the Responses API (e.g. gpt-5/o-series). Guarded
+ * so an unexpected shape degrades to the standard block rather than throwing.
+ */
+// Structural view of the ChatOpenAI internals we probe. `_useResponsesApi` is
+// protected and `useResponsesApi` is public; neither is part of BaseChatModel, so
+// we read them defensively and treat their absence as "not OpenAI Responses".
+type ResponsesApiModel = {
+	_useResponsesApi?: (options?: unknown) => boolean;
+	useResponsesApi?: boolean;
+};
+
+function resolveBinaryContentFormat(model?: BaseChatModel): BinaryContentFormat {
+	if (!model) return 'standard';
+	const candidate = model as unknown as ResponsesApiModel;
+	try {
+		const usesResponsesApi =
+			typeof candidate._useResponsesApi === 'function'
+				? candidate._useResponsesApi(undefined)
+				: candidate.useResponsesApi === true;
+		return usesResponsesApi ? 'openai-responses' : 'standard';
+	} catch {
+		return 'standard';
+	}
+}
+
 /**
  * Processes a binary data to be used in agent passthrough.
  * @param ctx - The execution context
@@ -94,6 +132,7 @@ async function processBinaryForAgentPassthrough(
 	ctx: IExecuteFunctions | ISupplyDataFunctions,
 	data: IBinaryData,
 	type: 'image_url' | 'file',
+	contentFormat: BinaryContentFormat = 'standard',
 ) {
 	// Resolve the binary contents to a raw base64 string. In filesystem mode the
 	// binary is stored by id and must be streamed before it can be encoded.
@@ -130,9 +169,17 @@ async function processBinaryForAgentPassthrough(
 		);
 	}
 
-	// PDFs (and other documents) are passed as a provider-agnostic file content
-	// block so any chat model with native PDF support can consume them.
+	// PDFs (and other documents) are passed as a file content block. OpenAI's
+	// Responses API needs its native `input_file` part; every other supported
+	// provider consumes the LangChain standard data content block.
 	if (type === 'file') {
+		if (contentFormat === 'openai-responses') {
+			return {
+				type: 'input_file',
+				file_data: `data:${data.mimeType};base64,${base64Data}`,
+				filename: data.fileName ?? 'attachment.pdf',
+			};
+		}
 		return {
 			type: 'file',
 			source_type: 'base64',
@@ -160,12 +207,14 @@ async function processBinaryForAgentPassthrough(
  * @param ctx - The execution context
  * @param itemIndex - The current item index
  * @param options - The enabled binary passthrough options
+ * @param contentFormat - How file attachments must be encoded for the connected model
  * @returns A HumanMessage containing the binary messages (images and text files).
  */
 export async function extractBinaryMessages(
 	ctx: IExecuteFunctions | ISupplyDataFunctions,
 	itemIndex: number,
 	options: BinaryPassthroughOptions,
+	contentFormat: BinaryContentFormat = 'standard',
 ): Promise<HumanMessage> {
 	const binaryData = ctx.getInputData()?.[itemIndex]?.binary ?? {};
 	const binaryMessages = await Promise.all(
@@ -175,9 +224,9 @@ export async function extractBinaryMessages(
 			.map(async (data) => {
 				// Handle images and PDFs
 				if (isImageFile(data.mimeType)) {
-					return await processBinaryForAgentPassthrough(ctx, data, 'image_url');
+					return await processBinaryForAgentPassthrough(ctx, data, 'image_url', contentFormat);
 				} else if (isPdfFile(data.mimeType)) {
-					return await processBinaryForAgentPassthrough(ctx, data, 'file');
+					return await processBinaryForAgentPassthrough(ctx, data, 'file', contentFormat);
 				} else {
 					// Handle text files
 					let textContent: string;
@@ -509,6 +558,8 @@ export async function prepareMessages(
 		passthroughBinaryImages?: boolean;
 		passthroughBinaryPdfs?: boolean;
 		outputParser?: N8nOutputParser;
+		// The connected chat model, used to pick the right file content-block format.
+		model?: BaseChatModel;
 	},
 ): Promise<BaseMessagePromptTemplateLike[]> {
 	const useSystemMessage = options.systemMessage ?? ctx.getNode().typeVersion < 1.9;
@@ -530,7 +581,8 @@ export async function prepareMessages(
 	// extractBinaryMessages only processes the binary types that are enabled.
 	const hasBinaryData = ctx.getInputData()?.[itemIndex]?.binary !== undefined;
 	if (hasBinaryData && (options.passthroughBinaryImages || options.passthroughBinaryPdfs)) {
-		const binaryMessage = await extractBinaryMessages(ctx, itemIndex, options);
+		const contentFormat = resolveBinaryContentFormat(options.model);
+		const binaryMessage = await extractBinaryMessages(ctx, itemIndex, options, contentFormat);
 
 		if (binaryMessage.content.length !== 0) {
 			messages.push(binaryMessage);

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -185,6 +185,9 @@ async function processBinaryForAgentPassthrough(
 			source_type: 'base64',
 			mime_type: data.mimeType,
 			data: base64Data,
+			// OpenAI's Completions API requires a filename for file blocks (it warns and
+			// uses a placeholder otherwise); other providers ignore this metadata.
+			metadata: { filename: data.fileName ?? 'attachment.pdf' },
 		};
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -88,17 +88,6 @@ function shouldPassthroughBinary(data: IBinaryData, options: BinaryPassthroughOp
 // - 'openai-responses': OpenAI Responses API native part, which rejects the standard block
 type BinaryContentFormat = 'standard' | 'openai-responses';
 
-/**
- * OpenAI's Responses API rejects the standard `file` content block (it expects an
- * `input_file` part), so when the connected model talks to that API we must emit a
- * provider-native block instead. Gemini, Anthropic, and OpenAI's Completions API all
- * consume the standard block.
- *
- * Detection relies on ChatOpenAI's `_useResponsesApi()` because LangChain exposes no
- * public API for it; `_useResponsesApi()` (unlike the `useResponsesApi` flag alone)
- * also covers models that auto-select the Responses API (e.g. gpt-5/o-series). Guarded
- * so an unexpected shape degrades to the standard block rather than throwing.
- */
 // Structural view of the ChatOpenAI internals we probe. `_useResponsesApi` is
 // protected and `useResponsesApi` is public; neither is part of BaseChatModel, so
 // we read them defensively and treat their absence as "not OpenAI Responses".
@@ -107,6 +96,19 @@ type ResponsesApiModel = {
 	useResponsesApi?: boolean;
 };
 
+/**
+ * OpenAI's Responses API rejects the standard `file` content block (it expects an
+ * `input_file` part), so when the connected model talks to that API we must emit a
+ * provider-native block instead. Gemini, Anthropic, and OpenAI's Completions API all
+ * consume the standard block.
+ *
+ * Detection relies on ChatOpenAI's `_useResponsesApi()` because LangChain exposes no
+ * public API for it; `_useResponsesApi()` (unlike the `useResponsesApi` flag alone)
+ * also covers models that auto-select the Responses API (e.g. gpt-5/o-series). Note it
+ * is evaluated without invoke-time call options, so Responses usage triggered solely by
+ * call-time tools/kwargs is not detected here. Guarded so an unexpected shape degrades
+ * to the standard block rather than throwing.
+ */
 function resolveBinaryContentFormat(model?: BaseChatModel): BinaryContentFormat {
 	if (!model) return 'standard';
 	const candidate = model as unknown as ResponsesApiModel;
@@ -584,6 +586,10 @@ export async function prepareMessages(
 	// extractBinaryMessages only processes the binary types that are enabled.
 	const hasBinaryData = ctx.getInputData()?.[itemIndex]?.binary !== undefined;
 	if (hasBinaryData && (options.passthroughBinaryImages || options.passthroughBinaryPdfs)) {
+		// Known limitation: the format is resolved from the primary model only, and the
+		// prompt (incl. this block) is shared with the fallback model. A fallback from a
+		// different provider family (e.g. OpenAI Responses -> Gemini) will receive a
+		// mismatched file block and fail; cross-provider PDF fallback is unsupported.
 		const contentFormat = resolveBinaryContentFormat(options.model);
 		const binaryMessage = await extractBinaryMessages(ctx, itemIndex, options, contentFormat);
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
@@ -221,6 +221,56 @@ describe('extractBinaryMessages', () => {
 		});
 	});
 
+	it('should emit an OpenAI input_file block for PDFs when content format is openai-responses', async () => {
+		const fakeItem = {
+			json: {},
+			binary: {
+				doc1: {
+					mimeType: 'application/pdf',
+					fileName: 'report.pdf',
+					data: 'data:application/pdf;base64,samplePdfData',
+				},
+			},
+		};
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+
+		const humanMsg: HumanMessage = await extractBinaryMessages(
+			mockContext,
+			0,
+			{ passthroughBinaryImages: true, passthroughBinaryPdfs: true },
+			'openai-responses',
+		);
+		expect(humanMsg.content[0]).toEqual({
+			type: 'input_file',
+			file_data: 'data:application/pdf;base64,samplePdfData',
+			filename: 'report.pdf',
+		});
+	});
+
+	it('should keep images as image_url even for openai-responses format', async () => {
+		const fakeItem = {
+			json: {},
+			binary: {
+				img1: {
+					mimeType: 'image/png',
+					data: 'data:image/png;base64,imageData',
+				},
+			},
+		};
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+
+		const humanMsg: HumanMessage = await extractBinaryMessages(
+			mockContext,
+			0,
+			{ passthroughBinaryImages: true, passthroughBinaryPdfs: true },
+			'openai-responses',
+		);
+		expect(humanMsg.content[0]).toEqual({
+			type: 'image_url',
+			image_url: { url: 'data:image/png;base64,imageData' },
+		});
+	});
+
 	it('should extract both images and PDFs together', async () => {
 		const fakeItem = {
 			json: {},
@@ -637,6 +687,39 @@ describe('prepareMessages', () => {
 			(m) => typeof m === 'object' && m instanceof HumanMessage,
 		);
 		expect(hasBinaryMessage).toBe(true);
+	});
+
+	it('should emit input_file for PDFs when the connected model uses the OpenAI Responses API', async () => {
+		const fakeItem = {
+			json: {},
+			binary: {
+				doc1: {
+					mimeType: 'application/pdf',
+					fileName: 'report.pdf',
+					data: 'data:application/pdf;base64,samplePdfData',
+				},
+			},
+		};
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+
+		// Stand-in for a ChatOpenAI configured against the Responses API.
+		const responsesApiModel = mock<BaseChatModel>();
+		(responsesApiModel as unknown as { _useResponsesApi: () => boolean })._useResponsesApi = () =>
+			true;
+
+		const messages = await prepareMessages(mockContext, 0, {
+			systemMessage: 'Test system',
+			passthroughBinaryImages: false,
+			passthroughBinaryPdfs: true,
+			model: responsesApiModel,
+		});
+		const binaryMessage = messages.find((m) => m instanceof HumanMessage) as HumanMessage;
+		expect(binaryMessage).toBeDefined();
+		expect(binaryMessage.content[0]).toEqual({
+			type: 'input_file',
+			file_data: 'data:application/pdf;base64,samplePdfData',
+			filename: 'report.pdf',
+		});
 	});
 
 	it('should not include system_message in prompt templates if not provided after version 1.9', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
@@ -218,6 +218,7 @@ describe('extractBinaryMessages', () => {
 			source_type: 'base64',
 			mime_type: 'application/pdf',
 			data: 'samplePdfData',
+			metadata: { filename: 'attachment.pdf' },
 		});
 	});
 
@@ -306,6 +307,7 @@ describe('extractBinaryMessages', () => {
 					source_type: 'base64',
 					mime_type: 'application/pdf',
 					data: 'pdfData456',
+					metadata: { filename: 'test.pdf' },
 				},
 			]),
 		);
@@ -338,6 +340,7 @@ describe('extractBinaryMessages', () => {
 			source_type: 'base64',
 			mime_type: 'application/pdf',
 			data: Buffer.from('fakepdfdata').toString(BINARY_ENCODING),
+			metadata: { filename: 'attachment.pdf' },
 		});
 	});
 
@@ -371,6 +374,7 @@ describe('extractBinaryMessages', () => {
 			source_type: 'base64',
 			mime_type: 'application/pdf',
 			data: 'pdfData456',
+			metadata: { filename: 'test.pdf' },
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/commons.test.ts
@@ -3,7 +3,7 @@ import type { ToolsAgentAction } from '@langchain/classic/dist/agents/tool_calli
 import type { Tool } from '@langchain/classic/tools';
 import type { BaseChatMemory } from '@langchain/community/memory/chat_memory';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { HumanMessage } from '@langchain/core/messages';
+import { HumanMessage, isDataContentBlock } from '@langchain/core/messages';
 import type { BaseMessagePromptTemplateLike } from '@langchain/core/prompts';
 import { FakeLLM, FakeStreamingChatModel } from '@langchain/core/utils/testing';
 import { Buffer } from 'buffer';
@@ -220,6 +220,29 @@ describe('extractBinaryMessages', () => {
 			data: 'samplePdfData',
 			metadata: { filename: 'attachment.pdf' },
 		});
+	});
+
+	it('should produce a valid LangChain standard data content block for PDFs', async () => {
+		// Contract check: the standard `file` block must satisfy isDataContentBlock so
+		// provider converters (Gemini, Anthropic, OpenAI Completions) translate it
+		// instead of rejecting it. The original `file_url` shape failed this check.
+		const fakeItem = {
+			json: {},
+			binary: {
+				doc1: {
+					mimeType: 'application/pdf',
+					fileName: 'report.pdf',
+					data: 'data:application/pdf;base64,samplePdfData',
+				},
+			},
+		};
+		mockContext.getInputData.mockReturnValue([fakeItem]);
+
+		const humanMsg: HumanMessage = await extractBinaryMessages(mockContext, 0, {
+			passthroughBinaryImages: true,
+			passthroughBinaryPdfs: true,
+		});
+		expect(isDataContentBlock(humanMsg.content[0] as object)).toBe(true);
 	});
 
 	it('should emit an OpenAI input_file block for PDFs when content format is openai-responses', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #28038, which added binary PDF passthrough to the AI Agent node. That feature emits a LangChain **standard `file` data content block**, which works for Gemini and Anthropic but is **rejected by OpenAI's Responses API** — the API expects an `input_file` part and returns `400 Invalid value: 'file'. Supported values are: 'input_text', 'input_image', 'input_file', ...`. Since the n8n OpenAI Chat Model defaults using Responses API, PDF passthrough was broken out of the box for the most common OpenAI setup.

This PR makes the file content-block format **provider-aware**:

- When the connected model talks to the **OpenAI Responses API**, PDFs are emitted as the native `{ type: 'input_file', file_data, filename }` part.
- For every other supported provider (**Gemini, Anthropic, OpenAI Completions**), the standard `file` data content block is kept.
- Images are unchanged (`image_url`) — the Responses API already converts those correctly.

It also sets a `filename` on the standard `file` block's `metadata`, which OpenAI's **Completions** API requires (it otherwise warns and substitutes a placeholder); other providers ignore the field.

### Why detection works this way

Responses-API usage is detected via ChatOpenAI's `_useResponsesApi()` rather than the public `useResponsesApi` flag alone, because the flag misses models that **auto-select** the Responses API (e.g. `gpt-5`/o-series). LangChain exposes no public API for this, so the call is made defensively and degrades to the standard block on any unexpected shape. Scope is limited to **V3** — V1/V2 already reject Responses-API models entirely.

## Changes

- `resolveBinaryContentFormat()` helper that maps the connected model to `'standard'` or `'openai-responses'`.
- `processBinaryForAgentPassthrough` / `extractBinaryMessages` emit the format-appropriate file block.
- The connected model is threaded through `prepareMessages` → `extractBinaryMessages` (V3 `executeBatch` → `prepareItemContext`).
- `filename` added to the standard block metadata for OpenAI Completions.
- Tests: `input_file` emission for Responses; images stay `image_url`; an end-to-end `prepareMessages` test with a Responses-API model; and a contract test asserting the standard block satisfies `isDataContentBlock` (the predicate every standard-path converter relies on — this is what the original `file_url` shape failed).

## Known limitation — cross-provider fallback with PDFs

The content-block format is resolved from the **primary** model, and the agent shares one prompt between the primary and fallback models. If the fallback model is a different provider family than the primary (e.g. primary OpenAI Responses → fallback Gemini, or vice versa), the fallback receives a file block in the wrong format and fails. PDF passthrough is therefore only supported when the primary and fallback models are in the same provider family. A proper fix would require building the prompt per-model, which is out of scope here.

## How to test

1. Build a workflow: a node that outputs a binary PDF (e.g. **Read/Write Files from Disk** or an **HTTP Request** with response format "File") → **AI Agent**.
2. In the AI Agent **Options**, enable **Automatically Passthrough Binary PDFs**.
3. Connect an **OpenAI Chat Model** (default `gpt-5-mini`, which uses the Responses API) and ask the agent a question about the PDF's contents.
4. Verify the agent reads the PDF and answers (previously this failed with `400 Invalid value: 'file'`).
5. Repeat with a **Google Gemini** and an **Anthropic** chat model to confirm no regression on the standard path.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
https://linear.app/n8n/issue/[TICKET-ID]
-->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
