### PR TITLE
feat(core): Add RFC 9207 iss parameter to MCP OAuth authorization responses

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-consent.service.test.ts
@@ -12,6 +12,9 @@ import {
 	ProtectedResourceRegistry,
 	type ProtectedResource,
 } from '@/services/protected-resource.registry';
+import { UrlService } from '@/services/url.service';
+
+const issuer = 'https://n8n.example.com';
 
 let logger: jest.Mocked<Logger>;
 let oauthSessionService: jest.Mocked<OAuthSessionService>;
@@ -19,6 +22,7 @@ let oauthClientRepository: jest.Mocked<OAuthClientRepository>;
 let userConsentRepository: jest.Mocked<UserConsentRepository>;
 let authorizationCodeService: jest.Mocked<OAuthAuthorizationCodeService>;
 let protectedResourceRegistry: jest.Mocked<ProtectedResourceRegistry>;
+let urlService: jest.Mocked<UrlService>;
 let service: OAuthConsentService;
 
 describe('OAuthConsentService', () => {
@@ -35,6 +39,7 @@ describe('OAuthConsentService', () => {
 		protectedResourceRegistry = mockInstance(
 			ProtectedResourceRegistry,
 		) as jest.Mocked<ProtectedResourceRegistry>;
+		urlService = mockInstance(UrlService) as jest.Mocked<UrlService>;
 
 		service = new OAuthConsentService(
 			logger,
@@ -43,11 +48,13 @@ describe('OAuthConsentService', () => {
 			userConsentRepository,
 			authorizationCodeService,
 			protectedResourceRegistry,
+			urlService,
 		);
 	});
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		urlService.getInstanceBaseUrl.mockReturnValue(issuer);
 	});
 
 	describe('getConsentDetails', () => {
@@ -240,6 +247,7 @@ describe('OAuthConsentService', () => {
 				'error_description=User+denied+the+authorization+request',
 			);
 			expect(result.redirectUrl).toContain('state=state-xyz');
+			expect(new URL(result.redirectUrl).searchParams.get('iss')).toBe(issuer);
 			expect(logger.info).toHaveBeenCalledWith('Consent denied', {
 				clientId: 'client-123',
 				userId: 'user-123',
@@ -267,6 +275,7 @@ describe('OAuthConsentService', () => {
 
 			expect(result.redirectUrl).toContain('code=generated-auth-code');
 			expect(result.redirectUrl).toContain('state=state-xyz');
+			expect(new URL(result.redirectUrl).searchParams.get('iss')).toBe(issuer);
 			expect(userConsentRepository.upsert).toHaveBeenCalledWith(
 				{
 					userId: 'user-123',

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
@@ -42,6 +42,7 @@ describe('GET /.well-known/oauth-authorization-server', () => {
 			grant_types_supported: ['authorization_code', 'refresh_token'],
 			token_endpoint_auth_methods_supported: ['none', 'client_secret_post', 'client_secret_basic'],
 			code_challenge_methods_supported: ['S256'],
+			authorization_response_iss_parameter_supported: true,
 			...(SUPPORTED_SCOPES.length > 0 && { scopes_supported: SUPPORTED_SCOPES }),
 		});
 	});

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.helpers.test.ts
@@ -1,5 +1,7 @@
 import { OAuthHelpers } from '../oauth.helpers';
 
+const issuer = 'https://n8n.example.com';
+
 describe('OAuthHelpers', () => {
 	describe('buildSuccessRedirectUrl', () => {
 		it('should build redirect URL with authorization code', () => {
@@ -7,9 +9,11 @@ describe('OAuthHelpers', () => {
 			const code = 'auth-code-123';
 			const state = null;
 
-			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state);
+			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state, issuer);
 
-			expect(result).toBe('https://example.com/callback?code=auth-code-123');
+			expect(result).toBe(
+				'https://example.com/callback?code=auth-code-123&iss=https%3A%2F%2Fn8n.example.com',
+			);
 		});
 
 		it('should include state parameter when provided', () => {
@@ -17,9 +21,11 @@ describe('OAuthHelpers', () => {
 			const code = 'auth-code-123';
 			const state = 'state-xyz';
 
-			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state);
+			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state, issuer);
 
-			expect(result).toBe('https://example.com/callback?code=auth-code-123&state=state-xyz');
+			expect(result).toBe(
+				'https://example.com/callback?code=auth-code-123&state=state-xyz&iss=https%3A%2F%2Fn8n.example.com',
+			);
 		});
 
 		it('should preserve existing query parameters', () => {
@@ -27,7 +33,7 @@ describe('OAuthHelpers', () => {
 			const code = 'auth-code-123';
 			const state = 'state-xyz';
 
-			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state);
+			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state, issuer);
 
 			expect(result).toContain('foo=bar');
 			expect(result).toContain('code=auth-code-123');
@@ -39,9 +45,11 @@ describe('OAuthHelpers', () => {
 			const code = 'auth-code-123';
 			const state = null;
 
-			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state);
+			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state, issuer);
 
-			expect(result).toBe('http://localhost:3000/callback?code=auth-code-123');
+			expect(result).toBe(
+				'http://localhost:3000/callback?code=auth-code-123&iss=https%3A%2F%2Fn8n.example.com',
+			);
 		});
 
 		it('should URL-encode special characters in code', () => {
@@ -49,9 +57,20 @@ describe('OAuthHelpers', () => {
 			const code = 'code+with/special=chars';
 			const state = null;
 
-			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state);
+			const result = OAuthHelpers.buildSuccessRedirectUrl(redirectUri, code, state, issuer);
 
 			expect(result).toContain('code=code%2Bwith%2Fspecial%3Dchars');
+		});
+
+		it('should include the RFC 9207 iss parameter set to the issuer', () => {
+			const result = OAuthHelpers.buildSuccessRedirectUrl(
+				'https://example.com/callback',
+				'auth-code-123',
+				null,
+				issuer,
+			);
+
+			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
 		});
 	});
 
@@ -67,6 +86,7 @@ describe('OAuthHelpers', () => {
 				error,
 				errorDescription,
 				state,
+				issuer,
 			);
 
 			expect(result).toContain('error=access_denied');
@@ -84,6 +104,7 @@ describe('OAuthHelpers', () => {
 				error,
 				errorDescription,
 				state,
+				issuer,
 			);
 
 			expect(result).toContain('error=invalid_request');
@@ -101,6 +122,7 @@ describe('OAuthHelpers', () => {
 				error,
 				errorDescription,
 				state,
+				issuer,
 			);
 
 			expect(result).toContain('foo=bar');
@@ -124,6 +146,7 @@ describe('OAuthHelpers', () => {
 					error,
 					description,
 					null,
+					issuer,
 				);
 
 				expect(result).toContain(`error=${error}`);
@@ -142,10 +165,23 @@ describe('OAuthHelpers', () => {
 				error,
 				errorDescription,
 				state,
+				issuer,
 			);
 
 			expect(result).toContain('error_description=');
 			expect(result).not.toContain('"'); // Should be encoded
+		});
+
+		it('should include the RFC 9207 iss parameter set to the issuer', () => {
+			const result = OAuthHelpers.buildErrorRedirectUrl(
+				'https://example.com/callback',
+				'access_denied',
+				'User denied the authorization request',
+				null,
+				issuer,
+			);
+
+			expect(new URL(result).searchParams.get('iss')).toBe(issuer);
 		});
 	});
 });

--- a/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-consent.service.ts
@@ -8,6 +8,7 @@ import { OAuthAuthorizationCodeService } from './oauth-authorization-code.servic
 import { OAuthSessionService, type OAuthSessionPayload } from './oauth-session.service';
 import { OAuthHelpers } from './oauth.helpers';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
+import { UrlService } from '@/services/url.service';
 
 type ConsentDetailsResult =
 	| { ok: true; clientName: string; clientId: string; resourceName?: string; redirectUri?: string }
@@ -26,6 +27,7 @@ export class OAuthConsentService {
 		private readonly userConsentRepository: UserConsentRepository,
 		private readonly authorizationCodeService: OAuthAuthorizationCodeService,
 		private readonly protectedResourceRegistry: ProtectedResourceRegistry,
+		private readonly urlService: UrlService,
 	) {}
 
 	/**
@@ -90,12 +92,15 @@ export class OAuthConsentService {
 			throw new UserError('Invalid or expired session');
 		}
 
+		const issuer = this.urlService.getInstanceBaseUrl();
+
 		if (!approved) {
 			const redirectUrl = OAuthHelpers.buildErrorRedirectUrl(
 				sessionPayload.redirectUri,
 				'access_denied',
 				'User denied the authorization request',
 				sessionPayload.state,
+				issuer,
 			);
 
 			this.logger.info('Consent denied', {
@@ -128,6 +133,7 @@ export class OAuthConsentService {
 			sessionPayload.redirectUri,
 			code,
 			sessionPayload.state,
+			issuer,
 		);
 
 		this.logger.info('Consent approved', {

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -168,6 +168,8 @@ export class OAuthController {
 			grant_types_supported: ['authorization_code', 'refresh_token'],
 			token_endpoint_auth_methods_supported: ['none', 'client_secret_post', 'client_secret_basic'],
 			code_challenge_methods_supported: ['S256'],
+			// RFC 9207: we include the `iss` parameter on authorization responses
+			authorization_response_iss_parameter_supported: true,
 		};
 
 		if (allScopes.length > 0) {

--- a/packages/cli/src/modules/oauth-server/oauth.helpers.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.helpers.ts
@@ -5,25 +5,38 @@ export class OAuthHelpers {
 	/**
 	 * Build success redirect URL with authorization code
 	 * Used when user approves consent
+	 *
+	 * `issuer` is the RFC 9207 issuer identifier (the instance origin, matching
+	 * the `issuer` advertised in authorization-server metadata). Clients use it
+	 * to detect authorization-server mix-up.
 	 */
-	static buildSuccessRedirectUrl(redirectUri: string, code: string, state: string | null): string {
+	static buildSuccessRedirectUrl(
+		redirectUri: string,
+		code: string,
+		state: string | null,
+		issuer: string,
+	): string {
 		const targetUrl = new URL(redirectUri);
 		targetUrl.searchParams.set('code', code);
 		if (state) {
 			targetUrl.searchParams.set('state', state);
 		}
+		targetUrl.searchParams.set('iss', issuer);
 		return targetUrl.toString();
 	}
 
 	/**
 	 * Build error redirect URL
 	 * Used when user denies consent or errors occur
+	 *
+	 * `issuer` is the RFC 9207 issuer identifier; see `buildSuccessRedirectUrl`.
 	 */
 	static buildErrorRedirectUrl(
 		redirectUri: string,
 		error: string,
 		errorDescription: string,
 		state: string | null,
+		issuer: string,
 	): string {
 		const targetUrl = new URL(redirectUri);
 		targetUrl.searchParams.set('error', error);
@@ -31,6 +44,7 @@ export class OAuthHelpers {
 		if (state) {
 			targetUrl.searchParams.set('state', state);
 		}
+		targetUrl.searchParams.set('iss', issuer);
 		return targetUrl.toString();
 	}
 }


### PR DESCRIPTION
## Summary

The MCP OAuth authorization server now includes the RFC 9207 `iss` (issuer identifier) parameter on both the success and error authorization redirects. The value is the instance origin (`UrlService.getInstanceBaseUrl()`), matching the `issuer` already advertised at `/.well-known/oauth-authorization-server`.

This aligns with the MCP authorization-hardening changes (SEP-2468): clients are now expected to validate `iss` on authorization responses as a mitigation against authorization-server mix-up, and a future spec version will have clients reject responses that omit it. Supplying it now keeps spec-compliant clients working.

Both `OAuthHelpers.buildSuccessRedirectUrl` and `buildErrorRedirectUrl` take a required `issuer` argument, threaded through from `OAuthConsentService`. These are the only authorization-response redirects; the internal `/oauth/consent` redirect and the direct 400/500 JSON error responses are out of RFC 9207 scope.

## How to test

1. Register an MCP OAuth client (DCR) and start an authorization request.
2. Approve consent and inspect the redirect to the client's `redirect_uri`: the query string includes `iss=<instance-origin>` alongside `code` (and `state` if supplied).
3. Deny consent: the error redirect includes `iss=<instance-origin>` alongside `error`/`error_description`.
4. Confirm the `iss` value equals the `issuer` field from `GET /.well-known/oauth-authorization-server`.

Unit coverage added in `oauth.helpers.test.ts` and `oauth-consent.service.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5483

Reference: https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/#authorization-hardening

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

