### PR TITLE
feat(core): Fix building incorrect chained nodes

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -141,7 +141,12 @@ When mapping downstream fields from an OpenAI node, read
    task's final deliverable.
 9. Trace wiring before declaring done. For IF, Switch, Merge, AI-agent, loop, or
    multi-workflow wiring, trace each branch from source to target. Confirm IF
-   outputs use `.onTrue()` and `.onFalse()`, Switch outputs use zero-based
+   branches are wired on the workflow builder (`.to(ifNode).onTrue(...).onFalse(...)`
+   or `.to(ifNode.onTrue(...).onFalse(...))`), not as standalone calls on the IF
+   node variable after `export default`. Confirm branch action nodes appear in the
+   saved graph — not just trigger → middle nodes → IF. Confirm the IF node has
+   connections on both outputs (true and false). For escalation flows, confirm
+   every requested side effect is on a wired branch. Switch outputs use zero-based
    `.onCase(index, target)`, Merge modes match the data shape, and sub-nodes are
    attached to the correct parent.
 10. Fix errors by editing the same workspace source file and calling
@@ -346,6 +351,9 @@ column names.
   Code node, even when the user asks to fetch inside a Code node.
 
 - Use `@n8n/workflow-sdk`.
+- `export default workflow(...)...` must be the last statement in the file, with
+  all wiring composed inside that chain. Statements after it (e.g.
+  `ifNode.onTrue(...)`) do not reach the builder and their nodes are dropped.
 - Do not specify node positions. They are auto-calculated by the layout engine.
 - Use `expr('{{ $json.field }}')` for n8n expressions. Variables must be inside
   `{{ }}`. `$json` is only the current item from the immediate predecessor.
@@ -425,7 +433,8 @@ Follow these rules strictly when generating workflows:
      feeding the per-item work and looping back via `nextBatch`.
    - Drop items that do not match a predicate: `filter`.
    - Two mutually exclusive paths that both do real work: IF with `.onTrue()`
-     and `.onFalse()`.
+     and `.onFalse()` wired on the workflow builder — never as standalone
+     statements on the IF node variable.
    - Many mutually exclusive paths keyed off a value: Switch with
      `.onCase(index, target)`.
    - Mandatory outcome when upstream can be empty (digest/alert must still send):
@@ -542,7 +551,11 @@ export default workflow('id', 'name')
   .to(processResults);
 ```
 
-For IF:
+For IF, each branch is a complete processing path. Wire branches on the workflow
+builder, not as standalone calls on the IF node variable. Chain steps inside a
+branch with `.to()`, or pass an array for parallel fan-out.
+Never call `.onFalse()` more than once (same for `.onTrue()`); each repeat
+overwrites the previous target.
 
 ```ts
 const isImportant = ifElse({
@@ -561,12 +574,29 @@ const isImportant = ifElse({
   },
 });
 
-source.to(isImportant);
-isImportant.onTrue(handleImportant);
-isImportant.onFalse(ignore);
+export default workflow('id', 'name')
+  .add(startTrigger)
+  .to(isImportant)
+  .onTrue(handleImportant)                               // single step
+  .onFalse(sendHolding.to(createTicket.to(alertSlack))); // chained multi-step
+// Equivalent inline form: .to(isImportant.onTrue(a).onFalse(b))
+// Parallel fan-out on a branch: .onFalse([a, b, c])
 ```
 
-For Switch, use zero-based `.onCase(index, target)` for each rule output.
+Do NOT wire branches as standalone statements.
+Then branch nodes are omitted from the saved graph, and repeated `.onFalse()`
+calls keep only the last target.
+
+```ts
+// WRONG
+export default workflow('id', 'name').add(startTrigger).to(isImportant);
+isImportant.onTrue(handleImportant); // never reaches the builder
+isImportant.onFalse(sendHolding);    // overwritten
+isImportant.onFalse(alertSlack);     // only this one would wire
+```
+
+For Switch, wire cases the same way — `.to(switchNode).onCase(0, a).onCase(1, b)`
+or inline — using zero-based `.onCase(index, target)` for each rule output.
 
 For Split in Batches, use it for per-item side effects and loop back with
 `nextBatch`. Do not add a separate IF gate just to check whether items exist.

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -126,6 +126,10 @@ describe('Instance AI runtime skills', () => {
 		);
 		expect(loaded?.instructions).toMatch(/inline setup card in the AI\s+Assistant panel/);
 		expect(loaded?.instructions).toContain('Do not call `delegate`');
+		expect(loaded?.instructions).toContain('.to(isImportant)');
+		expect(loaded?.instructions).toContain('.onTrue(handleImportant)');
+		expect(loaded?.instructions).toContain('Never call `.onFalse()` more than once');
+		expect(loaded?.instructions).toContain('branch nodes are omitted from the saved graph');
 	});
 
 	it('loads the bundled planning skill', async () => {


### PR DESCRIPTION
## Summary

Code generated after export default from the iai agent will end up being dropped. Add skill guidance for now, but it should be validated as well after code is generated. 

Right now this is what is generated:
```
export default workflow('whatsapp-faq-triage', 'WhatsApp FAQ Triage & Escalation')
  .add(whatsappTrigger)
  .to(triageAgent)
  .to(isResolved);

isResolved.onTrue(sendAnswer);
isResolved.onFalse(sendHolding);
isResolved.onFalse(createTicket);
isResolved.onFalse(alertSlack);
```

True:
```
export default workflow('whatsapp-faq-triage', 'WhatsApp FAQ Triage & Escalation')
  .add(whatsappTrigger)
  .to(triageAgent)
  .to(isResolved)
  .onTrue(sendAnswer)
  .onFalse(sendHolding.to(createTicket.to(alertSlack)));
```
## Related Linear tickets, Github issues, and Community forum posts
RESOLVES INS-635

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32844">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->