### PR TITLE
feat(core): Add CRDT collaboration mode setting (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -213,6 +213,9 @@ export interface FrontendSettings {
 	folders: {
 		enabled: boolean;
 	};
+	collaboration: {
+		crdt: 'off' | 'local' | 'server';
+	};
 	banners: {
 		dismissed: string[];
 	};

--- a/packages/@n8n/config/src/configs/collaboration.config.ts
+++ b/packages/@n8n/config/src/configs/collaboration.config.ts
@@ -1,0 +1,14 @@
+import z from 'zod';
+
+import { Config, Env } from '../decorators';
+
+const crdtModeSchema = z.enum(['off', 'local', 'server']);
+
+export type CrdtMode = z.infer<typeof crdtModeSchema>;
+
+@Config
+export class CollaborationConfig {
+	/** CRDT collaborative editing mode. 'off' disables it; 'local' enables cross-tab (BroadcastChannel) sync; 'server' enables YJS-server-backed sync. */
+	@Env('N8N_COLLABORATION_CRDT', crdtModeSchema)
+	crdt: CrdtMode = 'off';
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -8,6 +8,7 @@ import { AuthConfig } from './configs/auth.config';
 import { CacheConfig } from './configs/cache.config';
 import { ChatHubConfig } from './configs/chat-hub.config';
 import { ChatTriggerConfig } from './configs/chat-trigger.config';
+import { CollaborationConfig } from './configs/collaboration.config';
 import { CompressionNodeConfig } from './configs/compression.config';
 import { CredentialsConfig } from './configs/credentials.config';
 import { DataTableConfig } from './configs/data-table.config';
@@ -266,6 +267,9 @@ export class GlobalConfig {
 
 	@Nested
 	chatTrigger: ChatTriggerConfig;
+
+	@Nested
+	collaboration: CollaborationConfig;
 
 	@Nested
 	compressionNode: CompressionNodeConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -487,6 +487,9 @@ describe('GlobalConfig', () => {
 		aiBuilder: {
 			apiKey: '',
 		},
+		collaboration: {
+			crdt: 'off',
+		},
 		tags: {
 			disabled: false,
 		},

--- a/packages/cli/src/services/__tests__/frontend.service.test.ts
+++ b/packages/cli/src/services/__tests__/frontend.service.test.ts
@@ -33,6 +33,7 @@ describe('FrontendService', () => {
 		templates: { enabled: false, host: '' },
 		nodes: {},
 		tags: { disabled: false },
+		collaboration: { crdt: 'off' },
 		logging: { level: 'info' },
 		hiringBanner: { enabled: false },
 		versionNotifications: {
@@ -563,6 +564,25 @@ describe('FrontendService', () => {
 			const settings = await service.getSettings();
 
 			expect(settings.aiBuilder.enabled).toBe(false);
+		});
+	});
+
+	describe('collaboration setting', () => {
+		afterEach(() => {
+			globalConfig.collaboration.crdt = 'off';
+		});
+
+		it('should default collaboration.crdt to off', async () => {
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+			expect(settings.collaboration.crdt).toBe('off');
+		});
+
+		it('should reflect the collaboration.crdt mode from config', async () => {
+			globalConfig.collaboration.crdt = 'local';
+			const { service } = createMockService();
+			const settings = await service.getSettings();
+			expect(settings.collaboration.crdt).toBe('local');
 		});
 	});
 

--- a/packages/cli/src/services/frontend.service.ts
+++ b/packages/cli/src/services/frontend.service.ts
@@ -404,6 +404,9 @@ export class FrontendService {
 			},
 			activeModules: this.moduleRegistry.getActiveModules(),
 			canvasOnly: this.globalConfig.canvasOnly,
+			collaboration: {
+				crdt: this.globalConfig.collaboration.crdt,
+			},
 			envFeatureFlags: this.collectEnvFeatureFlags(),
 		};
 	}

--- a/packages/frontend/editor-ui/src/__tests__/defaults.ts
+++ b/packages/frontend/editor-ui/src/__tests__/defaults.ts
@@ -176,6 +176,9 @@ export const defaultSettings: FrontendSettings = {
 	folders: {
 		enabled: false,
 	},
+	collaboration: {
+		crdt: 'off',
+	},
 	evaluation: {
 		quota: 0,
 	},

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.test.ts
@@ -121,6 +121,56 @@ describe('settings.store', () => {
 		});
 	});
 
+	describe('isCrdtCollaborationEnabled', () => {
+		it('should return true when collaboration.crdt is local', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				collaboration: { crdt: 'local' },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCrdtCollaborationEnabled).toBe(true);
+		});
+
+		it('should return true when collaboration.crdt is server', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				collaboration: { crdt: 'server' },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCrdtCollaborationEnabled).toBe(true);
+		});
+
+		it('should return false when collaboration.crdt is off', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				collaboration: { crdt: 'off' },
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCrdtCollaborationEnabled).toBe(false);
+		});
+
+		it('should return false when collaboration is undefined', async () => {
+			getSettings.mockResolvedValueOnce({
+				...mockSettings,
+				collaboration: undefined,
+			});
+
+			const settingsStore = useSettingsStore();
+			await settingsStore.getSettings();
+
+			expect(settingsStore.isCrdtCollaborationEnabled).toBe(false);
+		});
+	});
+
 	describe('getSettings', () => {
 		describe('telemetry', () => {
 			it('should fetch settings and call sessionStarted if telemetry is enabled', async () => {

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -83,6 +83,10 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 
 	const isCanvasOnly = computed(() => settings.value.canvasOnly);
 
+	const isCrdtCollaborationEnabled = computed(
+		() => (settings.value.collaboration?.crdt ?? 'off') !== 'off',
+	);
+
 	const publicApiLatestVersion = computed(() => api.value.latestVersion);
 
 	const publicApiPath = computed(() => api.value.path);
@@ -426,6 +430,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		isSwaggerUIEnabled,
 		isPreviewMode,
 		isCanvasOnly,
+		isCrdtCollaborationEnabled,
 		publicApiLatestVersion,
 		publicApiPath,
 		showSetupPage,


### PR DESCRIPTION
## Summary

Adds a backend-controlled setting for CRDT collaborative editing, exposed to the frontend.

- New `CollaborationConfig` with `N8N_COLLABORATION_CRDT` env var accepting `off` | `local` | `server` (default `off`):
  - `off` — disabled
  - `local` — cross-tab sync via BroadcastChannel
  - `server` — YJS-server-backed sync
- Surfaced through `FrontendSettings.collaboration.crdt`.
- New `isCrdtCollaborationEnabled` getter on the settings store (true for `local`/`server`).

This is an inert flag for now — no behavior is wired up to it yet.

## How to test

1. Start n8n without the env var → `GET /rest/settings` returns `collaboration.crdt: "off"` and `isCrdtCollaborationEnabled` is `false`.
2. Start with `N8N_COLLABORATION_CRDT=local` (or `server`) → settings reflect the mode and `isCrdtCollaborationEnabled` is `true`.
3. Invalid values are rejected by the zod enum at config load.

Unit tests cover the config default, frontend service output, and the store getter.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No linked ticket yet — add one if applicable. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)