### PR TITLE
feat(Google Cloud Storage Node): Allow custom OAuth2 scopes

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -115,6 +115,7 @@ export const GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE = [
 	'wordpressOAuth2Api',
 	'figmaOAuth2Api',
 	'gumroadOAuth2Api',
+	'googleCloudStorageOAuth2Api',
 ];
 
 export const ARTIFICIAL_TASK_DATA = {

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1590,6 +1590,32 @@ describe('OauthService', () => {
 			);
 		});
 
+		it('should not delete scope for googleCloudStorageOAuth2Api credentials', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'googleCloudStorageOAuth2Api',
+				isManaged: false,
+			});
+			const mockDecryptedData = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockOAuthCredentials = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+
+			await service.getOAuthCredentials(credential);
+
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				mockAdditionalData,
+				{ clientId: 'client-id', scope: 'custom-scope' },
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+			);
+		});
+
 		it('should not delete scope for non-OAuth2 credentials', async () => {
 			const credential = mock<CredentialsEntity>({
 				id: '1',

--- a/packages/nodes-base/credentials/GoogleCloudStorageOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/GoogleCloudStorageOAuth2Api.credentials.ts
@@ -19,10 +19,41 @@ export class GoogleCloudStorageOAuth2Api implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: scopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: scopes.join(' '),
+			default: '={{$self["customScopes"] ? $self["enabledScopes"] : "' + scopes.join(' ') + '"}}',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/test/GoogleCloudStorageOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/GoogleCloudStorageOAuth2Api.credentials.test.ts
@@ -1,0 +1,133 @@
+import { ClientOAuth2 } from '@n8n/client-oauth2';
+import nock from 'nock';
+
+import { GoogleCloudStorageOAuth2Api } from '../GoogleCloudStorageOAuth2Api.credentials';
+
+describe('GoogleCloudStorageOAuth2Api Credential', () => {
+	const googleCloudStorageOAuth2Api = new GoogleCloudStorageOAuth2Api();
+	const defaultScopes = [
+		'https://www.googleapis.com/auth/cloud-platform',
+		'https://www.googleapis.com/auth/cloud-platform.read-only',
+		'https://www.googleapis.com/auth/devstorage.full_control',
+		'https://www.googleapis.com/auth/devstorage.read_only',
+		'https://www.googleapis.com/auth/devstorage.read_write',
+	];
+
+	// Shared OAuth2 configuration (inherited from googleOAuth2Api)
+	const authorizationUri = 'https://accounts.google.com/o/oauth2/v2/auth';
+	const tokenBaseUrl = 'https://oauth2.googleapis.com';
+	const accessTokenUri = `${tokenBaseUrl}/token`;
+	const redirectUri = 'http://localhost:5678/rest/oauth2-credential/callback';
+	const clientId = 'test-client-id';
+	const clientSecret = 'test-client-secret';
+
+	const createOAuthClient = (scopes: string[]) =>
+		new ClientOAuth2({
+			clientId,
+			clientSecret,
+			accessTokenUri,
+			authorizationUri,
+			redirectUri,
+			scopes,
+		});
+
+	const mockTokenEndpoint = (code: string, responseScopes: string[]) => {
+		nock(tokenBaseUrl)
+			.post('/token', (body: Record<string, unknown>) => {
+				return (
+					body.code === code &&
+					body.grant_type === 'authorization_code' &&
+					body.redirect_uri === redirectUri
+				);
+			})
+			.reply(200, {
+				access_token: 'test-access-token',
+				token_type: 'Bearer',
+				expires_in: 3600,
+				scope: responseScopes.join(' '),
+			});
+	};
+
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	afterAll(() => {
+		nock.restore();
+	});
+
+	afterEach(() => {
+		nock.cleanAll();
+	});
+
+	it('should have correct credential metadata', () => {
+		expect(googleCloudStorageOAuth2Api.name).toBe('googleCloudStorageOAuth2Api');
+		expect(googleCloudStorageOAuth2Api.extends).toEqual(['googleOAuth2Api']);
+
+		// Custom scopes default to the node's required scopes
+		const enabledScopesProperty = googleCloudStorageOAuth2Api.properties.find(
+			(p) => p.name === 'enabledScopes',
+		);
+		expect(enabledScopesProperty?.default).toBe(defaultScopes.join(' '));
+	});
+
+	it('should keep scope hidden and resolve it from the customScopes toggle', () => {
+		const scopeProperty = googleCloudStorageOAuth2Api.properties.find((p) => p.name === 'scope');
+		expect(scopeProperty?.type).toBe('hidden');
+		expect(scopeProperty?.default).toContain('$self["customScopes"] ? $self["enabledScopes"]');
+		expect(scopeProperty?.default).toContain(defaultScopes.join(' '));
+	});
+
+	describe('OAuth2 flow with default scopes', () => {
+		it('should include default scopes in authorization URI', () => {
+			const oauthClient = createOAuthClient(defaultScopes);
+			const authUri = oauthClient.code.getUri();
+
+			expect(authUri).toContain('scope=');
+			expect(authUri).toContain('cloud-platform');
+			expect(authUri).toContain('devstorage.full_control');
+			expect(authUri).toContain(`client_id=${clientId}`);
+			expect(authUri).toContain('response_type=code');
+		});
+
+		it('should retrieve token successfully with default scopes', async () => {
+			const code = 'test-auth-code';
+			mockTokenEndpoint(code, defaultScopes);
+
+			const oauthClient = createOAuthClient(defaultScopes);
+			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
+
+			expect(token.data.scope).toBe(defaultScopes.join(' '));
+		});
+	});
+
+	describe('OAuth2 flow with custom scopes', () => {
+		const customScopes = [...defaultScopes, 'https://www.googleapis.com/auth/compute'];
+
+		it('should include custom scopes in authorization URI', () => {
+			const oauthClient = createOAuthClient(customScopes);
+			const authUri = oauthClient.code.getUri();
+
+			expect(authUri).toContain('scope=');
+			expect(authUri).toContain('cloud-platform');
+			expect(authUri).toContain('compute');
+		});
+
+		it('should handle completely different custom scopes', async () => {
+			const differentScopes = ['https://www.googleapis.com/auth/devstorage.read_only'];
+			const code = 'test-auth-code';
+			mockTokenEndpoint(code, differentScopes);
+
+			const oauthClient = createOAuthClient(differentScopes);
+			const authUri = oauthClient.code.getUri();
+
+			expect(authUri).toContain('devstorage.read_only');
+			expect(authUri).not.toContain('cloud-platform');
+
+			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
+
+			expect(token.data.scope).toContain('devstorage.read_only');
+			expect(token.data.scope).not.toContain('cloud-platform');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`GoogleCloudStorageOAuth2Api` hardcodes its OAuth scopes in a hidden field. This adds a **Custom Scopes** toggle so users can request scopes beyond the defaults, following the established pattern used by `MicrosoftExcelOAuth2Api` / `DiscordOAuth2Api`.

- A new **Custom Scopes** boolean (default `false`) and, when enabled, an **Enabled Scopes** field pre-filled with the current default scopes.
- The hidden `scope` is now an expression: when Custom Scopes is **off** it resolves to exactly the existing default scope string (byte-for-byte — no change for existing credentials); when **on** it uses **Enabled Scopes**.
- The credential is registered in `GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE` so a user's manually-entered scopes survive reconnects (consistent with the other credentials in this project — Strava, Wordpress, Figma, Snowflake, Gumroad, Facebook).

## How to test

1. Create or edit a **Google Cloud Storage** OAuth2 credential and connect — it works exactly as before with the default scopes.
2. Toggle **Custom Scopes** on → an **Enabled Scopes** field appears, pre-filled with the defaults.
3. Edit the scopes and reconnect → the consent screen requests your scopes, and they persist across subsequent reconnects.

Covered by:
- `packages/nodes-base/credentials/test/GoogleCloudStorageOAuth2Api.credentials.test.ts`
- `packages/cli/src/oauth/__tests__/oauth.service.test.ts` (scope survives reconnect for `googleCloudStorageOAuth2Api`)

## Screenshots

### Custom scopes input (with defaults)

<img width="1214" height="768" alt="image" src="https://github.com/user-attachments/assets/20608ddd-d273-4ae4-9521-d7737b09ee65" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-93

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

