### PR TITLE
fix(core): Prevent startup failure from partially-installed community packages

### DIFF
--- a/packages/core/src/nodes-loader/__tests__/scan-directory-for-packages.test.ts
+++ b/packages/core/src/nodes-loader/__tests__/scan-directory-for-packages.test.ts
@@ -1,0 +1,106 @@
+// eslint-disable-next-line import-x/order
+import { mock } from 'vitest-mock-extended';
+import { Logger } from '@n8n/backend-common';
+import * as fs from 'node:fs';
+import type * as fsPromises from 'node:fs/promises';
+
+vi.mock('node:fs', () => mock<typeof fs>());
+vi.mock('node:fs/promises', () => mock<typeof fsPromises>());
+
+const mockFs = mock(fs);
+
+vi.mock('fast-glob', () => ({
+	default: async (pattern: string) => {
+		if (pattern === '@*/n8n-nodes-*') {
+			return ['@mendable/n8n-nodes-firecrawl', '@elevenlabs/n8n-nodes-elevenlabs'];
+		}
+		return [];
+	},
+}));
+
+import { mockInstance } from '@test/utils';
+
+import { LazyPackageDirectoryLoader } from '../lazy-package-directory-loader';
+import { scanDirectoryForPackages } from '../scan-directory-for-packages';
+
+describe('scanDirectoryForPackages', () => {
+	const nodeModulesDir = '/data/nodes/node_modules';
+	let logger: ReturnType<typeof mock<Logger>>;
+
+	const packageJsonFor = (filePath: string) =>
+		filePath.includes('elevenlabs')
+			? JSON.stringify({ name: '@elevenlabs/n8n-nodes-elevenlabs', version: '1.0.0' })
+			: JSON.stringify({ name: '@mendable/n8n-nodes-firecrawl', version: '2.1.2' });
+
+	const enoent = (file: string): NodeJS.ErrnoException => {
+		const error: NodeJS.ErrnoException = new Error(
+			`ENOENT: no such file or directory, open '${file}'`,
+		);
+		error.code = 'ENOENT';
+		return error;
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		logger = mockInstance(Logger);
+		// Symlink resolution at construction time resolves to the same path.
+		mockFs.realpathSync.mockImplementation((p) => p as string);
+	});
+
+	it('skips a directory whose package.json is missing and returns the valid loaders', async () => {
+		mockFs.readFileSync.mockImplementation((filePath) => {
+			const file = String(filePath);
+			if (file.includes('firecrawl')) throw enoent(file);
+			return packageJsonFor(file);
+		});
+
+		const loaders = await scanDirectoryForPackages(nodeModulesDir);
+
+		expect(loaders).toHaveLength(1);
+		expect(loaders[0]).toBeInstanceOf(LazyPackageDirectoryLoader);
+		expect((loaders[0] as LazyPackageDirectoryLoader).packageName).toBe(
+			'@elevenlabs/n8n-nodes-elevenlabs',
+		);
+	});
+
+	it('skips a directory whose package.json is malformed and returns the valid loaders', async () => {
+		mockFs.readFileSync.mockImplementation((filePath) => {
+			const file = String(filePath);
+			if (file.includes('firecrawl')) return '{ not valid json';
+			return packageJsonFor(file);
+		});
+
+		const loaders = await scanDirectoryForPackages(nodeModulesDir);
+
+		expect(loaders).toHaveLength(1);
+		expect((loaders[0] as LazyPackageDirectoryLoader).packageName).toBe(
+			'@elevenlabs/n8n-nodes-elevenlabs',
+		);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('logs a warning for each skipped directory', async () => {
+		mockFs.readFileSync.mockImplementation((filePath) => {
+			const file = String(filePath);
+			if (file.includes('firecrawl')) throw enoent(file);
+			return packageJsonFor(file);
+		});
+
+		await scanDirectoryForPackages(nodeModulesDir);
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('@mendable/n8n-nodes-firecrawl'),
+			expect.objectContaining({ error: expect.any(Error) }),
+		);
+	});
+
+	it('returns a loader for every directory when all are well-formed', async () => {
+		mockFs.readFileSync.mockImplementation((filePath) => packageJsonFor(String(filePath)));
+
+		const loaders = await scanDirectoryForPackages(nodeModulesDir);
+
+		expect(loaders).toHaveLength(2);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/nodes-loader/scan-directory-for-packages.ts
+++ b/packages/core/src/nodes-loader/scan-directory-for-packages.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
 import glob from 'fast-glob';
 import { type NodeLoader } from 'n8n-workflow';
 import path from 'path';
@@ -24,12 +26,25 @@ export async function scanDirectoryForPackages(
 		...(await glob('@*/n8n-nodes-*', { ...globOptions, deep: 2 })),
 	];
 
-	return installedPackagePaths.map(
-		(packagePath) =>
-			new LazyPackageDirectoryLoader(
-				path.join(nodeModulesDir, packagePath),
-				options.excludeNodes,
-				options.includeNodes,
-			),
-	);
+	const logger = Container.get(Logger);
+	const loaders: NodeLoader[] = [];
+
+	for (const packagePath of installedPackagePaths) {
+		try {
+			loaders.push(
+				new LazyPackageDirectoryLoader(
+					path.join(nodeModulesDir, packagePath),
+					options.excludeNodes,
+					options.includeNodes,
+				),
+			);
+		} catch (error) {
+			logger.warn(
+				`Skipping package directory "${packagePath}": failed to load package metadata. The package may be partially installed or corrupted.`,
+				{ error },
+			);
+		}
+	}
+
+	return loaders;
 }


### PR DESCRIPTION
## Summary

A community package directory under `~/.n8n/nodes/node_modules` that is missing or has an unreadable `package.json` (for example, after an interrupted install) caused the instance to crashloop on startup.

`scanDirectoryForPackages` globs every community package directory and immediately constructs a `LazyPackageDirectoryLoader` for each. The `PackageDirectoryLoader` constructor reads `package.json` synchronously, so a broken directory throws `ENOENT` (or a parse error) at construction time — before the lazy `loadAll()` try/catch can run. The error escaped `nodeLoaders()` → `ModuleRegistry.loadModules` and took the whole instance down.

This PR guards each loader construction: a directory that fails to load is skipped with a warning, and the remaining packages load normally so the instance starts. The existing missing-package reinstall flow (`CommunityPackagesService.checkForMissingPackages`, gated by `N8N_REINSTALL_MISSING_PACKAGES`) then recovers the skipped package on its own — no new retry logic needed.

```
Error: ENOENT: no such file or directory, open '.../@mendable/n8n-nodes-firecrawl/package.json'
    at PackageDirectoryLoader (package-directory-loader.ts)
    at new LazyPackageDirectoryLoader (lazy-package-directory-loader.ts)
    at scanDirectoryForPackages (scan-directory-for-packages.ts)
    at CommunityPackagesModule.nodeLoaders (community-packages.module.ts)
```

## How to test

Reproduced and verified end-to-end with an isolated data dir:

```bash
export N8N_USER_FOLDER=/tmp/n8n-repro
# Broken package: folder exists but has no package.json
mkdir -p "$N8N_USER_FOLDER/.n8n/nodes/node_modules/@mendable/n8n-nodes-firecrawl"
pnpm build && pnpm start
```

- **Before:** startup aborts with the `ENOENT` trace above.
- **After:** the instance boots; the log shows `Skipping package directory "@mendable/n8n-nodes-firecrawl": failed to load package metadata...` and any valid packages still load.

Unit tests:

```bash
cd packages/core && pnpm test scan-directory-for-packages
```

Covers: missing `package.json` (ENOENT), malformed `package.json`, warning emitted, and the all-valid happy path. The broken package is ordered first so the tests also prove a failure doesn't abort the scan before later valid packages are collected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5313

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32908">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->