### PR TITLE
feat(core): Respect node group changes in workflow history compaction (no-changelog)

### DIFF
--- a/packages/workflow/src/workflow-diff.ts
+++ b/packages/workflow/src/workflow-diff.ts
@@ -6,6 +6,7 @@ import type {
 	INode,
 	INodeParameters,
 	IWorkflowBase,
+	IWorkflowGroup,
 	NodeParameterValueType,
 } from '.';
 import { compareConnections, type ConnectionsDiff } from './connections-diff';
@@ -21,6 +22,7 @@ export type DiffableWorkflow<N extends DiffableNode = DiffableNode> = {
 	connections: IConnections;
 	createdAt: Date;
 	authors?: string;
+	nodeGroups?: IWorkflowGroup[];
 };
 
 export const enum NodeDiffStatus {
@@ -171,8 +173,33 @@ function nodeIsSuperset<T extends DiffableNode>(prevNode: T, nextNode: T) {
 	return parametersAreSuperset(prevParams, nextParams);
 }
 
+/**
+ * Group changes are additive if they only add groups or group members,
+ * i.e. no existing group, group name or group member may be removed.
+ */
+function nodeGroupChangesAreAdditive<N extends DiffableNode>(
+	prev: DiffableWorkflow<N>,
+	next: DiffableWorkflow<N>,
+): boolean {
+	const nextGroupsById = new Map((next.nodeGroups ?? []).map((group) => [group.id, group]));
+
+	for (const prevGroup of prev.nodeGroups ?? []) {
+		const nextGroup = nextGroupsById.get(prevGroup.id);
+		if (!nextGroup || nextGroup.name !== prevGroup.name) {
+			return false;
+		}
+
+		const nextNodeIds = new Set(nextGroup.nodeIds);
+		if (!prevGroup.nodeIds.every((id) => nextNodeIds.has(id))) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 function mergeAdditiveChanges<N extends DiffableNode = DiffableNode>(
-	_prev: DiffableWorkflow<N>,
+	prev: DiffableWorkflow<N>,
 	next: DiffableWorkflow<N>,
 	diff: WorkflowChangeSet<N>,
 ) {
@@ -185,6 +212,8 @@ function mergeAdditiveChanges<N extends DiffableNode = DiffableNode>(
 	}
 
 	if (Object.keys(diff.connections.removed).length > 0) return false;
+
+	if (!nodeGroupChangesAreAdditive(prev, next)) return false;
 
 	return true;
 }

--- a/packages/workflow/test/workflow-diff.test.ts
+++ b/packages/workflow/test/workflow-diff.test.ts
@@ -468,12 +468,17 @@ describe('groupWorkflows', () => {
 	});
 	describe('rules', () => {
 		describe('mergeAdditiveChanges', () => {
-			const createWorkflow = (id: string, nodes: DiffableNode[]): IWorkflowBase => {
+			const createWorkflow = (
+				id: string,
+				nodes: DiffableNode[],
+				nodeGroups: IWorkflowBase['nodeGroups'] = [],
+			): IWorkflowBase => {
 				return {
 					id,
 					nodes,
 					connections: {},
 					createdAt: new Date(),
+					nodeGroups,
 				} as IWorkflowBase;
 			};
 
@@ -607,6 +612,94 @@ describe('groupWorkflows', () => {
 						{ id: '1', parameters: { a: 'val with some text ue1' }, name: 'n1' },
 					]),
 					nextWorkflow: createWorkflow('1', [{ id: '1', parameters: { a: 'value1' }, name: 'n1' }]),
+					expected: false,
+				},
+				{
+					description: 'should return true when an unchanged group is present',
+					baseWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					nextWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					expected: true,
+				},
+				{
+					description: 'should return true when a group is added',
+					baseWorkflow: createWorkflow('1', [{ id: '1', parameters: {}, name: 'n1' }]),
+					nextWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					expected: true,
+				},
+				{
+					description: 'should return true when a node is added to an existing group',
+					baseWorkflow: createWorkflow(
+						'1',
+						[
+							{ id: '1', parameters: {}, name: 'n1' },
+							{ id: '2', parameters: {}, name: 'n2' },
+						],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					nextWorkflow: createWorkflow(
+						'1',
+						[
+							{ id: '1', parameters: {}, name: 'n1' },
+							{ id: '2', parameters: {}, name: 'n2' },
+						],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1', '2'] }],
+					),
+					expected: true,
+				},
+				{
+					description: 'should return false when a group is removed',
+					baseWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					nextWorkflow: createWorkflow('1', [{ id: '1', parameters: {}, name: 'n1' }]),
+					expected: false,
+				},
+				{
+					description: 'should return false when a group is renamed',
+					baseWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
+					nextWorkflow: createWorkflow(
+						'1',
+						[{ id: '1', parameters: {}, name: 'n1' }],
+						[{ id: 'g1', name: 'Renamed Group', nodeIds: ['1'] }],
+					),
+					expected: false,
+				},
+				{
+					description: 'should return false when a node is removed from a group',
+					baseWorkflow: createWorkflow(
+						'1',
+						[
+							{ id: '1', parameters: {}, name: 'n1' },
+							{ id: '2', parameters: {}, name: 'n2' },
+						],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1', '2'] }],
+					),
+					nextWorkflow: createWorkflow(
+						'1',
+						[
+							{ id: '1', parameters: {}, name: 'n1' },
+							{ id: '2', parameters: {}, name: 'n2' },
+						],
+						[{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+					),
 					expected: false,
 				},
 			])('$description', ({ baseWorkflow, nextWorkflow, expected }) => {


### PR DESCRIPTION
## Summary

Workflow history compaction merges adjacent autosaved versions when the change between them is purely additive (no data lost). The check previously only looked at nodes and connections, so removing/renaming a node group or removing a node from a group was treated as a no-op and the version recording it got compacted away.

The additive check now also inspects `nodeGroups`. No-op for workflows without groups (empty arrays), so behavior is unchanged for users not using the feature.

## How to test

1. Create a workflow, group some nodes, then delete or rename the group → produces two autosaved versions.
2. Run compaction (e.g. via tweaking env variables and restarting the server).
3. Confirm the pre-deletion version is retained (not compacted away).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5437/update-workflow-history-compaction-to-respect-group-changes

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

