### PR TITLE
fix(Email Read Imap Node): Default to 7BIT when a message part has no encoding

### DIFF
--- a/packages/@n8n/imap/src/imap-simple.test.ts
+++ b/packages/@n8n/imap/src/imap-simple.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'vitest-mock-extended';
 
 import { ImapSimple } from './imap-simple';
 import { PartData } from './part-data';
+import type { MessagePart } from './types';
 
 type MockImap = EventEmitter & {
 	connect: Mocked<() => unknown>;
@@ -216,8 +217,8 @@ describe('ImapSimple', () => {
 			mockImap.fetch = vi.fn(() => fetchEmitter);
 
 			const message = { attributes: { uid: 123 } };
-			const part = { partID: '1.2', encoding: 'BASE64' };
-			const partDataPromise = imapSimple.getPartData(mock(message), mock(part));
+			const part = mock<MessagePart>({ partID: '1.2', encoding: 'BASE64' });
+			const partDataPromise = imapSimple.getPartData(mock(message), part);
 
 			const messageEmitter = new EventEmitter();
 			const bodyStream = Readable.from('body');
@@ -241,9 +242,9 @@ describe('ImapSimple', () => {
 			mockImap.fetch = vi.fn(() => fetchEmitter);
 
 			const message = { attributes: { uid: 123 } };
-			const part = { partID: '1.2', encoding: 'BASE64' };
+			const part = mock<MessagePart>({ partID: '1.2', encoding: 'BASE64' });
 
-			const partDataPromise = imapSimple.getPartData(mock(message), mock(part));
+			const partDataPromise = imapSimple.getPartData(mock(message), part);
 
 			const body = 'encoded-body';
 			const messageEmitter = new EventEmitter();
@@ -263,6 +264,37 @@ describe('ImapSimple', () => {
 
 			const result = await partDataPromise;
 			expect(PartData.fromData).toHaveBeenCalledWith('encoded-body', 'BASE64');
+			expect(result).toBe('decoded');
+		});
+
+		it('should default to 7BIT when the part encoding is missing', async () => {
+			const { imapSimple, mockImap } = createImap();
+
+			const fetchEmitter = new EventEmitter();
+			mockImap.fetch = vi.fn(() => fetchEmitter);
+
+			const message = { attributes: { uid: 123 } };
+			const part = mock<MessagePart>({ partID: '1.2', encoding: null });
+
+			const partDataPromise = imapSimple.getPartData(mock(message), part);
+
+			const body = 'plain-body';
+			const messageEmitter = new EventEmitter();
+			const bodyStream = Readable.from(body);
+
+			fetchEmitter.emit('message', messageEmitter);
+			messageEmitter.emit('body', bodyStream, {
+				which: part.partID,
+				size: Buffer.byteLength(body),
+			});
+			messageEmitter.emit('attributes', {});
+			await new Promise((resolve) => bodyStream.on('end', resolve));
+			messageEmitter.emit('end');
+
+			fetchEmitter.emit('end');
+
+			const result = await partDataPromise;
+			expect(PartData.fromData).toHaveBeenCalledWith('plain-body', '7BIT');
 			expect(result).toBe('decoded');
 		});
 	});

--- a/packages/@n8n/imap/src/imap-simple.ts
+++ b/packages/@n8n/imap/src/imap-simple.ts
@@ -139,7 +139,9 @@ export class ImapSimple extends EventEmitter {
 				}
 
 				const data = result.parts[0].body as string;
-				const encoding = part.encoding.toUpperCase();
+				// Some providers (e.g. iCloud) omit a part's encoding; 7BIT is the IMAP
+				// default and leaves the body untransformed.
+				const encoding = (part.encoding || '7BIT').toUpperCase();
 				resolve(PartData.fromData(data, encoding));
 			};
 

--- a/packages/@n8n/imap/src/types.ts
+++ b/packages/@n8n/imap/src/types.ts
@@ -18,7 +18,7 @@ export interface ImapSimpleOptions {
 
 export interface MessagePart {
 	partID: string;
-	encoding: 'BASE64' | 'QUOTED-PRINTABLE' | '7BIT' | '8BIT' | 'BINARY' | 'UUENCODE';
+	encoding: 'BASE64' | 'QUOTED-PRINTABLE' | '7BIT' | '8BIT' | 'BINARY' | 'UUENCODE' | null;
 	type: 'TEXT';
 	subtype: string;
 	params?: {


### PR DESCRIPTION
## Summary

The IMAP Email Trigger could crash with `Cannot read properties of null (reading 'toUpperCase')` and silently stop emitting executions when a mail server returns a body part **without a Content-Transfer-Encoding**. iCloud is the common trigger: when an incoming message omits the header (legal per RFC 2045 — `7bit` is the default), iCloud reports `NIL` for `body-fld-enc` in the IMAP `BODYSTRUCTURE`, which `node-imap` surfaces as `part.encoding === null`. `ImapSimple.getPartData` then called `part.encoding.toUpperCase()` unguarded and threw.

Because the throw happens inside the async fetch handler, the `getPartData` promise never settles — the trigger stops processing that message and the workflow never fires, while one-shot manual/CRON fetches of well-formed messages keep working. This matches the reported symptom: "auto-trigger does nothing, no error in the UI."

### Fix
- `ImapSimple.getPartData` now defaults to `7BIT` when a part has no encoding (`(part.encoding || '7BIT').toUpperCase()`), reconstructing the RFC 2045 §6.1 default the server should have sent.
- `MessagePart.encoding` is marked nullable to reflect that the field can be absent.

The fix lives in the shared `@n8n/imap` `getPartData`, so it covers **both v1 and v2** of the Email Trigger (IMAP) node.

Supersedes closed PR #23673 — the original contributor's branch had unrelated mass deletions, so this re-lands their fix on a clean branch (authorship preserved via cherry-pick). The redundant `conn.on('error')` hunk from that PR is omitted as it is already fixed on master.

## How to test

Deterministic (code-level), exercising the exact production method:

```bash
cd packages/@n8n/imap && pnpm test imap-simple
```

The added test `should default to 7BIT when the part encoding is missing` feeds a part with `encoding: null` through `getPartData`. On the pre-fix code it reproduces the exact production error (`TypeError: Cannot read properties of null (reading 'toUpperCase')` at `imap-simple.ts`); with the fix it decodes as `7BIT` and resolves.

End-to-end (optional): send a `text/plain`, 7-bit message **without** a `Content-Transfer-Encoding` header to an iCloud mailbox (e.g. via `swaks`), point an active Email Trigger (IMAP) node at it. Pre-fix: the trigger does not fire; post-fix: it fires normally. (Ordinary mail from Gmail/Outlook always sets the header, so it does not reproduce — the crash is message-dependent.)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4124
- fixes #23502
- Supersedes #23673 (closed) — original fix by @manav-parasiya

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- No docs change needed; behavior-preserving crash fix. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) <!-- Consider backport: crash reported by multiple users since Dec 2025. -->

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32914">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->