### PR TITLE
fix(Schedule Node): Fix schedules that permanently stop firing

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -202,9 +202,37 @@ export function intervalToRecurrence(interval: ScheduleInterval, index: number) 
 }
 
 /**
+ * Whether a stored last-execution value can still be read meaningfully under
+ * the current interval type. `recurrenceCheck`'s `(now - last + base) % base`
+ * always converges for an in-range value, so only out-of-range values block the
+ * trigger forever. `months` switched to an absolute count this release, so any
+ * pre-signature value is the old 0-11 encoding and must be discarded.
+ */
+function isRecurrenceValueValidForType(
+	typeInterval: 'hours' | 'days' | 'weeks' | 'months',
+	value: number,
+): boolean {
+	switch (typeInterval) {
+		case 'hours':
+			return value >= 0 && value <= 23;
+		case 'days':
+			return value >= 1 && value <= 366;
+		case 'weeks':
+			return value >= 1 && value <= 53;
+		case 'months':
+			return false;
+	}
+}
+
+/**
  * Clears stored recurrence state when a schedule is edited, keyed by a per-index
- * `type:size` signature. A stale or wrong-unit value from a previous config (or a
- * missing signature pre-upgrade) would otherwise permanently block the trigger.
+ * `type:size` signature. A stale or wrong-unit value from a previous config would
+ * otherwise permanently block the trigger.
+ *
+ * A missing signature means pre-upgrade state: the schedule config itself hasn't
+ * changed, so a value still in range for its type is healthy and kept (only the
+ * signature is backfilled) to avoid an off-cadence fire on upgrade. Only an
+ * out-of-range value — the case that actually blocks the trigger — is cleared.
  */
 export function resetStaleRecurrence(
 	staticData: {
@@ -217,10 +245,21 @@ export function resetStaleRecurrence(
 		const signature = recurrence.activated
 			? `${recurrence.typeInterval}:${recurrence.intervalSize}`
 			: undefined;
-		if (staticData.recurrenceRuleSignatures[index] !== signature) {
-			staticData.recurrenceRules[index] = undefined;
-			staticData.recurrenceRuleSignatures[index] = signature;
-		}
+		const storedSignature = staticData.recurrenceRuleSignatures[index];
+
+		if (storedSignature === signature) return;
+
+		const storedValue = staticData.recurrenceRules[index];
+		// On upgrade (no signature yet) keep a value that's still valid for its
+		// type; an explicit config change (signature present but different) always clears.
+		const keepValue =
+			storedSignature === undefined &&
+			recurrence.activated &&
+			typeof storedValue === 'number' &&
+			isRecurrenceValueValidForType(recurrence.typeInterval, storedValue);
+
+		if (!keepValue) staticData.recurrenceRules[index] = undefined;
+		staticData.recurrenceRuleSignatures[index] = signature;
 	});
 
 	// Drop entries left by a previous config with more intervals.

--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -39,7 +39,7 @@ export function validateInterval(node: INode, itemIndex: number, interval: Sched
 
 export function recurrenceCheck(
 	recurrence: IRecurrenceRule,
-	recurrenceRules: number[],
+	recurrenceRules: Array<number | undefined | null>,
 	timezone: string,
 ): boolean {
 	if (!recurrence.activated) return true;
@@ -49,7 +49,9 @@ export function recurrenceCheck(
 
 	const index = recurrence.index;
 	const typeInterval = recurrence.typeInterval;
-	const lastExecution = recurrenceRules[index];
+	// A reset slot reads back as null once persisted (JSON turns undefined into null);
+	// treat both as "no prior run".
+	const lastExecution = recurrenceRules[index] ?? undefined;
 
 	const momentTz = moment.tz(timezone);
 	if (typeInterval === 'hours') {
@@ -75,9 +77,11 @@ export function recurrenceCheck(
 			return true;
 		}
 	} else if (typeInterval === 'months') {
-		const month = momentTz.month();
-		if (lastExecution === undefined || (month - lastExecution + 12) % 12 >= intervalSize) {
-			recurrenceRules[index] = month;
+		// Absolute month count (not the 0-11 index other branches use) so it stays
+		// monotonic and `intervalSize >= 12` works, which `% 12` could never reach.
+		const absoluteMonth = momentTz.year() * 12 + momentTz.month();
+		if (lastExecution === undefined || absoluteMonth - lastExecution >= intervalSize) {
+			recurrenceRules[index] = absoluteMonth;
 			return true;
 		}
 	}
@@ -136,7 +140,11 @@ export const toCronExpression = (interval: ScheduleInterval, nodeKey: string): C
 	// Cap at 29 (exclusive) so jitter yields 1-28: any higher day would silently
 	// skip months that don't contain it (e.g. day 30 skips February every year).
 	const dayOfMonth = interval.triggerAtDayOfMonth ?? stableInt(nodeKey, 'dayOfMonth', 1, 29);
-	return `${second} ${minute} ${hour} ${dayOfMonth} */${interval.monthsInterval} *`;
+	const months = interval.monthsInterval;
+	if (12 % months === 0) return `${second} ${minute} ${hour} ${dayOfMonth} */${months} *`;
+	// `*/${months}` only spaces evenly when months divides 12; otherwise fire every month
+	// and let recurrenceCheck enforce the gap (mirrors the hours handling above).
+	return `${second} ${minute} ${hour} ${dayOfMonth} * *`;
 };
 
 export function intervalToRecurrence(interval: ScheduleInterval, index: number) {
@@ -191,4 +199,31 @@ export function intervalToRecurrence(interval: ScheduleInterval, index: number) 
 	}
 
 	return recurrence;
+}
+
+/**
+ * Clears stored recurrence state when a schedule is edited, keyed by a per-index
+ * `type:size` signature. A stale or wrong-unit value from a previous config (or a
+ * missing signature pre-upgrade) would otherwise permanently block the trigger.
+ */
+export function resetStaleRecurrence(
+	staticData: {
+		recurrenceRules: Array<number | undefined>;
+		recurrenceRuleSignatures: Array<string | undefined>;
+	},
+	rules: Array<{ recurrence: IRecurrenceRule }>,
+): void {
+	rules.forEach(({ recurrence }, index) => {
+		const signature = recurrence.activated
+			? `${recurrence.typeInterval}:${recurrence.intervalSize}`
+			: undefined;
+		if (staticData.recurrenceRuleSignatures[index] !== signature) {
+			staticData.recurrenceRules[index] = undefined;
+			staticData.recurrenceRuleSignatures[index] = signature;
+		}
+	});
+
+	// Drop entries left by a previous config with more intervals.
+	staticData.recurrenceRules.length = rules.length;
+	staticData.recurrenceRuleSignatures.length = rules.length;
 }

--- a/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
+++ b/packages/nodes-base/nodes/Schedule/ScheduleTrigger.node.ts
@@ -12,6 +12,7 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import {
 	intervalToRecurrence,
 	recurrenceCheck,
+	resetStaleRecurrence,
 	toCronExpression,
 	validateInterval,
 } from './GenericFunctions';
@@ -172,6 +173,9 @@ export class ScheduleTrigger implements INodeType {
 								displayName: 'Months Between Triggers',
 								name: 'monthsInterval',
 								type: 'number',
+								typeOptions: {
+									minValue: 1,
+								},
 								displayOptions: {
 									show: {
 										field: ['months'],
@@ -429,10 +433,14 @@ export class ScheduleTrigger implements INodeType {
 		const { interval: intervals } = this.getNodeParameter('rule', []) as Rule;
 		const timezone = this.getTimezone();
 		const staticData = this.getWorkflowStaticData('node') as {
-			recurrenceRules: number[];
+			recurrenceRules: Array<number | undefined>;
+			recurrenceRuleSignatures: Array<string | undefined>;
 		};
 		if (!staticData.recurrenceRules) {
 			staticData.recurrenceRules = [];
+		}
+		if (!staticData.recurrenceRuleSignatures) {
+			staticData.recurrenceRuleSignatures = [];
 		}
 
 		if (version >= 1.3) {
@@ -492,6 +500,9 @@ export class ScheduleTrigger implements INodeType {
 		}));
 
 		if (this.getMode() !== 'manual') {
+			// Re-arm rules left stale by a previous schedule config (scheduled mode only).
+			resetStaleRecurrence(staticData, rules);
+
 			for (const { interval, cronExpression, recurrence } of rules) {
 				try {
 					const cron: Cron = {

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -772,11 +772,34 @@ describe('resetStaleRecurrence', () => {
 		typeInterval: 'days',
 	} as const;
 
-	it('clears the stored value and records a signature when none exists (pre-upgrade self-heal)', () => {
+	it('keeps an in-range value and backfills the signature on upgrade', () => {
+		// No signature yet (pre-upgrade) + a value still valid for its type: the
+		// schedule is healthy, so keep its cadence and only record the signature.
 		const staticData = { recurrenceRules: [200], recurrenceRuleSignatures: [] as string[] };
 		resetStaleRecurrence(staticData, [{ recurrence: daysRule }]);
-		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRules[0]).toBe(200);
 		expect(staticData.recurrenceRuleSignatures[0]).toBe('days:3');
+	});
+
+	it('clears an out-of-range value and records the signature on upgrade', () => {
+		// No signature yet + a value impossible for the type (200 as an hour): this
+		// is the stale wrong-unit state that blocks the trigger, so clear it.
+		const staticData = { recurrenceRules: [200], recurrenceRuleSignatures: [] as string[] };
+		resetStaleRecurrence(staticData, [
+			{ recurrence: { activated: true, index: 0, intervalSize: 3, typeInterval: 'hours' } },
+		]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('hours:3');
+	});
+
+	it('clears a months value on upgrade (absolute-month encoding is new)', () => {
+		// Old 0-11 month index is meaningless under the new absolute count.
+		const staticData = { recurrenceRules: [5], recurrenceRuleSignatures: [] as string[] };
+		resetStaleRecurrence(staticData, [
+			{ recurrence: { activated: true, index: 0, intervalSize: 2, typeInterval: 'months' } },
+		]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('months:2');
 	});
 
 	it('leaves the stored value intact when the signature is unchanged', () => {

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -4,6 +4,7 @@ import type { INode } from 'n8n-workflow';
 import {
 	intervalToRecurrence,
 	recurrenceCheck,
+	resetStaleRecurrence,
 	toCronExpression,
 	validateInterval,
 } from '../GenericFunctions';
@@ -18,12 +19,14 @@ function mockMomentTz(values: {
 	dayOfYear?: number;
 	week?: number;
 	month?: number;
+	year?: number;
 }) {
 	const tzObj = {
 		hour: () => values.hour ?? 0,
 		dayOfYear: () => values.dayOfYear ?? 1,
 		week: () => values.week ?? 1,
 		month: () => values.month ?? 0,
+		year: () => values.year ?? 0,
 	};
 	(mockedMoment.tz as unknown as Mock).mockReturnValue(tzObj);
 }
@@ -178,6 +181,21 @@ describe('toCronExpression', () => {
 		);
 		expect(result1).toEqual('56 19 14 22 */3 *');
 	});
+
+	it('should keep `*/N` for month intervals that divide 12, and fire monthly otherwise', () => {
+		// Divisors of 12 keep their calendar-anchored cron unchanged.
+		for (const months of [1, 2, 3, 4, 6, 12]) {
+			expect(toCronExpression({ field: 'months', monthsInterval: months }, TEST_SEED)).toEqual(
+				`56 19 14 22 */${months} *`,
+			);
+		}
+		// Non-divisors fire every month; recurrenceCheck enforces the elapsed-months gap.
+		for (const months of [5, 7, 8, 13, 24]) {
+			expect(toCronExpression({ field: 'months', monthsInterval: months }, TEST_SEED)).toEqual(
+				'56 19 14 22 * *',
+			);
+		}
+	});
 });
 
 describe('validateInterval', () => {
@@ -269,6 +287,18 @@ describe('recurrenceCheck', () => {
 	it('should return true on first execution when lastExecution is undefined', () => {
 		mockMomentTz({ dayOfYear: 100 });
 		const recurrenceRules: number[] = [];
+		const result = recurrenceCheck(
+			{ activated: true, index: 0, intervalSize: 3, typeInterval: 'days' },
+			recurrenceRules,
+			'UTC',
+		);
+		expect(result).toBe(true);
+		expect(recurrenceRules[0]).toBe(100);
+	});
+
+	it('should treat a persisted null (reset slot) as a first execution', () => {
+		mockMomentTz({ dayOfYear: 100 });
+		const recurrenceRules: Array<number | null> = [null];
 		const result = recurrenceCheck(
 			{ activated: true, index: 0, intervalSize: 3, typeInterval: 'days' },
 			recurrenceRules,
@@ -520,9 +550,9 @@ describe('recurrenceCheck', () => {
 			expect(recurrenceRules[0]).toBe(8);
 		});
 
-		it('should handle wrap-around (e.g., month 10 → month 1)', () => {
-			mockMomentTz({ month: 1 });
-			const recurrenceRules = [10]; // elapsed = (1-10+12)%12 = 3, interval = 3
+		it('should handle wrap-around across the year boundary (month 10 → month 1)', () => {
+			mockMomentTz({ month: 1, year: 1 }); // absolute month = 13
+			const recurrenceRules = [10]; // last fired month 10 of year 0; elapsed = 13-10 = 3
 			const result = recurrenceCheck(
 				{ activated: true, index: 0, intervalSize: 3, typeInterval: 'months' },
 				recurrenceRules,
@@ -531,15 +561,34 @@ describe('recurrenceCheck', () => {
 			expect(result).toBe(true);
 		});
 
-		it('should not trigger before interval on wrap-around', () => {
-			mockMomentTz({ month: 0 });
-			const recurrenceRules = [10]; // elapsed = (0-10+12)%12 = 2, need 3
+		it('should not trigger before interval across the year boundary', () => {
+			mockMomentTz({ month: 0, year: 1 }); // absolute month = 12
+			const recurrenceRules = [10]; // last fired month 10 of year 0; elapsed = 12-10 = 2, need 3
 			const result = recurrenceCheck(
 				{ activated: true, index: 0, intervalSize: 3, typeInterval: 'months' },
 				recurrenceRules,
 				'UTC',
 			);
 			expect(result).toBe(false);
+		});
+
+		it('should keep firing "every 12 months" after the first execution', () => {
+			const recurrenceRules: number[] = [];
+			const rule = {
+				activated: true,
+				index: 0,
+				intervalSize: 12,
+				typeInterval: 'months',
+			} as const;
+
+			mockMomentTz({ month: 0, year: 1 }); // first January
+			expect(recurrenceCheck(rule, recurrenceRules, 'UTC')).toBe(true);
+
+			mockMomentTz({ month: 11, year: 1 }); // 11 months later, not yet due
+			expect(recurrenceCheck(rule, recurrenceRules, 'UTC')).toBe(false);
+
+			mockMomentTz({ month: 0, year: 2 }); // 12 months later, next January
+			expect(recurrenceCheck(rule, recurrenceRules, 'UTC')).toBe(true);
 		});
 	});
 
@@ -556,6 +605,36 @@ describe('recurrenceCheck', () => {
 			);
 			expect(result).toBe(true);
 			expect(recurrenceRules[0]).toBe(25);
+		});
+	});
+
+	describe('stale value left by a type change from days to hours', () => {
+		const hoursRule = {
+			activated: true,
+			index: 0,
+			intervalSize: 3,
+			typeInterval: 'hours',
+		} as const;
+
+		it('never fires when a day-of-year value lingers under an hours rule', () => {
+			// staticData holds a day-of-year (200) at index 0 from a previous "every 3 days"
+			// schedule. Read as an hour, it blocks the trigger across every hour of the day.
+			const recurrenceRules = [200];
+			let everFires = false;
+			for (let h = 0; h < 24; h++) {
+				mockMomentTz({ hour: h });
+				if (recurrenceCheck(hoursRule, [...recurrenceRules], 'UTC')) everFires = true;
+			}
+			expect(everFires).toBe(false);
+		});
+
+		it('fires again once resetStaleRecurrence clears the stale value', () => {
+			const recurrenceRules: number[] = [200];
+			resetStaleRecurrence({ recurrenceRules, recurrenceRuleSignatures: [] }, [
+				{ recurrence: hoursRule },
+			]);
+			mockMomentTz({ hour: 0 });
+			expect(recurrenceCheck(hoursRule, recurrenceRules, 'UTC')).toBe(true);
 		});
 	});
 });
@@ -682,5 +761,63 @@ describe('intervalToRecurrence', () => {
 			intervalSize: 3,
 			typeInterval: 'months',
 		});
+	});
+});
+
+describe('resetStaleRecurrence', () => {
+	const daysRule = {
+		activated: true,
+		index: 0,
+		intervalSize: 3,
+		typeInterval: 'days',
+	} as const;
+
+	it('clears the stored value and records a signature when none exists (pre-upgrade self-heal)', () => {
+		const staticData = { recurrenceRules: [200], recurrenceRuleSignatures: [] as string[] };
+		resetStaleRecurrence(staticData, [{ recurrence: daysRule }]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('days:3');
+	});
+
+	it('leaves the stored value intact when the signature is unchanged', () => {
+		const staticData = { recurrenceRules: [21], recurrenceRuleSignatures: ['days:3'] };
+		resetStaleRecurrence(staticData, [{ recurrence: daysRule }]);
+		expect(staticData.recurrenceRules[0]).toBe(21);
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('days:3');
+	});
+
+	it('clears the stored value when the interval type changes', () => {
+		const staticData = { recurrenceRules: [200], recurrenceRuleSignatures: ['days:3'] };
+		resetStaleRecurrence(staticData, [
+			{ recurrence: { activated: true, index: 0, intervalSize: 3, typeInterval: 'hours' } },
+		]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('hours:3');
+	});
+
+	it('clears the stored value when the interval size changes', () => {
+		const staticData = { recurrenceRules: [21], recurrenceRuleSignatures: ['days:3'] };
+		resetStaleRecurrence(staticData, [
+			{ recurrence: { activated: true, index: 0, intervalSize: 5, typeInterval: 'days' } },
+		]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBe('days:5');
+	});
+
+	it('clears value and signature when a rule becomes non-recurring', () => {
+		const staticData = { recurrenceRules: [21], recurrenceRuleSignatures: ['days:3'] };
+		resetStaleRecurrence(staticData, [{ recurrence: { activated: false } }]);
+		expect(staticData.recurrenceRules[0]).toBeUndefined();
+		expect(staticData.recurrenceRuleSignatures[0]).toBeUndefined();
+	});
+
+	it('trims entries left by a previous config with more intervals', () => {
+		const staticData = {
+			recurrenceRules: [21, 5, 9],
+			recurrenceRuleSignatures: ['days:3', 'hours:2', 'weeks:4'],
+		};
+		resetStaleRecurrence(staticData, [{ recurrence: daysRule }]);
+		expect(staticData.recurrenceRules).toEqual([21]);
+		expect(staticData.recurrenceRuleSignatures).toEqual(['days:3']);
 	});
 });

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -59,6 +59,25 @@ describe('ScheduleTrigger', () => {
 			expect(emit).toHaveBeenCalledTimes(2);
 		});
 
+		it('should re-arm a schedule whose stored recurrence state is stale', async () => {
+			// staticData carries a stale day-of-year value (200) and no signature, as if the
+			// interval was switched from "every N days" to "every 3 hours". Without re-arming,
+			// recurrenceCheck reads 200 as an hour and the trigger never fires again.
+			const { emit } = await testTriggerNode(ScheduleTrigger, {
+				timezone,
+				node: { parameters: { rule: { interval: [{ field: 'hours', hoursInterval: 3 }] } } },
+				workflowStaticData: { recurrenceRules: [200] },
+			});
+
+			expect(emit).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(HOUR);
+			expect(emit).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(2 * HOUR);
+			expect(emit).toHaveBeenCalledTimes(1);
+		});
+
 		it('should emit repeatedly for hourly intervals that do not divide evenly into a day', async () => {
 			const { emit } = await testTriggerNode(ScheduleTrigger, {
 				timezone,


### PR DESCRIPTION
## Summary

Fixes two cases where a **Schedule Trigger** silently stops firing forever, with no end-user-visible way to recover (static data isn't editable in the UI, and duplicating the workflow doesn't help).

- **"Every N months" with N ≥ 12 never re-fired.** `recurrenceCheck()` compared a `0–11` month index using `(month - last + 12) % 12`, which can never reach an `intervalSize` of 12 or more — so the schedule fired once and then went silent. It now tracks a monotonic **absolute month count** (`year*12 + month`).
- **Changing an interval's type or size left stale, wrong-unit state.** The per-index value in `staticData.recurrenceRules` is unit-specific (hour / day-of-year / week / month). After switching e.g. *every N days* → *every N hours*, the stale day-of-year value was read as an hour, and JavaScript's sign-preserving `%` made the elapsed-time check permanently negative — the trigger never fired again. A new `resetStaleRecurrence()` keys each slot by a `type:size` **signature** and clears stale state when the schedule changes (and on upgrade, where the signature is absent), re-arming the trigger.

Month cron expressions keep the calendar-anchored `*/N` when `N` divides 12 (so existing *every 2/3/4/6/12 months* schedules are unaffected) and otherwise fire monthly, filtered by `recurrenceCheck` — mirroring how hours already work.

## How to test

**Automated** (the before/after proof — fail on `master`, pass here):

```bash
cd packages/nodes-base && pnpm test Schedule
```

- `recurrenceCheck > months > should keep firing "every 12 months" after the first execution`
- `recurrenceCheck > stale value left by a type change from days to hours` (never fires → cleared → fires)
- `toCronExpression > should keep \`*/N\` for month intervals that divide 12, and fire monthly otherwise` (no cadence regression)
- `resetStaleRecurrence` suite (signature transitions, pre-upgrade self-heal, array trimming) and a node-level re-arm test

**Manual** (verified against a running instance). `resetStaleRecurrence` runs at activation, so the re-arm is observable without waiting for a tick. Note the public API ignores `staticData` on write, so inject via the DB:

1. Create + activate a Schedule Trigger set to **Hours / every 2 hours**.
2. Deactivate, then inject a stale value straight into the DB:
   `UPDATE workflow_entity SET staticData='{"node:Schedule Trigger":{"recurrenceRules":[200]}}' WHERE id='<id>';`
3. Confirm the DB now holds `recurrenceRules: [200]`.
4. Activate → re-registration runs `resetStaleRecurrence`.
5. Confirm the DB now shows `recurrenceRules: [null]` + `recurrenceRuleSignatures: ["hours:2"]` — the stale value is cleared and the trigger is re-armed. On `master` the `[200]` would persist and the trigger would never fire.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4170

Relates to #23711

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->