### PR TITLE
feat(editor): Display canvas groups in read only workflow views (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
@@ -49,6 +49,7 @@ provide(
 	EditorEnabledFeaturesKey,
 	computed<EditorEnabledFeatures>(() => ({
 		readOnly: true,
+		expandGroups: true,
 		aiAssistant: false,
 		aiBuilder: false,
 		askAi: false,

--- a/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
@@ -57,6 +57,7 @@ export function useEditorContext() {
 		askAi: featureEnabled('askAi'),
 		instanceAi: featureEnabled('instanceAi'),
 		readOnly: computed(() => enabledFeatures?.value?.readOnly === true),
+		expandGroups: computed(() => enabledFeatures?.value?.expandGroups === true),
 		executionSuccessToasts: computed(
 			() => enabledFeatures?.value?.executionSuccessToasts !== false,
 		),

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -52,10 +52,13 @@ export type EditorFeature = 'aiAssistant' | 'aiBuilder' | 'askAi' | 'instanceAi'
  * (mirrors the old iframe `suppressNotifications` / `allowErrorNotifications`
  * knobs, but scoped per editor instead of via the shared UI store). Hosts that
  * surface results in their own UI — e.g. the Instance AI preview — set them.
+ * `expandGroups` is a direct state flag — `true` shows every canvas group
+ * expanded and leaves the editor's persisted view state untouched
  * Provided by editor hosts that supersede capabilities.
  */
 export type EditorEnabledFeatures = Partial<Record<EditorFeature, boolean>> & {
 	readOnly?: boolean;
+	expandGroups?: boolean;
 	executionSuccessToasts?: boolean;
 	executionErrorToasts?: boolean;
 };

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -304,7 +304,7 @@ const isNDVV2 = computed(() => true);
 
 // Per-editor host overrides (AI features + read-only). The artifact host marks
 // the canvas read-only while a workflow-builder agent mutates the workflow.
-const { readOnly: externalReadOnly } = useEditorContext();
+const { readOnly: externalReadOnly, expandGroups: externalExpandGroups } = useEditorContext();
 
 const isCanvasReadOnly = computed(() => {
 	return (
@@ -316,6 +316,12 @@ const isCanvasReadOnly = computed(() => {
 		(builderStore.streaming && !builderStore.isHelpStreaming) ||
 		externalReadOnly.value
 	);
+});
+
+// Read-only views that aren't the user's own workflow canvas
+// (previews/history/templates/embeds), except the Instance AI artifact preview
+const isNonCuratedReadOnlyView = computed(() => {
+	return isDemoRoute.value || externalExpandGroups.value;
 });
 
 const canExecuteOnCanvas = computed(() => {
@@ -1951,6 +1957,8 @@ onBeforeUnmount(() => {
 			:show-fallback-nodes="showFallbackNodes"
 			:event-bus="canvasEventBus"
 			:read-only="isCanvasReadOnly"
+			:expand-all-groups="isNonCuratedReadOnlyView"
+			:ignore-group-view-state="isNonCuratedReadOnlyView"
 			:can-execute="canExecuteOnCanvas"
 			:executing="isWorkflowRunning"
 			:key-bindings="keyBindingsEnabled"

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -318,9 +318,7 @@ const isCanvasReadOnly = computed(() => {
 	);
 });
 
-// Read-only views that aren't the user's own workflow canvas
-// (previews/history/templates/embeds), except the Instance AI artifact preview
-const isNonCuratedReadOnlyView = computed(() => {
+const forceAllGroupsExpanded = computed(() => {
 	return isDemoRoute.value || externalExpandGroups.value;
 });
 
@@ -1957,8 +1955,7 @@ onBeforeUnmount(() => {
 			:show-fallback-nodes="showFallbackNodes"
 			:event-bus="canvasEventBus"
 			:read-only="isCanvasReadOnly"
-			:expand-all-groups="isNonCuratedReadOnlyView"
-			:ignore-group-view-state="isNonCuratedReadOnlyView"
+			:force-all-groups-expanded="forceAllGroupsExpanded"
 			:can-execute="canExecuteOnCanvas"
 			:executing="isWorkflowRunning"
 			:key-bindings="keyBindingsEnabled"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -589,6 +589,8 @@ describe('Canvas', () => {
 				getCurrentGroupIds: () => workflowDocumentStore.allGroups.map((group) => group.id),
 				onNodeGroupsChange: workflowDocumentStore.onNodeGroupsChange,
 				isGroupingEnabled: () => true,
+				expandAll: () => false,
+				ignorePersistedState: () => false,
 			});
 		}
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -589,8 +589,7 @@ describe('Canvas', () => {
 				getCurrentGroupIds: () => workflowDocumentStore.allGroups.map((group) => group.id),
 				onNodeGroupsChange: workflowDocumentStore.onNodeGroupsChange,
 				isGroupingEnabled: () => true,
-				expandAll: () => false,
-				ignorePersistedState: () => false,
+				forceAllGroupsExpanded: () => false,
 			});
 		}
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -108,6 +108,13 @@ const nodeGroupView = useCanvasNodeGroupView({
 	expandAll: () => props.expandAllGroups ?? false,
 	ignorePersistedState: () => props.ignoreGroupViewState ?? false,
 });
+
+// Keep the group view in sync with the currently displayed document
+watch(
+	() => workflowDocumentStore.value.documentId,
+	() => nodeGroupView.reinitialize(),
+);
+
 const allGroups = computed(() => workflowDocumentStore.value.allGroups);
 const readOnlyRef = computed(() => props.readOnly ?? false);
 const suppressInteractionRef = computed(() => props.suppressInteraction ?? false);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -42,8 +42,7 @@ const props = withDefaults(
 		showFallbackNodes?: boolean;
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
-		expandAllGroups?: boolean;
-		ignoreGroupViewState?: boolean;
+		forceAllGroupsExpanded?: boolean;
 		canExecute?: boolean;
 		executing?: boolean;
 		suppressInteraction?: boolean;
@@ -105,8 +104,7 @@ const nodeGroupView = useCanvasNodeGroupView({
 	getCurrentGroupIds: () => workflowDocumentStore.value.allGroups.map((group) => group.id),
 	onNodeGroupsChange: (handler) => workflowDocumentStore.value.onNodeGroupsChange(handler),
 	isGroupingEnabled: () => isCanvasNodeGroupingEnabled.value,
-	expandAll: () => props.expandAllGroups ?? false,
-	ignorePersistedState: () => props.ignoreGroupViewState ?? false,
+	forceAllGroupsExpanded: () => props.forceAllGroupsExpanded ?? false,
 });
 
 // Keep the group view in sync with the currently displayed document

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -42,6 +42,8 @@ const props = withDefaults(
 		showFallbackNodes?: boolean;
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
+		expandAllGroups?: boolean;
+		ignoreGroupViewState?: boolean;
 		canExecute?: boolean;
 		executing?: boolean;
 		suppressInteraction?: boolean;
@@ -103,6 +105,8 @@ const nodeGroupView = useCanvasNodeGroupView({
 	getCurrentGroupIds: () => workflowDocumentStore.value.allGroups.map((group) => group.id),
 	onNodeGroupsChange: (handler) => workflowDocumentStore.value.onNodeGroupsChange(handler),
 	isGroupingEnabled: () => isCanvasNodeGroupingEnabled.value,
+	expandAll: () => props.expandAllGroups ?? false,
+	ignorePersistedState: () => props.ignoreGroupViewState ?? false,
 });
 const allGroups = computed(() => workflowDocumentStore.value.allGroups);
 const readOnlyRef = computed(() => props.readOnly ?? false);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
@@ -84,6 +84,21 @@ describe('useCanvasNodeGroupView', () => {
 			expect(view.isGroupCollapsed('g2')).toBe(true);
 		});
 
+		it('does not clobber persisted state when restoring before groups are loaded', () => {
+			localStorage.setItem(
+				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
+				JSON.stringify({ 'wf-test': ['g1'] }),
+			);
+
+			// Canvas mounts before the document hydrates its groups: the initial
+			// restore sees no groups and must leave the saved state untouched.
+			const { nodeGroups, view } = setup();
+			expect(readStored()).toEqual(['g1']);
+
+			nodeGroups.setNodeGroups([{ id: 'g1', name: 'A', nodeIds: ['a'] }]);
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+		});
+
 		it('drops persisted ids whose groups are no longer present', () => {
 			localStorage.setItem(
 				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
@@ -222,6 +222,56 @@ describe('useCanvasNodeGroupView', () => {
 		});
 	});
 
+	describe('reinitialize (document swap under a persistent canvas)', () => {
+		it('rebinds to the swapped document and re-seeds its groups', () => {
+			const versionA = useWorkflowDocumentNodeGroups();
+			versionA.setNodeGroups([{ id: 'a1', name: 'A', nodeIds: ['n1'] }]);
+			const versionB = useWorkflowDocumentNodeGroups();
+			versionB.setNodeGroups([{ id: 'b1', name: 'B', nodeIds: ['n2'] }]);
+
+			let active = versionA;
+			const view = useCanvasNodeGroupView({
+				workflowId: () => 'wf',
+				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
+				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
+				isGroupingEnabled: () => true,
+				expandAll: () => true,
+				ignorePersistedState: () => true,
+			});
+
+			expect(view.isGroupCollapsed('a1')).toBe(false);
+
+			// Swap the document without reinitializing: the new version's group is
+			// stale (collapsed) because the expanded set still reflects version A.
+			active = versionB;
+			expect(view.isGroupCollapsed('b1')).toBe(true);
+
+			view.reinitialize();
+			expect(view.isGroupCollapsed('b1')).toBe(false);
+		});
+
+		it('hears change events from the swapped document after rebinding', () => {
+			const versionA = useWorkflowDocumentNodeGroups();
+			const versionB = useWorkflowDocumentNodeGroups();
+
+			let active = versionA;
+			const view = useCanvasNodeGroupView({
+				workflowId: () => 'wf',
+				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
+				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
+				isGroupingEnabled: () => true,
+				expandAll: () => true,
+				ignorePersistedState: () => true,
+			});
+
+			active = versionB;
+			view.reinitialize();
+
+			versionB.setNodeGroups([{ id: 'b1', name: 'B', nodeIds: ['n2'] }]);
+			expect(view.isGroupCollapsed('b1')).toBe(false);
+		});
+	});
+
 	describe('expansion order', () => {
 		it('appends the most recently expanded group to the end', () => {
 			const { view } = setup([

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
@@ -9,13 +9,11 @@ function setup(
 	{
 		workflowId = 'wf-test',
 		isGroupingEnabled = () => true,
-		expandAll = () => false,
-		ignorePersistedState = () => false,
+		forceAllGroupsExpanded = () => false,
 	}: {
 		workflowId?: string;
 		isGroupingEnabled?: () => boolean;
-		expandAll?: () => boolean;
-		ignorePersistedState?: () => boolean;
+		forceAllGroupsExpanded?: () => boolean;
 	} = {},
 ) {
 	const nodeGroups = useWorkflowDocumentNodeGroups();
@@ -27,8 +25,7 @@ function setup(
 		getCurrentGroupIds: () => nodeGroups.allGroups.value.map((group) => group.id),
 		onNodeGroupsChange: nodeGroups.onNodeGroupsChange,
 		isGroupingEnabled,
-		expandAll,
-		ignorePersistedState,
+		forceAllGroupsExpanded,
 	});
 	return { nodeGroups, view };
 }
@@ -142,8 +139,8 @@ describe('useCanvasNodeGroupView', () => {
 		});
 	});
 
-	describe('expandAll', () => {
-		it('expands every group on load, ignoring the persisted collapsed default', () => {
+	describe('forceAllGroupsExpanded', () => {
+		it('expands every group on load, ignoring persisted state', () => {
 			localStorage.setItem(
 				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
 				JSON.stringify({ 'wf-test': ['g1'] }),
@@ -154,7 +151,7 @@ describe('useCanvasNodeGroupView', () => {
 					{ id: 'g1', name: 'A', nodeIds: ['a'] },
 					{ id: 'g2', name: 'B', nodeIds: ['b'] },
 				],
-				{ expandAll: () => true },
+				{ forceAllGroupsExpanded: () => true },
 			);
 
 			expect(view.isGroupCollapsed('g1')).toBe(false);
@@ -162,7 +159,7 @@ describe('useCanvasNodeGroupView', () => {
 		});
 
 		it('expands groups loaded via the SET event', () => {
-			const { nodeGroups, view } = setup([], { expandAll: () => true });
+			const { nodeGroups, view } = setup([], { forceAllGroupsExpanded: () => true });
 
 			nodeGroups.setNodeGroups([
 				{ id: 'g1', name: 'A', nodeIds: ['a'] },
@@ -175,7 +172,7 @@ describe('useCanvasNodeGroupView', () => {
 
 		it('still allows collapsing a group in memory', () => {
 			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				expandAll: () => true,
+				forceAllGroupsExpanded: () => true,
 			});
 
 			expect(view.isGroupCollapsed('g1')).toBe(false);
@@ -183,56 +180,16 @@ describe('useCanvasNodeGroupView', () => {
 			expect(view.isGroupCollapsed('g1')).toBe(true);
 		});
 
-		it('persists expanded state when persistence is not ignored', () => {
-			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				expandAll: () => true,
-			});
-
-			expect(view.isGroupCollapsed('g1')).toBe(false);
-			expect(readStored()).toEqual(['g1']);
-		});
-	});
-
-	describe('ignorePersistedState', () => {
-		it('does not read persisted expanded ids on load', () => {
-			localStorage.setItem(
-				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
-				JSON.stringify({ 'wf-test': ['g1'] }),
-			);
-
-			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				ignorePersistedState: () => true,
-			});
-
-			expect(view.isGroupCollapsed('g1')).toBe(true);
-		});
-
-		it('does not write view state to localStorage on toggle', () => {
-			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				ignorePersistedState: () => true,
-			});
-
-			view.toggleCollapsed('g1');
-			view.toggleCollapsed('g1');
-
-			expect(readStored()).toBeUndefined();
-		});
-	});
-
-	describe('preview contexts (expandAll + ignorePersistedState)', () => {
-		it('expands every group without touching localStorage', () => {
+		it('never reads or writes persisted view state', () => {
 			localStorage.setItem(LOCAL_STORAGE_CANVAS_GROUP_EXPANDED, JSON.stringify({ 'wf-test': [] }));
 
-			const { view } = setup(
-				[
-					{ id: 'g1', name: 'A', nodeIds: ['a'] },
-					{ id: 'g2', name: 'B', nodeIds: ['b'] },
-				],
-				{ expandAll: () => true, ignorePersistedState: () => true },
-			);
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				forceAllGroupsExpanded: () => true,
+			});
 
-			expect(view.isGroupCollapsed('g1')).toBe(false);
-			expect(view.isGroupCollapsed('g2')).toBe(false);
+			view.toggleCollapsed('g1');
+			view.toggleCollapsed('g1');
+
 			expect(readStored()).toEqual([]);
 		});
 	});
@@ -250,8 +207,7 @@ describe('useCanvasNodeGroupView', () => {
 				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
 				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
 				isGroupingEnabled: () => true,
-				expandAll: () => true,
-				ignorePersistedState: () => true,
+				forceAllGroupsExpanded: () => true,
 			});
 
 			expect(view.isGroupCollapsed('a1')).toBe(false);
@@ -275,8 +231,7 @@ describe('useCanvasNodeGroupView', () => {
 				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
 				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
 				isGroupingEnabled: () => true,
-				expandAll: () => true,
-				ignorePersistedState: () => true,
+				forceAllGroupsExpanded: () => true,
 			});
 
 			active = versionB;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
@@ -9,7 +9,14 @@ function setup(
 	{
 		workflowId = 'wf-test',
 		isGroupingEnabled = () => true,
-	}: { workflowId?: string; isGroupingEnabled?: () => boolean } = {},
+		expandAll = () => false,
+		ignorePersistedState = () => false,
+	}: {
+		workflowId?: string;
+		isGroupingEnabled?: () => boolean;
+		expandAll?: () => boolean;
+		ignorePersistedState?: () => boolean;
+	} = {},
 ) {
 	const nodeGroups = useWorkflowDocumentNodeGroups();
 	if (initialGroups.length > 0) {
@@ -20,6 +27,8 @@ function setup(
 		getCurrentGroupIds: () => nodeGroups.allGroups.value.map((group) => group.id),
 		onNodeGroupsChange: nodeGroups.onNodeGroupsChange,
 		isGroupingEnabled,
+		expandAll,
+		ignorePersistedState,
 	});
 	return { nodeGroups, view };
 }
@@ -115,6 +124,101 @@ describe('useCanvasNodeGroupView', () => {
 			expect(b.view.isGroupCollapsed('g1')).toBe(true);
 			expect(readStored('wf-a')).toEqual(['g1']);
 			expect(readStored('wf-b')).toEqual([]);
+		});
+	});
+
+	describe('expandAll', () => {
+		it('expands every group on load, ignoring the persisted collapsed default', () => {
+			localStorage.setItem(
+				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
+				JSON.stringify({ 'wf-test': ['g1'] }),
+			);
+
+			const { view } = setup(
+				[
+					{ id: 'g1', name: 'A', nodeIds: ['a'] },
+					{ id: 'g2', name: 'B', nodeIds: ['b'] },
+				],
+				{ expandAll: () => true },
+			);
+
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+			expect(view.isGroupCollapsed('g2')).toBe(false);
+		});
+
+		it('expands groups loaded via the SET event', () => {
+			const { nodeGroups, view } = setup([], { expandAll: () => true });
+
+			nodeGroups.setNodeGroups([
+				{ id: 'g1', name: 'A', nodeIds: ['a'] },
+				{ id: 'g2', name: 'B', nodeIds: ['b'] },
+			]);
+
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+			expect(view.isGroupCollapsed('g2')).toBe(false);
+		});
+
+		it('still allows collapsing a group in memory', () => {
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				expandAll: () => true,
+			});
+
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+			view.toggleCollapsed('g1');
+			expect(view.isGroupCollapsed('g1')).toBe(true);
+		});
+
+		it('persists expanded state when persistence is not ignored', () => {
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				expandAll: () => true,
+			});
+
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+			expect(readStored()).toEqual(['g1']);
+		});
+	});
+
+	describe('ignorePersistedState', () => {
+		it('does not read persisted expanded ids on load', () => {
+			localStorage.setItem(
+				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
+				JSON.stringify({ 'wf-test': ['g1'] }),
+			);
+
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				ignorePersistedState: () => true,
+			});
+
+			expect(view.isGroupCollapsed('g1')).toBe(true);
+		});
+
+		it('does not write view state to localStorage on toggle', () => {
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				ignorePersistedState: () => true,
+			});
+
+			view.toggleCollapsed('g1');
+			view.toggleCollapsed('g1');
+
+			expect(readStored()).toBeUndefined();
+		});
+	});
+
+	describe('preview contexts (expandAll + ignorePersistedState)', () => {
+		it('expands every group without touching localStorage', () => {
+			localStorage.setItem(LOCAL_STORAGE_CANVAS_GROUP_EXPANDED, JSON.stringify({ 'wf-test': [] }));
+
+			const { view } = setup(
+				[
+					{ id: 'g1', name: 'A', nodeIds: ['a'] },
+					{ id: 'g2', name: 'B', nodeIds: ['b'] },
+				],
+				{ expandAll: () => true, ignorePersistedState: () => true },
+			);
+
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+			expect(view.isGroupCollapsed('g2')).toBe(false);
+			expect(readStored()).toEqual([]);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -17,6 +17,8 @@ export interface UseCanvasNodeGroupViewDeps {
 	getCurrentGroupIds: () => string[];
 	onNodeGroupsChange: (handler: (event: NodeGroupChangeEvent) => void) => { off: () => void };
 	isGroupingEnabled: () => boolean;
+	expandAll: () => boolean;
+	ignorePersistedState: () => boolean;
 }
 
 export interface NodeGroupNodePosition {
@@ -107,6 +109,7 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 	const componentOffsets = computed(() => aggregateNodeGroupLayoutOffsets(pushEntries.value));
 
 	function persist() {
+		if (deps.ignorePersistedState()) return;
 		writeStore({ ...readStore(), [deps.workflowId()]: [...expandedGroupIdOrder.value] });
 	}
 
@@ -126,9 +129,15 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		persist();
 	}
 
-	// Load the persisted ids, dropping any whose group no longer exists.
+	// Seed the expanded set on (re)load: all groups when `expandAll`, otherwise
+	// the persisted ids (none when persisted state is ignored).
+	// Drop any id whose group no longer exists.
 	function restore(presentIds: Set<string>) {
-		const stored = readStore()[deps.workflowId()] ?? [];
+		const stored = deps.expandAll()
+			? [...presentIds]
+			: deps.ignorePersistedState()
+				? []
+				: (readStore()[deps.workflowId()] ?? []);
 		expandedGroupIdOrder.value = stored.filter((id) => presentIds.has(id));
 		disabledPushSourceGroupIds.value = new Set();
 		ignoredNodeIdsBySourceGroup.value = new Map();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -141,7 +141,9 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		expandedGroupIdOrder.value = stored.filter((id) => presentIds.has(id));
 		disabledPushSourceGroupIds.value = new Set();
 		ignoredNodeIdsBySourceGroup.value = new Map();
-		persist();
+
+		const groupsLoaded = presentIds.size > 0;
+		if (groupsLoaded) persist();
 	}
 
 	function setGroupExpanded(id: string, value: boolean) {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -304,15 +304,12 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		return pushedNodeMoves;
 	}
 
-	// Seed from groups already loaded (the SET event can fire before we subscribe).
-	restore(new Set(deps.getCurrentGroupIds()));
-
 	// Default collapse state per change action: SET (workflow load /
 	// replacement) restores the persisted expanded state; ADD (new group)
 	// starts expanded, unless flagged `startCollapsed` (imported/pasted
 	// groups, whose stored positions describe the collapsed layout); DELETE
 	// removes the id; UPDATE leaves collapse state alone.
-	const subscription = deps.onNodeGroupsChange((event) => {
+	function handleNodeGroupsChange(event: NodeGroupChangeEvent) {
 		if (event.action === CHANGE_ACTION.SET) {
 			restore(new Set(event.payload.groups.map((group) => group.id)));
 		} else if (event.action === CHANGE_ACTION.ADD && !event.payload.startCollapsed) {
@@ -327,15 +324,28 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		} else if (event.action === CHANGE_ACTION.DELETE) {
 			removeDeletedGroup(event.payload.id);
 		}
-	});
+	}
+
+	let subscription: { off: () => void } | undefined;
+
+	// Bind to the current document and seed from its groups; re-run when a
+	// persistent canvas swaps documents (e.g. switching history versions).
+	function reinitialize() {
+		subscription?.off();
+		subscription = deps.onNodeGroupsChange(handleNodeGroupsChange);
+		restore(new Set(deps.getCurrentGroupIds()));
+	}
+
+	reinitialize();
 
 	// Release the subscription with the surrounding scope so the handler
 	// doesn't outlive its owner.
 	if (getCurrentScope()) {
-		onScopeDispose(() => subscription.off());
+		onScopeDispose(() => subscription?.off());
 	}
 
 	return {
+		reinitialize,
 		isGroupCollapsed,
 		toggleCollapsed,
 		syncLayoutComponents,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -17,8 +17,8 @@ export interface UseCanvasNodeGroupViewDeps {
 	getCurrentGroupIds: () => string[];
 	onNodeGroupsChange: (handler: (event: NodeGroupChangeEvent) => void) => { off: () => void };
 	isGroupingEnabled: () => boolean;
-	expandAll: () => boolean;
-	ignorePersistedState: () => boolean;
+	// Show every group expanded and leave persisted view state untouched
+	forceAllGroupsExpanded: () => boolean;
 }
 
 export interface NodeGroupNodePosition {
@@ -109,7 +109,7 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 	const componentOffsets = computed(() => aggregateNodeGroupLayoutOffsets(pushEntries.value));
 
 	function persist() {
-		if (deps.ignorePersistedState()) return;
+		if (deps.forceAllGroupsExpanded()) return;
 		writeStore({ ...readStore(), [deps.workflowId()]: [...expandedGroupIdOrder.value] });
 	}
 
@@ -129,15 +129,12 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		persist();
 	}
 
-	// Seed the expanded set on (re)load: all groups when `expandAll`, otherwise
-	// the persisted ids (none when persisted state is ignored).
-	// Drop any id whose group no longer exists.
+	// Seed the expanded set on (re)load: all groups when forced, otherwise
+	// the persisted ids. Drop any id whose group no longer exists.
 	function restore(presentIds: Set<string>) {
-		const stored = deps.expandAll()
+		const stored = deps.forceAllGroupsExpanded()
 			? [...presentIds]
-			: deps.ignorePersistedState()
-				? []
-				: (readStore()[deps.workflowId()] ?? []);
+			: (readStore()[deps.workflowId()] ?? []);
 		expandedGroupIdOrder.value = stored.filter((id) => presentIds.has(id));
 		disabledPushSourceGroupIds.value = new Set();
 		ignoredNodeIdsBySourceGroup.value = new Map();


### PR DESCRIPTION
## Summary

Read-only views that present a workflow — workflow history, templates, embeds — now display canvas groups **expanded by default**, while the editor and other read-only states (collaboration lock, branch protection, archived, shared view-only, AI builder) keep the user's own persisted expand/collapse state. Execution view and workflow diffs are out of scope (P1).

### Why it ended up this shape

- **First approach — reuse the read-only signal (`externalReadOnly`) to decide expand-by-default.** Too coarse: `externalReadOnly` (`EditorEnabledFeatures.readOnly`) is shared by *every* read-only host, so it also caught the **execution preview** (P1) and the **Instance AI artifact preview** (which should keep the user's state). The flag can't distinguish "a preview meant for display" from "read-only for some other reason."

- **So we added an explicit opt-in prop (`forceAllGroupsExpanded`, backed by `EditorEnabledFeatures.expandGroups`).** Only `WorkflowPreviewHost` (history/templates) sets it; the demo/embed route opts in via its route flag. Execution and artifact previews are excluded by *omission* rather than by an ever-growing condition.

- **Why a watcher.** The history preview reuses a single canvas and swaps the underlying document store per version without remounting. The group view seeded its state once at creation, so switching versions left stale expand state and some groups rendered collapsed. A watcher on the document id re-seeds (and re-subscribes) the group view on each swap.

- **Why the guard.** That watcher exposed a latent bug: `restore()` ended with `persist()`, and on a normal editor load `workflowId` flips *before* groups hydrate — so `restore()` ran with no groups and wrote an empty array, wiping the user's saved expand state. A "groups loaded" guard skips the prune-write until the document's groups are present.

## How to test

- Editor: collapse/expand groups, reload → state is remembered (regression check).
- Workflow History: switch between versions → groups show expanded for every version.
- Template preview / embedded canvas → groups show expanded.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5319](https://linear.app/n8n/issue/ADO-5319/feature-display-canvas-groups-in-read-only-workflow-views-expanded-by)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
