### PR TITLE
refactor(editor): Derive core store workflow ids from the route (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
@@ -26,6 +26,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
 	...(await importOriginal()),
 	injectWorkflowDocumentStore: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -55,6 +55,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
 	...(await importOriginal()),
 	injectWorkflowDocumentStore: vi.fn(),

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -268,6 +268,15 @@ vi.mock('vue-router', async (importOriginal) => {
 	};
 });
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 describe('useRunWorkflow({ router })', () => {
 	let pushConnectionStore: ReturnType<typeof usePushConnectionStore>;
 	let uiStore: ReturnType<typeof useUIStore>;

--- a/packages/frontend/editor-ui/src/app/stores/focusPanel.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/focusPanel.store.ts
@@ -9,7 +9,7 @@ import {
 	type INodeProperties,
 	jsonParse,
 } from 'n8n-workflow';
-import { useWorkflowsStore } from './workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -45,15 +45,15 @@ type FocusPanelDataByWid = Record<string, FocusPanelData>;
 const DEFAULT_FOCUS_PANEL_DATA: FocusPanelData = { isActive: false, parameters: [] };
 
 export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
-	const workflowsStore = useWorkflowsStore();
+	const routeWorkflowId = useRouteWorkflowId();
 	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+		useWorkflowDocumentStore(createWorkflowDocumentId(routeWorkflowId.value)),
 	);
 	const focusPanelStorage = useStorage(LOCAL_STORAGE_FOCUS_PANEL);
 
 	const focusPanelData = computed((): FocusPanelDataByWid => {
 		const defaultValue: FocusPanelDataByWid = {
-			[workflowsStore.workflowId]: DEFAULT_FOCUS_PANEL_DATA,
+			[routeWorkflowId.value]: DEFAULT_FOCUS_PANEL_DATA,
 		};
 
 		return focusPanelStorage.value
@@ -62,8 +62,7 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 	});
 
 	const currentFocusPanelData = computed(
-		(): FocusPanelData =>
-			focusPanelData.value[workflowsStore.workflowId] ?? DEFAULT_FOCUS_PANEL_DATA,
+		(): FocusPanelData => focusPanelData.value[routeWorkflowId.value] ?? DEFAULT_FOCUS_PANEL_DATA,
 	);
 
 	const lastFocusTimestamp = ref(0);
@@ -105,7 +104,7 @@ export const useFocusPanelStore = defineStore(STORES.FOCUS_PANEL, () => {
 	function _setOptions({
 		parameters,
 		isActive,
-		wid = workflowsStore.workflowId,
+		wid = routeWorkflowId.value,
 		width = undefined,
 		removeEmpty = false,
 	}: {

--- a/packages/frontend/editor-ui/src/app/stores/webhooks.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/webhooks.store.ts
@@ -11,14 +11,15 @@ import { useUIStore } from './ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from './workflows.store';
 import { useSettingsStore } from './settings.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 
 export const useWebhooksStore = defineStore(STORES.WEBHOOKS, () => {
-	const workflowsStore = useWorkflowsStore();
+	const routeWorkflowId = useRouteWorkflowId();
 
-	// Reactive lookups: re-evaluate when workflowsStore.workflowId changes,
+	// Reactive lookups: re-evaluate when the route's workflow id changes,
 	// so external consumers always see the current workflow's stores.
 	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+		useWorkflowDocumentStore(createWorkflowDocumentId(routeWorkflowId.value)),
 	);
 	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -8,6 +8,7 @@ import EvaluationsWizardSidepanel from './EvaluationsWizardSidepanel.vue';
 import { useEvaluationsWizardSidepanelStore } from '../../wizardSidepanel.store';
 import { useEvaluationStore } from '../../evaluation.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 // Plain mutable holders instead of module-scope `ref()`s — reactive refs
 // surviving teardown have caused post-teardown rejections on Node 24.
@@ -106,11 +107,23 @@ vi.mock('vue-router', async (importOriginal) => {
 	};
 });
 
+const { workflowIdHolder } = vi.hoisted(() => ({
+	workflowIdHolder: { current: (): string => '' },
+}));
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => workflowIdHolder.current()),
+		useRouteWorkflowId: () => computed(() => workflowIdHolder.current()),
+	};
+});
+
 const renderComponent = createComponentRenderer(EvaluationsWizardSidepanel);
 
 describe('EvaluationsWizardSidepanel', () => {
 	beforeEach(() => {
 		createTestingPinia({ stubActions: false });
+		workflowIdHolder.current = () => useWorkflowsStore().workflowId;
 		mocks.workflowId = 'workflow-id';
 		mocks.allNodes = [];
 		mocks.nodeTypeOutputs = {};

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/TestCaseForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/TestCaseForm.test.ts
@@ -9,6 +9,15 @@ vi.mock('@n8n/i18n', async (importOriginal) => ({
 	useI18n: () => ({ baseText: (key: string) => key }),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const renderComponent = createComponentRenderer(TestCaseForm);
 
 describe('TestCaseForm', () => {

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -73,6 +73,15 @@ vi.mock('@/stores/pushConnection.store', () => ({
 	}),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 describe('LogsPanel', () => {
 	const VIEWPORT_HEIGHT = 800;
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -106,6 +106,15 @@ vi.mock('vue-router', () => {
 	};
 });
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const mockBuilderState = {
 	trackWorkflowBuilderJourney: vi.fn(),
 	isAIBuilderEnabled: true,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.test.ts
@@ -46,6 +46,18 @@ vi.mock('vue-router', () => {
 	};
 });
 
+const { workflowIdHolder } = vi.hoisted(() => ({
+	workflowIdHolder: { current: (): string => '' },
+}));
+
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	return {
+		useWorkflowId: () => computed(() => workflowIdHolder.current()),
+		useRouteWorkflowId: () => computed(() => workflowIdHolder.current()),
+	};
+});
+
 const renderComponent = createComponentRenderer(WorkflowSelectorParameterInput);
 
 let projectsStore: MockedStore<typeof useProjectsStore>;
@@ -60,6 +72,7 @@ describe('WorkflowSelectorParameterInput', () => {
 		projectsStore.isTeamProjectFeatureEnabled = false;
 
 		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowIdHolder.current = () => useWorkflowsStore().workflowId;
 		workflowsListStore = mockedStore(useWorkflowsListStore);
 
 		// Mock store methods to prevent unhandled errors

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.test.ts
@@ -30,6 +30,15 @@ vi.mock('vue-router', () => ({
 	RouterLink: { template: '<a><slot /></a>' },
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const httpNode = createTestNode({
 	name: 'HTTP Request',
 	type: 'n8n-nodes-base.httpRequest',

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
@@ -16,6 +16,15 @@ import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
 import { CHAT_TRIGGER_NODE_TYPE, HTTP_REQUEST_NODE_TYPE, WEBHOOK_NODE_TYPE } from '@/app/constants';
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 describe('useNodeSettingsParameters', () => {
 	beforeEach(() => {
 		setActivePinia(createTestingPinia());

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeDetails.test.ts
@@ -85,6 +85,15 @@ vi.mock('@/app/composables/useToast', () => ({
 	})),
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 vi.mock('@/features/shared/nodeCreator/composables/useViewStacks', () => ({
 	useViewStacks: vi.fn(() => ({
 		activeViewStack: {

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.test.ts
@@ -22,6 +22,15 @@ vi.mock('@/features/ai/evaluation.ee/composables/useAiRootNodes', () => ({
 	useAiRootNodes: () => aiRootNodes,
 }));
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const renderComponent = createComponentRenderer(FocusSidebarTabs);
 
 describe('FocusSidebarTabs', () => {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
@@ -68,6 +68,15 @@ vi.mock('@/app/utils/nodeIcon', () => {
 	};
 });
 
+vi.mock('@/app/composables/useWorkflowId', async () => {
+	const { computed } = await import('vue');
+	const { useWorkflowsStore } = await import('@/app/stores/workflows.store');
+	return {
+		useWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+		useRouteWorkflowId: () => computed(() => useWorkflowsStore().workflowId),
+	};
+});
+
 const mockedPrepareCommunityNodeDetailsViewStack = vi.mocked(prepareCommunityNodeDetailsViewStack);
 const mockedGetNodeIconSource = vi.mocked(getNodeIconSource);
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -22,7 +22,7 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import type { TelemetryNdvType } from '@/app/types/telemetry';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import { isVueFlowConnection } from '@/app/utils/typeGuards';
@@ -47,8 +47,8 @@ import {
 } from '@/app/stores/workflowDocument.store';
 
 export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
-	const workflowsStore = useWorkflowsStore();
-	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
+	const routeWorkflowId = useRouteWorkflowId();
+	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(routeWorkflowId.value)));
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const telemetry = useTelemetry();


### PR DESCRIPTION
## Summary

Part of the staged removal of the deprecated, writable global `workflowsStore.workflowId` (current workflow id derived read-only from the route instead).

Migrates the remaining core stores to read the current workflow id via `useRouteWorkflowId()`:
- `app/stores/focusPanel.store.ts` (incl. the per-workflow focus-panel localStorage key)
- `app/stores/webhooks.store.ts`
- `features/shared/nodeCreator/nodeCreator.store.ts`

Behavior-preserving: the route param equals the workflow id, so the localStorage key and all derived stores are unchanged. (`ndv.store` and `collaboration.store` no longer read `workflowsStore.workflowId` on current master, so they're out of scope.)

## Related

Follows #32734, #32735 (merged) and #32912 (AI assistant/chat readers). Independent of the other reader PRs.

## Review / Testing

- 13 affected unit tests resolve the workflow id from the workflows store they drive (so id-dependent assertions hold); the full editor-ui suite passes (880 files / 12,212 tests) and `pnpm typecheck` is clean.
- `eslint` reports no remaining `workflowsStore.workflowId` warnings for the migrated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32919">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

