### PR TITLE
fix(editor): Hide template setup button when only disabled nodes lack credentials

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -300,6 +300,47 @@ describe('SetupWorkflowCredentialsButton', () => {
 			const { getByTestId } = renderComponent();
 			expect(getByTestId('setup-credentials-button')).toBeVisible();
 		});
+
+		it('ignores disabled nodes when deciding whether all credentials are filled', () => {
+			const nodes = [
+				{
+					id: '1',
+					name: 'OpenAI Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				},
+				{
+					id: '2',
+					name: 'Disabled Slack',
+					type: 'n8n-nodes-base.slack',
+					typeVersion: 1,
+					position: [200, 0] as [number, number],
+					parameters: {},
+					disabled: true,
+				},
+			];
+			workflowsStore.workflowId = workflowWithNodes.id;
+			setWorkflowDocumentStoreState(
+				{ templateId: '2722', templateCredsSetupCompleted: false },
+				nodes,
+			);
+			setupPanelStore.isFeatureEnabled = true;
+			// The enabled node has its credentials filled; the disabled node does not.
+			mockDoesNodeHaveAllCredentialsFilled.mockImplementation(
+				(_provider: unknown, node: { id: string }) => node.id === '1',
+			);
+
+			const { queryByTestId } = renderComponent();
+
+			expect(queryByTestId('setup-credentials-button')).toBeNull();
+			// The disabled node must never be checked for credentials.
+			expect(mockDoesNodeHaveAllCredentialsFilled).not.toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ id: '2' }),
+			);
+		});
 	});
 
 	describe('modal auto-open on mount', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -38,7 +38,9 @@ const allCredentialsFilled = computed(() => {
 		return true;
 	}
 
-	const nodes = workflowDocumentStore?.value?.allNodes ?? [];
+	// Disabled nodes are skipped during execution, so their unfilled
+	// credentials must not keep the setup button visible.
+	const nodes = (workflowDocumentStore?.value?.allNodes ?? []).filter((node) => !node.disabled);
 	if (!nodes.length) {
 		return true;
 	}


### PR DESCRIPTION
## Summary

The "Set up template" button stayed visible even after a template workflow ran successfully, with no way for the user to dismiss it.

The button hides once `allCredentialsFilled` is true, which required **every** node (including disabled ones) to have its credentials filled. A disabled node is skipped during execution, so the workflow can run successfully while the disabled node's unfilled credential keeps `allCredentialsFilled` false forever, leaving the button stuck on screen. Templates commonly ship with disabled example nodes, which is what triggered the reported cases.

This change excludes disabled nodes from the credential check, so they no longer keep the setup button visible.

## How to test

1. Open a template workflow that contains a disabled node which requires credentials (e.g. a disabled Slack/HTTP example node).
2. Fill in the credentials for the enabled nodes and run the workflow successfully.
3. The "Set up template" button should no longer be shown.

Regression coverage added in `SetupWorkflowCredentialsButton.test.ts`: the button hides when the only node with unfilled credentials is disabled, and disabled nodes are never checked for credentials.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5436

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

