### PR TITLE
feat(core): Add folder export to n8n packages (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
@@ -27,6 +27,39 @@ describe('ExportPackageRequestDto', () => {
 		});
 	});
 
+	describe('folderIds', () => {
+		it('accepts a non-empty array of folder ids', () => {
+			const result = ExportPackageRequestDto.safeParse({ folderIds: ['fld-1'] });
+			expect(result.success).toBe(true);
+		});
+
+		it('accepts up to 300 folder ids', () => {
+			const folderIds = Array.from({ length: 300 }, (_, i) => `fld-${i}`);
+			expect(ExportPackageRequestDto.safeParse({ folderIds }).success).toBe(true);
+		});
+
+		it('accepts workflow and folder ids together', () => {
+			const result = ExportPackageRequestDto.safeParse({
+				workflowIds: ['wf-1'],
+				folderIds: ['fld-1'],
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it.each([
+			{ name: 'empty folderIds array', request: { folderIds: [] } },
+			{ name: 'empty-string folder id', request: { folderIds: [''] } },
+			{ name: 'whitespace-only folder id', request: { folderIds: ['   '] } },
+			{ name: 'non-string folder id', request: { folderIds: [123] } },
+			{
+				name: 'more than 300 folder ids',
+				request: { folderIds: Array.from({ length: 301 }, (_, i) => `fld-${i}`) },
+			},
+		])('rejects $name', ({ request }) => {
+			expect(ExportPackageRequestDto.safeParse(request).success).toBe(false);
+		});
+	});
+
 	describe('projectIds', () => {
 		it('accepts a non-empty array of project ids', () => {
 			const result = ExportPackageRequestDto.safeParse({ projectIds: ['project-1'] });

--- a/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
@@ -4,5 +4,6 @@ import { Z } from '../../zod-class';
 
 export class ExportPackageRequestDto extends Z.class({
 	workflowIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
+	folderIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	projectIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 }) {}

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -6,12 +6,14 @@ Export and import workflows as portable n8n packages (`.n8np` archives).
 
 ## `package export`
 
-Export workflows or projects into a gzipped `.n8np` archive written to disk.
-Provide workflow IDs or project IDs, but not both.
+Export workflows, folders, or projects into a gzipped `.n8np` archive written
+to disk. Each exported folder includes its nested folders. Provide workflow
+and/or folder IDs, or project IDs, but not both groups in the same command.
 
 ```bash
 n8n-cli package export --workflow-id=abc --output=export.n8np
 n8n-cli package export -w abc -w def -o team.n8np
+n8n-cli package export --folder-id=xyz -o folders.n8np
 n8n-cli package export --project-id=abc -o project.n8np
 n8n-cli package export -p abc -p def -o projects.n8np
 ```
@@ -19,12 +21,13 @@ n8n-cli package export -p abc -p def -o projects.n8np
 | Flag | Description |
 |------|-------------|
 | `-w, --workflow-id` | Workflow ID to include. Repeat the flag to export several. |
+| `-f, --folder-id` | Folder ID to include with its nested folders. Repeat the flag to export several. |
 | `-p, --project-id` | Project ID to include. Repeat the flag to export several. |
 | `-o, --output` | File to write the package to. Defaults to `export.n8np`. |
 
-Provide at least one `--workflow-id` or `--project-id`. Requires the API key to
-hold `workflow:export` when exporting workflows, or `project:export` when
-exporting projects.
+Provide at least one `--workflow-id`, `--folder-id`, or `--project-id`. Requires
+the API key to hold `workflow:export` when exporting workflows or folders, or
+`project:export` when exporting projects.
 
 ## `package import`
 

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -68,6 +68,24 @@ describe('N8nClient packages', () => {
 			expect(url).toBe('https://n8n.example.com/api/v1/n8n-packages/export');
 			expect(init.body).toBe(JSON.stringify({ projectIds: ['proj-1', 'proj-2'] }));
 		});
+
+		it('includes folderIds in the body when provided', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
+
+			await client.exportPackage({ workflowIds: ['a'], folderIds: ['f1'] });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'], folderIds: ['f1'] }));
+		});
+
+		it('omits an empty collection from the body', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
+
+			await client.exportPackage({ workflowIds: [], folderIds: ['f1'] });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.body).toBe(JSON.stringify({ folderIds: ['f1'] }));
+		});
 	});
 
 	describe('importPackage', () => {

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -9,14 +9,30 @@ vi.mock('node:fs');
 
 const mockedWriteFileSync = vi.mocked(fs.writeFileSync);
 
-/** The command methods we stub to isolate the file-writing behaviour from oclif/networking. */
+/** The command methods we stub to isolate behaviour from oclif/networking. */
 interface ExportInternals {
 	parse: () => Promise<{
-		flags: { workflowId?: string[]; projectId?: string[]; output: string };
+		flags: { workflowId?: string[]; folderId?: string[]; projectId?: string[]; output: string };
 	}>;
 	getClient: () => N8nClient;
 	succeed: () => void;
 	error: (message: string) => never;
+}
+
+function stubCommand(
+	flags: { workflowId?: string[]; folderId?: string[]; projectId?: string[]; output: string },
+	exportPackage = vi.fn().mockResolvedValue(Buffer.from([1, 2, 3])),
+) {
+	const command = new PackageExport([], {} as Config);
+	const internals = command as unknown as ExportInternals;
+	// Bypass oclif arg parsing, connection setup, and the success/exit path.
+	vi.spyOn(internals, 'parse').mockResolvedValue({ flags });
+	vi.spyOn(internals, 'getClient').mockReturnValue({ exportPackage } as unknown as N8nClient);
+	vi.spyOn(internals, 'succeed').mockImplementation(() => {});
+	vi.spyOn(internals, 'error').mockImplementation((message: string) => {
+		throw new Error(message);
+	});
+	return { command, internals, exportPackage };
 }
 
 describe('package export command', () => {
@@ -24,64 +40,84 @@ describe('package export command', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('writes workflow export bytes returned by the client to the --output path', async () => {
-		const archive = Buffer.from([1, 2, 3]);
-		const exportPackage = vi.fn().mockResolvedValue(archive);
-
-		const command = new PackageExport([], {} as Config);
-		const internals = command as unknown as ExportInternals;
-		vi.spyOn(internals, 'parse').mockResolvedValue({
-			flags: { workflowId: ['wf-1', 'wf-2'], output: '/tmp/team.n8np' },
-		});
-		vi.spyOn(internals, 'getClient').mockReturnValue({ exportPackage } as unknown as N8nClient);
-		vi.spyOn(internals, 'succeed').mockImplementation(() => {});
-		vi.spyOn(internals, 'error').mockImplementation((message: string) => {
-			throw new Error(message);
+	it('forwards workflow ids (and an empty folder list) and writes the archive', async () => {
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1', 'wf-2'],
+			output: '/tmp/team.n8np',
 		});
 
 		await command.run();
 
-		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: ['wf-1', 'wf-2'] });
-		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/team.n8np', archive);
+		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: ['wf-1', 'wf-2'], folderIds: [] });
+		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/team.n8np', Buffer.from([1, 2, 3]));
 	});
 
-	it('writes project export bytes returned by the client to the --output path', async () => {
-		const archive = Buffer.from([4, 5, 6]);
-		const exportPackage = vi.fn().mockResolvedValue(archive);
-
-		const command = new PackageExport([], {} as Config);
-		const internals = command as unknown as ExportInternals;
-		vi.spyOn(internals, 'parse').mockResolvedValue({
-			flags: { projectId: ['proj-1', 'proj-2'], output: '/tmp/projects.n8np' },
+	it('supports a folder-only export', async () => {
+		const { command, exportPackage } = stubCommand({
+			folderId: ['fld-1'],
+			output: '/tmp/folders.n8np',
 		});
-		vi.spyOn(internals, 'getClient').mockReturnValue({ exportPackage } as unknown as N8nClient);
-		vi.spyOn(internals, 'succeed').mockImplementation(() => {});
-		vi.spyOn(internals, 'error').mockImplementation((message: string) => {
-			throw new Error(message);
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: [], folderIds: ['fld-1'] });
+		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/folders.n8np', Buffer.from([1, 2, 3]));
+	});
+
+	it('supports exporting workflows and folders together', async () => {
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1'],
+			folderId: ['fld-1'],
+			output: '/tmp/mixed.n8np',
+		});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: ['wf-1'], folderIds: ['fld-1'] });
+	});
+
+	it('forwards project ids and writes the archive', async () => {
+		const { command, exportPackage } = stubCommand({
+			projectId: ['proj-1', 'proj-2'],
+			output: '/tmp/projects.n8np',
 		});
 
 		await command.run();
 
 		expect(exportPackage).toHaveBeenCalledWith({ projectIds: ['proj-1', 'proj-2'] });
-		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/projects.n8np', archive);
+		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/projects.n8np', Buffer.from([1, 2, 3]));
 	});
 
 	it('rejects providing both workflow and project IDs', async () => {
-		const command = new PackageExport([], {} as Config);
-		const internals = command as unknown as ExportInternals;
-		vi.spyOn(internals, 'parse').mockResolvedValue({
-			flags: {
-				workflowId: ['wf-1'],
-				projectId: ['proj-1'],
-				output: '/tmp/export.n8np',
-			},
-		});
-		vi.spyOn(internals, 'error').mockImplementation((message: string) => {
-			throw new Error(message);
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1'],
+			projectId: ['proj-1'],
+			output: '/tmp/export.n8np',
 		});
 
 		await expect(command.run()).rejects.toThrow(
-			'Provide either --workflow-id or --project-id, not both',
+			'Provide either --workflow-id/--folder-id or --project-id, not both',
 		);
+		expect(exportPackage).not.toHaveBeenCalled();
+	});
+
+	it('rejects providing both folder and project IDs', async () => {
+		const { command, exportPackage } = stubCommand({
+			folderId: ['fld-1'],
+			projectId: ['proj-1'],
+			output: '/tmp/export.n8np',
+		});
+
+		await expect(command.run()).rejects.toThrow(
+			'Provide either --workflow-id/--folder-id or --project-id, not both',
+		);
+		expect(exportPackage).not.toHaveBeenCalled();
+	});
+
+	it('errors when neither a workflow, folder, nor project is given', async () => {
+		const { command, exportPackage } = stubCommand({ output: '/tmp/empty.n8np' });
+
+		await expect(command.run()).rejects.toThrow(/at least one/i);
+		expect(exportPackage).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -421,11 +421,19 @@ export class N8nClient {
 
 	// ─── Packages (beta) ───────────────────────────────────────────
 
-	async exportPackage(
-		fields: { workflowIds: string[] } | { projectIds: string[] },
-	): Promise<Buffer> {
+	async exportPackage(fields: {
+		workflowIds?: string[];
+		folderIds?: string[];
+		projectIds?: string[];
+	}): Promise<Buffer> {
+		// Empty collections are dropped so the API's per-field "at least one" rule isn't tripped.
+		const body: { workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] } = {};
+		if (fields.workflowIds?.length) body.workflowIds = fields.workflowIds;
+		if (fields.folderIds?.length) body.folderIds = fields.folderIds;
+		if (fields.projectIds?.length) body.projectIds = fields.projectIds;
+
 		return await this.request<Buffer>('POST', '/n8n-packages/export', {
-			body: fields,
+			body,
 			responseType: 'binary',
 		});
 	}

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -5,11 +5,12 @@ import { toPackagesError } from './shared';
 import { BaseCommand } from '../../base-command';
 
 export default class PackageExport extends BaseCommand {
-	static override description = 'Export workflows or projects as an n8n package (.n8np)';
+	static override description = 'Export workflows, folders, or projects as an n8n package (.n8np)';
 
 	static override examples = [
 		'<%= config.bin %> package export --workflow-id=abc --output=export.n8np',
 		'<%= config.bin %> package export -w abc -w def -o team.n8np',
+		'<%= config.bin %> package export --folder-id=xyz -o folders.n8np',
 		'<%= config.bin %> package export --project-id=abc -o project.n8np',
 		'<%= config.bin %> package export -p abc -p def -o projects.n8np',
 	];
@@ -21,6 +22,12 @@ export default class PackageExport extends BaseCommand {
 			description: 'Workflow ID to include (repeat for multiple)',
 			multiple: true,
 			aliases: ['workflow-id'],
+		}),
+		folderId: Flags.string({
+			char: 'f',
+			description: 'Folder ID to include with its nested folders (repeat for multiple)',
+			multiple: true,
+			aliases: ['folder-id'],
 		}),
 		projectId: Flags.string({
 			char: 'p',
@@ -38,13 +45,15 @@ export default class PackageExport extends BaseCommand {
 	async run(): Promise<void> {
 		const { flags } = await this.parse(PackageExport);
 		const workflowIds = flags.workflowId ?? [];
+		const folderIds = flags.folderId ?? [];
 		const projectIds = flags.projectId ?? [];
 
-		if (workflowIds.length > 0 && projectIds.length > 0) {
-			this.error('Provide either --workflow-id or --project-id, not both');
+		// A package is either loose workflows/folders or whole projects, not both.
+		if (projectIds.length > 0 && (workflowIds.length > 0 || folderIds.length > 0)) {
+			this.error('Provide either --workflow-id/--folder-id or --project-id, not both');
 		}
-		if (workflowIds.length === 0 && projectIds.length === 0) {
-			this.error('At least one --workflow-id or --project-id is required');
+		if (workflowIds.length === 0 && folderIds.length === 0 && projectIds.length === 0) {
+			this.error('At least one --workflow-id, --folder-id, or --project-id is required');
 		}
 
 		await this.execute(async () => {
@@ -52,25 +61,26 @@ export default class PackageExport extends BaseCommand {
 			let archive: Buffer;
 			try {
 				archive = await client.exportPackage(
-					workflowIds.length > 0 ? { workflowIds } : { projectIds },
+					projectIds.length > 0 ? { projectIds } : { workflowIds, folderIds },
 				);
 			} catch (error) {
 				throw toPackagesError(error);
 			}
 			fs.writeFileSync(flags.output, archive);
 
-			if (workflowIds.length > 0) {
-				this.succeed(`Exported ${workflowIds.length} workflow(s) to ${flags.output}`, flags, {
+			if (projectIds.length > 0) {
+				this.succeed(`Exported ${projectIds.length} project(s) to ${flags.output}`, flags, {
 					output: flags.output,
-					workflowIds,
+					projectIds,
 				});
 				return;
 			}
 
-			this.succeed(`Exported ${projectIds.length} project(s) to ${flags.output}`, flags, {
-				output: flags.output,
-				projectIds,
-			});
+			this.succeed(
+				`Exported ${workflowIds.length} workflow(s) and ${folderIds.length} folder(s) to ${flags.output}`,
+				flags,
+				{ output: flags.output, workflowIds, folderIds },
+			);
 		});
 	}
 }

--- a/packages/@n8n/db/src/repositories/folder.repository.ts
+++ b/packages/@n8n/db/src/repositories/folder.repository.ts
@@ -386,6 +386,39 @@ export class FolderRepository extends Repository<Folder> {
 		return result.map((row) => row.id);
 	}
 
+	/**
+	 * Batched form of {@link getAllFolderIdsInHierarchy}: resolves the descendants
+	 * of several parent folders in a single recursive query rather than one query
+	 * per parent. Returns descendant ids only (the parents themselves are not
+	 * included), deduplicated across all subtrees.
+	 */
+	async getAllFolderIdsInSubtrees(parentFolderIds: string[]): Promise<string[]> {
+		if (parentFolderIds.length === 0) return [];
+
+		// Base case: the direct children of any requested parent.
+		const baseQuery = this.createQueryBuilder('f')
+			.select('f.id', 'id')
+			.where('f.parentFolderId IN (:...parentFolderIds)', { parentFolderIds });
+
+		// Recursive case: descendants of folders already in the tree.
+		const recursiveQuery = this.createQueryBuilder('child')
+			.select('child.id', 'id')
+			.innerJoin('folder_tree', 'parent', 'child.parentFolderId = parent.id');
+
+		const query = this.createQueryBuilder()
+			.addCommonTableExpression(
+				`${baseQuery.getQuery()} UNION ALL ${recursiveQuery.getQuery()}`,
+				'folder_tree',
+				{ recursive: true },
+			)
+			.select('DISTINCT tree.id', 'id')
+			.from('folder_tree', 'tree')
+			.setParameters(baseQuery.getParameters());
+
+		const result = await query.getRawMany<{ id: string }>();
+		return result.map((row) => row.id);
+	}
+
 	async getFolderPathsToRoot(folderIds: string[]): Promise<Map<string, string[]>> {
 		if (!folderIds.length) {
 			return new Map();

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2030,6 +2030,7 @@ describe('TelemetryEventRelay', () => {
 				user: { id: 'user123' },
 				counts: {
 					workflows: 3,
+					folders: 1,
 					credentials: 2,
 				},
 			};
@@ -2039,6 +2040,7 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.track).toHaveBeenCalledWith('User exported n8n package', {
 				user_id: 'user123',
 				workflow_count: 3,
+				folder_count: 1,
 				credential_count: 2,
 			});
 		});

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -975,6 +975,7 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.track('User exported n8n package', {
 			user_id: user.id,
 			workflow_count: counts.workflows,
+			folder_count: counts.folders,
 			credential_count: counts.credentials,
 		});
 	}

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
@@ -101,11 +101,12 @@ describe('folder package export', () => {
 		}
 	});
 
-	it('preserves nesting when exporting a folder that contains a nested folder', async () => {
+	it('preserves nesting through multiple levels when exporting a folder subtree', async () => {
 		const owner = await createOwner();
 		const project = await createTeamProject('Project A', owner);
 		const parent = await createFolder(project, { name: 'in_progress' });
 		const child = await createFolder(project, { name: 'nested', parentFolder: parent });
+		const grandchild = await createFolder(project, { name: 'deep', parentFolder: child });
 
 		const stream = await service.exportPackage({
 			user: owner,
@@ -114,14 +115,18 @@ describe('folder package export', () => {
 		});
 		const { manifest, entries } = await readExport(stream);
 
-		expect(manifest.folders).toHaveLength(2);
+		expect(manifest.folders).toHaveLength(3);
 		const parentEntry = manifest.folders!.find((f) => f.id === parent.id)!;
 		const childEntry = manifest.folders!.find((f) => f.id === child.id)!;
+		const grandchildEntry = manifest.folders!.find((f) => f.id === grandchild.id)!;
 
-		// Child nests directly under the parent dir, no repeated "folders/" segment.
+		// Each level nests directly under its parent dir — recursion reaches beyond
+		// the first nesting level, with no repeated "folders/" segment.
 		expect(childEntry.target).toMatch(new RegExp(`^${parentEntry.target}/[^/]+$`));
+		expect(grandchildEntry.target).toMatch(new RegExp(`^${childEntry.target}/[^/]+$`));
 		expect(folderShell(entries, parentEntry.target).parentFolderId).toBeNull();
 		expect(folderShell(entries, childEntry.target).parentFolderId).toBe(parent.id);
+		expect(folderShell(entries, grandchildEntry.target).parentFolderId).toBe(child.id);
 	});
 
 	it('disambiguates same-named sibling folders by creation order', async () => {

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
@@ -1,0 +1,195 @@
+import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+
+import { createFolder } from '@test-integration/db/folders';
+import { createMember, createOwner } from '@test-integration/db/users';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import { readExport } from './utils/tar-support';
+
+type ExportEntries = Awaited<ReturnType<typeof readExport>>['entries'];
+
+function folderShell(entries: ExportEntries, target: string): Record<string, unknown> {
+	const file = entries.find((e) => e.name === `${target}/folder.json`);
+	if (!file) throw new Error(`missing ${target}/folder.json`);
+	return jsonParse<Record<string, unknown>>(file.content.toString());
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'Folder',
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'ProjectRelation',
+		'Project',
+	]);
+});
+
+describe('folder package export', () => {
+	let service: N8nPackagesService;
+
+	beforeAll(() => {
+		service = Container.get(N8nPackagesService);
+	});
+
+	it('exports an empty folder as a folder.json shell with a manifest pointer', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'to_production' });
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [folder.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.folders).toHaveLength(1);
+		expect(manifest.folders![0]).toMatchObject({ id: folder.id, name: 'to_production' });
+		const target = manifest.folders![0].target;
+		expect(target).toMatch(/^folders\//);
+
+		const folderFile = entries.find((e) => e.name === `${target}/folder.json`);
+		expect(folderFile).toBeDefined();
+		expect(jsonParse(folderFile!.content.toString())).toEqual({
+			id: folder.id,
+			name: 'to_production',
+			parentFolderId: null,
+		});
+	});
+
+	it('aborts the export when the user cannot access the folder', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'to_production' });
+		const outsider = await createMember();
+
+		await expect(
+			service.exportPackage({ user: outsider, workflowIds: [], folderIds: [folder.id] }),
+		).rejects.toThrow(/not found or not accessible/);
+	});
+
+	it('exports two sibling empty folders as separate shells', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const toProduction = await createFolder(project, { name: 'to_production' });
+		const inProgress = await createFolder(project, { name: 'in_progress' });
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [toProduction.id, inProgress.id],
+		});
+		const { manifest } = await readExport(stream);
+
+		expect(manifest.folders).toHaveLength(2);
+		expect(manifest.folders!.map((f) => f.id).sort()).toEqual(
+			[toProduction.id, inProgress.id].sort(),
+		);
+		for (const entry of manifest.folders!) {
+			expect(entry.target).toMatch(/^folders\/[^/]+$/);
+		}
+	});
+
+	it('preserves nesting when exporting a folder that contains a nested folder', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const parent = await createFolder(project, { name: 'in_progress' });
+		const child = await createFolder(project, { name: 'nested', parentFolder: parent });
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [parent.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.folders).toHaveLength(2);
+		const parentEntry = manifest.folders!.find((f) => f.id === parent.id)!;
+		const childEntry = manifest.folders!.find((f) => f.id === child.id)!;
+
+		// Child nests directly under the parent dir, no repeated "folders/" segment.
+		expect(childEntry.target).toMatch(new RegExp(`^${parentEntry.target}/[^/]+$`));
+		expect(folderShell(entries, parentEntry.target).parentFolderId).toBeNull();
+		expect(folderShell(entries, childEntry.target).parentFolderId).toBe(parent.id);
+	});
+
+	it('disambiguates same-named sibling folders by creation order', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const older = await createFolder(project, {
+			name: 'in_progress',
+			createdAt: new Date('2026-01-01T00:00:00.000Z'),
+		});
+		const newer = await createFolder(project, {
+			name: 'in_progress',
+			createdAt: new Date('2026-02-01T00:00:00.000Z'),
+		});
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [older.id, newer.id],
+		});
+		const { manifest } = await readExport(stream);
+
+		const olderTarget = manifest.folders!.find((f) => f.id === older.id)!.target;
+		const newerTarget = manifest.folders!.find((f) => f.id === newer.id)!.target;
+		// Oldest keeps the bare slug; the allocator suffixes the newer one.
+		expect(olderTarget).toBe('folders/inprogress');
+		expect(newerTarget).toBe('folders/inprogress-2');
+	});
+
+	it('re-roots an exported folder whose parent is left out of the export', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const parent = await createFolder(project, { name: 'in_progress' });
+		const child = await createFolder(project, { name: 'nested', parentFolder: parent });
+
+		// Request only the child; its real parent stays behind.
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [child.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		// Only the child ships, and it roots the package's forest.
+		expect(manifest.folders).toHaveLength(1);
+		const childEntry = manifest.folders![0];
+		expect(childEntry).toMatchObject({ id: child.id, name: 'nested' });
+		expect(childEntry.target).toMatch(/^folders\/[^/]+$/);
+		// Its out-of-set parent ref is severed so every parent ref resolves in-package.
+		expect(folderShell(entries, childEntry.target).parentFolderId).toBeNull();
+	});
+
+	it('aborts the whole export when any requested folder is inaccessible', async () => {
+		const member = await createMember();
+		const accessibleProject = await createTeamProject('Member project', member);
+		const accessibleFolder = await createFolder(accessibleProject, { name: 'to_production' });
+
+		const owner = await createOwner();
+		const foreignProject = await createTeamProject('Owner project', owner);
+		const inaccessibleFolder = await createFolder(foreignProject, { name: 'secret' });
+
+		// The member can read accessibleFolder but not inaccessibleFolder; one bad id
+		// poisons the batch, so the export aborts rather than shipping a partial set.
+		await expect(
+			service.exportPackage({
+				user: member,
+				workflowIds: [],
+				folderIds: [accessibleFolder.id, inaccessibleFolder.id],
+			}),
+		).rejects.toThrow(/1 folder\(s\) not found or not accessible/);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
@@ -1,0 +1,46 @@
+import type { Folder, User } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { FolderFinderService } from '@/services/folder-finder.service';
+
+import { CapturingWriter } from '../../../io/__tests__/utils/capturing-writer';
+import { FolderExporter } from '../folder.exporter';
+import { FolderSerializer } from '../folder.serializer';
+
+const user = mock<User>({ id: 'user-1' });
+
+function makeFolder(overrides: Partial<Folder> = {}): Folder {
+	return {
+		id: 'fld-1',
+		name: 'to_production',
+		parentFolderId: null,
+		createdAt: new Date('2026-01-01T00:00:00.000Z'),
+		...overrides,
+	} as unknown as Folder;
+}
+
+function makeExporter(found: Folder[]) {
+	const finder = mock<FolderFinderService>();
+	finder.findFolderSubtreesForUser.mockResolvedValue(found);
+	return new FolderExporter(finder, new FolderSerializer());
+}
+
+// The folder-export behaviour (shells, nesting, re-rooting, sibling ordering,
+// access control) is proven end-to-end in export-folder.integration.test.ts.
+// Only `basePrefix` is left here: it's the composition seam a ProjectExporter
+// uses (LIGO-685) and is unreachable through service.exportPackage, so the
+// integration test cannot cover it.
+describe('FolderExporter', () => {
+	it('honors basePrefix so the tree composes under a project namespace', async () => {
+		const exporter = makeExporter([makeFolder()]);
+
+		const { entries } = await exporter.export({
+			user,
+			folderIds: ['fld-1'],
+			writer: new CapturingWriter(),
+			basePrefix: 'projects/team-ligo',
+		});
+
+		expect(entries[0].target).toMatch(/^projects\/team-ligo\/folders\//);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
@@ -1,0 +1,147 @@
+import type { Folder, User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { UserError } from 'n8n-workflow';
+
+import { FolderFinderService } from '@/services/folder-finder.service';
+
+import { FolderSerializer } from './folder.serializer';
+import type { PackageWriter } from '../../io/package-writer';
+import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
+import type { ManifestEntry } from '../../spec/manifest.schema';
+
+export interface FolderExportRequest {
+	user: User;
+	folderIds: string[];
+	writer: PackageWriter;
+	/**
+	 * Directory the folder tree is written under. Empty for a top-level folder
+	 * export (`folders/...`); a project exporter passes `projects/<slug>` so the
+	 * same walk nests under `projects/<slug>/folders/...`.
+	 */
+	basePrefix?: string;
+}
+
+export interface FolderExportResult {
+	entries: ManifestEntry[];
+}
+
+@Service()
+export class FolderExporter {
+	constructor(
+		private readonly folderFinder: FolderFinderService,
+		private readonly folderSerializer: FolderSerializer,
+	) {}
+
+	async export(request: FolderExportRequest): Promise<FolderExportResult> {
+		const folders = await this.folderFinder.findFolderSubtreesForUser(
+			request.folderIds,
+			request.user,
+			['folder:read'],
+		);
+
+		this.assertAllRequestedFoldersFound(request.folderIds, folders);
+
+		const { roots, childrenByParent } = this.buildForest(folders);
+
+		const foldersDir = request.basePrefix ? `${request.basePrefix}/folders` : 'folders';
+		const entries = this.writeLevel(roots, foldersDir, null, childrenByParent, request.writer);
+
+		return { entries };
+	}
+
+	/**
+	 * Groups the exported folders into a forest. A folder whose parent is also in
+	 * the exported set nests under it; any other folder roots the forest and is
+	 * re-rooted (its serialized `parentFolderId` becomes null), so every parent
+	 * reference in the package resolves in-package.
+	 */
+	private buildForest(folders: Folder[]): {
+		roots: Folder[];
+		childrenByParent: Map<string, Folder[]>;
+	} {
+		const idsInSet = new Set(folders.map((folder) => folder.id));
+		const roots: Folder[] = [];
+		const childrenByParent = new Map<string, Folder[]>();
+
+		for (const folder of folders) {
+			const parentId = folder.parentFolderId;
+			if (parentId && idsInSet.has(parentId)) {
+				const siblings = childrenByParent.get(parentId) ?? [];
+				siblings.push(folder);
+				childrenByParent.set(parentId, siblings);
+			} else {
+				roots.push(folder);
+			}
+		}
+
+		return { roots, childrenByParent };
+	}
+
+	/**
+	 * Writes a set of sibling folders and their descendants under `parentDir`,
+	 * returning a manifest entry for each. A fresh allocator per call scopes slug
+	 * collisions to the parent directory; sub-folders nest directly (no repeated
+	 * `folders/` segment).
+	 */
+	private writeLevel(
+		siblings: Folder[],
+		parentDir: string,
+		effectiveParentId: string | null,
+		childrenByParent: Map<string, Folder[]>,
+		writer: PackageWriter,
+	): ManifestEntry[] {
+		const allocator = new UniqueFilenameAllocator(parentDir, 'folder');
+		const entries: ManifestEntry[] = [];
+
+		for (const folder of this.orderedByCreation(siblings)) {
+			const target = allocator.allocate(folder.name);
+			const serialized = this.folderSerializer.serialize(folder, effectiveParentId);
+
+			writer.writeDirectory(target);
+			writer.writeFile(`${target}/folder.json`, JSON.stringify(serialized, null, '\t'));
+
+			const children = childrenByParent.get(folder.id) ?? [];
+			entries.push(
+				{ id: folder.id, name: folder.name, target },
+				...this.writeLevel(children, target, folder.id, childrenByParent, writer),
+			);
+		}
+
+		return entries;
+	}
+
+	/**
+	 * Sorts siblings oldest-first (tie-broken by id) so that when two folders in
+	 * the same parent share a name, the oldest keeps the bare slug and the
+	 * allocator suffixes the rest deterministically.
+	 */
+	private orderedByCreation(folders: Folder[]): Folder[] {
+		return [...folders].sort((a, b) => {
+			const byCreatedAt = a.createdAt.getTime() - b.createdAt.getTime();
+			if (byCreatedAt !== 0) return byCreatedAt;
+			return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+		});
+	}
+
+	private assertAllRequestedFoldersFound(
+		requestedFolderIds: string[],
+		foundFolders: Array<{ id: string }>,
+	) {
+		const foundFolderIds = new Set(foundFolders.map(({ id }) => id));
+		const missingFolderIds = requestedFolderIds.filter((id) => !foundFolderIds.has(id));
+
+		if (missingFolderIds.length > 0) {
+			const displayedFolderIds = missingFolderIds.slice(0, 20);
+			const omittedCount = missingFolderIds.length - displayedFolderIds.length;
+
+			throw new UserError(
+				`${missingFolderIds.length} folder(s) not found or not accessible. Export aborted.`,
+				{
+					description: `Missing folder IDs: ${displayedFolderIds.join(', ')}${
+						omittedCount > 0 ? `, and ${omittedCount} more` : ''
+					}`,
+				},
+			);
+		}
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.serializer.ts
@@ -1,0 +1,21 @@
+import type { Folder } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { serializedFolderSchema, type SerializedFolder } from '../../spec/serialized/folder.schema';
+
+@Service()
+export class FolderSerializer {
+	/**
+	 * Serializes a folder into its package shell. The exporter passes the
+	 * `parentFolderId` it computed relative to the exported set (null when the
+	 * folder roots the exported forest), so we deliberately ignore the entity's
+	 * own parent.
+	 */
+	serialize(folder: Folder, parentFolderId: string | null): SerializedFolder {
+		return serializedFolderSchema.parse({
+			id: folder.id,
+			name: folder.name,
+			parentFolderId,
+		});
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -7,6 +7,7 @@ import { EventService } from '@/events/event.service';
 
 import { ImportPipeline } from './engine/import-pipeline';
 import { CredentialExporter } from './entities/credential/credential.exporter';
+import { FolderExporter } from './entities/folder/folder.exporter';
 import { ProjectExporter } from './entities/project/project.exporter';
 import { WorkflowExporter } from './entities/workflow/workflow.exporter';
 import { TarPackageWriter } from './io/tar/tar-package-writer';
@@ -23,6 +24,7 @@ export class N8nPackagesService {
 	constructor(
 		private readonly projectExporter: ProjectExporter,
 		private readonly workflowExporter: WorkflowExporter,
+		private readonly folderExporter: FolderExporter,
 		private readonly credentialExporter: CredentialExporter,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly importPipeline: ImportPipeline,
@@ -32,6 +34,7 @@ export class N8nPackagesService {
 	async exportPackage(request: ExportPackageRequest): Promise<Readable> {
 		const writer = new TarPackageWriter();
 		const workflowIds = request.workflowIds ?? [];
+		const folderIds = request.folderIds ?? [];
 		const projectIds = request.projectIds ?? [];
 
 		const workflowExportResult =
@@ -39,6 +42,15 @@ export class N8nPackagesService {
 				? await this.workflowExporter.export({
 						user: request.user,
 						workflowIds,
+						writer,
+					})
+				: undefined;
+
+		const folderExportResult =
+			folderIds.length > 0
+				? await this.folderExporter.export({
+						user: request.user,
+						folderIds,
 						writer,
 					})
 				: undefined;
@@ -70,6 +82,7 @@ export class N8nPackagesService {
 				? { requirements: { credentials: credentialExportResult.requirements } }
 				: {}),
 			...(workflowExportResult?.entries ? { workflows: workflowExportResult.entries } : {}),
+			...(folderExportResult?.entries ? { folders: folderExportResult.entries } : {}),
 			...(projectExportResult?.entries ? { projects: projectExportResult.entries } : {}),
 		});
 
@@ -82,6 +95,7 @@ export class N8nPackagesService {
 			user: request.user,
 			counts: {
 				workflows: workflowExportResult?.entries.length ?? 0,
+				folders: folderExportResult?.entries.length ?? 0,
 				credentials: credentialExportResult.entries.length,
 			},
 		});

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -38,6 +38,7 @@ export type WorkflowIdPolicy = (typeof WorkflowIdPolicy)[keyof typeof WorkflowId
 export interface ExportPackageRequest {
 	user: User;
 	workflowIds?: string[];
+	folderIds?: string[];
 	projectIds?: string[];
 }
 
@@ -104,6 +105,7 @@ export type ImportPackageEventCounts = {
 /** Per-entity counts for an export, carried on `n8n-package-exported` for telemetry. */
 export type ExportPackageEventCounts = {
 	workflows: number;
+	folders: number;
 	credentials: number;
 };
 

--- a/packages/cli/src/modules/n8n-packages/spec/__tests__/manifest.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/__tests__/manifest.schema.test.ts
@@ -45,6 +45,27 @@ describe('packageManifestSchema', () => {
 		expect(() => packageManifestSchema.parse(manifest)).toThrow(/duplicate credential id/i);
 	});
 
+	it('preserves a folders section', () => {
+		const manifest = {
+			...validManifest,
+			folders: [{ id: 'fld-1', name: 'to_production', target: 'folders/to_production' }],
+		};
+
+		expect(packageManifestSchema.parse(manifest).folders).toEqual(manifest.folders);
+	});
+
+	it('rejects a manifest containing duplicate folder ids', () => {
+		const manifest = {
+			...validManifest,
+			folders: [
+				{ id: 'fld-1', name: 'First', target: 'folders/first' },
+				{ id: 'fld-1', name: 'Second', target: 'folders/nested/second' },
+			],
+		};
+
+		expect(() => packageManifestSchema.parse(manifest)).toThrow(/duplicate folder id/i);
+	});
+
 	it('accepts manifests with unknown sections for forward compatibility', () => {
 		const manifest = {
 			...validManifest,

--- a/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/manifest.schema.ts
@@ -9,23 +9,23 @@ export const manifestEntrySchema = z.object({
 	target: z.string().min(1),
 });
 
-type ManifestEntryInput = z.infer<typeof manifestEntrySchema>;
+type ManifestEntryList = Array<z.infer<typeof manifestEntrySchema>>;
 
 function assertNoDuplicateIds(
-	items: Array<Pick<ManifestEntryInput, 'id'>> | undefined,
+	entries: ManifestEntryList | undefined,
+	label: string,
 	ctx: z.RefinementCtx,
-): void {
-	if (!items) return;
-
-	const seenIds = new Set<string>();
-	for (const item of items) {
-		if (seenIds.has(item.id)) {
+) {
+	if (!entries) return;
+	const seen = new Set<string>();
+	for (const entry of entries) {
+		if (seen.has(entry.id)) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: `Duplicate id in manifest: ${item.id}`,
+				message: `Duplicate ${label} id in manifest: ${entry.id}`,
 			});
 		}
-		seenIds.add(item.id);
+		seen.add(entry.id);
 	}
 }
 
@@ -36,14 +36,16 @@ export const packageManifestSchema = z
 		sourceN8nVersion: z.string().min(1),
 		sourceId: z.string().min(1),
 		workflows: z.array(manifestEntrySchema).optional(),
+		folders: z.array(manifestEntrySchema).optional(),
 		projects: z.array(manifestEntrySchema).optional(),
 		credentials: z.array(manifestEntrySchema).optional(),
 		requirements: packageRequirementsSchema.optional(),
 	})
 	.superRefine((manifest, ctx) => {
-		assertNoDuplicateIds(manifest.workflows, ctx);
-		assertNoDuplicateIds(manifest.projects, ctx);
-		assertNoDuplicateIds(manifest.credentials, ctx);
+		assertNoDuplicateIds(manifest.workflows, 'workflow', ctx);
+		assertNoDuplicateIds(manifest.folders, 'folder', ctx);
+		assertNoDuplicateIds(manifest.projects, 'project', ctx);
+		assertNoDuplicateIds(manifest.credentials, 'credential', ctx);
 	});
 
 export type ManifestEntry = z.infer<typeof manifestEntrySchema>;

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/folder.schema.test.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/__tests__/folder.schema.test.ts
@@ -1,0 +1,38 @@
+import { serializedFolderSchema } from '../folder.schema';
+
+describe('serializedFolderSchema', () => {
+	it('accepts a folder shell with a null parentFolderId (re-rooted folder)', () => {
+		const folder = { id: 'fld-1', name: 'to_production', parentFolderId: null };
+
+		expect(() => serializedFolderSchema.parse(folder)).not.toThrow();
+	});
+
+	it('accepts a folder shell whose parent is present in the package', () => {
+		const folder = { id: 'fld-2', name: 'nested', parentFolderId: 'fld-1' };
+
+		expect(() => serializedFolderSchema.parse(folder)).not.toThrow();
+	});
+
+	it('rejects unknown keys', () => {
+		const folder = {
+			id: 'fld-1',
+			name: 'to_production',
+			parentFolderId: null,
+			createdAt: '2026-01-01T00:00:00.000Z',
+		};
+
+		expect(() => serializedFolderSchema.parse(folder)).toThrow();
+	});
+
+	it('requires parentFolderId to be present (nullable, not optional)', () => {
+		const folder = { id: 'fld-1', name: 'to_production' };
+
+		expect(() => serializedFolderSchema.parse(folder)).toThrow();
+	});
+
+	it('rejects an empty id', () => {
+		const folder = { id: '', name: 'to_production', parentFolderId: null };
+
+		expect(() => serializedFolderSchema.parse(folder)).toThrow();
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/spec/serialized/folder.schema.ts
+++ b/packages/cli/src/modules/n8n-packages/spec/serialized/folder.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const serializedFolderSchema = z
+	.object({
+		id: z.string().min(1),
+		name: z.string().min(1),
+		// Parent relative to the exported set: a folder that roots the exported
+		// forest serializes `null`; a folder whose parent is also in the package
+		// keeps that parent's id, so every reference resolves in-package.
+		parentFolderId: z.string().nullable(),
+	})
+	.strict();
+
+export type SerializedFolder = z.infer<typeof serializedFolderSchema>;

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -31,7 +31,7 @@ describe('n8n-packages handler', () => {
 	let mockService: Mocked<N8nPackagesService>;
 
 	function makeRequest(
-		body: { workflowIds?: string[]; projectIds?: string[] },
+		body: { workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] },
 		apiKeyScopes?: string[],
 	) {
 		return {
@@ -93,17 +93,33 @@ describe('n8n-packages handler', () => {
 
 		expect(caught).toBeInstanceOf(BadRequestError);
 		expect(caught).toMatchObject({
-			message: 'Provide either workflowIds or projectIds, not both',
+			message: 'Provide either workflowIds/folderIds or projectIds, not both',
 		});
 		expect(mockService.exportPackage).not.toHaveBeenCalled();
 	});
 
-	it('throws BadRequestError when neither workflowIds nor projectIds are provided', async () => {
+	it('throws BadRequestError when folderIds and projectIds are both provided', async () => {
+		const caught = await run(
+			makeRequest({ folderIds: ['fld-1'], projectIds: ['project-1'] }, [
+				'workflow:export',
+				'project:export',
+			]),
+			makeResponse(),
+		);
+
+		expect(caught).toBeInstanceOf(BadRequestError);
+		expect(caught).toMatchObject({
+			message: 'Provide either workflowIds/folderIds or projectIds, not both',
+		});
+		expect(mockService.exportPackage).not.toHaveBeenCalled();
+	});
+
+	it('throws BadRequestError when neither workflowIds, folderIds nor projectIds are provided', async () => {
 		const caught = await run(makeRequest({}, ['workflow:export']), makeResponse());
 
 		expect(caught).toBeInstanceOf(BadRequestError);
 		expect(caught).toMatchObject({
-			message: 'At least one workflowId or projectId is required',
+			message: 'At least one workflowId, folderId, or projectId is required',
 		});
 		expect(mockService.exportPackage).not.toHaveBeenCalled();
 	});
@@ -135,6 +151,16 @@ describe('n8n-packages handler', () => {
 		expect(mockService.exportPackage).not.toHaveBeenCalled();
 	});
 
+	it('throws ForbiddenError when exporting folders without workflow:export scope', async () => {
+		const caught = await run(
+			makeRequest({ folderIds: ['fld-1'] }, ['project:export']),
+			makeResponse(),
+		);
+
+		expect(caught).toBeInstanceOf(ForbiddenError);
+		expect(mockService.exportPackage).not.toHaveBeenCalled();
+	});
+
 	it('streams the export for a valid workflow request', async () => {
 		const stream = new PassThrough();
 		mockService.exportPackage.mockResolvedValue(stream);
@@ -151,6 +177,7 @@ describe('n8n-packages handler', () => {
 		expect(mockService.exportPackage).toHaveBeenCalledWith({
 			user: { id: 'user-1' },
 			workflowIds: ['wf-1', 'wf-2'],
+			folderIds: [],
 			projectIds: [],
 		});
 		expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/gzip');
@@ -173,7 +200,26 @@ describe('n8n-packages handler', () => {
 		expect(mockService.exportPackage).toHaveBeenCalledWith({
 			user: { id: 'user-1' },
 			workflowIds: [],
+			folderIds: [],
 			projectIds: ['project-1'],
+		});
+	});
+
+	it('streams the export for a valid folder request', async () => {
+		const stream = new PassThrough();
+		mockService.exportPackage.mockResolvedValue(stream);
+		const res = makeResponse();
+
+		const resultPromise = run(makeRequest({ folderIds: ['fld-1'] }, ['workflow:export']), res);
+		stream.end(Buffer.from('package-bytes'));
+		const caught = await resultPromise;
+
+		expect(caught).toBeUndefined();
+		expect(mockService.exportPackage).toHaveBeenCalledWith({
+			user: { id: 'user-1' },
+			workflowIds: [],
+			folderIds: ['fld-1'],
+			projectIds: [],
 		});
 	});
 });

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -91,9 +91,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 
 			// A package is either a set of loose workflows/folders or a set of whole projects, not both.
 			if (projectIds.length > 0 && (workflowIds.length > 0 || folderIds.length > 0)) {
-				throw new BadRequestError(
-					'Provide either workflowIds/folderIds or projectIds, not both',
-				);
+				throw new BadRequestError('Provide either workflowIds/folderIds or projectIds, not both');
 			}
 
 			if (workflowIds.length === 0 && folderIds.length === 0 && projectIds.length === 0) {

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -22,7 +22,7 @@ const PACKAGE_EXPORT_SCOPES = 'project:export,workflow:export';
 type ExportPackageRequest = AuthenticatedRequest<
 	{},
 	{},
-	{ workflowIds?: string[]; projectIds?: string[] }
+	{ workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] }
 >;
 
 type ImportPackageRequest = PackageRequest.Import & {
@@ -37,6 +37,7 @@ type N8nPackagesHandlers = {
 function assertPackageExportApiKeyScopes(
 	req: AuthenticatedRequest,
 	workflowIds: string[],
+	folderIds: string[],
 	projectIds: string[],
 ) {
 	const apiKeyScopes = req.tokenGrant?.apiKeyScopes;
@@ -45,7 +46,8 @@ function assertPackageExportApiKeyScopes(
 	}
 
 	const requiredScopes: ApiKeyScope[] = [];
-	if (workflowIds.length > 0) {
+	// Folders are exported as a workflow-organization concern, so they share the workflow:export scope.
+	if (workflowIds.length > 0 || folderIds.length > 0) {
 		requiredScopes.push('workflow:export');
 	}
 	if (projectIds.length > 0) {
@@ -82,22 +84,28 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 			if (!payload.success) {
 				throw new BadRequestError(payload.error.errors.map(({ message }) => message).join('; '));
 			}
-			if (payload.data.workflowIds && payload.data.projectIds) {
-				throw new BadRequestError('Provide either workflowIds or projectIds, not both');
-			}
 
 			const workflowIds = payload.data.workflowIds ?? [];
+			const folderIds = payload.data.folderIds ?? [];
 			const projectIds = payload.data.projectIds ?? [];
 
-			if (workflowIds.length === 0 && projectIds.length === 0) {
-				throw new BadRequestError('At least one workflowId or projectId is required');
+			// A package is either a set of loose workflows/folders or a set of whole projects, not both.
+			if (projectIds.length > 0 && (workflowIds.length > 0 || folderIds.length > 0)) {
+				throw new BadRequestError(
+					'Provide either workflowIds/folderIds or projectIds, not both',
+				);
 			}
 
-			assertPackageExportApiKeyScopes(req, workflowIds, projectIds);
+			if (workflowIds.length === 0 && folderIds.length === 0 && projectIds.length === 0) {
+				throw new BadRequestError('At least one workflowId, folderId, or projectId is required');
+			}
+
+			assertPackageExportApiKeyScopes(req, workflowIds, folderIds, projectIds);
 
 			const stream = await Container.get(N8nPackagesService).exportPackage({
 				user: req.user,
 				workflowIds,
+				folderIds,
 				projectIds,
 			});
 

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.export.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.export.yml
@@ -4,19 +4,20 @@ post:
   x-eov-operation-handler: v1/handlers/n8n-packages/n8n-packages.handler
   tags:
     - N8nPackage
-  summary: 'Beta: Export workflows and projects as an n8n package'
+  summary: 'Beta: Export workflows, folders, or projects as an n8n package'
   description: |
     **Beta** — breaking changes may still occur without major version bump.
 
-    Export either workflows or projects as a gzipped tar archive (.n8np).
-    Provide `workflowIds` or `projectIds`, but not both. Empty projects export
-    project metadata only. The response is streamed as `application/gzip` with a
-    `Content-Disposition` attachment header. Requires the n8n Packages feature to be
-    licensed.
+    Export workflows and/or folders, or projects, as a gzipped tar archive
+    (.n8np). Provide `workflowIds`/`folderIds`, or `projectIds`, but not both
+    groups. Each exported folder includes its nested folders. Empty projects
+    export project metadata only. The response is streamed as `application/gzip`
+    with a `Content-Disposition` attachment header. Requires the n8n Packages
+    feature to be licensed.
 
-    API key scopes: `workflow:export` is required when exporting workflows, and `project:export` is required when exporting projects.
+    API key scopes: `workflow:export` is required when exporting workflows or folders, and `project:export` is required when exporting projects.
   requestBody:
-    description: Workflows or projects to include in the exported package.
+    description: Workflows, folders, or projects to include in the exported package.
     required: true
     content:
       application/json:

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -1,5 +1,9 @@
 type: object
 additionalProperties: false
+description: >-
+  Selects what to export. Provide `workflowIds` and/or `folderIds` to export
+  loose workflows and folders, or `projectIds` to export whole projects, but not
+  both groups in the same request. At least one id must be supplied.
 properties:
   workflowIds:
     type: array
@@ -10,6 +14,17 @@ properties:
       minLength: 1
     example:
       - 2tUt1wbLX592XDdX
+  folderIds:
+    type: array
+    maxItems: 300
+    description: >-
+      IDs of the folders to include in the exported package. Each folder is
+      exported with its nested folders.
+    items:
+      type: string
+      minLength: 1
+    example:
+      - 9xKp2mNqRzAbCdEf
   projectIds:
     type: array
     description: IDs of the projects to include in the exported package.

--- a/packages/cli/src/services/__tests__/folder-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/folder-finder.service.test.ts
@@ -61,23 +61,28 @@ describe('FolderFinderService', () => {
 	});
 
 	describe('findFolderSubtreesForUser', () => {
-		it('loads each requested folder together with its descendants', async () => {
-			const parent = makeFolder({ id: 'parent' });
-			const child = makeFolder({ id: 'child', parentFolderId: 'parent' });
-			const { finder, folderRepository } = makeFinder([parent, child]);
-			folderRepository.getAllFolderIdsInHierarchy.mockResolvedValue(['child']);
+		it('resolves all requested folders and their descendants in a single batched query', async () => {
+			const parentA = makeFolder({ id: 'parentA' });
+			const parentB = makeFolder({ id: 'parentB' });
+			const childA = makeFolder({ id: 'childA', parentFolderId: 'parentA' });
+			const { finder, folderRepository } = makeFinder([parentA, parentB, childA]);
+			folderRepository.getAllFolderIdsInSubtrees.mockResolvedValue(['childA']);
 
-			const result = await finder.findFolderSubtreesForUser(['parent'], nonGlobalUser, [
+			const result = await finder.findFolderSubtreesForUser(['parentA', 'parentB'], nonGlobalUser, [
 				'folder:read',
 			]);
 
-			expect(result).toEqual([parent, child]);
-			expect(folderRepository.getAllFolderIdsInHierarchy.mock.calls[0]).toEqual(['parent']);
-			// requested id + descendant id, deduped, are authorized in one query
+			expect(result).toEqual([parentA, parentB, childA]);
+			// One batched call for every requested subtree, not one query per id.
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(1);
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls[0]).toEqual([
+				['parentA', 'parentB'],
+			]);
+			// requested ids + descendant id, deduped, are authorized in one query
 			const where = folderRepository.find.mock.calls[0][0]?.where as unknown as {
 				id: { value: string[] };
 			};
-			expect(where.id.value).toEqual(['parent', 'child']);
+			expect(where.id.value).toEqual(['parentA', 'parentB', 'childA']);
 		});
 
 		it('returns an empty list for an empty request without querying', async () => {
@@ -86,7 +91,7 @@ describe('FolderFinderService', () => {
 			const result = await finder.findFolderSubtreesForUser([], nonGlobalUser, ['folder:read']);
 
 			expect(result).toEqual([]);
-			expect(folderRepository.getAllFolderIdsInHierarchy.mock.calls).toHaveLength(0);
+			expect(folderRepository.getAllFolderIdsInSubtrees.mock.calls).toHaveLength(0);
 			expect(folderRepository.find.mock.calls).toHaveLength(0);
 		});
 	});

--- a/packages/cli/src/services/__tests__/folder-finder.service.test.ts
+++ b/packages/cli/src/services/__tests__/folder-finder.service.test.ts
@@ -1,0 +1,93 @@
+import type { Folder, FolderRepository, User } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { RoleService } from '@/services/role.service';
+
+import { FolderFinderService } from '../folder-finder.service';
+
+const nonGlobalUser = {
+	id: 'user-1',
+	role: { slug: 'global:member', scopes: [] },
+} as unknown as User;
+
+function makeFolder(overrides: Partial<Folder> = {}): Folder {
+	return {
+		id: 'fld-1',
+		name: 'to_production',
+		parentFolderId: null,
+		homeProject: { id: 'proj-1' },
+		...overrides,
+	} as unknown as Folder;
+}
+
+function makeFinder(found: Folder[]) {
+	const folderRepository = mock<FolderRepository>();
+	folderRepository.find.mockResolvedValue(found);
+	const roleService = mock<RoleService>();
+	roleService.rolesWithScope.mockResolvedValue(['project:admin', 'project:editor']);
+	const finder = new FolderFinderService(folderRepository, roleService);
+	return { finder, folderRepository, roleService };
+}
+
+describe('FolderFinderService', () => {
+	it('returns an empty list without querying for an empty folderIds list', async () => {
+		const { finder, folderRepository } = makeFinder([]);
+
+		const result = await finder.findFoldersByIdsForUser([], nonGlobalUser, ['folder:read']);
+
+		expect(result).toEqual([]);
+		expect(folderRepository.find.mock.calls).toHaveLength(0);
+	});
+
+	it('returns the folders the repository resolves', async () => {
+		const folders = [makeFolder({ id: 'a' }), makeFolder({ id: 'b' })];
+		const { finder } = makeFinder(folders);
+
+		const result = await finder.findFoldersByIdsForUser(['a', 'b'], nonGlobalUser, ['folder:read']);
+
+		expect(result).toEqual(folders);
+	});
+
+	it('filters by the requested project scope for non-global users', async () => {
+		const { finder, folderRepository, roleService } = makeFinder([makeFolder()]);
+
+		await finder.findFoldersByIdsForUser(['fld-1'], nonGlobalUser, ['folder:read']);
+
+		expect(roleService.rolesWithScope.mock.calls[0]).toEqual(['project', ['folder:read']]);
+		const where = folderRepository.find.mock.calls[0][0]?.where as {
+			homeProject: { projectRelations: { userId: string } };
+		};
+		expect(where.homeProject.projectRelations.userId).toBe('user-1');
+	});
+
+	describe('findFolderSubtreesForUser', () => {
+		it('loads each requested folder together with its descendants', async () => {
+			const parent = makeFolder({ id: 'parent' });
+			const child = makeFolder({ id: 'child', parentFolderId: 'parent' });
+			const { finder, folderRepository } = makeFinder([parent, child]);
+			folderRepository.getAllFolderIdsInHierarchy.mockResolvedValue(['child']);
+
+			const result = await finder.findFolderSubtreesForUser(['parent'], nonGlobalUser, [
+				'folder:read',
+			]);
+
+			expect(result).toEqual([parent, child]);
+			expect(folderRepository.getAllFolderIdsInHierarchy.mock.calls[0]).toEqual(['parent']);
+			// requested id + descendant id, deduped, are authorized in one query
+			const where = folderRepository.find.mock.calls[0][0]?.where as unknown as {
+				id: { value: string[] };
+			};
+			expect(where.id.value).toEqual(['parent', 'child']);
+		});
+
+		it('returns an empty list for an empty request without querying', async () => {
+			const { finder, folderRepository } = makeFinder([]);
+
+			const result = await finder.findFolderSubtreesForUser([], nonGlobalUser, ['folder:read']);
+
+			expect(result).toEqual([]);
+			expect(folderRepository.getAllFolderIdsInHierarchy.mock.calls).toHaveLength(0);
+			expect(folderRepository.find.mock.calls).toHaveLength(0);
+		});
+	});
+});

--- a/packages/cli/src/services/folder-finder.service.ts
+++ b/packages/cli/src/services/folder-finder.service.ts
@@ -1,0 +1,80 @@
+import type { Folder, User } from '@n8n/db';
+import { FolderRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { hasGlobalScope, type Scope } from '@n8n/permissions';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import type { FindOptionsWhere } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import { In } from '@n8n/typeorm';
+
+import { RoleService } from '@/services/role.service';
+
+/**
+ * Resolves folders by id for a user, enforcing access through the folder's home
+ * project. Mirrors {@link WorkflowFinderService.findWorkflowsByIdsForUser}:
+ * folders the user cannot access are simply omitted from the result, leaving
+ * the caller to decide how to treat the gap (the exporter aborts on any miss).
+ */
+@Service()
+export class FolderFinderService {
+	constructor(
+		private readonly folderRepository: FolderRepository,
+		private readonly roleService: RoleService,
+	) {}
+
+	async findFoldersByIdsForUser(
+		folderIds: string[],
+		user: User,
+		scopes: Scope[],
+	): Promise<Folder[]> {
+		if (folderIds.length === 0) return [];
+
+		const accessWhere = await this.buildFolderReadWhere(user, scopes);
+
+		return await this.folderRepository.find({
+			where: { id: In(folderIds), ...accessWhere },
+		});
+	}
+
+	/**
+	 * Resolves each requested folder together with all of its descendant folders
+	 * (the subtree to export). Descendants share their ancestor's project, so the
+	 * same access check authorizes the whole set in one query; an inaccessible
+	 * requested folder is dropped here and the caller aborts on the gap.
+	 */
+	async findFolderSubtreesForUser(
+		folderIds: string[],
+		user: User,
+		scopes: Scope[],
+	): Promise<Folder[]> {
+		if (folderIds.length === 0) return [];
+
+		const descendantIds = (
+			await Promise.all(
+				folderIds.map(async (id) => await this.folderRepository.getAllFolderIdsInHierarchy(id)),
+			)
+		).flat();
+
+		const allFolderIds = [...new Set([...folderIds, ...descendantIds])];
+
+		return await this.findFoldersByIdsForUser(allFolderIds, user, scopes);
+	}
+
+	private async buildFolderReadWhere(
+		user: User,
+		scopes: Scope[],
+	): Promise<FindOptionsWhere<Folder>> {
+		if (hasGlobalScope(user, scopes, { mode: 'allOf' })) return {};
+
+		const projectRoles = await this.roleService.rolesWithScope('project', scopes);
+
+		return {
+			homeProject: {
+				projectRelations: {
+					role: In(projectRoles),
+					userId: user.id,
+				},
+			},
+		};
+	}
+}

--- a/packages/cli/src/services/folder-finder.service.ts
+++ b/packages/cli/src/services/folder-finder.service.ts
@@ -49,12 +49,8 @@ export class FolderFinderService {
 	): Promise<Folder[]> {
 		if (folderIds.length === 0) return [];
 
-		const descendantIds = (
-			await Promise.all(
-				folderIds.map(async (id) => await this.folderRepository.getAllFolderIdsInHierarchy(id)),
-			)
-		).flat();
-
+		// One recursive query for every requested subtree, rather than one per id.
+		const descendantIds = await this.folderRepository.getAllFolderIdsInSubtrees(folderIds);
 		const allFolderIds = [...new Set([...folderIds, ...descendantIds])];
 
 		return await this.findFoldersByIdsForUser(allFolderIds, user, scopes);

--- a/packages/cli/test/integration/public-api/n8n-packages-export.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-export.test.ts
@@ -1,8 +1,9 @@
-import { testDb } from '@n8n/backend-test-utils';
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { InstanceSettings } from 'n8n-core';
 
+import { createFolder } from '@test-integration/db/folders';
 import { createOwnerWithApiKey } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
@@ -22,7 +23,13 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'ProjectRelation', 'Project']);
+	await testDb.truncate([
+		'Folder',
+		'WorkflowEntity',
+		'SharedWorkflow',
+		'ProjectRelation',
+		'Project',
+	]);
 });
 
 describe('POST /n8n-packages/export', () => {
@@ -34,7 +41,32 @@ describe('POST /n8n-packages/export', () => {
 
 		expect(response.statusCode).toBe(400);
 		expect(response.body).toEqual({
-			message: 'Provide either workflowIds or projectIds, not both',
+			message: 'Provide either workflowIds/folderIds or projectIds, not both',
 		});
+	});
+
+	test('rejects requests that provide both folderIds and projectIds', async () => {
+		const response = await authOwnerAgent.post('/n8n-packages/export').send({
+			folderIds: ['fld-1'],
+			projectIds: ['project-1'],
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body).toEqual({
+			message: 'Provide either workflowIds/folderIds or projectIds, not both',
+		});
+	});
+
+	test('streams a gzipped package when exporting a folder', async () => {
+		const project = await createTeamProject('Export project', owner);
+		const folder = await createFolder(project, { name: 'to_production' });
+
+		const response = await authOwnerAgent
+			.post('/n8n-packages/export')
+			.send({ folderIds: [folder.id] });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers['content-type']).toContain('application/gzip');
+		expect(response.headers['content-disposition']).toContain('export.n8np');
 	});
 });

--- a/packages/cli/test/integration/shared/db/folders.ts
+++ b/packages/cli/test/integration/shared/db/folders.ts
@@ -21,7 +21,7 @@ export const createFolder = async (
 			parentFolder: options.parentFolder ?? null,
 			tags: options.tags ?? [],
 			updatedAt: options.updatedAt ?? new Date(),
-			createdAt: options.updatedAt ?? new Date(),
+			createdAt: options.createdAt ?? options.updatedAt ?? new Date(),
 		}),
 	);
 


### PR DESCRIPTION
## Summary

Adds **folder export** to the `.n8np` package format. The export endpoint and CLI gain a `folderIds` parameter; each requested folder is written as a `folder.json` shell under a `folders/` tree that mirrors the n8n hierarchy, with a pointer in `manifest.json`.

- **Empty folders** export just the shell; **nested folders** are preserved (sub-folders nest directly under their parent — no repeated `folders/` segment).
- **Same-named siblings** in the same parent are ordered by `createdAt` so the oldest keeps the bare slug; later ones are disambiguated by the existing allocator.
- **Authorization**: a new `FolderFinderService` resolves folders for the user via their home project and the `folder:read` scope; the export aborts if any requested folder is missing or inaccessible.
- **Re-rooting**: a folder that roots the exported set serializes `parentFolderId: null`, so every parent reference in a package resolves in-package.
- Threaded through all four layers per the module's propagation contract: **module** (`FolderExporter`/`FolderSerializer`/manifest `folders[]`) → **DTO** (`ExportWorkflowsRequestDto.folderIds`) → **public API** (handler + OpenAPI schema) → **CLI** (`--folder-id`).

The recursive `FolderExporter` takes a `basePrefix`, so a future project exporter (LIGO-685) can compose the same walk under `projects/<slug>/folders/`. **Out of scope:** exporting the workflows *inside* a folder — that's the follow-up, LIGO-684.

```
|- folders
  |- in_progress
    |- folder.json
    |- nested
      |- folder.json
|- manifest.json
```

### Note for reviewers
Per discussion, the existing `UniqueFilenameAllocator` is reused **as-is**, so same-named siblings are suffixed `-2` (e.g. `in_progress`, `in_progress-2`). The ticket diagrams show `-1`; aligning the suffix numbering is a separate cross-cutting decision (it affects the project tickets too) and is intentionally deferred.

## How to test

Requires the packages feature enabled (license `feat:n8nPackages`; public API also needs `N8N_PUBLIC_API_PACKAGES_ENABLED=true`).

- **CLI:** `n8n-cli package export --folder-id=<folderId> -o folders.n8np`, then `tar -tzf folders.n8np` to inspect the `folders/.../folder.json` layout and `manifest.json`.
- **Public API:** `POST /api/v1/n8n-packages/export` with `{ "folderIds": ["<folderId>"] }` (or combine with `workflowIds`).
- **Automated:**
  - `pnpm --filter n8n test src/modules/n8n-packages` (incl. `export-folder.integration.test.ts` covering all 4 ACs + an authorization-deny case)
  - `pnpm --filter @n8n/api-types test export-workflows-request`
  - `pnpm --filter @n8n/cli test`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-683

Blocks LIGO-684 (export a folder with workflows).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->