### PR TITLE
feat(core): Display canvas groups in execution view

### DIFF
--- a/packages/cli/src/execution-lifecycle/shared/shared-hook-functions.ts
+++ b/packages/cli/src/execution-lifecycle/shared/shared-hook-functions.ts
@@ -47,6 +47,7 @@ export function prepareExecutionDataForDbUpdate(parameters: {
 		'settings',
 		'staticData',
 		'pinData',
+		'nodeGroups',
 	]);
 
 	const fullExecutionData: UpdateExecutionPayload = {

--- a/packages/cli/src/executions/__tests__/execution-persistence.integration.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.integration.test.ts
@@ -56,6 +56,7 @@ describe('ExecutionPersistence', () => {
 				nodes: workflow.nodes,
 				name: workflow.name,
 				settings: workflow.settings,
+				nodeGroups: workflow.nodeGroups,
 			});
 			expect(executionData?.data).toEqual('[{"resultData":"1"},{}]');
 		});
@@ -168,8 +169,8 @@ describe('ExecutionPersistence', () => {
 				includeData: true,
 			});
 
-			// 51 (run data) + 67 (workflow snapshot) + 15 ("v-roundtrip-456") = 133 bytes
-			expect(execution?.jsonSizeBytes).toBe(133);
+			// 51 (run data) + 83 (workflow snapshot incl. empty nodeGroups) + 15 ("v-roundtrip-456") = 149 bytes
+			expect(execution?.jsonSizeBytes).toBe(149);
 			expect(execution?.workflowVersionId).toBe('v-roundtrip-456');
 		});
 

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -232,6 +232,7 @@ describe('ExecutionPersistence', () => {
 					nodes: workflowData.nodes,
 					connections: workflowData.connections,
 					settings: workflowData.settings,
+					nodeGroups: workflowData.nodeGroups,
 				};
 				expect(fsStore.write).toHaveBeenCalledWith(
 					{ workflowId: 'workflow-123', executionId: 'exec-2' },
@@ -530,6 +531,7 @@ describe('ExecutionPersistence', () => {
 							nodes: workflowData.nodes,
 							connections: workflowData.connections,
 							settings: workflowData.settings,
+							nodeGroups: workflowData.nodeGroups,
 						},
 						// sourced from the entity row, not the incoming workflowData.versionId
 						workflowVersionId: 'v-entity',
@@ -714,6 +716,7 @@ describe('ExecutionPersistence', () => {
 							nodes: workflowData.nodes,
 							connections: workflowData.connections,
 							settings: workflowData.settings,
+							nodeGroups: workflowData.nodeGroups,
 						},
 						// from the entity row, not the incoming workflowData.versionId
 						workflowVersionId: 'v-entity',

--- a/packages/cli/src/executions/execution-data/types.ts
+++ b/packages/cli/src/executions/execution-data/types.ts
@@ -12,7 +12,7 @@ export function createExecutionRef(workflowId: string, executionId: string): Exe
 
 export type WorkflowSnapshot = Pick<
 	IWorkflowBase,
-	'id' | 'name' | 'nodes' | 'connections' | 'settings'
+	'id' | 'name' | 'nodes' | 'connections' | 'settings' | 'nodeGroups'
 >;
 
 export type ExecutionDataPayload = {

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -93,8 +93,15 @@ export class ExecutionPersistence {
 	 */
 	async create(payload: CreateExecutionPayload) {
 		const { data: rawData, workflowData, ...rest } = payload;
-		const { connections, nodes, name, settings, id } = workflowData;
-		const workflowSnapshot: WorkflowSnapshot = { connections, nodes, name, settings, id };
+		const { connections, nodes, name, settings, id, nodeGroups } = workflowData;
+		const workflowSnapshot: WorkflowSnapshot = {
+			connections,
+			nodes,
+			name,
+			settings,
+			id,
+			nodeGroups,
+		};
 		const storedAt = this.storageConfig.modeTag;
 		const workflowVersionId = workflowData.versionId ?? null;
 		const executionEntity = { ...rest, createdAt: new Date(), storedAt, workflowVersionId };
@@ -799,8 +806,8 @@ export class ExecutionPersistence {
 	private toWorkflowSnapshot(
 		workflowData: NonNullable<IExecutionResponse['workflowData']>,
 	): WorkflowSnapshot {
-		const { id, name, nodes, connections, settings } = workflowData;
-		return { id, name, nodes, connections, settings };
+		const { id, name, nodes, connections, settings, nodeGroups } = workflowData;
+		return { id, name, nodes, connections, settings, nodeGroups };
 	}
 
 	private async assembleExecution(

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreviewHost.vue
@@ -49,7 +49,7 @@ provide(
 	EditorEnabledFeaturesKey,
 	computed<EditorEnabledFeatures>(() => ({
 		readOnly: true,
-		expandGroups: true,
+		expandGroups: 'all',
 		aiAssistant: false,
 		aiBuilder: false,
 		askAi: false,

--- a/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
@@ -57,7 +57,7 @@ export function useEditorContext() {
 		askAi: featureEnabled('askAi'),
 		instanceAi: featureEnabled('instanceAi'),
 		readOnly: computed(() => enabledFeatures?.value?.readOnly === true),
-		expandGroups: computed(() => enabledFeatures?.value?.expandGroups === true),
+		expandGroups: computed(() => enabledFeatures?.value?.expandGroups),
 		executionSuccessToasts: computed(
 			() => enabledFeatures?.value?.executionSuccessToasts !== false,
 		),

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -2,6 +2,7 @@ import type {
 	CanvasInjectionData,
 	CanvasNodeHandleInjectionData,
 	CanvasNodeInjectionData,
+	GroupExpansionMode,
 } from '@/features/workflows/canvas/canvas.types';
 import type { ComputedRef, InjectionKey, Ref, ShallowRef } from 'vue';
 import type { ExpressionLocalResolveContext } from '@/app/types/expressions';
@@ -52,13 +53,13 @@ export type EditorFeature = 'aiAssistant' | 'aiBuilder' | 'askAi' | 'instanceAi'
  * (mirrors the old iframe `suppressNotifications` / `allowErrorNotifications`
  * knobs, but scoped per editor instead of via the shared UI store). Hosts that
  * surface results in their own UI — e.g. the Instance AI preview — set them.
- * `expandGroups` is a direct state flag — `true` shows every canvas group
- * expanded and leaves the editor's persisted view state untouched
+ * `expandGroups` overrides canvas group expansion without touching the editor's
+ * persisted view state.
  * Provided by editor hosts that supersede capabilities.
  */
 export type EditorEnabledFeatures = Partial<Record<EditorFeature, boolean>> & {
 	readOnly?: boolean;
-	expandGroups?: boolean;
+	expandGroups?: GroupExpansionMode;
 	executionSuccessToasts?: boolean;
 	executionErrorToasts?: boolean;
 };

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -45,6 +45,7 @@ import type {
 	CanvasNode,
 	CanvasNodeMoveEvent,
 	ConnectStartEvent,
+	GroupExpansionMode,
 	ViewportBoundaries,
 } from '@/features/workflows/canvas/canvas.types';
 import {
@@ -319,8 +320,8 @@ const isCanvasReadOnly = computed(() => {
 	);
 });
 
-const forceAllGroupsExpanded = computed(() => {
-	return isDemoRoute.value || externalExpandGroups.value;
+const groupExpansionMode = computed<GroupExpansionMode | undefined>(() => {
+	return isDemoRoute.value ? 'all' : externalExpandGroups.value;
 });
 
 const canExecuteOnCanvas = computed(() => {
@@ -1974,7 +1975,7 @@ onBeforeUnmount(() => {
 			:show-fallback-nodes="showFallbackNodes"
 			:event-bus="canvasEventBus"
 			:read-only="isCanvasReadOnly"
-			:force-all-groups-expanded="forceAllGroupsExpanded"
+			:group-expansion-mode="groupExpansionMode"
 			:can-execute="canExecuteOnCanvas"
 			:executing="isWorkflowRunning"
 			:key-bindings="keyBindingsEnabled"

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
@@ -142,6 +142,7 @@ describe('ExecutionPreviewHost', () => {
 			askAi: false,
 			executionSuccessToasts: false,
 			executionErrorToasts: false,
+			expandGroups: 'errored',
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
@@ -48,6 +48,8 @@ provide(
 		askAi: false,
 		executionSuccessToasts: false,
 		executionErrorToasts: false,
+		// Keep groups collapsed but surface the ones that contain a failed node.
+		expandGroups: 'errored',
 	})),
 );
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -141,6 +141,9 @@ export const CANVAS_NODE_GROUP_ID_PREFIX = 'group:';
 export const CANVAS_NODE_GROUP_HANDLE_LEFT = 'left';
 export const CANVAS_NODE_GROUP_HANDLE_RIGHT = 'right';
 
+// Host override for group expansion; leaves persisted view state untouched.
+export type GroupExpansionMode = 'all' | 'errored';
+
 export function createCanvasGroupNodeId(groupId: string): string {
 	return `${CANVAS_NODE_GROUP_ID_PREFIX}${groupId}`;
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -589,7 +589,6 @@ describe('Canvas', () => {
 				getCurrentGroupIds: () => workflowDocumentStore.allGroups.map((group) => group.id),
 				onNodeGroupsChange: workflowDocumentStore.onNodeGroupsChange,
 				isGroupingEnabled: () => true,
-				forceAllGroupsExpanded: () => false,
 			});
 		}
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.test.ts
@@ -110,6 +110,48 @@ describe('WorkflowCanvas', () => {
 		expect(container.querySelector('[data-id="1"]')).not.toBeInTheDocument();
 	});
 
+	it('expands every group when groupExpansionMode is "all"', async () => {
+		const posthogStore = usePostHog();
+		vi.spyOn(posthogStore, 'isFeatureEnabled').mockImplementation(
+			(name) => name === CANVAS_NODES_GROUPING_EXPERIMENT.name,
+		);
+
+		const workflow = createTestWorkflow({
+			nodes: [createTestNode({ id: '1', name: 'Node 1' })],
+			connections: {},
+			nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+		});
+		setupWorkflow(workflow);
+
+		const { container } = renderComponent({ props: { groupExpansionMode: 'all' } });
+
+		// An expanded group renders its member node; a collapsed one hides it.
+		await waitFor(() => expect(container.querySelector('[data-id="1"]')).toBeInTheDocument());
+	});
+
+	it('keeps groups without an errored node collapsed when groupExpansionMode is "errored"', async () => {
+		const posthogStore = usePostHog();
+		vi.spyOn(posthogStore, 'isFeatureEnabled').mockImplementation(
+			(name) => name === CANVAS_NODES_GROUPING_EXPERIMENT.name,
+		);
+
+		const workflow = createTestWorkflow({
+			nodes: [createTestNode({ id: '1', name: 'Node 1' })],
+			connections: {},
+			nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['1'] }],
+		});
+		setupWorkflow(workflow);
+
+		const { container } = renderComponent({ props: { groupExpansionMode: 'errored' } });
+
+		await waitFor(() =>
+			expect(
+				container.querySelector(`[data-id="${CANVAS_NODE_GROUP_ID_PREFIX}g1"]`),
+			).toBeInTheDocument(),
+		);
+		expect(container.querySelector('[data-id="1"]')).not.toBeInTheDocument();
+	});
+
 	it('should handle empty nodes and connections gracefully', async () => {
 		const { container } = renderComponent();
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -18,10 +18,13 @@ import {
 	watch,
 	type EffectScope,
 } from 'vue';
-import type { CanvasEventBusEvents } from '../canvas.types';
+import type { CanvasEventBusEvents, GroupExpansionMode } from '../canvas.types';
 import { createEmptyCanvasRenderData, type CanvasRenderData } from '../canvas.utils';
 import { useCanvasMapping } from '../composables/useCanvasMapping';
-import { mapGroupsToVueFlowNodes } from '../composables/useCanvasMapping.groups';
+import {
+	aggregateGroupExecution,
+	mapGroupsToVueFlowNodes,
+} from '../composables/useCanvasMapping.groups';
 import { NodeGroupViewKey, useCanvasNodeGroupView } from '../composables/useCanvasNodeGroupView';
 import { buildNodeGroupLayoutComponents } from '../composables/useCanvasNodeGroupLayout';
 import Canvas from './Canvas.vue';
@@ -42,7 +45,7 @@ const props = withDefaults(
 		showFallbackNodes?: boolean;
 		eventBus?: EventBus<CanvasEventBusEvents>;
 		readOnly?: boolean;
-		forceAllGroupsExpanded?: boolean;
+		groupExpansionMode?: GroupExpansionMode;
 		canExecute?: boolean;
 		executing?: boolean;
 		suppressInteraction?: boolean;
@@ -56,6 +59,7 @@ const props = withDefaults(
 		showFallbackNodes: true,
 		suppressInteraction: false,
 		stripedBackground: true,
+		groupExpansionMode: undefined,
 	},
 );
 
@@ -104,13 +108,16 @@ const nodeGroupView = useCanvasNodeGroupView({
 	getCurrentGroupIds: () => workflowDocumentStore.value.allGroups.map((group) => group.id),
 	onNodeGroupsChange: (handler) => workflowDocumentStore.value.onNodeGroupsChange(handler),
 	isGroupingEnabled: () => isCanvasNodeGroupingEnabled.value,
-	forceAllGroupsExpanded: () => props.forceAllGroupsExpanded ?? false,
+	getGroupExpansionMode: () => props.groupExpansionMode,
 });
 
 // Keep the group view in sync with the currently displayed document
 watch(
 	() => workflowDocumentStore.value.documentId,
-	() => nodeGroupView.reinitialize(),
+	() => {
+		nodeGroupView.reinitialize();
+		applyGroupExpansion();
+	},
 );
 
 const allGroups = computed(() => workflowDocumentStore.value.allGroups);
@@ -133,6 +140,29 @@ const {
 	nodeGroupView,
 	isExperimentalNdvActive,
 });
+
+const groupIdsToExpand = computed(() => {
+	switch (props.groupExpansionMode) {
+		case 'all':
+			return allGroups.value.map((group) => group.id);
+		case 'errored':
+			return allGroups.value
+				.filter(
+					(group) => aggregateGroupExecution(group.nodeIds, getNodeExecutionSnapshot) === 'error',
+				)
+				.map((group) => group.id);
+		default:
+			return [];
+	}
+});
+
+function applyGroupExpansion() {
+	for (const id of groupIdsToExpand.value) {
+		nodeGroupView.setGroupExpanded(id, true);
+	}
+}
+
+watch(groupIdsToExpand, applyGroupExpansion, { immediate: true });
 
 const layoutComponents = computed(() =>
 	// Without grouping enabled or without groups there can be no pushes —

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.test.ts
@@ -3,17 +3,18 @@ import { useWorkflowDocumentNodeGroups } from '@/app/stores/workflowDocument/use
 import { LOCAL_STORAGE_CANVAS_GROUP_EXPANDED } from '@/app/constants/localStorage';
 import { useCanvasNodeGroupView } from './useCanvasNodeGroupView';
 import type { NodeGroupLayoutComponent } from './useCanvasNodeGroupLayout';
+import type { GroupExpansionMode } from '../canvas.types';
 
 function setup(
 	initialGroups: Array<{ id: string; name: string; nodeIds: string[] }> = [],
 	{
 		workflowId = 'wf-test',
 		isGroupingEnabled = () => true,
-		forceAllGroupsExpanded = () => false,
+		getGroupExpansionMode,
 	}: {
 		workflowId?: string;
 		isGroupingEnabled?: () => boolean;
-		forceAllGroupsExpanded?: () => boolean;
+		getGroupExpansionMode?: () => GroupExpansionMode | undefined;
 	} = {},
 ) {
 	const nodeGroups = useWorkflowDocumentNodeGroups();
@@ -25,7 +26,7 @@ function setup(
 		getCurrentGroupIds: () => nodeGroups.allGroups.value.map((group) => group.id),
 		onNodeGroupsChange: nodeGroups.onNodeGroupsChange,
 		isGroupingEnabled,
-		forceAllGroupsExpanded,
+		getGroupExpansionMode,
 	});
 	return { nodeGroups, view };
 }
@@ -139,8 +140,8 @@ describe('useCanvasNodeGroupView', () => {
 		});
 	});
 
-	describe('forceAllGroupsExpanded', () => {
-		it('expands every group on load, ignoring persisted state', () => {
+	describe.each(['all', 'errored'] as const)('host-managed expansion (%s)', (mode) => {
+		it('seeds every group collapsed, ignoring persisted state', () => {
 			localStorage.setItem(
 				LOCAL_STORAGE_CANVAS_GROUP_EXPANDED,
 				JSON.stringify({ 'wf-test': ['g1'] }),
@@ -151,46 +152,30 @@ describe('useCanvasNodeGroupView', () => {
 					{ id: 'g1', name: 'A', nodeIds: ['a'] },
 					{ id: 'g2', name: 'B', nodeIds: ['b'] },
 				],
-				{ forceAllGroupsExpanded: () => true },
+				{ getGroupExpansionMode: () => mode },
 			);
 
-			expect(view.isGroupCollapsed('g1')).toBe(false);
-			expect(view.isGroupCollapsed('g2')).toBe(false);
-		});
-
-		it('expands groups loaded via the SET event', () => {
-			const { nodeGroups, view } = setup([], { forceAllGroupsExpanded: () => true });
-
-			nodeGroups.setNodeGroups([
-				{ id: 'g1', name: 'A', nodeIds: ['a'] },
-				{ id: 'g2', name: 'B', nodeIds: ['b'] },
-			]);
-
-			expect(view.isGroupCollapsed('g1')).toBe(false);
-			expect(view.isGroupCollapsed('g2')).toBe(false);
-		});
-
-		it('still allows collapsing a group in memory', () => {
-			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				forceAllGroupsExpanded: () => true,
-			});
-
-			expect(view.isGroupCollapsed('g1')).toBe(false);
-			view.toggleCollapsed('g1');
 			expect(view.isGroupCollapsed('g1')).toBe(true);
+			expect(view.isGroupCollapsed('g2')).toBe(true);
 		});
 
-		it('never reads or writes persisted view state', () => {
-			localStorage.setItem(LOCAL_STORAGE_CANVAS_GROUP_EXPANDED, JSON.stringify({ 'wf-test': [] }));
-
+		it('lets the canvas expand a group via setGroupExpanded', () => {
 			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
-				forceAllGroupsExpanded: () => true,
+				getGroupExpansionMode: () => mode,
 			});
 
-			view.toggleCollapsed('g1');
-			view.toggleCollapsed('g1');
+			view.setGroupExpanded('g1', true);
+			expect(view.isGroupCollapsed('g1')).toBe(false);
+		});
 
-			expect(readStored()).toEqual([]);
+		it('never writes persisted view state', () => {
+			const { view } = setup([{ id: 'g1', name: 'A', nodeIds: ['a'] }], {
+				getGroupExpansionMode: () => mode,
+			});
+
+			view.setGroupExpanded('g1', true);
+
+			expect(readStored()).toBeUndefined();
 		});
 	});
 
@@ -207,21 +192,23 @@ describe('useCanvasNodeGroupView', () => {
 				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
 				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
 				isGroupingEnabled: () => true,
-				forceAllGroupsExpanded: () => true,
+				getGroupExpansionMode: () => 'all',
 			});
 
+			view.setGroupExpanded('a1', true);
 			expect(view.isGroupCollapsed('a1')).toBe(false);
 
-			// Swap the document without reinitializing: the new version's group is
-			// stale (collapsed) because the expanded set still reflects version A.
+			// Swap the document and reinitialize: the expanded set is re-seeded for
+			// version B's groups, dropping version A's stale expansion.
 			active = versionB;
-			expect(view.isGroupCollapsed('b1')).toBe(true);
-
 			view.reinitialize();
-			expect(view.isGroupCollapsed('b1')).toBe(false);
+			expect(view.isGroupCollapsed('a1')).toBe(true);
+			expect(view.isGroupCollapsed('b1')).toBe(true);
 		});
 
 		it('hears change events from the swapped document after rebinding', () => {
+			// b1 is persisted expanded, so hearing version B's SET event restores it.
+			localStorage.setItem(LOCAL_STORAGE_CANVAS_GROUP_EXPANDED, JSON.stringify({ wf: ['b1'] }));
 			const versionA = useWorkflowDocumentNodeGroups();
 			const versionB = useWorkflowDocumentNodeGroups();
 
@@ -231,7 +218,6 @@ describe('useCanvasNodeGroupView', () => {
 				getCurrentGroupIds: () => active.allGroups.value.map((group) => group.id),
 				onNodeGroupsChange: (handler) => active.onNodeGroupsChange(handler),
 				isGroupingEnabled: () => true,
-				forceAllGroupsExpanded: () => true,
 			});
 
 			active = versionB;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupView.ts
@@ -3,6 +3,7 @@ import { jsonParse } from 'n8n-workflow';
 import type { NodeGroupChangeEvent } from '@/app/stores/workflowDocument/useWorkflowDocumentNodeGroups';
 import { CHANGE_ACTION } from '@/app/stores/workflowDocument/types';
 import { LOCAL_STORAGE_CANVAS_GROUP_EXPANDED } from '@/app/constants/localStorage';
+import type { GroupExpansionMode } from '../canvas.types';
 import { isStringArrayRecord } from '@/app/utils/objectUtils';
 import {
 	aggregateNodeGroupLayoutOffsets,
@@ -17,8 +18,8 @@ export interface UseCanvasNodeGroupViewDeps {
 	getCurrentGroupIds: () => string[];
 	onNodeGroupsChange: (handler: (event: NodeGroupChangeEvent) => void) => { off: () => void };
 	isGroupingEnabled: () => boolean;
-	// Show every group expanded and leave persisted view state untouched
-	forceAllGroupsExpanded: () => boolean;
+	// Host override for group expansion; leaves persisted view state untouched.
+	getGroupExpansionMode?: () => GroupExpansionMode | undefined;
 }
 
 export interface NodeGroupNodePosition {
@@ -108,8 +109,10 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 	);
 	const componentOffsets = computed(() => aggregateNodeGroupLayoutOffsets(pushEntries.value));
 
+	const usesStoredExpansion = () => deps.getGroupExpansionMode?.() === undefined;
+
 	function persist() {
-		if (deps.forceAllGroupsExpanded()) return;
+		if (!usesStoredExpansion()) return;
 		writeStore({ ...readStore(), [deps.workflowId()]: [...expandedGroupIdOrder.value] });
 	}
 
@@ -129,15 +132,18 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		persist();
 	}
 
-	// Seed the expanded set on (re)load: all groups when forced, otherwise
-	// the persisted ids. Drop any id whose group no longer exists.
 	function restore(presentIds: Set<string>) {
-		const stored = deps.forceAllGroupsExpanded()
-			? [...presentIds]
-			: (readStore()[deps.workflowId()] ?? []);
-		expandedGroupIdOrder.value = stored.filter((id) => presentIds.has(id));
 		disabledPushSourceGroupIds.value = new Set();
 		ignoredNodeIdsBySourceGroup.value = new Map();
+
+		if (!usesStoredExpansion()) {
+			expandedGroupIdOrder.value = [];
+			return;
+		}
+
+		const storedExpandedGroupIds = readStore()[deps.workflowId()] ?? [];
+		// Prune ids whose group no longer exists
+		expandedGroupIdOrder.value = storedExpandedGroupIds.filter((id) => presentIds.has(id));
 
 		const groupsLoaded = presentIds.size > 0;
 		if (groupsLoaded) persist();
@@ -347,6 +353,7 @@ export function useCanvasNodeGroupView(deps: UseCanvasNodeGroupViewDeps) {
 		reinitialize,
 		isGroupCollapsed,
 		toggleCollapsed,
+		setGroupExpanded,
 		syncLayoutComponents,
 		getVisualOffsetForComponent,
 		getVisualOffsetForNode,


### PR DESCRIPTION
## Summary

This PR persists `nodeGroups` through the whole execution persistence chain and renders the groups in the execution view.

Groups are **collapsed by default** there (matching the editor's default), and only groups that contain a node that **errored** are auto-expanded — so failures are visible at a glance without manually opening every group. Groups can still be toggled manually, but the collapse state is not persisted in the execution view: that storage is keyed to the live workflow version, not the execution snapshot, so the editor's own collapse state stays untouched.

Old executions are not backfilled, so they render without groups.

## How to test

[Test instance](https://stage-app.n8n.cloud/login?code=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzMGVhODI4ZC05OWZmLTQxNWUtOTVlOC1iZjU4ZWRjODQzMjUiLCJvd25lciI6ODMxMSwidHYiOjAsImlzRm9yU3VwcG9ydCI6dHJ1ZSwiaWF0IjoxNzgyMzA1MzIxLCJleHAiOjE3ODIzMDYyMjF9.dPEKh-b6VGvNdn6Z-wt67pt3oRLHilXNFUL5jlYuSog)

1. Open a workflow and create one or more node groups.
2. Put a node that will fail inside one group, and run the workflow.
3. Open the finished execution in the **execution view**.
4. Groups should be **collapsed by default**, except the group containing the failed node, which should be **expanded**.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5322

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
