### PR TITLE
refactor(GoogleGemini Node): Use HTTP request helper for file downloads

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.test.ts
@@ -1,7 +1,5 @@
-import axios from 'axios';
 import type { IBinaryData, IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import type { Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import {
@@ -15,9 +13,6 @@ import {
 	uploadToFileSearchStore,
 } from './utils';
 import * as transport from '../transport';
-
-vi.mock('axios');
-const mockedAxios = axios as Mocked<typeof axios>;
 
 describe('GoogleGemini -> utils', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
@@ -289,14 +284,14 @@ describe('GoogleGemini -> utils', () => {
 	});
 
 	describe('transferFile', () => {
-		it('should transfer file from URL using axios', async () => {
+		it('should transfer file from URL', async () => {
 			const mockStream = {
 				pipe: vi.fn(),
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf; charset=utf-8',
 				},
@@ -331,9 +326,12 @@ describe('GoogleGemini -> utils', () => {
 				mimeType: 'application/pdf',
 			});
 
-			expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/file.pdf', {
-				params: undefined,
-				responseType: 'stream',
+			expect(mockExecuteFunctions.helpers.httpRequest).toHaveBeenCalledWith({
+				method: 'GET',
+				url: 'https://example.com/file.pdf',
+				qs: undefined,
+				returnFullResponse: true,
+				encoding: 'stream',
 			});
 
 			expect(apiRequestMock).toHaveBeenCalledWith('POST', '/upload/v1beta/files', {
@@ -477,8 +475,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf',
 				},
@@ -506,8 +504,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf',
 				},
@@ -584,8 +582,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf; charset=utf-8',
 				},
@@ -632,9 +630,12 @@ describe('GoogleGemini -> utils', () => {
 				name: 'fileSearchStores/abc123/files/file123',
 			});
 
-			expect(mockedAxios.get).toHaveBeenCalledWith('https://example.com/file.pdf', {
-				params: undefined,
-				responseType: 'stream',
+			expect(mockExecuteFunctions.helpers.httpRequest).toHaveBeenCalledWith({
+				method: 'GET',
+				url: 'https://example.com/file.pdf',
+				qs: undefined,
+				returnFullResponse: true,
+				encoding: 'stream',
 			});
 
 			expect(apiRequestMock).toHaveBeenCalledWith(
@@ -771,8 +772,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf',
 				},
@@ -834,8 +835,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf',
 				},
@@ -906,8 +907,8 @@ describe('GoogleGemini -> utils', () => {
 				on: vi.fn(),
 			} as any;
 
-			mockedAxios.get.mockResolvedValue({
-				data: mockStream,
+			mockExecuteFunctions.helpers.httpRequest.mockResolvedValueOnce({
+				body: mockStream,
 				headers: {
 					'content-type': 'application/pdf',
 				},

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { extension } from 'mime-types';
 import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
@@ -128,16 +127,19 @@ async function getFileStreamFromUrlOrBinary(
 	qs?: IDataObject,
 ): Promise<FileStreamData | FileBufferData> {
 	if (downloadUrl) {
-		const downloadResponse = await axios.get(downloadUrl, {
-			params: qs,
-			responseType: 'stream',
-		});
+		const downloadResponse = (await this.helpers.httpRequest({
+			method: 'GET',
+			url: downloadUrl,
+			qs,
+			returnFullResponse: true,
+			encoding: 'stream',
+		})) as { body: Stream; headers: IDataObject };
 
 		const contentType = downloadResponse.headers['content-type'] as string | undefined;
 		const mimeType = contentType?.split(';')?.[0] ?? fallbackMimeType ?? 'application/octet-stream';
 
 		return {
-			stream: downloadResponse.data as Stream,
+			stream: downloadResponse.body,
 			mimeType,
 		};
 	}


### PR DESCRIPTION
## Summary

Routes the Google Gemini node's streaming file downloads through the standard `httpRequest` helper instead of calling `axios` directly. The helper centralizes URL handling, redirect handling, and outbound request policy that the direct call previously bypassed.

## How to test manually

* Run `python3 -m http.server 9999 --bind 127.0.0.1` 
* Enable SSRF (`N8N_SSRF_PROTECTION_ENABLED=true`)
* Create a node `Upload a file to a File Search store` with the destination URL `https://127.0.0.1:9999/test.pdf`

<img width="1049" height="534" alt="image" src="https://github.com/user-attachments/assets/b29ea483-3444-435b-bff9-dc98457d95a6" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2388

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32611">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->