### PR TITLE
fix(editor): Allow dragging a node group from the title bar next to its name (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/InlineTextEdit.vue
@@ -135,8 +135,10 @@ defineExpose({ forceFocus, forceCancel });
 			/>
 			<!-- Stop propagation for space key to prevent VueFlow from intercepting it -->
 			<!-- when modifier keys (like Shift) are pressed. See: https://github.com/bcakmakoglu/vue-flow/issues/1999 -->
+			<!-- size=1 stops the input's default intrinsic width from inflating fit-content sizing -->
 			<EditableInput
 				ref="input"
+				:size="1"
 				:class="$style.inlineRenameInput"
 				data-test-id="inline-edit-input"
 				:style="computedContentStyles"

--- a/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/__snapshots__/InlineTextEdit.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInlineTextEdit/__snapshots__/InlineTextEdit.test.ts.snap
@@ -3,7 +3,8 @@
 exports[`N8nInlineTextEdit > should render correctly 1`] = `
 "<div class="inlineRenameRoot" title="Test Value" dir="ltr" data-dismissable-layer="">
   <div data-placeholder-shown="" style="display: inline-grid; width: 64px; max-width: 200px; z-index: 1;" class="inlineRenameArea" data-test-id="inline-editable-area"><span class="measureSpan">Test Value</span><span tabindex="0" data-placeholder-shown="" style="white-space: pre; user-select: none; grid-area: 1 / 1 / auto / auto; overflow: hidden; text-overflow: ellipsis; width: 100%; max-width: 100%; z-index: 1;" data-test-id="inline-edit-preview" class="inlineRenamePreview">Test Value</span><!-- Stop propagation for space key to prevent VueFlow from intercepting it -->
-    <!-- when modifier keys (like Shift) are pressed. See: https://github.com/bcakmakoglu/vue-flow/issues/1999 --><input placeholder="Enter text..." maxlength="100" aria-label="editable input" style="all: unset; grid-area: 1 / 1 / auto / auto; visibility: hidden; width: 100%; max-width: 100%; z-index: 1;" class="inlineRenameInput" data-test-id="inline-edit-input" value="Test Value">
+    <!-- when modifier keys (like Shift) are pressed. See: https://github.com/bcakmakoglu/vue-flow/issues/1999 -->
+    <!-- size=1 stops the input's default intrinsic width from inflating fit-content sizing --><input placeholder="Enter text..." maxlength="100" aria-label="editable input" style="all: unset; grid-area: 1 / 1 / auto / auto; visibility: hidden; width: 100%; max-width: 100%; z-index: 1;" size="1" class="inlineRenameInput" data-test-id="inline-edit-input" value="Test Value">
   </div>
   <!--v-if-->
 </div>"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -383,7 +383,6 @@ function onWrapperPointerDown(event: PointerEvent) {
 	overflow-clip-margin: var(--spacing--2xs);
 }
 
-// Hug the name so the `nodrag` box doesn't cover the draggable title bar beside a short name.
 .inlineEdit {
 	width: fit-content;
 	max-width: 100%;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -247,7 +247,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 						<div ref="titleText" :class="$style.titleText">
 							<N8nInlineTextEdit
 								ref="titleEdit"
-								class="nodrag"
+								:class="['nodrag', $style.inlineEdit]"
 								:model-value="group.name"
 								:read-only="readOnly"
 								:min-width="0"
@@ -381,6 +381,12 @@ function onWrapperPointerDown(event: PointerEvent) {
 	max-width: 100%;
 	overflow: clip;
 	overflow-clip-margin: var(--spacing--2xs);
+}
+
+// Hug the name so the `nodrag` box doesn't cover the draggable title bar beside a short name.
+.inlineEdit {
+	width: fit-content;
+	max-width: 100%;
 }
 
 .statusIcons {

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -1181,6 +1181,24 @@ export class CanvasPage extends BasePage {
 		return box;
 	}
 
+	async dragNodeGroupFromTitleBar(
+		title: string,
+		deltaX: number,
+		deltaY: number,
+		grabFraction = 0.9,
+	): Promise<void> {
+		const box = await this.getNodeGroupTitle(title).boundingBox();
+		if (!box) throw new Error(`Node group title "${title}" not found or not visible`);
+
+		const startX = box.x + box.width * grabFraction;
+		const startY = box.y + box.height / 2;
+
+		await this.page.mouse.move(startX, startY);
+		await this.page.mouse.down();
+		await this.page.mouse.move(startX + deltaX, startY + deltaY, { steps: 10 });
+		await this.page.mouse.up();
+	}
+
 	async editNodeGroupTitle(oldTitle: string, newTitle: string, commit: 'enter' | 'blur' = 'enter') {
 		const group = await this.lockNodeGroupByTitle(oldTitle);
 		await group.getByTestId('inline-edit-preview').click();

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
@@ -67,6 +67,20 @@ test.describe(
 			expect(after.width).toBeGreaterThan(before.width);
 		});
 
+		test('drags the group when grabbing the title bar beside a short name', async ({ n8n }) => {
+			await n8n.canvas.selectNodes(['Set A', 'Set B']);
+			await n8n.canvas.selectionToolbar.groupButton().click();
+			await n8n.canvas.deselectAll();
+
+			const before = await n8n.canvas.getNodeGroupBoundingBox(DEFAULT_GROUP_TITLE);
+			// Grab the empty space to the right of the (short) name, not over the name input.
+			await n8n.canvas.dragNodeGroupFromTitleBar(DEFAULT_GROUP_TITLE, 120, 80);
+			const after = await n8n.canvas.getNodeGroupBoundingBox(DEFAULT_GROUP_TITLE);
+
+			expect(after.x).toBeGreaterThan(before.x);
+			expect(after.y).toBeGreaterThan(before.y);
+		});
+
 		test('commits a new title on Enter and reverts on Escape', async ({ n8n }) => {
 			const renamed = `Renamed ${nanoid(6)}`;
 			await n8n.canvas.selectNodes(['Set A', 'Set B']);


### PR DESCRIPTION
## Summary

Dragging a node group failed when grabbing the title bar just to the right of a short group name — the click registered as "over the name" without entering edit mode, so the group wouldn't move.

The inline name editor carries VueFlow's `nodrag` class, but its reka-ui root rendered as a full-width block `<div>`, so its non-draggable box spanned the **entire** title bar even when the visible name was short. Two changes make the `nodrag` box hug only the visible name:

- **`editor-ui` / `CanvasNodeGroupTitleBar.vue`** — constrain the inline editor to `width: fit-content; max-width: 100%`, so the empty space beside the name belongs to the draggable title bar rather than the editor.
- **`@n8n/design-system` / `InlineTextEdit.vue`** — give the native `<input>` `size="1"`. The default 20-char intrinsic width (~187px) otherwise dominated `fit-content` sizing. The rendered width is always driven explicitly by the component's `inputWidth`, so this is a no-op for every other consumer (all of which pass a numeric `max-width`, or sit in a flex-stretched/definite-width container).

Now you can drag a group by clicking anywhere on the title bar except over the name input itself — as intended.

## How to test

1. Enable the canvas groups experiment (`083_canvas_nodes_grouping`).
2. Select two nodes and group them; keep the short default name ("Group 1").
3. Click-drag the title bar in the empty space to the right of the name → the group moves.
4. Click directly on the name → it enters edit mode (and does not drag).

Covered by a new Playwright regression test in `node-groups.spec.ts` ("drags the group when grabbing the title bar beside a short name"), which fails on the original code and passes with the fix.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5411

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32761">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->