### PR TITLE
refactor(editor): Extract applyOffset util for canvas group offsets

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
@@ -31,6 +31,19 @@ import type { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocumen
 export type CanvasRenderData = ReturnType<typeof useWorkflowDocumentRenderData>;
 
 /**
+ * Adds an `{ x, y }` offset to a position (a `{ x, y }` or a `[x, y]` tuple),
+ * returning a new `{ x, y }`.
+ */
+export function applyOffset(
+	position: { x: number; y: number } | [number, number],
+	offset: { x: number; y: number },
+): { x: number; y: number } {
+	const x = Array.isArray(position) ? position[0] : position.x;
+	const y = Array.isArray(position) ? position[1] : position.y;
+	return { x: x + offset.x, y: y + offset.y };
+}
+
+/**
  * Display size for a node with `Default` render type — pulls port counts from
  * render data and forwards to `calculateNodeSize`. Single source of truth for
  * "what size would this node render at?" outside of the actual VueFlow runtime.

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
@@ -20,7 +20,7 @@ import {
 	GROUP_PADDING_X,
 	GROUP_PADDING_Y_TOP,
 } from '../stores/canvasNodeGroups.constants';
-import { createCanvasConnectionId } from '../canvas.utils';
+import { applyOffset, createCanvasConnectionId } from '../canvas.utils';
 import { DEFAULT_NODE_SIZE, GRID_SIZE } from '@/app/utils/nodeViewUtils';
 import { STICKY_NODE_TYPE } from '@/app/constants/nodeTypes';
 
@@ -228,10 +228,7 @@ export function mapGroupsToVueFlowNodes({
 		out.push({
 			id,
 			type: CANVAS_NODE_GROUP_TYPE,
-			position: {
-				x: titleBar.position.x + offset.x,
-				y: titleBar.position.y + offset.y,
-			},
+			position: applyOffset(titleBar.position, offset),
 			width: titleBar.width,
 			height: GROUP_HEADER_HEIGHT,
 			draggable: !readOnly,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -21,6 +21,7 @@ import {
 	remapCollapsedGroupConnections,
 } from './useCanvasMapping.groups';
 import {
+	applyOffset,
 	computeNodeDisplaySize,
 	mapLegacyConnectionsToCanvasConnections,
 	parseCanvasConnectionHandleString,
@@ -184,7 +185,7 @@ export function useCanvasMapping({
 				id: node.id,
 				label: node.name,
 				type: 'canvas-node',
-				position: { x: node.position[0] + offset.x, y: node.position[1] + offset.y },
+				position: applyOffset(node.position, offset),
 				data,
 				...additionalProperties[node.id],
 				draggable: node.draggable,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.ts
@@ -12,6 +12,7 @@ import {
 	titleBarFromNodesRect,
 	type GetNodeDisplaySize,
 } from './useCanvasMapping.groups';
+import { applyOffset } from '../canvas.utils';
 
 export interface UseCanvasNodeGroupDragDeps {
 	canvasId?: string;
@@ -131,10 +132,8 @@ export function useCanvasNodeGroupDrag(deps: UseCanvasNodeGroupDragDeps) {
 			const node = deps.getNodeById(move.id);
 			if (!node) return true;
 			const offset = deps.getNodeVisualOffset?.(move.id) ?? { x: 0, y: 0 };
-			return (
-				node.position[0] + offset.x !== move.position.x ||
-				node.position[1] + offset.y !== move.position.y
-			);
+			const visual = applyOffset(node.position, offset);
+			return visual.x !== move.position.x || visual.y !== move.position.y;
 		});
 	}
 
@@ -176,10 +175,7 @@ export function useCanvasNodeGroupDrag(deps: UseCanvasNodeGroupDragDeps) {
 				const node = deps.getNodeById(nodeId);
 				if (!node) continue;
 				const offset = deps.getNodeVisualOffset?.(nodeId) ?? { x: 0, y: 0 };
-				positionOverrides.set(nodeId, {
-					x: node.position[0] + offset.x,
-					y: node.position[1] + offset.y,
-				});
+				positionOverrides.set(nodeId, applyOffset(node.position, offset));
 			}
 
 			const rect = computeNodesRectFromStore(

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupLayout.ts
@@ -5,7 +5,7 @@ import {
 	createCanvasGroupNodeId,
 	type BoundingBox,
 } from '@/features/workflows/canvas/canvas.types';
-import { checkOverlap } from '@/features/workflows/canvas/canvas.utils';
+import { applyOffset, checkOverlap } from '@/features/workflows/canvas/canvas.utils';
 import {
 	GROUP_HEADER_HEIGHT,
 	GROUP_HEADER_WIDTH_COLLAPSED,
@@ -149,7 +149,7 @@ export function getOffsetForComponent(
 }
 
 function translateRect(rect: BoundingBox, offset: NodeGroupLayoutOffset): BoundingBox {
-	return { ...rect, x: rect.x + offset.x, y: rect.y + offset.y };
+	return { ...rect, ...applyOffset(rect, offset) };
 }
 
 function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -4,6 +4,7 @@ import type { NodeGroupChangeEvent } from '@/app/stores/workflowDocument/useWork
 import { CHANGE_ACTION } from '@/app/stores/workflowDocument/types';
 import { LOCAL_STORAGE_CANVAS_GROUP_EXPANDED } from '@/app/constants/localStorage';
 import { isStringArrayRecord } from '@/app/utils/objectUtils';
+import { applyOffset } from '../canvas.utils';
 import {
 	aggregateNodeGroupLayoutOffsets,
 	computeNodeGroupLayoutPushes,
@@ -264,7 +265,7 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 					if (!position) continue;
 					bakedMoves.push({
 						id: nodeId,
-						position: { x: position[0] + offset.x, y: position[1] + offset.y },
+						position: applyOffset(position, offset),
 					});
 				}
 			}
@@ -287,10 +288,7 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 			return [
 				{
 					id: nodeId,
-					position: {
-						x: position[0] + offset.x,
-						y: position[1] + offset.y,
-					},
+					position: applyOffset(position, offset),
 				},
 			];
 		});


### PR DESCRIPTION
## Summary

Extracts an `applyOffset` helper into `canvas.utils.ts` and uses it to replace the repeated inline `{ x: pos.x + offset.x, y: pos.y + offset.y }` arithmetic scattered across the canvas group composables.

The helper accepts a position as either an `{ x, y }` object or an `[x, y]` tuple (so it works for both VueFlow positions and stored node positions) and returns a new `{ x, y }`. Call sites updated:

- `useCanvasMapping.groups.ts` – group node position
- `useCanvasMapping.ts` – node position
- `useCanvasNodeGroupDrag.ts` – move filtering and position overrides
- `useCanvasNodeGroupLayout.ts` – `translateRect`
- `useCanvasNodeGroupView.ts` – baked moves and offset-adjusted positions

First PR in a stack of canvas group refactors (followed by #32829 and #32830).

## How to test

No behavior change, so existing canvas group behavior should be identical. Create a group of nodes, collapse/expand it, and drag both members and the group — positions and offsets should be unchanged. Run the canvas unit tests.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5487

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
