### PR TITLE
refactor(editor): Re-parent frontend error subclasses to Error (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/utils.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/utils.ts
@@ -2,7 +2,7 @@ import { BROWSER_ID_STORAGE_KEY } from '@n8n/constants';
 import { assert } from '@n8n/utils/assert';
 import type { AxiosRequestConfig, Method, RawAxiosRequestHeaders } from 'axios';
 import axios from 'axios';
-import { ApplicationError, jsonParse } from 'n8n-workflow';
+import { jsonParse } from 'n8n-workflow';
 import type { GenericValue, IDataObject } from 'n8n-workflow';
 
 import type { IRestApiContext } from './types';
@@ -19,14 +19,14 @@ const getBrowserId = () => {
 export const NO_NETWORK_ERROR_CODE = 999;
 export const STREAM_SEPARATOR = '⧉⇋⇋➽⌑⧉§§\n';
 
-export class MfaRequiredError extends ApplicationError {
+export class MfaRequiredError extends Error {
 	constructor() {
 		super('MFA is required to access this resource. Please set up MFA in your user settings.');
 		this.name = 'MfaRequiredError';
 	}
 }
 
-export class ResponseError extends ApplicationError {
+export class ResponseError extends Error {
 	// The HTTP status code of response
 	httpStatusCode?: number;
 


### PR DESCRIPTION
## Summary

On backend we rely on `BaseError` and `UserError`, `OperationalError` and `UnexpectedError` to define how errors should be reported. We have been migrating the old `ApplicationError` to these new errors. AFAIK we don't do this on FE, so this PR remove the usage of `ApplicationError` on FE.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3255

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32777">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

