### PR TITLE
fix(core): Serialize source control work folder operations

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.controller.ee.test.ts
@@ -36,7 +36,6 @@ describe('SourceControlController', () => {
 			pushWorkfolder: jest.fn().mockResolvedValue({ statusCode: 200 }),
 			pullWorkfolder: jest.fn().mockResolvedValue({ statusCode: 200 }),
 			getStatus: jest.fn().mockResolvedValue([]),
-			setGitUserDetails: jest.fn(),
 		} as unknown as SourceControlService;
 
 		sourceControlPreferencesService = mock<SourceControlPreferencesService>();
@@ -65,10 +64,6 @@ describe('SourceControlController', () => {
 			const payload = { force: true } as PushWorkFolderRequestDto;
 
 			await controller.pushWorkfolder(req, res, payload);
-			expect(sourceControlService.setGitUserDetails).toHaveBeenCalledWith(
-				'John Doe',
-				'john.doe@example.com',
-			);
 			expect(sourceControlService.pushWorkfolder).toHaveBeenCalledWith(req.user, payload);
 		});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -1185,9 +1185,24 @@ describe('SourceControlService', () => {
 			commitMessage: 'Test commit',
 		};
 
-		// Flush enough microtasks for the parked push to advance to its export step.
-		const flushMicrotasks = async () => {
-			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+		// Parks an in-flight push inside its export step. `exportStarted` resolves once the push
+		// has reached the export call; `releaseExport` lets it continue from there. This keeps the
+		// race tests deterministic instead of relying on a fixed number of microtask ticks.
+		const installExportGate = () => {
+			let releaseExport!: () => void;
+			let signalExportStarted!: () => void;
+			const exportGate = new Promise<void>((resolve) => {
+				releaseExport = resolve;
+			});
+			const exportStarted = new Promise<void>((resolve) => {
+				signalExportStarted = resolve;
+			});
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
+				signalExportStarted();
+				await exportGate;
+				return mock<ExportResult>();
+			});
+			return { exportStarted, releaseExport };
 		};
 
 		const arrangeSuccessfulPushMocks = () => {
@@ -1223,24 +1238,14 @@ describe('SourceControlService', () => {
 			});
 			gitService.pull.mockResolvedValue(mock<PullResult>());
 
-			// Park the push inside the export step until we manually release it.
-			let releaseExport!: () => void;
-			const exportGate = new Promise<void>((resolve) => {
-				releaseExport = resolve;
-			});
-			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
-				await exportGate;
-				return mock<ExportResult>();
-			});
+			const { exportStarted, releaseExport } = installExportGate();
 
-			// ACT
+			// ACT: start the push and wait until it is parked inside the export step.
 			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
-			await flushMicrotasks();
-			expect(sourceControlExportService.exportWorkflowsToWorkFolder).toHaveBeenCalled();
+			await exportStarted;
 
 			// A concurrent reset arrives while the push holds the lock.
 			const resetPromise = sourceControlService.resetWorkfolder();
-			await flushMicrotasks();
 
 			// ASSERT: the reset is queued behind the mutex, so no `git reset --hard` runs yet.
 			expect(gitService.resetBranch).not.toHaveBeenCalled();
@@ -1260,24 +1265,16 @@ describe('SourceControlService', () => {
 			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
 			gitService.commit.mockResolvedValue(mock<CommitResult>());
 
-			let releaseExport!: () => void;
-			const exportGate = new Promise<void>((resolve) => {
-				releaseExport = resolve;
-			});
-			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
-				await exportGate;
-				return mock<ExportResult>();
-			});
+			const { exportStarted, releaseExport } = installExportGate();
 
 			// ACT
 			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
-			await flushMicrotasks();
+			await exportStarted;
 
 			// The push has already read status once before parking at the export gate.
 			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
 
 			const statusPromise = sourceControlService.getStatus(user, {} as any);
-			await flushMicrotasks();
 
 			// ASSERT: the queued getStatus has not run its own status read yet.
 			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
@@ -1288,6 +1285,69 @@ describe('SourceControlService', () => {
 
 			// Once the push releases the lock, the queued getStatus runs.
 			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(2);
+		});
+
+		it('queues a pull behind an in-flight push', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+			gitService.commit.mockResolvedValue(mock<CommitResult>());
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([]);
+
+			const { exportStarted, releaseExport } = installExportGate();
+
+			// ACT
+			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
+			await exportStarted;
+
+			// The push has already read status once before parking at the export gate.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			const pullPromise = sourceControlService.pullWorkfolder(user, { force: true } as any);
+
+			// ASSERT: the queued pull has not run its own status read yet.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			releaseExport();
+			await pushPromise;
+			await pullPromise;
+
+			// Once the push releases the lock, the queued pull runs its status read.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(2);
+		});
+
+		it('sets the git author inside the locked push, before the commit it applies to', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockResolvedValue(
+				mock<ExportResult>(),
+			);
+
+			const callOrder: string[] = [];
+			gitService.setGitUserDetails.mockImplementation(async () => {
+				callOrder.push('setAuthor');
+				await Promise.resolve();
+			});
+			gitService.commit.mockImplementation(async () => {
+				callOrder.push('commit');
+				return await Promise.resolve(mock<CommitResult>());
+			});
+
+			const author = Object.assign(new User(), {
+				role: GLOBAL_ADMIN_ROLE,
+				firstName: 'Ada',
+				lastName: 'Lovelace',
+				email: 'ada@example.com',
+			});
+
+			// ACT
+			await sourceControlService.pushWorkfolder(author, pushOptions);
+
+			// ASSERT: the author is set from the pushing user, immediately before the commit,
+			// both inside the serialized section.
+			expect(gitService.setGitUserDetails).toHaveBeenCalledWith('Ada Lovelace', 'ada@example.com');
+			expect(callOrder).toEqual(['setAuthor', 'commit']);
 		});
 
 		it('releases the lock when an operation fails so the next operation can proceed', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -15,7 +15,11 @@ import type { SourceControlGitService } from '../source-control-git.service.ee';
 import type { SourceControlImportService } from '../source-control-import.service.ee';
 import type { SourceControlContextFactory } from '../source-control-context.factory';
 import type { SourceControlScopedService } from '../source-control-scoped.service';
-import { SOURCE_CONTROL_DEFAULT_BRANCH_COLOR } from '../constants';
+import {
+	SOURCE_CONTROL_DEFAULT_BRANCH_COLOR,
+	SOURCE_CONTROL_DEFAULT_EMAIL,
+	SOURCE_CONTROL_DEFAULT_NAME,
+} from '../constants';
 import { sourceControlFoldersExistCheck } from '../source-control-helper.ee';
 import type { ExportResult } from '../types/export-result';
 
@@ -1348,6 +1352,32 @@ describe('SourceControlService', () => {
 			// both inside the serialized section.
 			expect(gitService.setGitUserDetails).toHaveBeenCalledWith('Ada Lovelace', 'ada@example.com');
 			expect(callOrder).toEqual(['setAuthor', 'commit']);
+		});
+
+		it('falls back to default author details when the pushing user has no full profile', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+			gitService.commit.mockResolvedValue(mock<CommitResult>());
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockResolvedValue(
+				mock<ExportResult>(),
+			);
+
+			const userWithoutProfile = Object.assign(new User(), {
+				role: GLOBAL_ADMIN_ROLE,
+				firstName: '',
+				lastName: '',
+				email: '',
+			});
+
+			// ACT
+			await sourceControlService.pushWorkfolder(userWithoutProfile, pushOptions);
+
+			// ASSERT: an empty profile must not produce an invalid git identity for the commit.
+			expect(gitService.setGitUserDetails).toHaveBeenCalledWith(
+				SOURCE_CONTROL_DEFAULT_NAME,
+				SOURCE_CONTROL_DEFAULT_EMAIL,
+			);
 		});
 
 		it('releases the lock when an operation fails so the next operation can proceed', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -4,7 +4,7 @@ import { GLOBAL_ADMIN_ROLE, GLOBAL_MEMBER_ROLE, User, type WorkflowEntity } from
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import type { PushResult } from 'simple-git';
+import type { CommitResult, PullResult, PushResult } from 'simple-git';
 
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
@@ -1151,6 +1151,155 @@ describe('SourceControlService', () => {
 
 			// ACT & ASSERT
 			await expect(sourceControlService.sanityCheck()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('work folder serialization', () => {
+		const user = Object.assign(new User(), { role: GLOBAL_ADMIN_ROLE });
+		const now = new Date().toISOString();
+
+		const workflowFile: SourceControlledFile = {
+			file: 'workflow-1.json',
+			id: 'wf-1',
+			name: 'Workflow 1',
+			type: 'workflow',
+			status: 'modified',
+			location: 'local',
+			conflict: false,
+			updatedAt: now,
+		};
+
+		const pushOptions = {
+			fileNames: [
+				{
+					file: workflowFile.file,
+					id: workflowFile.id,
+					name: workflowFile.name,
+					type: workflowFile.type,
+					status: workflowFile.status,
+					location: workflowFile.location,
+					conflict: workflowFile.conflict,
+					updatedAt: workflowFile.updatedAt,
+				},
+			],
+			commitMessage: 'Test commit',
+		};
+
+		// Flush enough microtasks for the parked push to advance to its export step.
+		const flushMicrotasks = async () => {
+			for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+		};
+
+		const arrangeSuccessfulPushMocks = () => {
+			(isContainedWithin as jest.Mock).mockReturnValue(true);
+			gitService.git = {} as any;
+			gitService.push.mockResolvedValue(mock<PushResult>());
+			sourceControlExportService.rmFilesFromExportFolder.mockResolvedValue(new Set());
+			sourceControlExportService.exportCredentialsToWorkFolder.mockResolvedValue({
+				count: 0,
+				missingIds: [],
+				folder: '',
+				files: [],
+			});
+			sourceControlExportService.exportTeamProjectsToWorkFolder.mockResolvedValue(
+				mock<ExportResult>(),
+			);
+			sourceControlExportService.exportTagsToWorkFolder.mockResolvedValue(mock<ExportResult>());
+		};
+
+		it('queues a reset behind an in-flight push and never resets the work tree mid-push', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+
+			const callOrder: string[] = [];
+			gitService.commit.mockImplementation(async () => {
+				callOrder.push('commit');
+				return await Promise.resolve(mock<CommitResult>());
+			});
+			gitService.resetBranch.mockImplementation(async () => {
+				callOrder.push('reset');
+				return await Promise.resolve('');
+			});
+			gitService.pull.mockResolvedValue(mock<PullResult>());
+
+			// Park the push inside the export step until we manually release it.
+			let releaseExport!: () => void;
+			const exportGate = new Promise<void>((resolve) => {
+				releaseExport = resolve;
+			});
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
+				await exportGate;
+				return mock<ExportResult>();
+			});
+
+			// ACT
+			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
+			await flushMicrotasks();
+			expect(sourceControlExportService.exportWorkflowsToWorkFolder).toHaveBeenCalled();
+
+			// A concurrent reset arrives while the push holds the lock.
+			const resetPromise = sourceControlService.resetWorkfolder();
+			await flushMicrotasks();
+
+			// ASSERT: the reset is queued behind the mutex, so no `git reset --hard` runs yet.
+			expect(gitService.resetBranch).not.toHaveBeenCalled();
+
+			releaseExport();
+			await pushPromise;
+			await resetPromise;
+
+			// Once the push releases the lock, the queued reset runs - but only after the commit.
+			expect(gitService.resetBranch).toHaveBeenCalled();
+			expect(callOrder).toEqual(['commit', 'reset']);
+		});
+
+		it('queues getStatus behind an in-flight push', async () => {
+			// ARRANGE
+			arrangeSuccessfulPushMocks();
+			mockStatusService.getStatus.mockResolvedValue([workflowFile]);
+			gitService.commit.mockResolvedValue(mock<CommitResult>());
+
+			let releaseExport!: () => void;
+			const exportGate = new Promise<void>((resolve) => {
+				releaseExport = resolve;
+			});
+			sourceControlExportService.exportWorkflowsToWorkFolder.mockImplementation(async () => {
+				await exportGate;
+				return mock<ExportResult>();
+			});
+
+			// ACT
+			const pushPromise = sourceControlService.pushWorkfolder(user, pushOptions);
+			await flushMicrotasks();
+
+			// The push has already read status once before parking at the export gate.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			const statusPromise = sourceControlService.getStatus(user, {} as any);
+			await flushMicrotasks();
+
+			// ASSERT: the queued getStatus has not run its own status read yet.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(1);
+
+			releaseExport();
+			await pushPromise;
+			await statusPromise;
+
+			// Once the push releases the lock, the queued getStatus runs.
+			expect(mockStatusService.getStatus).toHaveBeenCalledTimes(2);
+		});
+
+		it('releases the lock when an operation fails so the next operation can proceed', async () => {
+			// ARRANGE
+			gitService.git = {} as any;
+			gitService.resetBranch.mockRejectedValueOnce(new Error('reset failed'));
+
+			// ACT & ASSERT: a failing reset rejects but must not hold the lock.
+			await expect(sourceControlService.resetWorkfolder()).rejects.toThrow();
+
+			mockStatusService.getStatus.mockResolvedValueOnce([]);
+			await expect(sourceControlService.getStatus(user, {} as any)).resolves.toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.controller.ee.ts
@@ -202,11 +202,6 @@ export class SourceControlController {
 		await this.sourceControlScopedService.ensureIsAllowedToPush(req);
 
 		try {
-			await this.sourceControlService.setGitUserDetails(
-				`${req.user.firstName} ${req.user.lastName}`,
-				req.user.email,
-			);
-
 			const result = await this.sourceControlService.pushWorkfolder(req.user, payload);
 			res.statusCode = result.statusCode;
 

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -9,6 +9,7 @@ import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { writeFileSync } from 'fs';
 import { UnexpectedError, UserError, jsonParse } from 'n8n-workflow';
+import pLimit from 'p-limit';
 import * as path from 'path';
 import type { PushResult } from 'simple-git';
 
@@ -58,6 +59,13 @@ export class SourceControlService {
 
 	/** Flag to prevent concurrent configuration reloads */
 	private isReloading = false;
+
+	/**
+	 * Serializes all operations over the shared git work folder. The work folder is a single
+	 * local directory, so a concurrent reset (any push/pull/status call runs `git reset --hard`)
+	 * could otherwise discard files exported but not yet staged during an in-flight push.
+	 */
+	private readonly workfolderMutex = pLimit(1);
 
 	constructor(
 		private readonly logger: Logger,
@@ -278,6 +286,10 @@ export class SourceControlService {
 	// will reset the branch to the remote branch and pull
 	// this will discard all local changes
 	async resetWorkfolder(): Promise<ImportResult | undefined> {
+		return await this.workfolderMutex(async () => await this.resetWorkfolderUnsafe());
+	}
+
+	private async resetWorkfolderUnsafe(): Promise<ImportResult | undefined> {
 		if (!this.gitService.git) {
 			await this.initGitService();
 		}
@@ -294,6 +306,17 @@ export class SourceControlService {
 	}
 
 	async pushWorkfolder(
+		user: User,
+		options: PushWorkFolderRequestDto,
+	): Promise<{
+		statusCode: number;
+		pushResult: PushResult | undefined;
+		statusResult: SourceControlledFile[];
+	}> {
+		return await this.workfolderMutex(async () => await this.pushWorkfolderUnsafe(user, options));
+	}
+
+	private async pushWorkfolderUnsafe(
 		user: User,
 		options: PushWorkFolderRequestDto,
 	): Promise<{
@@ -475,6 +498,13 @@ export class SourceControlService {
 		user: User,
 		options: PullWorkFolderRequestDto,
 	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {
+		return await this.workfolderMutex(async () => await this.pullWorkfolderUnsafe(user, options));
+	}
+
+	private async pullWorkfolderUnsafe(
+		user: User,
+		options: PullWorkFolderRequestDto,
+	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {
 		await this.sanityCheck();
 
 		const statusResult = await this.sourceControlStatusService.getStatus(user, {
@@ -595,8 +625,10 @@ export class SourceControlService {
 	}
 
 	async getStatus(user: User, options: SourceControlGetStatus) {
-		await this.sanityCheck();
-		return await this.sourceControlStatusService.getStatus(user, options);
+		return await this.workfolderMutex(async () => {
+			await this.sanityCheck();
+			return await this.sourceControlStatusService.getStatus(user, options);
+		});
 	}
 
 	async setGitUserDetails(

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -15,8 +15,6 @@ import type { PushResult } from 'simple-git';
 
 import {
 	SOURCE_CONTROL_DEFAULT_BRANCH_COLOR,
-	SOURCE_CONTROL_DEFAULT_EMAIL,
-	SOURCE_CONTROL_DEFAULT_NAME,
 	SOURCE_CONTROL_README,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
@@ -449,6 +447,10 @@ export class SourceControlService {
 
 			await this.gitService.stage(filesToBePushed, filesToBeDeleted);
 
+			// Set the author within the locked section so a concurrent push can't change the
+			// repo-wide git config between staging and this commit.
+			await this.gitService.setGitUserDetails(`${user.firstName} ${user.lastName}`, user.email);
+
 			await this.gitService.commit(options.commitMessage ?? 'Updated Workfolder');
 		} catch (error) {
 			this.logger.error('Failed to export or commit changes', { error });
@@ -633,14 +635,6 @@ export class SourceControlService {
 			await this.sanityCheck();
 			return await this.sourceControlStatusService.getStatus(user, options);
 		});
-	}
-
-	async setGitUserDetails(
-		name = SOURCE_CONTROL_DEFAULT_NAME,
-		email = SOURCE_CONTROL_DEFAULT_EMAIL,
-	): Promise<void> {
-		await this.sanityCheck();
-		await this.gitService.setGitUserDetails(name, email);
 	}
 
 	async getRemoteFileEntity({

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -286,10 +286,10 @@ export class SourceControlService {
 	// will reset the branch to the remote branch and pull
 	// this will discard all local changes
 	async resetWorkfolder(): Promise<ImportResult | undefined> {
-		return await this.workfolderMutex(async () => await this.resetWorkfolderUnsafe());
+		return await this.workfolderMutex(async () => await this.resetWorkfolderWithoutLock());
 	}
 
-	private async resetWorkfolderUnsafe(): Promise<ImportResult | undefined> {
+	private async resetWorkfolderWithoutLock(): Promise<ImportResult | undefined> {
 		if (!this.gitService.git) {
 			await this.initGitService();
 		}
@@ -313,10 +313,12 @@ export class SourceControlService {
 		pushResult: PushResult | undefined;
 		statusResult: SourceControlledFile[];
 	}> {
-		return await this.workfolderMutex(async () => await this.pushWorkfolderUnsafe(user, options));
+		return await this.workfolderMutex(
+			async () => await this.pushWorkfolderWithoutLock(user, options),
+		);
 	}
 
-	private async pushWorkfolderUnsafe(
+	private async pushWorkfolderWithoutLock(
 		user: User,
 		options: PushWorkFolderRequestDto,
 	): Promise<{
@@ -498,10 +500,12 @@ export class SourceControlService {
 		user: User,
 		options: PullWorkFolderRequestDto,
 	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {
-		return await this.workfolderMutex(async () => await this.pullWorkfolderUnsafe(user, options));
+		return await this.workfolderMutex(
+			async () => await this.pullWorkfolderWithoutLock(user, options),
+		);
 	}
 
-	private async pullWorkfolderUnsafe(
+	private async pullWorkfolderWithoutLock(
 		user: User,
 		options: PullWorkFolderRequestDto,
 	): Promise<{ statusCode: number; statusResult: SourceControlledFile[] }> {

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -15,6 +15,8 @@ import type { PushResult } from 'simple-git';
 
 import {
 	SOURCE_CONTROL_DEFAULT_BRANCH_COLOR,
+	SOURCE_CONTROL_DEFAULT_EMAIL,
+	SOURCE_CONTROL_DEFAULT_NAME,
 	SOURCE_CONTROL_README,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
@@ -448,8 +450,15 @@ export class SourceControlService {
 			await this.gitService.stage(filesToBePushed, filesToBeDeleted);
 
 			// Set the author within the locked section so a concurrent push can't change the
-			// repo-wide git config between staging and this commit.
-			await this.gitService.setGitUserDetails(`${user.firstName} ${user.lastName}`, user.email);
+			// repo-wide git config between staging and this commit. Fall back to defaults when the
+			// user has no full profile, matching repo initialization, so the commit can't fail on an
+			// empty git identity.
+			await this.gitService.setGitUserDetails(
+				user.firstName && user.lastName
+					? `${user.firstName} ${user.lastName}`
+					: SOURCE_CONTROL_DEFAULT_NAME,
+				user.email || SOURCE_CONTROL_DEFAULT_EMAIL,
+			);
 
 			await this.gitService.commit(options.commitMessage ?? 'Updated Workfolder');
 		} catch (error) {


### PR DESCRIPTION
## Summary

Source control pushes ran as a lock-free read–modify–write over the single shared git working directory. A concurrent source control request (push, pull, status or reset) could run `git reset --hard` and discard freshly exported workflow files before the in-flight push staged them, so the push silently committed only `tags.json` instead of the selected workflows. This serializes all work folder operations behind a single in-process mutex so an in-flight push can no longer be interrupted by a concurrent reset, and adds regression coverage. It also sets the commit author inside that serialized section, so concurrent pushes can no longer attribute a commit to the wrong user.

## How to test

With an instance connected to a source control repository, select one or more workflows in the push modal and push while concurrently triggering another source control request from a second session (for example opening the push modal / hitting get-status, or running a pull). Confirm the resulting commit contains the selected workflow JSON files rather than only `tags.json`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-747

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32857">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
