### PR TITLE
fix(core): omit default OAuth scope when none advertised

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -148,6 +148,65 @@ describe('OAuth2CredentialController', () => {
 			expect(externalHooks.run).toHaveBeenCalledWith('oauth2.callback', expect.any(Array));
 		});
 
+		it('should not request openid during token exchange when the credential has no scope', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const mockGetToken = jest.fn().mockResolvedValue({
+				data: { access_token: 'new_token', refresh_token: 'refresh_token' },
+			});
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: {
+							getToken: mockGetToken,
+						},
+					}) as any,
+			);
+
+			const mockResolvedCredential = mock<CredentialsEntity>({ id: '1' });
+			const mockState = {
+				token: 'token',
+				cid: '1',
+				userId: '123',
+				origin: 'static-credential' as const,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			oauthService.resolveCredential.mockResolvedValueOnce([
+				mockResolvedCredential,
+				{ csrfSecret: 'csrf-secret' },
+				{
+					clientId: 'client_id',
+					clientSecret: 'client_secret',
+					authUrl: 'https://example.domain/oauth2/auth',
+					accessTokenUrl: 'https://example.domain/oauth2/token',
+					grantType: 'authorizationCode',
+					authentication: 'header',
+				},
+				mockState,
+				{ csrfSecret: 'csrf-secret' },
+			]);
+			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+			externalHooks.run.mockResolvedValue(undefined);
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: {
+					code: 'auth_code',
+					state: validState,
+				},
+				originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+			});
+
+			await controller.handleCallback(req, res);
+
+			expect(ClientOAuth2).toHaveBeenCalledWith(expect.objectContaining({ scopes: undefined }));
+			expect(oauthService.encryptAndSaveData).toHaveBeenCalledWith(
+				mockResolvedCredential,
+				expect.objectContaining({
+					oauthTokenData: { access_token: 'new_token', refresh_token: 'refresh_token' },
+				}),
+			);
+		});
+
 		it('should pass state resource to token exchange and store it for static credentials', async () => {
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetToken = jest.fn().mockResolvedValue({

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -164,6 +164,12 @@ export class OAuth2CredentialController {
 	}
 
 	private convertCredentialToOptions(credential: OAuth2CredentialData): ClientOAuth2Options {
+		const scopes = credential.scope
+			? split(credential.scope, ',')
+					.map((scope) => scope.trim())
+					.filter(Boolean)
+			: undefined;
+
 		const options: ClientOAuth2Options = {
 			clientId: credential.clientId,
 			clientSecret: credential.clientSecret ?? '',
@@ -171,7 +177,7 @@ export class OAuth2CredentialController {
 			authorizationUri: credential.authUrl ?? '',
 			authentication: credential.authentication ?? 'header',
 			redirectUri: `${this.oauthService.getBaseUrl(OauthVersion.V2)}/callback`,
-			scopes: split(credential.scope ?? 'openid', ','),
+			scopes,
 			scopesSeparator: credential.scope?.includes(',') ? ',' : ' ',
 			resource: credential.resource,
 			ignoreSSLIssues: credential.ignoreSSLIssues ?? false,

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { OutboundHttp, SsrfProtectionService, type HttpRequestClient } from '@n8n/backend-network';
 import { mockInstance } from '@n8n/backend-test-utils';
-import type { OAuth2CredentialData } from '@n8n/client-oauth2';
+import type { ClientOAuth2Options, OAuth2CredentialData } from '@n8n/client-oauth2';
 import { GlobalConfig, SsrfProtectionConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import type { AuthenticatedRequest, CredentialsEntity, ICredentialsDb, User } from '@n8n/db';
@@ -2108,6 +2108,64 @@ describe('OauthService', () => {
 					codeVerifier: 'code_verifier',
 				}),
 				expect.any(Number),
+			);
+		});
+
+		it('should omit scope for dynamic client registration when metadata does not advertise scopes', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+
+			let capturedOptions: ClientOAuth2Options | undefined;
+			jest.mocked(ClientOAuth2).mockImplementation((options) => {
+				capturedOptions = options;
+				return {
+					code: {
+						getUri: () => ({
+							toString: () =>
+								'https://calendly.example/oauth/authorize?client_id=registered_client_id&response_type=code&state=state',
+						}),
+					},
+				} as any;
+			});
+
+			const credential = mock<CredentialsEntity>({ id: '1', type: 'oAuth2Api' });
+			const oauthCredentials = {
+				serverUrl: 'https://mcp.calendly.com',
+				useDynamicClientRegistration: true,
+			} as OAuth2CredentialData;
+
+			jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
+			jest.mocked(httpClientMock.get).mockResolvedValue({
+				data: {
+					authorization_endpoint: 'https://calendly.example/oauth/authorize',
+					token_endpoint: 'https://calendly.example/oauth/token',
+					registration_endpoint: 'https://calendly.example/oauth/register',
+					grant_types_supported: ['authorization_code', 'refresh_token'],
+					token_endpoint_auth_methods_supported: ['client_secret_basic'],
+				},
+			} as any);
+			jest.mocked(httpClientMock.post).mockResolvedValue({
+				data: {
+					client_id: 'registered_client_id',
+					client_secret: 'registered_client_secret',
+				},
+			} as any);
+			jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
+
+			const authUri = await service.generateAOauth2AuthUri(credential, {
+				cid: credential.id,
+				origin: 'static-credential',
+				userId: 'user-id',
+			});
+
+			expect(authUri).not.toContain('scope=');
+			expect(capturedOptions?.scopes).toBeUndefined();
+			expect(httpClientMock.post).toHaveBeenCalledWith(
+				'https://calendly.example/oauth/register',
+				expect.not.objectContaining({ scope: expect.anything() }),
+			);
+			expect(service.encryptAndSaveData).toHaveBeenCalledWith(
+				credential,
+				expect.not.objectContaining({ scope: expect.anything() }),
 			);
 		});
 

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -1018,7 +1018,7 @@ export class OauthService {
 			response_types: ['code'],
 			client_name: 'n8n',
 			client_uri: 'https://n8n.io/',
-			scope,
+			...(scope ? { scope } : {}),
 			...(oauthCredentials.jweEnabled === true
 				? await this.oauthJweServiceProxy.getDcrJweFields(oauthCredentials.inlineJwks === true)
 				: {}),
@@ -1203,6 +1203,12 @@ export class OauthService {
 	}
 
 	private convertCredentialToOptions(credential: OAuth2CredentialData): ClientOAuth2Options {
+		const scopes = credential.scope
+			? split(credential.scope, ',')
+					.map((scope) => scope.trim())
+					.filter(Boolean)
+			: undefined;
+
 		const options: ClientOAuth2Options = {
 			clientId: credential.clientId,
 			clientSecret: credential.clientSecret ?? '',
@@ -1210,7 +1216,7 @@ export class OauthService {
 			authorizationUri: credential.authUrl ?? '',
 			authentication: credential.authentication ?? 'header',
 			redirectUri: `${this.getBaseUrl(OauthVersion.V2)}/callback`,
-			scopes: split(credential.scope ?? 'openid', ','),
+			scopes,
 			scopesSeparator: credential.scope?.includes(',') ? ',' : ' ',
 			resource: credential.resource,
 			ignoreSSLIssues: credential.ignoreSSLIssues ?? false,


### PR DESCRIPTION
## Summary
- stop defaulting OAuth2 credential scopes to `openid` when the credential or discovered MCP OAuth metadata does not provide any scopes
- omit `scope` from Dynamic Client Registration payloads when no scopes are advertised
- add regression coverage for DCR auth URI generation and callback token exchange without scopes

Fixes #30147

## Review / Merge checklist
- [x] PR title and summary are descriptive
- [x] Tests are included for the bug fix
- [ ] Documentation update is required

## Test plan
- `pnpm test packages/cli/src/oauth/__tests__/oauth.service.test.ts --runInBand`
- `pnpm test packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts --runInBand`
- `pnpm exec eslint src/oauth/oauth.service.ts src/controllers/oauth/oauth2-credential.controller.ts src/oauth/__tests__/oauth.service.test.ts src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts --quiet`

Also attempted `pnpm typecheck` in `packages/cli`; it is currently blocked in this worktree by existing missing workspace build/type outputs for packages such as `@n8n/instance-ai`, `@n8n/workflow-sdk`, and `nodes-base/dist` declarations before reaching these changes.

Created with: Hermes Agent


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32738">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

