### PR TITLE
fix(editor): Show execution link on failed evaluation test cases

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -1,5 +1,6 @@
 import { mockLogger, mockInstance } from '@n8n/backend-test-utils';
 import { ExecutionsConfig } from '@n8n/config';
+import { TestCaseExecutionErrorCode } from '@n8n/db';
 import type {
 	EvaluationCollectionRepository,
 	EvaluationConfigRepository,
@@ -2215,6 +2216,45 @@ describe('TestRunnerService', () => {
 			expect(errorRows).toHaveLength(1);
 			expect(successRows).toHaveLength(3);
 			expect(testRunRepository.markAsCompleted).toHaveBeenCalledTimes(1);
+		});
+
+		test('records executionId on a case that errors after running (so the UI can link to its execution)', async () => {
+			setupHappyPathMocks(2);
+
+			// Case 2's execution completes, but emits a non-numeric metric so
+			// metric extraction throws INVALID_METRICS *after* the execution ran.
+			// Its executionId must still be persisted on the error row.
+			activeExecutions.getPostExecutePromise.mockImplementation(async (executionId) => {
+				if (executionId === 'dataset-exec') {
+					return buildDatasetExecution(2);
+				}
+				if (executionId === 'case-exec-2') {
+					return {
+						data: {
+							resultData: {
+								runData: {
+									[METRICS_NODE_NAME]: [
+										{
+											data: {
+												[NodeConnectionTypes.Main]: [[{ json: { score: 'not-a-number' } }]],
+											},
+										},
+									],
+								},
+							},
+						},
+					} as unknown as IRun;
+				}
+				return buildCaseExecution(0.5);
+			});
+
+			await testRunnerService.runTest(USER as never, WORKFLOW_ID, 2);
+
+			const invalidMetricRow = testCaseExecutionRepository.update.mock.calls.find(
+				([, row]) => row.errorCode === TestCaseExecutionErrorCode.INVALID_METRICS,
+			);
+			expect(invalidMetricRow).toBeDefined();
+			expect(invalidMetricRow?.[1].executionId).toBe('case-exec-2');
 		});
 
 		test('throttle is called once per case and release is called once per case', async () => {

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -925,6 +925,10 @@ export class TestRunnerService {
 							const runAt = new Date();
 
 							try {
+								// Hoisted so the catch below can still link the failed case to
+								// its execution: errors thrown during metric extraction (e.g.
+								// INVALID_METRICS) happen after the execution already ran.
+								let testCaseExecutionId: string | undefined;
 								try {
 									const testCaseMetadata = { ...testRunMetadata };
 
@@ -949,8 +953,8 @@ export class TestRunnerService {
 										return [];
 									}
 
-									const { executionId: testCaseExecutionId, executionData: testCaseExecution } =
-										testCaseResult;
+									const { executionData: testCaseExecution } = testCaseResult;
+									testCaseExecutionId = testCaseResult.executionId;
 
 									assert(testCaseExecution);
 									assert(testCaseExecutionId);
@@ -1032,8 +1036,11 @@ export class TestRunnerService {
 
 									telemetryMeta.errored_test_case_count++;
 
+									// `executionId` is left undefined when the failure happened before
+									// an execution was created; TypeORM skips undefined fields on update.
 									if (e instanceof TestCaseExecutionError) {
 										await this.testCaseExecutionRepository.update(seededCase.id, {
+											executionId: testCaseExecutionId,
 											runAt,
 											completedAt,
 											status: 'error',
@@ -1042,6 +1049,7 @@ export class TestRunnerService {
 										});
 									} else {
 										await this.testCaseExecutionRepository.update(seededCase.id, {
+											executionId: testCaseExecutionId,
 											runAt,
 											completedAt,
 											status: 'error',

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/RunDetail/TestCaseHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/RunDetail/TestCaseHeader.vue
@@ -88,16 +88,9 @@ const cyclingVerbKey = useCyclingVerb(isRunning);
 					{{ locale.baseText('evaluation.runDetail.testCase.cancelled') }}
 				</N8nText>
 			</template>
-			<template v-else-if="isFailed">
-				<N8nButton
-					variant="outline"
-					size="mini"
-					:label="locale.baseText('evaluation.runDetail.testCase.rerun')"
-					data-test-id="test-case-rerun-button"
-					@click.stop="emit('rerun')"
-				/>
-			</template>
 			<template v-else>
+				<!-- View link shows for any finished case (success or failed); the
+				rerun button is appended only when the case failed. -->
 				<N8nTooltip
 					v-if="executionId"
 					:content="locale.baseText('evaluation.runDetail.testCase.viewLink')"
@@ -114,6 +107,14 @@ const cyclingVerbKey = useCyclingVerb(isRunning);
 						<N8nIcon icon="external-link" size="small" />
 					</button>
 				</N8nTooltip>
+				<N8nButton
+					v-if="isFailed"
+					variant="outline"
+					size="mini"
+					:label="locale.baseText('evaluation.runDetail.testCase.rerun')"
+					data-test-id="test-case-rerun-button"
+					@click.stop="emit('rerun')"
+				/>
 			</template>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.test.ts
@@ -206,6 +206,18 @@ describe('TestRunDetailView', () => {
 		});
 	});
 
+	it('renders the execution view link on failed cases alongside the rerun button', async () => {
+		// mockTestCases has one success and one error case, both with an
+		// executionId. The link must show for both so a failed case is still
+		// clickable through to its execution; only the failed case also gets
+		// the rerun button.
+		const { getAllByTestId } = renderComponent();
+		await waitFor(() => {
+			expect(getAllByTestId('test-case-view-link')).toHaveLength(mockTestCases.length);
+			expect(getAllByTestId('test-case-rerun-button')).toHaveLength(1);
+		});
+	});
+
 	it('does not render a partial-failure callout — failures are surfaced per-card via RunStatusPill', async () => {
 		const { container, queryByText } = renderComponent();
 		await waitFor(() => {


### PR DESCRIPTION
## Summary

On the evaluation test-run **results page**, a failed test case only showed a **"Re-run test"** button and no way to click through to its execution. Successful cases showed a "view execution" link. This was especially painful for failures — exactly when you want to open the execution to debug.

This PR makes the execution link show in **both** cases.

## Changes

**Frontend** (`TestCaseHeader.vue`)
- Merged the `isFailed` branch into the final `v-else` so the view-execution link renders for any finished case (success *or* failed) when an `executionId` exists. The "Re-run test" button is now appended only when the case failed, sitting next to the link.

**Backend** (`test-runner.service.ee.ts`)
- Some failure paths (notably `INVALID_METRICS`, thrown during metric extraction *after* the workflow execution already ran) persisted the error row **without** the `executionId`, so the new link would still have nothing to point at. The `executionId` is now hoisted and recorded on those error rows when an execution exists. `undefined` is skipped by TypeORM, so failures that happen *before* an execution is created are unaffected.

## Tests

- **Frontend**: new assertion in `TestRunDetailView.test.ts` — the view link renders for both the success and failed mock cases, with the rerun button only on the failed one.
- **Backend**: new test in `test-runner.service.ee.test.ts` — a case that errors *after* running (invalid metric) records its `executionId` on the error row. Verified it fails without the backend fix.

## Related

https://linear.app/n8n/issue/TRUST-110

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->