### PR TITLE
refactor(editor): Thread outgoing workflow id through workspace teardown (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -4776,6 +4776,40 @@ describe('useCanvasOperations', () => {
 			expect(credentialsUpdatedRef.value).toBe(false);
 		});
 
+		it('tears down the explicitly passed outgoing workflow, not the current id', () => {
+			const nodeCreatorStore = mockedStore(useNodeCreatorStore);
+			const workflowsStore = mockedStore(useWorkflowsStore);
+
+			nodeCreatorStore.setNodeCreatorState = vi.fn();
+			workflowsStore.removeTestWebhook = vi.fn();
+			workflowsStore.resetWorkflow = vi.fn();
+			workflowsStore.clearCurrentWorkflowExecutions = vi.fn();
+			workflowsStore.setLastSuccessfulExecution = vi.fn();
+			const resetWorkflowSpy = workflowsStore.resetWorkflow as ReturnType<typeof vi.fn>;
+
+			// The current id is already the INCOMING workflow (dispose-first flow); the
+			// OUTGOING id is passed explicitly and must be the one torn down.
+			workflowsStore.workflowId = 'incoming-id';
+			const outgoingExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('outgoing-id'),
+			);
+			vi.spyOn(outgoingExecutionStateStore, 'executionWaitingForWebhook', 'get').mockReturnValue(
+				true,
+			);
+
+			const { resetWorkspace } = useCanvasOperations();
+
+			resetWorkspace('outgoing-id');
+
+			expect(nodeCreatorStore.setNodeCreatorState).toHaveBeenCalledWith({
+				workflowId: 'outgoing-id',
+				createNodeActive: false,
+			});
+			expect(workflowsStore.removeTestWebhook).toHaveBeenCalledWith('outgoing-id');
+			expect(outgoingExecutionStateStore.resetExecutionState).toHaveBeenCalled();
+			expect(resetWorkflowSpy).toHaveBeenCalledWith('outgoing-id');
+		});
+
 		it('should not call removeTestWebhook if executionWaitingForWebhook is false', () => {
 			const nodeCreatorStore = mockedStore(useNodeCreatorStore);
 			const workflowsStore = mockedStore(useWorkflowsStore);

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2505,14 +2505,17 @@ export function useCanvasOperations() {
 	 * Workspace operations
 	 */
 
-	function resetWorkspace() {
+	function resetWorkspace(outgoingWorkflowId?: string) {
+		// The workflow being torn down. Dispose-first callers (route already on the
+		// next workflow) pass it explicitly; otherwise it is the current workflow.
+		const workflowId = outgoingWorkflowId ?? workflowsStore.workflowId;
+
 		// Reset node creator
 		nodeCreatorStore.setNodeCreatorState({
-			workflowId: workflowDocumentStore.value.workflowId,
+			workflowId,
 			createNodeActive: false,
 		});
 
-		const workflowId = workflowsStore.workflowId;
 		const executionStateStore = useWorkflowExecutionStateStore(
 			createWorkflowDocumentId(workflowId),
 		);
@@ -2540,7 +2543,7 @@ export function useCanvasOperations() {
 		// `resetExecutionState()` above already empties currentWorkflowExecutions and
 		// the last-successful reference (and disposes the tracked executionData
 		// stores), so no separate clear is needed here.
-		workflowsStore.resetWorkflow();
+		workflowsStore.resetWorkflow(workflowId);
 
 		// Reset actions
 		uiStore.resetLastInteractedWith();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -254,8 +254,11 @@ export function useWorkflowInitialization() {
 			);
 		}
 
+		// Capture the outgoing workflow id before disposal nulls the current document
+		// store, so teardown targets the workflow being left (not the route's next one).
+		const outgoingWorkflowId = currentWorkflowDocumentStore.value?.workflowId;
 		disposeCurrentWorkflowDocumentStore();
-		resetWorkspace();
+		resetWorkspace(outgoingWorkflowId);
 
 		if (builderStore.streaming) {
 			documentTitle.setDocumentTitle(data.name, 'AI_BUILDING');
@@ -293,8 +296,11 @@ export function useWorkflowInitialization() {
 	}
 
 	async function initializeWorkspaceForNewWorkflow() {
+		// Capture the outgoing workflow id before disposal nulls the current document
+		// store, so teardown targets the workflow being left (not the route's next one).
+		const outgoingWorkflowId = currentWorkflowDocumentStore.value?.workflowId;
 		disposeCurrentWorkflowDocumentStore();
-		resetWorkspace();
+		resetWorkspace(outgoingWorkflowId);
 
 		const parentFolderId = route.query.parentFolderId as string | undefined;
 
@@ -461,8 +467,11 @@ export function useWorkflowInitialization() {
 	}
 
 	function cleanup() {
+		// Capture the outgoing workflow id before disposal nulls the current document
+		// store, so teardown targets the workflow being left (not the route's next one).
+		const outgoingWorkflowId = currentWorkflowDocumentStore.value?.workflowId;
 		disposeCurrentWorkflowDocumentStore();
-		resetWorkspace();
+		resetWorkspace(outgoingWorkflowId);
 		uiStore.nodeViewInitialized = false;
 	}
 

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -166,8 +166,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		workflowId.value = id || '';
 	}
 
-	function resetWorkflow() {
-		const previousId = workflowId.value;
+	function resetWorkflow(outgoingWorkflowId?: string) {
+		// Reset the workflow being torn down. Callers pass it explicitly (the route may
+		// already point at the next workflow); fall back to the current id otherwise.
+		const previousId = outgoingWorkflowId ?? workflowId.value;
 		workflowId.value = '';
 		if (previousId) {
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(previousId));


### PR DESCRIPTION
## Summary

Part of removing the deprecated, writable global `workflowsStore.workflowId` ref in favor of deriving the current workflow id read-only from the route.

This first step is **behavior-preserving** prep. Workspace teardown (`resetWorkflow` / `resetWorkspace`) currently relies on `workflowsStore.workflowId` *lagging the route* (still holding the **outgoing** workflow because `setWorkflowId` for the incoming workflow fires later in init). Once the id becomes route-derived, that lag disappears — so in the dispose-first flows (where the route already points at the incoming workflow) teardown would target the wrong workflow and leak the outgoing workflow's execution-state store.

This PR threads the outgoing workflow id explicitly:
- `resetWorkflow(outgoingWorkflowId?)` and `resetWorkspace(outgoingWorkflowId?)` take the outgoing id.
- The three dispose-first callers (`openWorkflow`, `initializeWorkspaceForNewWorkflow`, `cleanup`) capture it from the current document store **before** disposal nulls it.
- Falls back to the current id when not provided (the no-dispose flows), so behavior is identical today.

## Related

Prep for the staged removal of `workflowsStore.workflowId` (see the migration recipe in `packages/frontend/editor-ui/MIGRATION_RECIPE.md`).

## Review / Testing

- New unit test asserts teardown targets the explicitly-passed outgoing workflow even when the current id is already the incoming one (no execution-state leak across a workflow switch).
- `pnpm typecheck`, the touched test files (283 tests), and `eslint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

