### PR TITLE
fix(editor): Prevent header NDV store crash on blank canvas (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.test.ts
@@ -132,4 +132,21 @@ describe('MainHeader', () => {
 		const workflowDetails = getByTestId('workflow-details-stub');
 		expect(workflowDetails).toBeInTheDocument();
 	});
+
+	// Regression: the header renders before the workflow document store is set
+	// (e.g. the blank-canvas boot window). It must not throw when no NDV store is
+	// available — it uses injectNDVStoreIfProvided() and guards the access.
+	// (WorkflowDetails is `v-if="workflowName"`, so it is absent with no workflow;
+	// the point is that rendering the header does not throw.)
+	it('renders without throwing when no workflow document is loaded', () => {
+		expect(() =>
+			renderComponent({
+				global: {
+					provide: {
+						[WorkflowDocumentStoreKey as symbol]: shallowRef(null),
+					},
+				},
+			}),
+		).not.toThrow();
+	});
 });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -11,7 +11,7 @@ import {
 	N8N_MAIN_GITHUB_REPO_URL,
 } from '@/app/constants';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
@@ -32,7 +32,9 @@ const route = useRoute();
 const locale = useI18n();
 const pushConnection = usePushConnection({ router });
 const toast = useToast();
-const ndvStore = injectNDVStore();
+// The editor header renders before a workflow document is loaded (e.g. the
+// blank-canvas boot window), so use the non-throwing accessor and guard reads.
+const ndvStore = injectNDVStoreIfProvided();
 const uiStore = useUIStore();
 const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
@@ -65,7 +67,7 @@ const tabBarItems = computed(() => {
 	];
 });
 
-const activeNode = computed(() => ndvStore.value.activeNode);
+const activeNode = computed(() => ndvStore.value?.activeNode ?? null);
 const hideMenuBar = computed(() =>
 	Boolean(activeNode.value && activeNode.value.type !== STICKY_NODE_TYPE),
 );


### PR DESCRIPTION
## Summary

The editor header (`MainHeader`) reads the per-workflow NDV store, which — since the strict-injection refactor (#32460) — throws when no workflow document is loaded. `MainHeader` renders during the blank-canvas boot window before the document store is set, so this threw an uncaught error and broke the `dev-server-smoke` "blank canvas boots cleanly" test. This switches `MainHeader` to the existing non-throwing `injectNDVStoreIfProvided()` accessor and guards the `activeNode` read; behaviour is unchanged once a workflow loads, and strict `injectNDVStore()` stays the default for NDV-internal consumers.

## How to test

- Open a blank canvas (new workflow) — the editor boots with no uncaught console/page error.
- `pnpm --filter=n8n-playwright test:dev-server-smoke` → the "blank canvas boots cleanly" case passes.
- `cd packages/frontend/editor-ui && pnpm vitest run src/app/components/MainHeader/MainHeader.test.ts` — includes a regression test that renders the header with no workflow document provided (fails without this fix).

## Related Linear tickets, Github issues, and Community forum posts

Follow-up fix for the strict `injectNDVStore` refactor (#32460). No separate ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32631">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

