### PR TITLE
refactor(core): Apply egress policy to credential test requests

### DIFF
--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -25,6 +25,7 @@ import type {
 	ICredentialTestFunctions,
 	IDataObject,
 	IExecuteData,
+	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
 import {
 	VersionedNodeType,
@@ -203,35 +204,38 @@ export class CredentialsTester {
 		}
 
 		let credentialsDataSecretKeys: string[] = [];
-		if (credentialsDecrypted.data) {
-			try {
-				const additionalData = await WorkflowExecuteAdditionalData.getBase({
-					userId,
-					projectId: credentialsDecrypted.homeProject?.id,
-				});
+		let baseAdditionalData: IWorkflowExecuteAdditionalData;
+		try {
+			baseAdditionalData = await WorkflowExecuteAdditionalData.getBase({
+				userId,
+				projectId: credentialsDecrypted.homeProject?.id,
+			});
 
+			if (credentialsDecrypted.data) {
 				// Keep all credentials data keys which have a secret value
 				credentialsDataSecretKeys = getExternalSecretExpressionPaths(credentialsDecrypted.data);
 				credentialsDecrypted.data = await this.credentialsHelper.applyDefaultsAndOverwrites(
-					additionalData,
+					baseAdditionalData,
 					credentialsDecrypted.data,
 					credentialType,
 					'internal' as WorkflowExecuteMode,
 					undefined,
 					undefined,
 				);
-			} catch (error) {
-				this.logger.debug('Credential test failed', error);
-				return {
-					status: 'Error',
-					message: error.message.toString(),
-				};
 			}
+		} catch (error) {
+			this.logger.debug('Credential test failed', error);
+			return {
+				status: 'Error',
+				message: error.message.toString(),
+			};
 		}
 
 		if (typeof credentialTestFunction === 'function') {
-			// The credentials get tested via a function that is defined on the node
-			const context = new CredentialTestContext();
+			// The credentials get tested via a function that is defined on the node.
+			// Pass the base additional data so the test's HTTP requests honour the
+			// egress policy carried by its SSRF bridge.
+			const context = new CredentialTestContext(baseAdditionalData);
 			const functionResult = credentialTestFunction.call(context, credentialsDecrypted);
 			if (functionResult instanceof Promise) {
 				const result = await functionResult;

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/credentials-test-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/credentials-test-context.test.ts
@@ -1,0 +1,59 @@
+import { OutboundHttp } from '@n8n/backend-network';
+import type { HttpRequestClient, SsrfBridge } from '@n8n/backend-network';
+import { Container } from '@n8n/di';
+import type { IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { CredentialTestContext } from '../credentials-test-context';
+
+// The SSH tunnel helpers resolve a manager from the container; stub them out so
+// constructing the context stays a pure unit test focused on the request path.
+vi.mock('../utils/ssh-tunnel-helper-functions', () => ({
+	getSSHTunnelFunctions: () => ({}),
+}));
+
+/**
+ * `CredentialTestContext` is the execution context for function-based credential
+ * tests. Its `helpers.request` must forward the execution's SSRF bridge so that
+ * test requests honour the same egress policy as regular node execution. These
+ * tests assert that wiring; the actual SSRF enforcement lives in
+ * `@n8n/backend-network`.
+ */
+describe('CredentialTestContext', () => {
+	const requestLegacy = vi.fn();
+	const requests = vi.fn();
+	const outboundHttp = mock<OutboundHttp>({ requests });
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		requestLegacy.mockResolvedValue('response-body');
+		requests.mockReturnValue(mock<HttpRequestClient>({ requestLegacy }));
+		Container.set(OutboundHttp, outboundHttp);
+	});
+
+	it('forwards the SSRF bridge from additionalData to the request', async () => {
+		const ssrfBridge = mock<SsrfBridge>();
+		const additionalData = mock<IWorkflowExecuteAdditionalData>({ ssrfBridge });
+
+		const context = new CredentialTestContext(additionalData);
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: ssrfBridge });
+	});
+
+	it('disables SSRF when additionalData carries no bridge', async () => {
+		const additionalData = mock<IWorkflowExecuteAdditionalData>({ ssrfBridge: undefined });
+
+		const context = new CredentialTestContext(additionalData);
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+	});
+
+	it('disables SSRF when no additionalData is provided', async () => {
+		const context = new CredentialTestContext();
+		await context.helpers.request('https://example.test');
+
+		expect(requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/credentials-test-context.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Memoized } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import type { ICredentialTestFunctions } from 'n8n-workflow';
+import type { ICredentialTestFunctions, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 
 import { proxyRequestToAxios } from './utils/request-helpers/legacy-request-adapter'; // This bypasses the index barrel on purpose
 import { getSSHTunnelFunctions } from './utils/ssh-tunnel-helper-functions';
@@ -9,12 +9,20 @@ import { getSSHTunnelFunctions } from './utils/ssh-tunnel-helper-functions';
 export class CredentialTestContext implements ICredentialTestFunctions {
 	readonly helpers: ICredentialTestFunctions['helpers'];
 
-	constructor() {
+	// `additionalData` carries the SSRF bridge so credential tests that issue
+	// requests honour the same egress policy as regular node execution.
+	constructor(additionalData?: IWorkflowExecuteAdditionalData) {
 		this.helpers = {
 			...getSSHTunnelFunctions(),
 			request: async (uriOrObject: string | object, options?: object) => {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-				return await proxyRequestToAxios(undefined, undefined, undefined, uriOrObject, options);
+				return await proxyRequestToAxios(
+					undefined,
+					additionalData,
+					undefined,
+					uriOrObject,
+					options,
+				);
 			},
 		};
 	}


### PR DESCRIPTION
## Summary

Credential tests that run through a node-defined test function (`methods.credentialTest`, e.g. HaloPSA, FTP, Emelia) issue their HTTP requests through a dedicated `CredentialTestContext`. That context's `request` helper did not carry the execution's egress policy, so those requests did not follow the same outbound-request policy that regular node execution and request-based credential tests already apply.

This change threads the execution's `additionalData` (which carries the egress-policy bridge) into `CredentialTestContext`, so function-based credential tests honour the same outbound policy as the rest of the app.

## How to test manually

## Setup

**1. Start a local listener** (shows whether the request reaches a blocked target):

```bash
python3 -m http.server 9999 --bind 127.0.0.1
```

**2. Start n8n with egress protection enabled**

```bash
N8N_SSRF_PROTECTION_ENABLED=true pnpm dev
```

Default blocked ranges already include loopback (`127.0.0.0/8`), so `127.0.0.1` is blocked.

## Step 3 — Create and test the credential (UI)

1. Open the editor (usually `http://localhost:5678`).
2. Go to **Credentials → Add credential**.
3. Search for and select **HaloPSA API**.
4. Fill in the fields:
   - **HaloPSA Authorisation Server URL** → `http://127.0.0.1:9999`
   - **Tenant** → any value (e.g. `test`)
   - **Client ID** → any value (e.g. `test`)
   - **Client Secret** → any value (e.g. `test`)
   - Leave **Hosting Type** at its default.
5. Click **Save** (or **Test**). n8n runs the function-based credential test,
   which makes an HTTP request to the URL entered.
6. Observe both:
   - The **result banner** in the UI (success vs. error).
   - The **listener terminal** — did it print an incoming request?

<img width="952" height="297" alt="image" src="https://github.com/user-attachments/assets/c47e230c-8dca-4a27-b8e6-57ef1a8d40f1" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2894

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32614">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->