### PR TITLE
ci: Split Daytona API token into prod and dev across CI workflows

### DIFF
--- a/.github/workflows/release-build-daytona-snapshot.yml
+++ b/.github/workflows/release-build-daytona-snapshot.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: string
     secrets:
-      DAYTONA_API_KEY:
+      DAYTONA_API_KEY_PROD:
         required: true
-      DAYTONA_API_URL:
+      DAYTONA_API_URL_PROD:
         required: false
 
   workflow_dispatch:
@@ -38,6 +38,6 @@ jobs:
       - name: Build versioned Daytona snapshot
         env:
           N8N_VERSION: ${{ inputs.n8n_version }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY_PROD }}
+          DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL_PROD }}
         run: node packages/@n8n/instance-ai/scripts/build-snapshot.cjs --version "$N8N_VERSION"

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -101,7 +101,7 @@ jobs:
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY_DEV }}
           # Prefer head_ref: inputs.branch may be a merge ref (refs/pull/N/merge).
           SANDBOX_NAME_PREFIX: evals-ci-${{ github.head_ref || inputs.branch || github.ref_name }}
           SANDBOX_PROVIDER: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
@@ -262,7 +262,7 @@ jobs:
         if: ${{ always() }}
         env:
           EVALS_ANTHROPIC_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY_DEV }}
           N8N_LICENSE_ACTIVATION_KEY: ${{ secrets.N8N_LICENSE_ACTIVATION_KEY }}
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}


### PR DESCRIPTION
## Summary

We've split our Daytona environments into **prod** and **dev** and want the two CI consumers of the Daytona API token to stop sharing a single credential.

There are exactly two CI/release consumers of `DAYTONA_API_KEY`:

| Use case | Workflow | Now uses |
|----------|----------|----------|
| Release snapshot publishing | `release-build-daytona-snapshot.yml` (called from `release-publish.yml`) | `DAYTONA_API_KEY_PROD` / `DAYTONA_API_URL_PROD` |
| PR / dispatch evals | `test-evals-instance-ai.yml` (dispatched by `ci-instance-ai-evals.yml`) | `DAYTONA_API_KEY_DEV` |

Snapshot publishing produces the artifact end users consume, so it points at **prod**; PR evals are a testing concern and point at **dev**.

Both call paths use `secrets: inherit`, so the workflows reference the new repo secrets directly — no caller changes needed. The eval workflow's `DAYTONA_API_URL` is a hardcoded public endpoint (not a secret) and is unchanged.

## Required before merge

These repo secrets must exist (in addition to or replacing the current `DAYTONA_API_KEY` / `DAYTONA_API_URL`):

- `DAYTONA_API_KEY_PROD` (required), `DAYTONA_API_URL_PROD` (optional)
- `DAYTONA_API_KEY_DEV` (required)

Once the snapshot workflow's `DAYTONA_API_KEY_PROD` secret declaration is in place, the old `DAYTONA_API_KEY` / `DAYTONA_API_URL` repo secrets can be removed.

## Scope

CI side only. Product runtime consumers (Instance AI / agents sandbox env vars on the deployments) are out of scope here and handled separately via deployment config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

