### PR TITLE
fix(editor): Avoid idle canvas edge hover timers

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.test.ts
@@ -35,6 +35,10 @@ beforeEach(() => {
 	setActivePinia(pinia);
 });
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 describe('CanvasEdge', () => {
 	it('should emit delete event when toolbar delete is clicked', async () => {
 		const { emitted, getByTestId } = renderComponent({
@@ -123,6 +127,17 @@ describe('CanvasEdge', () => {
 		await vi.advanceTimersByTimeAsync(600);
 
 		expect(queryByTestId('canvas-edge-toolbar')).not.toBeInTheDocument();
+	});
+
+	it('should not schedule a hide timer when initially not hovered', () => {
+		vi.useFakeTimers();
+		const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+		renderComponent({
+			props: { hovered: false },
+		});
+
+		expect(setTimeoutSpy).not.toHaveBeenCalled();
 	});
 
 	it('should compute edgeStyle correctly', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -5,7 +5,7 @@ import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import type { Connection, EdgeProps } from '@vue-flow/core';
 import { BaseEdge, EdgeLabelRenderer } from '@vue-flow/core';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import { computed, ref, toRef, useCssModule, watch } from 'vue';
+import { computed, onBeforeUnmount, ref, toRef, useCssModule, watch } from 'vue';
 import CanvasEdgeToolbar from './CanvasEdgeToolbar.vue';
 import { getEdgeRenderData } from './utils';
 import { useCanvas } from '../../../composables/useCanvas';
@@ -46,17 +46,29 @@ const delayedHoveredTimeout = 600;
 watch(
 	() => props.hovered,
 	(isHovered) => {
-		if (isHovered) {
-			if (delayedHoveredSetTimeoutRef.value) clearTimeout(delayedHoveredSetTimeoutRef.value);
-			delayedHovered.value = true;
-		} else {
-			delayedHoveredSetTimeoutRef.value = setTimeout(() => {
-				delayedHovered.value = false;
-			}, delayedHoveredTimeout);
+		if (delayedHoveredSetTimeoutRef.value) {
+			clearTimeout(delayedHoveredSetTimeoutRef.value);
+			delayedHoveredSetTimeoutRef.value = null;
 		}
+
+		if (isHovered) {
+			delayedHovered.value = true;
+			return;
+		}
+
+		if (!delayedHovered.value) return;
+
+		delayedHoveredSetTimeoutRef.value = setTimeout(() => {
+			delayedHovered.value = false;
+			delayedHoveredSetTimeoutRef.value = null;
+		}, delayedHoveredTimeout);
 	},
 	{ immediate: true },
 );
+
+onBeforeUnmount(() => {
+	if (delayedHoveredSetTimeoutRef.value) clearTimeout(delayedHoveredSetTimeoutRef.value);
+});
 
 const renderToolbar = computed(() => delayedHovered.value && !props.readOnly);
 
@@ -191,7 +203,7 @@ function onEdgeLabelMouseLeave() {
 				@add="onAdd"
 				@delete="onDelete"
 			/>
-			<div v-else :class="$style.edgeLabel">{{ label }}</div>
+			<div v-show="!renderToolbar" :class="$style.edgeLabel">{{ label }}</div>
 		</div>
 	</EdgeLabelRenderer>
 </template>
@@ -216,6 +228,7 @@ function onEdgeLabelMouseLeave() {
 .edgeLabelWrapper {
 	transform: translateY(calc(var(--spacing--xs) * -1));
 	position: absolute;
+	pointer-events: none;
 
 	/* stylelint-disable-next-line @n8n/css-var-naming */
 	--label-translate-y: 0;


### PR DESCRIPTION
## Summary

This PR reduces unnecessary work in **canvas edge hover rendering**.

Canvas edges currently run the hovered watcher immediately on mount. For edges mounted with `hovered=false`, this schedules a **delayed hide timer** even though the edge is already not hovered. On workflows with many visible connections, this can create unnecessary timers during canvas render.

<table>
    <thead>
      <tr>
        <th>Area</th>
        <th>Before</th>
        <th>After</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td>Initial non-hovered edge mount</td>
        <td>Schedules a delayed hide timer</td>
        <td>Does not schedule a timer</td>
      </tr>
      <tr>
        <td>Hover state change</td>
        <td>May leave timer cleanup spread across branches</td>
        <td>Clears any pending timer before handling the next state</td>
      </tr>
      <tr>
        <td>Edge unmount</td>
        <td>Pending timer may remain until it fires</td>
        <td>Pending timer is cleared on unmount</td>
      </tr>
      <tr>
        <td>Edge label / toolbar swap</td>
        <td>Label is removed from DOM when toolbar is shown</td>
        <td>Label stays mounted and is toggled with <code>v-show</code></td>
      </tr>
      <tr>
        <td>Passive label hit area</td>
        <td>Label wrapper can participate in pointer hit testing</td>
        <td>Passive label wrapper ignores pointer events; toolbar remains interactive</td>
      </tr>
    </tbody>
  </table>

I verified this with a Chrome Performance recording on a workflow with many visible connections: after this change, initially non-hovered edges no longer create delayed hover timers on mount.

## How to test

Automated test:

> pnpm test src/features/workflows/canvas/components/elements/edges/CanvasEdge.test.ts

Manual test:

1. Open a workflow with several visible connections.
2. Move the pointer over and away from canvas edges.
3. Confirm edge labels and edge toolbars behave as before.
4. Refresh the workflow editor and confirm edges mounted with `hovered=false` do not schedule
   delayed hide timers.

## Related Linear tickets, Github issues, and Community forum posts

None

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. Not applicable: editor performance fix only.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

