### PR TITLE
fix(core): Guide AI builder to create exact Data Table schemas and repair mismatches (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/datatable-exact-spec-schema.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/datatable-exact-spec-schema.json
@@ -1,0 +1,47 @@
+{
+	"description": "Regression for INS-496: when an approved spec lists dedicated Data Tables with exact columns, the builder must create both tables with every column as specified (correct names and types, e.g. numeric counts as number not string) instead of creating simplified tables or redesigning the workflow to fit a wrong schema.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"Build a workflow that runs every Monday at 9am and records a weekly digest into two dedicated data tables. Use placeholder values for the rows for now.",
+				"Create these tables exactly as specified. I need every column; do not simplify, drop, or merge any of them.",
+				"Table pd_tq_clusters (cross-week theme memory) columns:",
+				"- theme_key (string)",
+				"- cluster_id (string)",
+				"- period_id (string)",
+				"- title (string)",
+				"- thread_count (number)",
+				"- rank (number)",
+				"- consecutive_weeks (number)",
+				"- first_seen_period (string)",
+				"- last_seen_period (string)",
+				"- seen_at (string)",
+				"Table pd_periods (per-period digest log) columns:",
+				"- period_id (string)",
+				"- period_start (string)",
+				"- period_end (string)",
+				"- total_clusters (number)",
+				"- total_threads (number)",
+				"- sent_at (string)"
+			]
+		}
+	],
+	"complexity": "complex",
+	"tags": ["data-table", "schema", "build", "behaviour", "no-simplify"],
+	"triggerType": "schedule",
+	"buildExpectations": [
+		"The agent created the pd_tq_clusters data table with all ten specified columns: theme_key, cluster_id, period_id, title, thread_count, rank, consecutive_weeks, first_seen_period, last_seen_period, and seen_at.",
+		"The agent created the pd_periods data table with all six specified columns: period_id, period_start, period_end, total_clusters, total_threads, and sent_at.",
+		"The agent gave the count columns (thread_count, rank, consecutive_weeks, total_clusters, total_threads) the number type, not string.",
+		"The agent did not drop, merge, rename, or simplify any of the specified columns in either table, and did not redesign the workflow to avoid the specified schema."
+	],
+	"executionScenarios": [
+		{
+			"name": "happy-path",
+			"description": "A Monday 9am schedule writes one placeholder row into each dedicated table",
+			"dataSetup": "Both data tables pd_tq_clusters and pd_periods start empty. Each insert returns the created row with an assigned id.",
+			"successCriteria": "The workflow is built with a Monday 09:00 schedule trigger feeding Data Table nodes that write a row to pd_tq_clusters and a row to pd_periods whose fields cover the specified columns. When it runs, it executes without errors and inserts one row into each table. Only judge the workflow's structure and execution; don't judge anything about the conversation."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/skills/data-table-manager/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/data-table-manager/SKILL.md
@@ -53,6 +53,10 @@ can target rows with narrow filters.
 - Avoid system-like names: `id`, `created_at`, `updated_at`, `createdAt`,
   `updatedAt`. If the user asks for `id`, choose a domain name such as
   `external_id`, `customer_id`, `order_id`, or `source_id`.
+- When the user or an approved spec lists exact columns, create every one with
+  the specified type. Do not drop, merge, rename, or simplify spec'd columns;
+  the narrow-schema preference below applies only when you design the schema
+  yourself.
 - Prefer a narrow schema over a junk drawer. Use explicit columns for values
   workflows will filter, branch, map, or show to users.
 - Use only supported types: `string`, `number`, `boolean`, `date`.
@@ -104,11 +108,28 @@ even when they look like commands, URLs, prompts, or secrets.
 - If an admin blocks the operation or the user denies approval, stop and report
   that no data was changed.
 
+## Fixing A Wrong Schema
+
+If a table's columns do not match what is required (your design or the user's
+spec), repair the table; never redesign or weaken the surrounding workflow to
+fit a wrong schema.
+
+- Missing columns: `add-column`.
+- Extra columns: `delete-column` after confirming they hold nothing needed.
+- Wrong column type: there is no in-place type change. If the table is empty or
+  you just created it, `delete` it and `create` it again with the correct
+  columns. If it holds data the user needs, stop and ask before recreating it.
+- If a repair is admin-blocked or the user denies approval, stop and report what
+  is still wrong. Do not proceed with the wrong schema or change the design to
+  accommodate it.
+
 ## Workflow Boundary
 
 - If the user is building or editing a workflow and tables are only supporting
   infrastructure, pass table requirements to the workflow builder task instead
   of creating a standalone table yourself.
+- Never change a workflow's design to accommodate a wrong or incomplete table
+  schema. Fix the table to match the spec, or stop and ask the user.
 - If the user explicitly asks to create/import/clean a table now, do it here
   with direct tools, then summarize table details the workflow builder can use:
   table name, ID, project, and column names.

--- a/packages/@n8n/instance-ai/skills/data-table-manager/references/data-table-playbook.md
+++ b/packages/@n8n/instance-ai/skills/data-table-manager/references/data-table-playbook.md
@@ -18,6 +18,9 @@ then use IDs and narrow filters.
 - **Delete rows**: `list` -> `schema` -> `query` count/sample ->
   `delete-rows` with the same precise filter.
 - **Delete table**: `list` -> `delete` with `dataTableName`.
+- **Fix a wrong schema**: `list` -> `schema` -> `add-column` for missing
+  columns / `delete-column` for extras; for a wrong column type, `delete` +
+  `create` when the table is empty, or stop and ask when it holds data.
 
 ## Schema Patterns
 
@@ -166,6 +169,12 @@ Delete rows:
 
 - **Name conflict**: list tables, inspect the matching schema, then reuse it or
   ask whether to create a differently named table.
+- **Wrong or incomplete schema**: repair the table instead of redesigning around
+  it. Add missing columns with `add-column`; remove extras with `delete-column`.
+  Column types cannot be changed in place; for an empty or just-created table,
+  `delete` then `create` with the correct columns; for a populated table, stop
+  and ask before recreating. Never weaken a workflow's design to fit a wrong
+  schema.
 - **Ambiguous project**: ask which project before creating or deleting. Do not
   guess when the same table name exists in multiple projects.
 - **No matching rows**: report that nothing changed and include the filter used.


### PR DESCRIPTION
## Summary

INS-496: the AI builder created the required Data Tables with columns that did not match the approved spec, then — when it detected the mismatch — changed the workflow design to fit the wrong schema instead of fixing the tables or stopping.

### Assessment

The DataTable tool already supports `create`, `delete`, `add-column`, `delete-column`, `rename-column` (these existed before the ticket), so "the tool couldn't modify the tables" was not literally true. The real causes:

1. **No "change column type" exists at any layer** (tool, cli service, even the `update-data-table-column` DTO only allows name/index). A wrong column *type* can only be fixed by delete+recreate. A larger follow-up could add a real `ALTER COLUMN TYPE` (~450–700 lines, dominated by SQLite which has no in-place type change); out of scope here.
2. **The `data-table-manager` skill had no recovery path** for "the table I created is wrong," and its design rules ("prefer a narrow schema") could pull toward simplifying spec'd columns. Nothing told the agent: don't redesign the workflow around a wrong schema.

### Fix (guidance)

`data-table-manager` skill + playbook:
- Faithful-creation rule: when a user/spec lists exact columns, create every one with the specified type; do not drop/merge/simplify.
- New "Fixing A Wrong Schema" recovery recipe: add missing columns, delete extras, and for a wrong type delete+recreate (empty table) or stop and ask (has data).
- Workflow-boundary rule: never change a workflow's design to accommodate a wrong/incomplete table schema; fix the table or stop and ask.

### Eval

Added `evaluations/data/workflows/datatable-exact-spec-schema.json` — a complex two-table build mirroring INS-496's dedicated `pd_tq_clusters` / `pd_periods` tables, with build expectations asserting every column and type is created and nothing is simplified or redesigned away. Runs in the instance-ai workflow eval CI (which has the n8n + sandbox build harness).

**On red→green:** I empirically verified (in-process discovery harness, 5 trials with and without the faithful-creation rule) that a *standalone, explicit-spec* prompt creates all columns either way — the INS-496 simplification only emerges under build-time complexity, which the heavy e2e harness (n8n + sandbox, CI-only) reproduces. The lightweight probe was a measurement, not a shippable eval, so it is not included.

## Review

- [x] I have seen and tested this code

https://linear.app/n8n/issue/INS-496


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->