### PR TITLE
refactor: Remove unused AWS SDK dependency and load the SDK lazily

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
@@ -1,5 +1,4 @@
 import { getNodeProxyAgent } from '@n8n/ai-utilities';
-import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
 import type {
@@ -82,6 +81,9 @@ export async function resolveAwsCredentials(
 		? new NodeHttpHandler({ httpAgent: proxyAgent, httpsAgent: proxyAgent })
 		: undefined;
 
+	// Lazy-load the AWS SDK so the ~1.5 MB umbrella (Cognito/SSO clients) isn't
+	// pulled in at startup for workflows that never assume an AWS role.
+	const { fromTemporaryCredentials } = await import('@aws-sdk/credential-providers');
 	const provider = fromTemporaryCredentials({
 		params: {
 			RoleArn: creds.roleArn.trim(),

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -907,7 +907,6 @@
     "vitest-mock-extended": "catalog:"
   },
   "dependencies": {
-    "@aws-sdk/client-sso-oidc": "3.808.0",
     "@n8n/backend-network": "workspace:*",
     "@kafkajs/confluent-schema-registry": "3.8.0",
     "@mozilla/readability": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5000,9 +5000,6 @@ importers:
 
   packages/nodes-base:
     dependencies:
-      '@aws-sdk/client-sso-oidc':
-        specifier: 3.808.0
-        version: 3.808.0
       '@kafkajs/confluent-schema-registry':
         specifier: 3.8.0
         version: 3.8.0


### PR DESCRIPTION
## Summary

Two small, low-risk cleanups:

1. Remove the unused `@aws-sdk/client-sso-oidc` dependency from `nodes-base` — nothing in `nodes-base` source imports it (it signs AWS requests by hand), and the peer is already declared in `nodes-langchain` where the SDK is actually used.
2. Lazy-load `@aws-sdk/credential-providers` inside `resolveAwsCredentials` (via `await import`) instead of at the top of the file, so the ~1.5 MB SDK umbrella (Cognito/SSO clients) is no longer loaded at server/worker startup for workflows that never assume an AWS role.

## How to test

- `pnpm install --frozen-lockfile` succeeds with the dependency removed.
- Existing `resolveAwsCredentials.test.ts` passes (Bedrock node credential resolution unchanged).
- The AWS SDK is only loaded when `resolveAwsCredentials` runs, not during startup for non-AWS workflows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-65

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- internal cleanup, no doc-facing change -->
- [x] Tests included. <!-- existing resolveAwsCredentials.test.ts covers the change -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->