### PR TITLE
chore: Start publishing snapshots also on dev, separate prod and dev Daytona keys

### DIFF
--- a/.github/workflows/release-build-daytona-snapshot.yml
+++ b/.github/workflows/release-build-daytona-snapshot.yml
@@ -8,8 +8,15 @@ on:
         required: true
         type: string
     secrets:
-      DAYTONA_API_KEY:
+      DAYTONA_API_KEY_DEV:
         required: true
+      DAYTONA_API_URL_DEV:
+        required: false
+      DAYTONA_API_KEY_PROD:
+        required: true
+      DAYTONA_API_URL_PROD:
+        required: false
+      # Shared fallback URL used when an env-specific URL secret isn't set.
       DAYTONA_API_URL:
         required: false
 
@@ -25,9 +32,17 @@ permissions:
 
 jobs:
   build-snapshot:
-    name: Build versioned Daytona snapshot
+    name: Build versioned Daytona snapshot (${{ matrix.environment }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Dev is best-effort: a dev failure is reported but does not block the release.
+    # Only the prod publish gates the release.
+    continue-on-error: ${{ matrix.environment == 'dev' }}
+    strategy:
+      # Publish to every environment even if one fails, so a partial outage is visible.
+      fail-fast: false
+      matrix:
+        environment: [dev, prod]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,6 +53,7 @@ jobs:
       - name: Build versioned Daytona snapshot
         env:
           N8N_VERSION: ${{ inputs.n8n_version }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+          DAYTONA_API_KEY: ${{ matrix.environment == 'dev' && secrets.DAYTONA_API_KEY_DEV || secrets.DAYTONA_API_KEY_PROD }}
+          # Fall back to the shared DAYTONA_API_URL when an env-specific URL isn't set.
+          DAYTONA_API_URL: ${{ matrix.environment == 'dev' && (secrets.DAYTONA_API_URL_DEV || secrets.DAYTONA_API_URL) || (secrets.DAYTONA_API_URL_PROD || secrets.DAYTONA_API_URL) }}
         run: node packages/@n8n/instance-ai/scripts/build-snapshot.cjs --version "$N8N_VERSION"

--- a/.github/workflows/release-build-daytona-snapshot.yml
+++ b/.github/workflows/release-build-daytona-snapshot.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Build versioned Daytona snapshot
         env:
           N8N_VERSION: ${{ inputs.n8n_version }}
-          DAYTONA_API_KEY: ${{ matrix.environment == 'dev' && secrets.DAYTONA_API_KEY_DEV || secrets.DAYTONA_API_KEY_PROD }}
+          # Each branch is guarded on its own environment so an empty/unset key
+          # resolves to '' (and fails the script) rather than falling back to the
+          # other environment's credentials.
+          DAYTONA_API_KEY: ${{ matrix.environment == 'dev' && secrets.DAYTONA_API_KEY_DEV || matrix.environment == 'prod' && secrets.DAYTONA_API_KEY_PROD || '' }}
           # Fall back to the shared DAYTONA_API_URL when an env-specific URL isn't set.
-          DAYTONA_API_URL: ${{ matrix.environment == 'dev' && (secrets.DAYTONA_API_URL_DEV || secrets.DAYTONA_API_URL) || (secrets.DAYTONA_API_URL_PROD || secrets.DAYTONA_API_URL) }}
+          DAYTONA_API_URL: ${{ matrix.environment == 'dev' && secrets.DAYTONA_API_URL_DEV || matrix.environment == 'prod' && secrets.DAYTONA_API_URL_PROD || secrets.DAYTONA_API_URL }}
         run: node packages/@n8n/instance-ai/scripts/build-snapshot.cjs --version "$N8N_VERSION"


### PR DESCRIPTION
## Summary

Instead of just having one set of Daytona keys have separate keys (with just snapshot write permissions) for both dev and prod, and start publishing the snapshots on both environments.

Once this has been deployed and verified we can remove the existing `DAYTONA_API_KEY` (and revoke the key, I made new ones) and just use these per environment ones.

I've created the new secrets on our github CI secrets.
Ideally this would be out before today's release.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
