### PR TITLE
fix(core): Reject HTML markup in workflow names

### DIFF
--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
@@ -3,8 +3,10 @@ import { workflowNameSchema } from '../base-workflow.dto';
 describe('workflowNameSchema', () => {
 	test.each([
 		'My Workflow',
-		'Sales > Q1', // a bare `>` stays valid
-		'revenue > 1000',
+		'Sales > Q1', // bare comparison operators stay valid
+		'A < B',
+		'a < b > c',
+		'1 < 2 and 3 > 2',
 		'name with "quotes" & ampersand',
 	])('accepts %j', (name) => {
 		expect(workflowNameSchema.safeParse(name).success).toBe(true);
@@ -17,7 +19,6 @@ describe('workflowNameSchema', () => {
 		'</div>',
 		'prefix <a href="x">link</a> suffix',
 		'<a href="a>b">x</a>', // crafted attribute containing `>`
-		'A < B', // `<` adjacent to a letter is read as a tag start
 	])('rejects markup %j', (name) => {
 		expect(workflowNameSchema.safeParse(name).success).toBe(false);
 	});

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
@@ -3,11 +3,9 @@ import { workflowNameSchema } from '../base-workflow.dto';
 describe('workflowNameSchema', () => {
 	test.each([
 		'My Workflow',
-		'Sales > Q1', // bare angle brackets stay valid
-		'A < B',
-		'a < b > c',
+		'Sales > Q1', // a bare `>` stays valid
+		'revenue > 1000',
 		'name with "quotes" & ampersand',
-		'1 < 2 and 3 > 2',
 	])('accepts %j', (name) => {
 		expect(workflowNameSchema.safeParse(name).success).toBe(true);
 	});
@@ -18,6 +16,8 @@ describe('workflowNameSchema', () => {
 		'<b>bold</b>',
 		'</div>',
 		'prefix <a href="x">link</a> suffix',
+		'<a href="a>b">x</a>', // crafted attribute containing `>`
+		'A < B', // `<` adjacent to a letter is read as a tag start
 	])('rejects markup %j', (name) => {
 		expect(workflowNameSchema.safeParse(name).success).toBe(false);
 	});

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/base-workflow.dto.test.ts
@@ -1,0 +1,32 @@
+import { workflowNameSchema } from '../base-workflow.dto';
+
+describe('workflowNameSchema', () => {
+	test.each([
+		'My Workflow',
+		'Sales > Q1', // bare angle brackets stay valid
+		'A < B',
+		'a < b > c',
+		'name with "quotes" & ampersand',
+		'1 < 2 and 3 > 2',
+	])('accepts %j', (name) => {
+		expect(workflowNameSchema.safeParse(name).success).toBe(true);
+	});
+
+	test.each([
+		'<script>alert(1)</script>',
+		'<img src=x onerror=alert(1)>',
+		'<b>bold</b>',
+		'</div>',
+		'prefix <a href="x">link</a> suffix',
+	])('rejects markup %j', (name) => {
+		expect(workflowNameSchema.safeParse(name).success).toBe(false);
+	});
+
+	it('rejects empty names', () => {
+		expect(workflowNameSchema.safeParse('').success).toBe(false);
+	});
+
+	it('rejects names longer than 128 characters', () => {
+		expect(workflowNameSchema.safeParse('a'.repeat(129)).success).toBe(false);
+	});
+});

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -12,11 +12,18 @@ export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16;
 /** Expected maximum workflow request metadata (i.e. headers) size in bytes (~2 KB) */
 export const MAX_EXPECTED_REQUEST_SIZE = 2048;
 
+// Matches HTML/markup tag patterns (e.g. "<script>", "</div>", "<!-- -->") so they
+// can be rejected, while leaving bare angle brackets (e.g. "Sales > Q1") valid.
+const HTML_TAG_PATTERN = /<[a-zA-Z!/?][^>]*>/;
+
 export const workflowNameSchema = z
 	.string()
 	.min(1, { message: 'Workflow name is required' })
 	.max(WORKFLOW_NAME_MAX_LENGTH, {
 		message: `Workflow name must be ${WORKFLOW_NAME_MAX_LENGTH} characters or less`,
+	})
+	.refine((name) => !HTML_TAG_PATTERN.test(name), {
+		message: 'Workflow name cannot contain HTML or script markup',
 	});
 
 export const workflowDescriptionSchema = z.string().nullable();

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -1,4 +1,5 @@
 import type { IPinData, IConnections, IDataObject, INode, IWorkflowSettings } from 'n8n-workflow';
+import xss from 'xss';
 import { z } from 'zod';
 
 export const WORKFLOW_NAME_MAX_LENGTH = 128;
@@ -12,9 +13,11 @@ export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16;
 /** Expected maximum workflow request metadata (i.e. headers) size in bytes (~2 KB) */
 export const MAX_EXPECTED_REQUEST_SIZE = 2048;
 
-// Matches HTML/markup tag patterns (e.g. "<script>", "</div>", "<!-- -->") so they
-// can be rejected, while leaving bare angle brackets (e.g. "Sales > Q1") valid.
-const HTML_TAG_PATTERN = /<[a-zA-Z!/?][^>]*>/;
+// A name is tag-free when stripping every HTML tag leaves it unchanged. Bare `>`
+// is preserved (escapeHtml is a no-op), so names like "Sales > Q1" stay valid,
+// while anything the parser reads as a tag (e.g. "<script>", "<img …>") is rejected.
+const isTagFree = (value: string): boolean =>
+	value === xss(value, { whiteList: {}, stripIgnoreTag: true, escapeHtml: (html) => html });
 
 export const workflowNameSchema = z
 	.string()
@@ -22,7 +25,7 @@ export const workflowNameSchema = z
 	.max(WORKFLOW_NAME_MAX_LENGTH, {
 		message: `Workflow name must be ${WORKFLOW_NAME_MAX_LENGTH} characters or less`,
 	})
-	.refine((name) => !HTML_TAG_PATTERN.test(name), {
+	.refine(isTagFree, {
 		message: 'Workflow name cannot contain HTML or script markup',
 	});
 

--- a/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/base-workflow.dto.ts
@@ -1,5 +1,4 @@
 import type { IPinData, IConnections, IDataObject, INode, IWorkflowSettings } from 'n8n-workflow';
-import xss from 'xss';
 import { z } from 'zod';
 
 export const WORKFLOW_NAME_MAX_LENGTH = 128;
@@ -13,11 +12,10 @@ export const MAX_WORKFLOW_SIZE = 1024 * 1024 * 16;
 /** Expected maximum workflow request metadata (i.e. headers) size in bytes (~2 KB) */
 export const MAX_EXPECTED_REQUEST_SIZE = 2048;
 
-// A name is tag-free when stripping every HTML tag leaves it unchanged. Bare `>`
-// is preserved (escapeHtml is a no-op), so names like "Sales > Q1" stay valid,
-// while anything the parser reads as a tag (e.g. "<script>", "<img …>") is rejected.
-const isTagFree = (value: string): boolean =>
-	value === xss(value, { whiteList: {}, stripIgnoreTag: true, escapeHtml: (html) => html });
+// Matches a complete HTML tag (e.g. "<script>", "</div>", "<img …>") so it can be
+// rejected. A "<" must be immediately followed by a name char and later closed by
+// ">", so bare comparisons like "A < B" or "Sales > Q1" stay valid.
+const HTML_TAG_PATTERN = /<[a-zA-Z!/?][^>]*>/;
 
 export const workflowNameSchema = z
 	.string()
@@ -25,7 +23,7 @@ export const workflowNameSchema = z
 	.max(WORKFLOW_NAME_MAX_LENGTH, {
 		message: `Workflow name must be ${WORKFLOW_NAME_MAX_LENGTH} characters or less`,
 	})
-	.refine(isTagFree, {
+	.refine((name) => !HTML_TAG_PATTERN.test(name), {
 		message: 'Workflow name cannot contain HTML or script markup',
 	});
 

--- a/packages/@n8n/db/src/entities/workflow-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-entity.ts
@@ -24,7 +24,6 @@ import { objectRetriever, sqlite } from '../utils/transformers';
 
 @Entity()
 export class WorkflowEntity extends WithTimestampsAndStringId implements IWorkflowDb {
-	// TODO: Add XSS check
 	@Index({ unique: true })
 	@Length(1, 128, {
 		message: 'Workflow name must be $constraint1 to $constraint2 characters long.',


### PR DESCRIPTION
## Summary

Adds backend validation that rejects HTML/markup in workflow names. Until now the backend persisted whatever name the client sent, relying solely on frontend escaping at render time.

The check rejects complete HTML tag patterns while leaving bare comparison operators valid, so legitimate names keep saving normally:

- Rejected: `<script>…`, `<img …>`, `<b>`, `</div>`, and crafted attributes containing `>` (e.g. `<a href="a>b">`).
- Allowed: `Sales > Q1`, `A < B`, `a < b > c`, `1 < 2 and 3 > 2`.

A `<` only counts as a tag when it is immediately followed by a name character and later closed by `>`, which is why comparison-style names with spaces around the operator stay valid.

Changes:
- `workflowNameSchema` (shared by the create and update DTOs) gains a refine that rejects names containing an HTML tag pattern.
- Removes the stale `// TODO: Add XSS check` on `WorkflowEntity.name`, now that the validation exists at the DTO layer.
- Unit tests covering accepted names (including comparison operators) and rejected markup.

No migration is included: comparison-style names remain valid, and the rare names carrying literal tag markup are handled on next rename.

## How to test

1. Create or rename a workflow with a name containing markup, e.g. `<script>alert(1)</script>`, via the API or editor. The request is rejected with a 400.
2. Confirm comparison-style names still save, e.g. `Sales > Q1` or `A < B`.
3. Run the unit tests: `pnpm --filter @n8n/api-types test src/dto/workflows`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5226

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)