### PR TITLE
feat(core): Track Instance AI run completion telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -2221,6 +2221,11 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 			'text-delta',
 			'run-finish',
 		]);
+		expect(service.telemetry.track).toHaveBeenCalledWith('instance_ai_run_finished', {
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			status: 'completed',
+		});
 	});
 
 	it('does not publish completed fallback output when silence is expected', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -5296,6 +5296,12 @@ export class InstanceAiService {
 				...(hasArchived ? { archivedWorkflowIds } : {}),
 			},
 		});
+		// ponytail: success-drop heartbeat; every real run finish funnels here
+		this.telemetry.track('instance_ai_run_finished', {
+			thread_id: threadId,
+			run_id: runId,
+			status: effectiveStatus,
+		});
 	}
 
 	private async finalizeRun(


### PR DESCRIPTION
## Summary

Adds a dedicated `instance_ai_run_finished` telemetry event so we can build a **run-volume heartbeat** in PostHog: detect drops in successful Instance AI runs vs the same-hour historical baseline.

Existing telemetry (`instance_ai_terminal_response_decision`) is a terminal-guard decision with a replay path that can re-fire on redelivery, so it slightly over-counts. This event fires exactly once per real run finish because every production run funnels through `publishRunFinish` (the remaining direct `run-finish` publishes are a debug simulation, mid-stream cancel, and error paths).

Event payload: `{ thread_id, run_id, status }` where `status` is `completed | cancelled | error`. A PostHog Insight on `status = completed` per hour + an anomaly alert covers the success-drop heartbeat with no further code.

## How to test

`pnpm --filter n8n test src/modules/instance-ai/__tests__/instance-ai.service.test.ts -t run-finish` — the completed-run test asserts the new `instance_ai_run_finished` track call.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->