### PR TITLE
Groups in logs

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1740,6 +1740,7 @@
 	"logs.overview.body.run": "Execute step",
 	"logs.overview.body.open": "Open...",
 	"logs.overview.body.toggleRow": "Toggle row",
+	"logs.overview.body.group.nodeCount": "{count} node | {count} nodes",
 	"logs.details.header.actions.input": "Input",
 	"logs.details.header.actions.output": "Output",
 	"logs.details.header.actions.viewAgentSession": "View session",

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
@@ -3,6 +3,7 @@ import LogsViewExecutionSummary from '@/features/execution/logs/components/LogsV
 import LogsViewConsumedTokenCountText from '@/features/execution/logs/components/LogsViewConsumedTokenCountText.vue';
 import LogsPanelHeader from '@/features/execution/logs/components/LogsPanelHeader.vue';
 import LogsViewRunData from '@/features/execution/logs/components/LogsViewRunData.vue';
+import LogsGroupRunData from '@/features/execution/logs/components/LogsGroupRunData.vue';
 import { useResizablePanel } from '@/app/composables/useResizablePanel';
 import {
 	isLogGroupEntry,
@@ -17,6 +18,8 @@ import LogsViewNodeName from '@/features/execution/logs/components/LogsViewNodeN
 import { computed, useTemplateRef } from 'vue';
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import {
+	getGroupInputEntries,
+	getGroupOutputEntries,
 	getSubtreeTotalConsumedTokens,
 	isPlaceholderLog,
 } from '@/features/execution/logs/logs.utils';
@@ -75,6 +78,14 @@ const isGroup = computed(() => isLogGroupEntry(logEntry));
 const inputEntry = computed(() => (isLogGroupEntry(logEntry) ? logEntry.inputLogEntry : logEntry));
 const outputEntry = computed(() =>
 	isLogGroupEntry(logEntry) ? logEntry.outputLogEntry : logEntry,
+);
+// A group can have multiple boundary members on either side; the panes let the
+// user switch between them (run selection is handled by RunData below).
+const groupInputEntries = computed(() =>
+	isLogGroupEntry(logEntry) ? getGroupInputEntries(logEntry) : [],
+);
+const groupOutputEntries = computed(() =>
+	isLogGroupEntry(logEntry) ? getGroupOutputEntries(logEntry) : [],
 );
 const type = computed(() =>
 	isLogGroupEntry(logEntry) ? undefined : nodeTypeStore.getNodeType(logEntry.node.type),
@@ -223,7 +234,19 @@ function handleResizeEnd() {
 					@resize="resizer.onResize"
 					@resizeend="handleResizeEnd"
 				>
+					<LogsGroupRunData
+						v-if="isGroup"
+						pane-type="input"
+						:title="locale.baseText('logs.details.header.actions.input')"
+						:entries="groupInputEntries"
+						:default-entry="inputEntry"
+						:collapsing-table-column-name="collapsingInputTableColumnName"
+						:search-shortcut="searchShortcutPriorityPanel === 'input' ? 'ctrl+f' : undefined"
+						:show-redacted-overlay="panels !== LOG_DETAILS_PANEL_STATE.BOTH"
+						@collapsing-table-column-changed="emit('collapsingInputTableColumnChanged', $event)"
+					/>
 					<LogsViewRunData
+						v-else
 						data-test-id="log-details-input"
 						pane-type="input"
 						:title="locale.baseText('logs.details.header.actions.input')"
@@ -234,8 +257,20 @@ function handleResizeEnd() {
 						@collapsing-table-column-changed="emit('collapsingInputTableColumnChanged', $event)"
 					/>
 				</N8nResizeWrapper>
+				<LogsGroupRunData
+					v-if="isGroup && panels !== LOG_DETAILS_PANEL_STATE.INPUT"
+					pane-type="output"
+					:class="$style.outputPanel"
+					:title="locale.baseText('logs.details.header.actions.output')"
+					:entries="groupOutputEntries"
+					:default-entry="outputEntry"
+					:collapsing-table-column-name="collapsingOutputTableColumnName"
+					:search-shortcut="searchShortcutPriorityPanel === 'output' ? 'ctrl+f' : undefined"
+					:show-redacted-overlay="panels !== LOG_DETAILS_PANEL_STATE.BOTH"
+					@collapsing-table-column-changed="emit('collapsingOutputTableColumnChanged', $event)"
+				/>
 				<LogsViewRunData
-					v-if="isTriggerNode || panels !== LOG_DETAILS_PANEL_STATE.INPUT"
+					v-else-if="isTriggerNode || panels !== LOG_DETAILS_PANEL_STATE.INPUT"
 					data-test-id="log-details-output"
 					pane-type="output"
 					:class="$style.outputPanel"

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import LogsViewExecutionSummary from '@/features/execution/logs/components/LogsViewExecutionSummary.vue';
+import LogsViewConsumedTokenCountText from '@/features/execution/logs/components/LogsViewConsumedTokenCountText.vue';
 import LogsPanelHeader from '@/features/execution/logs/components/LogsPanelHeader.vue';
 import LogsViewRunData from '@/features/execution/logs/components/LogsViewRunData.vue';
 import { useResizablePanel } from '@/app/composables/useResizablePanel';
 import {
+	isLogGroupEntry,
 	type LatestNodeInfo,
-	type LogEntry,
+	type LogTreeEntry,
 	type LogDetailsPanelState,
 } from '@/features/execution/logs/logs.types';
 import NodeIcon from '@/app/components/NodeIcon.vue';
@@ -41,7 +43,7 @@ const {
 	isHeaderClickable,
 } = defineProps<{
 	isOpen: boolean;
-	logEntry: LogEntry;
+	logEntry: LogTreeEntry;
 	window?: Window;
 	latestInfo?: LatestNodeInfo;
 	panels: LogDetailsPanelState;
@@ -67,10 +69,38 @@ const experimentalNdvStore = useExperimentalNdvStore();
 const uiStore = useUIStore();
 const { isRedacted, canReveal, isDynamicCredentials, revealData } = useExecutionRedaction();
 
-const type = computed(() => nodeTypeStore.getNodeType(logEntry.node.type));
+const isGroup = computed(() => isLogGroupEntry(logEntry));
+// A group has no run data of its own — its input/output is the entry member's
+// input and the exit member's output, so it reads exactly like a single node.
+const inputEntry = computed(() => (isLogGroupEntry(logEntry) ? logEntry.inputLogEntry : logEntry));
+const outputEntry = computed(() =>
+	isLogGroupEntry(logEntry) ? logEntry.outputLogEntry : logEntry,
+);
+const type = computed(() =>
+	isLogGroupEntry(logEntry) ? undefined : nodeTypeStore.getNodeType(logEntry.node.type),
+);
+const headerName = computed(() =>
+	isLogGroupEntry(logEntry) ? logEntry.group.name : (latestInfo?.name ?? logEntry.node.name),
+);
+const headerIsDeleted = computed(
+	() => !isLogGroupEntry(logEntry) && (latestInfo?.deleted ?? false),
+);
+// Header execution summary only applies to concrete node runs.
+const nodeSummary = computed(() => {
+	if (isLogGroupEntry(logEntry) || logEntry.runData === undefined) {
+		return undefined;
+	}
+
+	return {
+		status: logEntry.runData.executionStatus ?? ('unknown' as const),
+		startTime: logEntry.runData.startTime,
+		timeTook: logEntry.runData.executionTime,
+	};
+});
 const consumedTokens = computed(() => getSubtreeTotalConsumedTokens(logEntry, false));
-const isTriggerNode = computed(() => type.value?.group.includes('trigger'));
-const { link: messageAgentSessionLink } = useMessageAgentSessionLink(computed(() => logEntry));
+// Groups never contain triggers, so the input pane always renders for them.
+const isTriggerNode = computed(() => !isGroup.value && !!type.value?.group.includes('trigger'));
+const { link: messageAgentSessionLink } = useMessageAgentSessionLink(inputEntry);
 const container = useTemplateRef<HTMLElement>('container');
 const resizer = useResizablePanel('N8N_LOGS_INPUT_PANEL_WIDTH', {
 	container,
@@ -112,18 +142,20 @@ function handleResizeEnd() {
 		>
 			<template #title>
 				<div :class="$style.title">
-					<NodeIcon :node-type="type" :size="16" :class="$style.icon" />
-					<LogsViewNodeName
-						:name="latestInfo?.name ?? logEntry.node.name"
-						:is-deleted="latestInfo?.deleted ?? false"
-					/>
+					<NodeIcon v-if="!isGroup" :node-type="type" :size="16" :class="$style.icon" />
+					<LogsViewNodeName :name="headerName" :is-deleted="headerIsDeleted" />
 					<LogsViewExecutionSummary
-						v-if="isOpen && logEntry.runData !== undefined"
+						v-if="isOpen && nodeSummary"
 						:class="$style.executionSummary"
-						:status="logEntry.runData.executionStatus ?? 'unknown'"
+						:status="nodeSummary.status"
 						:consumed-tokens="consumedTokens"
-						:start-time="logEntry.runData.startTime"
-						:time-took="logEntry.runData.executionTime"
+						:start-time="nodeSummary.startTime"
+						:time-took="nodeSummary.timeTook"
+					/>
+					<LogsViewConsumedTokenCountText
+						v-else-if="isOpen && isGroup && consumedTokens.totalTokens > 0"
+						:class="$style.executionSummary"
+						:consumed-tokens="consumedTokens"
 					/>
 				</div>
 			</template>
@@ -195,7 +227,7 @@ function handleResizeEnd() {
 						data-test-id="log-details-input"
 						pane-type="input"
 						:title="locale.baseText('logs.details.header.actions.input')"
-						:log-entry="logEntry"
+						:log-entry="inputEntry"
 						:collapsing-table-column-name="collapsingInputTableColumnName"
 						:search-shortcut="searchShortcutPriorityPanel === 'input' ? 'ctrl+f' : undefined"
 						:show-redacted-overlay="panels !== LOG_DETAILS_PANEL_STATE.BOTH"
@@ -208,7 +240,7 @@ function handleResizeEnd() {
 					pane-type="output"
 					:class="$style.outputPanel"
 					:title="locale.baseText('logs.details.header.actions.output')"
-					:log-entry="logEntry"
+					:log-entry="outputEntry"
 					:collapsing-table-column-name="collapsingOutputTableColumnName"
 					:search-shortcut="searchShortcutPriorityPanel === 'output' ? 'ctrl+f' : undefined"
 					:show-redacted-overlay="panels !== LOG_DETAILS_PANEL_STATE.BOTH"

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsGroupPortSelect.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsGroupPortSelect.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { N8nOption, N8nSelect } from '@n8n/design-system';
+import NodeIcon from '@/app/components/NodeIcon.vue';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import type { LogEntry } from '@/features/execution/logs/logs.types';
+
+const props = defineProps<{
+	entries: LogEntry[];
+	modelValue: number;
+	ariaLabel?: string;
+}>();
+
+const emit = defineEmits<{
+	'update:model-value': [value: number];
+}>();
+
+const nodeTypesStore = useNodeTypesStore();
+
+const options = computed(() =>
+	props.entries.map((entry, index) => ({
+		index,
+		name: entry.node.name,
+		type: nodeTypesStore.getNodeType(entry.node.type, entry.node.typeVersion),
+	})),
+);
+
+const selectedType = computed(() => options.value[props.modelValue]?.type ?? null);
+
+function onChange(value: unknown) {
+	emit('update:model-value', Number(value));
+}
+</script>
+
+<template>
+	<N8nSelect
+		:model-value="modelValue"
+		:aria-label="ariaLabel"
+		:class="$style.select"
+		size="small"
+		teleported
+		data-test-id="logs-group-port-select"
+		@update:model-value="onChange"
+	>
+		<template #prefix>
+			<NodeIcon :node-type="selectedType" :size="14" :shrink="false" />
+		</template>
+		<N8nOption
+			v-for="option of options"
+			:key="option.index"
+			:value="option.index"
+			:label="option.name"
+			:class="$style.option"
+			data-test-id="logs-group-port-option"
+		>
+			<NodeIcon :node-type="option.type" :size="14" :shrink="false" :class="$style.icon" />
+			<span :class="$style.title">{{ option.name }}</span>
+		</N8nOption>
+	</N8nSelect>
+</template>
+
+<style lang="scss" module>
+.select {
+	max-width: 224px;
+
+	:global(.el-input--suffix .el-input__inner) {
+		padding-left: calc(var(--spacing--lg) + var(--spacing--4xs));
+	}
+}
+
+.option {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
+	font-size: var(--font-size--2xs);
+}
+
+.icon {
+	padding-right: var(--spacing--4xs);
+}
+
+.title {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	color: var(--color--text--shade-1);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsGroupRunData.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsGroupRunData.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import type { NodePanelType } from '@/features/ndv/shared/ndv.types';
+import type { LogEntry } from '@/features/execution/logs/logs.types';
+import type { SearchShortcut } from '@/features/workflows/canvas/canvas.types';
+import LogsViewRunData from '@/features/execution/logs/components/LogsViewRunData.vue';
+import LogsGroupPortSelect from '@/features/execution/logs/components/LogsGroupPortSelect.vue';
+
+const props = withDefaults(
+	defineProps<{
+		entries: LogEntry[];
+		defaultEntry: LogEntry;
+		paneType: NodePanelType;
+		title: string;
+		collapsingTableColumnName: string | null;
+		searchShortcut?: SearchShortcut;
+		showRedactedOverlay?: boolean;
+	}>(),
+	{ showRedactedOverlay: true },
+);
+
+const emit = defineEmits<{
+	collapsingTableColumnChanged: [columnName: string | null];
+}>();
+
+const defaultIndex = computed(() => {
+	const idx = props.entries.findIndex((e) => e.node.id === props.defaultEntry.node.id);
+	return idx >= 0 ? idx : 0;
+});
+
+const selectedIndex = ref(defaultIndex.value);
+
+// Keep the selection valid as the group's members change between runs, and
+// re-default to the boundary member when the list changes.
+watch(
+	() => props.entries,
+	(entries) => {
+		if (selectedIndex.value >= entries.length) {
+			selectedIndex.value = defaultIndex.value;
+		}
+	},
+);
+
+const selectedEntry = computed(() => props.entries[selectedIndex.value]);
+const dataTestId = computed(() =>
+	props.paneType === 'input' ? 'log-details-input' : 'log-details-output',
+);
+</script>
+
+<template>
+	<div :class="$style.container">
+		<LogsViewRunData
+			v-if="selectedEntry"
+			:class="$style.runData"
+			:data-test-id="dataTestId"
+			:pane-type="paneType"
+			:title="title"
+			:log-entry="selectedEntry"
+			:enable-run-selection="true"
+			:collapsing-table-column-name="collapsingTableColumnName"
+			:search-shortcut="searchShortcut"
+			:show-redacted-overlay="showRedactedOverlay"
+			@collapsing-table-column-changed="emit('collapsingTableColumnChanged', $event)"
+		>
+			<template v-if="entries.length > 1" #run-selector-prepend>
+				<LogsGroupPortSelect
+					:entries="entries"
+					:model-value="selectedIndex"
+					:aria-label="title"
+					@update:model-value="selectedIndex = $event"
+				/>
+			</template>
+		</LogsViewRunData>
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	width: 100%;
+	overflow: hidden;
+}
+
+.runData {
+	flex: 1;
+	min-height: 0;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewGroupRow.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewGroupRow.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+import { computed, nextTick, useTemplateRef, watch } from 'vue';
+import { useI18n } from '@n8n/i18n';
+import LogsViewConsumedTokenCountText from '@/features/execution/logs/components/LogsViewConsumedTokenCountText.vue';
+import LogsViewNodeName from '@/features/execution/logs/components/LogsViewNodeName.vue';
+import { getSubtreeTotalConsumedTokens } from '@/features/execution/logs/logs.utils';
+import { useLogsTreeIndents } from '@/features/execution/logs/composables/useLogsTreeIndents';
+import type { LogGroupEntry } from '@/features/execution/logs/logs.types';
+import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
+import AnimatedSpinner from '@/app/components/AnimatedSpinner.vue';
+
+const props = defineProps<{
+	data: LogGroupEntry;
+	isSelected: boolean;
+	isCompact: boolean;
+	shouldShowTokenCountColumn: boolean;
+	expanded: boolean;
+}>();
+
+const emit = defineEmits<{
+	toggleExpanded: [];
+	toggleSelected: [];
+}>();
+
+const container = useTemplateRef('containerRef');
+const locale = useI18n();
+
+const indents = useLogsTreeIndents(() => props.data);
+
+const status = computed(() => props.data.executionStatus);
+const isRunning = computed(() => status.value === 'running');
+const isWaiting = computed(() => status.value === 'waiting');
+const isError = computed(() => status.value === 'error');
+const isWarning = computed(() => status.value === 'warning' || status.value === 'issues');
+const isSuccess = computed(() => status.value === 'success');
+
+const memberCountText = computed(() =>
+	locale.baseText('logs.overview.body.group.nodeCount', {
+		adjustToNumber: props.data.executedMemberCount,
+		interpolate: { count: props.data.executedMemberCount },
+	}),
+);
+
+const subtreeConsumedTokens = computed(() =>
+	props.shouldShowTokenCountColumn ? getSubtreeTotalConsumedTokens(props.data, false) : undefined,
+);
+
+// Focus when selected: for scrolling into view and keyboard navigation to work
+watch(
+	() => props.isSelected,
+	(isSelected) => {
+		void nextTick(() => {
+			if (isSelected) {
+				container.value?.focus();
+			}
+		});
+	},
+	{ immediate: true },
+);
+</script>
+
+<template>
+	<div
+		ref="containerRef"
+		role="treeitem"
+		tabindex="-1"
+		data-test-id="logs-overview-group-row"
+		:aria-expanded="props.expanded"
+		:aria-selected="props.isSelected"
+		:class="{
+			[$style.container]: true,
+			[$style.compact]: props.isCompact,
+			[$style.error]: isError,
+			[$style.selected]: props.isSelected,
+		}"
+		@click.stop="emit('toggleSelected')"
+	>
+		<div
+			v-for="(indent, level) in indents"
+			:key="level"
+			:class="{
+				[$style.indent]: true,
+				[$style.connectorCurved]: indent.curved,
+				[$style.connectorStraight]: indent.straight,
+			}"
+		/>
+		<div :class="$style.background" :style="{ '--indent-depth': indents.length }" />
+		<LogsViewNodeName :class="$style.name" :name="data.group.name" :is-error="isError" />
+		<N8nText tag="span" color="text-light" size="small" :class="$style.count">
+			{{ memberCountText }}
+		</N8nText>
+		<N8nText v-if="!isCompact" tag="div" color="text-light" size="small" :class="$style.status">
+			<AnimatedSpinner v-if="isRunning" :class="$style.statusIcon" />
+			<N8nIcon v-else-if="isWaiting" icon="status-waiting" :class="$style.statusIcon" />
+			<N8nText v-else-if="isError" color="danger" :bold="true" size="small">
+				<N8nIcon icon="triangle-alert" :class="$style.statusIcon" />
+			</N8nText>
+			<N8nIcon v-else-if="isWarning" icon="status-warning" :class="$style.statusIcon" />
+			<N8nIcon v-else-if="isSuccess" icon="circle-check" :class="$style.statusIcon" />
+		</N8nText>
+		<N8nText
+			v-if="!isCompact && subtreeConsumedTokens !== undefined"
+			tag="div"
+			color="text-light"
+			size="small"
+			:class="$style.consumedTokens"
+		>
+			<LogsViewConsumedTokenCountText
+				v-if="subtreeConsumedTokens.totalTokens > 0 && !props.expanded"
+				:consumed-tokens="subtreeConsumedTokens"
+			/>
+		</N8nText>
+		<N8nIcon
+			v-if="isError && isCompact"
+			size="medium"
+			color="danger"
+			icon="triangle-alert"
+			:class="$style.compactErrorIcon"
+		/>
+		<N8nButton
+			variant="ghost"
+			icon-only
+			size="small"
+			:icon="props.expanded ? 'chevron-down' : 'chevron-up'"
+			icon-size="medium"
+			:class="$style.toggleButton"
+			:aria-label="locale.baseText('logs.overview.body.toggleRow')"
+			@click.stop="emit('toggleExpanded')"
+		/>
+	</div>
+</template>
+
+<style lang="scss" module>
+.container {
+	display: flex;
+	align-items: center;
+	justify-content: stretch;
+	overflow: hidden;
+	position: relative;
+	z-index: 1;
+	padding-inline-end: var(--spacing--5xs);
+	cursor: pointer;
+
+	& > * {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		padding: var(--spacing--2xs);
+	}
+}
+
+.background {
+	position: absolute;
+	/* stylelint-disable-next-line @n8n/css-var-naming */
+	left: calc(var(--indent-depth) * 32px);
+	top: 0;
+	/* stylelint-disable-next-line @n8n/css-var-naming */
+	width: calc(100% - var(--indent-depth) * 32px);
+	height: 100%;
+	border-radius: var(--radius);
+	z-index: -1;
+
+	.selected & {
+		background-color: var(--color--foreground);
+	}
+
+	.container:hover:not(.selected) & {
+		background-color: var(--color--background--light-1);
+	}
+
+	.selected:not(:hover).error & {
+		background-color: var(--callout--color--background--danger);
+	}
+}
+
+.indent {
+	flex-grow: 0;
+	flex-shrink: 0;
+	width: var(--spacing--xl);
+	align-self: stretch;
+	position: relative;
+	overflow: hidden;
+	margin-bottom: 0;
+
+	&.connectorCurved:before {
+		content: '';
+		position: absolute;
+		left: var(--spacing--sm);
+		bottom: var(--spacing--sm);
+		border: 2px solid var(--canvas--dot--color);
+		width: var(--spacing--lg);
+		height: var(--spacing--lg);
+		border-radius: var(--radius--lg);
+	}
+
+	&.connectorStraight:after {
+		content: '';
+		position: absolute;
+		left: var(--spacing--sm);
+		top: 0;
+		border-left: 2px solid var(--canvas--dot--color);
+		height: 100%;
+	}
+}
+
+.name {
+	flex-shrink: 1;
+	/* stylelint-disable-next-line @n8n/css-var-naming */
+	margin-left: var(--row-gap-thickness);
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.count {
+	flex-grow: 1;
+	flex-shrink: 0;
+	padding-inline-start: 0;
+}
+
+.status {
+	flex-grow: 0;
+	flex-shrink: 0;
+	width: 20%;
+
+	.statusIcon {
+		vertical-align: text-bottom;
+	}
+}
+
+.consumedTokens {
+	flex-grow: 0;
+	flex-shrink: 0;
+	width: 15%;
+	text-align: right;
+}
+
+.compactErrorIcon {
+	flex-grow: 0;
+	flex-shrink: 0;
+	width: 26px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	.container:hover & {
+		display: none;
+	}
+}
+
+.toggleButton {
+	display: inline-flex;
+	flex-grow: 0;
+	flex-shrink: 0;
+	border: none;
+	background: transparent;
+	color: var(--color--text);
+	align-items: center;
+	justify-content: center;
+
+	&:hover {
+		background: transparent;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.vue
@@ -3,7 +3,7 @@ import LogsOverviewRows from '@/features/execution/logs/components/LogsOverviewR
 import LogsPanelHeader from '@/features/execution/logs/components/LogsPanelHeader.vue';
 import LogsViewExecutionSummary from '@/features/execution/logs/components/LogsViewExecutionSummary.vue';
 import { useClearExecutionButtonVisible } from '@/features/execution/logs/composables/useClearExecutionButtonVisible';
-import type { LatestNodeInfo, LogEntry } from '@/features/execution/logs/logs.types';
+import type { LatestNodeInfo, LogTreeEntry } from '@/features/execution/logs/logs.types';
 import {
 	getSubtreeTotalConsumedTokens,
 	getTotalConsumedTokens,
@@ -26,22 +26,22 @@ const {
 	isHeaderClickable,
 } = defineProps<{
 	isOpen: boolean;
-	selected?: LogEntry;
+	selected?: LogTreeEntry;
 	isReadOnly: boolean;
 	isCompact: boolean;
 	execution?: IExecutionResponse;
-	entries: LogEntry[];
-	flatLogEntries: LogEntry[];
+	entries: LogTreeEntry[];
+	flatLogEntries: LogTreeEntry[];
 	latestNodeInfo: Record<string, LatestNodeInfo>;
 	isHeaderClickable: boolean;
 }>();
 
 const emit = defineEmits<{
 	clickHeader: [];
-	select: [LogEntry | undefined];
+	select: [LogTreeEntry | undefined];
 	clearExecutionData: [];
-	openNdv: [LogEntry];
-	toggleExpanded: [LogEntry];
+	openNdv: [LogTreeEntry];
+	toggleExpanded: [LogTreeEntry];
 }>();
 
 defineSlots<{ actions: {} }>();

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRow.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRow.vue
@@ -12,6 +12,7 @@ import {
 	getSubtreeTotalConsumedTokens,
 	hasSubExecution,
 } from '@/features/execution/logs/logs.utils';
+import { useLogsTreeIndents } from '@/features/execution/logs/composables/useLogsTreeIndents';
 import { useTimestamp } from '@vueuse/core';
 import type { LatestNodeInfo, LogEntry } from '@/features/execution/logs/logs.types';
 
@@ -78,21 +79,7 @@ const subtreeConsumedTokens = computed(() =>
 
 const hasChildren = computed(() => props.data.children.length > 0 || hasSubExecution(props.data));
 
-const indents = computed(() => {
-	const ret: Array<{ straight: boolean; curved: boolean }> = [];
-
-	let data: LogEntry = props.data;
-
-	while (data.parent !== undefined) {
-		const siblings = data.parent?.children ?? [];
-		const lastSibling = siblings[siblings.length - 1];
-
-		ret.unshift({ straight: lastSibling?.id !== data.id, curved: data === props.data });
-		data = data.parent;
-	}
-
-	return ret;
-});
+const indents = useLogsTreeIndents(() => props.data);
 
 // Focus when selected: For scrolling into view and for keyboard navigation to work
 watch(

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewRows.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import LogsOverviewRow from '@/features/execution/logs/components/LogsOverviewRow.vue';
-import type { LatestNodeInfo, LogEntry } from '@/features/execution/logs/logs.types';
+import LogsOverviewGroupRow from '@/features/execution/logs/components/LogsOverviewGroupRow.vue';
+import {
+	isLogGroupEntry,
+	type LatestNodeInfo,
+	type LogEntry,
+	type LogTreeEntry,
+} from '@/features/execution/logs/logs.types';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { useVirtualList } from '@vueuse/core';
 import { watch } from 'vue';
@@ -18,20 +24,20 @@ const {
 	shouldShowTokenCountColumn,
 	execution,
 } = defineProps<{
-	selected?: LogEntry;
+	selected?: LogTreeEntry;
 	isReadOnly: boolean;
 	isCompact: boolean;
 	shouldShowTokenCountColumn: boolean;
 	canOpenNdv: boolean;
-	flatLogEntries: LogEntry[];
+	flatLogEntries: LogTreeEntry[];
 	latestNodeInfo: Record<string, LatestNodeInfo>;
 	execution?: IExecutionResponse;
 }>();
 
 const emit = defineEmits<{
-	select: [LogEntry | undefined];
+	select: [LogTreeEntry | undefined];
 	openNdv: [LogEntry];
-	toggleExpanded: [LogEntry];
+	toggleExpanded: [LogTreeEntry];
 }>();
 
 const router = useRouter();
@@ -100,22 +106,33 @@ watch(
 <template>
 	<div :class="$style.tree" v-bind="virtualList.containerProps">
 		<div role="tree" v-bind="virtualList.wrapperProps.value">
-			<LogsOverviewRow
-				v-for="{ data, index } of virtualList.list.value"
-				:key="index"
-				:data="data"
-				:is-read-only="isReadOnly"
-				:is-selected="data.id === selected?.id"
-				:is-compact="isCompact"
-				:should-show-token-count-column="shouldShowTokenCountColumn"
-				:latest-info="latestNodeInfo[data.node.id]"
-				:expanded="isExpanded[data.id]"
-				:can-open-ndv="canOpenNdv"
-				@toggle-expanded="emit('toggleExpanded', data)"
-				@open-ndv="emit('openNdv', data)"
-				@trigger-partial-execution="handleTriggerPartialExecution(data)"
-				@toggle-selected="emit('select', selected?.id === data.id ? undefined : data)"
-			/>
+			<template v-for="{ data, index } of virtualList.list.value" :key="index">
+				<LogsOverviewGroupRow
+					v-if="isLogGroupEntry(data)"
+					:data="data"
+					:is-selected="data.id === selected?.id"
+					:is-compact="isCompact"
+					:should-show-token-count-column="shouldShowTokenCountColumn"
+					:expanded="isExpanded[data.id]"
+					@toggle-expanded="emit('toggleExpanded', data)"
+					@toggle-selected="emit('select', selected?.id === data.id ? undefined : data)"
+				/>
+				<LogsOverviewRow
+					v-else
+					:data="data"
+					:is-read-only="isReadOnly"
+					:is-selected="data.id === selected?.id"
+					:is-compact="isCompact"
+					:should-show-token-count-column="shouldShowTokenCountColumn"
+					:latest-info="latestNodeInfo[data.node.id]"
+					:expanded="isExpanded[data.id]"
+					:can-open-ndv="canOpenNdv"
+					@toggle-expanded="emit('toggleExpanded', data)"
+					@open-ndv="emit('openNdv', data)"
+					@trigger-partial-execution="handleTriggerPartialExecution(data)"
+					@toggle-selected="emit('select', selected?.id === data.id ? undefined : data)"
+				/>
+			</template>
 		</div>
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.vue
@@ -10,7 +10,7 @@ import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useLogsSelection } from '@/features/execution/logs/composables/useLogsSelection';
 import { useLogsTreeExpand } from '@/features/execution/logs/composables/useLogsTreeExpand';
-import { type LogEntry } from '@/features/execution/logs/logs.types';
+import { isLogGroupEntry, type LogTreeEntry } from '@/features/execution/logs/logs.types';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useLogsPanelLayout } from '@/features/execution/logs/composables/useLogsPanelLayout';
 import { type KeyMap } from '@/app/composables/useKeybindings';
@@ -80,13 +80,21 @@ const logsPanelActionsProps = computed<InstanceType<typeof LogsPanelActions>['$p
 	onToggleOpen,
 	onToggleSyncSelection: logsStore.toggleLogSelectionSync,
 }));
+const selectedNodeName = computed(() =>
+	selected.value && !isLogGroupEntry(selected.value) ? selected.value.node.name : undefined,
+);
+const selectedLatestInfo = computed(() =>
+	selected.value && !isLogGroupEntry(selected.value)
+		? latestNodeNameById.value[selected.value.node.id]
+		: undefined,
+);
 const inputCollapsingColumnName = computed(() =>
-	inputTableColumnCollapsing.value?.nodeName === selected.value?.node.name
+	inputTableColumnCollapsing.value?.nodeName === selectedNodeName.value
 		? (inputTableColumnCollapsing.value?.columnName ?? null)
 		: null,
 );
 const outputCollapsingColumnName = computed(() =>
-	outputTableColumnCollapsing.value?.nodeName === selected.value?.node.name
+	outputTableColumnCollapsing.value?.nodeName === selectedNodeName.value
 		? (outputTableColumnCollapsing.value?.columnName ?? null)
 		: null,
 );
@@ -117,7 +125,12 @@ function handleResizeOverviewPanelEnd() {
 	onOverviewPanelResizeEnd();
 }
 
-function handleOpenNdv(treeNode: LogEntry) {
+function handleOpenNdv(treeNode: LogTreeEntry) {
+	// Groups have no underlying node to open in the NDV.
+	if (isLogGroupEntry(treeNode)) {
+		return;
+	}
+
 	ndvStore.value.setActiveNodeName(treeNode.node.name, 'logs_view');
 
 	void nextTick(() => {
@@ -132,12 +145,16 @@ function handleOpenNdv(treeNode: LogEntry) {
 
 function handleChangeInputTableColumnCollapsing(columnName: string | null) {
 	inputTableColumnCollapsing.value =
-		columnName && selected.value ? { nodeName: selected.value.node.name, columnName } : undefined;
+		columnName && selectedNodeName.value
+			? { nodeName: selectedNodeName.value, columnName }
+			: undefined;
 }
 
 function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 	outputTableColumnCollapsing.value =
-		columnName && selected.value ? { nodeName: selected.value.node.name, columnName } : undefined;
+		columnName && selectedNodeName.value
+			? { nodeName: selectedNodeName.value, columnName }
+			: undefined;
 }
 </script>
 
@@ -228,7 +245,7 @@ function handleChangeOutputTableColumnCollapsing(columnName: string | null) {
 							:is-open="isOpen"
 							:log-entry="selected"
 							:window="popOutWindow"
-							:latest-info="latestNodeNameById[selected.node.id]"
+							:latest-info="selectedLatestInfo"
 							:panels="logsStore.detailsState"
 							:collapsing-input-table-column-name="inputCollapsingColumnName"
 							:collapsing-output-table-column-name="outputCollapsingColumnName"

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.vue
@@ -25,6 +25,7 @@ const {
 	paneType,
 	collapsingTableColumnName,
 	showRedactedOverlay = true,
+	enableRunSelection = false,
 } = defineProps<{
 	title: string;
 	paneType: NodePanelType;
@@ -32,6 +33,7 @@ const {
 	collapsingTableColumnName: string | null;
 	searchShortcut?: SearchShortcut;
 	showRedactedOverlay?: boolean;
+	enableRunSelection?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -72,6 +74,15 @@ const runDataProps = computed<
 		overrideOutputs: [source.previousNodeOutput ?? 0],
 	};
 });
+// For the source-based path (input pane), RunData must read the source node's
+// OUTPUT data (taskData.data), not its inputOverride (what it received). Using
+// paneType="output" makes getNodeInputData skip inputOverride and read taskData.data,
+// which is the data the selected node actually receives as input.
+const effectivePaneType = computed<NodePanelType>(() =>
+	paneType === 'input' && !isSubNodeLog(logEntry) && !!runDataProps.value?.overrideOutputs
+		? 'output'
+		: paneType,
+);
 const isExecuting = computed(
 	() =>
 		paneType === 'output' &&
@@ -92,14 +103,14 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 	<RunData
 		v-if="runDataProps"
 		v-bind="runDataProps"
-		:key="`run-data${popOutWindow ? '-pop-out' : ''}`"
+		:key="`run-data-${logEntry.id}${popOutWindow ? '-pop-out' : ''}`"
 		:class="$style.component"
 		:workflow-object="logEntry.workflow"
 		:workflow-execution="logEntry.execution"
 		:no-data-in-branch-message="locale.baseText('ndv.output.noOutputDataInBranch')"
 		:executing-message="locale.baseText('ndv.output.executing')"
-		:pane-type="paneType"
-		:disable-run-index-selection="true"
+		:pane-type="effectivePaneType"
+		:disable-run-index-selection="!enableRunSelection"
 		:compact="true"
 		:show-actions-on-hover="true"
 		:disable-pin="true"
@@ -115,6 +126,10 @@ function handleChangeDisplayMode(value: IRunDataDisplayMode) {
 		@display-mode-change="handleChangeDisplayMode"
 		@collapsing-table-column-changed="emit('collapsingTableColumnChanged', $event)"
 	>
+		<template v-if="$slots['run-selector-prepend']" #run-selector-prepend>
+			<slot name="run-selector-prepend" />
+		</template>
+
 		<template #header>
 			<N8nText :class="$style.title" :bold="true" color="text-light" size="small">
 				{{ title }}

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsExecutionData.ts
@@ -10,11 +10,22 @@ import {
 	createLogTree,
 	findSubExecutionLocator,
 	mergeStartData,
+	wrapLogEntriesInGroups,
 } from '@/features/execution/logs/logs.utils';
 import { useToast } from '@/app/composables/useToast';
-import type { LatestNodeInfo, LogEntry, LogTreeFilter } from '../logs.types';
+import {
+	isLogGroupEntry,
+	type LatestNodeInfo,
+	type LogTreeEntry,
+	type LogTreeFilter,
+} from '../logs.types';
 import { isChatNode } from '@/app/utils/aiUtils';
-import { CHAT_TRIGGER_NODE_TYPE, LOGS_EXECUTION_DATA_THROTTLE_DURATION } from '@/app/constants';
+import {
+	CANVAS_NODES_GROUPING_EXPERIMENT,
+	CHAT_TRIGGER_NODE_TYPE,
+	LOGS_EXECUTION_DATA_THROTTLE_DURATION,
+} from '@/app/constants';
+import { usePostHog } from '@/app/stores/posthog.store';
 import { useChatHubPanelStore } from '@/features/ai/chatHub/chatHubPanel.store';
 import { useThrottleFn } from '@vueuse/core';
 import { useThrottleWithReactiveDelay } from '@n8n/composables/useThrottleWithReactiveDelay';
@@ -34,6 +45,13 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const workflowExecutionStateStore = injectWorkflowExecutionStateStore();
+	const posthogStore = usePostHog();
+	const isNodeGroupingEnabled = computed(() =>
+		posthogStore.isFeatureEnabled(CANVAS_NODES_GROUPING_EXPERIMENT.name),
+	);
+	const nodeGroups = computed(() =>
+		isNodeGroupingEnabled.value ? workflowDocumentStore.value.allGroups : [],
+	);
 	const currentExecution = computed(() => workflowExecutionStateStore.value.activeExecution);
 	const toast = useToast();
 
@@ -85,7 +103,7 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		);
 	});
 
-	const entries = computed<LogEntry[]>(() => {
+	const entries = computed<LogTreeEntry[]>(() => {
 		if ((isEnabled !== undefined && !isEnabled.value) || !throttledState.value || !workflow.value) {
 			return [];
 		}
@@ -95,13 +113,17 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 			throttledState.value.response,
 		);
 
-		return createLogTree(
+		const tree = createLogTree(
 			workflow.value,
 			mergedExecutionData,
 			subWorkflows.value,
 			subWorkflowExecData.value,
 			filter?.value,
 		);
+
+		// Skip group wrapping when filtering to a single run — the filter exists to
+		// drill into one run, so the group ancestor would only add noise.
+		return wrapLogEntriesInGroups(tree, filter?.value !== undefined ? [] : nodeGroups.value);
 	});
 
 	function resetExecutionData() {
@@ -113,7 +135,11 @@ export function useLogsExecutionData({ isEnabled, filter }: UseLogsExecutionData
 		void workflowsStore.fetchLastSuccessfulExecution();
 	}
 
-	async function loadSubExecution(logEntry: LogEntry) {
+	async function loadSubExecution(logEntry: LogTreeEntry) {
+		if (isLogGroupEntry(logEntry)) {
+			return;
+		}
+
 		const locator = findSubExecutionLocator(logEntry);
 
 		if (!state.value || locator === undefined) {

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsSelection.ts
@@ -1,4 +1,8 @@
-import type { LogEntry, LogEntrySelection } from '@/features/execution/logs/logs.types';
+import {
+	isLogGroupEntry,
+	type LogEntrySelection,
+	type LogTreeEntry,
+} from '@/features/execution/logs/logs.types';
 import {
 	findLogEntryRec,
 	findSelectedLogEntry,
@@ -8,6 +12,7 @@ import {
 } from '@/features/execution/logs/logs.utils';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
+import { createCanvasGroupNodeId } from '@/features/workflows/canvas/canvas.types';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { useCanvasStore } from '@/app/stores/canvas.store';
 import { useLogsStore } from '@/app/stores/logs.store';
@@ -19,9 +24,9 @@ import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store
 
 export function useLogsSelection(
 	execution: ComputedRef<IExecutionResponse | undefined>,
-	tree: Ref<LogEntry[]>,
-	flatLogEntries: ComputedRef<LogEntry[]>,
-	toggleExpand: (entry: LogEntry, expand?: boolean) => void,
+	tree: Ref<LogTreeEntry[]>,
+	flatLogEntries: ComputedRef<LogTreeEntry[]>,
+	toggleExpand: (entry: LogTreeEntry, expand?: boolean) => void,
 ) {
 	const telemetry = useTelemetry();
 	const manualLogEntrySelection = shallowRef<LogEntrySelection>({ type: 'initial' });
@@ -35,28 +40,35 @@ export function useLogsSelection(
 	const canvasStore = useCanvasStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 
-	function syncSelectionToCanvasIfEnabled(value: LogEntry) {
+	function syncSelectionToCanvasIfEnabled(value: LogTreeEntry) {
 		if (!logsStore.isLogSelectionSyncedWithCanvas) {
 			return;
 		}
 
-		canvasEventBus.emit('nodes:select', { ids: [value.node.id], panIntoView: true });
+		// A group maps to its collapsed group node on the canvas; a node maps to itself.
+		const canvasId = isLogGroupEntry(value)
+			? createCanvasGroupNodeId(value.group.id)
+			: value.node.id;
+
+		canvasEventBus.emit('nodes:select', { ids: [canvasId], panIntoView: true });
 	}
 
-	function select(value: LogEntry | undefined) {
+	function select(value: LogTreeEntry | undefined) {
 		manualLogEntrySelection.value =
 			value === undefined ? { type: 'none' } : { type: 'selected', entry: value };
 
 		if (value) {
 			syncSelectionToCanvasIfEnabled(value);
 
-			telemetry.track('User selected node in log view', {
-				node_type: value.node.type,
-				node_id: value.node.id,
-				execution_id: execution.value?.id,
-				workflow_id: execution.value?.workflowData.id,
-				subworkflow_depth: getDepth(value),
-			});
+			if (!isLogGroupEntry(value)) {
+				telemetry.track('User selected node in log view', {
+					node_type: value.node.type,
+					node_id: value.node.id,
+					execution_id: execution.value?.id,
+					workflow_id: execution.value?.workflowData.id,
+					subworkflow_depth: getDepth(value),
+				});
+			}
 		}
 	}
 
@@ -107,9 +119,11 @@ export function useLogsSelection(
 			const selectedNodeId = selectedOnCanvas
 				? workflowDocumentStore.value.nodesByName[selectedOnCanvas]?.id
 				: undefined;
+			const currentSelectedNodeId =
+				selected.value && !isLogGroupEntry(selected.value) ? selected.value.node.id : undefined;
 
 			nodeIdToSelect.value =
-				shouldSync && !canvasStore.hasRangeSelection && selected.value?.node.id !== selectedNodeId
+				shouldSync && !canvasStore.hasRangeSelection && currentSelectedNodeId !== selectedNodeId
 					? selectedNodeId
 					: undefined;
 		},
@@ -123,7 +137,7 @@ export function useLogsSelection(
 				return;
 			}
 
-			const entry = findLogEntryRec((e) => e.node.id === id, latestTree);
+			const entry = findLogEntryRec((e) => !isLogGroupEntry(e) && e.node.id === id, latestTree);
 
 			if (!entry) {
 				return;

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeExpand.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeExpand.ts
@@ -1,18 +1,47 @@
-import { flattenLogEntries, hasSubExecution } from '@/features/execution/logs/logs.utils';
-import { computed, shallowRef, type Ref } from 'vue';
-import type { LogEntry } from '../logs.types';
+import {
+	flattenLogEntries,
+	getDefaultCollapsedEntries,
+	hasSubExecution,
+} from '@/features/execution/logs/logs.utils';
+import { computed, shallowRef, watch, type Ref } from 'vue';
+import { isLogGroupEntry, type LogTreeEntry } from '../logs.types';
 
 export function useLogsTreeExpand(
-	entries: Ref<LogEntry[]>,
-	loadSubExecution: (logEntry: LogEntry) => Promise<void>,
+	entries: Ref<LogTreeEntry[]>,
+	loadSubExecution: (logEntry: LogTreeEntry) => Promise<void>,
 ) {
 	const collapsedEntries = shallowRef<Record<string, boolean>>({});
-	const flatLogEntries = computed<LogEntry[]>(() =>
+	// Entry ids we've already applied a default collapse state for, so user
+	// toggles aren't overwritten when the tree rebuilds (e.g. while executing).
+	const appliedDefaults = new Set<string>();
+	const flatLogEntries = computed<LogTreeEntry[]>(() =>
 		flattenLogEntries(entries.value, collapsedEntries.value),
 	);
 
-	function toggleExpanded(treeNode: LogEntry, expand?: boolean) {
-		if (hasSubExecution(treeNode) && treeNode.children.length === 0) {
+	// Apply default collapse state (groups + empty sub-execution placeholders)
+	// the first time each entry appears, without clobbering existing choices.
+	watch(
+		entries,
+		(latest) => {
+			const defaults = getDefaultCollapsedEntries(latest);
+			const pending = Object.entries(defaults).filter(([id]) => !appliedDefaults.has(id));
+
+			if (pending.length === 0) {
+				return;
+			}
+
+			const next = { ...collapsedEntries.value };
+			for (const [id, collapsed] of pending) {
+				next[id] = collapsed;
+				appliedDefaults.add(id);
+			}
+			collapsedEntries.value = next;
+		},
+		{ immediate: true },
+	);
+
+	function toggleExpanded(treeNode: LogTreeEntry, expand?: boolean) {
+		if (!isLogGroupEntry(treeNode) && hasSubExecution(treeNode) && treeNode.children.length === 0) {
 			void loadSubExecution(treeNode);
 			return;
 		}

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeExpand.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeExpand.ts
@@ -11,30 +11,35 @@ export function useLogsTreeExpand(
 	loadSubExecution: (logEntry: LogTreeEntry) => Promise<void>,
 ) {
 	const collapsedEntries = shallowRef<Record<string, boolean>>({});
-	// Entry ids we've already applied a default collapse state for, so user
-	// toggles aren't overwritten when the tree rebuilds (e.g. while executing).
-	const appliedDefaults = new Set<string>();
+	// Ids the user has explicitly expanded/collapsed. Their choice always wins
+	// over the computed defaults, even as the tree rebuilds while executing.
+	const userToggled = new Set<string>();
 	const flatLogEntries = computed<LogTreeEntry[]>(() =>
 		flattenLogEntries(entries.value, collapsedEntries.value),
 	);
 
-	// Apply default collapse state (groups + empty sub-execution placeholders)
-	// the first time each entry appears, without clobbering existing choices.
+	// (Re)apply default collapse state (groups collapse unless they contain an
+	// error; empty sub-execution placeholders collapse) on every rebuild, leaving
+	// any entry the user has manually toggled untouched. Re-applying — rather than
+	// applying once — lets a group expand if a member errors after it first appears.
 	watch(
 		entries,
 		(latest) => {
 			const defaults = getDefaultCollapsedEntries(latest);
-			const pending = Object.entries(defaults).filter(([id]) => !appliedDefaults.has(id));
+			const next: Record<string, boolean> = {};
 
-			if (pending.length === 0) {
-				return;
+			for (const id of userToggled) {
+				if (collapsedEntries.value[id] !== undefined) {
+					next[id] = collapsedEntries.value[id];
+				}
 			}
 
-			const next = { ...collapsedEntries.value };
-			for (const [id, collapsed] of pending) {
-				next[id] = collapsed;
-				appliedDefaults.add(id);
+			for (const [id, collapsed] of Object.entries(defaults)) {
+				if (!userToggled.has(id)) {
+					next[id] = collapsed;
+				}
 			}
+
 			collapsedEntries.value = next;
 		},
 		{ immediate: true },
@@ -46,6 +51,7 @@ export function useLogsTreeExpand(
 			return;
 		}
 
+		userToggled.add(treeNode.id);
 		collapsedEntries.value = {
 			...collapsedEntries.value,
 			[treeNode.id]: expand === undefined ? !collapsedEntries.value[treeNode.id] : !expand,

--- a/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeIndents.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/composables/useLogsTreeIndents.ts
@@ -1,0 +1,30 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue';
+import type { LogTreeEntry } from '@/features/execution/logs/logs.types';
+
+export interface LogTreeIndent {
+	straight: boolean;
+	curved: boolean;
+}
+
+/**
+ * Computes the tree-connector indents for a log row by walking the entry's
+ * parent back-pointers. Shared by node rows and group rows so both draw the
+ * same curved/straight connectors regardless of entry kind.
+ */
+export function useLogsTreeIndents(entry: MaybeRefOrGetter<LogTreeEntry>) {
+	return computed<LogTreeIndent[]>(() => {
+		const ret: LogTreeIndent[] = [];
+		const self = toValue(entry);
+		let data: LogTreeEntry = self;
+
+		while (data.parent !== undefined) {
+			const siblings = data.parent.children ?? [];
+			const lastSibling = siblings[siblings.length - 1];
+
+			ret.unshift({ straight: lastSibling?.id !== data.id, curved: data === self });
+			data = data.parent;
+		}
+
+		return ret;
+	});
+}

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.types.ts
@@ -3,11 +3,12 @@ import type {
 	LOG_DETAILS_PANEL_STATE,
 	LOGS_PANEL_STATE,
 } from '@/features/execution/logs/logs.constants';
+import type { GroupExecutionStatus } from '@/features/workflows/canvas/canvas.types';
 import type { INodeUi, LlmTokenUsageData } from '@/Interface';
-import type { IRunExecutionData, ITaskData } from 'n8n-workflow';
+import type { IRunExecutionData, ITaskData, IWorkflowGroup } from 'n8n-workflow';
 
 export type LogEntry = {
-	parent?: LogEntry;
+	parent?: LogTreeEntry;
 	node: INodeUi;
 	id: string;
 	children: LogEntry[];
@@ -19,6 +20,38 @@ export type LogEntry = {
 	execution: IRunExecutionData;
 	isSubExecution: boolean;
 };
+
+/**
+ * A workflow group surfaced in the logs tree. It wraps the log entries of its
+ * member nodes as `children`, mirroring how AI sub-nodes nest under their
+ * parent node. A group carries no run data of its own — its input/output is
+ * read from its entry/exit member entries, and its status/tokens are rolled
+ * up from members.
+ */
+export interface LogGroupEntry {
+	parent?: LogTreeEntry;
+	group: IWorkflowGroup;
+	id: string;
+	children: LogEntry[];
+	consumedTokens: LlmTokenUsageData;
+	executionStatus: GroupExecutionStatus | undefined;
+	/** Number of member nodes that produced run data. */
+	executedMemberCount: number;
+	/** Entry member (earliest in execution order) — drives the input pane. */
+	inputLogEntry: LogEntry;
+	/** Exit member (latest in execution order) — drives the output pane. */
+	outputLogEntry: LogEntry;
+	workflow: WorkflowObjectAccessors;
+	executionId: string;
+	execution: IRunExecutionData;
+	isSubExecution: boolean;
+}
+
+export type LogTreeEntry = LogEntry | LogGroupEntry;
+
+export function isLogGroupEntry(entry: LogTreeEntry): entry is LogGroupEntry {
+	return 'group' in entry;
+}
 
 export interface LogTreeCreationContext {
 	parent: LogEntry | undefined;
@@ -39,7 +72,7 @@ export interface LatestNodeInfo {
 
 export type LogEntrySelection =
 	| { type: 'initial' }
-	| { type: 'selected'; entry: LogEntry }
+	| { type: 'selected'; entry: LogTreeEntry }
 	| { type: 'none' };
 
 export type LogsPanelState = (typeof LOGS_PANEL_STATE)[keyof typeof LOGS_PANEL_STATE];

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
@@ -16,6 +16,8 @@ import {
 	processFiles,
 	extractBotResponse,
 	wrapLogEntriesInGroups,
+	getGroupInputEntries,
+	getGroupOutputEntries,
 } from './logs.utils';
 import {
 	AGENT_LANGCHAIN_NODE_TYPE,
@@ -1956,5 +1958,195 @@ describe(wrapLogEntriesInGroups, () => {
 		]);
 
 		expect(getDefaultCollapsedEntries(result)).toEqual({});
+	});
+});
+
+describe('group input / output entries', () => {
+	const triggerNode = createTestNode({ name: 'Trigger', id: 'id-trigger' });
+	const nodeA = createTestNode({ name: 'A', id: 'id-a' });
+	const nodeB = createTestNode({ name: 'B', id: 'id-b' });
+	const nodeC = createTestNode({ name: 'C', id: 'id-c' });
+	const nodeD = createTestNode({ name: 'D', id: 'id-d' });
+	const nodeE = createTestNode({ name: 'E', id: 'id-e' });
+
+	const mainTo = (node: string) => ({
+		main: [[{ node, type: NodeConnectionTypes.Main, index: 0 }]],
+	});
+
+	const mainBranch = (...nodes: string[]) => ({
+		main: nodes.map((node) => [{ node, type: NodeConnectionTypes.Main, index: 0 }]),
+	});
+
+	function buildGroup(
+		runData: IRunExecutionData['resultData']['runData'],
+		nodeIds: string[],
+		options?: { nodes?: INodeUi[]; connections?: IConnections },
+	) {
+		const nodes = options?.nodes ?? [triggerNode, nodeA, nodeB, nodeC];
+		const connections = options?.connections ?? {
+			Trigger: mainTo('A'),
+			A: mainTo('B'),
+			B: mainTo('C'),
+		};
+		const workflow = createTestWorkflowObject({ id: 'wf-1', nodes, connections });
+		const response = createTestWorkflowExecutionResponse({
+			id: 'exec-1',
+			workflowData: createTestWorkflow({ id: 'wf-1', nodes }),
+			data: createRunExecutionData({ resultData: { runData } }),
+		});
+		const [group] = wrapLogEntriesInGroups(createLogTree(workflow, response), [
+			{ id: 'g1', name: 'G', nodeIds },
+		]).filter(isLogGroupEntry);
+		return group;
+	}
+
+	const baseRunData = {
+		Trigger: [createTestTaskData({ startTime: 1 })],
+		A: [createTestTaskData({ startTime: 2 })],
+		B: [createTestTaskData({ startTime: 3 })],
+		C: [createTestTaskData({ startTime: 4 })],
+		D: [createTestTaskData({ startTime: 5 })],
+	};
+
+	describe(getGroupInputEntries, () => {
+		it('returns only root members (not targeted by any internal connection)', () => {
+			// a → b → [c, d],  group [a, b, c, d]
+			const group = buildGroup(baseRunData, ['id-a', 'id-b', 'id-c', 'id-d'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC, nodeD],
+				connections: {
+					Trigger: mainTo('A'),
+					A: mainTo('B'),
+					B: mainBranch('C', 'D'),
+				},
+			});
+
+			expect(getGroupInputEntries(group).map((e) => e.node.name)).toEqual(['A']);
+		});
+
+		it('returns a single root for a linear group', () => {
+			// a → b → c, group [b, c]
+			const group = buildGroup(baseRunData, ['id-b', 'id-c'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC],
+				connections: { Trigger: mainTo('A'), A: mainTo('B'), B: mainTo('C') },
+			});
+
+			expect(getGroupInputEntries(group).map((e) => e.node.name)).toEqual(['B']);
+		});
+
+		it('returns the single member for a one-member group', () => {
+			const group = buildGroup(baseRunData, ['id-b'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC],
+				connections: { Trigger: mainTo('A'), A: mainTo('B'), B: mainTo('C') },
+			});
+
+			expect(getGroupInputEntries(group).map((e) => e.node.name)).toEqual(['B']);
+		});
+
+		it('deduplicates a member with multiple runs to its first run', () => {
+			const group = buildGroup(
+				{
+					Trigger: [createTestTaskData({ startTime: 1 })],
+					A: [createTestTaskData({ startTime: 2 })],
+					B: [
+						createTestTaskData({ startTime: 3, executionIndex: 1 }),
+						createTestTaskData({ startTime: 5, executionIndex: 3 }),
+					],
+					C: [createTestTaskData({ startTime: 4, executionIndex: 2 })],
+				},
+				['id-b', 'id-c'],
+				{
+					nodes: [triggerNode, nodeA, nodeB, nodeC],
+					connections: { Trigger: mainTo('A'), A: mainTo('B'), B: mainTo('C') },
+				},
+			);
+
+			const entries = getGroupInputEntries(group);
+			expect(entries).toHaveLength(1);
+			expect(entries[0].node.name).toBe('B');
+			expect(entries[0].runIndex).toBe(0);
+		});
+
+		it('falls back to inputLogEntry when no root is found', () => {
+			// Cyclic group where every member is targeted by another member.
+			// In practice validation prevents this, but the fallback keeps the pane non-empty.
+			const group = buildGroup(baseRunData, ['id-a', 'id-b'], {
+				nodes: [triggerNode, nodeA, nodeB],
+				connections: {
+					Trigger: mainTo('A'),
+					A: mainTo('B'),
+					B: mainTo('A'),
+				},
+			});
+
+			expect(getGroupInputEntries(group)).toEqual([group.inputLogEntry]);
+		});
+	});
+
+	describe(getGroupOutputEntries, () => {
+		it('returns leaf members for a branched group', () => {
+			// a → b → [c, d],  group [a, b, c, d]
+			const group = buildGroup(baseRunData, ['id-a', 'id-b', 'id-c', 'id-d'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC, nodeD],
+				connections: {
+					Trigger: mainTo('A'),
+					A: mainTo('B'),
+					B: mainBranch('C', 'D'),
+				},
+			});
+
+			expect(getGroupOutputEntries(group).map((e) => e.node.name)).toEqual(['C', 'D']);
+		});
+
+		it('includes leaves that pass data externally', () => {
+			// a → b → [c → e (external), d],  group [a, b, c, d]
+			const group = buildGroup(
+				{ ...baseRunData, E: [createTestTaskData({ startTime: 6 })] },
+				['id-a', 'id-b', 'id-c', 'id-d'],
+				{
+					nodes: [triggerNode, nodeA, nodeB, nodeC, nodeD, nodeE],
+					connections: {
+						Trigger: mainTo('A'),
+						A: mainTo('B'),
+						B: mainBranch('C', 'D'),
+						C: mainTo('E'),
+					},
+				},
+			);
+
+			expect(getGroupOutputEntries(group).map((e) => e.node.name)).toEqual(['C', 'D']);
+		});
+
+		it('returns a single leaf for a linear group', () => {
+			// a → b → c, group [b, c]
+			const group = buildGroup(baseRunData, ['id-b', 'id-c'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC],
+				connections: { Trigger: mainTo('A'), A: mainTo('B'), B: mainTo('C') },
+			});
+
+			expect(getGroupOutputEntries(group).map((e) => e.node.name)).toEqual(['C']);
+		});
+
+		it('returns the single member for a one-member group', () => {
+			const group = buildGroup(baseRunData, ['id-b'], {
+				nodes: [triggerNode, nodeA, nodeB, nodeC],
+				connections: { Trigger: mainTo('A'), A: mainTo('B'), B: mainTo('C') },
+			});
+
+			expect(getGroupOutputEntries(group).map((e) => e.node.name)).toEqual(['B']);
+		});
+
+		it('falls back to outputLogEntry when no leaf is found', () => {
+			// Cyclic group where every member has an outgoing internal connection.
+			const group = buildGroup(baseRunData, ['id-a', 'id-b'], {
+				nodes: [triggerNode, nodeA, nodeB],
+				connections: {
+					Trigger: mainTo('A'),
+					A: mainTo('B'),
+					B: mainTo('A'),
+				},
+			});
+
+			expect(getGroupOutputEntries(group)).toEqual([group.outputLogEntry]);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
@@ -15,6 +15,7 @@ import {
 	restoreChatHistory,
 	processFiles,
 	extractBotResponse,
+	wrapLogEntriesInGroups,
 } from './logs.utils';
 import {
 	AGENT_LANGCHAIN_NODE_TYPE,
@@ -22,17 +23,29 @@ import {
 	createRunExecutionData,
 	NodeConnectionTypes,
 } from 'n8n-workflow';
-import type { ExecutionError, ITaskStartedData, IRunExecutionData } from 'n8n-workflow';
+import type {
+	ExecutionError,
+	IConnections,
+	ITaskStartedData,
+	IRunExecutionData,
+} from 'n8n-workflow';
+import type { INodeUi } from '@/Interface';
 import {
 	aiAgentNode,
 	aiChatWorkflow,
 	aiModelNode,
 	createTestLogTreeCreationContext,
 } from './__test__/data';
-import type { LogEntrySelection } from './logs.types';
+import { isLogGroupEntry, type LogEntrySelection, type LogTreeEntry } from './logs.types';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { createTestLogEntry } from './__test__/mocks';
 import { AGENT_NODE_TYPE, CHAT_TRIGGER_NODE_TYPE } from '@/app/constants';
+
+// Test helper: read a parent entry's node name (parents in these trees are nodes).
+function parentNodeName(entry: LogTreeEntry): string | undefined {
+	const parent = entry.parent;
+	return parent && !isLogGroupEntry(parent) ? parent.node.name : undefined;
+}
 
 describe(getTreeNodeData, () => {
 	it('should generate one node per execution', () => {
@@ -88,7 +101,7 @@ describe(getTreeNodeData, () => {
 
 		expect(logTree[0].children[0].id).toBe('test-wf-id:test-node-id-b:0:0');
 		expect(logTree[0].children[0].runIndex).toBe(0);
-		expect(logTree[0].children[0].parent?.node.name).toBe('A');
+		expect(parentNodeName(logTree[0].children[0])).toBe('A');
 		expect(logTree[0].children[0].runData?.startTime).toBe(1740528000001);
 		expect(logTree[0].children[0].consumedTokens.isEstimate).toBe(false);
 		expect(logTree[0].children[0].consumedTokens.completionTokens).toBe(1);
@@ -96,20 +109,20 @@ describe(getTreeNodeData, () => {
 
 		expect(logTree[0].children[0].children[0].id).toBe('test-wf-id:test-node-id-c:0:0:0');
 		expect(logTree[0].children[0].children[0].runIndex).toBe(0);
-		expect(logTree[0].children[0].children[0].parent?.node.name).toBe('B');
+		expect(parentNodeName(logTree[0].children[0].children[0])).toBe('B');
 		expect(logTree[0].children[0].children[0].consumedTokens.isEstimate).toBe(true);
 		expect(logTree[0].children[0].children[0].consumedTokens.completionTokens).toBe(7);
 
 		expect(logTree[0].children[1].id).toBe('test-wf-id:test-node-id-b:0:1');
 		expect(logTree[0].children[1].runIndex).toBe(1);
-		expect(logTree[0].children[1].parent?.node.name).toBe('A');
+		expect(parentNodeName(logTree[0].children[1])).toBe('A');
 		expect(logTree[0].children[1].consumedTokens.isEstimate).toBe(false);
 		expect(logTree[0].children[1].consumedTokens.completionTokens).toBe(4);
 		expect(logTree[0].children[1].children.length).toBe(1);
 
 		expect(logTree[0].children[1].children[0].id).toBe('test-wf-id:test-node-id-c:0:1:1');
 		expect(logTree[0].children[1].children[0].runIndex).toBe(1);
-		expect(logTree[0].children[1].children[0].parent?.node.name).toBe('B');
+		expect(parentNodeName(logTree[0].children[1].children[0])).toBe('B');
 		expect(logTree[0].children[1].children[0].consumedTokens.completionTokens).toBe(0);
 	});
 
@@ -1717,5 +1730,216 @@ describe(findSubExecutionLocator, () => {
 		);
 
 		expect(found).toEqual({ workflowId: 'w1', executionId: 'e1' });
+	});
+});
+
+describe(wrapLogEntriesInGroups, () => {
+	const triggerNode = createTestNode({ name: 'Trigger', id: 'id-trigger' });
+	const nodeA = createTestNode({ name: 'A', id: 'id-a' });
+	const nodeB = createTestNode({ name: 'B', id: 'id-b' });
+	const nodeC = createTestNode({ name: 'C', id: 'id-c' });
+
+	function buildTree(
+		runData: IRunExecutionData['resultData']['runData'],
+		nodes: INodeUi[] = [triggerNode, nodeA, nodeB, nodeC],
+		connections: IConnections = {
+			Trigger: { main: [[{ node: 'A', type: NodeConnectionTypes.Main, index: 0 }]] },
+			A: { main: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]] },
+			B: { main: [[{ node: 'C', type: NodeConnectionTypes.Main, index: 0 }]] },
+		},
+	) {
+		const workflow = createTestWorkflowObject({ id: 'wf-1', nodes, connections });
+		const response = createTestWorkflowExecutionResponse({
+			id: 'exec-1',
+			workflowData: createTestWorkflow({ id: 'wf-1', nodes }),
+			data: createRunExecutionData({ resultData: { runData } }),
+		});
+		return createLogTree(workflow, response);
+	}
+
+	const tokenUsage = (total: number) => ({
+		tokenUsage: { completionTokens: total, promptTokens: 0, totalTokens: total },
+	});
+
+	it('returns entries unchanged when no groups are given', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+		});
+
+		expect(wrapLogEntriesInGroups(tree, [])).toBe(tree);
+	});
+
+	it('wraps grouped root entries under a single group entry', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4 })],
+		});
+
+		const result = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'My group', nodeIds: ['id-b', 'id-c'] },
+		]);
+
+		// Trigger, A, then the group (placed at the earliest member's time)
+		expect(result).toHaveLength(3);
+		const group = result[2];
+		expect(isLogGroupEntry(group)).toBe(true);
+		if (!isLogGroupEntry(group)) return;
+
+		expect(group.group.name).toBe('My group');
+		expect(group.id).toBe('group:wf-1:g1');
+		expect(group.children).toHaveLength(2);
+		expect(group.children.every((c) => c.parent === group)).toBe(true);
+		expect(group.children[0].node.name).toBe('B');
+		expect(group.children[1].node.name).toBe('C');
+	});
+
+	it('sets inputLogEntry to the earliest member and outputLogEntry to the latest', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4 })],
+		});
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.inputLogEntry.node.name).toBe('B');
+		expect(group.outputLogEntry.node.name).toBe('C');
+	});
+
+	it('places the group chronologically by its earliest member', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 10 })],
+			B: [createTestTaskData({ startTime: 2 })],
+			C: [createTestTaskData({ startTime: 3 })],
+		});
+
+		const result = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]);
+
+		// Group's earliest member (B@2) precedes ungrouped A@10
+		expect(result.map((e) => (isLogGroupEntry(e) ? e.group.name : e.node.name))).toEqual([
+			'Trigger',
+			'G',
+			'A',
+		]);
+	});
+
+	it('rolls up an error status from any member', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4, executionStatus: 'error' })],
+		});
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.executionStatus).toBe('error');
+	});
+
+	it('rolls up success when all members succeed', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4 })],
+		});
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.executionStatus).toBe('success');
+	});
+
+	it('sums consumed tokens across members', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3, data: { main: [[{ json: tokenUsage(3) }]] } })],
+			C: [createTestTaskData({ startTime: 4, data: { main: [[{ json: tokenUsage(6) }]] } })],
+		});
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.consumedTokens.totalTokens).toBe(9);
+	});
+
+	it('only wraps members that produced run data (partial execution)', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+		});
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.children).toHaveLength(1);
+		expect(group.executedMemberCount).toBe(1);
+		expect(group.inputLogEntry.node.name).toBe('B');
+		expect(group.outputLogEntry.node.name).toBe('B');
+	});
+
+	it('preserves AI sub-node nesting inside a group (group → agent → sub-node)', () => {
+		const agentNode = createTestNode({ name: 'Agent', id: 'id-agent' });
+		const modelNode = createTestNode({ name: 'Model', id: 'id-model' });
+		const tree = buildTree(
+			{
+				Trigger: [createTestTaskData({ startTime: 1 })],
+				Agent: [createTestTaskData({ startTime: 2 })],
+				Model: [
+					createTestTaskData({
+						startTime: 3,
+						source: [{ previousNode: 'Agent', previousNodeRun: 0 }],
+					}),
+				],
+			},
+			[triggerNode, agentNode, modelNode],
+			{
+				Trigger: { main: [[{ node: 'Agent', type: NodeConnectionTypes.Main, index: 0 }]] },
+				Model: {
+					[NodeConnectionTypes.AiLanguageModel]: [
+						[{ node: 'Agent', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+					],
+				},
+			},
+		);
+
+		const [group] = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-agent'] },
+		]).filter(isLogGroupEntry);
+
+		expect(group.children).toHaveLength(1);
+		expect(group.children[0].node.name).toBe('Agent');
+		expect(group.children[0].children[0].node.name).toBe('Model');
+	});
+
+	it('default-collapses group entries', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4 })],
+		});
+
+		const result = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]);
+
+		expect(getDefaultCollapsedEntries(result)).toEqual({ 'group:wf-1:g1': true });
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.test.ts
@@ -1942,4 +1942,19 @@ describe(wrapLogEntriesInGroups, () => {
 
 		expect(getDefaultCollapsedEntries(result)).toEqual({ 'group:wf-1:g1': true });
 	});
+
+	it('does not collapse a group whose member errored', () => {
+		const tree = buildTree({
+			Trigger: [createTestTaskData({ startTime: 1 })],
+			A: [createTestTaskData({ startTime: 2 })],
+			B: [createTestTaskData({ startTime: 3 })],
+			C: [createTestTaskData({ startTime: 4, executionStatus: 'error' })],
+		});
+
+		const result = wrapLogEntriesInGroups(tree, [
+			{ id: 'g1', name: 'G', nodeIds: ['id-b', 'id-c'] },
+		]);
+
+		expect(getDefaultCollapsedEntries(result)).toEqual({});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -611,8 +611,11 @@ export function getDefaultCollapsedEntries(entries: LogTreeEntry[]): Record<stri
 	function collect(children: LogTreeEntry[]) {
 		for (const entry of children) {
 			if (isLogGroupEntry(entry)) {
-				// Groups load collapsed by default, mirroring the canvas.
-				ret[entry.id] = true;
+				// Groups load collapsed by default, except when a member errored —
+				// surface the failure by expanding the group on first open.
+				if (entry.executionStatus !== 'error') {
+					ret[entry.id] = true;
+				}
 			} else if (hasSubExecution(entry) && entry.children.length === 0) {
 				ret[entry.id] = true;
 			}

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -14,15 +14,21 @@ import {
 	parseErrorMetadata,
 	type RelatedExecution,
 	type INodeExecutionData,
+	type IWorkflowGroup,
 	createEmptyRunExecutionData,
 	createRunExecutionData,
 } from 'n8n-workflow';
 import type {
 	LogEntry,
 	LogEntrySelection,
+	LogGroupEntry,
 	LogTreeCreationContext,
+	LogTreeEntry,
 	LogTreeFilter,
 } from './logs.types';
+import { isLogGroupEntry } from './logs.types';
+import type { NodeExecutionSnapshot } from '@/features/workflows/canvas/canvas.types';
+import { aggregateGroupExecutionFromSnapshots } from '@/features/workflows/canvas/groupExecutionStatus';
 import { CHAT_TRIGGER_NODE_TYPE, MANUAL_CHAT_TRIGGER_NODE_TYPE } from '@/app/constants';
 import { type ChatMessage } from '@n8n/chat/types';
 import get from 'lodash/get';
@@ -164,12 +170,12 @@ export function getTotalConsumedTokens(...usage: LlmTokenUsageData[]): LlmTokenU
 }
 
 export function getSubtreeTotalConsumedTokens(
-	treeNode: LogEntry,
+	treeNode: LogTreeEntry,
 	includeSubWorkflow: boolean,
 ): LlmTokenUsageData {
 	const executionId = treeNode.executionId;
 
-	function calculate(currentNode: LogEntry): LlmTokenUsageData {
+	function calculate(currentNode: LogTreeEntry): LlmTokenUsageData {
 		if (!includeSubWorkflow && currentNode.executionId !== executionId) {
 			return emptyTokenUsageData;
 		}
@@ -183,8 +189,8 @@ export function getSubtreeTotalConsumedTokens(
 	return calculate(treeNode);
 }
 
-function findLogEntryToAutoSelect(subTree: LogEntry[]): LogEntry | undefined {
-	const entryWithError = findLogEntryRec((e) => !!e.runData?.error, subTree);
+function findLogEntryToAutoSelect(subTree: LogTreeEntry[]): LogTreeEntry | undefined {
+	const entryWithError = findLogEntryRec((e) => !isLogGroupEntry(e) && !!e.runData?.error, subTree);
 
 	if (entryWithError) {
 		return entryWithError;
@@ -192,8 +198,12 @@ function findLogEntryToAutoSelect(subTree: LogEntry[]): LogEntry | undefined {
 
 	const entryForAiAgent = findLogEntryRec(
 		(entry) =>
-			entry.node.type === AGENT_LANGCHAIN_NODE_TYPE ||
-			(entry.parent?.node.type === AGENT_LANGCHAIN_NODE_TYPE && isPlaceholderLog(entry.parent)),
+			!isLogGroupEntry(entry) &&
+			(entry.node.type === AGENT_LANGCHAIN_NODE_TYPE ||
+				(entry.parent !== undefined &&
+					!isLogGroupEntry(entry.parent) &&
+					entry.parent.node.type === AGENT_LANGCHAIN_NODE_TYPE &&
+					isPlaceholderLog(entry.parent))),
 		subTree,
 	);
 
@@ -201,7 +211,11 @@ function findLogEntryToAutoSelect(subTree: LogEntry[]): LogEntry | undefined {
 		return entryForAiAgent;
 	}
 
-	return subTree[subTree.length - 1];
+	// Prefer a concrete node entry as the default selection; fall back to the
+	// last entry (which may be a group) only if nothing else is available.
+	return (
+		[...subTree].reverse().find((entry) => !isLogGroupEntry(entry)) ?? subTree[subTree.length - 1]
+	);
 }
 
 function createLogTreeRec(
@@ -300,14 +314,116 @@ export function createLogTree(
 	});
 }
 
-export function findLogEntryById(id: string, entries: LogEntry[]) {
+/** Roll a single member run's task data into a snapshot for status aggregation. */
+function snapshotFromLogEntry(entry: LogEntry): NodeExecutionSnapshot {
+	const status = entry.runData?.executionStatus;
+
+	return {
+		running: status === 'running',
+		waitingForNext: false,
+		waiting: undefined,
+		// In the logs view an error is signalled by the error object or the status;
+		// `crashed` folds into error too.
+		hasExecutionError: !!entry.runData?.error || status === 'error' || status === 'crashed',
+		hasValidationError: false,
+		status,
+		dirty: false,
+		iterations: 1,
+	};
+}
+
+/**
+ * Wrap the top-level root entries that belong to a node group inside a
+ * synthetic {@link LogGroupEntry}, mirroring how AI sub-nodes nest under their
+ * parent. Only groups with at least one executed member are emitted, and a
+ * group is placed at the position of its earliest member so the final list
+ * stays in chronological order. Ungrouped roots are left untouched.
+ *
+ * Operates only on the top-level entries of a single execution; sub-execution
+ * subtrees keep their own structure. Context (workflow id, execution, etc.) is
+ * derived from the wrapped member entries, which all share it.
+ */
+export function wrapLogEntriesInGroups(
+	roots: LogEntry[],
+	nodeGroups: IWorkflowGroup[],
+): LogTreeEntry[] {
+	if (nodeGroups.length === 0) {
+		return roots;
+	}
+
+	const groupByNodeId = new Map<string, IWorkflowGroup>();
+	for (const group of nodeGroups) {
+		for (const nodeId of group.nodeIds) {
+			groupByNodeId.set(nodeId, group);
+		}
+	}
+
+	const result: LogTreeEntry[] = [];
+	const groupEntryById = new Map<string, LogGroupEntry>();
+
+	for (const root of roots) {
+		const group = groupByNodeId.get(root.node.id);
+
+		if (!group) {
+			result.push(root);
+			continue;
+		}
+
+		const existing = groupEntryById.get(group.id);
+
+		if (existing) {
+			existing.children.push(root);
+			root.parent = existing;
+			continue;
+		}
+
+		const groupEntry: LogGroupEntry = {
+			parent: root.parent,
+			group,
+			id: `group:${root.workflow.id}:${group.id}`,
+			children: [root],
+			consumedTokens: emptyTokenUsageData,
+			executionStatus: undefined,
+			executedMemberCount: 0,
+			// Reassigned below once children are finalized.
+			inputLogEntry: root,
+			outputLogEntry: root,
+			workflow: root.workflow,
+			executionId: root.executionId,
+			execution: root.execution,
+			isSubExecution: root.isSubExecution,
+		};
+		root.parent = groupEntry;
+		groupEntryById.set(group.id, groupEntry);
+		result.push(groupEntry);
+	}
+
+	for (const groupEntry of groupEntryById.values()) {
+		groupEntry.children.sort(sortLogEntries);
+		groupEntry.inputLogEntry = groupEntry.children[0];
+		groupEntry.outputLogEntry = groupEntry.children[groupEntry.children.length - 1];
+		groupEntry.executedMemberCount = new Set(
+			groupEntry.children.map((child) => child.node.id),
+		).size;
+		groupEntry.consumedTokens = getTotalConsumedTokens(
+			...groupEntry.children.map((child) => getSubtreeTotalConsumedTokens(child, false)),
+		);
+		groupEntry.executionStatus = aggregateGroupExecutionFromSnapshots(
+			groupEntry.children.map(snapshotFromLogEntry),
+		);
+	}
+
+	return result.sort(sortLogEntries);
+}
+
+export function findLogEntryById(id: string, entries: LogTreeEntry[]) {
 	return findLogEntryRec((entry) => entry.id === id, entries);
 }
 
 export function findLogEntryRec(
-	isMatched: (entry: LogEntry) => boolean,
-	entries: LogEntry[],
-): LogEntry | undefined {
+	isMatched: (entry: LogTreeEntry) => boolean,
+	entries: LogTreeEntry[],
+): LogTreeEntry | undefined {
 	for (const entry of entries) {
 		if (isMatched(entry)) {
 			return entry;
@@ -325,23 +441,26 @@ export function findLogEntryRec(
 
 export function findSelectedLogEntry(
 	selection: LogEntrySelection,
-	entries: LogEntry[],
+	entries: LogTreeEntry[],
 	isExecuting: boolean,
-): LogEntry | undefined {
+): LogTreeEntry | undefined {
 	switch (selection.type) {
 		case 'initial':
 			return isExecuting ? undefined : findLogEntryToAutoSelect(entries);
 		case 'none':
 			return undefined;
 		case 'selected': {
-			const found = findLogEntryRec((e) => e.id === selection.entry.id, entries);
+			const selectedEntry = selection.entry;
+			const found = findLogEntryRec((e) => e.id === selectedEntry.id, entries);
 
-			if (found === undefined && !isExecuting) {
-				for (let runIndex = selection.entry.runIndex - 1; runIndex >= 0; runIndex--) {
+			// Run-index fallback only applies to node entries; groups have no run index.
+			if (found === undefined && !isExecuting && !isLogGroupEntry(selectedEntry)) {
+				for (let runIndex = selectedEntry.runIndex - 1; runIndex >= 0; runIndex--) {
 					const fallback = findLogEntryRec(
 						(e) =>
-							e.workflow.id === selection.entry.workflow.id &&
-							e.node.id === selection.entry.node.id &&
+							!isLogGroupEntry(e) &&
+							e.workflow.id === selectedEntry.workflow.id &&
+							e.node.id === selectedEntry.node.id &&
 							e.runIndex === runIndex,
 						entries,
 					);
@@ -357,16 +476,18 @@ export function findSelectedLogEntry(
 	}
 }
 
-export function flattenLogEntries(
-	entries: LogEntry[],
+export function flattenLogEntries<T extends LogTreeEntry = LogTreeEntry>(
+	entries: T[],
 	collapsedEntryIds: Record<string, boolean>,
-	ret: LogEntry[] = [],
-): LogEntry[] {
+	ret: T[] = [],
+): T[] {
 	for (const entry of entries) {
 		ret.push(entry);
 
 		if (!collapsedEntryIds[entry.id]) {
-			flattenLogEntries(entry.children, collapsedEntryIds, ret);
+			// children are always LogEntry[]; for callers that pass LogEntry[] (T=LogEntry)
+			// or LogTreeEntry[] (T=LogTreeEntry) the element type is compatible.
+			flattenLogEntries(entry.children as T[], collapsedEntryIds, ret);
 		}
 	}
 
@@ -374,31 +495,41 @@ export function flattenLogEntries(
 }
 
 export function getEntryAtRelativeIndex(
-	entries: LogEntry[],
+	entries: LogTreeEntry[],
 	id: string,
 	relativeIndex: number,
-): LogEntry | undefined {
+): LogTreeEntry | undefined {
 	const offset = entries.findIndex((e) => e.id === id);
 
 	return offset === -1 ? undefined : entries[offset + relativeIndex];
 }
 
-function sortLogEntries(a: LogEntry, b: LogEntry): number {
-	if (a.runData === undefined) {
+/** Run data of a tree entry, or undefined for group entries (which carry none). */
+function getEntryRunData(entry: LogTreeEntry): ITaskData | undefined {
+	return isLogGroupEntry(entry) ? undefined : entry.runData;
+}
+
+function sortLogEntries(a: LogTreeEntry, b: LogTreeEntry): number {
+	const aRunData = getEntryRunData(a);
+	const bRunData = getEntryRunData(b);
+
+	// Entries without run data (groups, sub-execution placeholders) sort by their
+	// earliest child, keeping them in chronological order with concrete runs.
+	if (aRunData === undefined) {
 		return a.children.length > 0 ? sortLogEntries(a.children[0], b) : 0;
 	}
 
-	if (b.runData === undefined) {
+	if (bRunData === undefined) {
 		return b.children.length > 0 ? sortLogEntries(a, b.children[0]) : 0;
 	}
 
 	// We rely on execution index only when startTime is different
 	// Because it is reset to 0 when execution is waited, and therefore not necessarily unique
-	if (a.runData.startTime === b.runData.startTime) {
-		return a.runData.executionIndex - b.runData.executionIndex;
+	if (aRunData.startTime === bRunData.startTime) {
+		return aRunData.executionIndex - bRunData.executionIndex;
 	}
 
-	return a.runData.startTime - b.runData.startTime;
+	return aRunData.startTime - bRunData.startTime;
 }
 
 export function mergeStartData(
@@ -474,12 +605,15 @@ export function findSubExecutionLocator(entry: LogEntry): RelatedExecution | und
 	return parseErrorMetadata(entry.runData?.error)?.subExecution;
 }
 
-export function getDefaultCollapsedEntries(entries: LogEntry[]): Record<string, boolean> {
+export function getDefaultCollapsedEntries(entries: LogTreeEntry[]): Record<string, boolean> {
 	const ret: Record<string, boolean> = {};
 
-	function collect(children: LogEntry[]) {
+	function collect(children: LogTreeEntry[]) {
 		for (const entry of children) {
-			if (hasSubExecution(entry) && entry.children.length === 0) {
+			if (isLogGroupEntry(entry)) {
+				// Groups load collapsed by default, mirroring the canvas.
+				ret[entry.id] = true;
+			} else if (hasSubExecution(entry) && entry.children.length === 0) {
 				ret[entry.id] = true;
 			}
 
@@ -492,9 +626,9 @@ export function getDefaultCollapsedEntries(entries: LogEntry[]): Record<string, 
 	return ret;
 }
 
-export function getDepth(entry: LogEntry): number {
+export function getDepth(entry: LogTreeEntry): number {
 	let depth = 0;
-	let currentEntry = entry;
+	let currentEntry: LogTreeEntry = entry;
 
 	while (currentEntry.parent !== undefined) {
 		currentEntry = currentEntry.parent;
@@ -674,12 +808,17 @@ export async function processFiles(data: File[] | undefined) {
 	return await Promise.all(filePromises);
 }
 
-export function isSubNodeLog(logEntry: LogEntry): boolean {
-	return logEntry.parent !== undefined && logEntry.parent.executionId === logEntry.executionId;
+export function isSubNodeLog(logEntry: LogTreeEntry): boolean {
+	const parent = logEntry.parent;
+
+	// A node nested under a group is a regular node, not an AI sub-node.
+	return (
+		parent !== undefined && !isLogGroupEntry(parent) && parent.executionId === logEntry.executionId
+	);
 }
 
-export function isPlaceholderLog(treeNode: LogEntry): boolean {
-	return treeNode.runData === undefined;
+export function isPlaceholderLog(treeNode: LogTreeEntry): boolean {
+	return !isLogGroupEntry(treeNode) && treeNode.runData === undefined;
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/logs.utils.ts
@@ -416,6 +416,69 @@ export function wrapLogEntriesInGroups(
 	return result.sort(sortLogEntries);
 }
 
+/**
+ * Root member entries of a group — members not targeted by any main connection
+ * from another member. These are the entry points where data first enters the
+ * group's internal flow. Deduplicated by node ID (first run only); RunData's
+ * own run selector handles additional runs. Falls back to
+ * {@link LogGroupEntry.inputLogEntry} when no root is found.
+ */
+export function getGroupInputEntries(group: LogGroupEntry): LogEntry[] {
+	const members = dedupeMembersByNodeId(group.children);
+	const memberNames = new Set(members.map((m) => m.node.name));
+
+	// Collect every node name that is targeted by a main connection from a member.
+	const internalTargets = new Set<string>();
+	for (const member of members) {
+		const outputs = group.workflow.connectionsBySourceNode[member.node.name]?.main ?? [];
+		for (const connections of outputs) {
+			for (const connection of connections ?? []) {
+				if (memberNames.has(connection.node)) {
+					internalTargets.add(connection.node);
+				}
+			}
+		}
+	}
+
+	const roots = members.filter((m) => !internalTargets.has(m.node.name));
+	return roots.length > 0 ? roots : [group.inputLogEntry];
+}
+
+/**
+ * Leaf member entries of a group — members with no outgoing main connection to
+ * another member. These are the last nodes in each internal branch, regardless
+ * of whether they pass data externally. Deduplicated by node ID (first run
+ * only); RunData's own run selector handles additional runs. Falls back to
+ * {@link LogGroupEntry.outputLogEntry} when no leaf is found.
+ */
+export function getGroupOutputEntries(group: LogGroupEntry): LogEntry[] {
+	const members = dedupeMembersByNodeId(group.children);
+	const memberNames = new Set(members.map((m) => m.node.name));
+
+	const leaves = members.filter((member) => {
+		const outputs = group.workflow.connectionsBySourceNode[member.node.name]?.main ?? [];
+		// A leaf has no main output targeting another member.
+		return !outputs.some((connections) =>
+			(connections ?? []).some((connection) => memberNames.has(connection.node)),
+		);
+	});
+
+	return leaves.length > 0 ? leaves : [group.outputLogEntry];
+}
+
+function dedupeMembersByNodeId(children: LogEntry[]): LogEntry[] {
+	const seen = new Set<string>();
+	const result: LogEntry[] = [];
+
+	for (const child of children) {
+		if (seen.has(child.node.id)) continue;
+		seen.add(child.node.id);
+		result.push(child);
+	}
+
+	return result;
+}
+
 export function findLogEntryById(id: string, entries: LogTreeEntry[]) {
 	return findLogEntryRec((entry) => entry.id === id, entries);
 }

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -1635,18 +1635,19 @@ defineExpose({ enterEditMode });
 
 			<div
 				v-if="
-					maxRunIndex > 0 &&
+					(maxRunIndex > 0 || $slots['run-selector-prepend']) &&
 					!displaysMultipleNodes &&
-					!props.disableRunIndexSelection &&
 					!isExecutionRedacted
 				"
 				v-show="!editMode.enabled"
 				:class="$style.runSelector"
 			>
 				<div :class="$style.runSelectorInner">
+					<slot name="run-selector-prepend" />
 					<slot v-if="inputSelectLocation === 'runs'" name="input-select"></slot>
 
 					<N8nSelect
+						v-if="maxRunIndex > 0 && !props.disableRunIndexSelection"
 						:model-value="runIndex"
 						:class="$style.runSelectorSelect"
 						size="small"

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/RunDataAi.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/ai/RunDataAi.vue
@@ -2,7 +2,12 @@
 import LogsOverviewRows from '@/features/execution/logs/components/LogsOverviewRows.vue';
 import { useLogsExecutionData } from '@/features/execution/logs/composables/useLogsExecutionData';
 import { useLogsTreeExpand } from '@/features/execution/logs/composables/useLogsTreeExpand';
-import type { LogEntry, LogTreeFilter } from '@/features/execution/logs/logs.types';
+import {
+	isLogGroupEntry,
+	type LogEntry,
+	type LogTreeEntry,
+	type LogTreeFilter,
+} from '@/features/execution/logs/logs.types';
 import { findLogEntryById } from '@/features/execution/logs/logs.utils';
 import type { INodeUi } from '@/Interface';
 import { N8nText } from '@n8n/design-system';
@@ -29,8 +34,14 @@ const { entries, execution, latestNodeNameById, loadSubExecution } = useLogsExec
 const { flatLogEntries, toggleExpanded } = useLogsTreeExpand(entries, loadSubExecution);
 const selected = shallowRef<LogEntry>();
 
-function select(entry: LogEntry | undefined) {
-	selected.value = entry?.node.id === node.id ? undefined : entry;
+function select(entry: LogTreeEntry | undefined) {
+	// This view is filtered to a single node, so group entries never appear here.
+	if (!entry || isLogGroupEntry(entry)) {
+		selected.value = undefined;
+		return;
+	}
+
+	selected.value = entry.node.id === node.id ? undefined : entry;
 }
 
 watch(

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.groups.ts
@@ -1,12 +1,12 @@
-import type { ExecutionStatus, IWorkflowGroup } from 'n8n-workflow';
+import type { IWorkflowGroup } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
 import type {
 	CanvasConnection,
 	CanvasGroupNode,
 	CanvasGroupNodeData,
-	GroupExecutionStatus,
 	NodeExecutionSnapshot,
 } from '../canvas.types';
+import { aggregateGroupExecution } from '../groupExecutionStatus';
 import {
 	CANVAS_NODE_GROUP_HANDLE_LEFT,
 	CANVAS_NODE_GROUP_HANDLE_RIGHT,
@@ -134,54 +134,8 @@ export function computeNodesRectFromStore(
 	};
 }
 
-// Highest priority first. `success` is resolved separately.
-const GROUP_STATUS_PRIORITY: readonly GroupExecutionStatus[] = [
-	'waiting',
-	'running',
-	'error',
-	'issues',
-	'warning',
-];
-
-const IDLE_STATUSES: readonly ExecutionStatus[] = ['new', 'unknown', 'canceled'];
-
-/**
- * Classify a single member for the group rollup by this priority:
- * waiting > running > error > issues > warning > success > idle.
- * Validation issues are kept distinct from execution errors.
- * Other is an active-but-unhandled status that must block a misleading success.
- * Idle statuses return undefined (they neither paint nor veto).
- */
-function classifyNodeForGroup(
-	snapshot: NodeExecutionSnapshot,
-): GroupExecutionStatus | 'other' | undefined {
-	const { status } = snapshot;
-	if (snapshot.waiting || status === 'waiting') return 'waiting';
-	if (snapshot.running || snapshot.waitingForNext) return 'running';
-	if (snapshot.hasExecutionError) return 'error';
-	if (snapshot.hasValidationError) return 'issues';
-	if (snapshot.dirty) return 'warning';
-	if (status === 'success') return 'success';
-	if (status === undefined || IDLE_STATUSES.includes(status)) return undefined;
-	return 'other';
-}
-
-/** Reduce a group's per-node state into one dominant status. */
-export function aggregateGroupExecution(
-	nodeIds: string[],
-	getNodeExecutionSnapshot: (id: string) => NodeExecutionSnapshot,
-): GroupExecutionStatus | undefined {
-	const seen = new Set<GroupExecutionStatus | 'other' | undefined>();
-	for (const id of nodeIds) {
-		seen.add(classifyNodeForGroup(getNodeExecutionSnapshot(id)));
-	}
-
-	for (const status of GROUP_STATUS_PRIORITY) {
-		if (seen.has(status)) return status;
-	}
-	// success is the only status that speaks for every member
-	return seen.has('success') && !seen.has('other') ? 'success' : undefined;
-}
+// Re-exported for backwards compatibility with existing canvas imports/tests.
+export { aggregateGroupExecution };
 
 export interface MapGroupsToVueFlowNodesInputs {
 	allGroups: IWorkflowGroup[];

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/groupExecutionStatus.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/groupExecutionStatus.ts
@@ -1,0 +1,62 @@
+import type { ExecutionStatus } from 'n8n-workflow';
+import type { GroupExecutionStatus, NodeExecutionSnapshot } from './canvas.types';
+
+// Highest priority first. `success` is resolved separately.
+const GROUP_STATUS_PRIORITY: readonly GroupExecutionStatus[] = [
+	'waiting',
+	'running',
+	'error',
+	'issues',
+	'warning',
+];
+
+const IDLE_STATUSES: readonly ExecutionStatus[] = ['new', 'unknown', 'canceled'];
+
+/**
+ * Classify a single member for the group rollup by this priority:
+ * waiting > running > error > issues > warning > success > idle.
+ * Validation issues are kept distinct from execution errors.
+ * Other is an active-but-unhandled status that must block a misleading success.
+ * Idle statuses return undefined (they neither paint nor veto).
+ */
+function classifyNodeForGroup(
+	snapshot: NodeExecutionSnapshot,
+): GroupExecutionStatus | 'other' | undefined {
+	const { status } = snapshot;
+	if (snapshot.waiting || status === 'waiting') return 'waiting';
+	if (snapshot.running || snapshot.waitingForNext) return 'running';
+	if (snapshot.hasExecutionError) return 'error';
+	if (snapshot.hasValidationError) return 'issues';
+	if (snapshot.dirty) return 'warning';
+	if (status === 'success') return 'success';
+	if (status === undefined || IDLE_STATUSES.includes(status)) return undefined;
+	return 'other';
+}
+
+/**
+ * Reduce a set of per-node execution snapshots into one dominant status.
+ * Shared between the canvas group title bar and the logs panel group row so
+ * both surfaces always agree on what a group's status is.
+ */
+export function aggregateGroupExecutionFromSnapshots(
+	snapshots: NodeExecutionSnapshot[],
+): GroupExecutionStatus | undefined {
+	const seen = new Set<GroupExecutionStatus | 'other' | undefined>();
+	for (const snapshot of snapshots) {
+		seen.add(classifyNodeForGroup(snapshot));
+	}
+
+	for (const status of GROUP_STATUS_PRIORITY) {
+		if (seen.has(status)) return status;
+	}
+	// success is the only status that speaks for every member
+	return seen.has('success') && !seen.has('other') ? 'success' : undefined;
+}
+
+/** Reduce a group's per-node state into one dominant status. */
+export function aggregateGroupExecution(
+	nodeIds: string[],
+	getNodeExecutionSnapshot: (id: string) => NodeExecutionSnapshot,
+): GroupExecutionStatus | undefined {
+	return aggregateGroupExecutionFromSnapshots(nodeIds.map(getNodeExecutionSnapshot));
+}

--- a/packages/testing/playwright/pages/components/LogsPanel.ts
+++ b/packages/testing/playwright/pages/components/LogsPanel.ts
@@ -48,6 +48,10 @@ export class LogsPanel {
 		return this.getGroupLogEntries().filter({ hasText: name });
 	}
 
+	getGroupPortSelects(): Locator {
+		return this.root.getByTestId('logs-group-port-select');
+	}
+
 	getSelectedLogEntry(): Locator {
 		return this.root.getByTestId('logs-overview-body').getByRole('treeitem', { selected: true });
 	}

--- a/packages/testing/playwright/pages/components/LogsPanel.ts
+++ b/packages/testing/playwright/pages/components/LogsPanel.ts
@@ -40,6 +40,14 @@ export class LogsPanel {
 		return this.root.getByTestId('logs-overview-body').getByRole('treeitem');
 	}
 
+	getGroupLogEntries(): Locator {
+		return this.root.getByTestId('logs-overview-body').getByTestId('logs-overview-group-row');
+	}
+
+	getGroupLogEntryByName(name: string): Locator {
+		return this.getGroupLogEntries().filter({ hasText: name });
+	}
+
 	getSelectedLogEntry(): Locator {
 		return this.root.getByTestId('logs-overview-body').getByRole('treeitem', { selected: true });
 	}

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
@@ -228,6 +228,37 @@ test.describe(
 			await expect(n8n.canvas.selectionToolbar.root()).toBeHidden();
 		});
 
+		test('nests a group and its members in the logs panel', async ({ n8n }) => {
+			await n8n.canvas.selectNodes(['Set A', 'Set B']);
+			await n8n.canvas.selectionToolbar.groupButton().click();
+			await n8n.canvas.deselectAll();
+			await expect(n8n.canvas.getNodeGroups()).toHaveCount(1);
+
+			await n8n.canvas.logsPanel.open();
+			await n8n.canvas.clickExecuteWorkflowButton();
+
+			// The group surfaces as a single row, collapsed by default so members are hidden.
+			const groupRow = n8n.canvas.logsPanel.getGroupLogEntryByName(DEFAULT_GROUP_TITLE);
+			await expect(groupRow).toBeVisible();
+			await expect(n8n.canvas.logsPanel.getLogEntries().filter({ hasText: 'Set A' })).toHaveCount(
+				0,
+			);
+
+			// Expanding reveals its members nested underneath.
+			await groupRow.getByLabel('Toggle row').click();
+			await expect(n8n.canvas.logsPanel.getLogEntries().filter({ hasText: 'Set A' })).toHaveCount(
+				1,
+			);
+			await expect(n8n.canvas.logsPanel.getLogEntries().filter({ hasText: 'Set B' })).toHaveCount(
+				1,
+			);
+
+			// Selecting the group shows input and output, exactly like a node.
+			await groupRow.click();
+			await expect(n8n.canvas.logsPanel.inputPanel.get()).toBeVisible();
+			await expect(n8n.canvas.logsPanel.outputPanel.get()).toBeVisible();
+		});
+
 		test('auto-extends the group when a new connection would otherwise invalidate it', async ({
 			n8n,
 		}) => {

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
@@ -257,6 +257,9 @@ test.describe(
 			await groupRow.click();
 			await expect(n8n.canvas.logsPanel.inputPanel.get()).toBeVisible();
 			await expect(n8n.canvas.logsPanel.outputPanel.get()).toBeVisible();
+
+			// Linear group: single root (Set A) and single leaf (Set B), so no port selectors.
+			await expect(n8n.canvas.logsPanel.getGroupPortSelects()).toHaveCount(0);
 		});
 
 		test('auto-extends the group when a new connection would otherwise invalidate it', async ({
@@ -433,6 +436,56 @@ test.describe(
 					'Collapse',
 				);
 			});
+		});
+	},
+);
+
+test.describe(
+	'Canvas node groups — leaf port selection in logs',
+	{ annotation: [{ type: 'owner', description: 'Adore' }] },
+	() => {
+		const BRANCHED_FIXTURE = 'Canvas-node-groups-branched-fixture.json';
+		const BRANCHED_GROUP_TITLE = 'Branched group';
+
+		test.beforeEach(async ({ n8n, setupRequirements }) => {
+			await setupRequirements(requirements);
+			await n8n.start.fromImportedWorkflow(BRANCHED_FIXTURE);
+			await n8n.canvas.clickZoomToFitButton();
+			await n8n.canvas.deselectAll();
+		});
+
+		test('shows an output port selector for a group with multiple leaves', async ({ n8n }) => {
+			await n8n.canvas.logsPanel.open();
+			await n8n.canvas.clickExecuteWorkflowButton();
+
+			const groupRow = n8n.canvas.logsPanel.getGroupLogEntryByName(BRANCHED_GROUP_TITLE);
+			await expect(groupRow).toBeVisible();
+			await groupRow.click();
+
+			// Single root (a) → no input port selector.
+			// Two leaves (c, d) → one output port selector.
+			await expect(n8n.canvas.logsPanel.getGroupPortSelects()).toHaveCount(1);
+		});
+
+		test('switching output port changes the visible leaf member', async ({ n8n }) => {
+			await n8n.canvas.logsPanel.open();
+			await n8n.canvas.clickExecuteWorkflowButton();
+
+			const groupRow = n8n.canvas.logsPanel.getGroupLogEntryByName(BRANCHED_GROUP_TITLE);
+			await groupRow.click();
+
+			const portSelect = n8n.canvas.logsPanel.getGroupPortSelects();
+			await expect(portSelect).toHaveCount(1);
+
+			// Open the output port selector and switch to the second leaf (d)
+			await portSelect.click();
+
+			const options = n8n.page.getByTestId('logs-group-port-option');
+			await expect(options).toHaveCount(2);
+			await options.nth(1).click();
+
+			// The output pane now shows node d's output data
+			await expect(n8n.canvas.logsPanel.outputPanel.get().getByText('d')).toBeVisible();
 		});
 	},
 );

--- a/packages/testing/playwright/workflows/Canvas-node-groups-branched-fixture.json
+++ b/packages/testing/playwright/workflows/Canvas-node-groups-branched-fixture.json
@@ -1,0 +1,87 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [32, 144],
+			"id": "f1c5b6a8-1f5b-4a92-9bb2-3e6e8a8a0001",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"category": "randomData",
+				"randomDataCount": 1
+			},
+			"type": "n8n-nodes-base.debugHelper",
+			"typeVersion": 1,
+			"position": [272, 144],
+			"id": "5809aa61-863c-4086-a5e2-deb824f7bc00",
+			"name": "DebugHelper"
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [560, 128],
+			"id": "5f47ab06-70a3-4cab-9ff7-3071da5809f2",
+			"name": "a"
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [768, 128],
+			"id": "563d1de9-efda-4b91-bf23-a85d55b4dc08",
+			"name": "b"
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1024, 0],
+			"id": "26b484e0-461b-4f21-bb20-abbe9695e441",
+			"name": "c"
+		},
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1024, 224],
+			"id": "6e1a8a52-482a-4860-8301-b7bf7a3c46fb",
+			"name": "d"
+		}
+	],
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [[{ "node": "DebugHelper", "type": "main", "index": 0 }]]
+		},
+		"DebugHelper": {
+			"main": [[{ "node": "a", "type": "main", "index": 0 }]]
+		},
+		"a": {
+			"main": [[{ "node": "b", "type": "main", "index": 0 }]]
+		},
+		"b": {
+			"main": [
+				[{ "node": "c", "type": "main", "index": 0 }, { "node": "d", "type": "main", "index": 0 }]
+			]
+		}
+	},
+	"nodeGroups": [
+		{
+			"id": "229926ec-f89d-44a8-b46c-502538dabead",
+			"name": "Branched group",
+			"nodeIds": [
+				"5f47ab06-70a3-4cab-9ff7-3071da5809f2",
+				"563d1de9-efda-4b91-bf23-a85d55b4dc08",
+				"26b484e0-461b-4f21-bb20-abbe9695e441",
+				"6e1a8a52-482a-4860-8301-b7bf7a3c46fb"
+			]
+		}
+	],
+	"pinData": {},
+	"meta": {
+		"instanceId": "canvas-node-groups-branched-fixture"
+	}
+}


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

