### PR TITLE
refactor(editor): Remove @ts-ignore in executions list dropdown handler (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
@@ -7,6 +7,7 @@ import { useI18n } from '@n8n/i18n';
 import { VIEWS } from '@/app/constants';
 import type { PermissionsRecord } from '@n8n/permissions';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
+import { checkExhaustive } from '@/app/utils/typeGuards';
 import type { IconColor } from '@n8n/design-system/types/icon';
 import type { ExecutionStatus, ExecutionSummary } from 'n8n-workflow';
 import { WAIT_INDEFINITELY } from 'n8n-workflow';
@@ -169,8 +170,19 @@ function onSelect() {
 }
 
 async function handleActionItemClick(commandData: Command) {
-	//@ts-ignore todo: fix this type
-	emit(commandData, props.execution);
+	switch (commandData) {
+		case 'retrySaved':
+			emit('retrySaved', props.execution);
+			break;
+		case 'retryOriginal':
+			emit('retryOriginal', props.execution);
+			break;
+		case 'delete':
+			emit('delete', props.execution);
+			break;
+		default:
+			checkExhaustive(commandData);
+	}
 }
 </script>
 <template>


### PR DESCRIPTION
## Summary

Removes a `@ts-ignore` in `GlobalExecutionsListItem.vue`.

The dropdown handler called `emit(commandData, props.execution)`, where `commandData` is a union of event names. TypeScript does not allow that, so the line was silenced with `@ts-ignore`. I replaced it with a `switch` that emits each event by name, plus a `default` case that calls `checkExhaustive`. If someone adds a new command later and forgets to handle it, the build fails instead of doing nothing.

## How to test

Open the Executions list and use the row menu actions (retry with saved workflow, retry with original workflow, delete). They work as before. `pnpm --filter n8n-editor-ui typecheck` passes.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
