### PR TITLE
fix(core): Serialize source control work folder operations

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -4,7 +4,7 @@ import { GLOBAL_ADMIN_ROLE, GLOBAL_MEMBER_ROLE, User, type WorkflowEntity } from
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import type { PushResult } from 'simple-git';
+import type { CommitResult, PullResult, PushResult } from 'simple-git';
 
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
@@ -1151,6 +1151,155 @@ describe('SourceControlService', () => {
 
 			// ACT & ASSERT
 			await expect(sourceControlService.sanityCheck()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('work folder serialization', () => {
+		const user = Object.assign(new User(), { role: GLOBAL_ADMIN_ROLE });
+		const now = new Date().toISOString();
+
+		const workflowFile: SourceControlledFile = {
+			file: 'workflow-1.json',
+			id: 'wf-1',
+			name: 'Workflow 1',
+			type: 'workflow',
+			status: 'modified',
+			location: 'local',
+			conflict: false,
+			updatedAt: now,
+		};
+
+		const pushOptions = {
+			fileNames: [
+				{
+					file: workflowFile.file,
+					id: workflowFile.id,
+					name: workflowFile.name,
+					type: workflowFile.type,
+					status: workflowFile.status,
+					location: workflowFile.location,
+					conflict: workflowFile.conflict,
+					updatedAt: workflowFile.updatedAt,
+				},
+			],
+			commitMessage: 'Test commit',
+		};
+
+		// Flush enough microtasks for the parked push to advance to its export step.
+		const flushMicrotasks = async () => {
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+		};
+
+		const arrangeSuccessfulPushMocks = () => {
+			(isContainedWithin as jest.Mock).mockReturnValue(true);
+			gitService.git = {} as any;
+			gitService.push.mockResolvedValue(mock<PushResult>());
+			sourceControlExportService.rmFilesFromExportFolder.mockResolvedValue(new Set());
+			sourceControlExportService.exportCredentialsToWorkFolder.mockResolvedValue({
+				count: 0,
+				missingIds: [],
+				folder: '',
+				files: [],
+			});
+			sourceControlExportService.exportTeamProjectsToWorkFolder.mockResolvedValue(
+				mock<ExportResult>(),
+			);
+			sourceControlExportService.exportTagsToWorkFolder.mockResolvedValue(mock<ExportResult>());
+		};
+
+		it('queues a reset behind an in-flight push and never resets the work tree mid-push', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+
+			const callOrder: string[] = [];
+			gitService.commit.mockImplementation(async () => {
+				callOrder.push('commit');
+				return await Promise.resolve(mock<CommitResult>());
+			});
+			gitService.resetBranch.mockImplementation(async () => {
+				callOrder.push('reset');
+				return await Promise.resolve('');
+			});
+			gitService.pull.mockResolvedValue(mock<PullResult>());
+
+			// Park the push inside the export step until we manually release it.
+			let releaseExport!: () => void;
+			const exportGate = new Promise<void>((resolve) => {
+				releaseExport = resolve;
+			});
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
+				await exportGate;
+				return mock<ExportResult>();
+			});
+
+			// ACT
+			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
+			await flushMicrotasks();
+			expect(sourceControlExportService.exportWorkflowsToWorkFolder).toHaveBeenCalled();
+
+			// A concurrent reset arrives while the push holds the lock.
+			const resetPromise = sourceControlService.resetWorkfolder();
+			await flushMicrotasks();
+
+			// ASSERT: the reset is queued behind the mutex, so no `git reset --hard` runs yet.
+			expect(gitService.resetBranch).not.toHaveBeenCalled();
+
+			releaseExport();
+			await pushPromise;
+			await resetPromise;
+
+			// Once the push releases the lock, the queued reset runs - but only after the commit.
+			expect(gitService.resetBranch).toHaveBeenCalled();
+			expect(callOrder).toEqual(['commit', 'reset']);
+		});
+
+		it('queues getStatus behind an in-flight push', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+			gitService.commit.mockResolvedValue(mock<CommitResult>());
+
+			let releaseExport!: () => void;
+			const exportGate = new Promise<void>((resolve) => {
+				releaseExport = resolve;
+			});
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
+				await exportGate;
+				return mock<ExportResult>();
+			});
+
+			// ACT
+			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
+			await flushMicrotasks();
+
+			// The push has already read status once before parking at the export gate.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			const statusPromise = sourceControlService.getStatus(user, {} as any);
+			await flushMicrotasks();
+
+			// ASSERT: the queued getStatus has not run its own status read yet.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			releaseExport();
+			await pushPromise;
+			await statusPromise;
+
+			// Once the push releases the lock, the queued getStatus runs.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(2);
+		});
+
+		it('releases the lock when an operation fails so the next operation can proceed', async () => {
+			// ARRANGE
+			gitService.git = {} as any;
+			gitService.resetBranch.mockRejectedValueOnce(new Error('reset failed'));
+
+			// ACT & ASSERT: a failing reset rejects but must not hold the lock.
+			await expect(sourceControlService.resetWorkfolder()).rejects.toThrow();
+
+			mockStatusService.getStatus.mockResolvedValueOnce([]);
+			await expect(sourceControlService.getStatus(user, {} as any)).resolves.toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -9,6 +9,7 @@ import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { writeFileSync } from 'fs';
 import { UnexpectedError, UserError, jsonParse } from 'n8n-workflow';
+import pLimit from 'p-limit';
 import * as path from 'path';
 import type { PushResult } from 'simple-git';
 
@@ -58,6 +59,13 @@ export class SourceControlService {
 
 	/** Flag to prevent concurrent configuration reloads */
 	private isReloading = false;
+
+	/**
+	 * Serializes all operations over the shared git work folder. The work folder is a single
+	 * local directory, so a concurrent reset (any push/pull/status call runs `git reset --hard`)
+	 * could otherwise discard files exported but not yet staged during an in-flight push.
+	 */
+	private readonly workfolderMutex = pLimit(1);
 
 	constructor(
 		private readonly logger: Logger,
@@ -278,6 +286,10 @@ export class SourceControlService {
 	// will reset the branch to the remote branch and pull
 	// this will discard all local changes
 	async resetWorkfolder(): Promise<ImportResult | undefined> {
+		return await this.workfolderMutex(async () => await this.resetWorkfolderUnsafe());
+	}
+
+	private async resetWorkfolderUnsafe(): Promise<ImportResult | undefined> {
 		if (!this.gitService.git) {
 			await this.initGitService();
 		}
@@ -294,6 +306,17 @@ export class SourceControlService {
 	}
 
 	async pushWorkfolder(
+		user: User,
+		options: PushWorkFolderRequestDto,
+	): Promise<{
+		statusCode: number;
+		pushResult: PushResult | undefined;
+		statusResult: SourceControlledFile[];
+	}> {
+		return await this.workfolderMutex(async () => await this.pushWorkfolderUnsafe(user, options));
+	}
+
+	private async pushWorkfolderUnsafe(
 		user: User,
 		options: PushWorkFolderRequestDto,
 	): Promise<{
@@ -475,6 +498,13 @@ export class SourceControlService {
 		user: User,
 		options: PullWorkFolderRequestDto,
 	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {
+		return await this.workfolderMutex(async () => await this.pullWorkfolderUnsafe(user, options));
+	}
+
+	private async pullWorkfolderUnsafe(
+		user: User,
+		options: PullWorkFolderRequestDto,
+	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {
 		await this.sanityCheck();
 
 		const statusResult = await this.sourceControlStatusService.getStatus(user, {
@@ -595,8 +625,10 @@ export class SourceControlService {
 	}
 
 	async getStatus(user: User, options: SourceControlGetStatus) {
-		await this.sanityCheck();
-		return await this.sourceControlStatusService.getStatus(user, options);
+		return await this.workfolderMutex(async () => {
+			await this.sanityCheck();
+			return await this.sourceControlStatusService.getStatus(user, options);
+		});
 	}
 
 	async setGitUserDetails(


### PR DESCRIPTION
## Summary

Source control pushes ran as a lock-free read–modify–write over the single shared git working directory. A concurrent source control request (push, pull, status or reset) could run `git reset --hard` and discard freshly exported workflow files before the in-flight push staged them, so the push silently committed only `tags.json` instead of the selected workflows. This serializes all work folder operations behind a single in-process mutex so an in-flight push can no longer be interrupted by a concurrent reset, and adds regression coverage.

## How to test

With an instance connected to a source control repository, select one or more workflows in the push modal and push while concurrently triggering another source control request from a second session (for example opening the push modal / hitting get-status, or running a pull). Confirm the resulting commit contains the selected workflow JSON files rather than only `tags.json`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-747

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

