### PR TITLE
fix: Revert"Hide AI Transform node when Instance AI is enabled" (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -10,7 +10,6 @@ import {
 	HTTP_REQUEST_NODE_TYPE,
 	CREDENTIAL_ONLY_HTTP_NODE_VERSION,
 	MODULE_ENABLED_NODES,
-	AI_TRANSFORM_NODE_TYPE,
 } from '@/app/constants';
 import { STORES } from '@n8n/stores';
 import type { NodeTypesByTypeNameAndVersion } from '@/Interface';
@@ -221,18 +220,10 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 	});
 
 	const visibleNodeTypes = computed(() => {
-		// Instance AI replaces the legacy "AI Transform" node; hide it from the
-		// creator/search when the instance has Instance AI on.
-		const instanceAiActive =
-			settingsStore.isModuleActive('instance-ai') &&
-			settingsStore.moduleSettings['instance-ai']?.enabled !== false;
 		return allLatestNodeTypes.value
 			.concat(officialCommunityNodeTypes.value)
 			.concat(moduleEnabledNodeTypes.value)
-			.filter(
-				(nodeType) =>
-					!nodeType.hidden && !(instanceAiActive && nodeType.name === AI_TRANSFORM_NODE_TYPE),
-			);
+			.filter((nodeType) => !nodeType.hidden);
 	});
 
 	const nativelyNumberSuffixedDefaults = computed(() => {


### PR DESCRIPTION
Reverts n8n-io/n8n#32603

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32671">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

