### PR TITLE
refactor(core): Re-parent ExecutionBaseError to BaseError (no-changelog)

### DIFF
--- a/packages/core/src/errors/__tests__/error-reporter.test.ts
+++ b/packages/core/src/errors/__tests__/error-reporter.test.ts
@@ -2,7 +2,8 @@ import type { Logger } from '@n8n/backend-common';
 import { QueryFailedError } from '@n8n/typeorm';
 import type { ErrorEvent } from '@sentry/core';
 import { AxiosError } from 'axios';
-import { ApplicationError, BaseError } from 'n8n-workflow';
+import { ApplicationError, BaseError, ExpressionError, NodeOperationError } from 'n8n-workflow';
+import type { INode } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -247,6 +248,32 @@ describe('ErrorReporter', () => {
 						tag1: 'value1',
 					},
 				});
+			});
+		});
+
+		// `ExecutionBaseError` (the base of NodeApiError/NodeOperationError/ExpressionError)
+		// extends `BaseError`, so these errors are classified by the BaseError branch.
+		// Reporting must still be driven by their level, as before the re-parenting.
+		describe('ExecutionBaseError subclasses', () => {
+			const node = mock<INode>();
+
+			it('should drop warning-level node errors', async () => {
+				const originalException = new NodeOperationError(node, 'boom');
+
+				expect(originalException.level).toBe('warning');
+				expect(await errorReporter.beforeSend(event, { originalException })).toEqual(null);
+			});
+
+			it('should keep error-level node errors', async () => {
+				const originalException = new NodeOperationError(node, 'boom', { level: 'error' });
+
+				expect(await errorReporter.beforeSend(event, { originalException })).toEqual(event);
+			});
+
+			it('should drop an ExpressionError', async () => {
+				const originalException = new ExpressionError('bad expression');
+
+				expect(await errorReporter.beforeSend(event, { originalException })).toEqual(null);
 			});
 		});
 	});

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -9,7 +9,7 @@ import type {
 	INodeType,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	BaseError,
 	NodeConnectionTypes,
 	UnexpectedError,
 	createRunExecutionData,
@@ -254,7 +254,7 @@ describe('processRunExecutionData', () => {
 			// eslint-disable-next-line @typescript-eslint/promise-function-async
 			const execution = () => workflowExecute.processRunExecutionData(workflow);
 
-			expect(execution).toThrow(ApplicationError);
+			expect(execution).toThrow(BaseError);
 			expect(execution).toThrow(
 				/^The 'node' node has issues:\n- Parameter "Required Text" is required\.$/,
 			);

--- a/packages/nodes-base/nodes/Aws/Cognito/test/listSearch/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Aws/Cognito/test/listSearch/listSearch.test.ts
@@ -1,5 +1,5 @@
 import {
-	ApplicationError,
+	NodeOperationError,
 	type ILoadOptionsFunctions,
 	type INodeListSearchResult,
 } from 'n8n-workflow';
@@ -138,7 +138,7 @@ describe('AWS Cognito Functions', () => {
 				getNode: vi.fn(),
 			} as unknown as ILoadOptionsFunctions;
 
-			await expect(searchGroups.call(mockContext)).rejects.toThrow(ApplicationError);
+			await expect(searchGroups.call(mockContext)).rejects.toThrow(NodeOperationError);
 		});
 	});
 

--- a/packages/workflow/src/errors/abstract/execution-base.error.ts
+++ b/packages/workflow/src/errors/abstract/execution-base.error.ts
@@ -1,14 +1,16 @@
-import { ApplicationError, type ReportingOptions } from '@n8n/errors';
-
+import { BaseError, type BaseErrorOptions } from '../base/base.error';
 import type { Functionality, IDataObject, JsonObject } from '../../interfaces';
 
-interface ExecutionBaseErrorOptions extends ReportingOptions {
+interface ExecutionBaseErrorOptions extends BaseErrorOptions {
 	cause?: Error;
 	errorResponse?: JsonObject;
 }
 
-export abstract class ExecutionBaseError extends ApplicationError {
-	description: string | null | undefined;
+export abstract class ExecutionBaseError extends BaseError {
+	// `BaseError.description` is readonly, but subclasses (e.g. NodeApiError,
+	// ExpressionError) reassign it, so redeclare it as writable here. `declare`
+	// avoids re-initializing the field and clobbering the value set by `super`.
+	declare description: string | null | undefined;
 
 	override cause?: Error;
 


### PR DESCRIPTION
## Summary

Final Phase 2 PR of the `ApplicationError` migration. `ExecutionBaseError` — the base of `NodeApiError`, `NodeOperationError` and `ExpressionError`, used ~1,500 times across the codebase — now extends `BaseError` instead of the deprecated `ApplicationError`.

`BaseError` is a superset of `ApplicationError`: it keeps `level`/`tags`/`extra` and adds `description`/`shouldReport`. So the only observable change is that these errors are now `instanceof BaseError` rather than `instanceof ApplicationError`.

Notes on the reconciliation:
- `description` is redeclared with `declare` so it stays writable (subclasses reassign it) without re-initializing the field and clobbering the value set by `super`.
- `toJSON` output, `level`, `cause` handling and the default warning level of node errors are all unchanged — verified against the built output.
- The error-reporter and `WorkflowExecute` already branch on `BaseError`, so node errors now flow through those branches as intended. The negated `instanceof BaseError` check in the OpenAi assistant node was pre-adjusted for this in #32471, so this PR restores its original swallow semantics.

A few tests asserted `toThrow(ApplicationError)` / `instanceof ApplicationError` on errors that are now `BaseError`; these were updated to the correct type. Added focused error-reporter coverage for the re-parented classes.

## How to test

`pnpm test` in `packages/workflow` and `packages/core`. Manually: trigger a node-level error in a running instance and confirm the UI, logs and error reporter behave as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3256

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32920">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

