### PR TITLE
chore(core): Changing tool call concurrency values (default 5 and max 100) (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
@@ -290,7 +290,7 @@ export const AgentJsonConfigSchema = z.object({
 		.object({
 			thinking: ThinkingConfigSchema.optional(),
 			webSearch: WebSearchConfigSchema.optional(),
-			toolCallConcurrency: z.number().int().min(1).max(200).optional(),
+			toolCallConcurrency: z.number().int().min(1).max(100).optional(),
 			maxIterations: z
 				.number()
 				.int()

--- a/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
@@ -290,7 +290,7 @@ export const AgentJsonConfigSchema = z.object({
 		.object({
 			thinking: ThinkingConfigSchema.optional(),
 			webSearch: WebSearchConfigSchema.optional(),
-			toolCallConcurrency: z.number().int().min(1).max(20).optional(),
+			toolCallConcurrency: z.number().int().min(1).max(200).optional(),
 			maxIterations: z
 				.number()
 				.int()

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAdvancedPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAdvancedPanel.vue
@@ -145,7 +145,7 @@ function makeNumberField(key: NumberConfigKey, options: NumberFieldOptions) {
 // ---------------------------------------------------------------------------
 
 const CONCURRENCY_MIN = 1;
-const CONCURRENCY_MAX = 200;
+const CONCURRENCY_MAX = 100;
 const CONCURRENCY_DEFAULT = 5;
 const MAX_ITERATIONS_MIN = 1;
 const MAX_ITERATIONS_MAX = 200;

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAdvancedPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAdvancedPanel.vue
@@ -145,7 +145,8 @@ function makeNumberField(key: NumberConfigKey, options: NumberFieldOptions) {
 // ---------------------------------------------------------------------------
 
 const CONCURRENCY_MIN = 1;
-const CONCURRENCY_MAX = 20;
+const CONCURRENCY_MAX = 200;
+const CONCURRENCY_DEFAULT = 5;
 const MAX_ITERATIONS_MIN = 1;
 const MAX_ITERATIONS_MAX = 200;
 const MAX_ITERATIONS_DEFAULT = 30;
@@ -156,7 +157,7 @@ const {
 	modelValue: concurrencyModelValue,
 	onChange: onConcurrencyChange,
 	sync: syncConcurrency,
-} = makeNumberField('toolCallConcurrency', CONCURRENCY_MIN);
+} = makeNumberField('toolCallConcurrency', CONCURRENCY_DEFAULT);
 
 const {
 	modelValue: maxIterationsModelValue,


### PR DESCRIPTION
## Summary

As title.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

