### PR TITLE
feat(editor): Add published workflow count to dynamic banners (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -116,6 +116,9 @@ export interface FrontendSettings {
 	dynamicBanners: {
 		endpoint: string;
 		enabled: boolean;
+		filters: {
+			publishedWorkflowCount: number;
+		};
 	};
 	instanceId: string;
 	telemetry: ITelemetrySettings;

--- a/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/workflow.repository.test.ts
@@ -1,5 +1,5 @@
 import { GlobalConfig } from '@n8n/config';
-import { In, type SelectQueryBuilder } from '@n8n/typeorm';
+import { In, IsNull, Not, type SelectQueryBuilder } from '@n8n/typeorm';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -573,6 +573,22 @@ describe('WorkflowRepository', () => {
 			const result = await workflowRepository.getPublishedPersonalWorkflowsCount();
 
 			expect(result).toBe(3);
+		});
+	});
+
+	describe('getPublishedCount', () => {
+		it('should count non-archived workflows with an active version', async () => {
+			const countSpy = vi.spyOn(workflowRepository, 'count').mockResolvedValue(7);
+
+			const result = await workflowRepository.getPublishedCount();
+
+			expect(result).toBe(7);
+			expect(countSpy).toHaveBeenCalledWith({
+				where: {
+					activeVersionId: Not(IsNull()),
+					isArchived: false,
+				},
+			});
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -99,6 +99,12 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 		});
 	}
 
+	async getPublishedCount() {
+		return await this.count({
+			where: { activeVersionId: Not(IsNull()), isArchived: false },
+		});
+	}
+
 	async getPublishedPersonalWorkflowsCount(): Promise<number> {
 		return await this.createQueryBuilder('workflow')
 			.innerJoin('workflow.shared', 'shared')

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -1,5 +1,6 @@
 import type { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
 import type { GlobalConfig, SecurityConfig } from '@n8n/config';
+import type { WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import type { BinaryDataConfig, InstanceSettings } from 'n8n-core';
@@ -41,6 +42,10 @@ describe('FrontendService', () => {
 			whatsNewEnabled: false,
 			whatsNewEndpoint: '',
 			infoUrl: '',
+		},
+		dynamicBanners: {
+			endpoint: 'https://api.n8n.io/api/banners',
+			enabled: true,
 		},
 		personalization: { enabled: false },
 		defaultLocale: 'en',
@@ -178,6 +183,10 @@ describe('FrontendService', () => {
 		getAiUsageSettings: jest.fn().mockResolvedValue(true),
 	});
 
+	const workflowRepository = mock<WorkflowRepository>({
+		getPublishedCount: jest.fn().mockResolvedValue(7),
+	});
+
 	const createMockService = () => {
 		Container.set(
 			CommunityPackagesConfig,
@@ -205,6 +214,7 @@ describe('FrontendService', () => {
 				mfaService,
 				ownershipService,
 				aiUsageService,
+				workflowRepository,
 			),
 			license,
 		};
@@ -213,6 +223,7 @@ describe('FrontendService', () => {
 	beforeEach(() => {
 		originalEnv = process.env;
 		jest.clearAllMocks();
+		globalConfig.diagnostics.enabled = false;
 	});
 
 	afterEach(() => {
@@ -228,6 +239,43 @@ describe('FrontendService', () => {
 				expect.objectContaining({
 					settingsMode: 'authenticated',
 				}),
+			);
+		});
+
+		it('should include dynamic banner filters', async () => {
+			globalConfig.diagnostics.enabled = true;
+			globalConfig.diagnostics.frontendConfig = 'key;http://localhost';
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.dynamicBanners.filters).toEqual({
+				publishedWorkflowCount: 7,
+			});
+			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(1);
+
+			const refreshedSettings = await service.getSettings();
+
+			expect(refreshedSettings.dynamicBanners.filters).toEqual({
+				publishedWorkflowCount: 7,
+			});
+			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fall back when dynamic banner filters cannot be loaded', async () => {
+			globalConfig.diagnostics.enabled = true;
+			globalConfig.diagnostics.frontendConfig = 'key;http://localhost';
+			workflowRepository.getPublishedCount.mockRejectedValueOnce(new Error('database unavailable'));
+
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+
+			expect(settings.dynamicBanners.filters).toEqual({
+				publishedWorkflowCount: 0,
+			});
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to fetch published workflow count for dynamic banners',
+				expect.objectContaining({ error: expect.any(Error) }),
 			);
 		});
 

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -227,6 +227,7 @@ describe('FrontendService', () => {
 	});
 
 	afterEach(() => {
+		jest.useRealTimers();
 		process.env = originalEnv;
 	});
 
@@ -242,9 +243,11 @@ describe('FrontendService', () => {
 			);
 		});
 
-		it('should include dynamic banner filters', async () => {
+		it('should cache dynamic banner filters for 30 seconds', async () => {
+			jest.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z') });
 			globalConfig.diagnostics.enabled = true;
 			globalConfig.diagnostics.frontendConfig = 'key;http://localhost';
+			workflowRepository.getPublishedCount.mockResolvedValueOnce(7).mockResolvedValueOnce(8);
 
 			const { service } = createMockService();
 			const settings = await service.getSettings();
@@ -254,12 +257,21 @@ describe('FrontendService', () => {
 			});
 			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(1);
 
-			const refreshedSettings = await service.getSettings();
+			jest.advanceTimersByTime(29_999);
+			const cachedSettings = await service.getSettings();
 
-			expect(refreshedSettings.dynamicBanners.filters).toEqual({
+			expect(cachedSettings.dynamicBanners.filters).toEqual({
 				publishedWorkflowCount: 7,
 			});
 			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(1);
+
+			jest.advanceTimersByTime(1);
+			const refreshedSettings = await service.getSettings();
+
+			expect(refreshedSettings.dynamicBanners.filters).toEqual({
+				publishedWorkflowCount: 8,
+			});
+			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(2);
 		});
 
 		it('should fall back when dynamic banner filters cannot be loaded', async () => {
@@ -273,6 +285,30 @@ describe('FrontendService', () => {
 			expect(settings.dynamicBanners.filters).toEqual({
 				publishedWorkflowCount: 0,
 			});
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to fetch published workflow count for dynamic banners',
+				expect.objectContaining({ error: expect.any(Error) }),
+			);
+		});
+
+		it('should fall back to the last published workflow count when refresh fails', async () => {
+			jest.useFakeTimers({ now: new Date('2026-01-01T00:00:00.000Z') });
+			globalConfig.diagnostics.enabled = true;
+			globalConfig.diagnostics.frontendConfig = 'key;http://localhost';
+			workflowRepository.getPublishedCount
+				.mockResolvedValueOnce(7)
+				.mockRejectedValueOnce(new Error('database unavailable'));
+
+			const { service } = createMockService();
+			await service.getSettings();
+			jest.advanceTimersByTime(30_000);
+
+			const settings = await service.getSettings();
+
+			expect(settings.dynamicBanners.filters).toEqual({
+				publishedWorkflowCount: 7,
+			});
+			expect(workflowRepository.getPublishedCount).toHaveBeenCalledTimes(2);
 			expect(logger.warn).toHaveBeenCalledWith(
 				'Failed to fetch published workflow count for dynamic banners',
 				expect.objectContaining({ error: expect.any(Error) }),

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -1,7 +1,8 @@
 import type { FrontendSettings, ITelemetrySettings, N8nEnvFeatFlags } from '@n8n/api-types';
 import { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig, SecurityConfig } from '@n8n/config';
-import { LICENSE_FEATURES, LICENSE_QUOTAS } from '@n8n/constants';
+import { LICENSE_FEATURES, LICENSE_QUOTAS, Time } from '@n8n/constants';
+import { WorkflowRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { createWriteStream } from 'fs';
 import { mkdir } from 'fs/promises';
@@ -32,6 +33,8 @@ import {
 } from '@/workflows/workflow-history/workflow-history-helper';
 import { AiUsageService } from './ai-usage.service';
 import { UrlService } from './url.service';
+
+const DYNAMIC_BANNER_FILTERS_CACHE_TTL = 5 * Time.minutes.toMilliseconds;
 
 /**
  * IMPORTANT: Only add settings that are absolutely necessary for non-authenticated pages
@@ -111,6 +114,10 @@ export class FrontendService {
 
 	private communityPackagesService?: CommunityPackagesService;
 
+	private publishedWorkflowCountCache?: { value: number; expiresAt: number };
+
+	private publishedWorkflowCountRequest?: Promise<number>;
+
 	constructor(
 		private readonly globalConfig: GlobalConfig,
 		private readonly logger: Logger,
@@ -129,6 +136,7 @@ export class FrontendService {
 		private readonly mfaService: MfaService,
 		private readonly ownershipService: OwnershipService,
 		private readonly aiUsageService: AiUsageService,
+		private readonly workflowRepository: WorkflowRepository,
 	) {
 		loadNodesAndCredentials.addPostProcessor(async () => await this.generateTypes());
 		void this.generateTypes();
@@ -238,6 +246,9 @@ export class FrontendService {
 			dynamicBanners: {
 				endpoint: this.globalConfig.dynamicBanners.endpoint,
 				enabled: this.globalConfig.dynamicBanners.enabled && this.globalConfig.diagnostics.enabled,
+				filters: {
+					publishedWorkflowCount: 0,
+				},
 			},
 			instanceId: this.instanceSettings.instanceId,
 			telemetry: telemetrySettings,
@@ -436,6 +447,8 @@ export class FrontendService {
 			oauth2: `${instanceBaseUrl}/${restEndpoint}/oauth2-credential/callback`,
 		};
 		this.settings.jwksUri = `${instanceBaseUrl}/${restEndpoint}/.well-known/jwks.json`;
+		this.settings.dynamicBanners.filters.publishedWorkflowCount =
+			await this.getPublishedWorkflowCountForDynamicBanners();
 
 		// refresh user management status
 		Object.assign(this.settings.userManagement, {
@@ -589,6 +602,34 @@ export class FrontendService {
 		this.settings.envFeatureFlags = this.collectEnvFeatureFlags();
 
 		return this.settings;
+	}
+
+	private async getPublishedWorkflowCountForDynamicBanners(): Promise<number> {
+		if (!this.settings.dynamicBanners.enabled) return 0;
+
+		const now = Date.now();
+		if (this.publishedWorkflowCountCache && this.publishedWorkflowCountCache.expiresAt > now) {
+			return this.publishedWorkflowCountCache.value;
+		}
+
+		try {
+			this.publishedWorkflowCountRequest ??= this.workflowRepository
+				.getPublishedCount()
+				.finally(() => {
+					this.publishedWorkflowCountRequest = undefined;
+				});
+
+			const value = await this.publishedWorkflowCountRequest;
+			this.publishedWorkflowCountCache = {
+				value,
+				expiresAt: Date.now() + DYNAMIC_BANNER_FILTERS_CACHE_TTL,
+			};
+
+			return value;
+		} catch (error) {
+			this.logger.warn('Failed to fetch published workflow count for dynamic banners', { error });
+			return this.publishedWorkflowCountCache?.value ?? 0;
+		}
 	}
 
 	/**

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -34,7 +34,7 @@ import {
 import { AiUsageService } from './ai-usage.service';
 import { UrlService } from './url.service';
 
-const DYNAMIC_BANNER_FILTERS_CACHE_TTL = 5 * Time.minutes.toMilliseconds;
+const DYNAMIC_BANNER_FILTERS_CACHE_TTL = 30 * Time.seconds.toMilliseconds;
 
 /**
  * IMPORTANT: Only add settings that are absolutely necessary for non-authenticated pages

--- a/packages/frontend/@n8n/rest-api-client/src/api/dynamic-banners.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/dynamic-banners.ts
@@ -17,6 +17,7 @@ type DynamicBannerFilters = {
 	deploymentType: string;
 	planName?: string;
 	instanceId: string;
+	userId?: string;
 	userCreatedAt?: string;
 	isOwner?: boolean;
 	role?: Role;

--- a/packages/frontend/@n8n/rest-api-client/src/api/dynamic-banners.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/dynamic-banners.ts
@@ -20,6 +20,7 @@ type DynamicBannerFilters = {
 	userCreatedAt?: string;
 	isOwner?: boolean;
 	role?: Role;
+	publishedWorkflowCount?: number;
 };
 
 export async function getDynamicBanners(

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -185,5 +185,8 @@ export const defaultSettings: FrontendSettings = {
 	dynamicBanners: {
 		endpoint: 'https://api.n8n.io/api/banners',
 		enabled: true,
+		filters: {
+			publishedWorkflowCount: 0,
+		},
 	},
 };

--- a/packages/frontend/editor-ui/src/features/shared/banners/banners.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/banners/banners.store.test.ts
@@ -17,11 +17,18 @@ describe('Banners store', () => {
 			dynamicBanners: {
 				endpoint: 'https://test.endpoint.com',
 				enabled: false,
+				filters: {
+					publishedWorkflowCount: 0,
+				},
 			},
 			banners: {
 				dismissed: [],
 			},
 		} as unknown as typeof settingsStore.settings;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it('should add non-production license banner to stack based on enterprise settings', () => {
@@ -83,6 +90,9 @@ describe('Banners store', () => {
 			dynamicBanners: {
 				endpoint: 'https://test.endpoint.com',
 				enabled: true,
+				filters: {
+					publishedWorkflowCount: 2,
+				},
 			},
 			banners: {
 				dismissed: ['dynamic-banner-2'],
@@ -99,5 +109,41 @@ describe('Banners store', () => {
 		expect(freshBannersStore.bannerStack).toContain('dynamic-banner-3');
 
 		expect(freshBannersStore.bannerStack).not.toContain('dynamic-banner-2');
+	});
+
+	it('should send dynamic banner filters as flat query params', async () => {
+		const getDynamicBannersSpy = vi
+			.spyOn(dynamicBannersApi, 'getDynamicBanners')
+			.mockResolvedValue([]);
+
+		settingsStore.settings = {
+			versionCli: '1.2.3',
+			deployment: { type: 'cloud' },
+			instanceId: 'instance-id',
+			license: { planName: 'Pro' },
+			dynamicBanners: {
+				endpoint: 'https://test.endpoint.com',
+				enabled: true,
+				filters: {
+					publishedWorkflowCount: 4,
+				},
+			},
+			banners: {
+				dismissed: [],
+			},
+		} as unknown as typeof settingsStore.settings;
+
+		await bannersStore.loadDynamicBanners();
+
+		expect(getDynamicBannersSpy).toHaveBeenCalledWith(
+			'https://test.endpoint.com',
+			expect.objectContaining({
+				version: '1.2.3',
+				deploymentType: 'cloud',
+				instanceId: 'instance-id',
+				planName: 'Pro',
+				publishedWorkflowCount: 4,
+			}),
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/shared/banners/banners.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/banners/banners.store.test.ts
@@ -2,15 +2,18 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import * as dynamicBannersApi from '@n8n/rest-api-client/api/dynamic-banners';
+import { useUsersStore } from '@/features/settings/users/users.store';
 
 let bannersStore: ReturnType<typeof useBannersStore>;
 let settingsStore: ReturnType<typeof useSettingsStore>;
+let usersStore: ReturnType<typeof useUsersStore>;
 
 describe('Banners store', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		bannersStore = useBannersStore();
 		settingsStore = useSettingsStore();
+		usersStore = useUsersStore();
 
 		// Set up settings store with required configuration
 		settingsStore.settings = {
@@ -132,6 +135,8 @@ describe('Banners store', () => {
 				dismissed: [],
 			},
 		} as unknown as typeof settingsStore.settings;
+		usersStore.addUsers([{ id: 'current-user-id' }]);
+		usersStore.currentUserId = 'current-user-id';
 
 		await bannersStore.loadDynamicBanners();
 
@@ -142,6 +147,7 @@ describe('Banners store', () => {
 				deploymentType: 'cloud',
 				instanceId: 'instance-id',
 				planName: 'Pro',
+				userId: 'current-user-id',
 				publishedWorkflowCount: 4,
 			}),
 		);

--- a/packages/frontend/editor-ui/src/features/shared/banners/banners.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/banners/banners.store.ts
@@ -51,6 +51,8 @@ export const useBannersStore = defineStore(STORES.BANNERS, () => {
 					userCreatedAt: usersStore.currentUser?.createdAt,
 					isOwner: usersStore.currentUser?.isOwner,
 					role: usersStore.currentUser?.role,
+					publishedWorkflowCount:
+						settingsStore.settings.dynamicBanners.filters.publishedWorkflowCount,
 				})
 			).map((item) => ({
 				...item,

--- a/packages/frontend/editor-ui/src/features/shared/banners/banners.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/banners/banners.store.ts
@@ -48,6 +48,7 @@ export const useBannersStore = defineStore(STORES.BANNERS, () => {
 					deploymentType,
 					instanceId: settingsStore.settings.instanceId,
 					planName: settingsStore.settings.license?.planName,
+					userId: usersStore.currentUser?.id,
 					userCreatedAt: usersStore.currentUser?.createdAt,
 					isOwner: usersStore.currentUser?.isOwner,
 					role: usersStore.currentUser?.role,


### PR DESCRIPTION
## Summary

Adds dynamic banner targeting data from n8n instances:

  - Adds `dynamicBanners.filters.publishedWorkflowCount` to frontend settings.
  - Counts published workflows as non-archived workflows with an active version.
  - Sends `publishedWorkflowCount` as a flat query param to the dynamic banners API.
  - Sends the current logged-in n8n user ID as `userId` to the dynamic banners API.
  - Keeps the published workflow count cached briefly, with a 30-second TTL and non-fatal
  fallback behavior if the count cannot be refreshed.


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/GROP-22
  https://linear.app/n8n/issue/GROP-25


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32619">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->