### PR TITLE
refactor(editor): Derive builder store workflow id from the route (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
@@ -22,7 +22,7 @@ import FocusPanel from './FocusPanel.vue';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
-	useRoute: () => reactive({}),
+	useRoute: () => reactive({ params: {} }),
 	RouterLink: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -51,7 +51,7 @@ vi.mock('@/features/ai/evaluation.ee/composables/useEvaluationsLicense', () => (
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
-	useRoute: () => reactive({}),
+	useRoute: () => reactive({ params: {} }),
 	RouterLink: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -49,6 +49,16 @@ const ModalStub = {
 
 vi.mock('vue-router');
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mocked(useRouter);
 
 const mockNode = {

--- a/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
@@ -9,6 +9,16 @@ import * as cloudPlanApi from '@n8n/rest-api-client/api/cloudPlans';
 import { useVersionsStore } from '@/app/stores/versions.store';
 import { useTelemetry } from './useTelemetry';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 let settingsStore: ReturnType<typeof useSettingsStore>;
 let usersStore: ReturnType<typeof useUsersStore>;
 let versionStore: ReturnType<typeof useVersionsStore>;

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -30,6 +30,16 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import type { PushHandlerOptions } from './types';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const documentId = createWorkflowDocumentId('1');
 const opts: PushHandlerOptions = {
 	router: mock<Router>(),

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowUpdate.test.ts
@@ -16,6 +16,16 @@ import type { INodeUi } from '@/Interface';
 import { DEFAULT_NEW_WORKFLOW_NAME } from '@/app/constants';
 import type { Workflow } from 'n8n-workflow';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 // Mock canvas event bus - using hoisted to ensure proper initialization order
 const canvasEventBusEmitMock = vi.hoisted(() => vi.fn());
 vi.mock('@/features/workflows/canvas/canvas.eventBus', () => ({

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -144,6 +144,20 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+// The builder store derives the current workflow id from the route via
+// useRouteWorkflowId(). Back it by a holder wired to the workflows store in
+// beforeEach, so existing tests keep driving the id through setWorkflowId().
+const { workflowIdHolder } = vi.hoisted(() => ({
+	workflowIdHolder: { current: (): string => '' },
+}));
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => workflowIdHolder.current()),
+		useRouteWorkflowId: () => computed(() => workflowIdHolder.current()),
+	};
+});
+
 describe('AI Builder store', () => {
 	beforeEach(() => {
 		mockDocumentState = undefined;
@@ -167,6 +181,9 @@ describe('AI Builder store', () => {
 		workflowsStore = mockedStore(useWorkflowsStore);
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		credentialsStore = mockedStore(useCredentialsStore);
+
+		// Route the mocked useRouteWorkflowId() at this test's workflows store.
+		workflowIdHolder.current = () => workflowsStore.workflowId;
 
 		workflowsStore.setWorkflowId('test-workflow-id');
 		workflowDocumentStore = useWorkflowDocumentStore(

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -42,6 +42,7 @@ import { dedupe } from 'n8n-workflow';
 import { useWorkflowHistoryStore } from '@/features/workflows/workflowHistory/workflowHistory.store';
 import type { IWorkflowDb } from '@/Interface';
 import { useWorkflowSaving } from '@/app/composables/useWorkflowSaving';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useBrowserNotifications } from '@/app/composables/useBrowserNotifications';
@@ -253,13 +254,15 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const settings = useSettingsStore();
 	const rootStore = useRootStore();
 	const workflowsStore = useWorkflowsStore();
+	// Current workflow id, derived read-only from the route (out-of-tree store).
+	const routeWorkflowId = useRouteWorkflowId();
 	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+		useWorkflowDocumentStore(createWorkflowDocumentId(routeWorkflowId.value)),
 	);
 	const workflowExecutionStateStore = computed(() =>
-		useWorkflowExecutionStateStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+		useWorkflowExecutionStateStore(createWorkflowDocumentId(routeWorkflowId.value)),
 	);
-	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
+	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(routeWorkflowId.value)));
 	const route = useRoute();
 	const locale = useI18n();
 	const telemetry = useTelemetry();
@@ -445,7 +448,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	 * This deletes persisted messages so they won't be reloaded on next visit.
 	 */
 	function clearBackendSession() {
-		const workflowId = workflowsStore.workflowId;
+		const workflowId = routeWorkflowId.value;
 		if (workflowId) {
 			void clearBuilderSession(rootStore.restApiContext, workflowId);
 		}
@@ -506,7 +509,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 		telemetry.track('End of response from builder', {
 			user_message_id: userMessageId,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: routeWorkflowId.value,
 			session_id: trackingSessionId.value,
 			tab_visible: document.visibilityState === 'visible',
 			code_builder: isCodeBuilder.value,
@@ -558,7 +561,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				interpolate: { workflowName },
 			}),
 			icon: '/favicon.ico',
-			tag: `workflow-build-${workflowsStore.workflowId}`,
+			tag: `workflow-build-${routeWorkflowId.value}`,
 			requireInteraction: false,
 		});
 
@@ -761,7 +764,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			message: text,
 			session_id: trackingSessionId.value,
 			start_workflow_json: currentWorkflowJson,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: routeWorkflowId.value,
 			type,
 			manual_exec_success_count_since_prev_msg: manualExecStatsInBetweenMessages.value.success,
 			manual_exec_error_count_since_prev_msg: manualExecStatsInBetweenMessages.value.error,
@@ -813,7 +816,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	async function verifyVersionExists(
 		versionId: string,
 	): Promise<{ id: string; createdAt: string } | undefined> {
-		const workflowId = workflowsStore.workflowId;
+		const workflowId = routeWorkflowId.value;
 		const existing = await fetchExistingVersionIds(rootStore.restApiContext, workflowId, [
 			versionId,
 		]);
@@ -992,7 +995,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				? mode
 				: (mode ?? (builderMode.value === 'plan' ? 'plan' : undefined));
 		const payload = await createBuilderPayload(text, userMessageId, {
-			workflowId: workflowsStore.workflowId,
+			workflowId: routeWorkflowId.value,
 			quickReplyType,
 			workflow: workflowDocumentStore.value.getSnapshot(),
 			executionData: executionResult,
@@ -1123,7 +1126,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	 * Silently fails and returns empty array on error to prevent UI disruption.
 	 */
 	async function loadSessions() {
-		const workflowId = workflowsStore.workflowId;
+		const workflowId = routeWorkflowId.value;
 		if (!workflowId) {
 			return [];
 		}
@@ -1333,7 +1336,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 					CODE_WORKFLOW_BUILDER_EXPERIMENT.codePinData;
 				if (isPinDataEnabled) {
 					const workflowDocumentStore = useWorkflowDocumentStore(
-						createWorkflowDocumentId(workflowsStore.workflowId),
+						createWorkflowDocumentId(routeWorkflowId.value),
 					);
 					const pinData = workflowDocumentStore.getPinDataSnapshot();
 					if (pinData && Object.keys(pinData).length > 0) {
@@ -1406,9 +1409,9 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	}
 
 	function applyGeneratedPinData() {
-		if (!generatedPinData.value || !workflowsStore.workflowId) return;
+		if (!generatedPinData.value || !routeWorkflowId.value) return;
 		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(routeWorkflowId.value),
 		);
 		workflowDocumentStore.setPinData({
 			...workflowDocumentStore.getPinDataSnapshot(),
@@ -1474,7 +1477,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 
 	// Watch workflowId changes to reset chat and load sessions when workflow changes
 	watch(
-		() => workflowsStore.workflowId,
+		() => routeWorkflowId.value,
 		(newWorkflowId, oldWorkflowId) => {
 			if (newWorkflowId === oldWorkflowId) {
 				return;
@@ -1507,7 +1510,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	// Only applies when the chat is fresh (no messages) so it doesn't interfere
 	// with an active conversation.
 	watch(
-		[() => workflowsStore.workflowId, () => workflowDocumentStore.value.allNodes.length],
+		[() => routeWorkflowId.value, () => workflowDocumentStore.value.allNodes.length],
 		([, nodesCount]) => {
 			if (chatMessages.value.length > 0) return;
 			builderMode.value = nodesCount === 0 ? 'plan' : 'build';
@@ -1524,7 +1527,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		eventProperties?: WorkflowBuilderJourneyEventProperties,
 	) {
 		const payload: WorkflowBuilderJourneyPayload = {
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: routeWorkflowId.value,
 			session_id: trackingSessionId.value,
 			event_type: eventType,
 		};
@@ -1575,7 +1578,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		versionId: string,
 		versionCardId: string,
 	): Promise<IWorkflowDb | undefined> {
-		const workflowId = workflowsStore.workflowId;
+		const workflowId = routeWorkflowId.value;
 
 		// Save current workflow if there are unsaved changes before restoring
 		if (uiStore.stateIsDirty) {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.test.ts
@@ -23,7 +23,7 @@ import type { ChatUI } from '@n8n/design-system/types/assistant';
 import merge from 'lodash-es/merge';
 
 // Mock vue-router
-const mockRoute = reactive({ name: VIEWS.WORKFLOW });
+const mockRoute = reactive({ name: VIEWS.WORKFLOW, params: {} });
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
 	useRoute: () => mockRoute,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/AssistantsHub.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/AssistantsHub.test.ts
@@ -13,7 +13,7 @@ import { VIEWS } from '@/app/constants';
 import { BUILDER_ENABLED_VIEWS } from '../constants';
 
 // Mock vue-router
-const mockRoute = reactive({ name: VIEWS.WORKFLOW });
+const mockRoute = reactive({ name: VIEWS.WORKFLOW, params: {} });
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
 	useRoute: () => mockRoute,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAskModeCoachmark.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAskModeCoachmark.test.ts
@@ -12,7 +12,7 @@ import { VIEWS } from '@/app/constants';
 import { BUILDER_ENABLED_VIEWS } from '../constants';
 
 // Mock vue-router
-const mockRoute = reactive({ name: VIEWS.WORKFLOW });
+const mockRoute = reactive({ name: VIEWS.WORKFLOW, params: {} });
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
 	useRoute: () => mockRoute,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderStreamingGuard.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderStreamingGuard.test.ts
@@ -3,6 +3,16 @@ import { confirmIfBuilderStreaming } from './useBuilderStreamingGuard';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { MODAL_CONFIRM, MODAL_CANCEL } from '@/app/constants';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const confirmMock = vi.fn();
 
 vi.mock('@/app/composables/useMessage', () => ({

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.test.ts
@@ -20,6 +20,16 @@ import { mockedStore } from '@/__tests__/utils';
 import { addCredentialTranslation } from '@n8n/i18n';
 import type { INodeUi } from '@/Interface';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@n8n/i18n', async () => {
 	const actual = await vi.importActual('@n8n/i18n');
 	return {

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.test.ts
@@ -20,6 +20,16 @@ import { AGENT_NODE_TYPE, OPEN_AI_CHAT_MODEL_NODE_TYPE } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { mockedStore } from '@/__tests__/utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('LogsViewRunData', () => {
 	let pinia: TestingPinia;
 

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputPanel.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/app/stores/workflowDocument.store', async () => {
 vi.mock('vue-router', () => {
 	return {
 		useRouter: () => ({}),
-		useRoute: () => ({ meta: {} }),
+		useRoute: () => ({ meta: {}, params: {} }),
 		RouterLink: vi.fn(),
 	};
 });

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.test.ts
@@ -15,6 +15,16 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/stores/workflowDocument.store', async () => {
 	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
 	return { ...actual, injectWorkflowDocumentStore: vi.fn() };

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.test.ts
@@ -12,6 +12,16 @@ import { flushPromises } from '@vue/test-utils';
 
 vi.mock('vue-router');
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const DEFAULT_SETUP: RenderOptions<typeof Assignment> = {
 	pinia: createTestingPinia({
 		initialState: { [STORES.SETTINGS]: { settings: merge({}, defaultSettings) } },

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.test.ts
@@ -13,6 +13,16 @@ import type { AssignmentCollectionValue, AssignmentValue } from 'n8n-workflow';
 
 vi.mock('vue-router');
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const DEFAULT_SETUP: RenderOptions<typeof AssignmentCollection> = {
 	pinia: createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameter.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameter.test.ts
@@ -5,6 +5,16 @@ import { createTestNodeProperties } from '@/__tests__/mocks';
 import { STORES } from '@n8n/stores';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const renderComponent = createComponentRenderer(CollectionParameter, {
 	pinia: createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.test.ts
@@ -8,6 +8,16 @@ import { setActivePinia } from 'pinia';
 import { nextTick } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('CollectionParameterLegacy.vue', () => {
 	const pinia = createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.test.ts
@@ -8,6 +8,16 @@ import { setActivePinia } from 'pinia';
 import { nextTick } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('CollectionParameterNew.vue', () => {
 	const pinia = createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.test.ts
@@ -16,6 +16,16 @@ import { flushPromises } from '@vue/test-utils';
 
 vi.mock('vue-router');
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const DEFAULT_OPTIONS: FilterOptionsValue = {
 	caseSensitive: true,
 	leftValue: '',

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameter.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameter.test.ts
@@ -9,6 +9,16 @@ import { usePostHog, type PosthogStore } from '@/app/stores/posthog.store';
 import userEvent from '@testing-library/user-event';
 import { flushPromises } from '@vue/test-utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const mockedGetVariant = vi.fn(() => 'control');
 vi.mock('@/app/stores/posthog.store', () => ({
 	usePostHog: vi.fn(() => ({

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.test.ts
@@ -8,6 +8,16 @@ import { fireEvent, waitFor } from '@testing-library/vue';
 import { setActivePinia } from 'pinia';
 import { flushPromises } from '@vue/test-utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('FixedCollectionParameterLegacy.vue', () => {
 	const pinia = createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.test.ts
@@ -9,6 +9,16 @@ import { setActivePinia } from 'pinia';
 import { nextTick } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('FixedCollectionParameterNew.vue', () => {
 	const pinia = createTestingPinia({
 		initialState: {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
@@ -8,6 +8,16 @@ import type { INodePropertyCollection } from 'n8n-workflow';
 import userEvent from '@testing-library/user-event';
 import { nextTick } from 'vue';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: () => ({
 		track: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
@@ -9,6 +9,16 @@ import { fireEvent } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestNodeProperties } from '@/__tests__/mocks';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 let mockNdvState: Partial<ReturnType<typeof useNDVStore>>;

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputOverrides/ParameterOverrideSelectableList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputOverrides/ParameterOverrideSelectableList.test.ts
@@ -13,7 +13,7 @@ vi.mock('vue-router', () => {
 			push: vi.fn(),
 			resolve: vi.fn().mockReturnValue({ href: 'https://test.com' }),
 		}),
-		useRoute: () => ({}),
+		useRoute: () => ({ params: {} }),
 		RouterLink: vi.fn(),
 	};
 });

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.test.ts
@@ -8,6 +8,16 @@ import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import { waitFor } from '@testing-library/vue';
 import { createTestNodeProperties } from '@/__tests__/mocks';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/composables/useWorkflowHelpers', () => {
 	return { useWorkflowHelpers: vi.fn(() => ({ resolveExpression: vi.fn(() => 'topSecret') })) };
 });

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.test.ts
@@ -53,7 +53,7 @@ vi.mock('vue-router', () => {
 				href: '',
 			})),
 		}),
-		useRoute: () => reactive({ meta: {} }),
+		useRoute: () => reactive({ meta: {}, params: {} }),
 		RouterLink: vi.fn(),
 	};
 });

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -41,6 +41,16 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const mockNode1 = createTestNode({
 	name: 'Manual Trigger',
 	type: MANUAL_TRIGGER_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/RunDataAi.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/RunDataAi.test.ts
@@ -16,6 +16,16 @@ import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it } from 'vitest';
 import RunDataAi from './RunDataAi.vue';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const renderComponent = createComponentRenderer(RunDataAi);
 
 describe('RunDataAi', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
@@ -22,7 +22,7 @@ import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injecti
 vi.mock('vue-router', () => {
 	return {
 		useRouter: () => ({}),
-		useRoute: () => ({ meta: {} }),
+		useRoute: () => ({ meta: {}, params: {} }),
 		RouterLink: vi.fn(),
 	};
 });

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useNodeCommands.test.ts
@@ -16,6 +16,16 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import { createTestNode } from '@/__tests__/mocks';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/composables/useCanvasOperations', () => ({
 	useCanvasOperations: () => ({
 		addNodes: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/commandBar/composables/useWorkflowCommands.test.ts
@@ -33,7 +33,7 @@ vi.mock('vue-router', () => ({
 	useRouter: () => ({
 		resolve: vi.fn((route) => ({ href: `/workflow/${route.params.workflowId}` })),
 	}),
-	useRoute: () => ({}),
+	useRoute: () => ({ params: {} }),
 	RouterLink: vi.fn(),
 }));
 vi.mock('@n8n/i18n', async (importOriginal) => ({

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
@@ -1,5 +1,15 @@
 import type { INodeUi } from '@/Interface';
 import { useContextMenu } from './useContextMenu';
+
+// Instantiates the builder store transitively, which derives the workflow id from
+// the route. This composable test runs without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
 import {
 	BASIC_CHAIN_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -35,6 +35,16 @@ import {
 } from '../composables/useCanvasNodeGroupView';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 const trackSpy = vi.hoisted(() => vi.fn());
 vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn(() => ({ track: trackSpy })),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
@@ -17,6 +17,16 @@ import * as vueuse from '@vueuse/core';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { CANVAS_NODES_GROUPING_EXPERIMENT } from '@/app/constants/experiments';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@vueuse/core', async () => {
 	const actual = await vi.importActual('@vueuse/core');
 	return {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -11,6 +11,16 @@ import {
 } from '@/features/workflows/canvas/__tests__/utils';
 import { CanvasNodeRenderType, type CanvasConnectionPort } from '../../../canvas.types';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/stores/nodeTypes.store', () => ({
 	useNodeTypesStore: vi.fn(() => ({
 		getNodeType: vi.fn(() => ({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.test.ts
@@ -13,6 +13,16 @@ import {
 import ExperimentalEmbeddedNdvMapper from './ExperimentalEmbeddedNdvMapper.vue';
 import { useExperimentalNdvStore } from '../experimentalNdv.store';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 describe('ExperimentalEmbeddedNdvMapper', () => {
 	const node = createTestNode({ name: 'n1' });
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.test.ts
@@ -14,6 +14,16 @@ import ExperimentalNodeDetailsDrawer from './ExperimentalNodeDetailsDrawer.vue';
 import { nextTick, shallowRef } from 'vue';
 import { fireEvent } from '@testing-library/vue';
 
+// Instantiates a store that derives the workflow id from the route. These tests run
+// without a router, so resolve the id directly.
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => ''),
+		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
 vi.mock('@/app/stores/workflowDocument.store', async () => {
 	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
 	return {


### PR DESCRIPTION
## Summary

Part of removing the deprecated, writable global `workflowsStore.workflowId` in favor of deriving the current workflow id read-only from the route.

`builder.store.ts` (an out-of-tree Pinia store) now reads the current workflow id via `useRouteWorkflowId()` — hoisted once at store setup — instead of `workflowsStore.workflowId` (16 sites: document-store keying, telemetry, watch sources, guards, local snapshots). Behavior-preserving: the value is identical in steady state.

## Related

Part of the staged `workflowsStore.workflowId` removal (see `packages/frontend/editor-ui/MIGRATION_RECIPE.md`). Independent of the other reader PRs.

## Review / Testing

- The builder store unit tests drive the id via `useRouteWorkflowId()` (mocked, wired to the workflows store) — all 166 tests pass with no changes to existing assertions.
- `pnpm typecheck` passes; `eslint` reports no remaining `workflowsStore.workflowId` warnings for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32735">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

