### PR TITLE
fix(Form Trigger Node): Add default value for authentication parameter to prevent crash on old workflows

### DIFF
--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -436,7 +436,9 @@ describe('FormTrigger, formWebhook', () => {
 		.calledWith('formDescription')
 		.mockReturnValue('Test Description');
 	executeFunctions.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
-	executeFunctions.getNodeParameter.calledWith('authentication').mockReturnValue('none');
+	executeFunctions.getNodeParameter
+		.calledWith('authentication', 'none')
+		.mockReturnValue('none');
 	executeFunctions.getRequestObject.mockReturnValue({ method: 'GET', query: {} } as any);
 	executeFunctions.getMode.mockReturnValue('manual');
 	executeFunctions.getInstanceId.mockReturnValue('instanceId');
@@ -831,7 +833,7 @@ describe('FormTrigger, formWebhook', () => {
 			ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
 			ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('Test Description');
 			ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
-			ctx.getNodeParameter.calledWith('authentication').mockReturnValue('n8nUserAuth');
+			ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('n8nUserAuth');
 			ctx.getNodeParameter.calledWith('formFields.values').mockReturnValue(formFields);
 			ctx.getRequestObject.mockReturnValue(request as any);
 			ctx.getHeaderData.mockReturnValue(request.headers);
@@ -879,7 +881,7 @@ describe('FormTrigger, formWebhook', () => {
 			};
 			ctx.getNode.mockReturnValue({ typeVersion: 2.6 } as INode);
 			ctx.getNodeParameter.calledWith('options').mockReturnValue({});
-			ctx.getNodeParameter.calledWith('authentication').mockReturnValue('n8nUserAuth');
+			ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('n8nUserAuth');
 			ctx.getRequestObject.mockReturnValue({
 				method: 'GET',
 				originalUrl: '/form/test',

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -436,9 +436,7 @@ describe('FormTrigger, formWebhook', () => {
 		.calledWith('formDescription')
 		.mockReturnValue('Test Description');
 	executeFunctions.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
-	executeFunctions.getNodeParameter
-		.calledWith('authentication', 'none')
-		.mockReturnValue('none');
+	executeFunctions.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('none');
 	executeFunctions.getRequestObject.mockReturnValue({ method: 'GET', query: {} } as any);
 	executeFunctions.getMode.mockReturnValue('manual');
 	executeFunctions.getInstanceId.mockReturnValue('instanceId');
@@ -447,6 +445,32 @@ describe('FormTrigger, formWebhook', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	it('renders the form when the node has no stored authentication parameter', async () => {
+		const ctx = mock<IWebhookFunctions>();
+		ctx.getNode.mockReturnValue({ typeVersion: 1, name: 'Form Trigger' } as INode);
+
+		// Mirror the engine: getNodeParameter throws when the key is absent and
+		// no default is supplied, but returns the default when one is given.
+		ctx.getNodeParameter.calledWith('authentication').mockImplementation(() => {
+			throw new Error('Could not get parameter');
+		});
+		ctx.getNodeParameter.calledWith('authentication', 'none').mockReturnValue('none');
+
+		ctx.getNodeParameter.calledWith('options').mockReturnValue({});
+		ctx.getNodeParameter.calledWith('formFields.values').mockReturnValue([]);
+		ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
+		ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('');
+		ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
+
+		ctx.getRequestObject.mockReturnValue({ method: 'GET', query: {}, headers: {} } as any);
+		ctx.getResponseObject.mockReturnValue({ render: vi.fn(), setHeader: vi.fn() } as any);
+		ctx.getMode.mockReturnValue('manual');
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getChildNodes.mockReturnValue([]);
+
+		await expect(formWebhook(ctx)).resolves.toEqual({ noWebhookResponse: true });
 	});
 
 	it('should call response render', async () => {

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -793,7 +793,7 @@ export async function formWebhook(
 		return { noWebhookResponse: true };
 	}
 
-	const authentication = (context.getNodeParameter(authProperty) as string) ?? 'none';
+	const authentication = context.getNodeParameter(authProperty, 'none') as string;
 	let authedUser: IUser | undefined;
 	if (node.typeVersion > 1) {
 		if (authentication === 'n8nUserAuth') {

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -714,7 +714,7 @@ describe('Auth token generation', () => {
 
 			await generateFormPostBasicAuthToken(webhookFunctions, 'authentication');
 
-			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith('authentication');
+			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith('authentication', 'none');
 		});
 
 		it('should use passed authentication key', async () => {
@@ -725,7 +725,7 @@ describe('Auth token generation', () => {
 
 			await generateFormPostBasicAuthToken(webhookFunctions, 'incomingAuthentication');
 
-			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith('incomingAuthentication');
+			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith('incomingAuthentication', 'none');
 		});
 
 		it('should handle "none" authentication', async () => {

--- a/packages/nodes-base/nodes/Webhook/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/utils.test.ts
@@ -725,7 +725,10 @@ describe('Auth token generation', () => {
 
 			await generateFormPostBasicAuthToken(webhookFunctions, 'incomingAuthentication');
 
-			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith('incomingAuthentication', 'none');
+			expect(webhookFunctions.getNodeParameter).toHaveBeenCalledWith(
+				'incomingAuthentication',
+				'none',
+			);
 		});
 
 		it('should handle "none" authentication', async () => {

--- a/packages/nodes-base/nodes/Webhook/utils.ts
+++ b/packages/nodes-base/nodes/Webhook/utils.ts
@@ -236,7 +236,7 @@ export async function validateWebhookAuthentication(
 	ctx: IWebhookFunctions,
 	authPropertyName: string,
 ): Promise<IDataObject | undefined> {
-	const authentication = ctx.getNodeParameter(authPropertyName) as string;
+	const authentication = ctx.getNodeParameter(authPropertyName, 'none') as string;
 	if (authentication === 'none') return;
 
 	const req = ctx.getRequestObject();
@@ -426,7 +426,7 @@ export async function generateFormPostBasicAuthToken(
 ) {
 	const node = context.getNode();
 
-	const authentication = context.getNodeParameter(authPropertyName);
+	const authentication = context.getNodeParameter(authPropertyName, 'none');
 	if (authentication === 'none') return;
 
 	let credentials: ICredentialDataDecryptedObject | undefined;


### PR DESCRIPTION
## Summary

Follow-up to community PR #32431 by @returnSGD, opened so we can land it with a formatting fix and a regression test.

Form Trigger nodes created before the `authentication` field existed throw `Could not get parameter` on form submission after an n8n upgrade. The regression was introduced in #30539 (n8n 2.24.0), which hoisted the `getNodeParameter('authentication')` read out of the `if (node.typeVersion > 1)` guard without a real default — so `typeVersion: 1` nodes (which have no `authentication` property in their node type) now hit it and throw. The existing `?? 'none'` was unreachable because `getNodeParameter` throws before returning.

This PR contains:
1. **@returnSGD's fix** (cherry-picked, authorship preserved) — pass `'none'` as the second-argument default to `getNodeParameter` at the three call sites in `Form/utils/utils.ts` and `Webhook/utils.ts`.
2. **Formatting fix** — the original test edits failed `biome` `format:check` (a chain that should be one line, and a call that needed wrapping).
3. **Regression test** — `formWebhook` now renders instead of throwing for a `typeVersion: 1` node whose stored params omit `authentication`.

The Webhook node itself is unaffected: it declares `authentication` in every version, so an absent stored key falls back to the schema default `'none'`. The two `Webhook/utils.ts` changes are defensive hardening of the shared helpers.

## How to test

1. Import a workflow with an `n8n-nodes-base.formTrigger` node pinned to `typeVersion: 1` (no `authentication` param), activate it, and open the production Form URL — it renders/submits instead of failing with `Workflow could not be started!`.
2. `cd packages/nodes-base && pnpm test nodes/Form/test/utils.test.ts nodes/Webhook/test/utils.test.ts` — all pass, including the new regression test.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5290
- Fixes #32406
- Follow-up to #32431

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->