### PR TITLE
test: Increase initialization budget for lengthy test inits

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/__tests__/cli.test.ts
@@ -181,6 +181,13 @@ describe('CLI', () => {
 	let mockExit: MockInstance;
 	const originalEnv = process.env;
 
+	// Warm the module cache once so the first test's `await import('../cli')`
+	// doesn't pay cold-compile cost against the default 5s test timeout on a
+	// loaded CI runner. Later imports resolve from cache.
+	beforeAll(async () => {
+		await import('../cli');
+	}, 30_000);
+
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {

--- a/packages/@n8n/task-runner/src/js-task-runner/__tests__/require-resolver-global-modules.test.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/__tests__/require-resolver-global-modules.test.ts
@@ -58,7 +58,9 @@ try {
   console.log(JSON.stringify({ success: false, error: e.message }));
 }`,
 		);
-	});
+		// `npm install` hits the registry and can exceed the default 10s hook
+		// timeout on a loaded CI runner, so give it ample headroom.
+	}, 60_000);
 
 	afterAll(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -366,7 +366,9 @@ describe('generate-types', () => {
 		} catch {
 			// Module doesn't export functions yet - tests will fail as expected in TDD
 		}
-	});
+		// Cold module compilation can exceed the default 10s hook timeout on a
+		// loaded CI runner, so give the import ample headroom.
+	}, 30_000);
 
 	// =========================================================================
 	// Property Type Mapping Tests
@@ -5085,7 +5087,9 @@ describe('orchestrateGeneration', () => {
 
 	beforeAll(async () => {
 		mod = await import('../generate-types/generate-types');
-	});
+		// Cold module compilation can exceed the default 10s hook timeout on a
+		// loaded CI runner, so give the import ample headroom.
+	}, 30_000);
 
 	afterAll(async () => {
 		await fs.promises.rm(outputDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes multiple flaky test initializations where timeout budgets were breached due to lengthy initialization cycles. 

Intentionally not bumping the global timeout since we don't want everything to have this level of timeout windows.


## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/actions/runs/27951019107/job/82708901774
- https://github.com/n8n-io/n8n/actions/runs/27947736998/job/82697321800
- https://github.com/n8n-io/n8n/actions/runs/27942868768/job/82681043490

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

