### PR TITLE
feat(Microsoft OneDrive Node): Add Entra service principal credential (spike PoC) (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftEntraServicePrincipalApi.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftEntraServicePrincipalApi.credentials.ts
@@ -1,0 +1,199 @@
+import type { AxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialTestRequest,
+	ICredentialType,
+	IHttpRequestOptions,
+	INodeProperties,
+	Icon,
+} from 'n8n-workflow';
+
+import { formatPrivateKey } from '../utils/utilities';
+
+const TOKEN_HOST = 'https://login.microsoftonline.com';
+
+/**
+ * Acquires an app-only Microsoft Graph access token using the OAuth2
+ * `client_credentials` grant. Supports both service-principal auth methods:
+ *
+ *  - Client secret: posts the secret directly.
+ *  - Certificate: signs a short-lived `client_assertion` JWT (RS256) whose `x5t`
+ *    header (base64url of the cert's SHA-1 thumbprint) tells Entra which uploaded
+ *    certificate to validate against.
+ *
+ * Note: `client_credentials` cannot request granular scopes — it always asks for
+ * `<resource>/.default` and receives whatever application permissions an admin
+ * has consented to for the app.
+ */
+async function getAccessToken(credentials: ICredentialDataDecryptedObject): Promise<string> {
+	const tenantId = (credentials.tenantId as string).trim();
+	const clientId = (credentials.clientId as string).trim();
+	const tokenUrl = `${TOKEN_HOST}/${tenantId}/oauth2/v2.0/token`;
+	const scope =
+		((credentials.scope as string) || '').trim() || 'https://graph.microsoft.com/.default';
+
+	const body = new URLSearchParams({
+		client_id: clientId,
+		scope,
+		grant_type: 'client_credentials',
+	});
+
+	if (credentials.authentication === 'certificate') {
+		const privateKey = formatPrivateKey(credentials.privateKey as string);
+		const certificate = formatPrivateKey(credentials.certificate as string);
+		const x5t = crypto
+			.createHash('sha1')
+			.update(new crypto.X509Certificate(certificate).raw)
+			.digest('base64url');
+
+		const now = Math.floor(Date.now() / 1000);
+		const clientAssertion = jwt.sign(
+			{
+				aud: tokenUrl,
+				iss: clientId,
+				sub: clientId,
+				jti: crypto.randomUUID(),
+				iat: now,
+				nbf: now,
+				exp: now + 300,
+			},
+			privateKey,
+			{ algorithm: 'RS256', header: { alg: 'RS256', typ: 'JWT', x5t } },
+		);
+
+		body.append('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+		body.append('client_assertion', clientAssertion);
+	} else {
+		body.append('client_secret', (credentials.clientSecret as string).trim());
+	}
+
+	const axiosRequestConfig: AxiosRequestConfig = {
+		method: 'POST',
+		url: tokenUrl,
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		data: body.toString(),
+	};
+
+	const result = await axios(axiosRequestConfig);
+	return result.data.access_token as string;
+}
+
+export class MicrosoftEntraServicePrincipalApi implements ICredentialType {
+	name = 'microsoftEntraServicePrincipalApi';
+
+	displayName = 'Microsoft Entra Service Principal API';
+
+	documentationUrl = 'microsoft';
+
+	icon: Icon = 'file:icons/Microsoft.svg';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			options: [
+				{ name: 'Client Secret', value: 'clientSecret' },
+				{ name: 'Certificate', value: 'certificate' },
+			],
+			default: 'clientSecret',
+		},
+		{
+			displayName: 'Directory (Tenant) ID',
+			name: 'tenantId',
+			type: 'string',
+			default: '',
+			required: true,
+			description: 'The Directory (tenant) ID from the Entra app registration overview',
+		},
+		{
+			displayName: 'Application (Client) ID',
+			name: 'clientId',
+			type: 'string',
+			default: '',
+			required: true,
+			description: 'The Application (client) ID from the Entra app registration overview',
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			displayOptions: { show: { authentication: ['clientSecret'] } },
+			description: 'A client secret created under Certificates & secrets → Client secrets',
+		},
+		{
+			displayName: 'Private Key',
+			name: 'privateKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			placeholder: '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----',
+			displayOptions: { show: { authentication: ['certificate'] } },
+			description: 'The PEM private key matching the certificate uploaded to Entra',
+		},
+		{
+			displayName: 'Certificate',
+			name: 'certificate',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			placeholder: '-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----',
+			displayOptions: { show: { authentication: ['certificate'] } },
+			description:
+				'The public certificate (PEM) uploaded to Entra. Used to compute the x5t thumbprint so Entra can validate the signed assertion.',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'string',
+			default: 'https://graph.microsoft.com/.default',
+			description:
+				'Resource scope. App-only must use the <resource>/.default form; the actual permissions come from admin-consented application permissions.',
+		},
+		{
+			displayName: 'Microsoft Graph Base URL',
+			name: 'graphApiBaseUrl',
+			type: 'string',
+			default: 'https://graph.microsoft.com',
+			description: 'Override for sovereign clouds (e.g. GCC High, China)',
+		},
+		{
+			displayName: 'User (UPN or ID)',
+			name: 'userId',
+			type: 'string',
+			default: '',
+			placeholder: 'user@contoso.com',
+			description:
+				'App-only has no signed-in user, so user-centric nodes (e.g. OneDrive) target this user instead of /me. The app needs the matching application permission (e.g. Files.Read.All).',
+		},
+	];
+
+	async authenticate(
+		credentials: ICredentialDataDecryptedObject,
+		requestOptions: IHttpRequestOptions,
+	): Promise<IHttpRequestOptions> {
+		const accessToken = await getAccessToken(credentials);
+		return {
+			...requestOptions,
+			headers: {
+				...requestOptions.headers,
+				Authorization: `Bearer ${accessToken}`,
+			},
+		};
+	}
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials.graphApiBaseUrl || "https://graph.microsoft.com"}}',
+			// If a user is configured, validate the realistic app-only path (uses the
+			// same Files.Read.All the consuming node needs). Otherwise fall back to a
+			// directory read (needs Organization.Read.All / Directory.Read.All).
+			url: '={{$credentials.userId ? ("/v1.0/users/" + $credentials.userId + "/drive") : "/v1.0/organization"}}',
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -53,7 +53,10 @@ export function validateOneDriveFileName(
 	}
 }
 
-export type OneDriveCredentialType = 'microsoftOneDriveOAuth2Api' | 'microsoftOAuth2Api';
+export type OneDriveCredentialType =
+	| 'microsoftOneDriveOAuth2Api'
+	| 'microsoftOAuth2Api'
+	| 'microsoftEntraServicePrincipalApi';
 
 /**
  * Resolves which credential type the node is configured to use. Defaults to the
@@ -87,6 +90,23 @@ export async function microsoftApiRequest(
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
+
+	const isServicePrincipal = credentialType === 'microsoftEntraServicePrincipalApi';
+
+	// App-only (service principal) has no signed-in user, so `/me` doesn't exist.
+	// Target the user configured on the credential instead.
+	let driveScope = '/me';
+	if (isServicePrincipal) {
+		const userId = (credentials.userId as string)?.trim();
+		if (!userId) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Set "User (UPN or ID)" on the Microsoft Entra Service Principal credential — app-only access has no /me.',
+			);
+		}
+		driveScope = `/users/${userId}`;
+	}
+
 	const options: IRequestOptions = {
 		headers: {
 			'Content-Type': 'application/json',
@@ -94,7 +114,7 @@ export async function microsoftApiRequest(
 		method,
 		body,
 		qs,
-		uri: uri || `${baseUrl}/v1.0/me${resource}`,
+		uri: uri || `${baseUrl}/v1.0${driveScope}${resource}`,
 	};
 	try {
 		Object.assign(options, option);
@@ -106,6 +126,10 @@ export async function microsoftApiRequest(
 		}
 		if (Object.keys(body as IDataObject).length === 0) {
 			delete options.body;
+		}
+		if (isServicePrincipal) {
+			// Custom-auth credential: its authenticate() mints the app-only token.
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
@@ -211,19 +235,12 @@ export async function getPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	itemId: string,
 ): Promise<string> {
-	const credentials = await this.getCredentials(getOneDriveCredentialType.call(this));
-	const baseUrl = (
-		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
-			? credentials.graphApiBaseUrl
-			: 'https://graph.microsoft.com'
-	).replace(/\/+$/, '');
+	// Pass the resource path (not a full URI) so the /me vs /users/{id} scope is
+	// resolved by microsoftApiRequest for whichever credential type is in use.
 	const responseData = (await microsoftApiRequest.call(
 		this,
 		'GET',
-		'',
-		{},
-		{},
-		`${baseUrl}/v1.0/me/drive/items/${itemId}`,
+		`/drive/items/${itemId}`,
 	)) as IDataObject;
 	if (responseData.folder) {
 		return (responseData?.parentReference as IDataObject)?.path + `/${responseData?.name}`;

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -52,6 +52,15 @@ export class MicrosoftOneDrive implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'microsoftEntraServicePrincipalApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftEntraServicePrincipalApi'],
+					},
+				},
+			},
 		],
 		properties: [
 			{
@@ -69,6 +78,13 @@ export class MicrosoftOneDrive implements INodeType {
 						value: 'microsoftOAuth2Api',
 						description:
 							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Files.ReadWrite.All) on the credential.',
+					},
+					{
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'Microsoft Entra Service Principal (app-only)',
+						value: 'microsoftEntraServicePrincipalApi',
+						description:
+							'App-only credential (no signed-in user). Requires the "User (UPN or ID)" field on the credential, since app-only has no /me.',
 					},
 				],
 				default: 'microsoftOneDriveOAuth2Api',

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -246,6 +246,7 @@
       "dist/credentials/MicrosoftAzureMonitorOAuth2Api.credentials.js",
       "dist/credentials/MicrosoftDynamicsOAuth2Api.credentials.js",
       "dist/credentials/MicrosoftEntraOAuth2Api.credentials.js",
+      "dist/credentials/MicrosoftEntraServicePrincipalApi.credentials.js",
       "dist/credentials/MicrosoftExcelOAuth2Api.credentials.js",
       "dist/credentials/MicrosoftGraphSecurityOAuth2Api.credentials.js",
       "dist/credentials/MicrosoftOAuth2Api.credentials.js",


### PR DESCRIPTION
## Summary

⚠️ **Draft / spike PoC — not for merge.** Output of the ENT-74 spike, for hands-on review.

Adds a Microsoft Entra **service-principal (app-only)** credential that gets a Microsoft Graph token via the OAuth2 `client_credentials` grant, supporting both methods:
- **Client secret** — posts the secret.
- **Certificate** — signs a short-lived `client_assertion` JWT (RS256) whose `x5t` header is the cert's SHA-1 thumbprint, so Entra can validate it.

Wires it into the **OneDrive node** as a third authentication option: the transport branches to `requestWithAuthentication` for this custom-auth credential, and the `/me` prefix is swapped for `/users/{userId}` since app-only has no signed-in user.

**Known gaps (intentional — it's a spike):** no tests; OneDrive **Search** is not handled (Graph rejects `search()` app-only with `403 accessDenied` — confirmed delegated-only); the **trigger** still uses `/me/.../delta`; the user target lives on the credential as a stopgap (belongs on the node); no token caching. Full findings are in the Linear ticket comment.

## How to test

1. Build and start n8n (`pnpm --filter n8n-nodes-base build`).
2. In Entra: register an app, add a **client secret** or upload a **certificate**, grant **Application** permission `Files.Read.All`/`Files.ReadWrite.All`, and **grant admin consent**.
3. In n8n, create a *Microsoft Entra Service Principal API* credential (tenant ID, client ID, secret or private key + certificate, and **User (UPN or ID)**). Click **Test** — should connect.
4. In a OneDrive node, set Authentication → *Microsoft Entra Service Principal (app-only)*, pick the credential, and run a non-search File/Folder operation (get / download / list). It addresses `/users/{upn}/drive`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-74

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32616">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->