### PR TITLE
feat(editor): Investigate failed executions on Instance AI editor hand-offs

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoff.ts
@@ -9,31 +9,30 @@ import { useToast } from '@/app/composables/useToast';
 import { INSTANCE_AI_THREAD_VIEW } from '../constants';
 import { useInstanceAiStore } from '../instanceAi.store';
 
-/** Names the node and the existing credential id whenever they're known, so the
- *  agent can act on them directly. */
-function credentialQuestionDetails(credential: InstanceAiCredentialContext): string {
-	const node = credential.nodeName ? ` It's for the "${credential.nodeName}" node.` : '';
-	const existing = credential.id ? ` The existing credential id is \`${credential.id}\`.` : '';
-	return node + existing;
+/** The existing credential id, when known, so the agent can act on it directly. */
+function existingCredentialNote(credential: InstanceAiCredentialContext): string {
+	return credential.id ? ` The existing credential id is \`${credential.id}\`.` : '';
 }
 
 /**
  * Opening question for a new-tab credential hand-off (credentials list, editor):
  * the new thread carries no workflow, so it names the credential setup modal as
- * the user's context.
+ * the user's context. The node isn't carried into the new tab, so it isn't named.
  */
 export function buildInstanceAiCredentialQuestion(credential: InstanceAiCredentialContext): string {
-	return `How do I set up the credentials for ${credential.displayName}?${credentialQuestionDetails(credential)} I'm looking at the credential setup modal.`;
+	return `How do I set up the credentials for ${credential.displayName}?${existingCredentialNote(credential)} I'm looking at the credential setup modal.`;
 }
 
 /**
  * Opening question for an in-thread credential hand-off (the workflow artifact):
- * the workflow is already the thread's subject, so it omits the modal context.
+ * the workflow is already the thread's subject, so it names the node and omits
+ * the modal context.
  */
 export function buildInstanceAiArtifactCredentialQuestion(
 	credential: InstanceAiCredentialContext,
 ): string {
-	return `How do I set up the credentials for ${credential.displayName}?${credentialQuestionDetails(credential)}`;
+	const node = credential.nodeName ? ` It's for the "${credential.nodeName}" node.` : '';
+	return `How do I set up the credentials for ${credential.displayName}?${node}${existingCredentialNote(credential)}`;
 }
 
 const pendingFirstMessageKey = (threadId: string) => `n8n-instance-ai-first-message:${threadId}`;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoffCapability.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoffCapability.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type { InstanceAiWorkflowAttachment } from '@n8n/api-types';
 
@@ -12,6 +13,7 @@ import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 
 import { INSTANCE_AI_VIEW } from '../constants';
 import { useInstanceAiStore } from '../instanceAi.store';
@@ -89,9 +91,28 @@ export function useInstanceAiHandoffCapability(): InstanceAiEditorCapability {
 		const executionSnapshot = executionId
 			? useExecutionDataStore(createExecutionDataId(executionId)).getExecutionSnapshot()
 			: null;
+		// An error hand-off (the node-error view, or a failed run shown on the canvas)
+		// asks the agent to investigate; a plain hand-off keeps the empty message so the
+		// editor-context block has it just greet.
+		const executionFailed =
+			executionSnapshot?.status === 'error' || executionSnapshot?.status === 'crashed';
+		const openingMessage =
+			message ||
+			(executionFailed
+				? 'The execution failed. Look into what went wrong and help me fix it.'
+				: '');
+		// Close any open NDV before navigating. Otherwise its children unmount during
+		// the route change — after the workflow document store is gone — and throw via
+		// injectNDVStore(), aborting the navigation and leaving a blank screen. No-op
+		// when nothing is open (e.g. the canvas action button).
+		const ndvStore = useNDVStore(documentStore.value.documentId);
+		if (ndvStore.activeNode) {
+			ndvStore.unsetActiveNodeName();
+			await nextTick();
+		}
 		await startThread(
 			projectId,
-			message,
+			openingMessage,
 			[attachment],
 			(threadId) => {
 				instanceAiStore.getOrCreateRuntime(threadId, projectId).setPendingHandoff({


### PR DESCRIPTION
## Summary

Follow-ups to the editor → Instance AI hand-off (the "One Assistant" UX), now that it's merged:

- **Investigate failed executions.** When the editor hand-off carries a failed execution — the node-error view, or a failed run shown on the canvas — the new thread now opens with a message asking the agent to look into what went wrong, instead of the empty message that just greets. A plain hand-off (no failure) still greets and waits for the user.
- **Fix a blank screen on the node-error hand-off.** The node-error button navigated *without closing the NDV*. Its children then unmounted mid-navigation — after the workflow document store had been torn down — and threw via `injectNDVStore()`, which aborted the route change and left a blank screen. The hand-off now closes any open NDV (and lets it unmount via `nextTick`) before navigating. No-op for the canvas action button, where nothing is open.
- **Drop the node from the new-tab credential question.** A new-tab credential hand-off opens a fresh thread with no workflow, so naming the node (*"It's for the 'X' node."*) was misleading. The new-tab question omits it now; the in-thread artifact question — where the workflow *is* the thread's subject — still names the node. Both still pass the existing credential id when one is set.

## How to test

1. Enable Instance AI on the instance.
2. Run a workflow that fails → open the failing node's error → **Ask AI Assistant** → a new thread opens (no blank screen) and the agent investigates the failed execution.
3. On a canvas showing a failed run, click the canvas AI action button → the agent investigates. On a canvas with no run (or a successful one), it just greets and waits.
4. Open a node's credential (NDV) → **Ask AI Assistant** → a new tab; the question names the credential (and its id, if existing) but **not** the node.
5. Inside an Instance AI artifact, open a node's credential → **Ask AI Assistant** → appended to the current thread; the question **does** name the node.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #32398 (One Assistant editor hand-off). _Linear ticket: TBD._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32675">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

