### PR TITLE
fix(core): Allow middle mouse/right click new tab on Agents preview button (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderHeader.test.ts
@@ -8,9 +8,14 @@ import type { AgentResource } from '../types';
 const ensureLoadedMock = vi.fn();
 const agentsListRef = ref<AgentResource[] | null>(null);
 const routerPush = vi.fn();
-const routerResolve = vi.fn((to: { params?: { projectId?: string } }) => ({
-	href: `/projects/${to.params?.projectId ?? ''}/agents`,
-}));
+const routerResolve = vi.fn(
+	(to: { name?: string; params?: { projectId?: string; agentId?: string } }) => ({
+		href:
+			to.name === 'AgentPreviewView'
+				? `/projects/${to.params?.projectId ?? ''}/agents/${to.params?.agentId ?? ''}/preview`
+				: `/projects/${to.params?.projectId ?? ''}/agents`,
+	}),
+);
 
 vi.mock('../composables/useProjectAgentsList', () => ({
 	useProjectAgentsList: () => ({
@@ -34,8 +39,8 @@ vi.mock('@n8n/design-system', () => ({
 	N8nIcon: { template: '<i v-bind="$attrs"></i>', props: ['icon', 'size'] },
 	N8nButton: {
 		template:
-			'<button v-bind="$attrs" :data-variant="variant" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
-		props: ['variant', 'size', 'icon', 'iconOnly', 'disabled'],
+			'<component :is="href ? \'a\' : \'button\'" v-bind="$attrs" :href="href" :data-variant="variant" :disabled="!href && disabled" :aria-disabled="disabled || undefined" @click="$emit(\'click\', $event)"><slot /></component>',
+		props: ['variant', 'size', 'icon', 'iconOnly', 'disabled', 'href'],
 		emits: ['click'],
 	},
 	N8nDropdownMenuItem: {
@@ -247,6 +252,13 @@ describe('AgentBuilderHeader', () => {
 		expect(wrapper.emitted('open-preview')).toEqual([[]]);
 	});
 
+	it('exposes the preview route href for browser new-tab actions', () => {
+		const wrapper = mountHeader();
+		const previewButton = wrapper.find('[data-testid="agent-header-preview-btn"]');
+
+		expect(previewButton.attributes('href')).toBe('/projects/p1/agents/a1/preview');
+	});
+
 	it('disables preview with a tooltip when the agent is not runnable', async () => {
 		const wrapper = mountHeader({
 			agent: { ...baseAgent, isRunnable: false } as AgentResource,
@@ -254,6 +266,7 @@ describe('AgentBuilderHeader', () => {
 		const previewButton = wrapper.find('[data-testid="agent-header-preview-btn"]');
 
 		expect(previewButton.attributes('disabled')).toBeDefined();
+		expect(previewButton.attributes('href')).toBeUndefined();
 		expect(wrapper.find('[data-testid="stub-tooltip"]').attributes('data-disabled')).toBe('false');
 		expect(wrapper.find('[data-testid="stub-tooltip"]').attributes('data-content')).toBe(
 			'agents.builder.preview.disabledTooltip',

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderHeader.vue
@@ -21,7 +21,7 @@ import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Brea
 import type { DropdownMenuItemProps } from '@n8n/design-system';
 import type { ActionDropdownItem } from '@n8n/design-system/types/action-dropdown';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
-import { NEW_AGENT_VIEW, PROJECT_AGENTS } from '@/features/agents/constants';
+import { AGENT_PREVIEW_VIEW, NEW_AGENT_VIEW, PROJECT_AGENTS } from '@/features/agents/constants';
 
 import AgentPublishButton from './AgentPublishButton.vue';
 import { useProjectAgentsList } from '../composables/useProjectAgentsList';
@@ -61,6 +61,11 @@ const projectRoute = computed<RouteLocationRaw>(() => ({
 	params: { projectId: props.projectId },
 }));
 
+const previewRoute = computed<RouteLocationRaw>(() => ({
+	name: AGENT_PREVIEW_VIEW,
+	params: { projectId: props.projectId, agentId: props.agentId },
+}));
+
 const breadcrumbItems = computed<PathItem[]>(() => [
 	{
 		id: props.projectId,
@@ -73,6 +78,9 @@ const breadcrumbItems = computed<PathItem[]>(() => [
 const agentDisplayName = computed(() => props.agent?.name ?? '…');
 
 const isPreviewDisabled = computed(() => props.agent?.isRunnable !== true);
+const previewHref = computed(() =>
+	isPreviewDisabled.value ? undefined : router.resolve(previewRoute.value).href,
+);
 const previewDisabledTooltip = computed(() =>
 	i18n.baseText('agents.builder.preview.disabledTooltip' as BaseTextKey),
 );
@@ -108,8 +116,21 @@ function onBreadcrumbSelect(item: PathItem) {
 	void router.push(projectRoute.value);
 }
 
-function onOpenPreview() {
-	if (isPreviewDisabled.value) return;
+function onPreviewClick(event: MouseEvent) {
+	if (isPreviewDisabled.value) {
+		event.preventDefault();
+		return;
+	}
+	if (
+		event.defaultPrevented ||
+		event.button !== 0 ||
+		event.metaKey ||
+		event.ctrlKey ||
+		event.shiftKey
+	) {
+		return;
+	}
+	event.preventDefault();
 	emit('open-preview');
 }
 
@@ -176,9 +197,10 @@ const isVersionHistoryDisabled = computed(() => !props.agent?.hasPublishHistory)
 					variant="ghost"
 					size="medium"
 					icon="play"
+					:href="previewHref"
 					:disabled="isPreviewDisabled"
 					data-testid="agent-header-preview-btn"
-					@click="onOpenPreview"
+					@click="onPreviewClick"
 				>
 					{{ i18n.baseText('agents.builder.preview.button' as BaseTextKey) }}
 				</N8nButton>


### PR DESCRIPTION
## Summary

Quick fix for preview button, turn into a link and allow middle mouse/right click new tab.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-269/bug-cant-rightmiddle-click-on-preview-to-open-in-new-tab

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

