### PR TITLE
fix(core): Include IPv6 loopback [::1] in MCP redirect URI DTO validation

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.test.ts
@@ -479,6 +479,21 @@ describe('McpSettingsController', () => {
 				process.env.NODE_ENV = originalEnv;
 			}
 		});
+
+		test('allows http for IPv6 loopback [::1] outside development', () => {
+			const originalEnv = process.env.NODE_ENV;
+			process.env.NODE_ENV = 'production';
+
+			try {
+				const dto = new UpdateAllowedRedirectUrisDto({
+					uris: ['http://[::1]:3000/callback'],
+				});
+
+				expect(dto.uris).toEqual(['http://[::1]:3000/callback']);
+			} finally {
+				process.env.NODE_ENV = originalEnv;
+			}
+		});
 	});
 
 	describe('UpdateWorkflowsAvailabilityDto', () => {

--- a/packages/cli/src/modules/mcp/dto/update-allowed-redirect-uris.dto.ts
+++ b/packages/cli/src/modules/mcp/dto/update-allowed-redirect-uris.dto.ts
@@ -2,7 +2,7 @@ import { Z } from '@n8n/api-types';
 import { z } from 'zod';
 
 const isLocalhost = (hostname: string): boolean =>
-	hostname === 'localhost' || hostname === '127.0.0.1';
+	hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
 
 const redirectUriSchema = z
 	.string()


### PR DESCRIPTION
## Summary

`isLocalhost` in `update-allowed-redirect-uris.dto.ts` only checks for `localhost` and `127.0.0.1`, but the runtime `isLoopbackHost` in `oauth-server.service.ts` also includes `[::1]`.

```typescript
// DTO validation — BEFORE (misses [::1])
const isLocalhost = (hostname: string): boolean =>
    hostname === 'localhost' || hostname === '127.0.0.1';

// Runtime check — already correct
private isLoopbackHost(hostname: string): boolean {
    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
}
```

**Result:** An admin trying to save `http://[::1]:3000/callback` via `PUT /mcp/settings/redirect-uris` hits a validation error — _"HTTPS required for redirect URI"_ — even though the same URI is correctly recognised as loopback at runtime.

Node.js `URL` parsing returns `[::1]` (with brackets) as the `hostname` for IPv6 loopback addresses:

```js
new URL('http://[::1]:3000/callback').hostname // → '[::1]'
```

## Fix

Add `|| hostname === '[::1]'` to `isLocalhost` in the DTO, mirroring what `isLoopbackHost` already does. One line change, plus a test case alongside the existing `localhost` / `127.0.0.1` tests.

## How I found it

I was reviewing commit `b513f54f` (the redirect URL allowlist feature) with a static analysis tool I built that flags cross-module inconsistencies — in this case a mismatch between the DTO validation helper and the runtime service method covering the same concept. Verified manually by checking Node.js `URL` hostname parsing for `[::1]`.

(Happy to share more about the tool if you're curious.)

## Test

Added `'allows http for IPv6 loopback [::1] outside development'` to the existing `UpdateAllowedRedirectUrisDto` describe block in `mcp.settings.controller.test.ts` — mirrors the structure of the `localhost` / `127.0.0.1` test.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32801">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

