### PR TITLE
refactor(core): Route AI web research requests through the outbound HTTP client (no-changelog)

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/outbound-http.ssrf.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/outbound-http.ssrf.test.ts
@@ -1,9 +1,11 @@
 import type { Logger } from '@n8n/backend-common';
+import dns from 'node:dns';
+import type { LookupFunction } from 'node:net';
 import type { Dispatcher } from 'undici';
 import { mock } from 'vitest-mock-extended';
 
 import type { SsrfBridge, SsrfProtectionService } from '../../ssrf';
-import { makeSsrfBridge } from '../../ssrf/__tests__/mock-ssrf-bridge';
+import { makeLookupFn, makeSsrfBridge } from '../../ssrf/__tests__/mock-ssrf-bridge';
 import { type LocalServer, startServer } from '../local-server';
 import { OutboundHttp } from '../outbound-http';
 import { createSsrfInterceptor } from '../undici/transport';
@@ -253,5 +255,66 @@ describe('SSRF end-to-end', () => {
 
 			await dispatcher.close();
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// (c) connect-time secure lookup — DNS rebinding (TOCTOU) on the dispatcher path
+// ---------------------------------------------------------------------------
+//
+// The interceptor validates the request URL pre-flight, but undici resolves the hostname again at connect time.
+// A connect-time secure lookup pins the validated IP to the socket so the two resolutions cannot diverge (rebinding).
+
+describe('connect-time secure lookup (DNS rebinding)', () => {
+	it('routes direct hostname connections through the SSRF secure lookup', async () => {
+		const server = await startServer((_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/plain' });
+			res.end('ok');
+		});
+		const lookupSpy = vi.fn((hostname: string, options: dns.LookupOptions, onResult: unknown) =>
+			dns.lookup(hostname, options, onResult as never),
+		);
+		const bridge = makeSsrfBridge({
+			createSecureLookup: () => lookupSpy as unknown as LookupFunction,
+		});
+		const { port } = new URL(server.url);
+		const fetchFn = makeTransport({ ssrf: bridge, proxy: false }).asCustomFetch();
+
+		try {
+			const res = await fetchFn(`http://localhost:${port}/x`);
+
+			expect(res.status).toBe(200);
+			expect(lookupSpy).toHaveBeenCalledWith('localhost', expect.anything(), expect.anything());
+		} finally {
+			await server.close();
+		}
+	});
+
+	it('rejects the connection when the secure lookup denies a rebound IP', async () => {
+		// `validateUrl` (pre-flight) passes, but the connect-time lookup denies the
+		// resolved IP — the connection must fail instead of reaching the target.
+		const denied = new Error('blocked: restricted IP address');
+		const lookup = ((_hostname: string, options: dns.LookupOptions, onResult: unknown) => {
+			(onResult as (error: Error | null, address?: unknown, family?: number) => void)(
+				denied,
+				options.all ? [] : '',
+				undefined,
+			);
+		}) as unknown as LookupFunction;
+		const bridge = makeSsrfBridge({ createSecureLookup: () => lookup });
+		const fetchFn = makeTransport({ ssrf: bridge, proxy: false }).asCustomFetch();
+
+		await expect(fetchFn('http://rebind.example/')).rejects.toThrow();
+	});
+
+	it('does not derive a connect-time lookup behind an explicit proxy', () => {
+		const createSecureLookup = vi.fn(makeLookupFn);
+		const bridge = makeSsrfBridge({ createSecureLookup });
+
+		// Forces the lazy dispatcher to build. The proxy resolves the target, so
+		// the secure lookup must not be consulted on our side.
+		makeTransport({ ssrf: bridge, proxy: 'http://proxy.invalid:3128' }).getDispatcher();
+
+		expect(createSecureLookup).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/backend-network/src/http/outbound-http.ts
+++ b/packages/@n8n/backend-network/src/http/outbound-http.ts
@@ -113,8 +113,10 @@ export interface HttpRequestClient {
  *   `http.Agent` / `https.Agent` instances (e.g. AWS SDK v3 via `NodeHttpHandler`).
  *
  * SSRF coverage is identical for `asCustomFetch()` and `getDispatcher()` (same
- * underlying dispatcher, validated per hop). For `getNodeAgent()` it is enforced
- * via a connect-time secure DNS lookup, injected only for direct connections.
+ * underlying dispatcher): every dispatched request — initial and each redirect
+ * hop — is validated, and direct connections also carry a connect-time secure
+ * DNS lookup that defeats DNS-rebinding (TOCTOU). `getNodeAgent()` enforces the
+ * same connect-time secure lookup for direct connections.
  */
 export interface HttpTransport {
 	asCustomFetch(): CustomFetch;

--- a/packages/@n8n/backend-network/src/http/undici/transport.ts
+++ b/packages/@n8n/backend-network/src/http/undici/transport.ts
@@ -52,29 +52,43 @@ export interface DispatcherTransport {
  * Builds the undici dispatcher for a given proxy + SSRF policy,
  * The transport plumbing behind `OutboundHttp.transport()`.
  * When SSRF is active the dispatcher is composed with {@link createSsrfInterceptor},
- * so every dispatched request, including each redirect hop, is validated.
+ * so every dispatched request, including each redirect hop, is validated, and a
+ * connect-time secure DNS lookup is installed for direct connections (see
+ * {@link buildDispatcherFromProxy}).
  */
 export function buildDispatcher(
 	proxy: ProxyOption,
 	ssrf: SsrfOption,
 	timeouts?: TransportTimeoutOptions,
 ): Dispatcher {
-	const dispatcher = buildDispatcherFromProxy(proxy, timeouts);
+	const dispatcher = buildDispatcherFromProxy(proxy, ssrf, timeouts);
 	return ssrf === 'disabled' ? dispatcher : dispatcher.compose(createSsrfInterceptor(ssrf));
 }
 
 function buildDispatcherFromProxy(
 	proxy: ProxyOption,
+	ssrf: SsrfOption,
 	timeouts?: TransportTimeoutOptions,
 ): Dispatcher {
 	const agentOptions = toAgentTimeoutOptions(timeouts);
 	if (proxy === false) {
-		return new Agent(agentOptions);
+		return new Agent({ ...agentOptions, ...secureConnect(ssrf) });
 	}
 	if (proxy === 'env') {
-		return new EnvHttpProxyAgent(agentOptions);
+		return new EnvHttpProxyAgent({ ...agentOptions, ...secureConnect(ssrf) });
 	}
+	// Explicit proxy URL: no direct path, so no connect-time lookup is injected —
+	// the proxy resolves the target. Mirrors `buildNodeAgents`.
 	return new ProxyAgent({ uri: proxy, ...agentOptions });
+}
+
+/**
+ * A connect-time secure DNS lookup for direct connections.
+ * It pins the validated IP to the socket, so a hostname that passed the interceptor's pre-flight
+ * `validateUrl` cannot be rebound to a private IP before undici resolves it again at connect time (DNS-rebinding / TOCTOU).
+ */
+function secureConnect(ssrf: SsrfOption) {
+	return ssrf === 'disabled' ? {} : { connect: { lookup: ssrf.createSecureLookup() } };
 }
 
 /**

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.security.test.ts
@@ -57,7 +57,7 @@ import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee'
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { EventService } from '@/events/event.service';
 import type { RoleService } from '@/services/role.service';
-import type { SsrfProtectionService } from '@n8n/backend-network';
+import type { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import type { Telemetry } from '@/telemetry';
 
 jest.mock('@/permissions.ee/check-access');
@@ -148,6 +148,7 @@ const service = new InstanceAiAdapterService(
 	telemetry,
 	aiBuilderTemporaryWorkflowRepository,
 	mock<SsrfProtectionService>(),
+	mock<OutboundHttp>(),
 );
 
 const user = mock<User>({

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1115,6 +1115,8 @@ import type { WorkflowService } from '@/workflows/workflow.service';
 import type { License } from '@/license';
 import type { RoleService } from '@/services/role.service';
 
+import type { OutboundHttp } from '@n8n/backend-network';
+
 import { InstanceAiAdapterService } from '../instance-ai.adapter.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
@@ -1167,6 +1169,7 @@ function createNodeAdapterForTests(nodes: Array<Record<string, unknown>>) {
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[29],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[30],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[31],
+		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 	);
 
 	(
@@ -1300,6 +1303,7 @@ function createDataTableAdapterForTests(overrides?: {
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[29],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[30],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[31],
+		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 	);
 
 	const adapter = service.createContext(mockUser, {
@@ -1620,6 +1624,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		mockTelemetry as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[29],
 		mockAiBuilderTemporaryWorkflowRepository as unknown as AiBuilderTemporaryWorkflowRepository,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[31],
+		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 	);
 
 	const boundProjectId =
@@ -2237,6 +2242,7 @@ function createExecutionAdapterForTests(overrides?: { sharingEnabled?: boolean }
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[29],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[30],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[31],
+		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 	);
 
 	const adapter = service.createContext(mockUser).executionService;
@@ -2509,6 +2515,7 @@ function createRunAdapterForTests(
 		mockTelemetry as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[29],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[30],
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[31],
+		mock<OutboundHttp>() as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[32],
 	);
 
 	const adapter = service.createContext(mockUser, { threadId: options?.threadId }).executionService;

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -63,7 +63,7 @@ import {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Logger } from '@n8n/backend-common';
-import { SsrfProtectionService } from '@n8n/backend-network';
+import { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { Container, Service } from '@n8n/di';
 import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
@@ -230,6 +230,7 @@ export class InstanceAiAdapterService {
 		private readonly telemetry: Telemetry,
 		private readonly aiBuilderTemporaryWorkflowRepository: AiBuilderTemporaryWorkflowRepository,
 		private readonly ssrfProtectionService: SsrfProtectionService,
+		private readonly outboundHttp: OutboundHttp,
 	) {
 		this.logger = logger.scoped('instance-ai');
 		this.allowSendingParameterValues = globalConfig.ai.allowSendingParameterValues;
@@ -1770,7 +1771,7 @@ export class InstanceAiAdapterService {
 		const fetchCache = this.webResearchCache;
 		const searchCacheRef = this.searchCache;
 		const settingsService = this.settingsService;
-		const ssrf = this.ssrfProtectionService;
+		const transport = this.outboundHttp.transport({ ssrf: this.ssrfProtectionService });
 		const userId = user.id;
 
 		// Lazy search method that resolves credentials on first call
@@ -1829,7 +1830,7 @@ export class InstanceAiAdapterService {
 					maxResponseBytes: options?.maxResponseBytes,
 					timeoutMs: options?.timeoutMs,
 					authorizeUrl: options?.authorizeUrl,
-					ssrf,
+					transport,
 				});
 
 				// Attempt summarization (truncation fallback — no model injection yet)

--- a/packages/cli/src/modules/instance-ai/web-research/__tests__/fetch-and-extract.test.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/__tests__/fetch-and-extract.test.ts
@@ -1,23 +1,35 @@
 import type { Logger } from '@n8n/backend-common';
-import type { DnsResolver, SsrfBridge } from '@n8n/backend-network';
-import { SsrfProtectionService } from '@n8n/backend-network';
-import { SsrfProtectionConfig } from '@n8n/config';
+import type {
+	CustomFetch,
+	HttpTransport,
+	SsrfBridge,
+	SsrfOption,
+	SsrfProtectionService,
+} from '@n8n/backend-network';
+import { OutboundHttp } from '@n8n/backend-network';
 import { mock } from 'jest-mock-extended';
-import { createResultOk } from 'n8n-workflow';
-import type { LookupFunction } from 'node:net';
+import { createResultError, createResultOk } from 'n8n-workflow';
+import dns from 'node:dns';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo, LookupFunction } from 'node:net';
 
 import { fetchAndExtract } from '../fetch-and-extract';
 
-function createSsrfMock(): jest.Mocked<SsrfBridge> {
-	const ssrf = mock<SsrfBridge>();
-	ssrf.validateUrl.mockResolvedValue(createResultOk(undefined));
-	ssrf.validateRedirectSync.mockReturnValue(undefined);
-	// Lookup is invoked by undici when fetching real hosts. Our tests stub fetch
-	// itself so the lookup is never called — return a noop.
-	ssrf.createSecureLookup.mockReturnValue((_h, _o, cb) =>
-		cb(null, '127.0.0.1', 4),
-	) as unknown as jest.Mocked<SsrfBridge>['createSecureLookup'];
-	return ssrf;
+// The SSRF interceptor hands `validateUrl` a `URL` object (not a string), so we
+// match on its `href` rather than comparing against a raw string.
+const validatedUrl = (href: string) => expect.objectContaining({ href }) as unknown as URL;
+
+/**
+ * Wires `fetchAndExtract` to a canned `fetch` by stubbing the transport. SSRF
+ * enforcement is the transport's job (covered by the factory's own tests and the
+ * end-to-end cases below), so these unit tests can drive the extraction logic
+ * with deterministic responses.
+ */
+function mockTransport(fetchImpl: CustomFetch) {
+	const transportFetch = jest.fn(fetchImpl);
+	const transport = mock<HttpTransport>();
+	transport.asCustomFetch.mockReturnValue(transportFetch);
+	return { transport, transportFetch };
 }
 
 // Helper to create a mock Response
@@ -53,16 +65,8 @@ function createMockResponse(
 }
 
 describe('fetchAndExtract', () => {
-	const originalFetch = globalThis.fetch;
-	let ssrf: jest.Mocked<SsrfBridge>;
-
 	beforeEach(() => {
 		jest.clearAllMocks();
-		ssrf = createSsrfMock();
-	});
-
-	afterAll(() => {
-		globalThis.fetch = originalFetch;
 	});
 
 	it('extracts markdown from HTML', async () => {
@@ -78,9 +82,9 @@ describe('fetchAndExtract', () => {
 				</body>
 			</html>`;
 
-		globalThis.fetch = jest.fn().mockResolvedValue(createMockResponse(html));
+		const { transport } = mockTransport(async () => createMockResponse(html));
 
-		const result = await fetchAndExtract('https://example.com/docs', { ssrf });
+		const result = await fetchAndExtract('https://example.com/docs', { transport });
 
 		expect(result.title).toBeTruthy();
 		expect(result.content).toContain('API Reference');
@@ -102,9 +106,9 @@ describe('fetchAndExtract', () => {
 				</body>
 			</html>`;
 
-		globalThis.fetch = jest.fn().mockResolvedValue(createMockResponse(html));
+		const { transport } = mockTransport(async () => createMockResponse(html));
 
-		const result = await fetchAndExtract('https://example.com/table', { ssrf });
+		const result = await fetchAndExtract('https://example.com/table', { transport });
 
 		expect(result.content).toContain('Code');
 		expect(result.content).toContain('200');
@@ -112,11 +116,11 @@ describe('fetchAndExtract', () => {
 
 	it('passes through plain text', async () => {
 		const text = 'Just some plain text content.';
-		globalThis.fetch = jest
-			.fn()
-			.mockResolvedValue(createMockResponse(text, { contentType: 'text/plain' }));
+		const { transport } = mockTransport(async () =>
+			createMockResponse(text, { contentType: 'text/plain' }),
+		);
 
-		const result = await fetchAndExtract('https://example.com/file.txt', { ssrf });
+		const result = await fetchAndExtract('https://example.com/file.txt', { transport });
 
 		expect(result.content).toBe(text);
 		expect(result.truncated).toBe(false);
@@ -124,18 +128,51 @@ describe('fetchAndExtract', () => {
 
 	it('truncates content exceeding maxContentLength', async () => {
 		const longText = 'a'.repeat(50_000);
-		globalThis.fetch = jest
-			.fn()
-			.mockResolvedValue(createMockResponse(longText, { contentType: 'text/plain' }));
+		const { transport } = mockTransport(async () =>
+			createMockResponse(longText, { contentType: 'text/plain' }),
+		);
 
 		const result = await fetchAndExtract('https://example.com/long', {
-			ssrf,
+			transport,
 			maxContentLength: 1000,
 		});
 
 		expect(result.content.length).toBe(1000);
 		expect(result.truncated).toBe(true);
 		expect(result.contentLength).toBe(50_000);
+	});
+
+	it('caps the body at maxResponseBytes and cancels the stream', async () => {
+		const encoder = new TextEncoder();
+		const cancel = jest.fn().mockResolvedValue(undefined);
+		// A stream that never closes on its own — emits a 4-byte chunk per pull so
+		// the byte cap is reached mid-stream and we must cancel to stop reading.
+		const body = new ReadableStream({
+			pull(controller) {
+				controller.enqueue(encoder.encode('aaaa'));
+			},
+			cancel,
+		});
+
+		const { transport } = mockTransport(
+			async () =>
+				({
+					ok: true,
+					status: 200,
+					statusText: 'OK',
+					url: 'https://example.com/big',
+					headers: new Headers({ 'content-type': 'text/plain' }),
+					body,
+				}) as unknown as Response,
+		);
+
+		const result = await fetchAndExtract('https://example.com/big', {
+			transport,
+			maxResponseBytes: 6,
+		});
+
+		expect(result.content).toBe('aaaaaa');
+		expect(cancel).toHaveBeenCalled();
 	});
 
 	it('detects JS rendering safety flag', async () => {
@@ -149,9 +186,9 @@ describe('fetchAndExtract', () => {
 				</body>
 			</html>`;
 
-		globalThis.fetch = jest.fn().mockResolvedValue(createMockResponse(html));
+		const { transport } = mockTransport(async () => createMockResponse(html));
 
-		const result = await fetchAndExtract('https://example.com/spa', { ssrf });
+		const result = await fetchAndExtract('https://example.com/spa', { transport });
 
 		expect(result.safetyFlags?.jsRenderingSuspected).toBe(true);
 	});
@@ -168,137 +205,64 @@ describe('fetchAndExtract', () => {
 				</body>
 			</html>`;
 
-		globalThis.fetch = jest.fn().mockResolvedValue(createMockResponse(html));
+		const { transport } = mockTransport(async () => createMockResponse(html));
 
-		const result = await fetchAndExtract('https://example.com/login', { ssrf });
+		const result = await fetchAndExtract('https://example.com/login', { transport });
 
 		expect(result.safetyFlags?.loginRequired).toBe(true);
 	});
 
 	it('handles HTTP errors gracefully', async () => {
-		globalThis.fetch = jest
-			.fn()
-			.mockResolvedValue(createMockResponse('Not Found', { status: 404 }));
+		const { transport } = mockTransport(async () =>
+			createMockResponse('Not Found', { status: 404 }),
+		);
 
-		const result = await fetchAndExtract('https://example.com/missing', { ssrf });
+		const result = await fetchAndExtract('https://example.com/missing', { transport });
 
 		expect(result.content).toContain('HTTP 404');
 		expect(result.contentLength).toBe(0);
 	});
 
-	describe('SSRF integration', () => {
-		it('validates the initial URL via SsrfBridge', async () => {
-			const html = '<html><body><p>Hi</p></body></html>';
-			globalThis.fetch = jest.fn().mockResolvedValue(createMockResponse(html));
+	it('follows redirects manually, authorizing each hop before fetching it', async () => {
+		const html = '<html><body><p>Hi</p></body></html>';
+		const transportFetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				createMockResponse('', { status: 301, location: 'https://final.example.com/page' }),
+			)
+			.mockResolvedValueOnce(createMockResponse(html));
+		const transport = mock<HttpTransport>();
+		transport.asCustomFetch.mockReturnValue(transportFetch);
 
-			await fetchAndExtract('https://example.com', { ssrf });
+		const authorizeUrl = jest.fn().mockResolvedValue(undefined);
 
-			expect(ssrf.validateUrl).toHaveBeenCalledWith('https://example.com');
+		const result = await fetchAndExtract('https://example.com', {
+			transport,
+			authorizeUrl,
 		});
 
-		it('aborts the fetch if validateUrl rejects', async () => {
-			const blockedError = new Error('Blocked: 10.0.0.1');
-			ssrf.validateUrl.mockResolvedValueOnce({ ok: false, error: blockedError });
-			globalThis.fetch = jest.fn();
+		expect(authorizeUrl).toHaveBeenCalledWith('https://final.example.com/page');
+		expect(transportFetch).toHaveBeenCalledTimes(2);
+		expect(result.finalUrl).toBe('https://final.example.com/page');
+	});
 
-			await expect(fetchAndExtract('https://blocked.example', { ssrf })).rejects.toThrow(
-				'Blocked: 10.0.0.1',
+	it('aborts before fetching a redirect target that authorizeUrl rejects', async () => {
+		const transportFetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				createMockResponse('', { status: 301, location: 'https://blocked.example.com/page' }),
 			);
-			expect(globalThis.fetch).not.toHaveBeenCalled();
-		});
+		const transport = mock<HttpTransport>();
+		transport.asCustomFetch.mockReturnValue(transportFetch);
 
-		it('passes a dispatcher with the secure lookup to fetch', async () => {
-			const html = '<html><body><p>Hi</p></body></html>';
-			const fetchSpy = jest.fn().mockResolvedValue(createMockResponse(html));
-			globalThis.fetch = fetchSpy;
+		const authorizeUrl = jest.fn().mockRejectedValue(new Error('Access blocked'));
 
-			await fetchAndExtract('https://example.com', { ssrf });
+		await expect(
+			fetchAndExtract('https://example.com', { transport, authorizeUrl }),
+		).rejects.toThrow('Access blocked');
 
-			expect(ssrf.createSecureLookup).toHaveBeenCalled();
-			const fetchOptions = fetchSpy.mock.calls[0][1] as { dispatcher?: unknown };
-			expect(fetchOptions.dispatcher).toBeDefined();
-		});
-
-		it('validates each redirect target via validateRedirectSync and validateUrl', async () => {
-			const html = '<html><body><p>Hi</p></body></html>';
-			globalThis.fetch = jest
-				.fn()
-				.mockResolvedValueOnce(
-					createMockResponse('', {
-						status: 301,
-						location: 'https://final.example.com/page',
-					}),
-				)
-				.mockResolvedValueOnce(createMockResponse(html));
-
-			await fetchAndExtract('https://example.com', { ssrf });
-
-			expect(ssrf.validateUrl).toHaveBeenCalledWith('https://example.com');
-			expect(ssrf.validateUrl).toHaveBeenCalledWith('https://final.example.com/page');
-			expect(ssrf.validateRedirectSync).toHaveBeenCalledWith('https://final.example.com/page');
-		});
-
-		it('blocks redirects whose direct-IP target is private', async () => {
-			globalThis.fetch = jest.fn().mockResolvedValueOnce(
-				createMockResponse('', {
-					status: 301,
-					location: 'http://10.0.0.1/secret',
-				}),
-			);
-			ssrf.validateRedirectSync.mockImplementationOnce(() => {
-				throw new Error('Blocked: 10.0.0.1');
-			});
-
-			await expect(fetchAndExtract('https://example.com', { ssrf })).rejects.toThrow(
-				'Blocked: 10.0.0.1',
-			);
-		});
-
-		it('defeats DNS rebinding: secure lookup rejects a private IP returned at connect time', async () => {
-			// End-to-end TOCTOU regression guard. Wires fetchAndExtract to a real
-			// SsrfProtectionService backed by a mocked DnsResolver that returns a
-			// public IP on the validation lookup and a private IP on the connect
-			// lookup. The secure lookup must reject the private IP rather than
-			// hand it to undici, even though validation passed.
-			const dnsResolver = mock<DnsResolver>();
-			dnsResolver.lookup
-				.mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
-				.mockResolvedValueOnce([{ address: '10.0.0.1', family: 4 }]);
-
-			const realSsrf = new SsrfProtectionService(
-				new SsrfProtectionConfig(),
-				dnsResolver,
-				mock<Logger>({ scoped: jest.fn().mockReturnThis() }),
-			);
-
-			// Capture the lookup function that fetchAndExtract installs on the dispatcher.
-			let dispatcherLookup: LookupFunction | undefined;
-			const realCreate = realSsrf.createSecureLookup.bind(realSsrf);
-			jest.spyOn(realSsrf, 'createSecureLookup').mockImplementation(() => {
-				dispatcherLookup = realCreate();
-				return dispatcherLookup;
-			});
-
-			globalThis.fetch = jest
-				.fn()
-				.mockResolvedValue(createMockResponse('<html><body>x</body></html>'));
-
-			// Validation lookup returns the public IP, so fetchAndExtract proceeds.
-			await fetchAndExtract('https://evil.example/', { ssrf: realSsrf });
-			expect(dispatcherLookup).toBeDefined();
-
-			// Simulate undici invoking the dispatcher's lookup at connect time.
-			// DnsResolver now returns the private IP — the secure lookup must error
-			// out instead of returning the rebound address.
-			await expect(
-				new Promise<void>((resolve, reject) => {
-					dispatcherLookup!('evil.example', { family: 0 }, (err) => {
-						if (err) reject(err);
-						else resolve();
-					});
-				}),
-			).rejects.toThrow(/restricted IP/i);
-		});
+		// The redirect target is never fetched — only the initial request was made.
+		expect(transportFetch).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not deadlock when the response body streams in chunks after fetch resolves', async () => {
@@ -313,22 +277,161 @@ describe('fetchAndExtract', () => {
 			},
 		});
 
-		globalThis.fetch = jest.fn().mockResolvedValue({
-			ok: true,
-			status: 200,
-			statusText: 'OK',
-			url: 'https://example.com/slow',
-			headers: new Headers({ 'content-type': 'text/html' }),
-			body: slowBody,
-		} as unknown as Response);
+		const { transport } = mockTransport(
+			async () =>
+				({
+					ok: true,
+					status: 200,
+					statusText: 'OK',
+					url: 'https://example.com/slow',
+					headers: new Headers({ 'content-type': 'text/html' }),
+					body: slowBody,
+				}) as unknown as Response,
+		);
 
 		const result = await Promise.race([
-			fetchAndExtract('https://example.com/slow', { ssrf }),
+			fetchAndExtract('https://example.com/slow', { transport }),
 			new Promise<never>((_, reject) =>
 				setTimeout(() => reject(new Error('fetchAndExtract deadlocked')), 2000),
 			),
 		]);
 
 		expect(result.content).toContain('hello world');
+	});
+
+	// ── End-to-end: real redirecting server, real factory transport ──────────
+	//
+	// Mirrors the factory's `outbound-http.ssrf.test.ts` approach: a real local
+	// server issues a 30x, and the transport's SSRF interceptor runs for real, so
+	// we prove SSRF coverage extends to redirect hops and that the AI research
+	// flow still extracts content through the factory.
+	describe('end-to-end against a real redirecting server', () => {
+		interface TestServer {
+			url: string;
+			captured: string[];
+			close: () => Promise<void>;
+		}
+
+		async function startRedirectServer(): Promise<TestServer> {
+			let serverUrl = '';
+			const captured: string[] = [];
+			const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+				captured.push(req.url ?? '');
+				if (req.url === '/start') {
+					res.writeHead(302, { Location: `${serverUrl}/internal` });
+					res.end();
+					return;
+				}
+				res.writeHead(200, { 'content-type': 'text/html' });
+				res.end(
+					'<html><head><title>Redirected</title></head><body><article><h1>Internal Page</h1>' +
+						'<p>This content was reached after following a redirect.</p></article></body></html>',
+				);
+			});
+
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+			const { port } = server.address() as AddressInfo;
+			serverUrl = `http://127.0.0.1:${port}`;
+
+			return {
+				url: serverUrl,
+				captured,
+				close: async () => await new Promise<void>((resolve) => server.close(() => resolve())),
+			};
+		}
+
+		// Builds a real transport (the wiring the adapter service performs) so the
+		// SSRF interceptor runs for real against the redirecting server below.
+		function realTransport(ssrf: SsrfOption) {
+			return new OutboundHttp(mock<SsrfProtectionService>(), mock<Logger>()).transport({ ssrf });
+		}
+
+		function makeBridge(blockedPath?: string): jest.Mocked<SsrfBridge> {
+			const bridge = mock<SsrfBridge>();
+			bridge.validateUrl.mockImplementation(async (url) => {
+				const href = typeof url === 'string' ? url : url.href;
+				return blockedPath && href.includes(blockedPath)
+					? createResultError(new Error(`SSRF: blocked ${blockedPath}`))
+					: createResultOk(undefined);
+			});
+			// The transport installs this as a connect-time lookup; delegate to real
+			// DNS so hostname connections resolve normally (IP-literal targets skip it).
+			bridge.createSecureLookup.mockReturnValue(((hostname, options, onResult) =>
+				dns.lookup(hostname, options, onResult as never)) as LookupFunction);
+			return bridge;
+		}
+
+		let server: TestServer;
+
+		beforeEach(async () => {
+			server = await startRedirectServer();
+		});
+
+		afterEach(async () => {
+			await server.close();
+		});
+
+		it('follows the redirect and extracts content when every hop passes SSRF validation', async () => {
+			const ssrf = makeBridge();
+
+			const result = await fetchAndExtract(`${server.url}/start`, {
+				transport: realTransport(ssrf),
+			});
+
+			expect(result.content).toContain('Internal Page');
+			expect(result.finalUrl).toBe(`${server.url}/internal`);
+			expect(ssrf.validateUrl).toHaveBeenCalledWith(validatedUrl(`${server.url}/start`));
+			expect(ssrf.validateUrl).toHaveBeenCalledWith(validatedUrl(`${server.url}/internal`));
+			expect(server.captured).toEqual(['/start', '/internal']);
+		});
+
+		it('blocks a redirect to an SSRF-rejected target without reaching it', async () => {
+			const ssrf = makeBridge('/internal');
+
+			await expect(
+				fetchAndExtract(`${server.url}/start`, { transport: realTransport(ssrf) }),
+			).rejects.toThrow();
+
+			expect(ssrf.validateUrl).toHaveBeenCalledWith(validatedUrl(`${server.url}/internal`));
+			expect(server.captured).toContain('/start');
+			expect(server.captured).not.toContain('/internal');
+		});
+
+		it('blocks the initial request when SSRF rejects its URL', async () => {
+			const ssrf = makeBridge('/start');
+
+			await expect(
+				fetchAndExtract(`${server.url}/start`, { transport: realTransport(ssrf) }),
+			).rejects.toThrow();
+
+			expect(server.captured).not.toContain('/start');
+		});
+
+		it('authorizes the redirect target before it is fetched', async () => {
+			const ssrf = makeBridge();
+			const authorizeUrl = jest.fn(async (target: string) => {
+				if (target.includes('/internal')) throw new Error('Redirect not allowed');
+			});
+
+			await expect(
+				fetchAndExtract(`${server.url}/start`, {
+					transport: realTransport(ssrf),
+					authorizeUrl,
+				}),
+			).rejects.toThrow('Redirect not allowed');
+
+			expect(authorizeUrl).toHaveBeenCalledWith(`${server.url}/internal`);
+			// The redirect target is gated before any request reaches it.
+			expect(server.captured).toEqual(['/start']);
+		});
+
+		it('follows the redirect without validation when SSRF is disabled', async () => {
+			const result = await fetchAndExtract(`${server.url}/start`, {
+				transport: realTransport('disabled'),
+			});
+
+			expect(result.content).toContain('Internal Page');
+			expect(server.captured).toEqual(['/start', '/internal']);
+		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
@@ -1,13 +1,12 @@
 import type * as JoplinTurndownGfm from '@joplin/turndown-plugin-gfm';
 import type { Readability as TReadability } from '@mozilla/readability';
 import type * as ReadabilityMod from '@mozilla/readability';
-import type { SsrfBridge } from '@n8n/backend-network';
+import type { HttpTransport } from '@n8n/backend-network';
 import type { FetchedPage } from '@n8n/instance-ai';
 import type * as LinkedomMod from 'linkedom';
 import type { parseHTML as TParseHtml } from 'linkedom';
 import type TTurndownService from 'turndown';
 import type * as TurndownMod from 'turndown';
-import { Agent } from 'undici';
 
 let _linkedom: typeof LinkedomMod | undefined;
 let _readability: typeof ReadabilityMod | undefined;
@@ -59,18 +58,18 @@ export interface FetchAndExtractOptions {
 	 */
 	authorizeUrl?: (url: string) => Promise<void>;
 	/**
-	 * SSRF guard. The same secure lookup function pins DNS for the actual
-	 * connect, so the IP that passes validation is the one fetch connects to.
+	 * SSRF-validated fetch transport.
 	 */
-	ssrf: SsrfBridge;
+	transport: HttpTransport;
 }
 
 /**
  * Fetch a URL, extract its main content, and convert to markdown.
  * Routes by content-type: HTML → Readability + Turndown, PDF → pdf-parse, text → passthrough.
  *
- * Every redirect hop is validated against the SSRF guard before following,
- * preventing open-redirect chains to internal/private addresses.
+ * The factory transport runs SSRF validation per dispatched request, so the
+ * initial fetch and every redirect hop are checked — closing open-redirect
+ * chains to internal/private addresses.
  */
 export async function fetchAndExtract(
 	url: string,
@@ -80,23 +79,20 @@ export async function fetchAndExtract(
 	const maxResponseBytes = options.maxResponseBytes ?? MAX_RESPONSE_BYTES;
 	const timeoutMs = Math.min(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
-	const { authorizeUrl, ssrf } = options;
+	const { authorizeUrl, transport } = options;
 
-	// Manual redirect handling — validate every hop against SSRF guard
+	const customFetch = transport.asCustomFetch();
+
 	let currentUrl = url;
 	let response!: Response;
 	let redirectCount = 0;
 
 	while (redirectCount <= MAX_REDIRECTS) {
-		const validation = await ssrf.validateUrl(currentUrl);
-		if (!validation.ok) throw validation.error;
-
-		const dispatcher = new Agent({ connect: { lookup: ssrf.createSecureLookup() } });
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
 		try {
-			response = await fetch(currentUrl, {
+			response = await customFetch(currentUrl, {
 				signal: controller.signal,
 				headers: {
 					'User-Agent': 'n8n-instance-ai/1.0 (content extraction)',
@@ -104,19 +100,18 @@ export async function fetchAndExtract(
 						'text/html,application/xhtml+xml,application/xml;q=0.9,text/plain;q=0.8,application/pdf;q=0.7,*/*;q=0.5',
 				},
 				redirect: 'manual',
-				// @ts-expect-error dispatcher is a valid undici option for Node.js fetch
-				dispatcher,
 			});
 		} finally {
 			clearTimeout(timeout);
-			// Fire-and-forget — awaiting Agent.close() deadlocks against an unread body.
-			void dispatcher.close().catch(() => {});
 		}
 
-		// Follow redirects manually so each hop is SSRF-checked
+		// Follow redirects manually so each hop can be authorized before it is fetched
 		if (response.status >= 300 && response.status < 400) {
 			const location = response.headers.get('location');
 			if (!location) break;
+
+			// Release the redirect response's connection back to the pool.
+			await response.body?.cancel().catch(() => {});
 
 			redirectCount++;
 			if (redirectCount > MAX_REDIRECTS) {
@@ -126,11 +121,8 @@ export async function fetchAndExtract(
 			// Resolve relative redirect URLs against the current URL
 			currentUrl = new URL(location, currentUrl).href;
 
-			// Direct-IP redirect targets are caught here; hostnames are caught by
-			// validateUrl on the next loop iteration before the dispatcher connects.
-			ssrf.validateRedirectSync(currentUrl);
-
-			// Domain-access authorization for the redirect target
+			// Domain-access authorization for the redirect target.
+			// SSRF for the target is enforced by the transport on the next dispatch.
 			if (authorizeUrl) {
 				await authorizeUrl(currentUrl);
 			}
@@ -144,6 +136,8 @@ export async function fetchAndExtract(
 	const finalUrl = currentUrl;
 
 	if (!response.ok) {
+		// Release the connection back to the pool — we don't read the error body.
+		await response.body?.cancel().catch(() => {});
 		return {
 			url,
 			finalUrl,
@@ -179,6 +173,7 @@ async function readLimitedBody(response: Response, maxBytes: number): Promise<Bu
 	}
 
 	const reader = response.body.getReader();
+	let truncated = false;
 	try {
 		for (;;) {
 			const { done, value } = await reader.read();
@@ -189,13 +184,20 @@ async function readLimitedBody(response: Response, maxBytes: number): Promise<Bu
 
 			if (totalBytes > maxBytes) {
 				chunks.push(chunk.subarray(0, maxBytes - (totalBytes - chunk.length)));
+				truncated = true;
 				break;
 			}
 
 			chunks.push(chunk);
 		}
 	} finally {
-		reader.releaseLock();
+		// Cancel when we stopped early so the pooled connection is released;
+		// cancel() also releases the lock, so only releaseLock() otherwise.
+		if (truncated) {
+			await reader.cancel().catch(() => {});
+		} else {
+			reader.releaseLock();
+		}
 	}
 
 	return Buffer.concat(chunks);

--- a/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
@@ -191,13 +191,11 @@ async function readLimitedBody(response: Response, maxBytes: number): Promise<Bu
 			chunks.push(chunk);
 		}
 	} finally {
-		// Cancel when we stopped early so the pooled connection is released;
-		// cancel() also releases the lock, so only releaseLock() otherwise.
 		if (truncated) {
+			// Cancel when we stopped early so the underlying connection is released back to the pool.
 			await reader.cancel().catch(() => {});
-		} else {
-			reader.releaseLock();
 		}
+		reader.releaseLock();
 	}
 
 	return Buffer.concat(chunks);


### PR DESCRIPTION
## Summary

`web-research/fetch-and-extract.ts` was the last remaining place in the backend that talked to **undici** directly.

This routes it through the shared `OutboundHttp` client instead, so all backend HTTP egress goes through one factory.

**`fetch-and-extract.ts`**
- Drops the direct `undici` import and the hand-built agent + global `fetch`. The function now receives a prebuilt `HttpTransport` and fetches via `transport.asCustomFetch()`.
- Removes the explicit per-hop validation calls: the transport validates **every dispatched request**
- **Keeps the manual redirect loop** (`redirect: 'manual'`) so each hop can be authorized (HITL domain gating via `authorizeUrl`) **before** it is fetched.

**`instance-ai.adapter.service.ts`**
- Injects `OutboundHttp` and builds the transport **once per web-research adapter**, so a research session's multiple fetches reuse a single connection pool.
- Request validation is kept **always-on** for these AI-chosen URLs (not gated by `ssrfConfig.enabled`)

**`@n8n/backend-network` transport hardening**
- The factory's `asCustomFetch()` / `getDispatcher()` paths previously validated up front only, with no connect-time host pinning
- `buildDispatcherFromProxy` now installs a connect-time secure DNS lookup for **direct** and `env` connections

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3512

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->