### PR TITLE
refactor: Re-parent workflow error subclasses away from ApplicationError (no-changelog)

### DIFF
--- a/packages/workflow/src/errors/db-connection-timeout-error.ts
+++ b/packages/workflow/src/errors/db-connection-timeout-error.ts
@@ -1,11 +1,11 @@
-import { ApplicationError } from '@n8n/errors';
+import { OperationalError } from './base/operational.error';
 
 export type DbConnectionTimeoutErrorOpts = {
 	configuredTimeoutInMs: number;
 	cause: Error;
 };
 
-export class DbConnectionTimeoutError extends ApplicationError {
+export class DbConnectionTimeoutError extends OperationalError {
 	constructor(opts: DbConnectionTimeoutErrorOpts) {
 		const numberFormat = Intl.NumberFormat();
 		const errorMessage = `Could not establish database connection within the configured timeout of ${numberFormat.format(opts.configuredTimeoutInMs)} ms. Please ensure the database is configured correctly and the server is reachable. You can increase the timeout by setting the 'DB_POSTGRESDB_CONNECTION_TIMEOUT' environment variable.`;

--- a/packages/workflow/src/errors/trigger-close.error.ts
+++ b/packages/workflow/src/errors/trigger-close.error.ts
@@ -1,16 +1,15 @@
-import { ApplicationError, type ErrorLevel } from '@n8n/errors';
 import type { INode } from '../interfaces';
+import { OperationalError, type OperationalErrorOptions } from './base/operational.error';
 
 interface TriggerCloseErrorOptions extends ErrorOptions {
-	level: ErrorLevel;
+	level: OperationalErrorOptions['level'];
 }
 
-export class TriggerCloseError extends ApplicationError {
+export class TriggerCloseError extends OperationalError {
 	constructor(
 		readonly node: INode,
 		{ cause, level }: TriggerCloseErrorOptions,
 	) {
-		super('Trigger Close Failed', { cause, extra: { nodeName: node.name } });
-		this.level = level;
+		super('Trigger Close Failed', { cause, level, extra: { nodeName: node.name } });
 	}
 }

--- a/packages/workflow/src/node-parameters/filter-parameter.ts
+++ b/packages/workflow/src/node-parameters/filter-parameter.ts
@@ -1,6 +1,6 @@
-import { ApplicationError } from '@n8n/errors';
 import type { DateTime } from 'luxon';
 
+import { UserError } from '../errors/base/user.error';
 import type {
 	FilterConditionValue,
 	FilterOperatorType,
@@ -20,12 +20,12 @@ type FilterConditionMetadata = {
 	errorFormat: 'full' | 'inline';
 };
 
-export class FilterError extends ApplicationError {
+export class FilterError extends UserError {
 	constructor(
 		message: string,
-		readonly description: string,
+		override readonly description: string,
 	) {
-		super(message, { level: 'warning' });
+		super(message, { level: 'warning', description });
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of the migration away from the deprecated `ApplicationError`. Re-parents three error subclasses in `packages/workflow/src/`:

- `DbConnectionTimeoutError` → `OperationalError` (transient DB connectivity issue)
- `TriggerCloseError` → `OperationalError` (level passed through, narrowed to the levels `OperationalError` accepts)
- `FilterError` → `UserError` (its `description` now flows through `BaseError`'s `description` option; `level: 'warning'` preserved)

`FilterError`'s `instanceof FilterError` consumers (Filter node + NDV filter conditions) are unaffected since the class identity is unchanged.

## How to test

- `pnpm typecheck` in `packages/workflow` — clean
- `pnpm test` in `packages/workflow` (filter-parameter), `packages/@n8n/db` (db-connection), and `packages/core` (active-workflow-triggers) — all pass

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3253


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

