### PR TITLE
test: Cap per-suite test fork pool to bound CI parallelism

### DIFF
--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -61,8 +61,13 @@ jobs:
       # for every backend package that hasn't yet added the script.
       # nodes-base is excluded too: it has its own (change-scoped) unit-test-nodes
       # job, so its `test:unit` script must only run in the full nightly, not here.
+      #
+      # --concurrency=2 bounds how many suites turbo runs at once. Combined with
+      # the in-CI per-suite cap (each vitest suite uses half the cores, see
+      # @n8n/vitest-config/node), peak forks ≈ 2 × 50% ≈ the core count, instead
+      # of ~10 concurrent suites each spawning a core-sized pool and pegging CPU.
       - name: Test Unit (backend, except cli and nodes-base)
-        run: pnpm turbo test:unit --continue --filter='!./packages/frontend/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
+        run: pnpm turbo test:unit --continue --concurrency=2 --filter='!./packages/frontend/**' --filter='!n8n' --filter='!n8n-nodes-base' --summarize
 
       - name: Test Unit (cli, scoped)
         if: ${{ !cancelled() }}

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -4,6 +4,25 @@ import type { InlineConfig } from 'vitest/node';
 import { coverageExcludes } from './coverage-excludes.js';
 
 /**
+ * Per-suite fork-pool cap, applied only in CI.
+ *
+ * CI runs many package test suites concurrently under turbo. Without a cap, each
+ * suite's fork pool is sized to the full core count, so a small runner ends up
+ * massively oversubscribed (e.g. ~10 suites × 4 forks on a 4-vCPU box): CPU is
+ * pegged for the whole run and timing-sensitive tests flake into timeouts.
+ *
+ * Capping each suite to half the available cores keeps the product with turbo's
+ * `--concurrency` near the core count, and adapts to the runner size instead of
+ * a hardcoded value. Off outside CI, so a single-package `pnpm test` keeps full
+ * parallelism and behaviour is unchanged.
+ */
+export const forkPoolOptions = (): InlineConfig => {
+	if (process.env.CI !== 'true') return {};
+	// Vitest accepts a percentage for `maxWorkers` (half of availableParallelism).
+	return { pool: 'forks', maxWorkers: '50%' };
+};
+
+/**
  * Shared test options without the outer defineConfig wrapper.
  * Use this when you need to spread the config into workspace projects.
  */
@@ -11,6 +30,7 @@ export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig
 	silent: true,
 	globals: true,
 	environment: 'node',
+	...forkPoolOptions(),
 	reporters: process.env.CI === 'true' ? ['default', 'junit'] : ['default'],
 	outputFile: { junit: './junit.xml' },
 	...(process.env.COVERAGE_ENABLED === 'true'

--- a/packages/testing/janitor/vitest.config.ts
+++ b/packages/testing/janitor/vitest.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from 'vitest/config';
 
+// In CI, many package suites run concurrently under turbo, and an uncapped
+// per-suite fork pool (sized to the core count) oversubscribes a small runner
+// and flakes timing-sensitive tests. Cap each suite to half the cores in CI;
+// off locally, so behaviour is unchanged. Mirrors `@n8n/vitest-config/node`,
+// which this standalone config doesn't extend.
+const forkPoolOptions =
+	process.env.CI === 'true' ? { pool: 'forks' as const, maxWorkers: '50%' } : {};
+
 export default defineConfig({
 	test: {
+		...forkPoolOptions,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.test.ts'],


### PR DESCRIPTION

## Summary

The backend unit job runs on a 4-vCPU runner, but turbo runs up to 10 package suites concurrently and each vitest suite spawned a fork pool sized to the core count. That oversubscribed the box ~10x, pegged CPU for the whole run, and starved timing-sensitive tests into flaky timeouts.

Add an env-gated `VITEST_MAX_FORKS` that caps each suite's `maxWorkers` (read by the shared `@n8n/vitest-config/node` base and mirrored in the standalone janitor config). The CI unit step sets `VITEST_MAX_FORKS=2` and `turbo --concurrency=2` so peak forks ~= 2x2 = 4 cores. Unset locally, so single-package runs keep full parallelism and behaviour is unchanged.


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

