### PR TITLE
feat(core): Update credential handling in workflows-imported event

### DIFF
--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -75,7 +75,11 @@ describe('LogStreamingEventRelay', () => {
 				},
 				packageSourceId: 'source-instance-1',
 				packageVersion: '1',
-				matchedCredentialIds: ['cred-1'],
+				credentialIds: {
+					matched: ['cred-1'],
+					created: [],
+					updated: [],
+				},
 			};
 
 			eventService.emit('workflows-imported', event);
@@ -100,6 +104,11 @@ describe('LogStreamingEventRelay', () => {
 					},
 					packageSourceId: 'source-instance-1',
 					packageVersion: '1',
+					credentialIds: {
+						matched: ['cred-1'],
+						created: [],
+						updated: [],
+					},
 				},
 			});
 		});

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -12,7 +12,10 @@ import type {
 } from 'n8n-workflow';
 
 import type { ConcurrencyQueueType } from '@/concurrency/concurrency-control.service';
-import type { ImportPackageEventOptions } from '@/modules/n8n-packages/n8n-packages.types';
+import type {
+	ImportAuditCredentialIds,
+	ImportPackageEventOptions,
+} from '@/modules/n8n-packages/n8n-packages.types';
 import type { TokenExchangeFailureReason } from '@/modules/token-exchange/token-exchange.types';
 
 import type { AiEventMap } from './ai.event-map';
@@ -93,7 +96,7 @@ export type RelayEventMap = {
 		options: ImportPackageEventOptions;
 		packageSourceId: string;
 		packageVersion: string;
-		matchedCredentialIds: string[];
+		credentialIds: ImportAuditCredentialIds;
 	};
 
 	'workflow-deleted': {

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -142,11 +142,7 @@ export class LogStreamingEventRelay extends EventRelay {
 	// #region Workflow
 
 	@Redactable()
-	private workflowsImported({
-		user,
-		matchedCredentialIds: _matchedCredentialIds,
-		...rest
-	}: RelayEventMap['workflows-imported']) {
+	private workflowsImported({ user, ...rest }: RelayEventMap['workflows-imported']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.n8n-package.imported',
 			payload: { ...user, ...rest },

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -1144,7 +1144,11 @@ describe('ImportPipeline event emission', () => {
 
 			const importedPayload = importedEvents[0][1] as RelayEventMap['workflows-imported'];
 			expect(importedPayload.workflowIds).toHaveLength(2);
-			expect(importedPayload.matchedCredentialIds).toEqual([]);
+			expect(importedPayload.credentialIds).toEqual({
+				matched: [],
+				created: [],
+				updated: [],
+			});
 			expect(importedPayload.folderId).toBeNull();
 			expect(importedPayload.options.workflowConflictPolicy).toBe(WorkflowConflictPolicy.Fail);
 			expect(importedPayload.options.workflowIdPolicy).toBe(WorkflowIdPolicy.New);
@@ -1155,6 +1159,68 @@ describe('ImportPipeline event emission', () => {
 			);
 			expect(importedPayload.packageSourceId).toBeDefined();
 			expect(importedPayload.packageVersion).toBe(FORMAT_VERSION);
+		} finally {
+			emitSpy.mockRestore();
+		}
+	});
+
+	it('records matched and created credential ids on workflows-imported', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const firstCredential = await saveOwnedCredential(
+			githubCredentialPayload({ name: 'First GitHub' }),
+			{ project: personalProject },
+		);
+		const secondCredential = await saveOwnedCredential(
+			githubCredentialPayload({ name: 'Second GitHub' }),
+			{ project: personalProject },
+		);
+		const eventService = Container.get(EventService);
+		const emitSpy = jest.spyOn(eventService, 'emit');
+
+		try {
+			await importPackage({
+				user: owner,
+				credentialMissingMode: 'create-stub',
+				packageBuffer: await buildImportPackageBuffer(
+					[
+						serializedWorkflowWithCredential({
+							id: 'wf-first-cred',
+							name: 'First credential workflow',
+							credentialId: firstCredential.id,
+							credentialName: firstCredential.name,
+						}),
+						serializedWorkflowWithCredential({
+							id: 'wf-second-cred',
+							name: 'Second credential workflow',
+							credentialId: secondCredential.id,
+							credentialName: secondCredential.name,
+						}),
+						serializedWorkflowWithCredential({
+							id: 'wf-stub-cred',
+							name: 'Stub credential workflow',
+							credentialId: 'missing-cred',
+							credentialName: 'Missing GitHub',
+						}),
+					],
+					{ sourceId: 'credential-audit-test' },
+				),
+			});
+
+			const importedEvents = emitSpy.mock.calls.filter(([name]) => name === 'workflows-imported');
+			expect(importedEvents).toHaveLength(1);
+
+			const importedPayload = importedEvents[0][1] as RelayEventMap['workflows-imported'];
+			expect(importedPayload.credentialIds.matched).toEqual(
+				expect.arrayContaining([firstCredential.id, secondCredential.id]),
+			);
+			expect(importedPayload.credentialIds.matched).toHaveLength(2);
+			expect(importedPayload.credentialIds.created).toHaveLength(1);
+			expect(importedPayload.credentialIds.created[0]).toEqual(expect.any(String));
+			expect(importedPayload.credentialIds.created[0]).not.toBe('missing-cred');
+			expect(importedPayload.credentialIds.updated).toEqual([]);
 		} finally {
 			emitSpy.mockRestore();
 		}

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -137,7 +137,11 @@ export class ImportPipeline {
 			},
 			packageSourceId: manifest.sourceId,
 			packageVersion: manifest.packageFormatVersion,
-			matchedCredentialIds: [...credentialApply.bindings.values()],
+			credentialIds: {
+				matched: credentialApply.matched.map((sourceId) => credentialApply.bindings.get(sourceId)!),
+				created: credentialApply.stubbed.map((sourceId) => credentialApply.bindings.get(sourceId)!),
+				updated: [],
+			},
 		});
 
 		return this.buildResult(packageSummary, target.projectId, outcomes, bindings, {

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -63,6 +63,13 @@ export type ImportWorkflowProperties = {
 export type ImportPackageEventOptions = Omit<ImportCredentialProperties, 'credentialBindings'> &
 	ImportWorkflowProperties;
 
+/** Credential ids involved in a package import, shaped for forward-compatible audit events. */
+export type ImportAuditCredentialIds = {
+	matched: string[];
+	created: string[];
+	updated: string[];
+};
+
 export interface ImportedWorkflowSummary {
 	sourceWorkflowId: string;
 	localId: string;


### PR DESCRIPTION
## Summary

- Changed `matchedCredentialIds` to a structured `credentialIds` object containing `matched`, `created`, and `updated` arrays.


## Related Linear tickets, Github issues, and Community forum posts

Implements [LIGO-614](https://linear.app/n8n/issue/LIGO-614/workflow-with-credentials-import-log-streaming-lifecycle-events)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32794">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->