### PR TITLE
refactor(core): Route RudderStack telemetry client through the HTTP client factory

### DIFF
--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -1,3 +1,4 @@
+import type { OutboundHttp } from '@n8n/backend-network';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import type RudderStack from '@rudderstack/rudder-sdk-node';
@@ -9,6 +10,12 @@ import { Telemetry } from '@/telemetry';
 
 jest.unmock('@/telemetry');
 jest.mock('@/posthog');
+
+const rudderStackConstructor = jest.fn().mockImplementation(() => mock<RudderStack>());
+jest.mock('@rudderstack/rudder-sdk-node', () => ({
+	__esModule: true,
+	default: rudderStackConstructor,
+}));
 
 describe('Telemetry', () => {
 	let spyTrack: jest.SpyInstance;
@@ -52,6 +59,7 @@ describe('Telemetry', () => {
 			mock(),
 			globalConfig,
 			mock(),
+			mock(),
 		);
 		// @ts-expect-error Assigning to private property
 		telemetry.rudderStack = mockRudderStack;
@@ -59,6 +67,69 @@ describe('Telemetry', () => {
 
 	afterEach(async () => {
 		await telemetry.stopTracking();
+	});
+
+	describe('init', () => {
+		const httpAgent = mock();
+		const httpsAgent = mock();
+		const getNodeAgent = jest.fn().mockReturnValue({ httpAgent, httpsAgent });
+		const transport = jest.fn().mockReturnValue({ getNodeAgent });
+		const outboundHttp = mock<OutboundHttp>({ transport });
+
+		const initConfig = mock<GlobalConfig>({
+			diagnostics: { enabled: true, backendConfig: 'test-key;https://data-plane.test' },
+			logging: { level: 'info', outputs: ['console'] },
+		});
+
+		let initTelemetry: Telemetry;
+
+		beforeEach(() => {
+			rudderStackConstructor.mockClear();
+			transport.mockClear();
+			getNodeAgent.mockClear();
+			initConfig.diagnostics.backendConfig = 'test-key;https://data-plane.test';
+			initTelemetry = new Telemetry(
+				mock(),
+				new PostHogClient(instanceSettings, mock()),
+				mock(),
+				instanceSettings,
+				mock(),
+				initConfig,
+				mock(),
+				outboundHttp,
+			);
+		});
+
+		afterEach(async () => {
+			await initTelemetry.stopTracking();
+		});
+
+		test('should route the RudderStack SDK through the outbound transport with SSRF disabled', async () => {
+			await initTelemetry.init();
+
+			expect(transport).toHaveBeenCalledWith({ ssrf: 'disabled' });
+			expect(getNodeAgent).toHaveBeenCalled();
+			expect(rudderStackConstructor).toHaveBeenCalledWith(
+				'test-key',
+				expect.objectContaining({
+					dataPlaneUrl: 'https://data-plane.test',
+					gzip: false,
+					axiosConfig: {
+						httpAgent,
+						httpsAgent,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				}),
+			);
+		});
+
+		test('should not initialize RudderStack when the backend config is invalid', async () => {
+			initConfig.diagnostics.backendConfig = 'missing-data-plane';
+
+			await initTelemetry.init();
+
+			expect(rudderStackConstructor).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('trackWorkflowExecution', () => {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@n8n/backend-common';
+import { OutboundHttp } from '@n8n/backend-network';
 import { GlobalConfig } from '@n8n/config';
 import {
 	ProjectRelationRepository,
@@ -9,7 +10,7 @@ import {
 import { OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import type RudderStack from '@rudderstack/rudder-sdk-node';
-import axios from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 
@@ -91,6 +92,7 @@ export class Telemetry {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly globalConfig: GlobalConfig,
 		private readonly errorReporter: ErrorReporter,
+		private readonly outboundHttp: OutboundHttp,
 	) {}
 
 	// PostHog groupIdentify only accepts flat objects with string or number values, function sanitizes objects to match that format.
@@ -152,13 +154,20 @@ export class Telemetry {
 			const logLevel = this.globalConfig.logging.level;
 
 			const { default: RudderStack } = await import('@rudderstack/rudder-sdk-node');
-			const axiosInstance = axios.create();
-			axiosInstance.interceptors.request.use((cfg) => {
-				cfg.headers.setContentType('application/json', false);
-				return cfg;
-			});
+
+			const { httpAgent, httpsAgent } = this.outboundHttp
+				.transport({
+					ssrf: 'disabled', // The data-plane host is fixed and the SDK owns the request lifecycle, so SSRF is disabled.
+				})
+				.getNodeAgent();
+			const axiosConfig: AxiosRequestConfig = {
+				httpAgent,
+				httpsAgent,
+				headers: { 'Content-Type': 'application/json' },
+			};
+
 			this.rudderStack = new RudderStack(key, {
-				axiosInstance,
+				axiosConfig,
 				logLevel,
 				dataPlaneUrl,
 				gzip: false,


### PR DESCRIPTION
## Summary

Routes the RudderStack telemetry client through n8n's outbound HTTP client factory instead of a bare `axios.create()` instance.

Changes:
- No more direct `axios.create()` in the telemetry module.
- SSRF is `'disabled'`: the data-plane host is fixed and the SDK owns the request lifecycle

No behavior change.

## How to test manually

* Start a tiny capture server: `npx http-echo-server 9000`
* Run n8n : `N8N_DIAGNOSTICS_ENABLED=true N8N_DIAGNOSTICS_CONFIG_BACKEND="test-key;http://localhost:9000" pnpm start`
* Telemetry events fire on startup, so check some events are posted in the server (RudderStack hits `/v1/batch`) with `content-type: application/json` and a JSON body)

<img width="421" height="257" alt="image" src="https://github.com/user-attachments/assets/d7f2d49e-d7d1-4a3e-9db2-e185ab5acc78" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3513

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32606">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->