### PR TITLE
feat(core): Validate timezone and trim permission lookups for MCP setWorkflowSettings (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -69,6 +69,7 @@ describe('update-workflow MCP tool', () => {
 	const user = userWithScopes(['tag:create']);
 	let workflowFinderService: WorkflowFinderService;
 	let findWorkflowMock: jest.Mock;
+	let findWorkflowHeadMock: jest.Mock;
 	let workflowService: WorkflowService;
 	let updateMock: jest.Mock;
 	let urlService: UrlService;
@@ -110,8 +111,10 @@ describe('update-workflow MCP tool', () => {
 		jest.clearAllMocks();
 
 		findWorkflowMock = jest.fn().mockResolvedValue(buildExistingWorkflow());
+		findWorkflowHeadMock = jest.fn().mockResolvedValue({ versionId: 'v1', updatedAt: new Date() });
 		workflowFinderService = mockInstance(WorkflowFinderService, {
 			findWorkflowForUser: findWorkflowMock,
+			findWorkflowHeadForUser: findWorkflowHeadMock,
 		});
 		updateMock = jest
 			.fn()
@@ -741,14 +744,13 @@ describe('update-workflow MCP tool', () => {
 			});
 
 			test('rejects settings changes on a published workflow without publish permission', async () => {
-				findWorkflowMock.mockImplementation(
-					async (id: string, _user: unknown, scopes: string[]) => {
-						if (id !== 'wf-1') return null;
-						// Edit access yes, publish access no.
-						if (scopes.includes('workflow:publish')) return null;
-						return Object.assign(buildExistingWorkflow(), { activeVersionId: 'wf-1-v1' });
-					},
+				findWorkflowMock.mockImplementation(async (id: string) =>
+					id === 'wf-1'
+						? Object.assign(buildExistingWorkflow(), { activeVersionId: 'wf-1-v1' })
+						: null,
 				);
+				// Edit access yes (findWorkflowForUser above), publish access no.
+				findWorkflowHeadMock.mockResolvedValue(null);
 
 				const result = await callHandler({
 					workflowId: 'wf-1',
@@ -758,6 +760,7 @@ describe('update-workflow MCP tool', () => {
 				const response = parseResult(result);
 				expect(result.isError).toBe(true);
 				expect(response.error).toContain('requires publish permission');
+				expect(findWorkflowHeadMock).toHaveBeenCalledWith('wf-1', user, ['workflow:publish']);
 				expect(workflowService.update).not.toHaveBeenCalled();
 			});
 
@@ -777,14 +780,48 @@ describe('update-workflow MCP tool', () => {
 				expect(workflowService.update).toHaveBeenCalled();
 			});
 
+			test('skips the publish-permission lookup when the user has a global publish scope', async () => {
+				const globalPublisher = userWithScopes(['workflow:update', 'workflow:publish']);
+				const tool = createUpdateWorkflowTool(
+					globalPublisher,
+					workflowFinderService,
+					workflowService,
+					urlService,
+					telemetry,
+					nodeTypes,
+					credentialsService,
+					sharedWorkflowRepository,
+					collaborationService,
+					dataTableOps as never,
+					tagService,
+					globalConfig,
+					subworkflowPolicyChecker,
+					workflowPublishedDataService,
+				);
+				findWorkflowMock.mockImplementation(async (id: string) =>
+					id === 'wf-1'
+						? Object.assign(buildExistingWorkflow(), { activeVersionId: 'wf-1-v1' })
+						: null,
+				);
+
+				const result = await tool.handler(
+					{
+						workflowId: 'wf-1',
+						operations: [{ type: 'setWorkflowSettings', settings: { timezone: 'UTC' } }],
+					},
+					{} as never,
+				);
+
+				expect(result.isError).toBeUndefined();
+				// Global publish scope is proven in-memory, so no DB probe is needed.
+				expect(findWorkflowHeadMock).not.toHaveBeenCalled();
+				expect(workflowService.update).toHaveBeenCalled();
+			});
+
 			test('does not require publish permission for settings on an unpublished workflow', async () => {
 				// No activeVersionId → not published → reactivation never happens.
-				findWorkflowMock.mockImplementation(
-					async (id: string, _user: unknown, scopes: string[]) => {
-						if (id !== 'wf-1') return null;
-						if (scopes.includes('workflow:publish')) return null; // would fail if checked
-						return buildExistingWorkflow();
-					},
+				findWorkflowMock.mockImplementation(async (id: string) =>
+					id === 'wf-1' ? buildExistingWorkflow() : null,
 				);
 
 				const result = await callHandler({
@@ -793,6 +830,8 @@ describe('update-workflow MCP tool', () => {
 				});
 
 				expect(result.isError).toBeUndefined();
+				// Unpublished → no publish probe at all.
+				expect(findWorkflowHeadMock).not.toHaveBeenCalled();
 				expect(workflowService.update).toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-operations.test.ts
@@ -756,6 +756,26 @@ describe('applyOperations', () => {
 			});
 			expect(parsed.success).toBe(true);
 		});
+
+		test('schema accepts a valid IANA timezone and "DEFAULT"', () => {
+			for (const timezone of ['America/New_York', 'UTC', 'Europe/Berlin', 'DEFAULT']) {
+				const parsed = partialUpdateOperationSchema.safeParse({
+					type: 'setWorkflowSettings',
+					settings: { timezone },
+				});
+				expect(parsed.success).toBe(true);
+			}
+		});
+
+		test('schema rejects an invalid timezone', () => {
+			for (const timezone of ['Not/AZone', 'EST5', 'Mars/Olympus_Mons', '']) {
+				const parsed = partialUpdateOperationSchema.safeParse({
+					type: 'setWorkflowSettings',
+					settings: { timezone },
+				});
+				expect(parsed.success).toBe(false);
+			}
+		});
 	});
 
 	describe('atomicity', () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -598,8 +598,15 @@ export const createUpdateWorkflowTool = (
 			// workflow:publish). Without this preflight, a user with edit-but-not-
 			// publish access would persist the settings and only then fail activation,
 			// breaking this tool's atomicity and leaving the running version stale.
-			if (hasSettingsOperations && existingWorkflow.activeVersionId) {
-				const canPublish = await workflowFinderService.findWorkflowForUser(workflowId, user, [
+			// A global publish scope already guarantees access, so skip the DB lookup
+			// for instance owners/admins (the common MCP case) and only probe when the
+			// permission could come from a project/resource role.
+			if (
+				hasSettingsOperations &&
+				existingWorkflow.activeVersionId &&
+				!hasGlobalScope(user, 'workflow:publish')
+			) {
+				const canPublish = await workflowFinderService.findWorkflowHeadForUser(workflowId, user, [
 					'workflow:publish',
 				]);
 				if (!canPublish) {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -1,3 +1,4 @@
+import { IANAZone } from 'luxon';
 import type {
 	IConnection,
 	IConnections,
@@ -24,15 +25,14 @@ const credentialsSchema = z.record(
 	z.object({ id: z.string().optional(), name: z.string() }),
 );
 
-/** True when `tz` is an IANA zone the runtime accepts (validated via the Intl DB). */
-const isValidIanaTimezone = (tz: string): boolean => {
-	try {
-		Intl.DateTimeFormat('en-US', { timeZone: tz });
-		return true;
-	} catch {
-		return false;
-	}
-};
+/**
+ * True when `tz` is a zone the runtime accepts. Uses Luxon's `IANAZone.isValidZone`
+ * to match downstream semantics exactly — the same check the expression runtime
+ * applies before setting the default zone, and what Schedule Trigger/cron paths
+ * rely on — rather than calling `Intl` directly, which can drift across Node/ICU
+ * builds.
+ */
+const isValidIanaTimezone = (tz: string): boolean => IANAZone.isValidZone(tz);
 
 /**
  * Curated subset of `IWorkflowSettings` that is safe and useful to set from MCP.

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -24,6 +24,16 @@ const credentialsSchema = z.record(
 	z.object({ id: z.string().optional(), name: z.string() }),
 );
 
+/** True when `tz` is an IANA zone the runtime accepts (validated via the Intl DB). */
+const isValidIanaTimezone = (tz: string): boolean => {
+	try {
+		Intl.DateTimeFormat('en-US', { timeZone: tz });
+		return true;
+	} catch {
+		return false;
+	}
+};
+
 /**
  * Curated subset of `IWorkflowSettings` that is safe and useful to set from MCP.
  * Each key is optional and only the keys provided are written; omitted keys are
@@ -41,6 +51,10 @@ export const workflowSettingsObjectSchema = z.object({
 		.optional(),
 	timezone: z
 		.string()
+		.refine((tz) => tz === 'DEFAULT' || isValidIanaTimezone(tz), {
+			message:
+				'timezone must be a valid IANA timezone (e.g. "America/New_York"), or "DEFAULT" to inherit the instance timezone',
+		})
 		.describe(
 			'IANA timezone used by Schedule Triggers and date/time operations, e.g. "America/New_York". Pass "DEFAULT" to inherit the instance timezone.',
 		)


### PR DESCRIPTION
## Summary

Stacked on top of #32809. Two follow-up improvements to the new `setWorkflowSettings` MCP operation:

1. **Validate `timezone`.** It was accepted as any string, so a typo'd zone would persist and only fail later inside Schedule Triggers / date operations. It is now validated against the IANA database (via `Intl`) at the schema level, still allowing `"DEFAULT"`, and rejected with a self-correcting message the agent sees.

2. **Trim the publish-permission preflight.** Setting workflow settings on a published workflow needs `workflow:publish` (reactivation), so a preflight check exists to keep the operation atomic. That check was a full workflow load that duplicates the one `WorkflowService.activateWorkflow` runs again post-persist. It now:
   - short-circuits in-memory via `hasGlobalScope(user, 'workflow:publish')`, so instance owners/admins (the common MCP case) take **no** extra DB lookup, and
   - falls back to the lightweight `findWorkflowHeadForUser` (skips the `nodes`/`connections`/`settings` JSON columns) only when the scope could come from a project/resource role.

   Net effect: the worst-case "set error workflow on a published workflow" path drops from 4 permission lookups to 3 for global-scoped users, and the remaining probe is much cheaper.

## How to test

- `cd packages/cli && pnpm jest src/modules/mcp/__tests__/update-workflow.tool.test.ts src/modules/mcp/__tests__/workflow-operations.test.ts`
- New tests cover: valid/`DEFAULT`/invalid timezones at the schema level, the global-scope short-circuit (no DB probe), and the lightweight head probe on the project-role path.

## Notes

- Eliminating the last redundant lookup universally (project-scoped users still hit the preflight + the internal reactivation check) would require `WorkflowService.update` to verify publish permission before persisting. That touches shared code used by the HTTP controller, so it is intentionally left out of this PR; happy to do it as a separate change if wanted.

## Review / Merge checklist

- [ ] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32890">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

