### PR TITLE
fix: Suggest the configured AI provider's chat model when building workflows

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/nodes.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/nodes.tool.test.ts
@@ -212,6 +212,74 @@ describe('nodes tool', () => {
 			});
 		});
 
+		it("suggests the chat model for the user's configured provider on ai_languageModel requirements", async () => {
+			const searchableNodes = [
+				{
+					name: '@n8n/n8n-nodes-langchain.agent',
+					displayName: 'AI Agent',
+					description: 'Reasoning agent',
+					inputs: ['main'],
+					outputs: ['main'],
+					version: 1,
+					builderHint: { inputs: { ai_languageModel: { required: true } } },
+				},
+			];
+			const context = createMockContext();
+			(context.nodeService.listSearchable as Mock).mockResolvedValue(searchableNodes);
+			(context.credentialService.list as Mock).mockResolvedValue([
+				{ id: 'cred-1', name: 'My Anthropic key', type: 'anthropicApi' },
+			]);
+
+			const tool = createNodesTool(context, 'full');
+			const result = await executeTool(
+				tool,
+				{ action: 'search', query: 'agent', limit: 5 } as never,
+				{} as never,
+			);
+
+			expect(result).toMatchObject({
+				results: [
+					expect.objectContaining({
+						subnodeRequirements: [
+							expect.objectContaining({
+								connectionType: 'ai_languageModel',
+								suggestedNode: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+							}),
+						],
+					}),
+				],
+			});
+		});
+
+		it('does not suggest a chat model when no LLM credential is configured', async () => {
+			const searchableNodes = [
+				{
+					name: '@n8n/n8n-nodes-langchain.agent',
+					displayName: 'AI Agent',
+					description: 'Reasoning agent',
+					inputs: ['main'],
+					outputs: ['main'],
+					version: 1,
+					builderHint: { inputs: { ai_languageModel: { required: true } } },
+				},
+			];
+			const context = createMockContext();
+			(context.nodeService.listSearchable as Mock).mockResolvedValue(searchableNodes);
+			(context.credentialService.list as Mock).mockResolvedValue([]);
+
+			const tool = createNodesTool(context, 'full');
+			const result = await executeTool(
+				tool,
+				{ action: 'search', query: 'agent', limit: 5 } as never,
+				{} as never,
+			);
+
+			const [node] = (result as { results: Array<{ subnodeRequirements?: unknown[] }> }).results;
+			expect(node.subnodeRequirements).toEqual([
+				expect.not.objectContaining({ suggestedNode: expect.anything() }),
+			]);
+		});
+
 		it('should return no search results when neither query nor connection type is provided', async () => {
 			const context = createMockContext();
 			(context.nodeService.listSearchable as Mock).mockResolvedValue([]);

--- a/packages/@n8n/instance-ai/src/tools/nodes.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes.tool.ts
@@ -8,7 +8,9 @@ import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
 import type { InstanceAiContext } from '../types';
 import { NodeSearchEngine } from './nodes/node-search-engine';
 import { AI_CONNECTION_TYPES, type SearchableNodeType } from './nodes/node-search-engine.types';
+import { pickPreferredChatModelNode } from './nodes/preferred-chat-model';
 import { categoryList, suggestedNodesData } from './nodes/suggested-nodes-data';
+import { buildCredentialMap } from './workflows/resolve-credentials';
 
 // ── Action schemas ──────────────────────────────────────────────────────────
 
@@ -186,9 +188,38 @@ async function handleSearch(
 		}),
 	);
 
+	// Steer the language model subnode toward a provider the user already has a
+	// credential for, so the builder stops defaulting to OpenAI when only another
+	// provider is configured. Only hits the credential list when relevant.
+	const hasLanguageModelRequirement = enriched.some((r) =>
+		r.subnodeRequirements?.some((req) => req.connectionType === 'ai_languageModel'),
+	);
+	if (!hasLanguageModelRequirement) {
+		return { results: enriched, totalResults: enriched.length };
+	}
+
+	const credentialMap = await buildCredentialMap(context.credentialService);
+	const suggestedModelNode = pickPreferredChatModelNode(credentialMap.keys());
+	if (!suggestedModelNode) {
+		return { results: enriched, totalResults: enriched.length };
+	}
+
+	const withSuggestions = enriched.map((r) =>
+		r.subnodeRequirements
+			? {
+					...r,
+					subnodeRequirements: r.subnodeRequirements.map((req) =>
+						req.connectionType === 'ai_languageModel'
+							? { ...req, suggestedNode: suggestedModelNode }
+							: req,
+					),
+				}
+			: r,
+	);
+
 	return {
-		results: enriched,
-		totalResults: enriched.length,
+		results: withSuggestions,
+		totalResults: withSuggestions.length,
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/preferred-chat-model.test.ts
@@ -1,0 +1,23 @@
+import { pickPreferredChatModelNode } from '../preferred-chat-model';
+
+describe('pickPreferredChatModelNode', () => {
+	it('returns the matching chat model for a single provider credential', () => {
+		expect(pickPreferredChatModelNode(['anthropicApi'])).toBe(
+			'@n8n/n8n-nodes-langchain.lmChatAnthropic',
+		);
+	});
+
+	it('follows recommendation precedence when several providers are configured', () => {
+		expect(pickPreferredChatModelNode(['openAiApi', 'anthropicApi'])).toBe(
+			'@n8n/n8n-nodes-langchain.lmChatAnthropic',
+		);
+		expect(pickPreferredChatModelNode(['xAiApi', 'mistralCloudApi'])).toBe(
+			'@n8n/n8n-nodes-langchain.lmChatMistralCloud',
+		);
+	});
+
+	it('returns undefined when no credential maps to a chat model', () => {
+		expect(pickPreferredChatModelNode([])).toBeUndefined();
+		expect(pickPreferredChatModelNode(['slackApi', 'notionApi'])).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.types.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.types.ts
@@ -94,6 +94,12 @@ export interface SubnodeRequirement {
 	required: boolean;
 	/** Conditions under which this subnode is required. */
 	displayOptions?: Record<string, unknown>;
+	/**
+	 * Preferred node to satisfy this requirement, matching a provider the user
+	 * already has a credential for. Set for ai_languageModel when an LLM
+	 * credential exists; use it instead of the generic default.
+	 */
+	suggestedNode?: string;
 }
 
 /** Node search result with scoring and subnode requirements. */

--- a/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/preferred-chat-model.ts
@@ -1,0 +1,27 @@
+/**
+ * Maps an LLM-provider credential type to its chat model node, ordered by the
+ * provider recommendation precedence. When the user has credentials for several
+ * providers, the first match wins; with none, the builder keeps its own default.
+ */
+const CHAT_MODEL_BY_CREDENTIAL_TYPE: ReadonlyArray<[credentialType: string, nodeType: string]> = [
+	['anthropicApi', '@n8n/n8n-nodes-langchain.lmChatAnthropic'],
+	['openAiApi', '@n8n/n8n-nodes-langchain.lmChatOpenAi'],
+	['mistralCloudApi', '@n8n/n8n-nodes-langchain.lmChatMistralCloud'],
+	['xAiApi', '@n8n/n8n-nodes-langchain.lmChatXAiGrok'],
+	['googlePalmApi', '@n8n/n8n-nodes-langchain.lmChatGoogleGemini'],
+];
+
+/**
+ * Pick the chat model node for the provider the user already has a credential
+ * for, following the recommendation precedence. Returns undefined when none of
+ * the available credential types map to a supported chat model.
+ */
+export function pickPreferredChatModelNode(
+	availableCredentialTypes: Iterable<string>,
+): string | undefined {
+	const available = new Set(availableCredentialTypes);
+	for (const [credentialType, nodeType] of CHAT_MODEL_BY_CREDENTIAL_TYPE) {
+		if (available.has(credentialType)) return nodeType;
+	}
+	return undefined;
+}


### PR DESCRIPTION
## Summary

When Instance AI builds a workflow that needs an AI model, it defaulted to an **OpenAI** chat model regardless of which provider credential the user had configured — e.g. a user with only an Anthropic key still got an OpenAI node and was left to swap/connect a provider.

Root cause (corrected from initial triage): in `@n8n/instance-ai` the OpenAI choice is a **pure LLM default**. The `DEFAULT_SUBNODES = lmChatOpenAi` and the `ai-nodes.ts` "default OpenAI" prompt that the triage flagged are dead/unused on this path — node search only ever told the builder a node *needs* an `ai_languageModel`, never which provider, and the credential list is tool-gated (not in context). So nothing steered the builder toward the user's actual provider.

This adds a deterministic, credential-aware signal at the node-search decision point:

- New `pickPreferredChatModelNode` maps an LLM-provider credential type to its chat model node, in recommendation precedence (Anthropic → OpenAI → Mistral → xAI → Gemini). Single credential always wins; ties follow the order.
- `nodes` tool `search` attaches a `suggestedNode` to any `ai_languageModel` subnode requirement, set to the chat model for a provider the user already has a credential for.
- The credential list is only consulted when an AI-model requirement is actually in the results. With **no** AI-provider credential, behaviour is unchanged (OpenAI default).

## How to test

1. Configure **only** an Anthropic API credential (no OpenAI).
2. Ask Instance AI to build a workflow that needs an AI Agent / chat model.
3. The builder should produce an **Anthropic** chat model node, not OpenAI, with no provider prompt.
4. With multiple provider credentials → the first by precedence (Anthropic) is used silently.
5. With no AI-provider credential → unchanged (OpenAI default).

Automated coverage (`@n8n/instance-ai`):
- `preferred-chat-model.test.ts` — single credential, multi-credential precedence, no-match.
- `nodes.tool.test.ts` — search attaches `suggestedNode` for a configured provider; omits it when no LLM credential exists.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-577

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32634">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->