### PR TITLE
fix(core): Reconcile webhook triggers against stored state during publication (no-changelog)

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook.service.test.ts
@@ -338,6 +338,18 @@ describe('WebhookService', () => {
 		});
 	});
 
+	describe('getRegisteredWebhooks()', () => {
+		test('returns the webhooks registered for the workflow', async () => {
+			const rows = [createWebhook('GET', 'users'), createWebhook('POST', 'user/:id')];
+			webhookRepository.findBy.mockResolvedValue(rows);
+
+			const result = await webhookService.getRegisteredWebhooks('wf-1');
+
+			expect(result).toBe(rows);
+			expect(webhookRepository.findBy).toHaveBeenCalledWith({ workflowId: 'wf-1' });
+		});
+	});
+
 	describe('storeWebhook()', () => {
 		const buildWebhook = (overrides: Partial<WebhookEntity> = {}) =>
 			Object.assign(new WebhookEntity(), {

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -190,6 +190,11 @@ export class WebhookService {
 		return this.webhookRepository.create(data);
 	}
 
+	/** The webhooks currently registered (stored locally) for a workflow. */
+	async getRegisteredWebhooks(workflowId: string) {
+		return await this.webhookRepository.findBy({ workflowId });
+	}
+
 	async deleteWorkflowWebhooks(workflowId: string) {
 		const webhooks = await this.webhookRepository.findBy({ workflowId });
 

--- a/packages/cli/src/webhooks/webhook.service.ts
+++ b/packages/cli/src/webhooks/webhook.service.ts
@@ -250,7 +250,7 @@ export class WebhookService {
 	}
 
 	/**
-	 * Returns all the webhooks which should be created for the give node
+	 * Returns all the webhooks which should be created for the given node.
 	 */
 	getNodeWebhooks(
 		workflow: Workflow,

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -105,6 +105,7 @@ describe('WorkflowPublicationApplier', () => {
 		workflowHistoryRepository.findOneBy.mockResolvedValue(newVersion);
 		workflowTriggerActivator.getEnabledTriggerNodes.mockReturnValue([]);
 		workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds.mockReturnValue(new Set());
+		workflowTriggerActivator.getNodesWithUnregisteredWebhooks.mockResolvedValue(new Set());
 		workflowTriggerActivator.activate.mockResolvedValue({ activated: [], failures: [] });
 		workflowTriggerActivator.deactivate.mockResolvedValue(undefined);
 		workflowTriggerActivator.updateTriggerCount.mockResolvedValue(undefined);
@@ -271,6 +272,44 @@ describe('WorkflowPublicationApplier', () => {
 		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
 			'wf-1',
 			'v-2',
+		);
+	});
+
+	test('reconciles by registering desired webhook nodes missing from storage', async () => {
+		// Same version on both sides: the version diff is empty, but a desired
+		// webhook is not registered locally (e.g. a crash after the version
+		// advanced), so it must be re-added.
+		const trigger = triggerNode('a');
+		setTriggerSets([trigger], [{ ...trigger }]);
+		workflowTriggerActivator.getNodesWithUnregisteredWebhooks.mockResolvedValue(new Set(['a']));
+
+		const result = await applier.apply(makeRecord());
+
+		expect(result).toEqual({ type: 'completed' });
+		expect(workflowTriggerActivator.getNodesWithUnregisteredWebhooks).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'wf-1' }),
+			newVersion,
+		);
+		expect(workflowTriggerActivator.deactivate).not.toHaveBeenCalled();
+		expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'wf-1' }),
+			newVersion,
+			new Set(['a']),
+		);
+	});
+
+	test('merges webhook reconciliation with the version diff', async () => {
+		// The diff adds 'b'; reconciliation surfaces an unregistered webhook 'c'.
+		setTriggerSets([triggerNode('a')], [triggerNode('a'), triggerNode('b')]);
+		workflowTriggerActivator.getNodesWithUnregisteredWebhooks.mockResolvedValue(new Set(['c']));
+
+		const result = await applier.apply(makeRecord());
+
+		expect(result).toEqual({ type: 'completed' });
+		expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'wf-1' }),
+			newVersion,
+			new Set(['b', 'c']),
 		);
 	});
 

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -114,6 +114,13 @@ export class WorkflowPublicationApplier {
 			.getUnregisteredNonWebhookTriggerNodeIds(record.workflowId, desiredTriggerNodes)
 			.forEach((nodeId) => toAdd.add(nodeId));
 
+		// Webhook triggers live in the `webhook_entity` table, so reconcile them
+		// against that stored state the same way: re-add any desired webhook node
+		// whose webhooks aren't all registered locally.
+		const nodesWithUnregisteredWebhooks =
+			await this.workflowTriggerActivator.getNodesWithUnregisteredWebhooks(workflow, newVersion);
+		nodesWithUnregisteredWebhooks.forEach((nodeId) => toAdd.add(nodeId));
+
 		// No trigger changed: advance the published version and finish. Unchanged
 		// triggers keep running and re-read the new version on their next fire.
 		if (toAdd.size === 0 && toRemove.size === 0) {

--- a/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { WebhookEntity } from '@n8n/db';
-import { mock } from 'jest-mock-extended';
+import { mock, type MockProxy } from 'jest-mock-extended';
 import type { ErrorReporter, Span, Tracing } from 'n8n-core';
 import type { IWebhookData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { WebhookPathTakenError } from 'n8n-workflow';
@@ -226,5 +226,135 @@ describe('WebhookTriggerRegistrar', () => {
 		).rejects.toBeInstanceOf(WebhookPathTakenError);
 		expect(webhookService.createWebhookIfNotExists).not.toHaveBeenCalled();
 		expect(workflowStaticDataService.saveStaticData).not.toHaveBeenCalled();
+	});
+
+	describe('getNodesWithUnregisteredWebhooks', () => {
+		const additionalData = mock<IWorkflowExecuteAdditionalData>();
+		let webhookService: MockProxy<WebhookService>;
+		let registrar: WebhookTriggerRegistrar;
+
+		beforeEach(() => {
+			webhookService = mock<WebhookService>();
+			// `createWebhook` builds the entity the key is derived from; mirror the real
+			// passthrough so path normalization runs against the data under test.
+			webhookService.createWebhook.mockImplementation(
+				(data) =>
+					({
+						webhookPath: data.webhookPath,
+						node: data.node,
+						method: data.method,
+					}) as WebhookEntity,
+			);
+			registrar = new WebhookTriggerRegistrar(
+				logger,
+				mock<ErrorReporter>(),
+				webhookService,
+				mock<WorkflowStaticDataService>(),
+				tracing,
+			);
+		});
+
+		function desiredWebhook(overrides: Partial<IWebhookData>): IWebhookData {
+			return { workflowId: 'wf-1', ...overrides } as IWebhookData;
+		}
+
+		test('returns empty when every desired webhook has a registered row', async () => {
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+			jest
+				.spyOn(WebhookHelpers, 'getWorkflowWebhooks')
+				.mockReturnValue([desiredWebhook({ node: 'Webhook', httpMethod: 'GET', path: 'users' })]);
+			webhookService.getRegisteredWebhooks.mockResolvedValue([
+				{ node: 'Webhook', method: 'GET', webhookPath: 'users' } as WebhookEntity,
+			]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set());
+			expect(webhookService.getRegisteredWebhooks).toHaveBeenCalledWith('wf-1');
+		});
+
+		test('returns a node that has no registered rows at all', async () => {
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+			jest
+				.spyOn(WebhookHelpers, 'getWorkflowWebhooks')
+				.mockReturnValue([desiredWebhook({ node: 'Webhook', httpMethod: 'GET', path: 'users' })]);
+			webhookService.getRegisteredWebhooks.mockResolvedValue([]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set(['webhook-node']));
+		});
+
+		test('returns a node that is only partially registered', async () => {
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+			// One node, two webhooks; only the first is present in storage.
+			jest
+				.spyOn(WebhookHelpers, 'getWorkflowWebhooks')
+				.mockReturnValue([
+					desiredWebhook({ node: 'Webhook', httpMethod: 'GET', path: 'users' }),
+					desiredWebhook({ node: 'Webhook', httpMethod: 'POST', path: 'users/action' }),
+				]);
+			webhookService.getRegisteredWebhooks.mockResolvedValue([
+				{ node: 'Webhook', method: 'GET', webhookPath: 'users' } as WebhookEntity,
+			]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set(['webhook-node']));
+		});
+
+		test('matches dynamic paths after normalization without re-adding', async () => {
+			const workflow = createWorkflow([
+				node('webhook-node', 'webhook', { name: 'Webhook', webhookId: 'hook-id' }),
+			]);
+			// Desired path has surrounding slashes; the stored row is already normalized.
+			jest
+				.spyOn(WebhookHelpers, 'getWorkflowWebhooks')
+				.mockReturnValue([
+					desiredWebhook({ node: 'Webhook', httpMethod: 'GET', path: '/team/:id/' }),
+				]);
+			webhookService.getRegisteredWebhooks.mockResolvedValue([
+				{ node: 'Webhook', method: 'GET', webhookPath: 'team/:id' } as WebhookEntity,
+			]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set());
+		});
+
+		test('ignores webhooks of nodes outside the requested set', async () => {
+			const workflow = createWorkflow([
+				node('webhook-node', 'webhook', { name: 'Webhook' }),
+				node('other-node', 'webhook', { name: 'Other' }),
+			]);
+			jest
+				.spyOn(WebhookHelpers, 'getWorkflowWebhooks')
+				.mockReturnValue([desiredWebhook({ node: 'Other', httpMethod: 'GET', path: 'other' })]);
+			webhookService.getRegisteredWebhooks.mockResolvedValue([]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set());
+		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -138,6 +138,44 @@ describe('WorkflowTriggerActivator', () => {
 		});
 	});
 
+	describe('getNodesWithUnregisteredWebhooks', () => {
+		test("delegates to the registrar with the version's enabled trigger node ids", async () => {
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
+			webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks.mockResolvedValue(new Set(['w']));
+			const activator = buildActivator({ webhookTriggerRegistrar });
+
+			const result = await activator.getNodesWithUnregisteredWebhooks(
+				mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
+				{
+					nodes: [node('w', 'webhook'), node('regular', 'n8n-nodes-base.set')],
+					connections: {},
+				},
+			);
+
+			expect(result).toEqual(new Set(['w']));
+			expect(webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				additionalData,
+				new Set(['w']),
+			);
+		});
+
+		test('returns empty without calling the registrar when there are no trigger nodes', async () => {
+			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
+			const activator = buildActivator({ webhookTriggerRegistrar });
+
+			const result = await activator.getNodesWithUnregisteredWebhooks(
+				mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
+				{ nodes: [node('regular', 'n8n-nodes-base.set')], connections: {} },
+			);
+
+			expect(result).toEqual(new Set());
+			expect(webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks).not.toHaveBeenCalled();
+		});
+	});
+
 	test('activates webhooks, non-webhook triggers, count, and persistence in order', async () => {
 		const callOrder: string[] = [];
 		jest.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -177,12 +177,11 @@ export class WebhookTriggerRegistrar {
 			return new Set();
 		}
 
-		const registeredKeysByNode = new Map<string, Set<string>>();
-		for (const webhook of await this.webhookService.getRegisteredWebhooks(workflow.id)) {
-			const keys = registeredKeysByNode.get(webhook.node) ?? new Set<string>();
-			keys.add(this.webhookKey(webhook.method, webhook.webhookPath));
-			registeredKeysByNode.set(webhook.node, keys);
-		}
+		const registeredKeys = new Set(
+			(await this.webhookService.getRegisteredWebhooks(workflow.id)).map((webhook) =>
+				this.webhookKey(webhook.method, webhook.webhookPath),
+			),
+		);
 
 		const unregistered = new Set<INode['id']>();
 		for (const webhookData of desiredWebhooks) {
@@ -193,7 +192,7 @@ export class WebhookTriggerRegistrar {
 
 			const webhook = this.buildNormalizedWebhook(workflow, webhookData);
 			const key = this.webhookKey(webhook.method, webhook.webhookPath);
-			if (!registeredKeysByNode.get(webhookData.node)?.has(key)) {
+			if (!registeredKeys.has(key)) {
 				unregistered.add(node.id);
 			}
 		}

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -155,12 +155,10 @@ export class WebhookTriggerRegistrar {
 
 	/**
 	 * Of the given trigger nodes, returns the ids of those whose desired webhooks
-	 * are not all present in storage. A node is treated atomically: if any one of
-	 * its webhooks is missing, the whole node is returned so it gets re-registered.
+	 * are not all present in storage. If any one of a node's webhooks is missing,
+	 * the whole node is returned so it gets re-registered.
 	 *
-	 * This compares the desired state against the actual local (`webhook_entity`)
-	 * state, so a node whose registration was never completed (e.g. a crash after
-	 * the published version advanced) is reconciled on the next publish.
+	 * This is used to recover from failures during registration.
 	 *
 	 * NOTE: it only considers the local registration, not any remote state
 	 * (e.g., a third-party service that has lost the webhook).
@@ -202,8 +200,7 @@ export class WebhookTriggerRegistrar {
 
 	/**
 	 * Builds the storage entity for a webhook, normalizing its path so static and
-	 * dynamic paths match what is persisted. Shared by registration and the
-	 * unregistered-webhook check so their comparison keys cannot drift.
+	 * dynamic paths match what is persisted.
 	 */
 	private buildNormalizedWebhook(workflow: Workflow, webhookData: IWebhookData): WebhookEntity {
 		const node = workflow.getNode(webhookData.node) as INode;

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -76,17 +76,7 @@ export class WebhookTriggerRegistrar {
 				},
 			},
 			async (span) => {
-				const node = workflow.getNode(webhookData.node) as INode;
-				node.name = webhookData.node;
-
-				const webhook = this.webhookService.createWebhook({
-					workflowId: webhookData.workflowId,
-					webhookPath: webhookData.path,
-					node: node.name,
-					method: webhookData.httpMethod,
-				});
-
-				this.normalizeWebhookPath(webhook, node.webhookId);
+				const webhook = this.buildNormalizedWebhook(workflow, webhookData);
 
 				let isStored = false;
 				try {
@@ -161,6 +151,79 @@ export class WebhookTriggerRegistrar {
 
 	async clearWorkflowWebhooksForNodes(workflowId: string, nodeNames: string[]) {
 		await this.webhookService.deleteWorkflowWebhooksForNodes(workflowId, nodeNames);
+	}
+
+	/**
+	 * Of the given trigger nodes, returns the ids of those whose desired webhooks
+	 * are not all present in storage. A node is treated atomically: if any one of
+	 * its webhooks is missing, the whole node is returned so it gets re-registered.
+	 *
+	 * This compares the desired state against the actual local (`webhook_entity`)
+	 * state, so a node whose registration was never completed (e.g. a crash after
+	 * the published version advanced) is reconciled on the next publish.
+	 *
+	 * NOTE: it only considers the local registration, not any remote state
+	 * (e.g., a third-party service that has lost the webhook).
+	 */
+	async getNodesWithUnregisteredWebhooks(
+		workflow: Workflow,
+		additionalData: IWorkflowExecuteAdditionalData,
+		desiredNodes: Set<INode['id']>,
+	): Promise<Set<INode['id']>> {
+		const desiredWebhooks = this.getWebhookTriggers(workflow, additionalData).filter(
+			(webhookData) => desiredNodes.has(workflow.getNode(webhookData.node)?.id ?? ''),
+		);
+		if (desiredWebhooks.length === 0) {
+			return new Set();
+		}
+
+		const registeredKeysByNode = new Map<string, Set<string>>();
+		for (const webhook of await this.webhookService.getRegisteredWebhooks(workflow.id)) {
+			const keys = registeredKeysByNode.get(webhook.node) ?? new Set<string>();
+			keys.add(this.webhookKey(webhook.method, webhook.webhookPath));
+			registeredKeysByNode.set(webhook.node, keys);
+		}
+
+		const unregistered = new Set<INode['id']>();
+		for (const webhookData of desiredWebhooks) {
+			const node = workflow.getNode(webhookData.node);
+			if (!node) {
+				continue;
+			}
+
+			const webhook = this.buildNormalizedWebhook(workflow, webhookData);
+			const key = this.webhookKey(webhook.method, webhook.webhookPath);
+			if (!registeredKeysByNode.get(webhookData.node)?.has(key)) {
+				unregistered.add(node.id);
+			}
+		}
+
+		return unregistered;
+	}
+
+	/**
+	 * Builds the storage entity for a webhook, normalizing its path so static and
+	 * dynamic paths match what is persisted. Shared by registration and the
+	 * unregistered-webhook check so their comparison keys cannot drift.
+	 */
+	private buildNormalizedWebhook(workflow: Workflow, webhookData: IWebhookData): WebhookEntity {
+		const node = workflow.getNode(webhookData.node) as INode;
+
+		const webhook = this.webhookService.createWebhook({
+			workflowId: webhookData.workflowId,
+			webhookPath: webhookData.path,
+			node: node.name,
+			method: webhookData.httpMethod,
+		});
+
+		this.normalizeWebhookPath(webhook, node.webhookId);
+
+		return webhook;
+	}
+
+	/** Identity of a webhook row: its `(method, path)` primary key. */
+	private webhookKey(method: string, webhookPath: string): string {
+		return `${method} ${webhookPath}`;
 	}
 
 	private async clearRegisteredWebhook(workflow: Workflow, webhookData: IWebhookData) {

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -177,7 +177,7 @@ export class WebhookTriggerRegistrar {
 
 		const registeredKeys = new Set(
 			(await this.webhookService.getRegisteredWebhooks(workflow.id)).map((webhook) =>
-				this.webhookKey(webhook.method, webhook.webhookPath),
+				this.buildWebhookKey(webhook.method, webhook.webhookPath),
 			),
 		);
 
@@ -189,7 +189,7 @@ export class WebhookTriggerRegistrar {
 			}
 
 			const webhook = this.buildNormalizedWebhook(workflow, webhookData);
-			const key = this.webhookKey(webhook.method, webhook.webhookPath);
+			const key = this.buildWebhookKey(webhook.method, webhook.webhookPath);
 			if (!registeredKeys.has(key)) {
 				unregistered.add(node.id);
 			}
@@ -218,7 +218,7 @@ export class WebhookTriggerRegistrar {
 	}
 
 	/** Identity of a webhook row: its `(method, path)` primary key. */
-	private webhookKey(method: string, webhookPath: string): string {
+	private buildWebhookKey(method: string, webhookPath: string): string {
 		return `${method} ${webhookPath}`;
 	}
 

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -127,6 +127,35 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
+	 * Returns the desired webhook trigger nodes of the given version whose webhooks
+	 * are not all registered in storage (the `webhook_entity` table). The webhook
+	 * counterpart to {@link getUnregisteredNonWebhookTriggerNodeIds}: it lets
+	 * publication reconcile a re-enqueued version whose webhooks were never (or only
+	 * partly) registered, e.g. after a crash that advanced the published version.
+	 */
+	async getNodesWithUnregisteredWebhooks(
+		dbWorkflow: WorkflowEntity,
+		version: WorkflowTriggerVersion,
+	): Promise<Set<INode['id']>> {
+		const desiredNodes = new Set(this.getEnabledTriggerNodes(version).map((node) => node.id));
+		if (desiredNodes.size === 0) return new Set();
+
+		this.applyVersionToDbWorkflow(dbWorkflow, version);
+		const workflow = this.createWorkflow(dbWorkflow);
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId: workflow.id,
+			workflowSettings: dbWorkflow.settings,
+		});
+
+		return await this.webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks(
+			workflow,
+			additionalData,
+			desiredNodes,
+		);
+	}
+
+	/**
 	 * Filters the given nodes to the non-webhook trigger nodes (active, schedule
 	 * and poll triggers), matching the registration logic in
 	 * `NonWebhookTriggerRegistrar`.


### PR DESCRIPTION
## Summary

When publishing a workflow, we register any webhooks that should be in the new version but aren't in the webhook table.

This closes a gap in error handling where we crash after advancing the workflow published version but before we finish registering webhooks. In this case, the diff against the old version wouldn't yield anything. We already do a diff against the live state for non-webhook triggers; this is analogous for webhooks.

This *doesn't* reconcile any 3rd-party state. That's left for a future improvement. If a node is missing one of multiple webhooks, we re-register the whole node. This should be safely idempotent.

## How to test

Added unit tests.

Manual: with the flag on, publish a workflow with a webhook trigger, delete its `webhook_entity` row to simulate a partial/missing registration, republish the same version, and confirm the webhook is re-registered.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3536

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32895">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

