### PR TITLE
refactor(core): Split agent chat bridge modules

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -816,7 +816,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(setAssistantStatus).toHaveBeenLastCalledWith('D123', '1779466577.518139', '');
 		});
 
-		it('buffers the response when resuming a Slack action', async () => {
+		it('sets a thinking status and buffers the response when resuming a Slack action', async () => {
 			const { bot, handlers } = makeBot();
 			const thread = makeThread();
 			const agentExecutor = {
@@ -852,7 +852,10 @@ describe('AgentChatBridge — consumeStream', () => {
 				adapter: { deleteMessage: jest.fn().mockResolvedValue(undefined) },
 			});
 
-			expect(thread.startTyping).not.toHaveBeenCalled();
+			expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
+			expect(thread.startTyping.mock.invocationCallOrder[0]).toBeLessThan(
+				thread.post.mock.invocationCallOrder[0],
+			);
 			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Approved response' });
 			expect(agentExecutor.resumeForChat).toHaveBeenCalled();
 		});

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -283,6 +283,51 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(thread.post).toHaveBeenCalledWith({ card: { kind: 'card' } });
 		});
 
+		it('falls back to a default suspension card for malformed payloads', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			componentMapper.toCard.mockResolvedValue({ kind: 'card' } as never);
+
+			const agentExecutor = makeAgentExecutor([
+				{
+					type: 'tool-call-suspended',
+					runId: 'run-1',
+					toolCallId: 'tool-1',
+					toolName: 'approval',
+					suspendPayload: 'Approve?',
+				},
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				bufferedIntegration,
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1', userName: 'user1' } });
+
+			expect(componentMapper.toCard).toHaveBeenCalledWith(
+				{
+					title: 'Action required — approve or deny?',
+					components: [
+						{ type: 'button', label: 'Approve', value: 'true', style: 'primary' },
+						{ type: 'button', label: 'Deny', value: 'false', style: 'danger' },
+					],
+				},
+				'run-1',
+				'tool-1',
+				undefined,
+				undefined,
+				'test-buffered',
+			);
+			expect(thread.post).toHaveBeenCalledWith({ card: { kind: 'card' } });
+		});
+
 		it('does not post when the buffer is only whitespace', async () => {
 			const { bot, handlers } = makeBot();
 			const thread = makeThread();
@@ -422,6 +467,34 @@ describe('AgentChatBridge — consumeStream', () => {
 			const received = await drainIterable(thread.post.mock.calls[0][0]);
 			expect(received).toBe('Hello world');
 		});
+
+		it('posts an error message when the streaming post fails', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			thread.post.mockRejectedValueOnce(new Error('send failed')).mockResolvedValueOnce(undefined);
+			const agentExecutor = makeAgentExecutor([
+				{ type: 'text-delta', id: 't1', delta: 'Hello' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+			);
+
+			await handlers.mention!(thread, { text: 'hi', author: { userId: 'u1', userName: 'user1' } });
+
+			expect(thread.post).toHaveBeenCalledTimes(2);
+			expect(thread.post).toHaveBeenNthCalledWith(
+				2,
+				'⚠️ Something went wrong while processing your request. Please try again.',
+			);
+		});
 	});
 
 	describe('Slack assistant status', () => {
@@ -465,7 +538,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(agentExecutor.executeForChatPublished).toHaveBeenCalled();
 		});
 
-		it('sets assistant status for top-level Slack channel mentions via the Slack adapter and buffers the response', async () => {
+		it('clears assistant status before responding to top-level Slack channel mentions', async () => {
 			const { bot, handlers } = makeBot();
 			const setAssistantStatus = jest.fn().mockResolvedValue(undefined);
 			bot.getAdapter.mockReturnValue({ setAssistantStatus });
@@ -502,9 +575,17 @@ describe('AgentChatBridge — consumeStream', () => {
 			});
 
 			expect(thread.startTyping).not.toHaveBeenCalled();
-			expect(setAssistantStatus).toHaveBeenCalledWith('C123', '1779466577.518139', 'Thinking...', [
+			expect(setAssistantStatus).toHaveBeenNthCalledWith(
+				1,
+				'C123',
+				'1779466577.518139',
 				'Thinking...',
-			]);
+				['Thinking...'],
+			);
+			expect(setAssistantStatus).toHaveBeenNthCalledWith(2, 'C123', '1779466577.518139', '');
+			expect(setAssistantStatus.mock.invocationCallOrder[1]).toBeLessThan(
+				thread.post.mock.invocationCallOrder[0],
+			);
 			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Hello' });
 		});
 

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../agent-chat-integration';
 import type { ComponentMapper } from '../component-mapper';
 import type { IntegrationMessageContextService } from '../integration-message-context.service';
+import { SlackIntegration } from '../platforms/slack-integration';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
 import type { RichCardComponentType } from '@n8n/api-types';
 
@@ -139,6 +140,7 @@ describe('AgentChatBridge — consumeStream', () => {
 		registry.register(new BufferingTestIntegration());
 		registry.register(new StreamingTestIntegration());
 		registry.register(new FormattedBufferedTestIntegration());
+		registry.register(new SlackIntegration());
 		Container.set(ChatIntegrationRegistry, registry);
 	});
 
@@ -733,14 +735,20 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(setAssistantStatus).toHaveBeenLastCalledWith('D123', '1779466577.518139', '');
 		});
 
-		it('sets a thinking status before resuming a Slack action', async () => {
+		it('buffers the response when resuming a Slack action', async () => {
 			const { bot, handlers } = makeBot();
 			const thread = makeThread();
 			const agentExecutor = {
 				executeForChatPublished: jest.fn(() =>
 					toStream([{ type: 'finish', finishReason: 'stop' }]),
 				),
-				resumeForChat: jest.fn(() => toStream([{ type: 'finish', finishReason: 'stop' }])),
+				resumeForChat: jest.fn(() =>
+					toStream([
+						{ type: 'text-delta', id: 't1', delta: 'Approved ' },
+						{ type: 'text-delta', id: 't1', delta: 'response' },
+						{ type: 'finish', finishReason: 'stop' },
+					]),
+				),
 			};
 
 			new AgentChatBridge(
@@ -763,7 +771,8 @@ describe('AgentChatBridge — consumeStream', () => {
 				adapter: { deleteMessage: jest.fn().mockResolvedValue(undefined) },
 			});
 
-			expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
+			expect(thread.startTyping).not.toHaveBeenCalled();
+			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Approved response' });
 			expect(agentExecutor.resumeForChat).toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
@@ -1,4 +1,5 @@
 import { SlackIntegration } from '../platforms/slack-integration';
+import type { ChatInstance } from '../chat-integration.service';
 
 describe('SlackIntegration', () => {
 	let integration: SlackIntegration;
@@ -18,6 +19,28 @@ describe('SlackIntegration', () => {
 
 	it('only advertises Slack bot token credentials for agent integrations', () => {
 		expect(integration.credentialTypes).toEqual(['slackApi']);
+	});
+
+	it('extracts the Slack bot user ID for bridge message context', () => {
+		const chat = {
+			getAdapter: jest.fn().mockReturnValue({ botUserId: 'U_BOT' }),
+		} as unknown as ChatInstance;
+
+		expect(integration.getPlatformAgentContext(chat)).toEqual({ agentUserId: 'U_BOT' });
+		expect(chat.getAdapter).toHaveBeenCalledWith('slack');
+	});
+
+	it('strips Slack bot self-mentions before handing text to the agent', () => {
+		expect(integration.prepareInboundText('<@U_BOT> hello', { agentUserId: 'U_BOT' })).toBe(
+			'hello',
+		);
+		expect(integration.prepareInboundText('@U_BOT hello', { agentUserId: 'U_BOT' })).toBe('hello');
+	});
+
+	it('buffers resume responses because Slack action events lack reliable thread context', async () => {
+		await expect(integration.createResumeExecutionContext()).resolves.toEqual({
+			forceBuffered: true,
+		});
 	});
 
 	describe('handleUnauthenticatedWebhook', () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
@@ -38,9 +38,22 @@ describe('SlackIntegration', () => {
 	});
 
 	it('buffers resume responses because Slack action events lack reliable thread context', async () => {
-		await expect(integration.createResumeExecutionContext()).resolves.toEqual({
-			forceBuffered: true,
+		const thread = {
+			startTyping: jest.fn().mockResolvedValue(undefined),
+		};
+
+		const context = await integration.createResumeExecutionContext({
+			chat: {
+				getAdapter: jest.fn().mockReturnValue(undefined),
+			} as unknown as ChatInstance,
+			thread: thread as never,
+			logger: { warn: jest.fn() } as never,
+			agentId: 'agent-1',
 		});
+
+		expect(context.forceBuffered).toBe(true);
+		expect(context.statusHandle).toBeUndefined();
+		expect(thread.startTyping).toHaveBeenCalledWith('Thinking...');
 	});
 
 	describe('handleUnauthenticatedWebhook', () => {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -125,8 +125,7 @@ export class AgentChatBridge {
 				const resumeExecutionContext =
 					await this.integrationImpl?.createResumeExecutionContext?.(params);
 				if (resumeExecutionContext) return resumeExecutionContext;
-				const statusHandle = await this.integrationImpl?.createResumeStatusHandle?.(params);
-				return { statusHandle };
+				return {};
 			},
 		});
 		this.registerHandlers();
@@ -313,22 +312,6 @@ export class AgentChatBridge {
 		);
 	}
 
-	// ---------------------------------------------------------------------------
-	// Stream consumer
-	// ---------------------------------------------------------------------------
-
-	/**
-	 * Consume the agent stream and post to the thread.
-	 *
-	 * Default: pipe text deltas as an AsyncIterable<string> to `thread.post()`
-	 * so Chat SDK can render incrementally (post-and-edit). Integrations that
-	 * set `disableStreaming` short-circuit to `consumeStreamBuffered`, which
-	 * accumulates deltas into a string and posts them as a single message per
-	 * flush event (used by Telegram to avoid Markdown streaming issues).
-	 *
-	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
-	 * `error`) flush any pending text first, then get handled in order.
-	 */
 	// ---------------------------------------------------------------------------
 	// Suspension handling (HITL tool cards)
 	// ---------------------------------------------------------------------------

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -4,7 +4,6 @@ import type { Author, Chat, Message, Thread } from 'chat';
 import type { Logger } from 'n8n-workflow';
 
 import type { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
-import type { RichSuspendPayload } from '../types';
 import { integrationMemoryResourceId } from '../utils/agent-memory-scope';
 import type {
 	AgentChatIntegration,
@@ -327,8 +326,7 @@ export class AgentChatBridge {
 			return;
 		}
 
-		const payload = suspendPayload as RichSuspendPayload | Record<string, unknown> | undefined;
-		const cardPayload = buildSuspendCardPayload(payload);
+		const cardPayload = buildSuspendCardPayload(suspendPayload);
 		if (!cardPayload) return;
 
 		try {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -1,49 +1,27 @@
 import type { AgentMessage, StreamChunk } from '@n8n/agents';
 import { Container } from '@n8n/di';
-import { isRecord } from '@n8n/utils';
-import type { ActionEvent, Author, Chat, Message, MessageSubject, Thread } from 'chat';
+import type { Author, Chat, Message, Thread } from 'chat';
 import type { Logger } from 'n8n-workflow';
 
 import type { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
 import type { RichSuspendPayload } from '../types';
 import { integrationMemoryResourceId } from '../utils/agent-memory-scope';
-import type { AgentChatIntegration } from './agent-chat-integration';
+import type {
+	AgentChatIntegration,
+	BridgeExecutionContext,
+	PlatformAgentContext,
+} from './agent-chat-integration';
 import { ChatIntegrationRegistry } from './agent-chat-integration';
+import { AgentChatHitlResumeHandler } from './agent-chat-hitl-resume-handler';
+import { AgentChatMessageContextBridge } from './agent-chat-message-context';
+import { AgentChatStreamConsumer } from './agent-chat-stream-consumer';
+import { buildSuspendCardPayload } from './agent-chat-suspension-cards';
 import { CallbackStore } from './callback-store';
 import type { ComponentMapper, ShortenCallback } from './component-mapper';
 import { IntegrationMessageContextService } from './integration-message-context.service';
-import {
-	buildIntegrationConnectionId,
-	type IntegrationMessageContext,
-	type IntegrationMessageSubject,
-} from './integration-tools';
 import type { AgentIntegrationConfig } from '@n8n/api-types';
 
-import { type InternalThread, type TextEndFn, type TextYieldFn, toInternalThreadId } from './types';
-
-interface PlatformAgentContext {
-	agentUserId?: string;
-}
-
-interface SlackThreadContext {
-	channelId: string;
-	threadTs: string;
-	hasRealThreadTs: boolean;
-	isDm: boolean;
-}
-
-interface SlackAssistantStatusAdapter {
-	setAssistantStatus(
-		channelId: string,
-		threadTs: string,
-		status: string,
-		loadingMessages?: string[],
-	): Promise<void>;
-}
-
-interface SlackAssistantStatusHandle {
-	clearBeforeResponse(): Promise<void>;
-}
+import { type InternalThread, toInternalThreadId } from './types';
 
 interface AgentExecutor {
 	executeForChatPublished(config: {
@@ -62,120 +40,6 @@ interface AgentExecutor {
 		resumeData: unknown;
 		integrationType?: string;
 	}): AsyncGenerator<StreamChunk>;
-}
-
-const SLACK_THINKING_STATUS = 'Thinking...';
-const SLACK_STATUS_RETRY_DELAY_MS = 750;
-const APPROVAL_INPUT_MAX_LENGTH = 1500;
-
-interface ApprovalSuspendPayload {
-	type: 'approval';
-	toolName: string;
-	displayName?: string;
-	args?: unknown;
-}
-
-function isIntegrationActionSuspendPayload(value: unknown): boolean {
-	return (
-		typeof value === 'object' &&
-		value !== null &&
-		'type' in value &&
-		value.type === 'integration_action'
-	);
-}
-
-function isApprovalSuspendPayload(value: unknown): value is ApprovalSuspendPayload {
-	return (
-		isRecord(value) &&
-		value.type === 'approval' &&
-		typeof value.toolName === 'string' &&
-		value.toolName.length > 0
-	);
-}
-
-function truncateApprovalInput(value: string): string {
-	if (value.length <= APPROVAL_INPUT_MAX_LENGTH) return value;
-	return `${value.slice(0, APPROVAL_INPUT_MAX_LENGTH)}...`;
-}
-
-function stringifyApprovalInput(value: unknown): string | undefined {
-	if (value === undefined) return undefined;
-
-	if (typeof value === 'string') {
-		return truncateApprovalInput(value);
-	}
-
-	try {
-		const serialized = JSON.stringify(value, null, 2);
-		return truncateApprovalInput(serialized ?? String(value));
-	} catch {
-		return truncateApprovalInput(String(value));
-	}
-}
-
-function getApprovalToolLabel(payload: ApprovalSuspendPayload): string {
-	return typeof payload.displayName === 'string' && payload.displayName.length > 0
-		? payload.displayName
-		: payload.toolName;
-}
-
-function buildApprovalCardPayload(payload: ApprovalSuspendPayload): {
-	title: string;
-	components: Array<{ type: string; [key: string]: unknown }>;
-} {
-	const toolLabel = getApprovalToolLabel(payload);
-	const fields: Array<{ label: string; value: string }> = [{ label: 'Tool', value: toolLabel }];
-	const input = stringifyApprovalInput(payload.args);
-
-	if (input) {
-		fields.push({ label: 'Input', value: input });
-	}
-
-	return {
-		title: 'Approval required',
-		components: [
-			{ type: 'section', text: `The agent wants to run this tool: ${toolLabel}` },
-			{ type: 'fields', fields },
-			{ type: 'button', label: 'Approve', value: 'true', style: 'primary' },
-			{ type: 'button', label: 'Deny', value: 'false', style: 'danger' },
-		],
-	};
-}
-
-function toIntegrationMessageSubject(
-	subject: MessageSubject | null | undefined,
-): IntegrationMessageSubject | undefined {
-	if (!subject || typeof subject.type !== 'string' || typeof subject.id !== 'string') {
-		return undefined;
-	}
-
-	const assignee = toIntegrationSubjectPerson(subject.assignee);
-	const author = toIntegrationSubjectPerson(subject.author);
-	const labels = subject.labels?.filter((label) => typeof label === 'string');
-
-	return {
-		type: subject.type,
-		id: subject.id,
-		...(typeof subject.title === 'string' ? { title: subject.title } : {}),
-		...(typeof subject.description === 'string' ? { description: subject.description } : {}),
-		...(typeof subject.url === 'string' ? { url: subject.url } : {}),
-		...(typeof subject.status === 'string' ? { status: subject.status } : {}),
-		...(labels && labels.length > 0 ? { labels } : {}),
-		...(assignee ? { assignee } : {}),
-		...(author ? { author } : {}),
-	};
-}
-
-function toIntegrationSubjectPerson(
-	person: MessageSubject['assignee'] | MessageSubject['author'],
-): IntegrationMessageSubject['assignee'] | undefined {
-	if (!person || typeof person.id !== 'string' || typeof person.name !== 'string') {
-		return undefined;
-	}
-	return {
-		id: person.id,
-		name: person.name,
-	};
 }
 
 /**
@@ -199,17 +63,17 @@ function toIntegrationSubjectPerson(
  * `error`) flush any pending text before being handled, preserving ordering.
  */
 export class AgentChatBridge {
-	/** Short-lived set of run IDs that have been resumed to prevent double resumption */
-	private readonly activeResumedRuns = new Set<string>();
-
 	/** Store for shortening callback data on platforms with size limits (Telegram) */
 	private readonly callbackStore?: CallbackStore;
 
-	/** When true, buffer deltas and post as a single message (see integration flag). */
-	private readonly disableStreaming: boolean;
-
 	/** Resolved integration for this platform (may be undefined for unknown types). */
 	private readonly integrationImpl: AgentChatIntegration | undefined;
+
+	private readonly messageContextBridge: AgentChatMessageContextBridge;
+
+	private readonly streamConsumer: AgentChatStreamConsumer;
+
+	private readonly hitlResumeHandler: AgentChatHitlResumeHandler;
 
 	constructor(
 		private readonly chat: Chat,
@@ -219,13 +83,52 @@ export class AgentChatBridge {
 		private readonly logger: Logger,
 		private readonly n8nProjectId: string,
 		private readonly integration: AgentIntegrationConfig,
-		private readonly messageContextStore?: IntegrationMessageContextService,
+		messageContextStore?: IntegrationMessageContextService,
 	) {
 		this.integrationImpl = Container.get(ChatIntegrationRegistry).get(integration.type);
+		this.messageContextBridge = new AgentChatMessageContextBridge(
+			messageContextStore,
+			integration,
+			agentId,
+			logger,
+		);
 		if (this.integrationImpl?.needsShortCallbackData) {
 			this.callbackStore = new CallbackStore();
 		}
-		this.disableStreaming = this.integrationImpl?.disableStreaming ?? false;
+		const disableStreaming = this.integrationImpl?.disableStreaming ?? false;
+		this.streamConsumer = new AgentChatStreamConsumer({
+			disableStreaming,
+			logger: this.logger,
+			postErrorToThread: this.postErrorToThread.bind(this),
+			handleSuspension: this.handleSuspension.bind(this),
+			handleMessage: this.handleMessage.bind(this),
+		});
+		this.hitlResumeHandler = new AgentChatHitlResumeHandler({
+			agentId,
+			projectId: n8nProjectId,
+			integration,
+			agentService,
+			logger,
+			callbackStore: this.callbackStore,
+			resolvePlatformThreadId: this.resolvePlatformThreadId.bind(this),
+			toAgentThreadId: this.toAgentThreadId.bind(this),
+			getPlatformAgentContext: this.getPlatformAgentContext.bind(this),
+			messageContextBridge: this.messageContextBridge,
+			streamConsumer: this.streamConsumer,
+			createResumeExecutionContext: async (thread) => {
+				const params = {
+					chat: this.chat,
+					thread,
+					logger: this.logger,
+					agentId: this.agentId,
+				};
+				const resumeExecutionContext =
+					await this.integrationImpl?.createResumeExecutionContext?.(params);
+				if (resumeExecutionContext) return resumeExecutionContext;
+				const statusHandle = await this.integrationImpl?.createResumeStatusHandle?.(params);
+				return { statusHandle };
+			},
+		});
 		this.registerHandlers();
 	}
 
@@ -301,7 +204,7 @@ export class AgentChatBridge {
 		this.chat.onAction(async (event) => {
 			try {
 				if (!this.canUserAccess(event.user)) return;
-				await this.handleAction(event);
+				await this.hitlResumeHandler.handleAction(event);
 			} catch (error) {
 				await this.postErrorToThread(event.thread, error);
 			}
@@ -353,21 +256,18 @@ export class AgentChatBridge {
 
 		const platformThreadId = this.resolvePlatformThreadId(thread);
 		const threadId = this.toAgentThreadId(platformThreadId);
-		const slackThreadContext = this.getSlackThreadContext(message);
-		const useNativeSlackThreadFeatures =
-			this.integration.type !== 'slack' || slackThreadContext?.hasRealThreadTs === true;
 		const statusRetry = new AbortController();
-		// startThinkingStatus (Slack assistant.threads.setStatus) and the lazy
+		// Platform status hooks and the lazy
 		// `message.subject` fetch are both remote round-trips on independent
 		// resources — run them concurrently.
-		const [statusHandle, subject] = await Promise.all([
-			this.startThinkingStatus(thread, slackThreadContext, statusRetry),
-			this.resolveMessageSubject(message),
+		const [bridgeExecutionContext, subject] = await Promise.all([
+			this.resolveBridgeExecutionContext(thread, message, platformAgentContext, statusRetry),
+			this.messageContextBridge.resolveSubject(message),
 		]);
-		await this.updateLatestMessageContext(threadId.id, message.author.userId, thread, {
+		await this.messageContextBridge.updateLatest(threadId.id, message.author.userId, thread, {
 			messageId: message.id,
 			interactingUserId: message.author.userId,
-			...platformAgentContext,
+			...bridgeExecutionContext.platformAgentContext,
 			subject,
 		});
 		// threadId.id is agent-prefixed for observation storage; resourceId keeps
@@ -386,13 +286,31 @@ export class AgentChatBridge {
 		});
 
 		try {
-			await this.consumeStream(stream, thread, {
-				forceBuffered: this.integration.type === 'slack' && !useNativeSlackThreadFeatures,
-				statusHandle,
+			await this.streamConsumer.consume(stream, thread, {
+				forceBuffered: bridgeExecutionContext.forceBuffered,
+				statusHandle: bridgeExecutionContext.statusHandle,
 			});
 		} finally {
 			statusRetry.abort();
 		}
+	}
+
+	private async resolveBridgeExecutionContext(
+		thread: Thread<unknown, unknown>,
+		message: Message<unknown>,
+		platformAgentContext: PlatformAgentContext,
+		statusRetry: AbortController,
+	): Promise<BridgeExecutionContext> {
+		return (
+			(await this.integrationImpl?.createBridgeExecutionContext?.({
+				chat: this.chat,
+				thread,
+				message,
+				logger: this.logger,
+				agentId: this.agentId,
+				statusRetry,
+			})) ?? { platformAgentContext }
+		);
 	}
 
 	// ---------------------------------------------------------------------------
@@ -411,240 +329,6 @@ export class AgentChatBridge {
 	 * In both strategies, non-text chunks (`tool-call-suspended`, `message`,
 	 * `error`) flush any pending text first, then get handled in order.
 	 */
-	private async consumeStream(
-		stream: AsyncGenerator<StreamChunk>,
-		thread: Thread,
-		options: { forceBuffered?: boolean; statusHandle?: SlackAssistantStatusHandle } = {},
-	): Promise<void> {
-		if (this.disableStreaming || options.forceBuffered) {
-			await this.consumeStreamBuffered(stream, thread, {
-				statusHandle: options.statusHandle,
-			});
-			return;
-		}
-
-		// Controller for the text stream iterable that Chat SDK consumes.
-		// These are reassigned inside `createTextIterable()` (called transitively
-		// by `ensureStreamingPost()`). TypeScript cannot track mutations through
-		// closures, so it incorrectly narrows these to `never` after the
-		// assignment. We use a wrapper object to avoid the TS closure analysis issue.
-		const textStream: { yield: TextYieldFn | null; end: TextEndFn | null } = {
-			yield: null,
-			end: null,
-		};
-		let streamingPost: Promise<unknown> | null = null;
-
-		const createTextIterable = (): AsyncIterable<string> => {
-			const queue: string[] = [];
-			let done = false;
-			let waiting: ((result: IteratorResult<string>) => void) | null = null;
-
-			textStream.yield = (text: string) => {
-				if (waiting) {
-					const resolve = waiting;
-					waiting = null;
-					resolve({ value: text, done: false });
-				} else {
-					queue.push(text);
-				}
-			};
-
-			textStream.end = () => {
-				done = true;
-				if (waiting) {
-					const resolve = waiting;
-					waiting = null;
-					resolve({ value: '', done: true });
-				}
-			};
-
-			return {
-				[Symbol.asyncIterator]() {
-					return {
-						async next(): Promise<IteratorResult<string>> {
-							if (queue.length > 0) {
-								return { value: queue.shift()!, done: false };
-							}
-							if (done) {
-								return { value: '', done: true };
-							}
-							return await new Promise((resolve) => {
-								waiting = resolve;
-							});
-						},
-					};
-				},
-			};
-		};
-
-		const startStreamingPost = () => {
-			const iterable = createTextIterable();
-			streamingPost = thread.post(iterable).catch((postError: unknown) => {
-				this.logger.error('[AgentChatBridge] Streaming post failed', {
-					error: postError instanceof Error ? postError.message : String(postError),
-				});
-			});
-		};
-
-		const endStreamingPost = async () => {
-			if (textStream.end) {
-				textStream.end();
-				textStream.end = null;
-				textStream.yield = null;
-			}
-			if (streamingPost) {
-				await streamingPost;
-				streamingPost = null;
-			}
-		};
-
-		// Don't start streaming post eagerly — wait for first text delta
-		const ensureStreamingPost = () => {
-			if (!streamingPost) startStreamingPost();
-		};
-		const responseLifecycle = this.createResponseLifecycle({
-			statusHandle: options.statusHandle,
-			ensureStreamingPost,
-			endStreamingPost,
-		});
-
-		try {
-			for await (const chunk of stream) {
-				switch (chunk.type) {
-					case 'text-delta': {
-						const { delta } = chunk;
-						await responseLifecycle.startStreamingResponse();
-						textStream.yield?.(delta);
-						break;
-					}
-					case 'reasoning-delta': {
-						const { delta } = chunk;
-						await responseLifecycle.startStreamingResponse();
-						textStream.yield?.(`_${delta}_`);
-						break;
-					}
-					case 'tool-call-suspended':
-						await responseLifecycle.startDiscreteResponse();
-						await this.handleSuspension(chunk, thread);
-						// Don't start new streaming post — wait for next text delta
-						break;
-					case 'message':
-						await responseLifecycle.startDiscreteResponse();
-						await this.handleMessage(chunk, thread);
-						break;
-					case 'error':
-						await responseLifecycle.startDiscreteResponse();
-						await this.postErrorToThread(thread, chunk.error);
-						break;
-					default:
-						// Ignore other chunk types (finish, tool-input-*,
-						// start-step, finish-step, etc.)
-						break;
-				}
-			}
-		} finally {
-			await responseLifecycle.finish();
-		}
-	}
-
-	private createResponseLifecycle(options: {
-		statusHandle?: SlackAssistantStatusHandle;
-		ensureStreamingPost?: () => void;
-		endStreamingPost?: () => Promise<void>;
-	}) {
-		let responseStarted = false;
-
-		const clearStatusBeforeFirstResponse = async () => {
-			if (responseStarted) return;
-			responseStarted = true;
-			await options.statusHandle?.clearBeforeResponse();
-		};
-
-		return {
-			startStreamingResponse: async () => {
-				await clearStatusBeforeFirstResponse();
-				options.ensureStreamingPost?.();
-			},
-			startDiscreteResponse: async () => {
-				await options.endStreamingPost?.();
-				await clearStatusBeforeFirstResponse();
-			},
-			finish: async () => {
-				await options.endStreamingPost?.();
-				await clearStatusBeforeFirstResponse();
-			},
-		};
-	}
-
-	/**
-	 * Buffered consumer — accumulates text/reasoning deltas and posts them as a
-	 * single message per flush. Used when the integration disables streaming
-	 * (e.g. Telegram).
-	 */
-	private async consumeStreamBuffered(
-		stream: AsyncGenerator<StreamChunk>,
-		thread: Thread,
-		options: { statusHandle?: SlackAssistantStatusHandle } = {},
-	): Promise<void> {
-		let buffer = '';
-		const responseLifecycle = this.createResponseLifecycle({
-			statusHandle: options.statusHandle,
-		});
-
-		const flushBuffer = async () => {
-			const text = buffer;
-			buffer = '';
-			if (!text.trim()) return;
-			try {
-				await responseLifecycle.startDiscreteResponse();
-				// Chat SDK's streaming path wraps accumulated deltas as `{ markdown }`
-				// so the platform adapter applies its markdown parse-mode (Telegram:
-				// sendMessage with parse_mode=Markdown). A raw string bypasses that
-				// and renders as plain text, so we post the buffered message the same
-				// shape the streaming path uses under the hood.
-				await thread.post({ markdown: text });
-			} catch (postError: unknown) {
-				await this.postErrorToThread(thread, postError);
-				this.logger.error('[AgentChatBridge] Buffered post failed', {
-					error: postError instanceof Error ? postError.message : String(postError),
-				});
-			}
-		};
-
-		try {
-			for await (const chunk of stream) {
-				switch (chunk.type) {
-					case 'text-delta':
-						buffer += chunk.delta;
-						break;
-					case 'reasoning-delta':
-						buffer += `_${chunk.delta}_`;
-						break;
-					case 'tool-call-suspended':
-						await flushBuffer();
-						await responseLifecycle.startDiscreteResponse();
-						await this.handleSuspension(chunk, thread);
-						break;
-					case 'message':
-						await flushBuffer();
-						await responseLifecycle.startDiscreteResponse();
-						await this.handleMessage(chunk, thread);
-						break;
-					case 'error':
-						await flushBuffer();
-						await responseLifecycle.startDiscreteResponse();
-						await this.postErrorToThread(thread, chunk.error);
-						break;
-					default:
-						break;
-				}
-			}
-		} finally {
-			await flushBuffer();
-			await responseLifecycle.finish();
-		}
-	}
-
 	// ---------------------------------------------------------------------------
 	// Suspension handling (HITL tool cards)
 	// ---------------------------------------------------------------------------
@@ -661,39 +345,8 @@ export class AgentChatBridge {
 		}
 
 		const payload = suspendPayload as RichSuspendPayload | Record<string, unknown> | undefined;
-		if (isIntegrationActionSuspendPayload(payload)) {
-			return;
-		}
-		const hasComponents =
-			payload &&
-			'components' in payload &&
-			Array.isArray(payload.components) &&
-			payload.components.length > 0;
-
-		let cardPayload: {
-			title?: string;
-			components: Array<{ type: string; [key: string]: unknown }>;
-		};
-
-		if (isApprovalSuspendPayload(payload)) {
-			cardPayload = buildApprovalCardPayload(payload);
-		} else if (hasComponents) {
-			cardPayload = payload as RichSuspendPayload;
-		} else {
-			// Plain suspend payload — auto-generate approve/deny buttons
-			const message =
-				payload && typeof payload === 'object' && 'message' in payload
-					? String(payload.message)
-					: 'Action required — approve or deny?';
-
-			cardPayload = {
-				title: message,
-				components: [
-					{ type: 'button', label: 'Approve', value: 'true', style: 'primary' },
-					{ type: 'button', label: 'Deny', value: 'false', style: 'danger' },
-				],
-			};
-		}
+		const cardPayload = buildSuspendCardPayload(payload);
+		if (!cardPayload) return;
 
 		try {
 			const card = await this.componentMapper.toCard(
@@ -751,392 +404,13 @@ export class AgentChatBridge {
 		}
 	}
 
-	// ---------------------------------------------------------------------------
-	// Button interaction handling (HITL resume)
-	// ---------------------------------------------------------------------------
-
-	/** Parsed result from an action ID. */
-	private parseActionId(
-		actionId: string,
-		value: string | undefined,
-	): { runId: string; toolCallId: string; resumeData: unknown } | null {
-		if (actionId.startsWith('ri-sel:')) {
-			const parts = actionId.split(':');
-			if (parts.length < 4) {
-				this.logger.warn('[AgentChatBridge] Malformed ri-sel action ID', { actionId });
-				return null;
-			}
-			return {
-				runId: parts[2],
-				toolCallId: parts.slice(3).join(':'),
-				resumeData: { type: 'select', id: parts[1], value },
-			};
-		}
-
-		if (actionId.startsWith('resume:')) {
-			const parts = actionId.split(':');
-			if (parts.length < 4) {
-				this.logger.warn('[AgentChatBridge] Malformed action ID', { actionId });
-				return null;
-			}
-			let resumeData: unknown;
-			try {
-				resumeData = JSON.parse(value ?? '');
-			} catch {
-				resumeData = { value };
-			}
-			return { runId: parts[1], toolCallId: parts.slice(2, -1).join(':'), resumeData };
-		}
-
-		return null;
-	}
-
-	/**
-	 * Resolve short callback keys when the platform uses them (e.g. Telegram).
-	 * Returns the resolved `{ actionId, value }` or `null` if expired/missing.
-	 */
-	private async resolveCallbackData(
-		actionId: string,
-		value: string | undefined,
-		thread: Thread<unknown, unknown>,
-	): Promise<{ actionId: string; value: string | undefined } | null> {
-		if (!this.callbackStore) return { actionId, value };
-
-		const resolved = await this.callbackStore.resolve(actionId);
-		if (!resolved) {
-			this.logger.warn('[AgentChatBridge] Callback key not found or expired', { actionId });
-			await thread.post(
-				'This action is no longer available. The link may have expired or already been used.',
-			);
-			return null;
-		}
-		return { actionId: resolved.actionId, value: resolved.value };
-	}
-
-	/**
-	 * Delete the card message and apply platform-specific workarounds before
-	 * resuming the agent.
-	 */
-	private async cleanUpBeforeResume(event: ActionEvent): Promise<void> {
-		try {
-			await event.adapter.deleteMessage(event.threadId, event.messageId);
-		} catch (deleteError) {
-			this.logger.warn('[AgentChatBridge] Failed to delete card message', {
-				error: deleteError instanceof Error ? deleteError.message : String(deleteError),
-			});
-		}
-	}
-
-	/**
-	 * Guard against double resumption, then resume the agent and stream the
-	 * response back into the thread.
-	 */
-	private async executeResume(
-		thread: Thread<unknown, unknown>,
-		runId: string,
-		toolCallId: string,
-		resumeData: unknown,
-	): Promise<void> {
-		if (this.activeResumedRuns.has(runId)) {
-			this.logger.warn('[AgentChatBridge] Run is already active', { runId, toolCallId });
-			await thread.post('This action has already been handled');
-			return;
-		}
-
-		this.activeResumedRuns.add(runId);
-		try {
-			await this.startThinkingStatus(thread);
-			const stream = this.agentService.resumeForChat({
-				agentId: this.agentId,
-				projectId: this.n8nProjectId,
-				runId,
-				toolCallId,
-				resumeData,
-				integrationType: this.integration.type,
-			});
-			await this.consumeStream(stream, thread as Thread);
-		} finally {
-			this.activeResumedRuns.delete(runId);
-		}
-	}
-
-	private async startThinkingStatus(
-		thread: Thread<unknown, unknown>,
-		slackThreadContext?: SlackThreadContext,
-		statusRetry?: AbortController,
-	): Promise<SlackAssistantStatusHandle | undefined> {
-		if (this.integration.type !== 'slack') return;
-
-		if (slackThreadContext && !slackThreadContext.hasRealThreadTs) {
-			const setStatus = this.setSlackAssistantStatus(slackThreadContext, statusRetry?.signal);
-			return slackThreadContext.isDm
-				? {
-						clearBeforeResponse: async () => {
-							// Cancel any pending status retry first: the retry waits out a
-							// delay before re-setting "Thinking...", and without this it could
-							// fire *after* we clear and leave a stale status behind.
-							statusRetry?.abort();
-							// Then wait for the set to settle. Aborting only cancels the
-							// retry's local wait — an *in-flight* "Thinking..." write can't
-							// be recalled, so we must let it land before we clear, otherwise
-							// its remote write could overwrite the clear and restore the
-							// stale status. (setStatus never rejects — it logs internally.)
-							await setStatus;
-							await this.clearSlackAssistantStatus(slackThreadContext);
-						},
-					}
-				: undefined;
-		}
-
-		try {
-			await thread.startTyping(SLACK_THINKING_STATUS);
-		} catch (error) {
-			this.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', {
-				agentId: this.agentId,
-				threadId: thread.id,
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-		return undefined;
-	}
-
-	/**
-	 * Kick off the "Thinking..." status set (with retry). Returns the in-flight
-	 * promise so callers can await it before clearing — see `clearBeforeResponse`
-	 * in `startThinkingStatus`. The returned promise never rejects; failures are
-	 * logged inside the retry helper.
-	 */
-	private async setSlackAssistantStatus(
-		context: SlackThreadContext,
-		statusRetrySignal?: AbortSignal,
-	): Promise<void> {
-		const adapter = this.getSlackAssistantStatusAdapter();
-		if (!adapter) return;
-
-		await this.setSlackAssistantStatusWithRetry(adapter, context, statusRetrySignal);
-	}
-
-	private async clearSlackAssistantStatus(context: SlackThreadContext): Promise<void> {
-		const adapter = this.getSlackAssistantStatusAdapter();
-		if (!adapter) return;
-
-		try {
-			await adapter.setAssistantStatus(context.channelId, context.threadTs, '');
-		} catch (error) {
-			this.logger.warn('[AgentChatBridge] Failed to clear Slack assistant status', {
-				agentId: this.agentId,
-				channelId: context.channelId,
-				threadTs: context.threadTs,
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	}
-
-	private async setSlackAssistantStatusWithRetry(
-		adapter: SlackAssistantStatusAdapter,
-		context: SlackThreadContext,
-		statusRetrySignal?: AbortSignal,
-	): Promise<void> {
-		try {
-			await adapter.setAssistantStatus(context.channelId, context.threadTs, SLACK_THINKING_STATUS, [
-				SLACK_THINKING_STATUS,
-			]);
-			return;
-		} catch (error) {
-			if (getSlackErrorCode(error) !== 'invalid_thread_ts') {
-				this.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', {
-					agentId: this.agentId,
-					channelId: context.channelId,
-					threadTs: context.threadTs,
-					error: error instanceof Error ? error.message : String(error),
-				});
-				return;
-			}
-		}
-
-		if (!(await sleep(SLACK_STATUS_RETRY_DELAY_MS, statusRetrySignal))) return;
-		// The status may have been cleared while we were sleeping. Bail out so the
-		// retry doesn't re-set "Thinking..." over an already-cleared status.
-		if (statusRetrySignal?.aborted) return;
-
-		try {
-			await adapter.setAssistantStatus(context.channelId, context.threadTs, SLACK_THINKING_STATUS, [
-				SLACK_THINKING_STATUS,
-			]);
-		} catch (error) {
-			const errorCode = getSlackErrorCode(error);
-			const logPayload = {
-				agentId: this.agentId,
-				channelId: context.channelId,
-				threadTs: context.threadTs,
-				error: error instanceof Error ? error.message : String(error),
-				...(errorCode ? { errorCode } : {}),
-			};
-			if (errorCode === 'invalid_thread_ts') {
-				this.logger.debug(
-					'[AgentChatBridge] Slack assistant status unavailable for thread',
-					logPayload,
-				);
-				return;
-			}
-			this.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', logPayload);
-		}
-	}
-
-	private getSlackThreadContext(message: Message<unknown>): SlackThreadContext | undefined {
-		if (this.integration.type !== 'slack') return undefined;
-
-		const raw = message.raw;
-		if (!isRecord(raw)) return undefined;
-
-		const channelId = stringValue(raw.channel);
-		const channelType = stringValue(raw.channel_type);
-		const realThreadTs = stringValue(raw.thread_ts);
-		const threadTs = realThreadTs ?? stringValue(raw.ts);
-		if (!channelId || !threadTs) return undefined;
-
-		return {
-			channelId,
-			threadTs,
-			hasRealThreadTs: realThreadTs !== undefined,
-			isDm: channelType === 'im',
-		};
-	}
-
-	private getSlackAssistantStatusAdapter(): SlackAssistantStatusAdapter | undefined {
-		const adapter = this.chat.getAdapter('slack');
-		return isSlackAssistantStatusAdapter(adapter) ? adapter : undefined;
-	}
-
-	private async updateLatestMessageContext(
-		threadId: string,
-		resourceId: string,
-		thread: Thread<unknown, unknown>,
-		options: {
-			messageId?: string;
-			interactingUserId?: string;
-			agentUserId?: string;
-			subject?: IntegrationMessageSubject;
-		} = {},
-	): Promise<IntegrationMessageContext | undefined> {
-		if (!this.messageContextStore) return undefined;
-
-		const integrationConnectionId = buildIntegrationConnectionId(this.integration);
-		const previousContext = await this.getPreviousContext(threadId, integrationConnectionId);
-		const agentUserId = options.agentUserId ?? previousContext?.agentUserId;
-		const context: IntegrationMessageContext = {
-			integrationConnectionId,
-			platform: this.integration.type,
-			target: {
-				type: 'thread',
-				threadId: thread.id,
-				channelId: thread.channelId,
-			},
-			...(options.messageId ? { messageId: options.messageId } : {}),
-			...(options.interactingUserId ? { interactingUserId: options.interactingUserId } : {}),
-			...(agentUserId ? { agentUserId } : {}),
-			...(options.subject ? { subject: options.subject } : {}),
-			...(!options.subject && previousContext?.subject ? { subject: previousContext.subject } : {}),
-			updatedAt: new Date().toISOString(),
-		};
-
-		try {
-			await this.messageContextStore.setLatest(threadId, resourceId, context);
-			return context;
-		} catch (error) {
-			this.logger.warn('[AgentChatBridge] Failed to update latest message context', {
-				agentId: this.agentId,
-				threadId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return undefined;
-		}
-	}
-
 	private getPlatformAgentContext(): PlatformAgentContext {
-		if (this.integration.type !== 'slack') return {};
-		const adapter = this.chat.getAdapter(this.integration.type);
-		if (!isRecord(adapter)) return {};
-		const agentUserId = stringValue(adapter.botUserId);
-		return agentUserId ? { agentUserId } : {};
+		return this.integrationImpl?.getPlatformAgentContext?.(this.chat) ?? {};
 	}
 
 	private prepareInboundText(text: string | undefined, context: PlatformAgentContext): string {
 		const trimmed = text?.trim() ?? '';
-		if (this.integration.type !== 'slack' || !context.agentUserId) return trimmed;
-		return stripSlackSelfMention(trimmed, context.agentUserId);
-	}
-
-	private async getPreviousContext(
-		threadId: string,
-		integrationConnectionId: string,
-	): Promise<IntegrationMessageContext | undefined> {
-		if (!this.messageContextStore) return undefined;
-		try {
-			const previousContext = await this.messageContextStore.getLatest(threadId);
-			if (previousContext?.integrationConnectionId !== integrationConnectionId) {
-				return undefined;
-			}
-			return previousContext;
-		} catch (error) {
-			this.logger.warn('[AgentChatBridge] Failed to read previous message context', {
-				agentId: this.agentId,
-				threadId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return undefined;
-		}
-	}
-
-	private async resolveMessageSubject(
-		message: Message<unknown>,
-	): Promise<IntegrationMessageSubject | undefined> {
-		try {
-			return toIntegrationMessageSubject(await message.subject);
-		} catch (error) {
-			this.logger.debug(
-				`[AgentChatBridge] Failed to fetch message subject: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
-			return undefined;
-		}
-	}
-
-	/**
-	 * Handle a button/select action. Action IDs use one of two prefixes:
-	 * - `ri-sel:{selectId}:{runId}:{toolCallId}` — interactive card select
-	 * - `resume:{runId}:{toolCallId}:{index}` — generic per-tool resume button
-	 */
-	private async handleAction(event: ActionEvent): Promise<void> {
-		const { thread } = event;
-
-		if (!thread) {
-			this.logger.warn('[AgentChatBridge] Thread is not set for event', {
-				threadId: event.threadId,
-				actionId: event.actionId,
-			});
-			return;
-		}
-
-		const callbackData = await this.resolveCallbackData(event.actionId, event.value, thread);
-		if (!callbackData) return;
-
-		const parsed = this.parseActionId(callbackData.actionId, callbackData.value);
-		if (!parsed) return;
-		// Persist the interacting user / messageId into the thread's message
-		// context so tools running on resume can read it via the message
-		// context store — no need to bolt a duplicate copy onto resumeData.
-		const platformThreadId = this.resolvePlatformThreadId(thread);
-		const threadId = this.toAgentThreadId(platformThreadId);
-		await this.updateLatestMessageContext(threadId.id, event.user.userId, thread, {
-			messageId: event.messageId,
-			interactingUserId: event.user.userId,
-			...this.getPlatformAgentContext(),
-		});
-
-		await this.cleanUpBeforeResume(event);
-		await this.executeResume(thread, parsed.runId, parsed.toolCallId, parsed.resumeData);
+		return this.integrationImpl?.prepareInboundText?.(trimmed, context) ?? trimmed;
 	}
 
 	// ---------------------------------------------------------------------------
@@ -1174,48 +448,4 @@ export class AgentChatBridge {
 			});
 		}
 	}
-}
-
-function stripSlackSelfMention(text: string, userId: string): string {
-	const escapedUserId = escapeRegExp(userId);
-	return text
-		.replace(new RegExp(`(^|\\s)<@!?${escapedUserId}(?:\\|[^>]+)?>`, 'gi'), '$1')
-		.replace(new RegExp(`(^|\\s)@${escapedUserId}\\b`, 'gi'), '$1')
-		.replace(/\s+/g, ' ')
-		.trim();
-}
-
-function isSlackAssistantStatusAdapter(value: unknown): value is SlackAssistantStatusAdapter {
-	return isRecord(value) && typeof value.setAssistantStatus === 'function';
-}
-
-function stringValue(value: unknown): string | undefined {
-	return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function getSlackErrorCode(error: unknown): string | undefined {
-	if (!isRecord(error)) return undefined;
-	const data = error.data;
-	if (!isRecord(data)) return undefined;
-	return stringValue(data.error);
-}
-
-async function sleep(ms: number, signal?: AbortSignal): Promise<boolean> {
-	if (signal?.aborted) return false;
-	return await new Promise((resolve) => {
-		const timeout = setTimeout(() => {
-			signal?.removeEventListener('abort', abort);
-			resolve(true);
-		}, ms);
-		const abort = () => {
-			clearTimeout(timeout);
-			signal?.removeEventListener('abort', abort);
-			resolve(false);
-		};
-		signal?.addEventListener('abort', abort, { once: true });
-	});
 }

--- a/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-hitl-resume-handler.ts
@@ -1,0 +1,186 @@
+import type { StreamChunk } from '@n8n/agents';
+import type { AgentIntegrationConfig } from '@n8n/api-types';
+import type { ActionEvent, Thread } from 'chat';
+import type { Logger } from 'n8n-workflow';
+
+import type { BridgeResumeExecutionContext, PlatformAgentContext } from './agent-chat-integration';
+import type { AgentChatMessageContextBridge } from './agent-chat-message-context';
+import type { AgentChatStreamConsumer } from './agent-chat-stream-consumer';
+import type { CallbackStore } from './callback-store';
+import type { InternalThread } from './types';
+
+interface ResumeExecutor {
+	resumeForChat(config: {
+		agentId: string;
+		projectId: string;
+		runId: string;
+		toolCallId: string;
+		resumeData: unknown;
+		integrationType?: string;
+	}): AsyncGenerator<StreamChunk>;
+}
+
+interface AgentChatHitlResumeHandlerOptions {
+	agentId: string;
+	projectId: string;
+	integration: AgentIntegrationConfig;
+	agentService: ResumeExecutor;
+	logger: Logger;
+	callbackStore?: CallbackStore;
+	resolvePlatformThreadId: (thread: Thread<unknown, unknown>) => string;
+	toAgentThreadId: (platformThreadId: string) => InternalThread;
+	getPlatformAgentContext: () => PlatformAgentContext;
+	messageContextBridge: AgentChatMessageContextBridge;
+	streamConsumer: AgentChatStreamConsumer;
+	createResumeExecutionContext: (
+		thread: Thread<unknown, unknown>,
+	) => Promise<BridgeResumeExecutionContext>;
+}
+
+export class AgentChatHitlResumeHandler {
+	/** Short-lived set of run IDs that have been resumed to prevent double resumption */
+	private readonly activeResumedRuns = new Set<string>();
+
+	constructor(private readonly options: AgentChatHitlResumeHandlerOptions) {}
+
+	/**
+	 * Handle a button/select action. Action IDs use one of two prefixes:
+	 * - `ri-sel:{selectId}:{runId}:{toolCallId}` — interactive card select
+	 * - `resume:{runId}:{toolCallId}:{index}` — generic per-tool resume button
+	 */
+	async handleAction(event: ActionEvent): Promise<void> {
+		const { thread } = event;
+
+		if (!thread) {
+			this.options.logger.warn('[AgentChatBridge] Thread is not set for event', {
+				threadId: event.threadId,
+				actionId: event.actionId,
+			});
+			return;
+		}
+
+		const callbackData = await this.resolveCallbackData(event.actionId, event.value, thread);
+		if (!callbackData) return;
+
+		const parsed = this.parseActionId(callbackData.actionId, callbackData.value);
+		if (!parsed) return;
+		// Persist the interacting user / messageId into the thread's message
+		// context so tools running on resume can read it via the message
+		// context store — no need to bolt a duplicate copy onto resumeData.
+		const platformThreadId = this.options.resolvePlatformThreadId(thread);
+		const threadId = this.options.toAgentThreadId(platformThreadId);
+		await this.options.messageContextBridge.updateLatest(threadId.id, event.user.userId, thread, {
+			messageId: event.messageId,
+			interactingUserId: event.user.userId,
+			...this.options.getPlatformAgentContext(),
+		});
+
+		await this.cleanUpBeforeResume(event);
+		await this.executeResume(thread, parsed.runId, parsed.toolCallId, parsed.resumeData);
+	}
+
+	/** Parsed result from an action ID. */
+	private parseActionId(
+		actionId: string,
+		value: string | undefined,
+	): { runId: string; toolCallId: string; resumeData: unknown } | null {
+		if (actionId.startsWith('ri-sel:')) {
+			const parts = actionId.split(':');
+			if (parts.length < 4) {
+				this.options.logger.warn('[AgentChatBridge] Malformed ri-sel action ID', { actionId });
+				return null;
+			}
+			return {
+				runId: parts[2],
+				toolCallId: parts.slice(3).join(':'),
+				resumeData: { type: 'select', id: parts[1], value },
+			};
+		}
+
+		if (actionId.startsWith('resume:')) {
+			const parts = actionId.split(':');
+			if (parts.length < 4) {
+				this.options.logger.warn('[AgentChatBridge] Malformed action ID', { actionId });
+				return null;
+			}
+			let resumeData: unknown;
+			try {
+				resumeData = JSON.parse(value ?? '');
+			} catch {
+				resumeData = { value };
+			}
+			return { runId: parts[1], toolCallId: parts.slice(2, -1).join(':'), resumeData };
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve short callback keys when the platform uses them (e.g. Telegram).
+	 * Returns the resolved `{ actionId, value }` or `null` if expired/missing.
+	 */
+	private async resolveCallbackData(
+		actionId: string,
+		value: string | undefined,
+		thread: Thread<unknown, unknown>,
+	): Promise<{ actionId: string; value: string | undefined } | null> {
+		if (!this.options.callbackStore) return { actionId, value };
+
+		const resolved = await this.options.callbackStore.resolve(actionId);
+		if (!resolved) {
+			this.options.logger.warn('[AgentChatBridge] Callback key not found or expired', { actionId });
+			await thread.post(
+				'This action is no longer available. The link may have expired or already been used.',
+			);
+			return null;
+		}
+		return { actionId: resolved.actionId, value: resolved.value };
+	}
+
+	/**
+	 * Delete the card message and apply platform-specific workarounds before
+	 * resuming the agent.
+	 */
+	private async cleanUpBeforeResume(event: ActionEvent): Promise<void> {
+		try {
+			await event.adapter.deleteMessage(event.threadId, event.messageId);
+		} catch (deleteError) {
+			this.options.logger.warn('[AgentChatBridge] Failed to delete card message', {
+				error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+			});
+		}
+	}
+
+	/**
+	 * Guard against double resumption, then resume the agent and stream the
+	 * response back into the thread.
+	 */
+	private async executeResume(
+		thread: Thread<unknown, unknown>,
+		runId: string,
+		toolCallId: string,
+		resumeData: unknown,
+	): Promise<void> {
+		if (this.activeResumedRuns.has(runId)) {
+			this.options.logger.warn('[AgentChatBridge] Run is already active', { runId, toolCallId });
+			await thread.post('This action has already been handled');
+			return;
+		}
+
+		this.activeResumedRuns.add(runId);
+		try {
+			const resumeExecutionContext = await this.options.createResumeExecutionContext(thread);
+			const stream = this.options.agentService.resumeForChat({
+				agentId: this.options.agentId,
+				projectId: this.options.projectId,
+				runId,
+				toolCallId,
+				resumeData,
+				integrationType: this.options.integration.type,
+			});
+			await this.options.streamConsumer.consume(stream, thread, resumeExecutionContext);
+		} finally {
+			this.activeResumedRuns.delete(runId);
+		}
+	}
+}

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -242,14 +242,6 @@ export abstract class AgentChatIntegration {
 		params: BridgeMessageContextParams,
 	): Promise<BridgeExecutionContext>;
 
-	/** Optional status hook used before streaming a resume response. */
-	createResumeStatusHandle?(params: {
-		chat: ChatInstance;
-		thread: Thread<unknown, unknown>;
-		logger: Logger;
-		agentId: string;
-	}): Promise<BridgeStatusHandle | undefined>;
-
 	/** Optional stream/status policy for responses after interactive resume actions. */
 	createResumeExecutionContext?(params: {
 		chat: ChatInstance;

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -1,5 +1,6 @@
 import { Service } from '@n8n/di';
-import type { Thread, Author } from 'chat';
+import type { Thread, Author, Message } from 'chat';
+import type { Logger } from 'n8n-workflow';
 
 import { AgentIntegrationConfig } from '@n8n/api-types';
 import type { RichCardComponentType } from '@n8n/api-types';
@@ -33,6 +34,34 @@ export interface AgentChatIntegrationBuilderGuidance {
 	capabilities: string[];
 	useIntegrationWhen: string[];
 	useNodeToolWhen: string[];
+}
+
+export interface PlatformAgentContext {
+	agentUserId?: string;
+}
+
+export interface BridgeStatusHandle {
+	clearBeforeResponse(): Promise<void>;
+}
+
+export interface BridgeExecutionContext {
+	platformAgentContext: PlatformAgentContext;
+	forceBuffered?: boolean;
+	statusHandle?: BridgeStatusHandle;
+}
+
+export type BridgeResumeExecutionContext = Pick<
+	BridgeExecutionContext,
+	'forceBuffered' | 'statusHandle'
+>;
+
+export interface BridgeMessageContextParams {
+	chat: ChatInstance;
+	thread: Thread<unknown, unknown>;
+	message: Message<unknown>;
+	logger: Logger;
+	agentId: string;
+	statusRetry?: AbortController;
 }
 
 /**
@@ -195,6 +224,39 @@ export abstract class AgentChatIntegration {
 	 * Private-mode allowlist.
 	 */
 	isUserAllowed?(author: Author, settings: AgentIntegrationConfig | undefined): boolean;
+
+	/**
+	 * Optional platform context needed by the bridge before execution. Slack uses
+	 * this to persist the bot user ID and strip self-mentions from inbound text.
+	 */
+	getPlatformAgentContext?(chat: ChatInstance): PlatformAgentContext;
+
+	/** Optional text normalization before the message is handed to the agent. */
+	prepareInboundText?(text: string, context: PlatformAgentContext): string;
+
+	/**
+	 * Optional per-message execution policy for platform-specific bridge behavior,
+	 * such as status indicators or forcing buffered output for a specific thread.
+	 */
+	createBridgeExecutionContext?(
+		params: BridgeMessageContextParams,
+	): Promise<BridgeExecutionContext>;
+
+	/** Optional status hook used before streaming a resume response. */
+	createResumeStatusHandle?(params: {
+		chat: ChatInstance;
+		thread: Thread<unknown, unknown>;
+		logger: Logger;
+		agentId: string;
+	}): Promise<BridgeStatusHandle | undefined>;
+
+	/** Optional stream/status policy for responses after interactive resume actions. */
+	createResumeExecutionContext?(params: {
+		chat: ChatInstance;
+		thread: Thread<unknown, unknown>;
+		logger: Logger;
+		agentId: string;
+	}): Promise<BridgeResumeExecutionContext>;
 
 	/**
 	 * Execute a context query that this platform owns (e.g. Linear `get_issue`,

--- a/packages/cli/src/modules/agents/integrations/agent-chat-message-context.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-message-context.ts
@@ -1,0 +1,136 @@
+import type { AgentIntegrationConfig } from '@n8n/api-types';
+import type { Message, MessageSubject, Thread } from 'chat';
+import type { Logger } from 'n8n-workflow';
+
+import type { IntegrationMessageContextService } from './integration-message-context.service';
+import {
+	buildIntegrationConnectionId,
+	type IntegrationMessageContext,
+	type IntegrationMessageSubject,
+} from './integration-tools';
+
+interface UpdateLatestMessageContextOptions {
+	messageId?: string;
+	interactingUserId?: string;
+	agentUserId?: string;
+	subject?: IntegrationMessageSubject;
+}
+
+export class AgentChatMessageContextBridge {
+	constructor(
+		private readonly messageContextStore: IntegrationMessageContextService | undefined,
+		private readonly integration: AgentIntegrationConfig,
+		private readonly agentId: string,
+		private readonly logger: Logger,
+	) {}
+
+	async updateLatest(
+		threadId: string,
+		resourceId: string,
+		thread: Thread<unknown, unknown>,
+		options: UpdateLatestMessageContextOptions = {},
+	): Promise<IntegrationMessageContext | undefined> {
+		if (!this.messageContextStore) return undefined;
+
+		const integrationConnectionId = buildIntegrationConnectionId(this.integration);
+		const previousContext = await this.getPreviousContext(threadId, integrationConnectionId);
+		const agentUserId = options.agentUserId ?? previousContext?.agentUserId;
+		const context: IntegrationMessageContext = {
+			integrationConnectionId,
+			platform: this.integration.type,
+			target: {
+				type: 'thread',
+				threadId: thread.id,
+				channelId: thread.channelId,
+			},
+			...(options.messageId ? { messageId: options.messageId } : {}),
+			...(options.interactingUserId ? { interactingUserId: options.interactingUserId } : {}),
+			...(agentUserId ? { agentUserId } : {}),
+			...(options.subject ? { subject: options.subject } : {}),
+			...(!options.subject && previousContext?.subject ? { subject: previousContext.subject } : {}),
+			updatedAt: new Date().toISOString(),
+		};
+
+		try {
+			await this.messageContextStore.setLatest(threadId, resourceId, context);
+			return context;
+		} catch (error) {
+			this.logger.warn('[AgentChatBridge] Failed to update latest message context', {
+				agentId: this.agentId,
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+
+	async resolveSubject(message: Message<unknown>): Promise<IntegrationMessageSubject | undefined> {
+		try {
+			return toIntegrationMessageSubject(await message.subject);
+		} catch (error) {
+			this.logger.debug(
+				`[AgentChatBridge] Failed to fetch message subject: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return undefined;
+		}
+	}
+
+	private async getPreviousContext(
+		threadId: string,
+		integrationConnectionId: string,
+	): Promise<IntegrationMessageContext | undefined> {
+		if (!this.messageContextStore) return undefined;
+		try {
+			const previousContext = await this.messageContextStore.getLatest(threadId);
+			if (previousContext?.integrationConnectionId !== integrationConnectionId) {
+				return undefined;
+			}
+			return previousContext;
+		} catch (error) {
+			this.logger.warn('[AgentChatBridge] Failed to read previous message context', {
+				agentId: this.agentId,
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+}
+
+function toIntegrationMessageSubject(
+	subject: MessageSubject | null | undefined,
+): IntegrationMessageSubject | undefined {
+	if (!subject || typeof subject.type !== 'string' || typeof subject.id !== 'string') {
+		return undefined;
+	}
+
+	const assignee = toIntegrationSubjectPerson(subject.assignee);
+	const author = toIntegrationSubjectPerson(subject.author);
+	const labels = subject.labels?.filter((label) => typeof label === 'string');
+
+	return {
+		type: subject.type,
+		id: subject.id,
+		...(typeof subject.title === 'string' ? { title: subject.title } : {}),
+		...(typeof subject.description === 'string' ? { description: subject.description } : {}),
+		...(typeof subject.url === 'string' ? { url: subject.url } : {}),
+		...(typeof subject.status === 'string' ? { status: subject.status } : {}),
+		...(labels && labels.length > 0 ? { labels } : {}),
+		...(assignee ? { assignee } : {}),
+		...(author ? { author } : {}),
+	};
+}
+
+function toIntegrationSubjectPerson(
+	person: MessageSubject['assignee'] | MessageSubject['author'],
+): IntegrationMessageSubject['assignee'] | undefined {
+	if (!person || typeof person.id !== 'string' || typeof person.name !== 'string') {
+		return undefined;
+	}
+	return {
+		id: person.id,
+		name: person.name,
+	};
+}

--- a/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
@@ -92,7 +92,8 @@ export class AgentChatStreamConsumer {
 
 		const startStreamingPost = () => {
 			const iterable = createTextIterable();
-			streamingPost = thread.post(iterable).catch((postError: unknown) => {
+			streamingPost = thread.post(iterable).catch(async (postError: unknown) => {
+				await this.options.postErrorToThread(thread, postError);
 				this.options.logger.error('[AgentChatBridge] Streaming post failed', {
 					error: postError instanceof Error ? postError.message : String(postError),
 				});

--- a/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, StreamChunk } from '@n8n/agents';
+import type { StreamChunk } from '@n8n/agents';
 import type { Thread } from 'chat';
 import type { Logger } from 'n8n-workflow';
 
@@ -13,7 +13,7 @@ interface AgentChatStreamConsumerOptions {
 	logger: Logger;
 	postErrorToThread: (thread: Thread<unknown, unknown> | null, error: unknown) => Promise<void>;
 	handleSuspension: (chunk: SuspendedChunk, thread: Thread<unknown, unknown>) => Promise<void>;
-	handleMessage?: (chunk: MessageChunk, thread: Thread<unknown, unknown>) => Promise<void>;
+	handleMessage: (chunk: MessageChunk, thread: Thread<unknown, unknown>) => Promise<void>;
 }
 
 interface ConsumeStreamOptions {
@@ -143,7 +143,7 @@ export class AgentChatStreamConsumer {
 						break;
 					case 'message':
 						await responseLifecycle.startDiscreteResponse();
-						await this.handleMessage(chunk, thread);
+						await this.options.handleMessage(chunk, thread);
 						break;
 					case 'error':
 						await responseLifecycle.startDiscreteResponse();
@@ -236,7 +236,7 @@ export class AgentChatStreamConsumer {
 					case 'message':
 						await flushBuffer();
 						await responseLifecycle.startDiscreteResponse();
-						await this.handleMessage(chunk, thread);
+						await this.options.handleMessage(chunk, thread);
 						break;
 					case 'error':
 						await flushBuffer();
@@ -250,42 +250,6 @@ export class AgentChatStreamConsumer {
 		} finally {
 			await flushBuffer();
 			await responseLifecycle.finish();
-		}
-	}
-
-	private async handleMessage(
-		chunk: MessageChunk,
-		thread: Thread<unknown, unknown>,
-	): Promise<void> {
-		if (this.options.handleMessage) {
-			await this.options.handleMessage(chunk, thread);
-			return;
-		}
-
-		const agentMessage: AgentMessage = chunk.message;
-
-		// AgentMessage is a union. LLM messages (Message) have a `content` array
-		// of typed content parts. Extract only text parts for display.
-		if (!('content' in agentMessage) || !Array.isArray(agentMessage.content)) return;
-
-		const textParts = agentMessage.content
-			.filter(
-				(part): part is { type: 'text'; text: string } => part.type === 'text' && 'text' in part,
-			)
-			.map((part) => part.text);
-
-		const textToPost = textParts.join('');
-
-		// Skip messages with no displayable text (e.g. tool-call-only messages)
-		if (!textToPost.trim()) return;
-
-		try {
-			await thread.post(textToPost);
-		} catch (error) {
-			this.options.logger.error('[AgentChatBridge] Failed to post message chunk', {
-				threadId: thread.id,
-				error: error instanceof Error ? error.message : String(error),
-			});
 		}
 	}
 }

--- a/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-stream-consumer.ts
@@ -1,0 +1,291 @@
+import type { AgentMessage, StreamChunk } from '@n8n/agents';
+import type { Thread } from 'chat';
+import type { Logger } from 'n8n-workflow';
+
+import type { BridgeStatusHandle } from './agent-chat-integration';
+import { type TextEndFn, type TextYieldFn } from './types';
+
+type SuspendedChunk = Extract<StreamChunk, { type: 'tool-call-suspended' }>;
+type MessageChunk = Extract<StreamChunk, { type: 'message' }>;
+
+interface AgentChatStreamConsumerOptions {
+	disableStreaming: boolean;
+	logger: Logger;
+	postErrorToThread: (thread: Thread<unknown, unknown> | null, error: unknown) => Promise<void>;
+	handleSuspension: (chunk: SuspendedChunk, thread: Thread<unknown, unknown>) => Promise<void>;
+	handleMessage?: (chunk: MessageChunk, thread: Thread<unknown, unknown>) => Promise<void>;
+}
+
+interface ConsumeStreamOptions {
+	forceBuffered?: boolean;
+	statusHandle?: BridgeStatusHandle;
+}
+
+export class AgentChatStreamConsumer {
+	constructor(private readonly options: AgentChatStreamConsumerOptions) {}
+
+	async consume(
+		stream: AsyncGenerator<StreamChunk>,
+		thread: Thread<unknown, unknown>,
+		options: ConsumeStreamOptions = {},
+	): Promise<void> {
+		if (this.options.disableStreaming || options.forceBuffered) {
+			await this.consumeBuffered(stream, thread, {
+				statusHandle: options.statusHandle,
+			});
+			return;
+		}
+
+		// Controller for the text stream iterable that Chat SDK consumes.
+		// These are reassigned inside `createTextIterable()` (called transitively
+		// by `ensureStreamingPost()`). TypeScript cannot track mutations through
+		// closures, so it incorrectly narrows these to `never` after the
+		// assignment. We use a wrapper object to avoid the TS closure analysis issue.
+		const textStream: { yield: TextYieldFn | null; end: TextEndFn | null } = {
+			yield: null,
+			end: null,
+		};
+		let streamingPost: Promise<unknown> | null = null;
+
+		const createTextIterable = (): AsyncIterable<string> => {
+			const queue: string[] = [];
+			let done = false;
+			let waiting: ((result: IteratorResult<string>) => void) | null = null;
+
+			textStream.yield = (text: string) => {
+				if (waiting) {
+					const resolve = waiting;
+					waiting = null;
+					resolve({ value: text, done: false });
+				} else {
+					queue.push(text);
+				}
+			};
+
+			textStream.end = () => {
+				done = true;
+				if (waiting) {
+					const resolve = waiting;
+					waiting = null;
+					resolve({ value: '', done: true });
+				}
+			};
+
+			return {
+				[Symbol.asyncIterator]() {
+					return {
+						async next(): Promise<IteratorResult<string>> {
+							if (queue.length > 0) {
+								return { value: queue.shift()!, done: false };
+							}
+							if (done) {
+								return { value: '', done: true };
+							}
+							return await new Promise((resolve) => {
+								waiting = resolve;
+							});
+						},
+					};
+				},
+			};
+		};
+
+		const startStreamingPost = () => {
+			const iterable = createTextIterable();
+			streamingPost = thread.post(iterable).catch((postError: unknown) => {
+				this.options.logger.error('[AgentChatBridge] Streaming post failed', {
+					error: postError instanceof Error ? postError.message : String(postError),
+				});
+			});
+		};
+
+		const endStreamingPost = async () => {
+			if (textStream.end) {
+				textStream.end();
+				textStream.end = null;
+				textStream.yield = null;
+			}
+			if (streamingPost) {
+				await streamingPost;
+				streamingPost = null;
+			}
+		};
+
+		// Don't start streaming post eagerly — wait for first text delta
+		const ensureStreamingPost = () => {
+			if (!streamingPost) startStreamingPost();
+		};
+		const responseLifecycle = this.createResponseLifecycle({
+			statusHandle: options.statusHandle,
+			ensureStreamingPost,
+			endStreamingPost,
+		});
+
+		try {
+			for await (const chunk of stream) {
+				switch (chunk.type) {
+					case 'text-delta': {
+						const { delta } = chunk;
+						await responseLifecycle.startStreamingResponse();
+						textStream.yield?.(delta);
+						break;
+					}
+					case 'reasoning-delta': {
+						const { delta } = chunk;
+						await responseLifecycle.startStreamingResponse();
+						textStream.yield?.(`_${delta}_`);
+						break;
+					}
+					case 'tool-call-suspended':
+						await responseLifecycle.startDiscreteResponse();
+						await this.options.handleSuspension(chunk, thread);
+						// Don't start new streaming post — wait for next text delta
+						break;
+					case 'message':
+						await responseLifecycle.startDiscreteResponse();
+						await this.handleMessage(chunk, thread);
+						break;
+					case 'error':
+						await responseLifecycle.startDiscreteResponse();
+						await this.options.postErrorToThread(thread, chunk.error);
+						break;
+					default:
+						// Ignore other chunk types (finish, tool-input-*,
+						// start-step, finish-step, etc.)
+						break;
+				}
+			}
+		} finally {
+			await responseLifecycle.finish();
+		}
+	}
+
+	private createResponseLifecycle(options: {
+		statusHandle?: BridgeStatusHandle;
+		ensureStreamingPost?: () => void;
+		endStreamingPost?: () => Promise<void>;
+	}) {
+		let responseStarted = false;
+
+		const clearStatusBeforeFirstResponse = async () => {
+			if (responseStarted) return;
+			responseStarted = true;
+			await options.statusHandle?.clearBeforeResponse();
+		};
+
+		return {
+			startStreamingResponse: async () => {
+				await clearStatusBeforeFirstResponse();
+				options.ensureStreamingPost?.();
+			},
+			startDiscreteResponse: async () => {
+				await options.endStreamingPost?.();
+				await clearStatusBeforeFirstResponse();
+			},
+			finish: async () => {
+				await options.endStreamingPost?.();
+				await clearStatusBeforeFirstResponse();
+			},
+		};
+	}
+
+	private async consumeBuffered(
+		stream: AsyncGenerator<StreamChunk>,
+		thread: Thread<unknown, unknown>,
+		options: { statusHandle?: BridgeStatusHandle } = {},
+	): Promise<void> {
+		let buffer = '';
+		const responseLifecycle = this.createResponseLifecycle({
+			statusHandle: options.statusHandle,
+		});
+
+		const flushBuffer = async () => {
+			const text = buffer;
+			buffer = '';
+			if (!text.trim()) return;
+			try {
+				await responseLifecycle.startDiscreteResponse();
+				// Chat SDK's streaming path wraps accumulated deltas as `{ markdown }`
+				// so the platform adapter applies its markdown parse-mode (Telegram:
+				// sendMessage with parse_mode=Markdown). A raw string bypasses that
+				// and renders as plain text, so we post the buffered message the same
+				// shape the streaming path uses under the hood.
+				await thread.post({ markdown: text });
+			} catch (postError: unknown) {
+				await this.options.postErrorToThread(thread, postError);
+				this.options.logger.error('[AgentChatBridge] Buffered post failed', {
+					error: postError instanceof Error ? postError.message : String(postError),
+				});
+			}
+		};
+
+		try {
+			for await (const chunk of stream) {
+				switch (chunk.type) {
+					case 'text-delta':
+						buffer += chunk.delta;
+						break;
+					case 'reasoning-delta':
+						buffer += `_${chunk.delta}_`;
+						break;
+					case 'tool-call-suspended':
+						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
+						await this.options.handleSuspension(chunk, thread);
+						break;
+					case 'message':
+						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
+						await this.handleMessage(chunk, thread);
+						break;
+					case 'error':
+						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
+						await this.options.postErrorToThread(thread, chunk.error);
+						break;
+					default:
+						break;
+				}
+			}
+		} finally {
+			await flushBuffer();
+			await responseLifecycle.finish();
+		}
+	}
+
+	private async handleMessage(
+		chunk: MessageChunk,
+		thread: Thread<unknown, unknown>,
+	): Promise<void> {
+		if (this.options.handleMessage) {
+			await this.options.handleMessage(chunk, thread);
+			return;
+		}
+
+		const agentMessage: AgentMessage = chunk.message;
+
+		// AgentMessage is a union. LLM messages (Message) have a `content` array
+		// of typed content parts. Extract only text parts for display.
+		if (!('content' in agentMessage) || !Array.isArray(agentMessage.content)) return;
+
+		const textParts = agentMessage.content
+			.filter(
+				(part): part is { type: 'text'; text: string } => part.type === 'text' && 'text' in part,
+			)
+			.map((part) => part.text);
+
+		const textToPost = textParts.join('');
+
+		// Skip messages with no displayable text (e.g. tool-call-only messages)
+		if (!textToPost.trim()) return;
+
+		try {
+			await thread.post(textToPost);
+		} catch (error) {
+			this.options.logger.error('[AgentChatBridge] Failed to post message chunk', {
+				threadId: thread.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+}

--- a/packages/cli/src/modules/agents/integrations/agent-chat-suspension-cards.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-suspension-cards.ts
@@ -1,0 +1,114 @@
+import { isRecord } from '@n8n/utils';
+
+import type { RichSuspendPayload } from '../types';
+
+const APPROVAL_INPUT_MAX_LENGTH = 1500;
+
+interface ApprovalSuspendPayload {
+	type: 'approval';
+	toolName: string;
+	displayName?: string;
+	args?: unknown;
+}
+
+export function isIntegrationActionSuspendPayload(value: unknown): boolean {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'type' in value &&
+		value.type === 'integration_action'
+	);
+}
+
+function isApprovalSuspendPayload(value: unknown): value is ApprovalSuspendPayload {
+	return (
+		isRecord(value) &&
+		value.type === 'approval' &&
+		typeof value.toolName === 'string' &&
+		value.toolName.length > 0
+	);
+}
+
+function truncateApprovalInput(value: string): string {
+	if (value.length <= APPROVAL_INPUT_MAX_LENGTH) return value;
+	return `${value.slice(0, APPROVAL_INPUT_MAX_LENGTH)}...`;
+}
+
+function stringifyApprovalInput(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+
+	if (typeof value === 'string') {
+		return truncateApprovalInput(value);
+	}
+
+	try {
+		const serialized = JSON.stringify(value, null, 2);
+		return truncateApprovalInput(serialized ?? String(value));
+	} catch {
+		return truncateApprovalInput(String(value));
+	}
+}
+
+function getApprovalToolLabel(payload: ApprovalSuspendPayload): string {
+	return typeof payload.displayName === 'string' && payload.displayName.length > 0
+		? payload.displayName
+		: payload.toolName;
+}
+
+function buildApprovalCardPayload(payload: ApprovalSuspendPayload): {
+	title: string;
+	components: Array<{ type: string; [key: string]: unknown }>;
+} {
+	const toolLabel = getApprovalToolLabel(payload);
+	const fields: Array<{ label: string; value: string }> = [{ label: 'Tool', value: toolLabel }];
+	const input = stringifyApprovalInput(payload.args);
+
+	if (input) {
+		fields.push({ label: 'Input', value: input });
+	}
+
+	return {
+		title: 'Approval required',
+		components: [
+			{ type: 'section', text: `The agent wants to run this tool: ${toolLabel}` },
+			{ type: 'fields', fields },
+			{ type: 'button', label: 'Approve', value: 'true', style: 'primary' },
+			{ type: 'button', label: 'Deny', value: 'false', style: 'danger' },
+		],
+	};
+}
+
+export function buildSuspendCardPayload(
+	payload: RichSuspendPayload | Record<string, unknown> | undefined,
+): { title?: string; components: Array<{ type: string; [key: string]: unknown }> } | undefined {
+	if (isIntegrationActionSuspendPayload(payload)) {
+		return undefined;
+	}
+
+	const hasComponents =
+		payload &&
+		'components' in payload &&
+		Array.isArray(payload.components) &&
+		payload.components.length > 0;
+
+	if (isApprovalSuspendPayload(payload)) {
+		return buildApprovalCardPayload(payload);
+	}
+
+	if (hasComponents) {
+		return payload as RichSuspendPayload;
+	}
+
+	const message =
+		payload && typeof payload === 'object' && 'message' in payload
+			? String(payload.message)
+			: 'Action required — approve or deny?';
+
+	return {
+		title: message,
+		components: [
+			{ type: 'button', label: 'Approve', value: 'true', style: 'primary' },
+			{ type: 'button', label: 'Deny', value: 'false', style: 'danger' },
+		],
+	};
+}

--- a/packages/cli/src/modules/agents/integrations/agent-chat-suspension-cards.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-suspension-cards.ts
@@ -1,8 +1,11 @@
 import { isRecord } from '@n8n/utils';
 
-import type { RichSuspendPayload } from '../types';
-
 const APPROVAL_INPUT_MAX_LENGTH = 1500;
+
+type SuspendCardPayload = {
+	title?: string;
+	components: Array<{ type: string; [key: string]: unknown }>;
+};
 
 interface ApprovalSuspendPayload {
 	type: 'approval';
@@ -27,6 +30,18 @@ function isApprovalSuspendPayload(value: unknown): value is ApprovalSuspendPaylo
 		typeof value.toolName === 'string' &&
 		value.toolName.length > 0
 	);
+}
+
+function isSuspendCardComponent(value: unknown): value is SuspendCardPayload['components'][number] {
+	return isRecord(value) && typeof value.type === 'string' && value.type.length > 0;
+}
+
+function isSuspendCardPayload(value: unknown): value is SuspendCardPayload {
+	if (!isRecord(value) || !Array.isArray(value.components) || value.components.length === 0) {
+		return false;
+	}
+
+	return value.components.every(isSuspendCardComponent);
 }
 
 function truncateApprovalInput(value: string): string {
@@ -78,29 +93,21 @@ function buildApprovalCardPayload(payload: ApprovalSuspendPayload): {
 	};
 }
 
-export function buildSuspendCardPayload(
-	payload: RichSuspendPayload | Record<string, unknown> | undefined,
-): { title?: string; components: Array<{ type: string; [key: string]: unknown }> } | undefined {
+export function buildSuspendCardPayload(payload: unknown): SuspendCardPayload | undefined {
 	if (isIntegrationActionSuspendPayload(payload)) {
 		return undefined;
 	}
-
-	const hasComponents =
-		payload &&
-		'components' in payload &&
-		Array.isArray(payload.components) &&
-		payload.components.length > 0;
 
 	if (isApprovalSuspendPayload(payload)) {
 		return buildApprovalCardPayload(payload);
 	}
 
-	if (hasComponents) {
-		return payload as RichSuspendPayload;
+	if (isSuspendCardPayload(payload)) {
+		return payload;
 	}
 
 	const message =
-		payload && typeof payload === 'object' && 'message' in payload
+		isRecord(payload) && 'message' in payload
 			? String(payload.message)
 			: 'Action required — approve or deny?';
 

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
@@ -1,0 +1,285 @@
+import { isRecord } from '@n8n/utils';
+import type { Thread } from 'chat';
+
+import type {
+	BridgeExecutionContext,
+	BridgeMessageContextParams,
+	BridgeResumeExecutionContext,
+	BridgeStatusHandle,
+	PlatformAgentContext,
+} from '../agent-chat-integration';
+import type { ChatInstance } from '../chat-integration.service';
+
+const SLACK_THINKING_STATUS = 'Thinking...';
+const SLACK_STATUS_RETRY_DELAY_MS = 750;
+
+interface SlackThreadContext {
+	channelId: string;
+	threadTs: string;
+	hasRealThreadTs: boolean;
+	isDm: boolean;
+}
+
+interface SlackAssistantStatusAdapter {
+	setAssistantStatus(
+		channelId: string,
+		threadTs: string,
+		status: string,
+		loadingMessages?: string[],
+	): Promise<void>;
+}
+
+export function getSlackPlatformAgentContext(chat: ChatInstance): PlatformAgentContext {
+	const adapter = chat.getAdapter('slack');
+	if (!isRecord(adapter)) return {};
+	const agentUserId = stringValue(adapter.botUserId);
+	return agentUserId ? { agentUserId } : {};
+}
+
+export function prepareSlackInboundText(text: string, context: PlatformAgentContext): string {
+	const trimmed = text.trim();
+	if (!context.agentUserId) return trimmed;
+	return stripSlackSelfMention(trimmed, context.agentUserId);
+}
+
+export async function createSlackBridgeExecutionContext(
+	params: BridgeMessageContextParams,
+): Promise<BridgeExecutionContext> {
+	const platformAgentContext = getSlackPlatformAgentContext(params.chat);
+	const slackThreadContext = getSlackThreadContext(params.message);
+	const statusHandle = await startSlackThinkingStatus(params.thread, {
+		chat: params.chat,
+		logger: params.logger,
+		agentId: params.agentId,
+		slackThreadContext,
+		statusRetry: params.statusRetry,
+	});
+
+	return {
+		platformAgentContext,
+		forceBuffered: slackThreadContext?.hasRealThreadTs !== true,
+		statusHandle,
+	};
+}
+
+export async function createSlackResumeExecutionContext(): Promise<BridgeResumeExecutionContext> {
+	// Slack action payloads do not reliably include the original message's raw
+	// thread_ts, so resume responses use the same safe buffered path as top-level
+	// messages without a materialized Slack thread.
+	return { forceBuffered: true };
+}
+
+async function startSlackThinkingStatus(
+	thread: Thread<unknown, unknown>,
+	options: {
+		chat: ChatInstance;
+		logger: BridgeMessageContextParams['logger'];
+		agentId: string;
+		slackThreadContext?: SlackThreadContext;
+		statusRetry?: AbortController;
+	},
+): Promise<BridgeStatusHandle | undefined> {
+	const { slackThreadContext, statusRetry } = options;
+
+	if (slackThreadContext && !slackThreadContext.hasRealThreadTs) {
+		const setStatus = setSlackAssistantStatus(slackThreadContext, options);
+		return slackThreadContext.isDm
+			? {
+					clearBeforeResponse: async () => {
+						// Cancel any pending status retry first: the retry waits out a
+						// delay before re-setting "Thinking...", and without this it could
+						// fire *after* we clear and leave a stale status behind.
+						statusRetry?.abort();
+						// Then wait for the set to settle. Aborting only cancels the
+						// retry's local wait — an *in-flight* "Thinking..." write can't
+						// be recalled, so we must let it land before we clear, otherwise
+						// its remote write could overwrite the clear and restore the
+						// stale status. (setStatus never rejects — it logs internally.)
+						await setStatus;
+						await clearSlackAssistantStatus(slackThreadContext, options);
+					},
+				}
+			: undefined;
+	}
+
+	try {
+		await thread.startTyping(SLACK_THINKING_STATUS);
+	} catch (error) {
+		options.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', {
+			agentId: options.agentId,
+			threadId: thread.id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+	return undefined;
+}
+
+/**
+ * Kick off the "Thinking..." status set (with retry). Returns the in-flight
+ * promise so callers can await it before clearing — see `clearBeforeResponse`
+ * in `startSlackThinkingStatus`. The returned promise never rejects; failures
+ * are logged inside the retry helper.
+ */
+async function setSlackAssistantStatus(
+	context: SlackThreadContext,
+	options: {
+		chat: ChatInstance;
+		logger: BridgeMessageContextParams['logger'];
+		agentId: string;
+		statusRetry?: AbortController;
+	},
+): Promise<void> {
+	const adapter = getSlackAssistantStatusAdapter(options.chat);
+	if (!adapter) return;
+
+	await setSlackAssistantStatusWithRetry(adapter, context, options);
+}
+
+async function clearSlackAssistantStatus(
+	context: SlackThreadContext,
+	options: {
+		chat: ChatInstance;
+		logger: BridgeMessageContextParams['logger'];
+		agentId: string;
+	},
+): Promise<void> {
+	const adapter = getSlackAssistantStatusAdapter(options.chat);
+	if (!adapter) return;
+
+	try {
+		await adapter.setAssistantStatus(context.channelId, context.threadTs, '');
+	} catch (error) {
+		options.logger.warn('[AgentChatBridge] Failed to clear Slack assistant status', {
+			agentId: options.agentId,
+			channelId: context.channelId,
+			threadTs: context.threadTs,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+async function setSlackAssistantStatusWithRetry(
+	adapter: SlackAssistantStatusAdapter,
+	context: SlackThreadContext,
+	options: {
+		logger: BridgeMessageContextParams['logger'];
+		agentId: string;
+		statusRetry?: AbortController;
+	},
+): Promise<void> {
+	try {
+		await adapter.setAssistantStatus(context.channelId, context.threadTs, SLACK_THINKING_STATUS, [
+			SLACK_THINKING_STATUS,
+		]);
+		return;
+	} catch (error) {
+		if (getSlackErrorCode(error) !== 'invalid_thread_ts') {
+			options.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', {
+				agentId: options.agentId,
+				channelId: context.channelId,
+				threadTs: context.threadTs,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+	}
+
+	if (!(await sleep(SLACK_STATUS_RETRY_DELAY_MS, options.statusRetry?.signal))) return;
+	// The status may have been cleared while we were sleeping. Bail out so the
+	// retry doesn't re-set "Thinking..." over an already-cleared status.
+	if (options.statusRetry?.signal.aborted) return;
+
+	try {
+		await adapter.setAssistantStatus(context.channelId, context.threadTs, SLACK_THINKING_STATUS, [
+			SLACK_THINKING_STATUS,
+		]);
+	} catch (error) {
+		const errorCode = getSlackErrorCode(error);
+		const logPayload = {
+			agentId: options.agentId,
+			channelId: context.channelId,
+			threadTs: context.threadTs,
+			error: error instanceof Error ? error.message : String(error),
+			...(errorCode ? { errorCode } : {}),
+		};
+		if (errorCode === 'invalid_thread_ts') {
+			options.logger.debug(
+				'[AgentChatBridge] Slack assistant status unavailable for thread',
+				logPayload,
+			);
+			return;
+		}
+		options.logger.warn('[AgentChatBridge] Failed to set Slack assistant status', logPayload);
+	}
+}
+
+function getSlackThreadContext(
+	message: BridgeMessageContextParams['message'],
+): SlackThreadContext | undefined {
+	const raw = message.raw;
+	if (!isRecord(raw)) return undefined;
+
+	const channelId = stringValue(raw.channel);
+	const channelType = stringValue(raw.channel_type);
+	const realThreadTs = stringValue(raw.thread_ts);
+	const threadTs = realThreadTs ?? stringValue(raw.ts);
+	if (!channelId || !threadTs) return undefined;
+
+	return {
+		channelId,
+		threadTs,
+		hasRealThreadTs: realThreadTs !== undefined,
+		isDm: channelType === 'im',
+	};
+}
+
+function getSlackAssistantStatusAdapter(
+	chat: ChatInstance,
+): SlackAssistantStatusAdapter | undefined {
+	const adapter = chat.getAdapter('slack');
+	return isSlackAssistantStatusAdapter(adapter) ? adapter : undefined;
+}
+
+function stripSlackSelfMention(text: string, userId: string): string {
+	const escapedUserId = escapeRegExp(userId);
+	return text
+		.replace(new RegExp(`(^|\\s)<@!?${escapedUserId}(?:\\|[^>]+)?>`, 'gi'), '$1')
+		.replace(new RegExp(`(^|\\s)@${escapedUserId}\\b`, 'gi'), '$1')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function isSlackAssistantStatusAdapter(value: unknown): value is SlackAssistantStatusAdapter {
+	return isRecord(value) && typeof value.setAssistantStatus === 'function';
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getSlackErrorCode(error: unknown): string | undefined {
+	if (!isRecord(error)) return undefined;
+	const data = error.data;
+	if (!isRecord(data)) return undefined;
+	return stringValue(data.error);
+}
+
+async function sleep(ms: number, signal?: AbortSignal): Promise<boolean> {
+	if (signal?.aborted) return false;
+	return await new Promise((resolve) => {
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener('abort', abort);
+			resolve(true);
+		}, ms);
+		const abort = () => {
+			clearTimeout(timeout);
+			signal?.removeEventListener('abort', abort);
+			resolve(false);
+		};
+		signal?.addEventListener('abort', abort, { once: true });
+	});
+}

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
@@ -61,11 +61,23 @@ export async function createSlackBridgeExecutionContext(
 	};
 }
 
-export async function createSlackResumeExecutionContext(): Promise<BridgeResumeExecutionContext> {
+export async function createSlackResumeExecutionContext(params: {
+	chat: ChatInstance;
+	thread: Thread<unknown, unknown>;
+	logger: BridgeMessageContextParams['logger'];
+	agentId: string;
+}): Promise<BridgeResumeExecutionContext> {
 	// Slack action payloads do not reliably include the original message's raw
 	// thread_ts, so resume responses use the same safe buffered path as top-level
 	// messages without a materialized Slack thread.
-	return { forceBuffered: true };
+	return {
+		forceBuffered: true,
+		statusHandle: await startSlackThinkingStatus(params.thread, {
+			chat: params.chat,
+			logger: params.logger,
+			agentId: params.agentId,
+		}),
+	};
 }
 
 async function startSlackThinkingStatus(

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-bridge-behavior.ts
@@ -17,7 +17,6 @@ interface SlackThreadContext {
 	channelId: string;
 	threadTs: string;
 	hasRealThreadTs: boolean;
-	isDm: boolean;
 }
 
 interface SlackAssistantStatusAdapter {
@@ -83,23 +82,21 @@ async function startSlackThinkingStatus(
 
 	if (slackThreadContext && !slackThreadContext.hasRealThreadTs) {
 		const setStatus = setSlackAssistantStatus(slackThreadContext, options);
-		return slackThreadContext.isDm
-			? {
-					clearBeforeResponse: async () => {
-						// Cancel any pending status retry first: the retry waits out a
-						// delay before re-setting "Thinking...", and without this it could
-						// fire *after* we clear and leave a stale status behind.
-						statusRetry?.abort();
-						// Then wait for the set to settle. Aborting only cancels the
-						// retry's local wait — an *in-flight* "Thinking..." write can't
-						// be recalled, so we must let it land before we clear, otherwise
-						// its remote write could overwrite the clear and restore the
-						// stale status. (setStatus never rejects — it logs internally.)
-						await setStatus;
-						await clearSlackAssistantStatus(slackThreadContext, options);
-					},
-				}
-			: undefined;
+		return {
+			clearBeforeResponse: async () => {
+				// Cancel any pending status retry first: the retry waits out a
+				// delay before re-setting "Thinking...", and without this it could
+				// fire *after* we clear and leave a stale status behind.
+				statusRetry?.abort();
+				// Then wait for the set to settle. Aborting only cancels the
+				// retry's local wait — an *in-flight* "Thinking..." write can't
+				// be recalled, so we must let it land before we clear, otherwise
+				// its remote write could overwrite the clear and restore the
+				// stale status. (setStatus never rejects — it logs internally.)
+				await setStatus;
+				await clearSlackAssistantStatus(slackThreadContext, options);
+			},
+		};
 	}
 
 	try {
@@ -220,7 +217,6 @@ function getSlackThreadContext(
 	if (!isRecord(raw)) return undefined;
 
 	const channelId = stringValue(raw.channel);
-	const channelType = stringValue(raw.channel_type);
 	const realThreadTs = stringValue(raw.thread_ts);
 	const threadTs = realThreadTs ?? stringValue(raw.ts);
 	if (!channelId || !threadTs) return undefined;
@@ -229,7 +225,6 @@ function getSlackThreadContext(
 		channelId,
 		threadTs,
 		hasRealThreadTs: realThreadTs !== undefined,
-		isDm: channelType === 'im',
 	};
 }
 

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
@@ -103,8 +103,13 @@ export class SlackIntegration extends AgentChatIntegration {
 		return await createSlackBridgeExecutionContext(params);
 	}
 
-	async createResumeExecutionContext(): Promise<BridgeResumeExecutionContext> {
-		return await createSlackResumeExecutionContext();
+	async createResumeExecutionContext(params: {
+		chat: ChatInstance;
+		thread: BridgeMessageContextParams['thread'];
+		logger: BridgeMessageContextParams['logger'];
+		agentId: string;
+	}): Promise<BridgeResumeExecutionContext> {
+		return await createSlackResumeExecutionContext(params);
 	}
 
 	async executeContextQuery(params: PlatformContextQueryParams): Promise<unknown> {

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
@@ -4,10 +4,15 @@ import type { RichCardComponentType } from '@n8n/api-types';
 import {
 	AgentChatIntegration,
 	type AgentChatIntegrationContext,
+	type BridgeExecutionContext,
+	type BridgeMessageContextParams,
+	type BridgeResumeExecutionContext,
+	type PlatformAgentContext,
 	type PlatformActionParams,
 	type PlatformContextQueryParams,
 	type UnauthenticatedWebhookResponse,
 } from '../agent-chat-integration';
+import type { ChatInstance } from '../chat-integration.service';
 import { loadSlackAdapter } from '../esm-loader';
 import { connectionUnavailable } from '../integration-helpers';
 import type {
@@ -15,6 +20,12 @@ import type {
 	IntegrationActionResult,
 	IntegrationContextQuery,
 } from '../integration-tools';
+import {
+	createSlackBridgeExecutionContext,
+	createSlackResumeExecutionContext,
+	getSlackPlatformAgentContext,
+	prepareSlackInboundText,
+} from './slack-bridge-behavior';
 import { executeSlackAction, executeSlackContextQuery } from './slack-operations';
 
 /**
@@ -77,6 +88,24 @@ export class SlackIntegration extends AgentChatIntegration {
 		'send_channel_message',
 		'add_reaction',
 	];
+
+	getPlatformAgentContext(chat: ChatInstance): PlatformAgentContext {
+		return getSlackPlatformAgentContext(chat);
+	}
+
+	prepareInboundText(text: string, context: PlatformAgentContext): string {
+		return prepareSlackInboundText(text, context);
+	}
+
+	async createBridgeExecutionContext(
+		params: BridgeMessageContextParams,
+	): Promise<BridgeExecutionContext> {
+		return await createSlackBridgeExecutionContext(params);
+	}
+
+	async createResumeExecutionContext(): Promise<BridgeResumeExecutionContext> {
+		return await createSlackResumeExecutionContext();
+	}
 
 	async executeContextQuery(params: PlatformContextQueryParams): Promise<unknown> {
 		if (!params.chat) return connectionUnavailable();


### PR DESCRIPTION
## Summary

- Splits AgentChatBridge into focused helpers for stream consumption, HITL resume handling, suspension cards, and message-context persistence.
- Adds integration-level bridge hooks so platform-specific behavior can live outside the generic bridge.
- Moves Slack thread/status/mention handling into Slack-owned modules and buffers Slack action resume responses to avoid invalid thread status/streaming failures.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-255/tech-debt-maintainability-refactor-agent-chat-bridgets-into-modules

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32880">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->