### PR TITLE
test(core): Mock the shared token client in Salesforce JWT credential test (flaky) 

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -36,6 +36,15 @@ jest.mock('@utils/utilities', () => ({ formatPrivateKey: (key: string) => key })
 	virtual: true,
 });
 
+// SalesforceJwtApi.preAuthentication exchanges its signed JWT for a token through the
+// shared outbound HTTP client (`getTokenRequestClient`), not `this.helpers.httpRequest`.
+// Mock that client so the token POST is observable and never hits the network.
+const mockTokenRequest = jest.fn();
+jest.mock('n8n-nodes-base/credentials/common/token-request', () => ({
+	getTokenRequestClient: () => ({ request: mockTokenRequest }),
+	TOKEN_REQUEST_TIMEOUT: 30_000,
+}));
+
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import { CredentialsHelper } from '@/credentials-helper';
@@ -1569,7 +1578,7 @@ describe('CredentialsHelper', () => {
 		// Proves the framework performs the JWT login only when the cached token is
 		// missing or expired, so chained Salesforce actions reuse one session instead
 		// of authenticating on every request. The login is the credential's
-		// `preAuthentication` hook, which we observe through a counting `httpRequest`.
+		// `preAuthentication` hook, which we observe through a counting token request.
 		const { privateKey } = generateKeyPairSync('rsa', {
 			modulusLength: 2048,
 			publicKeyEncoding: { type: 'spki', format: 'pem' },
@@ -1588,8 +1597,7 @@ describe('CredentialsHelper', () => {
 			credentials: { salesforceJwtApi: { id: 'sf-cred', name: 'Salesforce JWT' } },
 		};
 
-		let httpRequest: jest.Mock;
-		let helpers: IHttpRequestHelper;
+		const helpers = mock<IHttpRequestHelper>();
 		let updateSpy: jest.SpyInstance;
 		let credentials: ICredentialDataDecryptedObject;
 
@@ -1601,11 +1609,10 @@ describe('CredentialsHelper', () => {
 
 			let logins = 0;
 			// eslint-disable-next-line @typescript-eslint/require-await
-			httpRequest = jest.fn().mockImplementation(async () => ({
+			mockTokenRequest.mockImplementation(async () => ({
 				access_token: `TOKEN_${++logins}`,
 				instance_url: 'https://acme.my.salesforce.com',
 			}));
-			helpers = { helpers: { httpRequest } } as unknown as IHttpRequestHelper;
 
 			// Stub persistence so the test does not touch the DB. The returned token is
 			// what the request helper merges back into the in-memory credentials for the
@@ -1634,8 +1641,8 @@ describe('CredentialsHelper', () => {
 				false,
 			);
 
-			expect(httpRequest).toHaveBeenCalledTimes(1);
-			expect(httpRequest).toHaveBeenCalledWith(
+			expect(mockTokenRequest).toHaveBeenCalledTimes(1);
+			expect(mockTokenRequest).toHaveBeenCalledWith(
 				expect.objectContaining({
 					method: 'POST',
 					url: 'https://login.salesforce.com/services/oauth2/token',
@@ -1671,7 +1678,7 @@ describe('CredentialsHelper', () => {
 			expect(second).toBeUndefined();
 			expect(third).toBeUndefined();
 			// Still only the single login from request 1 across all three requests.
-			expect(httpRequest).toHaveBeenCalledTimes(1);
+			expect(mockTokenRequest).toHaveBeenCalledTimes(1);
 		});
 
 		test('re-authenticates when the cached token is reported expired (e.g. after a 401)', async () => {
@@ -1682,7 +1689,7 @@ describe('CredentialsHelper', () => {
 				node,
 				false,
 			);
-			expect(httpRequest).toHaveBeenCalledTimes(1);
+			expect(mockTokenRequest).toHaveBeenCalledTimes(1);
 			expect(credentials.accessToken).toBe('TOKEN_1');
 
 			// credentialsExpired = true mirrors the request helper's retry after a 401.
@@ -1694,7 +1701,7 @@ describe('CredentialsHelper', () => {
 				true,
 			);
 
-			expect(httpRequest).toHaveBeenCalledTimes(2);
+			expect(mockTokenRequest).toHaveBeenCalledTimes(2);
 			expect(refreshed).toMatchObject({ accessToken: 'TOKEN_2' });
 		});
 	});


### PR DESCRIPTION
## Summary

The `preAuthentication token caching` tests in `credentials-helper.test.ts` mocked `this.helpers.httpRequest`, but `SalesforceJwtApi.preAuthentication` was refactored (in #32595) to issue its token POST through the shared outbound HTTP client (`getTokenRequestClient()`), not the node request helper. The injected mock was therefore bypassed and the tests attempted a **real** connection to `login.salesforce.com`.

`nock` blocked the connection, axios produced an `AxiosError` carrying a circular `follow-redirects` request object, and when Jest serialized the test result over its worker IPC channel `JSON.stringify` threw `Converting circular structure to JSON`. That killed the worker process; after exhausting retries the runner reported `Test suite failed to run / Jest worker encountered 4 child process exceptions` against whatever file the worker was holding — surfacing as a confusing, seemingly-unrelated failure in CI.

This change mocks the module the credential actually calls — `n8n-nodes-base/credentials/common/token-request` — so `getTokenRequestClient()` returns a counting `request` stub. The caching assertions now observe that stub, no real network call is made, and the suite is stable.

## How to test

```bash
cd packages/cli
pnpm jest src/__tests__/credentials-helper.test.ts
```

All 43 tests pass (previously 41 passed / 2 failed in the `preAuthentication token caching` block). No network access is attempted.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No dedicated Linear ticket; this is a test-only fix for a regression introduced by #32595. -->
N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32679">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->