### PR TITLE
refactor(editor): Derive AI assistant/chat store workflow ids from the route (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.test.ts
@@ -32,6 +32,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 describe(useFloatingUiOffsets, () => {
 	beforeEach(() => {
 		setActivePinia(createTestingPinia({ stubActions: false }));

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -18,7 +18,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { useRoute } from 'vue-router';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { assert } from '@n8n/utils/assert';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import type { ICredentialType, NodeError, INode } from 'n8n-workflow';
 import { useI18n } from '@n8n/i18n';
@@ -41,8 +41,8 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const chatMessages = ref<ChatUI.AssistantMessage[]>([]);
 	const usersStore = useUsersStore();
 	const uiStore = useUIStore();
-	const workflowsStore = useWorkflowsStore();
-	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
+	const routeWorkflowId = useRouteWorkflowId();
+	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(routeWorkflowId.value)));
 	const route = useRoute();
 	const streaming = ref<boolean>();
 	const streamingAbortController = ref<AbortController | null>(null);
@@ -198,7 +198,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 		return (
 			chatSessionTask.value === 'error' &&
-			useWorkflowExecutionStateStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			useWorkflowExecutionStateStore(createWorkflowDocumentId(routeWorkflowId.value))
 				.activeExecutionId === currentSessionActiveExecutionId.value &&
 			targetNode === chatSessionError.value?.node.name
 		);
@@ -353,7 +353,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			? useCredentialsStore().getCredentialTypeByName(uiStore.activeCredentialType ?? '')
 			: undefined;
 		const executionResult = useWorkflowExecutionStateStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(routeWorkflowId.value),
 		).activeExecution?.data?.resultData;
 		const isCurrentNodeExecuted = Boolean(
 			executionResult?.runData?.hasOwnProperty(activeNode?.name ?? ''),
@@ -497,7 +497,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		currentSessionWorkflowId.value = workflowId;
 
 		const activeExecutionId = useWorkflowExecutionStateStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(routeWorkflowId.value),
 		).activeExecutionId;
 		if (activeExecutionId) {
 			currentSessionActiveExecutionId.value = activeExecutionId;
@@ -744,7 +744,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 
 	watch(
 		() =>
-			useWorkflowExecutionStateStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			useWorkflowExecutionStateStore(createWorkflowDocumentId(routeWorkflowId.value))
 				.activeExecutionResultDataLastUpdate,
 		() => {
 			workflowExecutionDataStale.value = true;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/chatPanel.store.ts
@@ -14,7 +14,7 @@ import { useChatPanelStateStore, type ChatPanelMode } from './chatPanelState.sto
 import { useAssistantStore } from './assistant.store';
 import { useBuilderStore } from './builder.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { MERGE_ASK_BUILD_EXPERIMENT } from '@/app/constants/experiments';
 import type { ICredentialType } from 'n8n-workflow';
@@ -41,7 +41,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 	const route = useRoute();
 	const chatPanelStateStore = useChatPanelStateStore();
 	const settingsStore = useSettingsStore();
-	const workflowsStore = useWorkflowsStore();
+	const routeWorkflowId = useRouteWorkflowId();
 	const posthogStore = usePostHog();
 	const locale = useI18n();
 
@@ -134,7 +134,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 
 			// Reset assistant only if session has ended
 			if (assistantStore.isSessionEnded) {
-				assistantStore.resetAssistantChat(workflowsStore.workflowId);
+				assistantStore.resetAssistantChat(routeWorkflowId.value);
 			}
 		}, ASK_AI_SLIDE_OUT_DURATION_MS + 50);
 	}
@@ -190,7 +190,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		await assistantStore.initCredHelp(workflowsStore.workflowId, credentialType);
+		await assistantStore.initCredHelp(routeWorkflowId.value, credentialType);
 		await open({ mode: 'assistant' });
 	}
 
@@ -208,7 +208,7 @@ export const useChatPanelStore = defineStore(STORES.CHAT_PANEL, () => {
 			return;
 		}
 		const assistantStore = useAssistantStore();
-		await assistantStore.initErrorHelper(workflowsStore.workflowId, context);
+		await assistantStore.initErrorHelper(routeWorkflowId.value, context);
 		await open({ mode: 'assistant' });
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -39,6 +39,15 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 function createMockInput(value = '', selectionStart: number | null = null): HTMLInputElement {
 	const input = document.createElement('input');
 	input.value = value;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.test.ts
@@ -95,6 +95,15 @@ vi.mock('@/app/stores/workflows.store', () => ({
 	useWorkflowsStore: () => mockWorkflowsStore,
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 vi.mock('@/app/stores/workflowDocument.store', () => ({
 	useWorkflowDocumentStore: () => mockWorkflowDocumentStore,
 	injectWorkflowDocumentStore: () => shallowRef(mockWorkflowDocumentStore),

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useReviewChanges.ts
@@ -9,7 +9,7 @@ import {
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useI18n } from '@n8n/i18n';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowHistoryStore } from '@/features/workflows/workflowHistory/workflowHistory.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -33,7 +33,7 @@ export interface NodeChangeEntry {
 
 export function useReviewChanges() {
 	const builderStore = useBuilderStore();
-	const workflowsStore = useWorkflowsStore();
+	const currentWorkflowId = useWorkflowId();
 	const workflowHistoryStore = useWorkflowHistoryStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const uiStore = useUIStore();
@@ -72,7 +72,7 @@ export function useReviewChanges() {
 		() => builderStore.versionCardMessages,
 		async (cards) => {
 			if (!cards?.length) return;
-			const workflowId = workflowsStore.workflowId;
+			const workflowId = currentWorkflowId.value;
 			for (const card of cards) {
 				const vid = card.data.versionId;
 				if (versionDataCache.value.has(vid) || fetchingVersionIds.value.has(vid)) continue;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.test.ts
@@ -49,6 +49,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const createMockNode = (id: string, name: string, type = 'n8n-nodes-base.httpRequest'): INodeUi =>
 	({
 		id,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
@@ -1,7 +1,7 @@
 import { computed, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -23,14 +23,14 @@ const COLLAPSE_THRESHOLD = 7;
 const MAX_UNCONFIRMED_DISPLAY = 50;
 
 export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
-	const workflowsStore = useWorkflowsStore();
+	const routeWorkflowId = useRouteWorkflowId();
 	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+		useWorkflowDocumentStore(createWorkflowDocumentId(routeWorkflowId.value)),
 	);
 	const posthogStore = usePostHog();
 	const telemetry = useTelemetry();
 	const chatPanelStateStore = useChatPanelStateStore();
-	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
+	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(routeWorkflowId.value)));
 
 	const isFeatureEnabled = computed(() => {
 		return posthogStore.isVariantEnabled(
@@ -264,7 +264,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	}
 
 	watch(
-		() => workflowsStore.workflowId,
+		() => routeWorkflowId.value,
 		(_newId, oldId) => {
 			const previousCount = confirmedNodes.value.length;
 			focusedNodesMap.value = {};

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -37,7 +37,7 @@ import {
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import {
 	useWorkflowDocumentStore,
@@ -111,6 +111,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 	const toast = useToast();
 	const telemetry = useTelemetry();
 	const i18n = useI18n();
+	const routeWorkflowId = useRouteWorkflowId();
 
 	const agents = ref<ChatModelsResponse | null>(null);
 	let pendingAgentsFetch: Promise<ChatModelsResponse> | null = null;
@@ -565,11 +566,10 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 	 * node results (makes nodes turn green during manual execution).
 	 */
 	function initManualExecutionScaffold(workflowId: string) {
-		const workflowsStore = useWorkflowsStore();
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
 		useWorkflowExecutionStateStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(routeWorkflowId.value),
 		).setWorkflowExecutionData({
 			id: IN_PROGRESS_EXECUTION_ID,
 			finished: false,
@@ -587,7 +587,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 
 		// Signal canvas that an execution is pending (null = waiting for execution ID)
 		useWorkflowExecutionStateStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(routeWorkflowId.value),
 		).setActiveExecutionId(null);
 	}
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.test.ts
@@ -26,6 +26,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 // Mock window.open
 Object.defineProperty(window, 'open', {
 	value: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -23,6 +23,15 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => {
 	};
 });
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const renderComponent = createComponentRenderer(CanvasNodeToolbar);
 
 describe('CanvasNodeToolbar', () => {


### PR DESCRIPTION
## Summary

Part of the staged removal of the deprecated, writable global `workflowsStore.workflowId` (current workflow id derived read-only from the route instead).

Migrates the AI assistant / chat stores and composable to read the current workflow id via `useRouteWorkflowId()` (out-of-tree stores) / `useWorkflowId()` (in-tree composable) instead of `workflowsStore.workflowId`:
- `features/ai/assistant/assistant.store.ts`
- `features/ai/assistant/chatPanel.store.ts`
- `features/ai/assistant/focusedNodes.store.ts`
- `features/ai/chatHub/chat.store.ts`
- `features/ai/assistant/composables/useReviewChanges.ts`

Behavior-preserving: the value is identical in steady state.

## Related

Follows #32734 (teardown prep) and #32735 (builder store), both merged. Independent of the remaining reader PRs.

## Review / Testing

- Affected unit tests resolve the workflow id from the workflows store they drive (so id-dependent assertions keep working); the full editor-ui suite passes (872 files / 12,147 tests) and `pnpm typecheck` is clean.
- `eslint` reports no remaining `workflowsStore.workflowId` warnings for the migrated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

