### PR TITLE
feat: Add state-vector handshake sync provider for late-join catch-up

### DIFF
--- a/packages/@n8n/crdt/src/index.ts
+++ b/packages/@n8n/crdt/src/index.ts
@@ -54,7 +54,12 @@ export type { WebSocketTransportConfig, WorkerTransportConfig } from './transpor
 
 // Sync
 export type { SyncProvider, CreateSyncProvider } from './sync';
-export { BaseSyncProvider, createSyncProvider } from './sync';
+export {
+	BaseSyncProvider,
+	createSyncProvider,
+	HandshakeSyncProvider,
+	createHandshakeSyncProvider,
+} from './sync';
 
 // Protocol
 export {

--- a/packages/@n8n/crdt/src/providers/yjs.ts
+++ b/packages/@n8n/crdt/src/providers/yjs.ts
@@ -340,6 +340,10 @@ class YjsDoc implements CRDTDoc {
 		return Y.encodeStateVector(this.yDoc);
 	}
 
+	encodeStateFrom(remoteStateVector: Uint8Array): Uint8Array {
+		return Y.encodeStateAsUpdate(this.yDoc, remoteStateVector);
+	}
+
 	applyUpdate(update: Uint8Array): void {
 		// Use remote origin so undo manager doesn't track these changes
 		Y.applyUpdate(this.yDoc, update, YjsRemoteOrigin);

--- a/packages/@n8n/crdt/src/sync/handshake-sync-provider.test.ts
+++ b/packages/@n8n/crdt/src/sync/handshake-sync-provider.test.ts
@@ -1,0 +1,166 @@
+import { createCRDTProvider, CRDTEngine } from '../index';
+import { MockTransport } from '../transports';
+import type { CRDTDoc, CRDTMap } from '../types';
+import { createHandshakeSyncProvider } from './handshake-sync-provider';
+import type { SyncProvider } from './types';
+
+describe('HandshakeSyncProvider', () => {
+	let doc1: CRDTDoc;
+	let doc2: CRDTDoc;
+	let map1: CRDTMap<unknown>;
+	let map2: CRDTMap<unknown>;
+	let transport1: MockTransport;
+	let transport2: MockTransport;
+	let sync1: SyncProvider;
+	let sync2: SyncProvider;
+
+	beforeEach(() => {
+		const provider = createCRDTProvider({ engine: CRDTEngine.yjs });
+		doc1 = provider.createDoc('doc-1');
+		doc2 = provider.createDoc('doc-2');
+		map1 = doc1.getMap('data');
+		map2 = doc2.getMap('data');
+
+		transport1 = new MockTransport();
+		transport2 = new MockTransport();
+		MockTransport.link(transport1, transport2);
+
+		sync1 = createHandshakeSyncProvider(doc1, transport1);
+		sync2 = createHandshakeSyncProvider(doc2, transport2);
+	});
+
+	afterEach(() => {
+		sync1.stop();
+		sync2.stop();
+		doc1.destroy();
+		doc2.destroy();
+	});
+
+	it('catches up a peer that joins AFTER edits were made (late join)', async () => {
+		// Peer 1 is already connected and makes edits before peer 2 exists.
+		await sync1.start();
+		map1.set('before-join', 'edit-1');
+		map1.set('node', { x: 10 });
+
+		// Peer 2 joins late — it must catch up to peer 1's current state.
+		await sync2.start();
+
+		expect(map2.get('before-join')).toBe('edit-1');
+		expect(map2.toJSON().node).toEqual({ x: 10 });
+	});
+
+	it('syncs when the receiver connects before the sender (reciprocal handshake)', async () => {
+		// Receiver (no data) connects first; sender (with data) connects second.
+		map1.set('initial', 'from-doc1');
+
+		await sync2.start();
+		await sync1.start();
+
+		expect(map2.get('initial')).toBe('from-doc1');
+	});
+
+	it('syncs changes made after both peers are connected', async () => {
+		await sync1.start();
+		await sync2.start();
+
+		map1.set('key', 'value');
+		expect(map2.get('key')).toBe('value');
+	});
+
+	it('syncs bidirectionally', async () => {
+		await sync1.start();
+		await sync2.start();
+
+		map1.set('from1', 'hello');
+		map2.set('from2', 'world');
+
+		expect(map1.get('from2')).toBe('world');
+		expect(map2.get('from1')).toBe('hello');
+	});
+
+	it('converges when both peers hold prior edits before connecting', async () => {
+		await sync1.start();
+		map1.set('onlyOn1', 'a');
+		await sync2.start();
+		// doc2 made an edit before its handshake reply lands back on doc1.
+		map2.set('onlyOn2', 'b');
+
+		expect(map1.toJSON()).toEqual({ onlyOn1: 'a', onlyOn2: 'b' });
+		expect(map2.toJSON()).toEqual({ onlyOn1: 'a', onlyOn2: 'b' });
+	});
+
+	it('does not create an infinite sync loop', async () => {
+		await sync1.start();
+		await sync2.start();
+
+		let updates1 = 0;
+		let updates2 = 0;
+		doc1.onUpdate(() => updates1++);
+		doc2.onUpdate(() => updates2++);
+
+		map1.set('key', 'value');
+
+		expect(updates1).toBeLessThan(5);
+		expect(updates2).toBeLessThan(5);
+	});
+
+	it('stops syncing after stop()', async () => {
+		await sync1.start();
+		await sync2.start();
+
+		map1.set('before', 'stop');
+		expect(map2.get('before')).toBe('stop');
+
+		sync1.stop();
+		expect(sync1.syncing).toBe(false);
+
+		map1.set('after', 'stop');
+		expect(map2.get('after')).toBeUndefined();
+	});
+
+	it('reports sync state changes', async () => {
+		const states: boolean[] = [];
+		sync1.onSyncStateChange((syncing) => states.push(syncing));
+
+		await sync1.start();
+		sync1.stop();
+
+		expect(states).toEqual([true, false]);
+	});
+
+	it('reports errors on malformed messages and keeps syncing', async () => {
+		await sync1.start();
+		await sync2.start();
+
+		const errors: Error[] = [];
+		sync2.onError((error) => errors.push(error));
+
+		// A SYNC_UPDATE (type byte 2) carrying garbage update bytes.
+		transport1.send(new Uint8Array([2, 9, 9, 9, 9]));
+
+		expect(errors.length).toBe(1);
+		expect(sync2.syncing).toBe(true);
+
+		map1.set('after-error', 'ok');
+		expect(map2.get('after-error')).toBe('ok');
+	});
+});
+
+describe('CRDTDoc.encodeStateFrom', () => {
+	it('encodes only the updates a peer with the given state vector is missing', () => {
+		const provider = createCRDTProvider({ engine: CRDTEngine.yjs });
+		const source = provider.createDoc('source');
+		const target = provider.createDoc('target');
+
+		source.getMap('data').set('a', 1);
+		target.applyUpdate(source.encodeState());
+		// target now matches source; capture its vector, then source diverges.
+		const targetVector = target.encodeStateVector();
+		source.getMap('data').set('b', 2);
+
+		const diff = source.encodeStateFrom(targetVector);
+		target.applyUpdate(diff);
+
+		expect(target.getMap('data').toJSON()).toEqual({ a: 1, b: 2 });
+	});
+});

--- a/packages/@n8n/crdt/src/sync/handshake-sync-provider.test.ts
+++ b/packages/@n8n/crdt/src/sync/handshake-sync-provider.test.ts
@@ -1,8 +1,60 @@
 import { createCRDTProvider, CRDTEngine } from '../index';
 import { MockTransport } from '../transports';
-import type { CRDTDoc, CRDTMap } from '../types';
+import type { SyncTransport } from '../transports';
+import type { CRDTDoc, CRDTMap, Unsubscribe } from '../types';
 import { createHandshakeSyncProvider } from './handshake-sync-provider';
 import type { SyncProvider } from './types';
+
+/**
+ * In-memory broadcast bus for testing multi-peer mesh sync. Each transport on the
+ * bus delivers every sent message to all OTHER connected transports (synchronously,
+ * for deterministic tests) — mirroring a BroadcastChannel across tabs.
+ */
+class BusTransport implements SyncTransport {
+	private handlers = new Set<(data: Uint8Array) => void>();
+	private _connected = false;
+
+	constructor(private readonly bus: BusTransport[]) {
+		bus.push(this);
+	}
+
+	get connected(): boolean {
+		return this._connected;
+	}
+
+	send(data: Uint8Array): void {
+		if (!this._connected) throw new Error('Transport not connected');
+		for (const peer of this.bus) {
+			if (peer !== this && peer._connected) peer.deliver(data);
+		}
+	}
+
+	onReceive(handler: (data: Uint8Array) => void): Unsubscribe {
+		this.handlers.add(handler);
+		return () => this.handlers.delete(handler);
+	}
+
+	async connect(): Promise<void> {
+		this._connected = true;
+		return await Promise.resolve();
+	}
+
+	disconnect(): void {
+		this._connected = false;
+	}
+
+	onConnectionChange(_handler: (connected: boolean) => void): Unsubscribe {
+		return () => {};
+	}
+
+	onError(_handler: (error: Error) => void): Unsubscribe {
+		return () => {};
+	}
+
+	private deliver(data: Uint8Array): void {
+		for (const handler of this.handlers) handler(data);
+	}
+}
 
 describe('HandshakeSyncProvider', () => {
 	let doc1: CRDTDoc;
@@ -162,5 +214,42 @@ describe('CRDTDoc.encodeStateFrom', () => {
 		target.applyUpdate(diff);
 
 		expect(target.getMap('data').toJSON()).toEqual({ a: 1, b: 2 });
+	});
+});
+
+describe('HandshakeSyncProvider — multi-peer mesh', () => {
+	it("pulls in every late joiner's history, not just the first peer's", async () => {
+		const bus: BusTransport[] = [];
+		const provider = createCRDTProvider({ engine: CRDTEngine.yjs });
+		const docA = provider.createDoc('A');
+		const docB = provider.createDoc('B');
+		const docC = provider.createDoc('C');
+		const syncA = createHandshakeSyncProvider(docA, new BusTransport(bus));
+		const syncB = createHandshakeSyncProvider(docB, new BusTransport(bus));
+		const syncC = createHandshakeSyncProvider(docC, new BusTransport(bus));
+
+		// A and B connect first and exchange — A reciprocates B's handshake, so a
+		// once-global reciprocation guard would now be spent.
+		await syncA.start();
+		docA.getMap('data').set('fromA', 1);
+		await syncB.start();
+
+		// C joins last, holding a unique edit it made before connecting.
+		docC.getMap('data').set('fromC', 3);
+		await syncC.start();
+
+		// All three must converge — crucially, A and B must pull in C's pre-connect
+		// edit, which only happens if they reciprocate C's (a late peer's) handshake.
+		const expected = { fromA: 1, fromC: 3 };
+		expect(docA.getMap('data').toJSON()).toEqual(expected);
+		expect(docB.getMap('data').toJSON()).toEqual(expected);
+		expect(docC.getMap('data').toJSON()).toEqual(expected);
+
+		syncA.stop();
+		syncB.stop();
+		syncC.stop();
+		docA.destroy();
+		docB.destroy();
+		docC.destroy();
 	});
 });

--- a/packages/@n8n/crdt/src/sync/handshake-sync-provider.ts
+++ b/packages/@n8n/crdt/src/sync/handshake-sync-provider.ts
@@ -1,0 +1,154 @@
+import { decodeMessage, encodeMessage } from '../protocol';
+import type { SyncTransport } from '../transports';
+import type { CRDTDoc, Unsubscribe } from '../types';
+import type { SyncProvider } from './types';
+
+type SyncStateHandler = (syncing: boolean) => void;
+type ErrorHandler = (error: Error) => void;
+
+/**
+ * Sync sub-message types, framed as `[type, ...payload]` over the transport.
+ * Modeled on the y-protocols sync flow.
+ */
+/** Announce our state vector so the peer can send what we're missing. */
+const SYNC_STEP1 = 0;
+/** Reply with the updates a peer is missing (diff for its state vector). */
+const SYNC_STEP2 = 1;
+/** An incremental document update. */
+const SYNC_UPDATE = 2;
+
+/**
+ * HandshakeSyncProvider - sync provider with a state-vector handshake.
+ *
+ * Unlike {@link BaseSyncProvider} (which only blindly sends its full state on
+ * connect), this performs a SyncStep1/SyncStep2 exchange: on connect each peer
+ * announces its state vector, and peers reply with exactly the updates the
+ * requester lacks. This lets a peer that joins *after* edits were made catch up
+ * to the current state — the late-join case BaseSyncProvider misses.
+ *
+ * Designed for broadcast/mesh transports (e.g. BroadcastChannel across tabs)
+ * where every peer receives every message; incremental updates are relayed to
+ * all peers and de-duplicated by the CRDT (applying a known update is a no-op).
+ */
+export class HandshakeSyncProvider implements SyncProvider {
+	private _syncing = false;
+	private stateHandlers = new Set<SyncStateHandler>();
+	private errorHandlers = new Set<ErrorHandler>();
+	private unsubscribeDoc: Unsubscribe | null = null;
+	private unsubscribeTransport: Unsubscribe | null = null;
+	// Whether we've already reciprocated a peer's handshake with our own STEP1.
+	// Bounds the exchange to at most two STEP1s per peer (connect + one reply),
+	// so it terminates instead of ping-ponging.
+	private reciprocated = false;
+
+	constructor(
+		readonly doc: CRDTDoc,
+		readonly transport: SyncTransport,
+	) {}
+
+	get syncing(): boolean {
+		return this._syncing;
+	}
+
+	async start(): Promise<void> {
+		if (this._syncing) return;
+
+		await this.transport.connect();
+
+		this.unsubscribeTransport = this.transport.onReceive((data) => this.handleMessage(data));
+
+		// Relay local document updates to peers.
+		this.unsubscribeDoc = this.doc.onUpdate((update) => {
+			if (this.transport.connected) {
+				this.transport.send(encodeMessage(SYNC_UPDATE, update));
+			}
+		});
+
+		// Kick off the handshake: tell peers what we already have so they can
+		// send us anything we're missing.
+		this.transport.send(encodeMessage(SYNC_STEP1, this.doc.encodeStateVector()));
+
+		this._syncing = true;
+		this.notifyStateChange();
+	}
+
+	stop(): void {
+		if (!this._syncing) return;
+
+		this.unsubscribeDoc?.();
+		this.unsubscribeDoc = null;
+		this.unsubscribeTransport?.();
+		this.unsubscribeTransport = null;
+		this.reciprocated = false;
+
+		this.transport.disconnect();
+
+		this._syncing = false;
+		this.notifyStateChange();
+	}
+
+	onSyncStateChange(handler: SyncStateHandler): Unsubscribe {
+		this.stateHandlers.add(handler);
+		return () => this.stateHandlers.delete(handler);
+	}
+
+	onError(handler: ErrorHandler): Unsubscribe {
+		this.errorHandlers.add(handler);
+		return () => this.errorHandlers.delete(handler);
+	}
+
+	private handleMessage(data: Uint8Array): void {
+		try {
+			const { messageType, payload } = decodeMessage(data);
+			switch (messageType) {
+				case SYNC_STEP1: {
+					if (!this.transport.connected) break;
+					// A peer announced its state vector — reply with the diff it lacks.
+					this.transport.send(encodeMessage(SYNC_STEP2, this.doc.encodeStateFrom(payload)));
+					// Reciprocate once so the peer sends us anything WE'RE missing. A
+					// peer's connect-time STEP1 is lost to peers that join later, so
+					// this is how an already-present peer requests a late joiner's
+					// pre-connect state. Guarded to terminate the exchange.
+					if (!this.reciprocated) {
+						this.reciprocated = true;
+						this.transport.send(encodeMessage(SYNC_STEP1, this.doc.encodeStateVector()));
+					}
+					break;
+				}
+				case SYNC_STEP2: {
+					this.doc.applyUpdate(payload);
+					// We have now caught up to a peer's state.
+					this.doc.setSynced(true);
+					break;
+				}
+				case SYNC_UPDATE: {
+					this.doc.applyUpdate(payload);
+					break;
+				}
+				default:
+					break;
+			}
+		} catch (error) {
+			this.notifyError(error instanceof Error ? error : new Error(String(error)));
+		}
+	}
+
+	private notifyStateChange(): void {
+		for (const handler of this.stateHandlers) {
+			handler(this._syncing);
+		}
+	}
+
+	private notifyError(error: Error): void {
+		for (const handler of this.errorHandlers) {
+			handler(error);
+		}
+	}
+}
+
+/**
+ * Create a {@link HandshakeSyncProvider} for any CRDTDoc.
+ */
+export function createHandshakeSyncProvider(doc: CRDTDoc, transport: SyncTransport): SyncProvider {
+	return new HandshakeSyncProvider(doc, transport);
+}

--- a/packages/@n8n/crdt/src/sync/handshake-sync-provider.ts
+++ b/packages/@n8n/crdt/src/sync/handshake-sync-provider.ts
@@ -16,6 +16,12 @@ const SYNC_STEP1 = 0;
 const SYNC_STEP2 = 1;
 /** An incremental document update. */
 const SYNC_UPDATE = 2;
+/**
+ * Like SYNC_STEP1 but sent in reply to a peer's SYNC_STEP1, so the peer sends us
+ * anything WE'RE missing. A distinct type so a reply is never itself replied to —
+ * that's what terminates the exchange (request → reply → diff, no STEP1 ping-pong).
+ */
+const SYNC_STEP1_REPLY = 3;
 
 /**
  * HandshakeSyncProvider - sync provider with a state-vector handshake.
@@ -36,10 +42,6 @@ export class HandshakeSyncProvider implements SyncProvider {
 	private errorHandlers = new Set<ErrorHandler>();
 	private unsubscribeDoc: Unsubscribe | null = null;
 	private unsubscribeTransport: Unsubscribe | null = null;
-	// Whether we've already reciprocated a peer's handshake with our own STEP1.
-	// Bounds the exchange to at most two STEP1s per peer (connect + one reply),
-	// so it terminates instead of ping-ponging.
-	private reciprocated = false;
 
 	constructor(
 		readonly doc: CRDTDoc,
@@ -79,7 +81,6 @@ export class HandshakeSyncProvider implements SyncProvider {
 		this.unsubscribeDoc = null;
 		this.unsubscribeTransport?.();
 		this.unsubscribeTransport = null;
-		this.reciprocated = false;
 
 		this.transport.disconnect();
 
@@ -103,16 +104,22 @@ export class HandshakeSyncProvider implements SyncProvider {
 			switch (messageType) {
 				case SYNC_STEP1: {
 					if (!this.transport.connected) break;
-					// A peer announced its state vector — reply with the diff it lacks.
+					// A peer announced its state vector on connect — reply with the diff
+					// it lacks, then reciprocate so it sends us anything WE'RE missing.
+					// (Its connect-time STEP1 never reached peers already present, so
+					// reciprocating is how we pull in a late joiner's pre-connect state.)
+					// Replying per incoming request — not once globally — is what makes
+					// this correct for sessions with more than two peers.
 					this.transport.send(encodeMessage(SYNC_STEP2, this.doc.encodeStateFrom(payload)));
-					// Reciprocate once so the peer sends us anything WE'RE missing. A
-					// peer's connect-time STEP1 is lost to peers that join later, so
-					// this is how an already-present peer requests a late joiner's
-					// pre-connect state. Guarded to terminate the exchange.
-					if (!this.reciprocated) {
-						this.reciprocated = true;
-						this.transport.send(encodeMessage(SYNC_STEP1, this.doc.encodeStateVector()));
-					}
+					this.transport.send(encodeMessage(SYNC_STEP1_REPLY, this.doc.encodeStateVector()));
+					break;
+				}
+				case SYNC_STEP1_REPLY: {
+					if (!this.transport.connected) break;
+					// Reciprocation from a peer — answer with the diff it lacks. A reply
+					// is never itself reciprocated, which terminates the handshake
+					// (request → reply → diff) instead of ping-ponging STEP1s forever.
+					this.transport.send(encodeMessage(SYNC_STEP2, this.doc.encodeStateFrom(payload)));
 					break;
 				}
 				case SYNC_STEP2: {

--- a/packages/@n8n/crdt/src/sync/index.ts
+++ b/packages/@n8n/crdt/src/sync/index.ts
@@ -1,2 +1,3 @@
 export type { SyncProvider, CreateSyncProvider } from './types';
 export { BaseSyncProvider, createSyncProvider } from './base-sync-provider';
+export { HandshakeSyncProvider, createHandshakeSyncProvider } from './handshake-sync-provider';

--- a/packages/@n8n/crdt/src/types.ts
+++ b/packages/@n8n/crdt/src/types.ts
@@ -188,6 +188,12 @@ export interface CRDTDoc {
 	 * Useful for efficient change detection - compare vectors to check if state changed.
 	 */
 	encodeStateVector(): Uint8Array;
+	/**
+	 * Encode only the updates missing from a peer that has the given state vector.
+	 * Produces a compact diff (like y-protocols SyncStep2) rather than the full
+	 * state, enabling efficient state-vector sync handshakes for late joiners.
+	 */
+	encodeStateFrom(remoteStateVector: Uint8Array): Uint8Array;
 	/** Apply an update (or full state) from another document */
 	applyUpdate(update: Uint8Array): void;
 	/** Subscribe to outgoing updates. Only fires for local changes (origin='local'). */


### PR DESCRIPTION
## Summary

Adds a `HandshakeSyncProvider` to `@n8n/crdt`: a sync provider that performs a state-vector handshake (SyncStep1/SyncStep2) on connect, so a peer joining **mid-edit** catches up to the current document state — the late-join case the existing `BaseSyncProvider` misses. Also adds the `CRDTDoc.encodeStateFrom(remoteStateVector)` primitive (the compact diff the handshake needs), implemented on Yjs via `Y.encodeStateAsUpdate`.

This is **PR 2 of an 8-PR series** introducing real-time CRDT collaboration to the workflow editor behind the PostHog experiment `089_crdt_collaboration`. It's a **root** of the dependency graph and is safe to merge while the feature is incomplete:

- **Nothing imports `@n8n/crdt` yet** — the new code is dead-by-default library code, exercised only by its own unit tests.
- **No feature-flag references** in the package.
- Every API the new code relies on (`setSynced`, `MockTransport.link`, `encodeMessage`/`decodeMessage`, …) already exists on `master`, so it compiles and merges in isolation.

### Changes
- `src/types.ts` — add `encodeStateFrom` to the `CRDTDoc` interface
- `src/providers/yjs.ts` — implement it via `Y.encodeStateAsUpdate`
- `src/sync/handshake-sync-provider.ts` *(new)* — `HandshakeSyncProvider` + `createHandshakeSyncProvider`
- `src/sync/handshake-sync-provider.test.ts` *(new)* — 10 unit tests
- `src/sync/index.ts`, `src/index.ts` — re-export the new provider/factory

> **Note:** an earlier draft of this branch also changed `package.json` (`module → src/index.ts`, dropping the `exports` map) so the frontend could resolve the package from source. That was **dropped** to keep `@n8n/crdt` publishable — frontend source resolution will be handled in the consumer PR via the editor-ui Vite alias + `tsconfig` `paths` (the same setup `@n8n/utils` uses).

## How to test

Library-only; no UI surface yet. From the package directory:

```bash
cd packages/@n8n/crdt
pnpm build && pnpm typecheck && pnpm lint && pnpm test
```

`handshake-sync-provider.test.ts` covers late-join catch-up, reciprocal handshake, bidirectional sync, convergence, loop-prevention, `stop()`, state-change events, and malformed-message handling. All **388** package tests pass.

## Related Linear tickets, Github issues, and Community forum posts

_None._ Part of the CRDT collaboration series.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32667">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

