### PR TITLE
fix(HTTP Request Node): Apply default batch interval when the field is left unchanged

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -329,9 +329,11 @@ export class HttpRequestV3 implements INodeType {
 
 				// defaults batch size to 1 of it's set to 0
 				const batchSize = batching?.batch?.batchSize > 0 ? batching?.batch?.batchSize : 1;
-				const batchInterval = batching?.batch.batchInterval;
+				// an unset field isn't saved, so fall back to the default shown in the UI
+				const batchInterval = batching?.batch?.batchInterval ?? 1000;
 
-				if (itemIndex > 0 && batchSize >= 0 && batchInterval > 0) {
+				// only delay when batching was actually configured, so other nodes aren't slowed
+				if (itemIndex > 0 && batching?.batch && batchSize >= 0 && batchInterval > 0) {
 					if (itemIndex % batchSize === 0) {
 						await sleep(batchInterval);
 					}

--- a/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/node/HttpRequestV3.test.ts
@@ -1,8 +1,15 @@
 import FormData from 'form-data';
+import { sleep } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeTypeBaseDescription } from 'n8n-workflow';
+import type * as nWorkflow from 'n8n-workflow';
 
 import { HttpRequestV3 } from '../../V3/HttpRequestV3.node';
 import type { Mock } from 'vitest';
+
+vi.mock('n8n-workflow', async () => ({
+	...(await vi.importActual<typeof nWorkflow>('n8n-workflow')),
+	sleep: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe('HttpRequestV3', () => {
 	let node: HttpRequestV3;
@@ -1132,6 +1139,72 @@ describe('HttpRequestV3', () => {
 			expect(result[0][0].json.error).toBeDefined();
 			// Item 1 → valid response, no crash
 			expect(result[0][1].json.ok).toBe(true);
+		});
+	});
+
+	describe('batch interval default', () => {
+		// Runs `itemCount` items through the node. Omit `batch` to simulate Batching never being added.
+		const setupBatchingItems = (
+			itemCount: number,
+			batch?: { batchSize?: number; batchInterval?: number },
+		) => {
+			const items = Array.from({ length: itemCount }, () => ({ json: {} }));
+			(executeFunctions.getInputData as Mock).mockReturnValue(items);
+			(executeFunctions.getNodeParameter as Mock).mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return baseUrl;
+					case 'authentication':
+						return 'none';
+					case 'options':
+						return batch ? { batching: { batch } } : {};
+					default:
+						return undefined;
+				}
+			});
+			// fresh object per call: the node deletes headers off the response between items
+			(executeFunctions.helpers.request as Mock).mockImplementation(async () => ({
+				headers: { 'content-type': 'application/json' },
+				body: Buffer.from(JSON.stringify({ success: true })),
+			}));
+		};
+
+		beforeEach(() => {
+			vi.mocked(sleep).mockClear();
+		});
+
+		it('falls back to the 1000ms UI default when Batching is enabled but the interval is unset', async () => {
+			setupBatchingItems(2, { batchSize: 1 });
+
+			await node.execute.call(executeFunctions);
+
+			expect(sleep).toHaveBeenCalledWith(1000);
+		});
+
+		it('does not delay when the Batching option was never added', async () => {
+			setupBatchingItems(2);
+
+			await node.execute.call(executeFunctions);
+
+			expect(sleep).not.toHaveBeenCalled();
+		});
+
+		it('does not delay when the batch interval is explicitly set to 0', async () => {
+			setupBatchingItems(2, { batchSize: 1, batchInterval: 0 });
+
+			await node.execute.call(executeFunctions);
+
+			expect(sleep).not.toHaveBeenCalled();
+		});
+
+		it('honours an explicit batch interval', async () => {
+			setupBatchingItems(2, { batchSize: 1, batchInterval: 500 });
+
+			await node.execute.call(executeFunctions);
+
+			expect(sleep).toHaveBeenCalledWith(500);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The HTTP Request node shows a **Batch Interval** of `1000` ms by default under Options → Batching. The problem is that when you enable Batching but never click into the Batch Interval field, that value is not saved onto the node. At runtime
the node reads it as `undefined`, the `batchInterval > 0` check quietly fails, and the requests fire back to back with no spacing at all.

This is confusing because the field looks configured (it shows `1000`), yet rate limited APIs still return `429 Too Many Requests`. It is also inconsistent with the **Batch Size** field next to it, which already falls back to a default
when it is missing.

The fix makes the node fall back to the documented `1000` ms default at runtime, but only when the Batching option was actually added. Nodes that never used batching are untouched and keep firing immediately. An explicit `0` still means
"disabled".

### Behavior

| Node state | Before | After this fix |
|---|---|---|
| Never opened Batching | no delay | no delay ✓ (unchanged) |
| Opened Batching, interval left at default | no delay (the bug) | 1s delay ✓|
| Opened Batching, interval set to `0` | no delay | no delay  |

## How to test

1. Add a Code node that returns several items (for example 4), feeding an HTTP
   Request node pointed at any endpoint.
2. On the HTTP Request node, open Options → Batching, set **Items per Batch** to
   `1`, and leave **Batch Interval** at its default `1000` without editing it.
3. Run the workflow.
   - Before the fix: all requests fire immediately.
   - After the fix: requests are spaced about 1 second apart.
4. Set **Batch Interval** to `0` and run again: requests fire back to back,
   confirming `0` still disables the delay.
5. Remove the Batching option entirely and run with multiple items: requests
   fire immediately, confirming non batching nodes are unaffected.

## Related Linear tickets, Github issues, and Community forum posts

fixes #32646


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (No docs change needed: behavior now matches existing docs.)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (decide if this should be backported).

## Notes for reviewer

- **Scope is V3 only (on purpose).** V1 and V2 read `batchInterval` the same way and have the same latent issue, but they are legacy versions. Silently adding 1 second of spacing to long running, years old workflows felt riskier than the bug itself, so I left them. Happy to extend the fix if you prefer consistency.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

