### PR TITLE
chore: Note gated-feature test requirements in create-pr skill

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -100,6 +100,10 @@ Based on `.github/pull_request_template.md`:
 ### How to test Section
 - Explain how to test the changes
 - Include an example workflow if appropriate
+- If the feature is gated in a default n8n instance (requires a non-default
+  module via `N8N_ENABLED_MODULES`, an enterprise license, a feature flag, or
+  similar), note which env vars/license are needed so the tester can deploy a
+  correctly configured instance
 
 ### Related Links Section
 - Link to Linear ticket: `https://linear.app/n8n/issue/[TICKET-ID]`


### PR DESCRIPTION
## Summary

Adds a note to the **How to test** section guidelines of the `create-pr` skill, reminding authors to document when a feature is gated in a default n8n instance (non-default module via `N8N_ENABLED_MODULES`, enterprise license, feature flag, etc.) and which env vars/license are needed. 

This helps reviewers and AI agents deploy a correctly configured test instance.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

