### PR TITLE
feat(editor): Read node types from the local SQLite database when enabled (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -3,7 +3,7 @@ import SourceControlInitializationErrorMessage from '@/features/integrations/sou
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
-import { LOCAL_STORAGE_DATA_WORKER } from '@/app/constants/localStorage';
+import { isDataWorkerEnabled } from '@/app/workers/isDataWorkerEnabled';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
 
 import type { UserManagementAuthenticationMethod } from '@/Interface';
@@ -218,7 +218,7 @@ export async function initializeAuthenticatedFeatures(
 	registerModuleSettingsPages();
 
 	// Initialize run data worker and load node types
-	if (window.localStorage.getItem(LOCAL_STORAGE_DATA_WORKER) === 'true') {
+	if (isDataWorkerEnabled()) {
 		const coordinator = await import('@/app/workers');
 		await coordinator.initialize({ version: settingsStore.settings.versionCli });
 		await coordinator.loadNodeTypes(rootStore.baseUrl);

--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.test.ts
@@ -3,6 +3,31 @@ import { createTestingPinia } from '@pinia/testing';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import * as nodeTypesApi from '@n8n/rest-api-client/api/nodeTypes';
+import { LOCAL_STORAGE_DATA_WORKER } from '@/app/constants/localStorage';
+
+const mocks = vi.hoisted(() => ({
+	rootStore: {
+		baseUrl: 'http://localhost:5678/',
+		restApiContext: { baseUrl: 'http://localhost:5678', pushRef: 'test' },
+		defaultLocale: 'en',
+	},
+	loadNodeTypes: vi.fn(),
+	getAllNodeTypes: vi.fn(),
+	getNodeType: vi.fn(),
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: vi.fn(() => mocks.rootStore),
+}));
+
+vi.mock('@/app/workers', () => ({
+	loadNodeTypes: mocks.loadNodeTypes,
+	getAllNodeTypes: mocks.getAllNodeTypes,
+	getNodeType: mocks.getNodeType,
+}));
+
+vi.mock('@n8n/rest-api-client/api/nodeTypes');
 
 function makeNodeType(
 	overrides: Partial<INodeTypeDescription> & Pick<INodeTypeDescription, 'name' | 'outputs'>,
@@ -127,6 +152,140 @@ describe('useNodeTypesStore', () => {
 
 		it('should return false for an unknown node type', () => {
 			expect(store.isToolNode('nonexistent.node')).toBe(false);
+		});
+	});
+
+	describe('getNodeTypes', () => {
+		const restNode = makeNodeType({
+			name: 'n8n-nodes-base.restNode',
+			outputs: [NodeConnectionTypes.Main],
+		});
+		const dbNode = makeNodeType({
+			name: 'n8n-nodes-base.dbNode',
+			outputs: [NodeConnectionTypes.Main],
+		});
+
+		beforeEach(() => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			vi.clearAllMocks();
+			window.localStorage.clear();
+			mocks.rootStore.defaultLocale = 'en';
+			vi.mocked(nodeTypesApi.getNodeTypes).mockResolvedValue([restNode]);
+			mocks.loadNodeTypes.mockResolvedValue(undefined);
+			mocks.getAllNodeTypes.mockResolvedValue([dbNode]);
+		});
+
+		it('should load node types from REST when the data worker is disabled', async () => {
+			const store = useNodeTypesStore();
+
+			await store.getNodeTypes();
+
+			expect(nodeTypesApi.getNodeTypes).toHaveBeenCalledWith(mocks.rootStore.baseUrl);
+			expect(mocks.getAllNodeTypes).not.toHaveBeenCalled();
+			expect(store.nodeTypes[restNode.name]).toBeDefined();
+		});
+
+		it('should sync and read from the local database when the data worker is enabled', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			const store = useNodeTypesStore();
+
+			await store.getNodeTypes();
+
+			expect(mocks.loadNodeTypes).toHaveBeenCalledWith(mocks.rootStore.baseUrl);
+			expect(mocks.getAllNodeTypes).toHaveBeenCalled();
+			expect(nodeTypesApi.getNodeTypes).not.toHaveBeenCalled();
+			expect(store.nodeTypes[dbNode.name]).toBeDefined();
+		});
+
+		it('should fall back to REST when the local database is empty', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			mocks.getAllNodeTypes.mockResolvedValue([]);
+			const store = useNodeTypesStore();
+
+			await store.getNodeTypes();
+
+			expect(nodeTypesApi.getNodeTypes).toHaveBeenCalledWith(mocks.rootStore.baseUrl);
+			expect(store.nodeTypes[restNode.name]).toBeDefined();
+		});
+
+		it('should fall back to REST when the local database read throws', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			mocks.loadNodeTypes.mockRejectedValue(new Error('worker unavailable'));
+			const store = useNodeTypesStore();
+
+			await store.getNodeTypes();
+
+			expect(nodeTypesApi.getNodeTypes).toHaveBeenCalledWith(mocks.rootStore.baseUrl);
+			expect(store.nodeTypes[restNode.name]).toBeDefined();
+		});
+	});
+
+	describe('getNodesInformation', () => {
+		const nodeInfo = { name: 'n8n-nodes-base.set', version: 1 };
+		const otherInfo = { name: 'n8n-nodes-base.if', version: 1 };
+		const dbNode = makeNodeType({ name: nodeInfo.name, outputs: [NodeConnectionTypes.Main] });
+		const restNode = makeNodeType({ name: otherInfo.name, outputs: [NodeConnectionTypes.Main] });
+
+		beforeEach(() => {
+			setActivePinia(createTestingPinia({ stubActions: false }));
+			vi.clearAllMocks();
+			window.localStorage.clear();
+			mocks.rootStore.defaultLocale = 'en';
+			vi.mocked(nodeTypesApi.getNodesInformation).mockResolvedValue([restNode]);
+			mocks.getNodeType.mockResolvedValue(dbNode);
+		});
+
+		it('should read from the local database for the English locale', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			const store = useNodeTypesStore();
+
+			const result = await store.getNodesInformation([nodeInfo]);
+
+			expect(mocks.getNodeType).toHaveBeenCalledWith(nodeInfo.name, nodeInfo.version);
+			expect(nodeTypesApi.getNodesInformation).not.toHaveBeenCalled();
+			expect(result).toEqual([dbNode]);
+		});
+
+		it('should use REST for non-English locales', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			mocks.rootStore.defaultLocale = 'de';
+			const store = useNodeTypesStore();
+
+			await store.getNodesInformation([nodeInfo]);
+
+			expect(mocks.getNodeType).not.toHaveBeenCalled();
+			expect(nodeTypesApi.getNodesInformation).toHaveBeenCalledWith(
+				mocks.rootStore.restApiContext,
+				[nodeInfo],
+			);
+		});
+
+		it('should fetch nodes missing from the local database over REST', async () => {
+			window.localStorage.setItem(LOCAL_STORAGE_DATA_WORKER, 'true');
+			mocks.getNodeType.mockImplementation(async (name: string) =>
+				name === nodeInfo.name ? dbNode : null,
+			);
+			const store = useNodeTypesStore();
+
+			const result = await store.getNodesInformation([nodeInfo, otherInfo]);
+
+			expect(nodeTypesApi.getNodesInformation).toHaveBeenCalledWith(
+				mocks.rootStore.restApiContext,
+				[otherInfo],
+			);
+			expect(result).toEqual([dbNode, restNode]);
+		});
+
+		it('should use REST when the data worker is disabled', async () => {
+			const store = useNodeTypesStore();
+
+			await store.getNodesInformation([nodeInfo]);
+
+			expect(mocks.getNodeType).not.toHaveBeenCalled();
+			expect(nodeTypesApi.getNodesInformation).toHaveBeenCalledWith(
+				mocks.rootStore.restApiContext,
+				[nodeInfo],
+			);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/nodeTypes.store.ts
@@ -36,6 +36,7 @@ import { computed, ref } from 'vue';
 import { useActionsGenerator } from '@/features/shared/nodeCreator/composables/useActionsGeneration';
 import { removePreviewToken } from '@/features/shared/nodeCreator/nodeCreator.utils';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { isDataWorkerEnabled } from '@/app/workers/isDataWorkerEnabled';
 import type { WorkflowObjectAccessors } from '../types';
 
 export type NodeTypesStore = ReturnType<typeof useNodeTypesStore>;
@@ -349,14 +350,45 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		);
 	};
 
+	// Read full node descriptions from the local SQLite database, falling back to
+	// REST for any node not present locally (e.g. community/dynamic nodes).
+	const loadNodesInformationFromLocalDb = async (
+		nodeInfos: INodeTypeNameVersion[],
+	): Promise<INodeTypeDescription[]> => {
+		try {
+			const { getNodeType } = await import('@/app/workers');
+			const found: INodeTypeDescription[] = [];
+			const missing: INodeTypeNameVersion[] = [];
+
+			for (const nodeInfo of nodeInfos) {
+				const nodeType = await getNodeType(nodeInfo.name, nodeInfo.version);
+				if (nodeType) {
+					found.push(nodeType);
+				} else {
+					missing.push(nodeInfo);
+				}
+			}
+
+			if (missing.length) {
+				found.push(...(await nodeTypesApi.getNodesInformation(rootStore.restApiContext, missing)));
+			}
+
+			return found;
+		} catch (error) {
+			return await nodeTypesApi.getNodesInformation(rootStore.restApiContext, nodeInfos);
+		}
+	};
+
 	const getNodesInformation = async (
 		nodeInfos: INodeTypeNameVersion[],
 		replace = true,
 	): Promise<INodeTypeDescription[]> => {
-		const nodesInformation = await nodeTypesApi.getNodesInformation(
-			rootStore.restApiContext,
-			nodeInfos,
-		);
+		// The local DB holds untranslated descriptions, so only read from it for
+		// the English locale; other locales need per-node translations from REST.
+		const nodesInformation =
+			isDataWorkerEnabled() && rootStore.defaultLocale === 'en'
+				? await loadNodesInformationFromLocalDb(nodeInfos)
+				: await nodeTypesApi.getNodesInformation(rootStore.restApiContext, nodeInfos);
 
 		nodesInformation.forEach((nodeInformation) => {
 			if (nodeInformation.translation) {
@@ -381,8 +413,25 @@ export const useNodeTypesStore = defineStore(STORES.NODE_TYPES, () => {
 		}
 	};
 
+	// Sync the local SQLite database with the server (cheap incremental diff after
+	// the initial load) and read all node descriptions back from it. Returns an
+	// empty array if the database is unavailable so the caller can fall back to REST.
+	const loadNodeTypesFromLocalDb = async (): Promise<INodeTypeDescription[]> => {
+		try {
+			const { loadNodeTypes, getAllNodeTypes } = await import('@/app/workers');
+			await loadNodeTypes(rootStore.baseUrl);
+			return await getAllNodeTypes();
+		} catch (error) {
+			return [];
+		}
+	};
+
 	const getNodeTypes = async () => {
-		const nodeTypes = await nodeTypesApi.getNodeTypes(rootStore.baseUrl);
+		const fetchedNodeTypes = isDataWorkerEnabled() ? await loadNodeTypesFromLocalDb() : [];
+		const nodeTypes = fetchedNodeTypes.length
+			? fetchedNodeTypes
+			: await nodeTypesApi.getNodeTypes(rootStore.baseUrl);
+
 		if (nodeTypes.length) {
 			setNodeTypes(nodeTypes);
 		}

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.test.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { CoordinatorState, TabConnection } from '../types';
 import type { DataWorkerApi } from '../../data/worker';
 import type * as Comlink from 'comlink';
-import { loadNodeTypes } from './loadNodeTypes';
+import { loadNodeTypes, getAllNodeTypes, getNodeType } from './loadNodeTypes';
 
 describe('Coordinator loadNodeTypes Operation', () => {
 	beforeEach(() => {
@@ -25,6 +25,8 @@ describe('Coordinator loadNodeTypes Operation', () => {
 			close: vi.fn().mockResolvedValue(undefined),
 			isInitialized: vi.fn().mockReturnValue(true),
 			loadNodeTypes: vi.fn().mockResolvedValue(undefined),
+			getAllNodeTypes: vi.fn().mockResolvedValue([]),
+			getNodeType: vi.fn().mockResolvedValue(null),
 			...overrides,
 		} as unknown as Comlink.Remote<DataWorkerApi>;
 	}
@@ -170,6 +172,84 @@ describe('Coordinator loadNodeTypes Operation', () => {
 			await expect(loadNodeTypes(state, 'http://localhost:5678')).rejects.toThrow();
 
 			expect(loadNodeTypesFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getAllNodeTypes', () => {
+		it('should throw error when no active data worker is available', async () => {
+			const state = createMockState({ version: '1.0.0' });
+
+			await expect(getAllNodeTypes(state)).rejects.toThrow(
+				'[Coordinator] No active data worker available',
+			);
+		});
+
+		it('should return node types from the active data worker', async () => {
+			const nodeTypes = [{ name: 'n8n-nodes-base.set' }];
+			const state = createStateWithActiveTab({
+				getAllNodeTypes: vi.fn().mockResolvedValue(nodeTypes),
+			});
+			state.initialized = true;
+
+			const result = await getAllNodeTypes(state);
+
+			expect(result).toEqual(nodeTypes);
+		});
+
+		it('should ensure initialization before reading', async () => {
+			const state = createStateWithActiveTab();
+			state.initialized = false;
+			state.version = '1.0.0';
+			const worker = state.tabs.get('active-tab')?.dataWorker;
+
+			await getAllNodeTypes(state);
+
+			expect(worker?.initialize).toHaveBeenCalledWith({ version: '1.0.0' });
+			expect(worker?.getAllNodeTypes).toHaveBeenCalled();
+		});
+
+		it('should propagate errors from the data worker', async () => {
+			const state = createStateWithActiveTab({
+				getAllNodeTypes: vi.fn().mockRejectedValue(new Error('read failed')),
+			});
+			state.initialized = true;
+
+			await expect(getAllNodeTypes(state)).rejects.toThrow('read failed');
+		});
+	});
+
+	describe('getNodeType', () => {
+		it('should throw error when no active data worker is available', async () => {
+			const state = createMockState({ version: '1.0.0' });
+
+			await expect(getNodeType(state, 'n8n-nodes-base.set', 1)).rejects.toThrow(
+				'[Coordinator] No active data worker available',
+			);
+		});
+
+		it('should pass name and version to the active data worker and return its result', async () => {
+			const nodeType = { name: 'n8n-nodes-base.set', version: 2 };
+			const state = createStateWithActiveTab({
+				getNodeType: vi.fn().mockResolvedValue(nodeType),
+			});
+			state.initialized = true;
+			const worker = state.tabs.get('active-tab')?.dataWorker;
+
+			const result = await getNodeType(state, 'n8n-nodes-base.set', 2);
+
+			expect(worker?.getNodeType).toHaveBeenCalledWith('n8n-nodes-base.set', 2);
+			expect(result).toEqual(nodeType);
+		});
+
+		it('should return null when the node type is not found', async () => {
+			const state = createStateWithActiveTab({
+				getNodeType: vi.fn().mockResolvedValue(null),
+			});
+			state.initialized = true;
+
+			const result = await getNodeType(state, 'unknown', 1);
+
+			expect(result).toBeNull();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/operations/loadNodeTypes.ts
@@ -18,3 +18,15 @@ export const loadNodeTypes = withActiveWorker(async (worker, baseUrl: string) =>
 	console.log('[Coordinator] loadNodeTypes');
 	return await worker.loadNodeTypes(baseUrl);
 });
+
+/**
+ * Get all node types from the local database (routes to active tab's worker)
+ */
+export const getAllNodeTypes = withActiveWorker(async (worker) => await worker.getAllNodeTypes());
+
+/**
+ * Get a single node type from the local database (routes to active tab's worker)
+ */
+export const getNodeType = withActiveWorker(
+	async (worker, name: string, version: number) => await worker.getNodeType(name, version),
+);

--- a/packages/frontend/editor-ui/src/app/workers/coordinator/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/coordinator/worker.ts
@@ -31,7 +31,11 @@ import {
 	getActiveTabId as getActiveTabIdOp,
 	getTabCount as getTabCountOp,
 } from './operations/query';
-import { loadNodeTypes as loadNodeTypesOp } from './operations/loadNodeTypes';
+import {
+	loadNodeTypes as loadNodeTypesOp,
+	getAllNodeTypes as getAllNodeTypesOp,
+	getNodeType as getNodeTypeOp,
+} from './operations/loadNodeTypes';
 import {
 	storeVersion as storeVersionOp,
 	getStoredVersion as getStoredVersionOp,
@@ -120,6 +124,20 @@ const coordinatorApi = {
 	 */
 	async loadNodeTypes(baseUrl: string): Promise<void> {
 		await loadNodeTypesOp(state, baseUrl);
+	},
+
+	/**
+	 * Get all node types from the local database (routes to active tab's worker)
+	 */
+	async getAllNodeTypes() {
+		return await getAllNodeTypesOp(state);
+	},
+
+	/**
+	 * Get a single node type from the local database (routes to active tab's worker)
+	 */
+	async getNodeType(name: string, version: number) {
+		return await getNodeTypeOp(state, name, version);
 	},
 
 	/**

--- a/packages/frontend/editor-ui/src/app/workers/data/worker.ts
+++ b/packages/frontend/editor-ui/src/app/workers/data/worker.ts
@@ -18,8 +18,13 @@ import * as Comlink from 'comlink';
 import SQLiteESMFactory from 'wa-sqlite/dist/wa-sqlite.mjs';
 import * as SQLite from 'wa-sqlite';
 import { AccessHandlePoolVFS } from 'wa-sqlite/src/examples/AccessHandlePoolVFS.js';
+import type { INodeTypeDescription } from 'n8n-workflow';
 import { getAllTableSchemas } from './db';
-import { loadNodeTypes as loadNodeTypesOp } from './operations/loadNodeTypes';
+import {
+	loadNodeTypes as loadNodeTypesOp,
+	getAllNodeTypes as getAllNodeTypesOp,
+	getNodeType as getNodeTypeOp,
+} from './operations/loadNodeTypes';
 import {
 	exec as execOp,
 	query as queryOp,
@@ -204,6 +209,20 @@ async function loadNodeTypes(baseUrl: string): Promise<void> {
 }
 
 /**
+ * Get all node types from the local database
+ */
+async function getAllNodeTypes(): Promise<INodeTypeDescription[]> {
+	return await getAllNodeTypesOp(state);
+}
+
+/**
+ * Get a single node type from the local database
+ */
+async function getNodeType(name: string, version: number): Promise<INodeTypeDescription | null> {
+	return await getNodeTypeOp(state, name, version);
+}
+
+/**
  * Store the n8n version in the database
  */
 async function storeVersion(version: string): Promise<void> {
@@ -226,6 +245,8 @@ export const dataWorkerApi = {
 	close,
 	isInitialized,
 	loadNodeTypes,
+	getAllNodeTypes,
+	getNodeType,
 	storeVersion,
 	getStoredVersion,
 };

--- a/packages/frontend/editor-ui/src/app/workers/index.ts
+++ b/packages/frontend/editor-ui/src/app/workers/index.ts
@@ -10,6 +10,7 @@
  * - Only one dedicated worker accesses OPFS at a time (prevents corruption)
  */
 
+import type { INodeTypeDescription } from 'n8n-workflow';
 import { coordinator, registerTab } from './coordinator';
 import type { SQLiteParam } from './data/types';
 
@@ -71,6 +72,25 @@ export async function isInitialized(): Promise<boolean> {
 export async function loadNodeTypes(baseUrl: string): Promise<void> {
 	await ensureRegistered();
 	await coordinator.loadNodeTypes(baseUrl);
+}
+
+/**
+ * Get all node types from the local database
+ */
+export async function getAllNodeTypes(): Promise<INodeTypeDescription[]> {
+	await ensureRegistered();
+	return await coordinator.getAllNodeTypes();
+}
+
+/**
+ * Get a single node type from the local database
+ */
+export async function getNodeType(
+	name: string,
+	version: number,
+): Promise<INodeTypeDescription | null> {
+	await ensureRegistered();
+	return await coordinator.getNodeType(name, version);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/app/workers/isDataWorkerEnabled.ts
+++ b/packages/frontend/editor-ui/src/app/workers/isDataWorkerEnabled.ts
@@ -1,0 +1,15 @@
+import { LOCAL_STORAGE_DATA_WORKER } from '@/app/constants/localStorage';
+
+/**
+ * Whether the local SQLite data worker is enabled. Gates both populating the
+ * local DB (init) and reading node types from it (nodeTypes store).
+ *
+ * Kept out of `./index` so callers can check the flag without importing that
+ * module, which eagerly spawns the SharedWorker/Worker on load.
+ */
+export function isDataWorkerEnabled(): boolean {
+	return (
+		typeof window !== 'undefined' &&
+		window.localStorage.getItem(LOCAL_STORAGE_DATA_WORKER) === 'true'
+	);
+}


### PR DESCRIPTION
## Summary

When the data worker is enabled (`LOCAL_STORAGE_DATA_WORKER`), the node types store now reads full node descriptions from the local SQLite database instead of the REST API. `getNodeTypes()` syncs the local DB and reads all descriptions back from it, while `getNodesInformation()` reads per-node descriptions for the English locale. Both fall back to REST when the local DB is empty/unavailable, when a node is missing locally (e.g. community/dynamic nodes), or for non-English locales (which need server-side translations). The data-worker gate was extracted into `isDataWorkerEnabled()` so callers can check the flag without eagerly spawning the worker.

## How to test

1. Set `localStorage.dataWorker = 'true'` and reload the editor.
2. Confirm node types and the node creator load correctly from the local DB (no `/node-types` REST calls).
3. Set the locale to a non-English language and confirm node descriptions still come from REST.
4. Disable the flag and confirm behavior is unchanged (REST-only).

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket if applicable -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32751">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->