### PR TITLE
feat(xAI Grok Chat Model Node): Add reasoning effort and priority options

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -301,8 +301,8 @@ export class LmChatXAiGrok implements INodeType {
 							response_format: { type: options.responseFormat },
 						}
 					: undefined),
-				...(reasoning ? { reasoning_effort: reasoning } : undefined),
-				...(priority ? { service_tier: 'priority' } : undefined),
+				reasoning_effort: reasoning,
+				service_tier: priority ? 'priority' : undefined,
 			},
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
 		});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -210,6 +210,28 @@ export class LmChatXAiGrok implements INodeType {
 							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.',
 						type: 'number',
 					},
+					{
+						displayName: 'Enable Priority',
+						name: 'priority',
+						default: false,
+						description:
+							'Priority Processing gives your xAI API requests higher scheduling priority',
+						type: 'boolean',
+					},
+					{
+						displayName: 'Reasoning',
+						name: 'reasoning',
+						type: 'options',
+						default: 'low',
+						description: 'Effort the model spends thinking before responding.',
+						// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
+						options: [
+							{ name: 'None', value: 'none' },
+							{ name: 'Low', value: 'low' },
+							{ name: 'Medium', value: 'medium' },
+							{ name: 'High', value: 'high' },
+						],
+					},
 				],
 			},
 		],
@@ -229,6 +251,8 @@ export class LmChatXAiGrok implements INodeType {
 			temperature?: number;
 			topP?: number;
 			responseFormat?: 'text' | 'json_object';
+			reasoning?: 'none' | 'low' | 'medium' | 'high';
+			priority?: boolean;
 		};
 
 		const timeout = options.timeout;
@@ -242,10 +266,14 @@ export class LmChatXAiGrok implements INodeType {
 			},
 		};
 
+		// `reasoning` (xAI reasoning effort) and `priority` are xAI-specific and passed via
+		// modelKwargs, so keep them out of the spread into the ChatOpenAI constructor.
+		const { reasoning, priority, ...restOptions } = options;
+
 		const model = new ChatOpenAI({
 			apiKey: credentials.apiKey,
 			model: modelName,
-			...options,
+			...restOptions,
 			timeout,
 			maxRetries: options.maxRetries ?? 2,
 			configuration,
@@ -257,6 +285,8 @@ export class LmChatXAiGrok implements INodeType {
 							response_format: { type: options.responseFormat },
 						}
 					: undefined),
+				...(reasoning ? { reasoning_effort: reasoning } : undefined),
+				...(priority ? { service_tier: 'priority' } : undefined),
 			},
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
 		});

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -215,7 +215,7 @@ export class LmChatXAiGrok implements INodeType {
 						name: 'priority',
 						default: false,
 						description:
-							'Priority Processing gives your xAI API requests higher scheduling priority',
+							'Whether to give your xAI API requests higher scheduling priority (Priority Processing)',
 						type: 'boolean',
 					},
 					{
@@ -223,7 +223,7 @@ export class LmChatXAiGrok implements INodeType {
 						name: 'reasoning',
 						type: 'options',
 						default: 'low',
-						description: 'Effort the model spends thinking before responding.',
+						description: 'Effort the model spends thinking before responding',
 						// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
 						options: [
 							{

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatXAiGrok/LmChatXAiGrok.node.ts
@@ -219,17 +219,33 @@ export class LmChatXAiGrok implements INodeType {
 						type: 'boolean',
 					},
 					{
-						displayName: 'Reasoning',
+						displayName: 'Reasoning Effort',
 						name: 'reasoning',
 						type: 'options',
 						default: 'low',
 						description: 'Effort the model spends thinking before responding.',
 						// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
 						options: [
-							{ name: 'None', value: 'none' },
-							{ name: 'Low', value: 'low' },
-							{ name: 'Medium', value: 'medium' },
-							{ name: 'High', value: 'high' },
+							{
+								name: 'None',
+								value: 'none',
+								description: 'Disables reasoning entirely; no thinking tokens are used',
+							},
+							{
+								name: 'Low',
+								value: 'low',
+								description: 'Uses some reasoning tokens, but still fast',
+							},
+							{
+								name: 'Medium',
+								value: 'medium',
+								description: 'More thinking for less-latency sensitive applications',
+							},
+							{
+								name: 'High',
+								value: 'high',
+								description: 'Uses more reasoning tokens for deeper thinking',
+							},
 						],
 					},
 				],


### PR DESCRIPTION
## Summary

Adds two xAI-specific options to the **xAI Grok Chat Model** node, exposed under **Options**:

- **Reasoning Effort** (`none` / `low` / `medium` / `high`) — sent to the xAI API as `reasoning_effort` in `modelKwargs`. Controls how much the model thinks before responding. Defaults to `low`.
- **Enable Priority** (boolean) — when on, sends `service_tier: 'priority'` in `modelKwargs`, giving requests higher scheduling priority.

Both fields are kept out of the `ChatOpenAI` constructor spread (`...restOptions`) and passed explicitly via `modelKwargs`, since `reasoning` (a string) would otherwise collide with langchain's typed `reasoning` object field, and `priority` is not a `ChatOpenAI` parameter.

## How to test

1. Add an **AI Agent** (or Basic LLM Chain) and attach the **xAI Grok Chat Model** sub-node with valid xAI credentials.
2. Open **Options → Add Option** and add **Reasoning Effort** and **Enable Priority**.
3. Send a chat message and confirm the outgoing request body includes `reasoning_effort` (matching the selected value) and, when Priority is enabled, `service_tier: "priority"`.
4. With **Enable Priority** off and **Reasoning Effort** not added, confirm neither field is sent.

Note: `reasoning_effort` is supported on reasoning-capable Grok models (e.g. `grok-3-mini`, `grok-4.x`). On models that don't accept it, the xAI API rejects the parameter.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket / GitHub issue here if applicable -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->