### PR TITLE
fix(editor): Land new instance owner on Instance AI after setup if enabled (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.test.ts
@@ -1,8 +1,11 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore } from '@/__tests__/utils';
 import { createTestingPinia } from '@pinia/testing';
+import userEvent from '@testing-library/user-event';
+import { useRouter } from 'vue-router';
 import SetupView from './SetupView.vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useUsersStore } from '@/features/settings/users/users.store';
 
 vi.mock('vue-router', () => {
 	const push = vi.fn();
@@ -58,5 +61,24 @@ describe('SetupView', () => {
 		const { getByText } = renderComponent({ pinia });
 
 		expect(getByText(/12\+ characters/)).toBeInTheDocument();
+	});
+
+	it('should route a forced-here new owner through root so the guard can land them on Instance AI', async () => {
+		const pinia = createTestingPinia();
+		const settingsStore = mockedStore(useSettingsStore);
+		const usersStore = mockedStore(useUsersStore);
+		settingsStore.userManagement.showSetupOnFirstLoad = true;
+		usersStore.createOwner.mockResolvedValueOnce(undefined);
+
+		const { getByRole, container } = renderComponent({ pinia });
+
+		await userEvent.type(container.querySelector('input[type="email"]')!, 'owner@n8n.io');
+		await userEvent.type(container.querySelector('input[name="firstName"]')!, 'Jane');
+		await userEvent.type(container.querySelector('input[name="lastName"]')!, 'Doe');
+		await userEvent.type(container.querySelector('input[type="password"]')!, '324R435gfg5fgj!');
+		await userEvent.click(getByRole('button', { name: 'Next' }));
+
+		expect(usersStore.createOwner).toHaveBeenCalled();
+		expect(useRouter().push).toHaveBeenCalledWith('/');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SetupView.vue
@@ -96,7 +96,8 @@ const onSubmit = async (values: { [key: string]: string | boolean }) => {
 			} catch {}
 		}
 		if (forceRedirectedHere) {
-			await router.push({ name: VIEWS.HOMEPAGE });
+			// Route through root so the guard can land the new owner on Instance AI when enabled.
+			await router.push('/');
 		} else {
 			await router.push({ name: VIEWS.USERS_SETTINGS });
 		}


### PR DESCRIPTION
## Summary

A brand-new instance owner was landing on the workflows home (canvas) instead of Instance AI after completing owner setup, even when the Instance AI module was enabled.

The Instance AI landing decision lives in a single place: the `/` root route guard (`router.ts`), which routes to Instance AI when the module is active, enabled, and the user has `instanceAi:message`. But `SetupView` redirected the freshly-created owner straight to `VIEWS.HOMEPAGE` (`/home/workflows`), bypassing that guard entirely. The guard was added after `SetupView`'s redirect already existed, so the two were never reconciled.

This change makes the post-setup redirect go through `/` so the existing guard makes the landing decision. The store state the guard reads (`activeModules` / `moduleSettings`) is already populated by the login hook that `createOwner` awaits, so there's no timing flap.

Scope note: this fixes the owner-setup path. If cloud provisions the owner server-side and auto-logs in, the landing URL is controlled by the cloud orchestrator and is out of scope here.

## How to test

1. Start an instance with the `instance-ai` module enabled and `showSetupOnFirstLoad` true (fresh instance).
2. Complete owner setup.
3. Expected: land on `/instance-ai`, not `/home/workflows`.
4. With the module disabled, completing setup should still land on `/home/workflows`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-592

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->