### PR TITLE
feat(editor): Improve credential saving UX for OAuth credentials

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1172,6 +1172,7 @@
 	"credentials.create.personal.toast.title": "Credential successfully created inside your personal space",
 	"credentials.create.project.toast.title": "Credential successfully created in {projectName}",
 	"credentials.create.project.toast.text": "All members from {projectName} will have access to this credential.",
+	"credentials.update.toast.title": "Credential saved",
 	"dataDisplay.needHelp": "Need help?",
 	"dataDisplay.nodeDocumentation": "Node Documentation",
 	"dataDisplay.openDocumentationFor": "Open {nodeTypeDisplayName} documentation",

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -208,7 +208,6 @@ const showOAuthSuccessBanner = computed(() => {
 const showOAuthNotConnectedBanner = computed(() => {
 	return (
 		props.isOAuthType &&
-		props.isResolvable &&
 		props.requiredPropertiesFilled &&
 		!props.isOAuthConnected &&
 		!props.authError
@@ -425,30 +424,6 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 				/>
 
 				<Banner
-					v-show="showOAuthNotConnectedBanner && !showValidationWarning"
-					theme="warning"
-					:message="i18n.baseText('credentialEdit.credentialConfig.accountNotConnected')"
-					:button-label="i18n.baseText('credentialEdit.credentialConfig.connect')"
-					:button-title="i18n.baseText('credentialEdit.credentialConfig.connectOAuth2Credential')"
-					data-test-id="oauth-not-connected-banner"
-					@click="$emit('oauth')"
-				>
-					<template v-if="isGoogleOAuthType" #button>
-						<GoogleAuthButton @click="$emit('oauth')" />
-					</template>
-					<template v-else #button>
-						<QuickConnectButton
-							size="small"
-							:service-name="serviceName"
-							:credential-type-name="credentialType.name"
-							:label="i18n.baseText('credentialEdit.credentialConfig.connect')"
-							data-test-id="quick-connect-not-connected-button"
-							@click="$emit('oauth')"
-						/>
-					</template>
-				</Banner>
-
-				<Banner
 					v-show="showOAuthSuccessBanner && !showValidationWarning"
 					theme="success"
 					:message="i18n.baseText('credentialEdit.credentialConfig.accountConnected')"
@@ -535,6 +510,32 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 					</div>
 				</div>
 
+				<Banner
+					v-show="showOAuthNotConnectedBanner && !showValidationWarning"
+					theme="warning"
+					:message="i18n.baseText('credentialEdit.credentialConfig.accountNotConnected')"
+					:button-label="i18n.baseText('credentialEdit.credentialConfig.connect')"
+					:button-title="i18n.baseText('credentialEdit.credentialConfig.connectOAuth2Credential')"
+					data-test-id="oauth-not-connected-banner"
+					@click="$emit('oauth')"
+				>
+					<template v-if="isGoogleOAuthType" #button>
+						<div data-test-id="quick-connect-button">
+							<GoogleAuthButton @click="$emit('oauth')" />
+						</div>
+					</template>
+					<template v-else #button>
+						<QuickConnectButton
+							size="small"
+							:service-name="serviceName"
+							:credential-type-name="credentialType.name"
+							:label="i18n.baseText('credentialEdit.credentialConfig.connect')"
+							data-test-id="quick-connect-button"
+							@click="$emit('oauth')"
+						/>
+					</template>
+				</Banner>
+
 				<template v-if="canWrite">
 					<!-- Instance AI credential setup help (mimics the assistant button) -->
 					<div
@@ -614,16 +615,6 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 					:documentation-url="documentationUrl"
 					:show-validation-warnings="showValidationWarning"
 					@update="onDataChange"
-				/>
-
-				<QuickConnectButton
-					v-if="isOAuthType && !isOAuthConnected && canWrite"
-					:service-name="serviceName"
-					:credential-type-name="credentialType.name"
-					:disabled="!requiredPropertiesFilled"
-					:disabled-tooltip="i18n.baseText('credentialEdit.credentialConfig.oauthDisabledTooltip')"
-					data-test-id="quick-connect-button"
-					@click="$emit('oauth')"
 				/>
 
 				<N8nText v-if="isMissingCredentials" color="text-base" size="medium">

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -1349,7 +1349,7 @@ describe('CredentialEdit', () => {
 			await retry(() => expect(queryByTestId('oauth-not-connected-banner')).not.toBeVisible());
 		});
 
-		test('does not show the not-connected warning banner for static OAuth credentials', async () => {
+		test('shows the not-connected warning banner for static OAuth credentials that are not yet connected', async () => {
 			const pinia = createPiniaForBannerTest();
 			const credentialsStore = setupOAuthCredential({
 				isResolvable: false,
@@ -1365,7 +1365,7 @@ describe('CredentialEdit', () => {
 			});
 
 			await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
-			await retry(() => expect(queryByTestId('oauth-not-connected-banner')).not.toBeVisible());
+			await retry(() => expect(queryByTestId('oauth-not-connected-banner')).toBeVisible());
 		});
 
 		describe('switching a connected private credential to static', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -439,7 +439,6 @@ const showSaveButton = computed(() => {
 	if (isQuickConnectMode.value) return false;
 	const hasPermission = credentialPermissions.value.create ?? credentialPermissions.value.update;
 	if (!hasPermission) return false;
-	if (isOAuthType.value && !isOAuthConnected.value) return false;
 	return true;
 });
 
@@ -1234,6 +1233,11 @@ async function updateCredential(
 		hasUnsavedChanges.value = false;
 		isSaved.value = true;
 
+		toast.showMessage({
+			title: i18n.baseText('credentials.update.toast.title'),
+			type: 'success',
+		});
+
 		if (credential) {
 			await externalHooks.run('credential.saved', {
 				credential_type: credentialDetails.type,
@@ -1635,9 +1639,12 @@ const { width } = useElementSize(credNameRef);
 					<SaveButton
 						v-if="showHeaderSaveButton"
 						:class="$style.saveButton"
-						:disabled="!hasUnsavedChanges && !isTesting && !!credentialId"
+						:disabled="
+							(!isNewCredential && !hasUnsavedChanges && !isTesting) || !requiredPropertiesFilled
+						"
+						:variant="hasUnsavedChanges || isTesting ? 'solid' : 'subtle'"
 						:is-saving="isSaving || isTesting"
-						:saved="!hasUnsavedChanges && !isTesting && !!credentialId"
+						:saved="!isNewCredential && isSaved && !hasUnsavedChanges && !isTesting"
 						:saving-label="
 							isTesting
 								? i18n.baseText('credentialEdit.credentialEdit.testing')
@@ -1825,5 +1832,6 @@ const { width } = useElementSize(credNameRef);
 
 .saveButton {
 	flex-shrink: 0;
+	min-width: 57px;
 }
 </style>


### PR DESCRIPTION
## Summary

Improves the credential saving flow for OAuth credentials. Previously, the Save button was hidden until the OAuth account was connected, which was confusing — users couldn't save partially filled credentials or understand the credential state.

**Changes:**
- **Save button always visible** for OAuth credentials (was hidden until account connected)
- **Save button disabled** until the user makes a change AND all required fields are filled
- **Smooth fade transition** between Save ↔ Saved button states (no layout jump)
- **Success toast** on every credential save, not just on create
- **"Connect your account" banner** moved below the "Set up for private credentials" toggle; redundant standalone connect button removed

## How to test

1. Go to Credentials → Create credential → select any OAuth type (e.g. Gmail OAuth2 API)
2. Verify Save button is visible but **disabled** (gray, no orange) before any input
3. Fill in Client ID → Save button becomes **orange/active**
4. Fill in Client Secret → "Connect your account" banner appears **below the toggle**
5. Click Save → **success toast** appears, button transitions to **Saved**
6. Reopen the credential, make a change → Save becomes active again
7. Confirm there is no standalone "Sign in with Google" button at the bottom

Button disabled:
<img width="1536" height="784" alt="image" src="https://github.com/user-attachments/assets/25e1c54d-eae7-46bc-b2bb-d4bede3a0876" />

Button avaliable:
<img width="1536" height="784" alt="image" src="https://github.com/user-attachments/assets/48772eeb-146a-407c-a3ea-c44ea5d5de4c" />

Toast:
<img width="1536" height="784" alt="image" src="https://github.com/user-attachments/assets/362fe36b-4aa3-433b-a03e-b33c73989876" />

Saved status:
<img width="1536" height="784" alt="image" src="https://github.com/user-attachments/assets/f8bdcbe4-ed19-4479-a203-12b6e5b48b30" />



## Related Linear tickets

https://linear.app/n8n/issue/IAM-762

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->