### PR TITLE
test: Add E2E coverage for log streaming delivery (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
+++ b/packages/testing/playwright/pages/SettingsLogStreamingPage.ts
@@ -232,4 +232,98 @@ export class SettingsLogStreamingPage extends BasePage {
 		await testButton.waitFor({ state: 'visible' });
 		await testButton.click();
 	}
+
+	// ===== Destination type-specific helpers =====
+
+	/**
+	 * Opens the add-destination modal and selects a type by its index in the
+	 * type dropdown (0 = Webhook, 1 = Sentry, 2 = Syslog), then confirms the
+	 * selection so the parameter form is shown.
+	 */
+	async openDestinationModalForType(typeIndex: number): Promise<void> {
+		await this.addDestination();
+		await this.getDestinationModal().waitFor({ state: 'visible' });
+		await this.clickSelectDestinationType();
+		await this.selectDestinationType(typeIndex);
+		await this.clickSelectDestinationButton();
+	}
+
+	/** Sets the destination name via the inline-edit title field. */
+	async setDestinationName(name: string): Promise<void> {
+		await this.clickDestinationNameInput();
+		await this.clickInlineEditPreview();
+		await this.typeDestinationName(name);
+	}
+
+	getDsnInput(): Locator {
+		return this.getDestinationModal().getByTestId('parameter-input-dsn').locator('input');
+	}
+
+	async fillDsn(value: string): Promise<void> {
+		await this.getDsnInput().fill(value);
+	}
+
+	async getDsnValue(): Promise<string> {
+		return await this.getDsnInput().inputValue();
+	}
+
+	getMethodInput(): Locator {
+		return this.getDestinationModal().getByTestId('parameter-input-method').locator('input');
+	}
+
+	/** Selects an HTTP method (GET/POST/PUT) from the method options dropdown. */
+	async selectMethod(method: string): Promise<void> {
+		await this.getDestinationModal().getByTestId('parameter-input-method').click();
+		await this.getVisiblePopoverOption(method).click();
+	}
+
+	async getMethodValue(): Promise<string> {
+		return await this.getMethodInput().inputValue();
+	}
+
+	/** Toggles the "Add Headers" switch to reveal the header parameter rows. */
+	async toggleSendHeaders(): Promise<void> {
+		await this.getDestinationModal()
+			.getByTestId('parameter-input-sendHeaders')
+			.locator('.el-switch')
+			.click();
+	}
+
+	/**
+	 * Selects how headers are specified. The schema default isn't applied in this
+	 * modal, so the option must be picked explicitly before the header inputs render.
+	 */
+	async selectSpecifyHeaders(optionText: string): Promise<void> {
+		await this.getDestinationModal().getByTestId('parameter-input-specifyHeaders').click();
+		await this.getVisiblePopoverOption(optionText).click();
+	}
+
+	/**
+	 * Fills the JSON headers editor. Requires headers enabled via
+	 * {@link toggleSendHeaders} and {@link selectSpecifyHeaders} set to "Using JSON".
+	 */
+	async fillJsonHeaders(json: string): Promise<void> {
+		const editor = this.getDestinationModal()
+			.getByTestId('parameter-input-jsonHeaders')
+			.locator('.cm-content');
+		await editor.click();
+		await editor.fill(json);
+		// ParameterInput.vue debounces updates by 200ms before they reach the model.
+		await this.page.waitForTimeout(200);
+	}
+
+	getCardToggle(index: number): Locator {
+		return this.getDestinationCards().nth(index).getByTestId('workflow-activate-switch');
+	}
+
+	async clickCardToggle(index: number): Promise<void> {
+		// Toggling the switch saves the destination via POST /eventbus/destination;
+		// await it so the enabled/disabled state is committed server-side before
+		// the test proceeds.
+		const responsePromise = this.page.waitForResponse(
+			(res) => res.url().includes('/eventbus/destination') && res.request().method() === 'POST',
+		);
+		await this.getCardToggle(index).click();
+		await responsePromise;
+	}
 }

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -469,6 +469,56 @@ export class ApiHelpers {
 	}
 
 	/**
+	 * Create a webhook destination for log streaming.
+	 * Requires the logStreaming feature to be enabled.
+	 *
+	 * @param config - Webhook destination configuration
+	 * @returns Created destination data
+	 */
+	async createWebhookDestination(config: {
+		url: string;
+		method?: string;
+		label?: string;
+		enabled?: boolean;
+		subscribedEvents?: string[];
+		anonymizeAuditMessages?: boolean;
+		sendHeaders?: boolean;
+		headerParameters?: Array<{ name: string; value: string }>;
+		authentication?: 'genericCredentialType' | 'none';
+		genericAuthType?: string;
+		credentials?: Record<string, { id: string; name: string }>;
+	}): Promise<{ id: string }> {
+		const response = await this.request.post('/rest/eventbus/destination', {
+			data: {
+				__type: '$$MessageEventBusDestinationWebhook',
+				url: config.url,
+				method: config.method ?? 'POST',
+				label: config.label ?? 'Webhook Endpoint',
+				// Destinations default to disabled in the backend; real events only
+				// reach enabled destinations (the test-message endpoint bypasses this).
+				enabled: config.enabled ?? true,
+				subscribedEvents: config.subscribedEvents ?? ['*'],
+				anonymizeAuditMessages: config.anonymizeAuditMessages ?? false,
+				authentication: config.authentication ?? 'none',
+				genericAuthType: config.genericAuthType ?? '',
+				sendHeaders: config.sendHeaders ?? Boolean(config.headerParameters),
+				specifyHeaders: config.headerParameters ? 'keypair' : '',
+				headerParameters: { parameters: config.headerParameters ?? [] },
+				credentials: config.credentials,
+			},
+		});
+
+		if (!response.ok()) {
+			throw new TestError(
+				`Failed to create webhook destination: ${response.status()} ${await response.text()}`,
+			);
+		}
+
+		const result = await response.json();
+		return result.data ?? result;
+	}
+
+	/**
 	 * Delete a log streaming destination.
 	 *
 	 * @param id - Destination ID to delete

--- a/packages/testing/playwright/services/public-api-helper.ts
+++ b/packages/testing/playwright/services/public-api-helper.ts
@@ -70,6 +70,16 @@ export class PublicApiHelper {
 		return apiKeyData;
 	}
 
+	/** Delete an API key by id. Emits the `n8n.audit.user.api.deleted` audit event. */
+	async deleteApiKey(id: string): Promise<void> {
+		const response = await this.api.request.delete(`/rest/api-keys/${id}`);
+		if (!response.ok()) {
+			throw new TestError(
+				`Failed to delete API key "${id}": ${response.status()} ${await response.text()}`,
+			);
+		}
+	}
+
 	private async ensureApiKey(): Promise<string> {
 		if (!this.apiKey) {
 			await this.createApiKey();

--- a/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming-delivery.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming-delivery.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * E2E tests for real log-streaming webhook delivery.
+ *
+ * These tests point webhook destinations at the MockServer proxy container and
+ * assert on the requests it actually received — proving header/method handling,
+ * credential auth, event-subscription filtering, audit anonymization, and the
+ * per-destination enable toggle end-to-end.
+ *
+ * Prerequisites:
+ * - Log streaming feature enabled (enterprise license, @licensed)
+ * - @capability:proxy tag to bring up the MockServer proxy
+ */
+import type { ProxyServer, RequestMade } from 'n8n-containers/services/proxy';
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../../fixtures/base';
+import type { ApiHelpers } from '../../../../services/api-helper';
+
+// n8n reaches the proxy container via its internal docker network alias.
+const PROXY_INTERNAL_URL = 'http://proxyserver:1080';
+
+test.use({ capability: 'proxy' });
+
+/** A request body recorded by MockServer can be a raw string or a wrapped object. */
+function parseBody(body: unknown): unknown {
+	if (body === undefined || body === null) return undefined;
+	if (typeof body === 'string') {
+		try {
+			return JSON.parse(body);
+		} catch {
+			return body;
+		}
+	}
+	if (typeof body === 'object') {
+		const wrapped = body as { json?: unknown };
+		if (wrapped.json !== undefined) return wrapped.json;
+	}
+	return body;
+}
+
+/** Read a header value case-insensitively from a recorded request. */
+function getHeader(request: RequestMade['httpRequest'], name: string): string | undefined {
+	const headers = request?.headers as Record<string, string[]> | undefined;
+	if (!headers) return undefined;
+	const lower = name.toLowerCase();
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() === lower) return Array.isArray(value) ? value[0] : String(value);
+	}
+	return undefined;
+}
+
+/** All requests MockServer received for the given path. */
+async function requestsForPath(proxy: ProxyServer, path: string): Promise<RequestMade[]> {
+	const all = await proxy.getAllRequestsMade();
+	return all.filter((r) => r.httpRequest?.path === path);
+}
+
+/** Parsed event payloads delivered to the given path. */
+async function deliveredEvents(
+	proxy: ProxyServer,
+	path: string,
+): Promise<Array<Record<string, unknown>>> {
+	const requests = await requestsForPath(proxy, path);
+	return requests
+		.map((r) => parseBody(r.httpRequest?.body))
+		.filter((b): b is Record<string, unknown> => typeof b === 'object' && b !== null);
+}
+
+/** Unique proxy path + a matching 200 expectation so MockServer serves rather than forwards. */
+async function makeSink(
+	proxy: ProxyServer,
+	method = 'POST',
+): Promise<{ path: string; url: string }> {
+	const path = `/log-stream/${nanoid()}`;
+	await proxy.createExpectation({
+		httpRequest: { method, path },
+		httpResponse: { statusCode: 200, body: 'ok' },
+	});
+	return { path, url: `${PROXY_INTERNAL_URL}${path}` };
+}
+
+/** Run a throwaway manual workflow to emit `n8n.workflow.*` events. Returns the execution id. */
+async function triggerWorkflowEvents(api: ApiHelpers): Promise<string> {
+	const workflow = await api.workflows.createWorkflow({
+		name: `Log streaming trigger ${nanoid()}`,
+		nodes: [
+			{
+				id: nanoid(),
+				name: 'Manual',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			},
+		],
+		connections: {},
+	});
+	const { executionId } = await api.workflows.runManually(workflow.id, 'Manual');
+	return executionId;
+}
+
+/** Whether any delivered event carries the given execution id in its payload. */
+function deliveredExecution(events: Array<Record<string, unknown>>, executionId: string): boolean {
+	return events.some((e) => {
+		const payload = e.payload as Record<string, unknown> | undefined;
+		return payload?.executionId === executionId;
+	});
+}
+
+/** Create then delete an API key to emit `n8n.audit.user.api.deleted` (carries `is_own`). */
+async function triggerApiKeyDeletedEvent(api: ApiHelpers): Promise<void> {
+	const key = await api.publicApi.createApiKey();
+	await api.publicApi.deleteApiKey(key.id);
+}
+
+test.describe(
+	'Log Streaming delivery @capability:proxy @licensed',
+	{
+		annotation: [{ type: 'owner', description: 'Lifecycle & Governance' }],
+	},
+	() => {
+		test.beforeEach(async ({ api, services }) => {
+			await api.enableFeature('logStreaming');
+			await api.deleteAllLogStreamingDestinations();
+			await services.proxy.clearAllExpectations();
+		});
+
+		test('should deliver configured method and custom headers set via the UI', async ({
+			n8n,
+			services,
+		}) => {
+			const { path } = await makeSink(services.proxy, 'PUT');
+			const headerName = 'X-Custom-Header';
+			const headerValue = `value-${nanoid()}`;
+
+			await n8n.navigate.toLogStreaming();
+			await n8n.settingsLogStreaming.openDestinationModalForType(0); // Webhook
+			await n8n.settingsLogStreaming.setDestinationName('UI Webhook');
+			await n8n.settingsLogStreaming.writeUrlToDestinationUrlInput(`${PROXY_INTERNAL_URL}${path}`);
+			await n8n.settingsLogStreaming.selectMethod('PUT');
+			await n8n.settingsLogStreaming.toggleSendHeaders();
+			await n8n.settingsLogStreaming.selectSpecifyHeaders('Using JSON');
+			await n8n.settingsLogStreaming.fillJsonHeaders(JSON.stringify({ [headerName]: headerValue }));
+			await n8n.settingsLogStreaming.saveDestination();
+
+			// The method + header survive a reload (proving they persisted).
+			await n8n.page.reload();
+			await n8n.settingsLogStreaming.clickDestinationCard(0);
+			expect(await n8n.settingsLogStreaming.getMethodValue()).toBe('PUT');
+
+			await n8n.settingsLogStreaming.sendTestEvent();
+
+			await expect
+				.poll(async () => (await requestsForPath(services.proxy, path)).length)
+				.toBeGreaterThan(0);
+			const [request] = await requestsForPath(services.proxy, path);
+			expect(request.httpRequest?.method).toBe('PUT');
+			expect(getHeader(request.httpRequest, headerName)).toBe(headerValue);
+		});
+
+		test('should deliver the Authorization header from a generic header-auth credential', async ({
+			api,
+			services,
+		}) => {
+			const { path, url } = await makeSink(services.proxy);
+			const token = `Bearer ${nanoid()}`;
+			const credential = await api.credentials.createCredential({
+				name: `Log streaming header auth ${nanoid()}`,
+				type: 'httpHeaderAuth',
+				data: { name: 'Authorization', value: token },
+			});
+
+			const destination = await api.createWebhookDestination({
+				url,
+				authentication: 'genericCredentialType',
+				genericAuthType: 'httpHeaderAuth',
+				credentials: { httpHeaderAuth: { id: credential.id, name: credential.name } },
+			});
+			await api.testLogStreamingDestination(destination.id);
+
+			await expect
+				.poll(async () => (await requestsForPath(services.proxy, path)).length)
+				.toBeGreaterThan(0);
+			const [request] = await requestsForPath(services.proxy, path);
+			expect(getHeader(request.httpRequest, 'Authorization')).toBe(token);
+		});
+
+		test('should route events to destinations by their event subscriptions', async ({
+			api,
+			services,
+		}) => {
+			const workflowSink = await makeSink(services.proxy);
+			const auditSink = await makeSink(services.proxy);
+
+			await api.createWebhookDestination({
+				url: workflowSink.url,
+				subscribedEvents: ['n8n.workflow'],
+				label: 'Workflow events',
+			});
+			await api.createWebhookDestination({
+				url: auditSink.url,
+				subscribedEvents: ['n8n.audit'],
+				label: 'Audit events',
+			});
+
+			await triggerWorkflowEvents(api);
+			await triggerApiKeyDeletedEvent(api);
+
+			// The workflow destination receives workflow events and no audit events.
+			await expect
+				.poll(async () => await deliveredEvents(services.proxy, workflowSink.path))
+				.toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							eventName: expect.stringMatching(/^n8n\.workflow\./),
+						}),
+					]),
+				);
+			const workflowEvents = await deliveredEvents(services.proxy, workflowSink.path);
+			expect(workflowEvents.every((e) => String(e.eventName).startsWith('n8n.workflow.'))).toBe(
+				true,
+			);
+
+			// The audit destination receives the api-key-deleted event and no workflow events.
+			await expect
+				.poll(async () => await deliveredEvents(services.proxy, auditSink.path))
+				.toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ eventName: 'n8n.audit.user.api.deleted' }),
+					]),
+				);
+			const auditEvents = await deliveredEvents(services.proxy, auditSink.path);
+			expect(auditEvents.every((e) => String(e.eventName).startsWith('n8n.audit.'))).toBe(true);
+		});
+
+		test('should redact underscored audit fields when anonymization is enabled', async ({
+			api,
+			services,
+		}) => {
+			const { path, url } = await makeSink(services.proxy);
+
+			await api.createWebhookDestination({
+				url,
+				subscribedEvents: ['n8n.audit'],
+				anonymizeAuditMessages: true,
+			});
+
+			await triggerApiKeyDeletedEvent(api);
+
+			await expect
+				.poll(async () => await deliveredEvents(services.proxy, path))
+				.toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ eventName: 'n8n.audit.user.api.deleted' }),
+					]),
+				);
+			const events = await deliveredEvents(services.proxy, path);
+			const deleted = events.find((e) => e.eventName === 'n8n.audit.user.api.deleted');
+			const payload = deleted?.payload as Record<string, unknown>;
+			// The @Redactable decorator prefixes user fields with `_`, which the
+			// anonymizer replaces with `*`. `is_own` (no underscore) is left intact.
+			expect(payload._email).toBe('*');
+		});
+
+		test('should stop delivering once a destination is toggled off', async ({
+			n8n,
+			api,
+			services,
+		}) => {
+			const target = await makeSink(services.proxy);
+			await api.createWebhookDestination({
+				url: target.url,
+				subscribedEvents: ['n8n.workflow'],
+			});
+
+			await n8n.navigate.toLogStreaming();
+
+			// Delivery works while the destination is enabled.
+			const enabledExecId = await triggerWorkflowEvents(api);
+			await expect
+				.poll(async () =>
+					deliveredExecution(await deliveredEvents(services.proxy, target.path), enabledExecId),
+				)
+				.toBe(true);
+
+			// Toggle the destination off via the card switch (awaits the save response,
+			// so the disabled state is committed before we re-trigger). Only this card
+			// exists yet, so index 0 is unambiguous.
+			await n8n.settingsLogStreaming.clickCardToggle(0);
+
+			// A second, still-enabled destination acts as a delivery barrier: once it
+			// receives the new execution, the event pipeline has processed it — no
+			// fixed sleep needed.
+			const control = await makeSink(services.proxy);
+			await api.createWebhookDestination({
+				url: control.url,
+				subscribedEvents: ['n8n.workflow'],
+			});
+
+			const disabledExecId = await triggerWorkflowEvents(api);
+			await expect
+				.poll(async () =>
+					deliveredExecution(await deliveredEvents(services.proxy, control.path), disabledExecId),
+				)
+				.toBe(true);
+
+			// The toggled-off destination received nothing for the second execution.
+			expect(
+				deliveredExecution(await deliveredEvents(services.proxy, target.path), disabledExecId),
+			).toBe(false);
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming.spec.ts
+++ b/packages/testing/playwright/tests/e2e/settings/log-streaming/log-streaming.spec.ts
@@ -74,6 +74,28 @@ test.describe(
 				await n8n.settingsLogStreaming.confirmDialog();
 			});
 
+			test('should create a Sentry destination and persist its DSN', async ({ n8n }) => {
+				const dsn = 'https://abc@example.com/1';
+
+				await n8n.settingsLogStreaming.openDestinationModalForType(1); // Sentry
+				await n8n.settingsLogStreaming.setDestinationName('Sentry Destination');
+				await n8n.settingsLogStreaming.fillDsn(dsn);
+				await n8n.settingsLogStreaming.saveDestination();
+
+				// Reopen the destination after a reload to prove the DSN was persisted.
+				await n8n.page.reload();
+				await n8n.settingsLogStreaming.clickDestinationCard(0);
+				expect(await n8n.settingsLogStreaming.getDsnValue()).toBe(dsn);
+
+				// The test message returns synchronously from the Sentry SDK; we assert
+				// the success state, not real ingest (delivery is fire-and-forget).
+				await n8n.settingsLogStreaming.sendTestEvent();
+				await expect(n8n.settingsLogStreaming.getSendTestEventButton()).toHaveAttribute(
+					'title',
+					'Event sent and returned OK',
+				);
+			});
+
 			test('should create a destination and delete it via card actions', async ({ n8n }) => {
 				await n8n.settingsLogStreaming.createDestination(DESTINATION_NAMES.SECOND);
 				await n8n.page.reload();


### PR DESCRIPTION
## Summary

Log Streaming (`feat:logStreaming`, `/rest/eventbus/*`) is an enterprise-licensed feature that previously had only happy-path E2E coverage (webhook create/delete, syslog→VictoriaLogs, license gating). The highest-risk paths — Sentry config, webhook auth/headers/method, event-subscription filtering, audit anonymization, and per-destination enable toggling — were untested. This PR adds Playwright E2E tests for those gaps.

The new delivery tests point webhook destinations at the existing **MockServer proxy** container (`@capability:proxy`) and assert on the requests it actually received, proving the behavior end-to-end rather than just checking that config persists. The Sentry test is config-only by design (see below).

**What's added (6 tests, 5 files, +489 lines):**

- **Sentry destination** (`log-streaming.spec.ts`, local/`@licensed`): create via the UI, fill a DSN, save, reload, reopen, and assert the DSN persisted; send a test event and assert the success state.
- **Webhook method + custom headers** (`log-streaming-delivery.spec.ts`): configure `PUT` + a custom header via the UI, save/reload to prove persistence, send a test event, and assert MockServer received a `PUT` carrying the header.
- **Webhook credential auth**: create an `httpHeaderAuth` credential + a destination referencing it, fire a test event, assert the `Authorization` header arrives at MockServer.
- **Event-subscription routing**: two destinations subscribed to `n8n.workflow` vs `n8n.audit`; trigger a workflow execution and an API-key deletion; assert each destination receives only its subscribed group.
- **Audit anonymization**: with `anonymizeAuditMessages` enabled, assert underscore-prefixed audit fields (e.g. `_email`) are delivered as `*`.
- **Enable toggle**: toggle a destination off via the card switch and assert it stops receiving events (a second, still-enabled destination acts as a delivery barrier, so no fixed sleeps are needed).

### Why these scoping decisions

Two ACs are deliberately verified at a shallower depth than "real delivery", because the implementation makes deeper assertions unreliable rather than valuable:

- **Sentry is config-only.** `captureMessage()` returns synchronously and the Sentry SDK only flushes on `destination.close()`, which the test-message path never calls. A real-ingest assertion would be racy, and the test-message success boolean is not proof of delivery. We assert config persistence + test-event success instead.
- **Anonymization tests what the code actually does.** `anonymize()` (`abstract-event-message.ts`) only redacts payload keys that start with `_`. The `@Redactable` decorator underscore-prefixes audit user fields (e.g. `_email`), so those become `*`; ordinary fields are never redacted. The test asserts the real `_email → *` behavior and documents that normal-field redaction is out of scope by design.

### Key implementation decisions

- **Reused the existing MockServer proxy** rather than adding a new webhook-receiver service — it already records POSTs to arbitrary paths and exposes headers/method/body for assertions. Destinations reach it via the internal docker alias `http://proxyserver:1080`.
- **API-first setup**: subscriptions, credentials, and most destinations are created via API helpers; the UI is driven only where the UI itself is the behavior under test (Sentry config, webhook method/headers, the enable toggle). This sidesteps the event-selection tree, which has no stable test-ids.
- **Deterministic waits**: delivery assertions use `expect.poll` against recorded requests, and the toggle test uses a still-enabled control destination as a barrier instead of a timeout.
- **New reusable helpers**: `ApiHelpers.createWebhookDestination`, `PublicApiHelper.deleteApiKey`, and webhook/Sentry config methods on `SettingsLogStreamingPage` (method/header/DSN inputs, card toggle that awaits the save response).


## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-51

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

