### PR TITLE
fix(Databricks Node): Allow configuring the token-expired status code on OAuth2 credential

### DIFF
--- a/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/DatabricksOAuth2Api.credentials.ts
@@ -52,6 +52,18 @@ export class DatabricksOAuth2Api implements ICredentialType {
 			type: 'hidden',
 			default: 'header',
 		},
+		{
+			// Re-declared because the base `oAuth2Api` field is `doNotInherit`, so it
+			// never reaches the decrypted credential. Without it the value is always
+			// undefined and token refresh is hardcoded to 401 — workspaces fronted by
+			// a proxy that rewrites 401 to 403 can set 403 here to keep refreshing.
+			displayName: 'Token Expired Status Code',
+			name: 'tokenExpiredStatusCode',
+			type: 'number',
+			default: 401,
+			description:
+				'HTTP status code that indicates the token has expired. Some APIs return 403 instead of 401.',
+		},
 	];
 
 	test: ICredentialTestRequest = {

--- a/packages/nodes-base/credentials/test/DatabricksOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/DatabricksOAuth2Api.credentials.test.ts
@@ -1,0 +1,36 @@
+import { DatabricksOAuth2Api } from '../DatabricksOAuth2Api.credentials';
+
+describe('DatabricksOAuth2Api Credential', () => {
+	const databricksOAuth2Api = new DatabricksOAuth2Api();
+
+	it('should have correct credential metadata', () => {
+		expect(databricksOAuth2Api.name).toBe('databricksOAuth2Api');
+		expect(databricksOAuth2Api.extends).toEqual(['oAuth2Api']);
+
+		const grantType = databricksOAuth2Api.properties.find((p) => p.name === 'grantType');
+		expect(grantType?.default).toBe('clientCredentials');
+
+		const accessTokenUrl = databricksOAuth2Api.properties.find((p) => p.name === 'accessTokenUrl');
+		expect(accessTokenUrl?.default).toContain('/oidc/v1/token');
+	});
+
+	describe('tokenExpiredStatusCode', () => {
+		const field = databricksOAuth2Api.properties.find((p) => p.name === 'tokenExpiredStatusCode');
+
+		// The base `oAuth2Api` field is `doNotInherit`, so it must be re-declared
+		// here or `credentials.tokenExpiredStatusCode` is always undefined and token
+		// refresh stays hardcoded to 401.
+		it('should be declared so it reaches the decrypted credential', () => {
+			expect(field).toBeDefined();
+		});
+
+		it('should default to 401 to preserve existing behavior', () => {
+			expect(field?.default).toBe(401);
+		});
+
+		it('should be a configurable number field (not hidden)', () => {
+			expect(field?.type).toBe('number');
+			expect(field?.type).not.toBe('hidden');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The `databricksOAuth2Api` credential never exposed `tokenExpiredStatusCode`. The base `oAuth2Api` credential declares that field with `doNotInherit: true`, so it was stripped from the Databricks credential and the decrypted value was always `undefined`. As a result, OAuth2 token refresh fell back to a hardcoded `401`: a Databricks workspace fronted by a proxy/gateway that rewrites `401 → 403` (or any endpoint that responds `403` on token expiry) would surface the error to the user instead of minting a fresh `client_credentials` token and retrying.

This re-declares `tokenExpiredStatusCode` on `DatabricksOAuth2Api` as a visible `number` field defaulting to `401`. Behaviour is unchanged out of the box (`401`); users who sit behind such a proxy can set `403` so refresh works again. The OAuth2 engine already honours a per-credential `tokenExpiredStatusCode` (`resolveTokenExpiredStatusCode` in `packages/core/.../request-helpers/oauth.ts`) — the only gap was the credential never surfacing the field.

## How to test

1. Create a **Databricks** credential using **OAuth2** authentication.
2. In the credential, set **Token Expired Status Code** to `403`.
3. Point a Databricks node at a workspace/endpoint that returns `403` for an expired bearer token (real, or a proxy/mock that rewrites `401 → 403`).
4. Let the cached `oauthTokenData` expire (or invalidate it server-side) and execute the node.
5. The node should mint a new token via `client_credentials` and retry once, instead of failing with `403`. With the field left at the default `401`, behaviour is unchanged.

Unit test:

```bash
cd packages/nodes-base && pnpm test DatabricksOAuth2Api
```
## Screenshots

### Override-able status code

<img width="1060" height="609" alt="image" src="https://github.com/user-attachments/assets/597b9fb6-fc63-4b59-9618-e2daea0fda6a" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-15
- closes #28832

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32824">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

