### PR TITLE
fix: Stop a timed-out background AI builder from respawning itself

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1098,6 +1098,30 @@ describe('InstanceAiService — background task auto-follow-up', () => {
 		);
 	});
 
+	it('skips internal follow-up when the task itself timed out', async () => {
+		const { service, task, getSpawnOptions } = createBackgroundTaskFollowUpService();
+		task.status = 'failed';
+		task.timeoutReason = 'idle_timeout';
+		task.error = 'Background workflow-builder task timed out after 600000ms';
+
+		service.spawnBackgroundTask(
+			'run-1',
+			{
+				taskId: 'task-1',
+				threadId: 'thread-a',
+				agentId: 'agent-builder',
+				role: 'workflow-builder',
+				run: async () => 'done',
+			},
+			{},
+			'group-1',
+		);
+		await getSpawnOptions().onSettled?.(task);
+
+		expect(service.startInternalFollowUpRun).not.toHaveBeenCalled();
+		expect(service.recordBackgroundTerminalOutcome).toHaveBeenCalledWith(task);
+	});
+
 	it('clears the active-timeout guard when the user starts a new run', () => {
 		const service = createStartRunService();
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -5253,6 +5253,16 @@ export class InstanceAiService {
 						return;
 					}
 
+					// Don't auto-respawn a task that timed out — hand back to the user instead.
+					if (task.timeoutReason) {
+						this.logger.debug('Skipping background auto-follow-up after task timeout', {
+							threadId: opts.threadId,
+							taskId: task.taskId,
+							timeoutReason: task.timeoutReason,
+						});
+						return;
+					}
+
 					const user = this.runState.getThreadUser(opts.threadId);
 					if (user) {
 						const verificationFollowUpStarted = await this.maybeStartWorkflowVerificationFollowUp(


### PR DESCRIPTION
## Summary

A production trace (instance-ai) showed a workflow-builder running as a background task for ~14 min, then ~64 min, with no active orchestrator run, burning credits, made worse by the orchestrator auto-continuing (`(continue)`) and respawning the builder each time it timed out.

This scopes down to the backend root cause: in `instance-ai.service` `onSettled`, the auto-continue follow-up now skips when the background task timed out (`task.timeoutReason`), handing back to the user instead of re-running and re-billing.

The frontend stop-button change is dropped from this PR: it relied on `collectActiveBuilderAgents`, the builder-agent signal that has since been removed.

## How to test

1. Start an Instance AI build that delegates to a background workflow-builder.
2. Simulate a builder timeout and confirm it does **not** auto-respawn with `(continue)`, the thread hands back to the user.

Automated coverage:
- `packages/cli` `instance-ai.service.test.ts`: skips internal follow-up when the task itself timed out.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-556

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
