### PR TITLE
feat(core): Add agent capability summary endpoint (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/agents/types.ts
+++ b/packages/@n8n/api-types/src/agents/types.ts
@@ -130,6 +130,49 @@ export interface AgentVersionListItemDto {
 	isActive: boolean;
 }
 
+/**
+ * Lightweight capability metadata for the AI Agent node card. Lets the canvas
+ * render capability chips (model + channels / tools / skills / tasks) without
+ * fetching the agent's full `AgentJsonConfig`. Per-item labels are returned so
+ * the card can render names inline; counts are derived from array lengths.
+ */
+export interface AgentCapabilityModel {
+	/** Provider prefix of the model id, e.g. 'anthropic'. Empty when the id has no prefix. */
+	provider: string;
+	/** Model name, e.g. 'claude-sonnet-4-5'. */
+	model: string;
+}
+
+export interface AgentCapabilityChannel {
+	/** Integration platform, e.g. 'slack' | 'telegram' | 'linear'. */
+	type: string;
+}
+
+export interface AgentCapabilityTool {
+	type: 'custom' | 'workflow' | 'node';
+	name: string;
+}
+
+export interface AgentCapabilityItem {
+	id: string;
+	name: string;
+}
+
+export interface AgentCapabilityTask extends AgentCapabilityItem {
+	enabled: boolean;
+}
+
+export interface AgentCapabilitySummary {
+	id: string;
+	name: string;
+	/** Null when no model is configured yet. */
+	model: AgentCapabilityModel | null;
+	channels: AgentCapabilityChannel[];
+	tools: AgentCapabilityTool[];
+	skills: AgentCapabilityItem[];
+	tasks: AgentCapabilityTask[];
+}
+
 export interface AgentPersistedMessageContentPart {
 	type: 'text' | 'reasoning' | 'tool-call' | (string & {});
 	text?: string;

--- a/packages/@n8n/api-types/src/agents/types.ts
+++ b/packages/@n8n/api-types/src/agents/types.ts
@@ -131,10 +131,7 @@ export interface AgentVersionListItemDto {
 }
 
 /**
- * Lightweight capability metadata for the AI Agent node card. Lets the canvas
- * render capability chips (model + channels / tools / skills / tasks) without
- * fetching the agent's full `AgentJsonConfig`. Per-item labels are returned so
- * the card can render names inline; counts are derived from array lengths.
+ * Lightweight capability metadata for the AI Agent node card.
  */
 export interface AgentCapabilityModel {
 	/** Provider prefix of the model id, e.g. 'anthropic'. Empty when the id has no prefix. */
@@ -153,12 +150,14 @@ export interface AgentCapabilityTool {
 	name: string;
 }
 
-export interface AgentCapabilityItem {
+export interface AgentCapabilitySkill {
 	id: string;
 	name: string;
 }
 
-export interface AgentCapabilityTask extends AgentCapabilityItem {
+export interface AgentCapabilityTask {
+	id: string;
+	name: string;
 	enabled: boolean;
 }
 
@@ -169,7 +168,7 @@ export interface AgentCapabilitySummary {
 	model: AgentCapabilityModel | null;
 	channels: AgentCapabilityChannel[];
 	tools: AgentCapabilityTool[];
-	skills: AgentCapabilityItem[];
+	skills: AgentCapabilitySkill[];
 	tasks: AgentCapabilityTask[];
 }
 

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -31,6 +31,7 @@ import type { UrlService } from '@/services/url.service';
 import { AgentTaskService } from '../agent-task.service';
 import { AgentsService, chatThreadId } from '../agents.service';
 import type { AgentHistory } from '../entities/agent-history.entity';
+import type { AgentTask } from '../entities/agent-task.entity';
 import type { AgentTaskSnapshot } from '../entities/agent-task-snapshot.entity';
 import type { Agent } from '../entities/agent.entity';
 import {
@@ -240,6 +241,109 @@ describe('AgentsService', () => {
 
 			agentsConfig.sandboxEnabled = false;
 			expect(service.isKnowledgeBaseEnabled()).toBe(false);
+		});
+	});
+
+	describe('getCapabilitySummary', () => {
+		it('projects model, channels, tools, skills and tasks into per-item labels', async () => {
+			agentRepository.findByIdAndProjectId.mockResolvedValue(
+				makeAgent({
+					name: 'Support Agent',
+					schema: {
+						name: 'Support Agent',
+						model: 'anthropic/claude-sonnet-4-5',
+						instructions: 'Help the user.',
+						tools: [
+							{ type: 'custom', id: 'c1' },
+							{ type: 'workflow', workflow: 'wf-1', name: 'Lookup order' },
+							{ type: 'node', name: 'HTTP Request' },
+						],
+						skills: [{ type: 'skill', id: 's1' }],
+						tasks: [{ type: 'task', id: 't1', enabled: true }],
+					},
+					integrations: [
+						{ type: 'slack', credentialId: 'cred-1' },
+						{ type: 'telegram', credentialId: 'cred-2' },
+					],
+					tools: { c1: { code: '', descriptor: { name: 'Refund tool' } } },
+					skills: { s1: { name: 'Triage', description: '', instructions: '' } },
+				} as unknown as Partial<Agent>),
+			);
+			agentTaskRepository.findByAgentId.mockResolvedValue([
+				{ id: 't1', name: 'Daily digest' } as AgentTask,
+			]);
+
+			const summary = await service.getCapabilitySummary(agentId, projectId);
+
+			expect(summary).toEqual({
+				id: agentId,
+				name: 'Support Agent',
+				model: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+				channels: [{ type: 'slack' }, { type: 'telegram' }],
+				tools: [
+					{ type: 'custom', name: 'Refund tool' },
+					{ type: 'workflow', name: 'Lookup order' },
+					{ type: 'node', name: 'HTTP Request' },
+				],
+				skills: [{ id: 's1', name: 'Triage' }],
+				tasks: [{ id: 't1', name: 'Daily digest', enabled: true }],
+			});
+		});
+
+		it('returns a null model and empty arrays for an unconfigured agent', async () => {
+			agentRepository.findByIdAndProjectId.mockResolvedValue(
+				makeAgent({ name: 'Empty Agent', schema: null }),
+			);
+
+			const summary = await service.getCapabilitySummary(agentId, projectId);
+
+			expect(summary).toEqual({
+				id: agentId,
+				name: 'Empty Agent',
+				model: null,
+				channels: [],
+				tools: [],
+				skills: [],
+				tasks: [],
+			});
+			// No task refs → no body lookup.
+			expect(agentTaskRepository.findByAgentId).not.toHaveBeenCalled();
+		});
+
+		it('falls back to ref ids when bodies are missing', async () => {
+			agentRepository.findByIdAndProjectId.mockResolvedValue(
+				makeAgent({
+					name: 'Partial Agent',
+					schema: {
+						name: 'Partial Agent',
+						model: 'claude-sonnet-4-5',
+						instructions: 'Help the user.',
+						tools: [
+							{ type: 'custom', id: 'c-missing' },
+							{ type: 'workflow', workflow: 'wf-2' },
+						],
+						skills: [{ type: 'skill', id: 's-missing' }],
+						tasks: [{ type: 'task', id: 't-missing', enabled: false }],
+					},
+				} as unknown as Partial<Agent>),
+			);
+			agentTaskRepository.findByAgentId.mockResolvedValue([]);
+
+			const summary = await service.getCapabilitySummary(agentId, projectId);
+
+			expect(summary.model).toEqual({ provider: '', model: 'claude-sonnet-4-5' });
+			expect(summary.tools).toEqual([
+				{ type: 'custom', name: 'c-missing' },
+				{ type: 'workflow', name: 'wf-2' },
+			]);
+			expect(summary.skills).toEqual([{ id: 's-missing', name: 's-missing' }]);
+			expect(summary.tasks).toEqual([{ id: 't-missing', name: 't-missing', enabled: false }]);
+		});
+
+		it('throws NotFoundError when the agent does not exist', async () => {
+			agentRepository.findByIdAndProjectId.mockResolvedValue(null);
+
+			await expect(service.getCapabilitySummary(agentId, projectId)).rejects.toThrow(NotFoundError);
 		});
 	});
 

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -4,6 +4,7 @@ import {
 	AgentChatResumeDto,
 	AgentIntegrationSchema,
 	type AgentBuilderMessagesResponse,
+	type AgentCapabilitySummary,
 	type AgentIntegrationStatusResponse,
 	type AgentPersistedMessageDto,
 	type AgentSkill,
@@ -195,6 +196,16 @@ export class AgentsController {
 	async getConfig(req: AuthenticatedRequest<{ projectId: string; agentId: string }>) {
 		const { projectId, agentId } = req.params;
 		return await this.agentsService.getConfig(agentId, projectId);
+	}
+
+	/** Capability metadata for the canvas node card (model + chip labels). */
+	@Get('/:agentId/summary')
+	@ProjectScope('agent:read')
+	async getSummary(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string }>,
+	): Promise<AgentCapabilitySummary> {
+		const { projectId, agentId } = req.params;
+		return await this.agentsService.getCapabilitySummary(agentId, projectId);
 	}
 
 	@Put('/:agentId/config')

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -15,6 +15,8 @@ import {
 	isNodeToolsEnabled,
 	sanitizeAgentJsonConfig,
 	AgentModelSchema,
+	type AgentCapabilitySummary,
+	type AgentCapabilityTool,
 	type AgentIntegrationConfig,
 	type AgentJsonConfig,
 	type AgentJsonToolConfig,
@@ -71,7 +73,7 @@ import { syncAgentIntegrations } from './integrations/integrations-sync';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import { N8nMemory } from './integrations/n8n-memory';
 import { composeJsonConfig, decomposeJsonConfig } from './json-config/agent-config-composition';
-import { getProviderPrefix } from './json-config/model-id';
+import { getProviderPrefix, splitModelId } from './json-config/model-id';
 import { sanitizeUnknownAgentCredentials } from './json-config/sanitize-unknown-agent-credentials';
 import { AgentRuntimeReconstructionService } from './agent-runtime-reconstruction.service';
 import { AgentHistoryRepository } from './repositories/agent-history.repository';
@@ -1572,6 +1574,69 @@ export class AgentsService {
 			throw new UserError('Agent has no JSON config yet.');
 		}
 		return config;
+	}
+
+	/**
+	 * Lightweight capability metadata for the AI Agent node card: the agent's
+	 * model plus per-item labels for channels / tools / skills / tasks. Reads the
+	 * live draft config (mirroring {@link getConfig}) so the card stays in sync
+	 * with edits, and avoids shipping the full `AgentJsonConfig`.
+	 */
+	async getCapabilitySummary(agentId: string, projectId: string): Promise<AgentCapabilitySummary> {
+		const entity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!entity) throw new NotFoundError('Agent not found');
+
+		const schema = entity.schema;
+
+		const modelId = schema?.model ?? '';
+		const model: AgentCapabilitySummary['model'] = modelId ? splitModelId(modelId) : null;
+
+		const channels = (entity.integrations ?? []).map((integration) => ({
+			type: integration.type,
+		}));
+
+		const tools = (schema?.tools ?? []).flatMap<AgentCapabilityTool>((tool) => {
+			switch (tool.type) {
+				case 'custom':
+					return [{ type: 'custom', name: entity.tools[tool.id]?.descriptor?.name ?? tool.id }];
+				case 'workflow':
+					return [{ type: 'workflow', name: tool.name ?? tool.workflow }];
+				case 'node':
+					return [{ type: 'node', name: tool.name }];
+				default:
+					// Unknown tool type from an unvalidated persisted config (import,
+					// history restore, version skew): drop it rather than emit an
+					// `undefined` chip the card would choke on.
+					return [];
+			}
+		});
+
+		const skills = (schema?.skills ?? []).map((skill) => ({
+			id: skill.id,
+			name: entity.skills[skill.id]?.name ?? skill.id,
+		}));
+
+		const taskRefs = schema?.tasks ?? [];
+		let taskNamesById: Record<string, string> = {};
+		if (taskRefs.length > 0) {
+			const taskBodies = await this.agentTaskRepository.findByAgentId(agentId);
+			taskNamesById = Object.fromEntries(taskBodies.map((task) => [task.id, task.name]));
+		}
+		const tasks = taskRefs.map((task) => ({
+			id: task.id,
+			name: taskNamesById[task.id] ?? task.id,
+			enabled: task.enabled,
+		}));
+
+		return {
+			id: entity.id,
+			name: entity.name,
+			model,
+			channels,
+			tools,
+			skills,
+			tasks,
+		};
 	}
 
 	/**

--- a/packages/cli/src/modules/agents/json-config/__tests__/model-id.test.ts
+++ b/packages/cli/src/modules/agents/json-config/__tests__/model-id.test.ts
@@ -1,0 +1,43 @@
+import { getProviderPrefix, splitModelId } from '../model-id';
+
+describe('getProviderPrefix', () => {
+	it('returns the prefix before the first slash', () => {
+		expect(getProviderPrefix('anthropic/claude-sonnet-4-5')).toBe('anthropic');
+	});
+
+	it('returns an empty string when there is no prefix', () => {
+		expect(getProviderPrefix('claude-sonnet-4-5')).toBe('');
+	});
+});
+
+describe('splitModelId', () => {
+	it('splits a prefixed id into provider and model', () => {
+		expect(splitModelId('anthropic/claude-sonnet-4-5')).toEqual({
+			provider: 'anthropic',
+			model: 'claude-sonnet-4-5',
+		});
+	});
+
+	it('treats an unprefixed id as the model with an empty provider', () => {
+		expect(splitModelId('claude-sonnet-4-5')).toEqual({
+			provider: '',
+			model: 'claude-sonnet-4-5',
+		});
+	});
+
+	it('keeps everything after the first slash as the model for multi-slash ids', () => {
+		expect(splitModelId('openrouter/amazon/nova-micro-v1')).toEqual({
+			provider: 'openrouter',
+			model: 'amazon/nova-micro-v1',
+		});
+	});
+
+	it('falls back to the raw id when the model segment is empty', () => {
+		expect(splitModelId('anthropic/')).toEqual({ provider: '', model: 'anthropic/' });
+		expect(splitModelId('/')).toEqual({ provider: '', model: '/' });
+	});
+
+	it('returns an empty model for an empty id', () => {
+		expect(splitModelId('')).toEqual({ provider: '', model: '' });
+	});
+});

--- a/packages/cli/src/modules/agents/json-config/model-id.ts
+++ b/packages/cli/src/modules/agents/json-config/model-id.ts
@@ -2,3 +2,18 @@ export function getProviderPrefix(modelId: string): string {
 	const slashIdx = modelId.indexOf('/');
 	return slashIdx !== -1 ? modelId.slice(0, slashIdx) : '';
 }
+
+/**
+ * Split a model id into its provider prefix and model name. Guards degenerate
+ * ids that an unvalidated persisted config may contain: an id with no prefix
+ * (`claude-...`) or an empty model segment (`anthropic/`, `/`) keeps the raw id
+ * as the model name with an empty provider, so callers never render a blank
+ * model label. Multi-slash ids keep everything after the first slash as the
+ * model name (`openrouter/amazon/x` -> `{ provider: 'openrouter', model: 'amazon/x' }`).
+ */
+export function splitModelId(modelId: string): { provider: string; model: string } {
+	const slashIdx = modelId.indexOf('/');
+	const model = modelId.slice(slashIdx + 1);
+	if (slashIdx === -1 || model === '') return { provider: '', model: modelId };
+	return { provider: modelId.slice(0, slashIdx), model };
+}


### PR DESCRIPTION
## Summary

Adds a `GET /:agentId/summary` endpoint that returns lightweight capability metadata — the agent's model plus  labels for channels, tools, skills, and tasks. 

## How to test

- Open/create an agent in a project and configure a model, integrations (channels), tools, skills, and tasks.
- `GET /rest/projects/:projectId/agents/v2/:agentId/summary` → expect `{ id, name, model, channels[], tools[], skills[], tasks[] }` with names resolved per item.
- Unconfigured agent → `model: null` and empty arrays; unknown `agentId` → `404`.
- Run the unit tests:
  ```bash
  cd packages/cli && pnpm test src/modules/agents/__tests__/agents.service.test.ts src/modules/agents/json-config/__tests__/model-id.test.ts
  ```

## Related Linear tickets, Github issues, and Community forum posts

Part of the new Agent node feature — stacked on `agent-272-feature-new-agent-node`.
- https://linear.app/n8n/issue/AGENT-275/ai-agent-node-agent-capability-metadata-for-the-card

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!-- **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** -->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

