### PR TITLE
feat(core): Split obersvation memory into its own system prompt block to hold cache

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -4132,9 +4132,13 @@ describe('tool systemInstruction merging', () => {
 
 	function getSystemMessageText(): string {
 		const callArgs = generateText.mock.calls[0][0] as Record<string, unknown>;
-		const systemMsg = callArgs.system as Record<string, unknown>;
-		expect(systemMsg.role).toBe('system');
-		return String(systemMsg.content);
+		const systemMsg = callArgs.system;
+		if (Array.isArray(systemMsg)) {
+			return systemMsg.map((entry) => String((entry as { content: string }).content)).join('');
+		}
+		const system = systemMsg as { role: string; content: string };
+		expect(system.role).toBe('system');
+		return String(system.content);
 	}
 
 	it("wraps a tool's systemInstruction in a built_in_rules block above user instructions", async () => {
@@ -4628,7 +4632,7 @@ describe('AgentRuntime — observation log jobs', () => {
 
 		const generateTextMock = generateText as MockedFunction<
 			(input: {
-				system: { content: string };
+				system: { content: string } | Array<{ content: string }>;
 				messages: Array<{
 					role: string;
 					content: unknown;
@@ -4636,8 +4640,11 @@ describe('AgentRuntime — observation log jobs', () => {
 			}) => unknown
 		>;
 		const [{ system, messages }] = generateTextMock.mock.calls[0];
-		expect(system.content).toContain('Resource one memory.');
-		expect(system.content).toContain('Resource two memory.');
+		const systemText = Array.isArray(system)
+			? system.map((entry) => entry.content).join('')
+			: system.content;
+		expect(systemText).toContain('Resource one memory.');
+		expect(systemText).toContain('Resource two memory.');
 		expect(JSON.stringify(messages)).not.toContain('remember resource-one preference');
 
 		await runtime.dispose();

--- a/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
@@ -5,7 +5,15 @@ import type {
 	ContentToolCall,
 	Message,
 } from '../../types/sdk/message';
-import { AgentMessageList } from '../model/message-list';
+import { AgentMessageList, buildSystemMessages } from '../model/message-list';
+import type { SystemModelMessage } from 'ai';
+
+function flattenSystemContent(system: SystemModelMessage | SystemModelMessage[]): string {
+	if (Array.isArray(system)) {
+		return system.map((entry) => entry.content).join('');
+	}
+	return system.content;
+}
 
 function makeUserMsg(text: string): AgentMessage {
 	return { role: 'user', content: [{ type: 'text', text }] };
@@ -114,12 +122,6 @@ describe('AgentMessageList — preserving DB timestamps', () => {
 // LLM context assembly
 // ---------------------------------------------------------------------------
 
-function systemContent(list: AgentMessageList): string {
-	const { system } = list.forLlm('Base instructions');
-	expect(system.role).toBe('system');
-	return system.content;
-}
-
 describe('AgentMessageList — forLlm observation memory', () => {
 	it('does not inject a memory section when no observation log has been rendered', () => {
 		const list = new AgentMessageList();
@@ -127,8 +129,9 @@ describe('AgentMessageList — forLlm observation memory', () => {
 
 		const { system, messages } = list.forLlm('Base instructions');
 
-		expect(system.content).toContain('Base instructions');
-		expect(system.content).not.toContain('## Memory');
+		expect(flattenSystemContent(system)).toContain('Base instructions');
+		expect(flattenSystemContent(system)).not.toContain('## Memory');
+		expect(Array.isArray(system)).toBe(false);
 		expect(messages).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -149,11 +152,41 @@ describe('AgentMessageList — forLlm observation memory', () => {
 			'</observations>',
 		].join('\n');
 
-		const prompt = systemContent(list);
+		const { system } = list.forLlm('Base instructions');
+		const prompt = flattenSystemContent(system);
 
+		expect(Array.isArray(system)).toBe(true);
 		expect(prompt).toContain('Base instructions');
 		expect(prompt).toContain('<observations>');
 		expect(prompt).toContain('* CRITICAL (14:30) User wants the SDK to stay unopinionated.');
+	});
+
+	it('places observation memory in a separate system message with its own cache breakpoint', () => {
+		const observationLog = [
+			'<observations>',
+			'* CRITICAL (14:30) User wants the SDK to stay unopinionated.',
+			'</observations>',
+		].join('\n');
+		const cacheOptions = {
+			anthropic: { cacheControl: { type: 'ephemeral' as const } },
+		};
+
+		const system = buildSystemMessages('Base instructions', observationLog, cacheOptions);
+
+		expect(Array.isArray(system)).toBe(true);
+		if (!Array.isArray(system)) throw new Error('Expected split system messages');
+		expect(system).toHaveLength(2);
+		expect(system[0]).toEqual({
+			role: 'system',
+			content: 'Base instructions',
+			providerOptions: cacheOptions,
+		});
+		expect(system[1]).toMatchObject({
+			role: 'system',
+			providerOptions: cacheOptions,
+		});
+		expect(system[1]?.content).toContain('<observations>');
+		expect(system[1]?.content).not.toContain('Base instructions');
 	});
 
 	it('keeps recent history messages in LLM context when observation memory is empty', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
@@ -1,3 +1,5 @@
+import type { SystemModelMessage } from 'ai';
+
 import { isLlmMessage } from '../../sdk/message';
 import type {
 	AgentDbMessage,
@@ -6,7 +8,6 @@ import type {
 	Message,
 } from '../../types/sdk/message';
 import { AgentMessageList, buildSystemMessages } from '../model/message-list';
-import type { SystemModelMessage } from 'ai';
 
 function flattenSystemContent(system: SystemModelMessage | SystemModelMessage[]): string {
 	if (Array.isArray(system)) {

--- a/packages/@n8n/agents/src/runtime/loop/run-output-sink.ts
+++ b/packages/@n8n/agents/src/runtime/loop/run-output-sink.ts
@@ -38,7 +38,7 @@ export interface ModelTurnResult {
 /** Per-iteration inputs for the LLM call, assembled by the shared loop. */
 export interface ModelCallContext {
 	model: LanguageModel;
-	system: SystemModelMessage;
+	system: SystemModelMessage | SystemModelMessage[];
 	messages: ModelMessage[];
 	abortSignal: AbortSignal;
 	hasTools: boolean;

--- a/packages/@n8n/agents/src/runtime/model/message-list.ts
+++ b/packages/@n8n/agents/src/runtime/model/message-list.ts
@@ -12,9 +12,47 @@ import { stripOrphanedToolMessages } from '../memory/strip-orphaned-tool-message
 export type { SerializedMessageList };
 
 export type LlmContext = {
-	system: SystemModelMessage;
+	system: SystemModelMessage | SystemModelMessage[];
 	messages: ModelMessage[];
 };
+
+/**
+ * Build the system message(s) for an LLM call. When observation-log memory is
+ * present, instructions and observations are sent as separate system messages
+ * so prompt-cache breakpoints on the static instructions are not invalidated
+ * when observations grow append-only.
+ */
+export function buildSystemMessages(
+	baseInstructions: string,
+	observationLogMemory: string | undefined,
+	instructionProviderOptions?: ProviderOptions,
+): SystemModelMessage | SystemModelMessage[] {
+	const trimmedObservations = observationLogMemory?.trim();
+	const cacheOptions = instructionProviderOptions
+		? { providerOptions: instructionProviderOptions }
+		: {};
+
+	if (!trimmedObservations) {
+		return {
+			role: 'system',
+			content: baseInstructions,
+			...cacheOptions,
+		};
+	}
+
+	return [
+		{
+			role: 'system',
+			content: baseInstructions,
+			...cacheOptions,
+		},
+		{
+			role: 'system',
+			content: `\n\n${trimmedObservations}`,
+			...cacheOptions,
+		},
+	];
+}
 
 type MessageSource = 'history' | 'input' | 'response';
 
@@ -225,25 +263,17 @@ export class AgentMessageList {
 
 	/**
 	 * Full LLM context for a generateText / streamText call.
-	 * Returns the system prompt separately (with observation-log memory appended if configured)
-	 * and conversation messages stripped via filterLlmMessages.
+	 * Returns the system prompt separately (observation-log memory in its own
+	 * system message when present) and conversation messages stripped via
+	 * filterLlmMessages.
 	 */
 	forLlm(baseInstructions: string, instructionProviderOptions?: ProviderOptions): LlmContext {
-		let systemPrompt = baseInstructions;
-
-		const observationLogMemory = this.observationLogMemory?.trim();
-		if (observationLogMemory) {
-			systemPrompt += `\n\n${observationLogMemory}`;
-		}
-
-		const system: SystemModelMessage = {
-			role: 'system',
-			content: systemPrompt,
-			...(instructionProviderOptions ? { providerOptions: instructionProviderOptions } : {}),
-		};
-
 		return {
-			system,
+			system: buildSystemMessages(
+				baseInstructions,
+				this.observationLogMemory,
+				instructionProviderOptions,
+			),
 			messages: toAiMessages(filterLlmMessages(stripOrphanedToolMessages(this.all))),
 		};
 	}


### PR DESCRIPTION
## Summary

When observation memory is appended to the system prompt on follow up messages, the caching breaks. Splitting them into 2 system prompt blocks, we can cache the first block and keep the second one out of it. 

## Related Linear tickets, Github issues, and Community forum posts

RESOLVES INS-649

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32923">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->