### PR TITLE
fix(core): Apply egress policy to credential test requests

### DIFF
--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -25,6 +25,7 @@ import type {
 	ICredentialTestFunctions,
 	IDataObject,
 	IExecuteData,
+	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 import {
 	VersionedNodeType,
@@ -203,35 +204,38 @@ export class CredentialsTester {
 		}
 
 		let credentialsDataSecretKeys: string[] = [];
-		if (credentialsDecrypted.data) {
-			try {
-				const additionalData = await WorkflowExecuteAdditionalData.getBase({
-					userId,
-					projectId: credentialsDecrypted.homeProject?.id,
-				});
+		let baseAdditionalData: IWorkflowExecuteAdditionalData;
+		try {
+			baseAdditionalData = await WorkflowExecuteAdditionalData.getBase({
+				userId,
+				projectId: credentialsDecrypted.homeProject?.id,
+			});
 
+			if (credentialsDecrypted.data) {
 				// Keep all credentials data keys which have a secret value
 				credentialsDataSecretKeys = getExternalSecretExpressionPaths(credentialsDecrypted.data);
 				credentialsDecrypted.data = await this.credentialsHelper.applyDefaultsAndOverwrites(
-					additionalData,
+					baseAdditionalData,
 					credentialsDecrypted.data,
 					credentialType,
 					'internal' as WorkflowExecuteMode,
 					undefined,
 					undefined,
 				);
-			} catch (error) {
-				this.logger.debug('Credential test failed', error);
-				return {
-					status: 'Error',
-					message: error.message.toString(),
-				};
 			}
+		} catch (error) {
+			this.logger.debug('Credential test failed', error);
+			return {
+				status: 'Error',
+				message: error.message.toString(),
+			};
 		}
 
 		if (typeof credentialTestFunction === 'function') {
-			// The credentials get tested via a function that is defined on the node
-			const context = new CredentialTestContext();
+			// The credentials get tested via a function that is defined on the node.
+			// Pass the base additional data so the test's HTTP requests honour the
+			// egress policy carried by its SSRF bridge.
+			const context = new CredentialTestContext(baseAdditionalData);
 			const functionResult = credentialTestFunction.call(context, credentialsDecrypted);
 			if (functionResult instanceof Promise) {
 				const result = await functionResult;

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/credentials-test-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/credentials-test-context.test.ts
@@ -1,0 +1,59 @@
+import { OutboundHttp } from '@n8n/backend-network';
+import type { HttpRequestClient, SsrfBridge } from '@n8n/backend-network';
+import { Container } from '@n8n/di';
+import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { CredentialTestContext } from '../credentials-test-context';
+
+// The SSH tunnel helpers resolve a manager from the container; stub them out so
+// constructing the context stays a pure unit test focused on the request path.
+vi.mock('../utils/ssh-tunnel-helper-functions', () => ({
+	getSSHTunnelFunctions: () => ({}),
+}));
+
+/**
+ * `CredentialTestContext` is the execution context for function-based credential
+ * tests. Its `helpers.request` must forward the execution's SSRF bridge so that
+ * test requests honour the same egress policy as regular node execution. These
+ * tests assert that wiring; the actual SSRF enforcement lives in
+ * `@n8n/backend-network`.
+ */
+describe('CredentialTestContext', () => {
+	const requestLegacy = vi.fn();
+	const requests = vi.fn();
+	const outboundHttp = mock<OutboundHttp>({ requests });
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		requestLegacy.mockResolvedValue('response-body');
+		requests.mockReturnValue(mock<HttpRequestClient>({ requestLegacy }));
+		Container.set(OutboundHttp, outboundHttp);
+	});
+
+	it('forwards the SSRF bridge from additionalData to the request', async () => {
+		const ssrfBridge = mock<SsrfBridge>();
+		const additionalData = mock<IWorkflowExecuteAdditionalData>({ ssrfBridge });
+
+		const context = new CredentialTestContext(additionalData);
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: ssrfBridge });
+	});
+
+	it('disables SSRF when additionalData carries no bridge', async () => {
+		const additionalData = mock<IWorkflowExecuteAdditionalData>({ ssrfBridge: undefined });
+
+		const context = new CredentialTestContext(additionalData);
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+	});
+
+	it('disables SSRF when no additionalData is provided', async () => {
+		const context = new CredentialTestContext();
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Memoized } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import type { ICredentialTestFunctions } from 'n8n-workflow';
+import type { ICredentialTestFunctions, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
 import { proxyRequestToAxios } from './utils/request-helpers/legacy-request-adapter'; // This bypasses the index barrel on purpose
 import { getSSHTunnelFunctions } from './utils/ssh-tunnel-helper-functions';
@@ -9,12 +9,20 @@ import { getSSHTunnelFunctions } from './utils/ssh-tunnel-helper-functions';
 export class CredentialTestContext implements ICredentialTestFunctions {
 	readonly helpers: ICredentialTestFunctions['helpers'];
 
-	constructor() {
+	// `additionalData` carries the SSRF bridge so credential tests that issue
+	// requests honour the same egress policy as regular node execution.
+	constructor(additionalData?: IWorkflowExecuteAdditionalData) {
 		this.helpers = {
 			...getSSHTunnelFunctions(),
 			request: async (uriOrObject: string | object, options?: object) => {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return await proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
+				return await proxyRequestToAxios(
+					undefined,
+					additionalData,
+					undefined,
+					uriOrObject,
+					options,
+				);
 			},
 		};
 	}


### PR DESCRIPTION
## Summary

Credential tests that run through a node-defined test function (`methods.credentialTest`, e.g. HaloPSA, FTP, Emelia) issue their HTTP requests through a dedicated `CredentialTestContext`. That context's `request` helper did not carry the execution's egress policy, so those requests did not follow the same outbound-request policy that regular node execution and request-based credential tests already apply.

This change threads the execution's `additionalData` (which carries the egress-policy bridge) into `CredentialTestContext`, so function-based credential tests honour the same outbound policy as the rest of the app.

- Request-based credential tests (declarative `test` definitions, routed through `ExecuteContext`) were already covered — no change there.
- When egress protection is disabled (the default), behaviour is unchanged: no bridge is present and requests proceed as before.

## How to test

1. Enable outbound protection: set `N8N_SSRF_PROTECTION_ENABLED=true` and configure blocked ranges as desired (`N8N_SSRF_BLOCKED_IP_RANGES`).
2. Create a credential for a node that uses a function-based credential test (e.g. HaloPSA) whose configured host resolves into a blocked range.
3. Click **Test** on the credential — the request is now subject to the configured egress policy (previously it connected directly).
4. With protection disabled (default), the test behaves exactly as before.

Automated coverage:
- `packages/core` — `node-execution-context/__tests__/credentials-test-context.test.ts` (helper forwards the policy bridge; falls back to disabled when absent)
- `packages/cli` — `services/__tests__/credentials-tester.service.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2894

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32613">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->