### PR TITLE
fix(core): Disable n8n AI assistant in credentials flows for agents UI (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -6958,7 +6958,7 @@
 	"agents.builder.addTrigger.helpText.linear": "Connect a Linear OAuth credential to let this agent respond in Linear. For agent sessions, choose Application as the actor, point a Linear webhook at the URL below, and paste its signing secret into the credential.",
 	"agents.builder.addTrigger.connectedText.slack": "Your agent is connected to Slack and ready to send and receive messages.",
 	"agents.builder.addTrigger.connectedText.telegram": "Your agent is connected to Telegram and can receive messages.",
-	"agents.builder.addTrigger.connectedText.linear": "Your agent is connected to Linear and can reply to @-mentions.",
+	"agents.builder.addTrigger.connectedText.linear": "Your agent is connected to Linear and can reply to {'@'}-mentions.",
 	"instanceAi.welcomeModal.gateway.title": "Connect AI Assistant to your computer",
 	"instanceAi.welcomeModal.gateway.description": "Allow AI Assistant to work with local files, run terminal commands, and control your browser so it can help build automations on your machine. It connects through n8n Computer Use, a lightweight local process you can disconnect anytime.",
 	"instanceAi.welcomeModal.gateway.warning": "AI Assistant is a preview and can be unpredictable. Be aware of allowing access to sensitive data. Permissions can be adjusted during setup.",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentModelSelector.spec.ts
@@ -7,6 +7,7 @@ import type { AgentModelsByProvider } from '../model-providers';
 const credentialsByType = vi.hoisted(() => ({
 	anthropicApi: [{ id: 'anthropic-cred', name: 'Anthropic credential', type: 'anthropicApi' }],
 }));
+const openNewCredential = vi.hoisted(() => vi.fn());
 
 vi.mock('@n8n/i18n', () => ({
 	useI18n: () => ({
@@ -55,7 +56,7 @@ vi.mock('@/features/collaboration/projects/projects.store', () => ({
 }));
 
 vi.mock('@/app/stores/ui.store', () => ({
-	useUIStore: () => ({ openNewCredential: vi.fn() }),
+	useUIStore: () => ({ openNewCredential }),
 }));
 
 vi.mock('@/features/ai/modelSelector/AiModelSelectorDropdown.vue', () => ({
@@ -74,6 +75,7 @@ vi.mock('@/features/ai/modelSelector/AiModelSelectorDropdown.vue', () => ({
 			'credentialDataTestId',
 			'maxSelectedNameChars',
 		],
+		emits: ['select'],
 		template: '<div data-testid="ai-model-selector-dropdown" />',
 	},
 }));
@@ -134,5 +136,23 @@ describe('AgentModelSelector', () => {
 		expect(dropdown.props('credentialsMissing')).toBe(false);
 		expect(dropdown.props('selectedCredentialName')).toBe('Anthropic credential');
 		expect(JSON.stringify(anthropicItem?.children ?? [])).toContain('Claude Sonnet 4.5');
+	});
+
+	it('hides the assistant when opening credential creation from the configure action', async () => {
+		const wrapper = await mountSelector({ anthropic: null });
+		const dropdown = wrapper.findComponent({ name: 'AiModelSelectorDropdown' });
+
+		dropdown.vm.$emit('select', 'anthropic::configure::anthropicApi');
+
+		expect(openNewCredential).toHaveBeenCalledWith(
+			'anthropicApi',
+			false,
+			false,
+			'project-1',
+			undefined,
+			undefined,
+			undefined,
+			{ hideAskAssistant: true },
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AskCredentialCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AskCredentialCard.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import-x/no-extraneous-dependencies, @typescript-eslint/no-explicit-any -- test-only */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
+import { inject } from 'vue';
+import { ChatHubToolContextKey } from '@/app/constants/injectionKeys';
 
 const credentialsById: Record<string, { id: string; name: string }> = {};
 const getCredentialById = vi.fn((id: string) => credentialsById[id]);
@@ -40,6 +42,11 @@ const NodeCredentialsStub = {
 		skipAutoSelect: { type: Boolean, default: false },
 		readonly: { type: Boolean, default: false },
 	},
+	setup() {
+		return {
+			isToolContext: inject(ChatHubToolContextKey, false),
+		};
+	},
 	emits: ['credentialSelected'],
 	template: `
 		<div
@@ -48,6 +55,7 @@ const NodeCredentialsStub = {
 			:data-project-id="projectId"
 			:data-standalone="String(standalone)"
 			:data-hide-issues="String(hideIssues)"
+			:data-tool-context="String(isToolContext)"
 			:data-skip-auto-select="String(skipAutoSelect)"
 			:data-readonly="String(readonly)"
 			:data-node-type="node?.type"
@@ -115,6 +123,7 @@ describe('AskCredentialCard', () => {
 		expect(stub.attributes('data-project-id')).toBe('p1');
 		expect(stub.attributes('data-standalone')).toBe('true');
 		expect(stub.attributes('data-hide-issues')).toBe('true');
+		expect(stub.attributes('data-tool-context')).toBe('true');
 		expect(stub.attributes('data-skip-auto-select')).toBe('true');
 		expect(stub.attributes('data-readonly')).toBe('false');
 	});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentModelSelector.vue
@@ -309,7 +309,16 @@ const filteredMenu = computed(() => {
 
 function openNewCredential(credentialType: string) {
 	if (!disabled && canCreateCredentials.value) {
-		uiStore.openNewCredential(credentialType, false, false, createCredentialProjectId.value);
+		uiStore.openNewCredential(
+			credentialType,
+			false,
+			false,
+			createCredentialProjectId.value,
+			undefined,
+			undefined,
+			undefined,
+			{ hideAskAssistant: true },
+		);
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigNodeContent.vue
@@ -44,7 +44,6 @@ defineExpose({
 		:initial-node="props.initialNode"
 		:existing-tool-names="props.existingToolNames"
 		:project-id="props.projectId"
-		:hide-ask-assistant="true"
 		:data-test-id="props.contentTestId"
 		@update:valid="emit('update:valid', $event)"
 		@update:node-name="emit('update:node-name', $event)"

--- a/packages/frontend/editor-ui/src/features/agents/components/interactive/AskCredentialCard.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/interactive/AskCredentialCard.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, provide, ref } from 'vue';
 import { N8nButton, N8nCard, N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import NodeCredentials from '@/features/credentials/components/NodeCredentials.vue';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import type { AskCredentialResume } from '@n8n/api-types';
 import type { INodeUi, INodeUpdatePropertiesInformation } from '@/Interface';
+import { ChatHubToolContextKey } from '@/app/constants';
 
 const props = defineProps<{
 	purpose: string;
@@ -24,6 +25,8 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const credentialsStore = useCredentialsStore();
+
+provide(ChatHubToolContextKey, true);
 
 // ---------------------------------------------------------------------------
 // Selection state — driven entirely by NodeCredentials' credentialSelected event

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -23,7 +23,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAiGateway } from '@/app/composables/useAiGateway';
-import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { ChatHubToolContextKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -312,6 +312,37 @@ describe('NodeCredentials', () => {
 			httpNode.name,
 			httpNode,
 			{ hideAskAssistant: false, closeOnSave: true },
+		);
+	});
+
+	it('should hide the assistant when opening credentials from a tool context', async () => {
+		ndvStore.activeNode = httpNode;
+		credentialsStore.state.credentials = {
+			c8vqdPpPClh4TgIO: createCredential(),
+		};
+
+		renderComponent({
+			global: {
+				provide: {
+					[ChatHubToolContextKey as symbol]: true,
+				},
+			},
+		});
+
+		const credentialsSelect = screen.getByTestId('node-credentials-select');
+
+		await userEvent.click(credentialsSelect);
+		await userEvent.click(screen.getByTestId('node-credentials-select-item-new'));
+
+		expect(uiStore.openNewCredential).toHaveBeenCalledWith(
+			'openAiApi',
+			false,
+			false,
+			undefined,
+			undefined,
+			httpNode.name,
+			httpNode,
+			{ hideAskAssistant: true, closeOnSave: true },
 		);
 	});
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -7,7 +7,7 @@ import type {
 	INodeCredentialsDetails,
 	NodeParameterValueType,
 } from 'n8n-workflow';
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import {
@@ -27,7 +27,7 @@ import {
 import TitledList from '@/app/components/TitledList.vue';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { CREDENTIAL_ONLY_NODE_PREFIX } from '@/app/constants';
+import { ChatHubToolContextKey, CREDENTIAL_ONLY_NODE_PREFIX } from '@/app/constants';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useCredentialsStore } from '../credentials.store';
 import { useQuickConnect } from '../quickConnect/composables/useQuickConnect';
@@ -100,6 +100,7 @@ const NEW_CREDENTIALS_TEXT = i18n.baseText('nodeCredentials.createNew');
 
 const instanceAiCapability = useInstanceAiEditorCapability();
 const { instanceAi } = useEditorContext();
+const isToolContext = inject(ChatHubToolContextKey, false);
 
 // The host's credential-help behavior, handed to the (teleported) credential
 // modal that can't inject it. Undefined when Instance AI is off in this editor or
@@ -129,6 +130,7 @@ const {
 const { canOAuthCredentialQuickConnect, hasManualCredentialInputFields } = useCredentialOAuth();
 
 const aiGateway = useAiGateway();
+const hideAskAssistant = computed(() => props.hideAskAssistant || isToolContext);
 
 const canCreateCredentials = computed(
 	() =>
@@ -459,7 +461,7 @@ function createNewCredential(
 		props.node.name,
 		props.node,
 		{
-			hideAskAssistant: props.hideAskAssistant,
+			hideAskAssistant: hideAskAssistant.value,
 			closeOnSave: true,
 			instanceAiCredentialHelp: instanceAiCredentialHelp(),
 		},
@@ -663,7 +665,7 @@ function editCredential(credentialType: string): void {
 	assert(credential?.id);
 
 	uiStore.openExistingCredential(credential.id, {
-		hideAskAssistant: props.hideAskAssistant,
+		hideAskAssistant: hideAskAssistant.value,
 		instanceAiCredentialHelp: instanceAiCredentialHelp(),
 	});
 


### PR DESCRIPTION
## Summary
  - Disable legacy n8n AI credential help in agent/tool credential flows, disabling as we don't want to have a duplicate chat experience, we may need to add this at some point but fix for now by disabling consistently
  - Reuse tool context to keep credential modal behavior consistent
  - Fix Linear channel i18n crash from literal `@-mentions`

Addresses: https://linear.app/n8n/issue/AGENT-262/bug-n8n-ai-assistance-for-credentials-setup-do-not-work-in-agents-page

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

