### PR TITLE
fix(core): Disable quick chat buttons on agent-builder while responding (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderChatColumn.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderChatColumn.test.ts
@@ -1,0 +1,97 @@
+/* eslint-disable import-x/no-extraneous-dependencies -- test-only pattern */
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import AgentBuilderChatColumn from '../components/AgentBuilderChatColumn.vue';
+
+vi.mock('@n8n/i18n', () => ({
+	useI18n: () => ({ baseText: (key: string) => key }),
+	i18n: { baseText: (key: string) => key },
+}));
+
+function mountChatColumn({
+	isBuildChatStreaming,
+	chatActionsDisabled = false,
+}: {
+	isBuildChatStreaming: boolean;
+	chatActionsDisabled?: boolean;
+}) {
+	return mount(AgentBuilderChatColumn, {
+		props: {
+			initialized: true,
+			projectId: 'p1',
+			agentId: 'a1',
+			agentName: 'Agent One',
+			agent: null,
+			localConfig: null,
+			connectedTriggers: [],
+			isBuilderConfigured: true,
+			isFullWidth: false,
+			canEditAgent: true,
+			isBuildChatStreaming,
+		},
+		global: {
+			stubs: {
+				N8nButton: { template: '<button><slot /><slot name="icon" /></button>' },
+				N8nIcon: { template: '<span />' },
+				N8nTooltip: { template: '<span><slot /></span>' },
+				AgentBuilderUnconfiguredEmptyState: { template: '<div />' },
+				AgentChatPanel: {
+					name: 'AgentChatPanel',
+					template: '<div><slot name="above-input" :disabled="chatActionsDisabled" /></div>',
+					props: [
+						'inputDraft',
+						'projectId',
+						'agentId',
+						'mode',
+						'endpoint',
+						'initialMessage',
+						'agentConfig',
+						'agentStatus',
+						'connectedTriggers',
+						'canEditAgent',
+						'beforeSend',
+						'chatActionsDisabled',
+					],
+					data: () => ({ chatActionsDisabled }),
+				},
+				AgentChatQuickActions: {
+					name: 'AgentChatQuickActions',
+					template: '<div data-testid="stub-agent-chat-quick-actions" />',
+					props: [
+						'tools',
+						'mcpServers',
+						'projectId',
+						'agentId',
+						'connectedTriggers',
+						'isPublished',
+						'disabled',
+					],
+				},
+			},
+		},
+	});
+}
+
+describe('AgentBuilderChatColumn', () => {
+	it('disables quick actions while the build chat is streaming', () => {
+		const wrapper = mountChatColumn({ isBuildChatStreaming: true });
+
+		expect(wrapper.findComponent({ name: 'AgentChatQuickActions' }).props('disabled')).toBe(true);
+	});
+
+	it('disables quick actions while the chat panel has an open HITL interaction', () => {
+		const wrapper = mountChatColumn({
+			isBuildChatStreaming: false,
+			chatActionsDisabled: true,
+		});
+
+		expect(wrapper.findComponent({ name: 'AgentChatQuickActions' }).props('disabled')).toBe(true);
+	});
+
+	it('keeps quick actions enabled while the build chat is idle', () => {
+		const wrapper = mountChatColumn({ isBuildChatStreaming: false });
+
+		expect(wrapper.findComponent({ name: 'AgentChatQuickActions' }).props('disabled')).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -331,7 +331,15 @@ const commonStubs = {
 	AgentChatQuickActions: {
 		name: 'AgentChatQuickActions',
 		template: '<div data-testid="stub-agent-chat-quick-actions" />',
-		props: ['tools', 'projectId', 'agentId', 'connectedTriggers'],
+		props: [
+			'tools',
+			'mcpServers',
+			'projectId',
+			'agentId',
+			'connectedTriggers',
+			'isPublished',
+			'disabled',
+		],
 		emits: ['update:tools', 'update:connected-triggers', 'trigger-added'],
 	},
 	AgentBuilderHeader: {
@@ -827,6 +835,18 @@ describe('AgentBuilderView — three-column shell', () => {
 		expect(
 			wrapper.findComponent({ name: 'AgentBuilderEditorColumn' }).props('isBuildChatStreaming'),
 		).toBe(false);
+	});
+
+	it('passes build streaming state to the chat column', async () => {
+		const wrapper = await renderView();
+		const chatColumn = wrapper.findComponent({ name: 'AgentBuilderChatColumn' });
+
+		chatColumn.vm.$emit('update:streaming', true);
+		await nextTick();
+
+		expect(
+			wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).props('isBuildChatStreaming'),
+		).toBe(true);
 	});
 
 	it('does not render the old Build/Test toggle inside the chat input footer', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatPanel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushPromises, mount } from '@vue/test-utils';
-import { computed, ref } from 'vue';
+import { computed, h, ref } from 'vue';
 import {
 	ASK_CREDENTIAL_TOOL_NAME,
 	ASK_LLM_TOOL_NAME,
@@ -252,6 +252,81 @@ describe('AgentChatPanel', () => {
 		// Input should be ENABLED so the user can cancel and steer
 		expect(chatInput.props('disabled')).toBe(false);
 		expect(chatInput.props('placeholder')).toBe('agents.chat.answerQuestionPlaceholder');
+	});
+
+	it('disables above-input actions while an interactive question is unresolved', () => {
+		messagesMock.value = [openInteractiveMessage()];
+
+		const wrapper = mount(AgentChatPanel, {
+			props: {
+				projectId: 'p1',
+				agentId: 'a1',
+				endpoint: 'build',
+				agentConfig: {
+					name: 'Agent',
+					model: 'anthropic/claude-sonnet-4-5',
+					instructions: 'Help.',
+				},
+				agentStatus: 'draft',
+				connectedTriggers: [],
+			},
+			slots: {
+				'above-input': ({ disabled }) =>
+					h('div', {
+						'data-testid': 'above-input-actions',
+						'data-disabled': String(disabled),
+					}),
+			},
+		});
+
+		expect(wrapper.find('[data-testid="above-input-actions"]').attributes('data-disabled')).toBe(
+			'true',
+		);
+	});
+
+	it('keeps above-input actions enabled when the interactive card is resolved', () => {
+		messagesMock.value = [
+			{
+				...openInteractiveMessage(),
+				status: 'success',
+				interactive: {
+					toolName: ASK_QUESTION_TOOL_NAME,
+					toolCallId: 'tc-1',
+					resolvedAt: 1,
+					input: {
+						question: 'Pick one',
+						options: [{ label: 'Slack', value: 'slack' }],
+					},
+					resolvedValue: { values: ['slack'] },
+				},
+			},
+		];
+
+		const wrapper = mount(AgentChatPanel, {
+			props: {
+				projectId: 'p1',
+				agentId: 'a1',
+				endpoint: 'build',
+				agentConfig: {
+					name: 'Agent',
+					model: 'anthropic/claude-sonnet-4-5',
+					instructions: 'Help.',
+				},
+				agentStatus: 'draft',
+				connectedTriggers: [],
+			},
+			slots: {
+				'above-input': ({ disabled }) =>
+					h('div', {
+						'data-testid': 'above-input-actions',
+						'data-disabled': String(disabled),
+					}),
+			},
+		});
+
+		expect(wrapper.find('[data-testid="above-input-actions"]').attributes('data-disabled')).toBe(
+			'false',
+		);
 	});
 
 	it('calls cancelAndSteer (not sendMessage) when the user submits while an interactive question is open', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatQuickActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatQuickActions.test.ts
@@ -86,6 +86,25 @@ describe('AgentChatQuickActions', () => {
 		).toBeUndefined();
 	});
 
+	it('disables add actions and does not open modals when disabled', async () => {
+		const wrapper = mount(AgentChatQuickActions, {
+			props: { ...defaultProps, disabled: true },
+			global: { stubs: globalStubs },
+		});
+
+		const addTool = wrapper.find('[data-testid="agent-quick-action-add-tool"]');
+		const addTrigger = wrapper.find('[data-testid="agent-quick-action-add-trigger"]');
+
+		expect(addTool.attributes('disabled')).toBeDefined();
+		expect(addTrigger.attributes('disabled')).toBeDefined();
+
+		await addTool.trigger('click');
+		await addTrigger.trigger('click');
+
+		expect(openModalWithData).not.toHaveBeenCalled();
+		expect(wrapper.findComponent({ name: 'AgentChannelModal' }).exists()).toBe(false);
+	});
+
 	it('Add tool opens the AgentToolsModal with current tools and ids', async () => {
 		const tools = [{ type: 'node', name: 'x' } as unknown as AgentJsonToolRef];
 		const wrapper = mount(AgentChatQuickActions, {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
 	isBuilderConfigured: boolean;
 	isFullWidth: boolean;
 	canEditAgent: boolean;
+	isBuildChatStreaming: boolean;
 	beforeBuildSend?: () => Promise<void> | void;
 }>();
 
@@ -94,7 +95,7 @@ const sharedInputDraft = ref('');
 				@build-done="emit('build-done')"
 				@update:streaming="emit('update:streaming', $event)"
 			>
-				<template v-if="canEditAgent" #above-input>
+				<template v-if="canEditAgent" #above-input="{ disabled: chatActionsDisabled }">
 					<div :class="$style.quickActionsRow">
 						<AgentChatQuickActions
 							:tools="localConfig?.tools ?? []"
@@ -105,6 +106,7 @@ const sharedInputDraft = ref('');
 							:is-published="
 								agent?.activeVersionId !== null && agent?.activeVersionId !== undefined
 							"
+							:disabled="isBuildChatStreaming || chatActionsDisabled"
 							@update:tools="emit('update:tools', $event)"
 							@update:mcp-servers="emit('update:mcp-servers', $event)"
 							@update:connected-triggers="emit('update:connected-triggers', $event)"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -120,6 +120,9 @@ const hasOpenApproval = computed(() => openInteractive.value?.toolName === APPRO
 const hasOpenInteractiveQuestion = computed(
 	() => hasOpenInteraction.value && !hasOpenApproval.value,
 );
+const areConfigurationActionsDisabled = computed(
+	() => isStreaming.value || isPreparingToSend.value || hasOpenInteraction.value,
+);
 
 const isBuilderReadOnly = computed(() => props.endpoint === 'build' && !props.canEditAgent);
 
@@ -298,7 +301,7 @@ onBeforeUnmount(() => {
 		/>
 
 		<div :class="$style.inputArea">
-			<slot name="above-input" />
+			<slot name="above-input" :disabled="areConfigurationActionsDisabled" />
 			<ChatInputBase
 				v-model="inputText"
 				:placeholder="chatPlaceholder"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatQuickActions.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatQuickActions.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
 	agentId: string;
 	connectedTriggers: string[];
 	isPublished: boolean;
+	disabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -38,6 +39,8 @@ const channelModalOpen = ref(false);
 const channelModalView = ref<ChannelView>('list');
 
 function onAddTool() {
+	if (props.disabled) return;
+
 	uiStore.openModalWithData({
 		name: AGENT_TOOLS_MODAL_KEY,
 		data: {
@@ -54,6 +57,8 @@ function onAddTool() {
 }
 
 function onAddTrigger() {
+	if (props.disabled) return;
+
 	channelModalView.value = 'list';
 	channelModalOpen.value = true;
 }
@@ -78,6 +83,7 @@ function handleChannelDisconnected(channelType: string) {
 			<AgentChipButton
 				variant="suggestion"
 				icon="wrench"
+				:disabled="props.disabled"
 				data-testid="agent-quick-action-add-tool"
 				@click="onAddTool"
 			>
@@ -86,6 +92,7 @@ function handleChannelDisconnected(channelType: string) {
 			<AgentChipButton
 				variant="suggestion"
 				icon="zap"
+				:disabled="props.disabled"
 				data-testid="agent-quick-action-add-trigger"
 				@click="onAddTrigger"
 			>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChipButton.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChipButton.vue
@@ -68,7 +68,7 @@ const emit = defineEmits<{
 	cursor: pointer;
 }
 
-.default:hover {
+.default:not(:disabled):hover {
 	background-color: var(--background--hover);
 }
 
@@ -94,9 +94,9 @@ const emit = defineEmits<{
 		transform 0.15s ease;
 }
 
-.suggestion:hover,
-.suggestion:focus-visible,
-.suggestion.active {
+.suggestion:not(:disabled):hover,
+.suggestion:not(:disabled):focus-visible,
+.suggestion.active:not(:disabled) {
 	color: color-mix(in srgb, var(--background--brand) 68%, var(--text-color));
 	border-color: color-mix(in srgb, var(--background--brand) 28%, var(--border-color--subtle));
 	background: color-mix(in srgb, var(--background--brand) 12%, var(--background--hover));
@@ -105,7 +105,7 @@ const emit = defineEmits<{
 	outline-color: var(--focus--border-color);
 }
 
-.suggestion:active {
+.suggestion:not(:disabled):active {
 	transform: translateY(0);
 	box-shadow: none;
 }
@@ -126,9 +126,9 @@ const emit = defineEmits<{
 	transition: opacity 0.15s ease;
 }
 
-.suggestion:hover .suggestionIcon,
-.suggestion:focus-visible .suggestionIcon,
-.suggestion.active .suggestionIcon {
+.suggestion:not(:disabled):hover .suggestionIcon,
+.suggestion:not(:disabled):focus-visible .suggestionIcon,
+.suggestion.active:not(:disabled) .suggestionIcon {
 	opacity: 1;
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -1240,6 +1240,7 @@ function onPreviewBreadcrumbSelect(item: PathItem) {
 					:is-builder-configured="isBuilderConfigured"
 					:is-full-width="isChatFullWidth"
 					:can-edit-agent="canEditAgent"
+					:is-build-chat-streaming="isBuildChatStreaming"
 					:before-build-send="flushAutosave"
 					@config-updated="onConfigUpdated"
 					@build-done="onBuildDone"


### PR DESCRIPTION
## Summary

Buttons above chat seen here:

<img width="339" height="108" alt="image" src="https://github.com/user-attachments/assets/68b37826-2aa4-4af2-9b7f-3109d5b3608d" />

They are disabled when the agent is currently working, also when a HITL interaction is active (like answering a question).


Addresses: https://linear.app/n8n/issue/AGENT-270/the-add-tool-and-add-channel-should-be-disabled-when-the-agent-is

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32881">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

