### PR TITLE
Update Nodemailer and tmp to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
       "form-data": "4.0.6",
       "pdf-parse": "catalog:",
       "tmp": "0.2.7",
-      "nodemailer": "8.0.10",
+      "nodemailer": "9.0.1",
       "validator": "13.15.26",
       "zod": "3.25.67",
       "js-yaml": "4.2.0",

--- a/packages/@n8n/scan-community-package/package.json
+++ b/packages/@n8n/scan-community-package/package.json
@@ -18,7 +18,7 @@
     "@n8n/eslint-plugin-community-nodes": "workspace:*",
     "@typescript-eslint/parser": "^8.35.0",
     "semver": "catalog:",
-    "tmp": "0.2.4"
+    "tmp": "0.2.7"
   },
   "devDependencies": {
     "@n8n/vitest-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,7 +578,7 @@ overrides:
   form-data: 4.0.6
   pdf-parse: 2.4.5
   tmp: 0.2.7
-  nodemailer: 8.0.10
+  nodemailer: 9.0.1
   validator: 13.15.26
   zod: 3.25.67
   js-yaml: 4.2.0
@@ -3498,8 +3498,8 @@ importers:
         specifier: 'catalog:'
         version: 3.3.8
       nodemailer:
-        specifier: 8.0.10
-        version: 8.0.10
+        specifier: 9.0.1
+        version: 9.0.1
       oauth-1.0a:
         specifier: 2.2.6
         version: 2.2.6
@@ -5157,8 +5157,8 @@ importers:
         specifier: 13.2.0
         version: 13.2.0
       nodemailer:
-        specifier: 8.0.10
-        version: 8.0.10
+        specifier: 9.0.1
+        version: 9.0.1
       oracledb:
         specifier: 6.10.0
         version: 6.10.0
@@ -7981,6 +7981,7 @@ packages:
   '@langchain/community@1.1.27':
     resolution: {integrity: sha512-s2U3w7QV7QpkFtY1eZMni4poz+nKLFclpDi3a7hUbZ67ttsGaU9WkZ2BiLuzLIs+IFaUvON/KcGkE8EqAl9aPA==}
     engines: {node: '>=20'}
+    deprecated: This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info
     peerDependencies:
       '@arcjet/redact': ^v1.2.0
       '@aws-crypto/sha256-js': ^5.0.0
@@ -17741,8 +17742,8 @@ packages:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
     engines: {node: '>=10'}
 
-  nodemailer@8.0.10:
-    resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+  nodemailer@9.0.1:
+    resolution: {integrity: sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==}
     engines: {node: '>=6.0.0'}
 
   nodemon@2.0.22:
@@ -18811,6 +18812,7 @@ packages:
     resolution: {integrity: sha512-gv6vLGcmAOg96/fgo3d9tvA4dJNZL3fMyBqVRrGxQ+Q/o4k9QzbJ3NQF9cOO/71wRodoXhaPgphvMFU68qVAJQ==}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode.vue@3.3.4:
@@ -24323,7 +24325,7 @@ snapshots:
       '@currents/commit-info': 1.0.1-beta.0
       async-retry: 1.3.3
       axios: 1.18.0(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.18.0)
+      axios-retry: 4.5.0(axios@1.18.0(debug@4.4.3))
       chalk: 4.1.2
       commander: 13.1.0
       date-fns: 2.30.0
@@ -27360,7 +27362,7 @@ snapshots:
   '@rudderstack/rudder-sdk-node@3.0.5':
     dependencies:
       axios: 1.18.0(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.18.0)
+      axios-retry: 4.5.0(axios@1.18.0(debug@4.4.3))
       component-type: 2.0.0
       join-component: 1.1.0
       lodash.clonedeep: 4.5.0
@@ -30354,7 +30356,7 @@ snapshots:
 
   axe-core@4.7.2: {}
 
-  axios-retry@4.5.0(axios@1.18.0):
+  axios-retry@4.5.0(axios@1.18.0(debug@4.4.3)):
     dependencies:
       axios: 1.18.0(debug@4.4.3)
       is-retry-allowed: 2.2.0
@@ -35449,7 +35451,7 @@ snapshots:
       iconv-lite: 0.7.2
       libmime: 5.3.7
       linkify-it: 5.0.0
-      nodemailer: 8.0.10
+      nodemailer: 9.0.1
       punycode.js: 2.3.1
       tlds: 1.261.0
 
@@ -36796,7 +36798,7 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
 
-  nodemailer@8.0.10: {}
+  nodemailer@9.0.1: {}
 
   nodemon@2.0.22:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -131,7 +131,7 @@ catalog:
   mysql2: 3.17.0
   nanoid: 3.3.8
   nock: 14.0.14
-  nodemailer: 8.0.10
+  nodemailer: 9.0.1
   openai: 6.19.0
   oxlint: ^1.61.0
   oxlint-tsgolint: ^0.21.1


### PR DESCRIPTION
## 10-second summary

This PR updates `nodemailer` from `8.0.10` to `9.0.1` and aligns `tmp` from `0.2.4` to `0.2.7` where it is declared by `@n8n/scan-community-package`.

The main risk is `nodemailer` GHSA-p6gq-j5cr-w38f: when an application relies on Nodemailer's file/URL access guards, crafted raw mail content can bypass those guards and disclose local files or fetch internal URLs through the delivered message. n8n uses Nodemailer in runtime email sending paths, so this is preventive remediation of a known advisory, not a claim of active exploitation in n8n.

## What Changed

- Updated the root `nodemailer` override from `8.0.10` to `9.0.1`.
- Updated the workspace catalog entry for `nodemailer` from `8.0.10` to `9.0.1`.
- Updated `@n8n/scan-community-package`'s `tmp` dependency from `0.2.4` to `0.2.7`.
- Regenerated `pnpm-lock.yaml` with `pnpm install --lockfile-only --ignore-scripts`.

## What Users Will See

No direct user-facing behavior change is expected. This keeps the existing email and community-package scanner behavior while removing known vulnerable dependency versions.

## Surface Area

- [x] Internal / non-user-facing
- [ ] UI
- [ ] API
- [ ] Default behavior
- [ ] Data/model/schema

Notes: the changed packages are internal dependencies used by runtime email delivery and the community-package scanner. This PR does not change n8n workflow behavior or public API contracts.

## Why This Change Is Needed

This PR addresses two dependency advisories:

- `nodemailer@8.0.10` is affected by GHSA-p6gq-j5cr-w38f. The patched version is `9.0.1`.
- `tmp@0.2.4` is affected by GHSA-ph9p-34f9-6g65. The repo already overrides/resolves `tmp` to `0.2.7` in the root lockfile, but `packages/@n8n/scan-community-package/package.json` still declared `0.2.4`; this PR aligns that manifest with the resolved safe version.

The Nodemailer issue matters when untrusted or attacker-influenced message data can reach raw mail content while an application expects `disableFileAccess` or `disableUrlAccess` to sandbox that data. The `tmp` issue matters when attacker-controlled `dir`, `prefix`, or `postfix` values can influence temporary file placement.

## Advisory References

- Nodemailer GitHub advisory: https://github.com/nodemailer/nodemailer/security/advisories/GHSA-p6gq-j5cr-w38f
- Nodemailer OSV: https://osv.dev/vulnerability/GHSA-p6gq-j5cr-w38f
- tmp GitHub advisory: https://github.com/raszi/node-tmp/security/advisories/GHSA-ph9p-34f9-6g65
- tmp OSV: https://osv.dev/vulnerability/GHSA-ph9p-34f9-6g65

## Where It Appears

Dependency path:

```text
package.json overrides
-> nodemailer@8.0.10
-> packages/cli and packages/nodes-base use nodemailer through catalog:

packages/@n8n/scan-community-package/package.json
-> tmp@0.2.4
```

Evidence:

- [`package.json`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/package.json#L138): root override now pins `nodemailer` to `9.0.1`.
- [`pnpm-workspace.yaml`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/pnpm-workspace.yaml#L134): workspace catalog now resolves `nodemailer` to `9.0.1`.
- [`packages/cli/package.json`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/cli/package.json#L216): `packages/cli` consumes `nodemailer` through the catalog.
- [`packages/nodes-base/package.json`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/nodes-base/package.json#L962): `packages/nodes-base` consumes `nodemailer` through the catalog.
- [`packages/@n8n/scan-community-package/package.json`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/@n8n/scan-community-package/package.json#L21): `tmp` is now declared as `0.2.7`.
- [`pnpm-lock.yaml`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/pnpm-lock.yaml#L17745): lockfile now resolves `nodemailer@9.0.1`.
- [`pnpm-lock.yaml`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/pnpm-lock.yaml#L20247): lockfile resolves `tmp@0.2.7`.

Generated dependency sidecars:

- `pnpm-lock.yaml`: updated.
- No other dependency sidecars were changed.

## Code Usage Review

Direct vulnerable package imports: found.

- [`packages/cli/src/user-management/email/node-mailer.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/cli/src/user-management/email/node-mailer.ts#L8): imports `createTransport` from `nodemailer`.
- [`packages/cli/src/user-management/email/node-mailer.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/cli/src/user-management/email/node-mailer.ts#L40): creates the SMTP transport for user-management email.
- [`packages/nodes-base/nodes/EmailSend/v2/utils.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/nodes-base/nodes/EmailSend/v2/utils.ts#L7): imports `createTransport`.
- [`packages/nodes-base/nodes/EmailSend/v2/utils.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/nodes-base/nodes/EmailSend/v2/utils.ts#L48): creates an Email Send node transport.
- [`packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts#L10): imports `createTransport`.
- [`packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts#L184): creates an Email Send v1 transport.
- [`packages/@n8n/scan-community-package/scanner/scanner.mjs`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/@n8n/scan-community-package/scanner/scanner.mjs#L7): imports `tmp`.
- [`packages/@n8n/scan-community-package/scanner/scanner.mjs`](https://github.com/gateway/n8n/blob/guardian/nodemailer-security/packages/@n8n/scan-community-package/scanner/scanner.mjs#L18): creates a temporary scanner directory.

Observed exposure: runtime-linked for Nodemailer email paths; tooling/scanner-linked for `tmp`.

## Fix

This PR updates dependency resolution so:

- `nodemailer` resolves to `9.0.1`, the patched version for GHSA-p6gq-j5cr-w38f.
- `tmp` resolves to `0.2.7` in both the monorepo lockfile and the `@n8n/scan-community-package` package manifest.

## Alternatives Considered

- Update only `pnpm-lock.yaml`: rejected because `nodemailer` is centrally pinned in the root override and workspace catalog.
- Leave `tmp` unchanged because the root lock already resolves `0.2.7`: rejected because `@n8n/scan-community-package` still declared `0.2.4`, which can matter for standalone package consumption and causes avoidable advisory noise.
- Broader dependency updates: rejected to keep this PR focused and reviewable.

## Risk Assessment

Upgrade risk: medium-low.

Reasoning:

- `nodemailer` moves from `8.0.10` to `9.0.1`, a major version bump, but Nodemailer has no package dependencies and the direct n8n usage is standard `createTransport` / `sendMail` usage.
- `tmp` moves from `0.2.4` to `0.2.7`, a patch-level update that is already the root lockfile resolution in this workspace.
- The diff is limited to four dependency files.

## Validation

Ran:

- `pnpm install --lockfile-only --ignore-scripts`: completed successfully and updated `pnpm-lock.yaml`.
- Guardian exact-version scan for `nodemailer@9.0.1` and `tmp@0.2.7`: no advisories returned from OSV, GHSA, or GitLab advisory data.
- `rg` check for `nodemailer@8.0.10`, `tmp@0.2.4`, and matching manifest pins: no remaining matches in manifests or lockfile.
- `git diff --check`: passed.

Attempted but not completed in this temp clone:

- `pnpm --filter n8n test:unit -- user-management/email/node-mailer.test.ts --runInBand`: blocked because this clone has no `node_modules` installed (`jest: command not found`).
- `pnpm --filter @n8n/scan-community-package test -- --runInBand`: blocked because this clone has no `node_modules` installed (`vitest: command not found`).

Suggested maintainer validation:

- `pnpm --filter n8n test:unit -- user-management/email/node-mailer.test.ts --runInBand`
- `pnpm --filter n8n-nodes-base test -- EmailSend`
- `pnpm --filter @n8n/scan-community-package test`
- Smoke-test user-management email and Email Send node SMTP flows.

## Notes

This PR is not claiming active exploitation in n8n. It removes known vulnerable dependency versions and documents where the affected packages are used.

Powered by Guardian: https://github.com/gateway/guardian


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

