### PR TITLE
feat(core): Expose $evaluation.runId expression global in eval executions

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/built-ins-parser/__tests__/built-ins-parser.test.ts
@@ -284,6 +284,7 @@ describe('BuiltInsParser', () => {
 				'Interval',
 				'Duration',
 				'$execution',
+				'$evaluation',
 				'$vars',
 				'$secrets',
 				'$executionId',

--- a/packages/@n8n/task-runner/src/runner-types.ts
+++ b/packages/@n8n/task-runner/src/runner-types.ts
@@ -99,6 +99,8 @@ export interface PartialAdditionalData {
 	executionTimeoutTimestamp?: number;
 	userId?: string;
 	variables: IDataObject;
+	/** Parent evaluation TestRun.id, exposed to Code nodes as `$evaluation.runId`. */
+	evaluationRunId?: string;
 }
 
 /** RPC methods that are exposed directly to the Code Node */

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -782,6 +782,7 @@ describe('TestRunnerService', () => {
 					},
 					userId: metadata.userId,
 					forceFullExecutionData: true,
+					evaluationRunId: metadata.testRunId,
 					triggerToStartFrom: {
 						name: triggerNodeName,
 					},
@@ -930,6 +931,7 @@ describe('TestRunnerService', () => {
 							},
 						},
 						userId: metadata.userId,
+						evaluationRunId: metadata.testRunId,
 						triggerToStartFrom: {
 							name: triggerNodeName,
 						},
@@ -944,6 +946,7 @@ describe('TestRunnerService', () => {
 								},
 								manualData: {
 									userId: metadata.userId,
+									evaluationRunId: metadata.testRunId,
 									triggerToStartFrom: {
 										name: triggerNodeName,
 									},

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -290,6 +290,7 @@ export class TestRunnerService {
 				},
 			},
 			userId: metadata.userId,
+			evaluationRunId: metadata.testRunId,
 			triggerToStartFrom: {
 				name: triggerNode.name,
 			},
@@ -305,6 +306,7 @@ export class TestRunnerService {
 				},
 				manualData: {
 					userId: metadata.userId,
+					evaluationRunId: metadata.testRunId,
 					triggerToStartFrom: {
 						name: triggerNode.name,
 					},

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -165,6 +165,7 @@ export class JobProcessor {
 		});
 		additionalData.streamingEnabled = job.data.streamingEnabled;
 		additionalData.restartExecutionId = job.data.restartExecutionId;
+		additionalData.evaluationRunId = execution.data.manualData?.evaluationRunId;
 
 		const { pushRef } = job.data;
 

--- a/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-builder.test.ts
+++ b/packages/cli/src/task-runners/task-managers/__tests__/data-request-response-builder.test.ts
@@ -24,6 +24,7 @@ const additionalData = mock<PartialAdditionalData>({
 	currentNodeParameters: undefined,
 	executionTimeoutTimestamp: undefined,
 	restartExecutionId: undefined,
+	evaluationRunId: 'test-run-id-123',
 });
 
 const node = mock<INode>();
@@ -108,6 +109,7 @@ describe('DataRequestResponseBuilder', () => {
 			currentNodeParameters: undefined,
 			executionTimeoutTimestamp: undefined,
 			restartExecutionId: undefined,
+			evaluationRunId: 'test-run-id-123',
 		});
 	});
 

--- a/packages/cli/src/task-runners/task-managers/data-request-response-builder.ts
+++ b/packages/cli/src/task-runners/task-managers/data-request-response-builder.ts
@@ -50,6 +50,7 @@ export class DataRequestResponseBuilder {
 			executionTimeoutTimestamp: additionalData.executionTimeoutTimestamp,
 			restartExecutionId: additionalData.restartExecutionId,
 			userId: additionalData.userId,
+			evaluationRunId: additionalData.evaluationRunId,
 		};
 	}
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -519,6 +519,8 @@ async function startExecution(
 		// mode (e.g. 'manual') even though their own WorkflowExecute runs as 'integrated'
 		additionalDataIntegrated.rootExecutionMode =
 			additionalData.rootExecutionMode ?? options.executionMode;
+		// Propagate the eval run id so sub-workflows of an eval run expose `$evaluation.runId`
+		additionalDataIntegrated.evaluationRunId = additionalData.evaluationRunId;
 		if (additionalData.httpResponse) {
 			additionalDataIntegrated.httpResponse = additionalData.httpResponse;
 		}

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -378,6 +378,7 @@ export class WorkflowRunner {
 		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
 
 		additionalData.executionId = executionId;
+		additionalData.evaluationRunId = data.evaluationRunId;
 
 		this.logger.debug(
 			`Execution for workflow ${data.workflowData.name} was assigned id ${executionId}`,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-additional-keys.test.ts
@@ -150,6 +150,20 @@ describe('getAdditionalKeys', () => {
 		expect(result.$execution?.customData).toBeUndefined();
 	});
 
+	it('should expose $evaluation.runId when evaluationRunId is set', () => {
+		const dataWithRunId = { ...additionalData, evaluationRunId: 'run-123' };
+		const result = getAdditionalKeys(dataWithRunId, 'manual', null);
+
+		expect(result.$evaluation).toEqual({ runId: 'run-123' });
+	});
+
+	it('should leave $evaluation undefined when evaluationRunId is unset', () => {
+		const dataWithoutRunId = { ...additionalData, evaluationRunId: undefined };
+		const result = getAdditionalKeys(dataWithoutRunId, 'manual', null);
+
+		expect(result.$evaluation).toBeUndefined();
+	});
+
 	it('should respect metadata KV limit', () => {
 		const result = getAdditionalKeys(additionalData, 'manual', runExecutionData);
 		const customData = result.$execution?.customData;

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-additional-keys.ts
@@ -40,6 +40,11 @@ export function getAdditionalKeys(
 				? createExecutionCustomData({ runExecutionData, mode })
 				: undefined,
 		},
+		// Gated on the value's presence, not on `mode`: sub-workflows of an eval run
+		// execute as 'integrated' but inherit evaluationRunId, so they must expose it too.
+		$evaluation: additionalData.evaluationRunId
+			? { runId: additionalData.evaluationRunId }
+			: undefined,
 		$vars: additionalData.variables,
 		$secrets: getSecretsProxy(additionalData),
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2819,6 +2819,7 @@ export type IWorkflowDataProxyAdditionalKeys = IDataObject & {
 		resumeFormUrl: string;
 		customData?: IWorkflowExecutionCustomData;
 	};
+	$evaluation?: { runId: string };
 	$vars?: IDataObject;
 	$secrets?: IDataObject;
 	$pageCount?: number;
@@ -3265,6 +3266,8 @@ export interface IWorkflowExecutionDataProcess {
 	tracingContext?: { traceparent: string; tracestate?: string };
 	/** Encrypted credential context for a manual editor-triggered execution. */
 	encryptedRunnerIdentity?: string;
+	/** Parent evaluation TestRun.id, exposed to expressions as `$evaluation.runId`. */
+	evaluationRunId?: string;
 }
 
 export interface ExecuteWorkflowOptions {
@@ -3374,6 +3377,8 @@ export interface IWorkflowExecuteAdditionalData {
 	 * data consistently across the entire execution tree.
 	 */
 	rootExecutionMode?: WorkflowExecuteMode;
+	/** Parent evaluation TestRun.id, exposed to expressions as `$evaluation.runId`. */
+	evaluationRunId?: string;
 	startRunnerTask<T, E = unknown>(
 		additionalData: IWorkflowExecuteAdditionalData,
 		jobType: string,

--- a/packages/workflow/src/run-execution-data/run-execution-data.v0.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v0.ts
@@ -51,6 +51,6 @@ export interface IRunExecutionDataV0 {
 	/** Data needed for a worker to run a manual execution. */
 	manualData?: Pick<
 		IWorkflowExecutionDataProcess,
-		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId'
+		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId'
 	>;
 }

--- a/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
@@ -72,7 +72,7 @@ export interface IRunExecutionDataV1 {
 	/** Data needed for a worker to run a manual execution. */
 	manualData?: Pick<
 		IWorkflowExecutionDataProcess,
-		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId'
+		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId'
 	>;
 
 	/** Metadata about whether and how this execution's data was redacted. */


### PR DESCRIPTION
## Summary

Adds a globally accessible `$evaluation.runId` expression that resolves to the parent evaluation `TestRun.id` in **every execution of an eval run**, including sub-workflows. This lets evaluation workflows tag/consolidate per-test-case results and export them to external systems (e.g. X-Ray, Jira).

Previously the run id existed only server-side (in `TestRunMetadata` and via the `TestCaseExecution → TestRun` relation) and was never exposed to expressions, so there was no way to read it from inside a running workflow.

**How it works** — `evaluationRunId` is threaded from the test runner through `IWorkflowExecutionDataProcess` → `additionalData` → `getAdditionalKeys`, reusing the existing pattern used for `$execution`/`$vars`:

- Set as `evaluationRunId: metadata.testRunId` in `TestRunnerService.runTestCase` (regular + queue paths).
- Built into the `$evaluation` expression global in `getAdditionalKeys`, **gated on the value's presence (not on `mode`)** so sub-workflows — which run as `integrated` mode but inherit the id — still expose it.
- Carried across the queue boundary via the `manualData` `Pick` (v0 + v1).

No persistence or DTO changes — execution↔run grouping already exists via `TestCaseExecution.testRunId`; this PR only adds the expression surface.

> Note: the value is populated only for executions launched by the eval runner (mode `evaluation`). A plain manual "Execute workflow" has no `TestRun`, so `$evaluation.runId` is intentionally empty there.

## How to test

1. Create a workflow with an Evaluation Trigger + a dataset, and a Set node with a field set to `={{ $evaluation.runId }}`.
2. Run the evaluation from the **Evaluations** tab.
3. Open one of the resulting per-test-case executions (mode `evaluation`) and confirm the Set node output contains the run id, matching the `TestRun.id` shown in the eval UI.
4. Add an Execute Workflow node calling a sub-workflow that also reads `={{ $evaluation.runId }}` and confirm it resolves to the same id.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-187

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32843">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

