### PR TITLE
fix(core): Persist thread anchor so Instance AI retains context across turns

### DIFF
--- a/packages/@n8n/instance-ai/docs/memory.md
+++ b/packages/@n8n/instance-ai/docs/memory.md
@@ -29,11 +29,20 @@ configuration — no separate config needed.
 
 ### Tier 2: Recent Messages
 
-A sliding window of the most recent N messages in the conversation, sent as
-context to the LLM on every request.
+The recent conversation history loaded from storage and sent as context to the
+LLM. For short threads the full history is loaded; once observational memory has
+run, only the messages since the observation cursor are loaded raw (older turns
+are represented by the observation block — see Tier 3).
 
-- **Default**: 20 messages
-- **Config**: `N8N_INSTANCE_AI_LAST_MESSAGES`
+### Tier 2.5: Thread Anchor
+
+Durable conversation invariants — the user's **original goal** and the
+**workflows built** in the thread — persisted on the thread and re-injected into
+the system prompt on **every** turn (see `ThreadAnchor`). Unlike Tiers 2–3 it is
+not part of the message list, so it survives the recent-message reconstruction,
+observational compaction, and HITL suspends. This is what stops the agent from
+re-asking answered questions, losing the original request, or claiming "this is
+the start of our conversation" mid-thread.
 
 ### Tier 3: Observational Memory
 
@@ -107,7 +116,6 @@ conversations.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `N8N_INSTANCE_AI_LAST_MESSAGES` | number | 20 | Recent message window |
 | `N8N_INSTANCE_AI_OBSERVER_MESSAGE_TOKENS` | number | 30000 | Observer trigger threshold |
 | `N8N_INSTANCE_AI_REFLECTOR_OBSERVATION_TOKENS` | number | 40000 | Reflector trigger threshold |
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/thread-anchor-section.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/thread-anchor-section.test.ts
@@ -1,0 +1,36 @@
+import { getSystemPrompt, getThreadAnchorSection } from '../system-prompt';
+
+describe('getThreadAnchorSection', () => {
+	it('returns empty string when there is no anchor', () => {
+		expect(getThreadAnchorSection(undefined)).toBe('');
+		expect(getThreadAnchorSection({})).toBe('');
+		expect(getThreadAnchorSection({ builtWorkflows: [] })).toBe('');
+	});
+
+	it('renders the original goal and instructs the agent not to claim a fresh start', () => {
+		const section = getThreadAnchorSection({ originalGoal: 'Send an SMS on missed calls' });
+		expect(section).toContain('Original request:** Send an SMS on missed calls');
+		expect(section).toContain('start of the conversation');
+	});
+
+	it('renders built workflows with names when available', () => {
+		const section = getThreadAnchorSection({
+			builtWorkflows: [{ id: 'wf-1', name: 'Zameen Engine' }, { id: 'wf-2' }],
+		});
+		expect(section).toContain('Zameen Engine (wf-1)');
+		expect(section).toContain('wf-2');
+	});
+});
+
+describe('getSystemPrompt thread anchor injection', () => {
+	it('includes the anchor section when an anchor is provided', () => {
+		const prompt = getSystemPrompt({ threadAnchor: { originalGoal: 'My goal' } });
+		expect(prompt).toContain('Thread context (persistent — always honor)');
+		expect(prompt).toContain('My goal');
+	});
+
+	it('omits the anchor section when no anchor is provided', () => {
+		const prompt = getSystemPrompt({});
+		expect(prompt).not.toContain('Thread context (persistent');
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -138,6 +138,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 			orchestrationContext?.workspace && orchestrationContext.workspaceRoot
 				? orchestrationContext.workspaceRoot
 				: undefined,
+		threadAnchor: orchestrationContext?.threadAnchor,
 	});
 
 	const telemetry = orchestrationContext?.tracing?.getTelemetry?.({

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 import { getComputerUsePrompt } from './computer-use-prompt';
 import { SECRET_ASK_GUARDRAIL } from './credential-guardrails.prompt';
 import { getSandboxWorkspaceSection, UNTRUSTED_CONTENT_DOCTRINE } from './shared-prompts';
-import type { LocalGatewayStatus } from '../types';
+import type { LocalGatewayStatus, ThreadAnchor } from '../types';
 
 interface SystemPromptOptions {
 	webhookBaseUrl?: string;
@@ -18,6 +18,33 @@ interface SystemPromptOptions {
 	projectId?: string;
 	/** Absolute or host-relative sandbox workspace root for `<workspace_root>` paths in prompts. */
 	workspaceRoot?: string;
+	/** Durable thread invariants re-injected every turn (original goal, built workflows). */
+	threadAnchor?: ThreadAnchor;
+}
+
+/**
+ * Render the persistent thread context. This survives the recent-message window
+ * and observational compaction, so the agent never loses the original goal or
+ * forgets the workflows it built mid-thread.
+ */
+export function getThreadAnchorSection(anchor?: ThreadAnchor): string {
+	if (!anchor) return '';
+	const lines: string[] = [];
+	if (anchor.originalGoal) {
+		lines.push(`- **Original request:** ${anchor.originalGoal}`);
+	}
+	if (anchor.builtWorkflows && anchor.builtWorkflows.length > 0) {
+		const list = anchor.builtWorkflows
+			.map((w) => (w.name ? `${w.name} (${w.id})` : w.id))
+			.join(', ');
+		lines.push(`- **Workflows built or edited in this thread:** ${list}`);
+	}
+	if (lines.length === 0) return '';
+	return `## Thread context (persistent — always honor)
+
+${lines.join('\n')}
+
+Treat the above as ground truth for this conversation even when it is not in the recent messages. Never re-ask for it or claim this is the start of the conversation.`;
 }
 
 export function getDateTimeSection(timeZone?: string): string {
@@ -111,10 +138,13 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 		branchReadOnly,
 		projectId,
 		workspaceRoot,
+		threadAnchor,
 	} = options;
 
+	const threadAnchorSection = getThreadAnchorSection(threadAnchor);
+
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
-${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
+${threadAnchorSection ? `\n${threadAnchorSection}\n` : ''}${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
 ${workspaceRoot ? `\n${getSandboxWorkspaceSection(workspaceRoot)}\n` : ''}
 
 You have access to workflow, execution, and credential tools plus runtime skills (see the skill catalog). You also have delegation capabilities for complex tasks, and may have access to MCP tools for extended capabilities.

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -622,6 +622,8 @@ export type {
 	PlannedTaskSchedulerAction,
 	PlannedTaskService,
 	OrchestrationContext,
+	ThreadAnchor,
+	ThreadAnchorWorkflow,
 	SpawnBackgroundTaskOptions,
 	SpawnBackgroundTaskResult,
 	BackgroundTaskResult,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -1230,6 +1230,27 @@ export interface WorkflowTaskService {
 
 // ── Orchestration context (plan + delegate tools) ───────────────────────────
 
+/** A workflow created or edited within a thread, tracked so follow-ups like
+ *  "continue" or "complete it" resolve to the right artifact. */
+export interface ThreadAnchorWorkflow {
+	id: string;
+	name?: string;
+}
+
+/**
+ * Durable, always-injected conversation invariants for a thread. The per-turn
+ * LLM context is a bounded/compressed reconstruction (recent-message window +
+ * observational summary), so the original goal and built artifacts can fall out
+ * of it. The anchor is stored on the thread and re-injected into the system
+ * prompt every turn, independent of windowing/compaction/suspension.
+ */
+export interface ThreadAnchor {
+	/** The user's first substantive request — the binding goal for the thread. */
+	originalGoal?: string;
+	/** Workflows created or edited in this thread. */
+	builtWorkflows?: ThreadAnchorWorkflow[];
+}
+
 export interface OrchestrationContext {
 	threadId: string;
 	runId: string;
@@ -1303,6 +1324,9 @@ export interface OrchestrationContext {
 	/** The current user message being processed — needed because memory history only
 	 *  returns previously-saved messages, so the in-flight message isn't available yet. */
 	currentUserMessage?: string;
+	/** Durable conversation invariants (original goal, built workflows) injected
+	 *  into the system prompt every turn so they survive window/compaction/suspend. */
+	threadAnchor?: ThreadAnchor;
 	/** True when the current run was started by the replan pipeline after a failed
 	 *  background task. Set by the host, not by user text — the create-tasks guard
 	 *  reads this instead of substring-matching `currentUserMessage`. */

--- a/packages/cli/src/modules/instance-ai/__tests__/thread-anchor.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/thread-anchor.test.ts
@@ -1,0 +1,110 @@
+import type { ThreadAnchor } from '@n8n/instance-ai';
+
+import {
+	deriveThreadAnchor,
+	isSubstantiveGoal,
+	parseThreadAnchor,
+	threadAnchorsEqual,
+} from '../thread-anchor';
+
+describe('thread-anchor', () => {
+	describe('isSubstantiveGoal', () => {
+		it('accepts real user intent', () => {
+			expect(isSubstantiveGoal('Send an SMS on missed calls')).toBe(true);
+		});
+
+		it.each([
+			['empty', ''],
+			['whitespace', '   '],
+			['undefined', undefined],
+			['system follow-up tag', '<workflow-setup-required>\n{}\n'],
+			['bare continue', '(continue)'],
+		])('rejects %s', (_label, message) => {
+			expect(isSubstantiveGoal(message)).toBe(false);
+		});
+	});
+
+	describe('deriveThreadAnchor', () => {
+		it('captures the first substantive message as the original goal', () => {
+			const anchor = deriveThreadAnchor(undefined, { userMessage: 'Build a missed-call SMS flow' });
+			expect(anchor.originalGoal).toBe('Build a missed-call SMS flow');
+		});
+
+		it('keeps the original goal once set, ignoring later messages', () => {
+			const prev: ThreadAnchor = { originalGoal: 'Original goal' };
+			const next = deriveThreadAnchor(prev, { userMessage: 'something else entirely' });
+			expect(next.originalGoal).toBe('Original goal');
+		});
+
+		it('does not set a goal from a system follow-up turn', () => {
+			const anchor = deriveThreadAnchor(undefined, {
+				userMessage: '<planned-task-follow-up type="build-workflow">',
+			});
+			expect(anchor.originalGoal).toBeUndefined();
+		});
+
+		it('truncates an over-long goal', () => {
+			const long = 'x'.repeat(5000);
+			const anchor = deriveThreadAnchor(undefined, { userMessage: long });
+			expect(anchor.originalGoal).toHaveLength(2000);
+			expect(anchor.originalGoal?.endsWith('…')).toBe(true);
+		});
+
+		it('merges built workflow ids, de-duplicated and order-stable', () => {
+			const first = deriveThreadAnchor(undefined, { builtWorkflowIds: ['wf-1', 'wf-2'] });
+			const second = deriveThreadAnchor(first, { builtWorkflowIds: ['wf-2', 'wf-3'] });
+			expect(second.builtWorkflows).toEqual([{ id: 'wf-1' }, { id: 'wf-2' }, { id: 'wf-3' }]);
+		});
+
+		it('captures goal and workflows in the same turn', () => {
+			const anchor = deriveThreadAnchor(undefined, {
+				userMessage: 'Build it',
+				builtWorkflowIds: ['wf-1'],
+			});
+			expect(anchor).toEqual({ originalGoal: 'Build it', builtWorkflows: [{ id: 'wf-1' }] });
+		});
+	});
+
+	describe('parseThreadAnchor', () => {
+		it('round-trips a derived anchor', () => {
+			const anchor = deriveThreadAnchor(undefined, {
+				userMessage: 'Goal',
+				builtWorkflowIds: ['wf-1'],
+			});
+			expect(parseThreadAnchor(anchor)).toEqual(anchor);
+		});
+
+		it.each([
+			['null', null],
+			['string', 'nope'],
+			['empty object', {}],
+			['unrelated keys', { foo: 'bar' }],
+		])('returns undefined for %s', (_label, value) => {
+			expect(parseThreadAnchor(value)).toBeUndefined();
+		});
+
+		it('drops malformed workflow entries', () => {
+			const parsed = parseThreadAnchor({
+				originalGoal: 'Goal',
+				builtWorkflows: [{ id: 'wf-1', name: 'Flow' }, { id: 42 }, 'bad', { name: 'no-id' }],
+			});
+			expect(parsed).toEqual({
+				originalGoal: 'Goal',
+				builtWorkflows: [{ id: 'wf-1', name: 'Flow' }],
+			});
+		});
+	});
+
+	describe('threadAnchorsEqual', () => {
+		it('treats undefined prev and empty derived anchor as equal (no write)', () => {
+			const next = deriveThreadAnchor(undefined, { userMessage: '<system>' });
+			expect(threadAnchorsEqual(undefined, next)).toBe(true);
+		});
+
+		it('detects a changed anchor', () => {
+			const prev: ThreadAnchor = { originalGoal: 'a' };
+			const next = deriveThreadAnchor(prev, { builtWorkflowIds: ['wf-1'] });
+			expect(threadAnchorsEqual(prev, next)).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1868,6 +1868,24 @@ export class InstanceAiService {
 		}
 	}
 
+	/**
+	 * Anchor the workflows a run persisted (created minus reaped previews) so later
+	 * "continue"/"complete it" turns resolve them even after the build has scrolled
+	 * out of the recent-message window. Called on every run-completion path.
+	 */
+	private async recordBuiltWorkflows(
+		threadId: string,
+		createdWorkflowIds: string[] | undefined,
+		archivedWorkflowIds: Iterable<string>,
+	): Promise<void> {
+		if (!createdWorkflowIds || createdWorkflowIds.length === 0) return;
+		const archived = new Set(archivedWorkflowIds);
+		const builtWorkflowIds = createdWorkflowIds.filter((id) => !archived.has(id));
+		if (builtWorkflowIds.length > 0) {
+			await this.advanceThreadAnchor(threadId, { builtWorkflowIds });
+		}
+	}
+
 	private async drainInFlightExecutions(timeoutMs: number): Promise<void> {
 		if (this.inFlightExecutions.size === 0) return;
 
@@ -4091,6 +4109,11 @@ export class InstanceAiService {
 					aiCreatedWorkflowIds,
 					this.backgroundTasks.getRunningTasks(threadId).length,
 				);
+				await this.recordBuiltWorkflows(
+					threadId,
+					aiCreatedWorkflowIds ? [...aiCreatedWorkflowIds] : undefined,
+					archivedWorkflowIds,
+				);
 				this.publishRunFinish(
 					threadId,
 					runId,
@@ -4141,6 +4164,11 @@ export class InstanceAiService {
 				user,
 				aiCreatedWorkflowIds,
 				this.backgroundTasks.getRunningTasks(threadId).length,
+			);
+			await this.recordBuiltWorkflows(
+				threadId,
+				aiCreatedWorkflowIds ? [...aiCreatedWorkflowIds] : undefined,
+				archivedWorkflowIds,
 			);
 			this.eventBus.publish(threadId, {
 				type: 'run-finish',
@@ -5467,16 +5495,11 @@ export class InstanceAiService {
 		this.publishRunFinish(threadId, runId, status, undefined, options?.archivedWorkflowIds);
 		this.emitRunMetrics(threadId, status, options);
 		await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);
-		// Anchor the workflows this run persisted (created minus reaped previews)
-		// so later "continue"/"complete it" turns resolve them after the original
-		// build has fallen out of the recent-message window.
-		if (options?.createdWorkflowIds && options.createdWorkflowIds.length > 0) {
-			const archived = new Set(options.archivedWorkflowIds ?? []);
-			const builtWorkflowIds = options.createdWorkflowIds.filter((id) => !archived.has(id));
-			if (builtWorkflowIds.length > 0) {
-				await this.advanceThreadAnchor(threadId, { builtWorkflowIds });
-			}
-		}
+		await this.recordBuiltWorkflows(
+			threadId,
+			options?.createdWorkflowIds,
+			options?.archivedWorkflowIds ?? [],
+		);
 		if (status === 'completed' && options?.userId && options?.modelId) {
 			void this.refineTitleIfNeeded(threadId, options.userId, options.modelId);
 		}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -65,6 +65,7 @@ import {
 	type McpServerConfig,
 	type ModelConfig,
 	type OrchestrationContext,
+	type ThreadAnchor,
 	type InstanceAiTraceContext,
 	type PlannedTaskGraph,
 	type PlannedTaskRecord,
@@ -152,6 +153,7 @@ import {
 	type ResumableOrphan,
 } from './suspended-run-restorer.service';
 import { SuspendedThreadPersistenceService } from './suspended-thread-persistence.service';
+import { deriveThreadAnchor, parseThreadAnchor, threadAnchorsEqual } from './thread-anchor';
 import { TraceReplayState } from './trace-replay-state';
 import {
 	parseWorkflowBuildOutcome,
@@ -1835,6 +1837,35 @@ export class InstanceAiService {
 			entry.message,
 		);
 		if (ok) this.userMessagePersistenceByRun.delete(runId);
+	}
+
+	/**
+	 * Advance and persist the thread's durable anchor (original goal + built
+	 * workflows) and return it for injection into the system prompt. Persists
+	 * only when the anchor changed. Failures never block the turn — the anchor is
+	 * an additive safety net against context-window/compaction loss.
+	 */
+	private async advanceThreadAnchor(
+		threadId: string,
+		input: { userMessage?: string; builtWorkflowIds?: string[] },
+	): Promise<ThreadAnchor | undefined> {
+		try {
+			const thread = await this.agentMemory.getThread(threadId);
+			const prev = parseThreadAnchor(thread?.metadata?.anchor);
+			const next = deriveThreadAnchor(prev, input);
+			if (threadAnchorsEqual(prev, next)) return prev;
+			await patchThread(this.agentMemory, {
+				threadId,
+				update: ({ metadata }) => ({ metadata: { ...(metadata ?? {}), anchor: next } }),
+			});
+			return next;
+		} catch (error) {
+			this.logger.warn('Failed to advance thread anchor', {
+				threadId,
+				error: getErrorMessage(error),
+			});
+			return undefined;
+		}
 	}
 
 	private async drainInFlightExecutions(timeoutMs: number): Promise<void> {
@@ -3580,6 +3611,11 @@ export class InstanceAiService {
 			// Make the current user message available since memory history only
 			// returns previously-saved messages.
 			orchestrationContext.currentUserMessage = message;
+			// Re-bind durable thread invariants so the original goal survives the
+			// recent-message window, observational compaction, and HITL suspends.
+			orchestrationContext.threadAnchor = await this.advanceThreadAnchor(threadId, {
+				userMessage: message,
+			});
 			orchestrationContext.isReplanFollowUp = isReplanFollowUp;
 			orchestrationContext.timeZone = timeZone ?? this.defaultTimeZone;
 
@@ -3998,6 +4034,7 @@ export class InstanceAiService {
 				userId: user.id,
 				modelId,
 				archivedWorkflowIds,
+				createdWorkflowIds: aiCreatedWorkflowIds ? [...aiCreatedWorkflowIds] : undefined,
 				workSummary: result.workSummary,
 				usage: result.usage,
 			});
@@ -5422,6 +5459,7 @@ export class InstanceAiService {
 			userId?: string;
 			modelId?: ModelConfig;
 			archivedWorkflowIds?: string[];
+			createdWorkflowIds?: string[];
 			workSummary?: WorkSummary;
 			usage?: RunTokenUsage;
 		},
@@ -5429,6 +5467,16 @@ export class InstanceAiService {
 		this.publishRunFinish(threadId, runId, status, undefined, options?.archivedWorkflowIds);
 		this.emitRunMetrics(threadId, status, options);
 		await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);
+		// Anchor the workflows this run persisted (created minus reaped previews)
+		// so later "continue"/"complete it" turns resolve them after the original
+		// build has fallen out of the recent-message window.
+		if (options?.createdWorkflowIds && options.createdWorkflowIds.length > 0) {
+			const archived = new Set(options.archivedWorkflowIds ?? []);
+			const builtWorkflowIds = options.createdWorkflowIds.filter((id) => !archived.has(id));
+			if (builtWorkflowIds.length > 0) {
+				await this.advanceThreadAnchor(threadId, { builtWorkflowIds });
+			}
+		}
 		if (status === 'completed' && options?.userId && options?.modelId) {
 			void this.refineTitleIfNeeded(threadId, options.userId, options.modelId);
 		}

--- a/packages/cli/src/modules/instance-ai/thread-anchor.ts
+++ b/packages/cli/src/modules/instance-ai/thread-anchor.ts
@@ -1,0 +1,92 @@
+import type { ThreadAnchor, ThreadAnchorWorkflow } from '@n8n/instance-ai';
+
+/** Cap the stored goal so a pasted spec can't bloat every future system prompt. */
+const MAX_GOAL_LENGTH = 2000;
+
+/**
+ * A user message is a goal candidate only when it carries real user intent —
+ * not an empty resume turn, a system follow-up tag (`<...>`), or a bare
+ * "(continue)". These never describe what the user wants built.
+ */
+export function isSubstantiveGoal(message: string | undefined): message is string {
+	if (!message) return false;
+	const trimmed = message.trim();
+	if (trimmed.length === 0) return false;
+	if (trimmed.startsWith('<')) return false;
+	if (trimmed === '(continue)') return false;
+	return true;
+}
+
+export interface ThreadAnchorInput {
+	/** The current user message; becomes the original goal if none is set yet. */
+	userMessage?: string;
+	/** Workflow ids persisted this turn (created/edited, excluding throwaway previews). */
+	builtWorkflowIds?: string[];
+}
+
+/**
+ * Advance the durable thread anchor. Pure: takes the previous anchor and the
+ * turn's inputs, returns the next anchor. The goal is captured once (first
+ * substantive message); built workflows accumulate, de-duplicated.
+ */
+export function deriveThreadAnchor(
+	prev: ThreadAnchor | undefined,
+	input: ThreadAnchorInput,
+): ThreadAnchor {
+	const next: ThreadAnchor = {
+		...(prev?.originalGoal ? { originalGoal: prev.originalGoal } : {}),
+		...(prev?.builtWorkflows ? { builtWorkflows: [...prev.builtWorkflows] } : {}),
+	};
+
+	if (!next.originalGoal && isSubstantiveGoal(input.userMessage)) {
+		const goal = input.userMessage.trim();
+		next.originalGoal =
+			goal.length > MAX_GOAL_LENGTH ? `${goal.slice(0, MAX_GOAL_LENGTH - 1)}…` : goal;
+	}
+
+	if (input.builtWorkflowIds && input.builtWorkflowIds.length > 0) {
+		const existing = next.builtWorkflows ?? [];
+		const known = new Set(existing.map((w) => w.id));
+		const added: ThreadAnchorWorkflow[] = input.builtWorkflowIds
+			.filter((id) => !known.has(id))
+			.map((id) => ({ id }));
+		if (added.length > 0) next.builtWorkflows = [...existing, ...added];
+	}
+
+	return next;
+}
+
+function parseAnchorWorkflow(value: unknown): ThreadAnchorWorkflow | undefined {
+	if (typeof value !== 'object' || value === null) return undefined;
+	if (!('id' in value) || typeof value.id !== 'string') return undefined;
+	const name = 'name' in value && typeof value.name === 'string' ? value.name : undefined;
+	return name ? { id: value.id, name } : { id: value.id };
+}
+
+/** Defensively read an anchor back from untyped thread metadata. */
+export function parseThreadAnchor(value: unknown): ThreadAnchor | undefined {
+	if (typeof value !== 'object' || value === null) return undefined;
+
+	const anchor: ThreadAnchor = {};
+	if (
+		'originalGoal' in value &&
+		typeof value.originalGoal === 'string' &&
+		value.originalGoal.length > 0
+	) {
+		anchor.originalGoal = value.originalGoal;
+	}
+	if ('builtWorkflows' in value && Array.isArray(value.builtWorkflows)) {
+		const workflows = value.builtWorkflows.flatMap((w) => {
+			const parsed = parseAnchorWorkflow(w);
+			return parsed ? [parsed] : [];
+		});
+		if (workflows.length > 0) anchor.builtWorkflows = workflows;
+	}
+
+	return (anchor.originalGoal ?? anchor.builtWorkflows) ? anchor : undefined;
+}
+
+/** Stable equality so we only write metadata when the anchor actually changed. */
+export function threadAnchorsEqual(a: ThreadAnchor | undefined, b: ThreadAnchor): boolean {
+	return JSON.stringify(a ?? {}) === JSON.stringify(b);
+}


### PR DESCRIPTION
## Summary

Instance AI rebuilds each turn's LLM context from a bounded recent-message window plus a lossy observational summary, with **nothing pinning the conversation's invariants**. The original goal and the workflows built in the thread fall out of context mid-conversation, so the agent re-asks answered questions, loses the original request, and even claims *"this appears to be the start of our conversation"* (observed across production traces in INS-607).

This adds a durable **`ThreadAnchor`** — the user's original goal plus the workflows built in the thread — persisted on the thread and **re-injected into the system prompt on every turn**. Because it rides the instructions rather than the message list, it survives the recent-message window, observational compaction, and HITL suspends.

- `ThreadAnchor` type + `getThreadAnchorSection()` rendered into the system prompt, wired through `OrchestrationContext` → `createInstanceAgent` → `getSystemPrompt`
- `deriveThreadAnchor` / `parseThreadAnchor` helpers; `advanceThreadAnchor` loads/merges/persists to thread metadata and sets it on the context each turn (original goal captured from the first substantive message)
- `builtWorkflows` recorded on run finalize (created minus reaped previews) so later "continue"/"complete it" turns resolve them
- `docs/memory.md`: documents the anchor tier and drops the unimplemented `N8N_INSTANCE_AI_LAST_MESSAGES` knob

Scoped to the memory mechanism (P1/P2/P2b/P4). Eager in-flight persistence (P1) was already implemented (`persistUserMessageOnFirstSuspend`) and is reused, not duplicated. `confirmedSlots`/`directives` and the intent-honoring gate (P3) are intentionally out of scope; the anchor struct is ready for them.

## How to test

1. Start a thread, state a goal, and run enough tool-heavy turns to push the original request out of the recent window.
2. Reference the original goal in a later turn — the agent keeps it instead of re-asking or claiming a fresh conversation.
3. Build a workflow, then in a later turn say "continue" / "complete it" — the built workflow is present in context.

Unit tests cover the anchor logic and rendering:
- `packages/cli/.../__tests__/thread-anchor.test.ts` (20 tests)
- `packages/@n8n/instance-ai/.../__tests__/thread-anchor-section.test.ts` (5 tests)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-607

Likely also addresses the narrower INS-584 / INS-365 / INS-523.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->