### PR TITLE
fix(core): Persist Instance AI assistant output when a turn suspends

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/tool-call-upsert.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/tool-call-upsert.test.ts
@@ -8,10 +8,11 @@
  * the checkpoint. Without upsert-by-id, a second row would be inserted for
  * the same message, breaking the thread ordering contract.
  *
- * Note: the inbound user message is persisted eagerly on receipt, but assistant
- * messages with a state:'pending' tool-call are transient and are NOT written to
- * memory during suspension — they only live in the checkpoint. The settled
- * assistant state is written after resume completes.
+ * Note: the turn-so-far is persisted eagerly on suspend (input + the assistant
+ * message holding the state:'pending' tool-call), so an abandoned suspension is
+ * not lost from memory. On resume the same assistant message — now with the
+ * tool-call resolved — is written under the same id, upserting in place rather
+ * than inserting a duplicate row.
  */
 import { afterEach, expect, it } from 'vitest';
 import { z } from 'zod';
@@ -74,8 +75,8 @@ describe('tool-call upsert via suspend/resume (in-memory storage)', () => {
 
 		const agent = buildInterruptibleAgent(memory);
 
-		// Turn 1: trigger the suspend — messages with pending tool-call are
-		// stored in the checkpoint only, NOT in memory yet.
+		// Turn 1: trigger the suspend — the turn-so-far is persisted on suspend,
+		// including the assistant message whose tool-call block is still pending.
 		const suspendResult = await agent.generate('Please delete /tmp/foo.txt', {
 			persistence,
 		});
@@ -84,13 +85,15 @@ describe('tool-call upsert via suspend/resume (in-memory storage)', () => {
 		expect(suspendResult.pendingSuspend).toBeDefined();
 		const { runId, toolCallId } = suspendResult.pendingSuspend![0];
 
-		// Before resume: no tool-call blocks in memory (pending stays in checkpoint)
+		// Before resume: the pending tool-call block is already in memory (persisted
+		// on suspend), so an abandoned suspension is not lost.
 		const msgsBefore = await memory.getMessages(threadId);
 		const blocksBefore = extractToolCallBlocks(msgsBefore);
-		expect(blocksBefore).toHaveLength(0);
+		expect(blocksBefore).toHaveLength(1);
+		expect(blocksBefore[0].state).toBe('pending');
 
-		// Turn 2: resume with approval — on completion saveToMemory is called and
-		// the assistant message (now resolved) is written for the first time.
+		// Turn 2: resume with approval — on completion saveToMemory rewrites the same
+		// assistant message (now resolved) under the same id, upserting in place.
 		const resumeResult = await agent.resume(
 			'generate',
 			{ approved: true },
@@ -136,9 +139,11 @@ describe('tool-call upsert via suspend/resume (in-memory storage)', () => {
 		expect(suspendResult.finishReason).toBe('tool-calls');
 		const { runId, toolCallId } = suspendResult.pendingSuspend![0];
 
-		// Before resume: no messages in memory
+		// Before resume: the pending tool-call block is already persisted on suspend
 		const msgsBefore = await memory.getMessages(threadId);
-		expect(extractToolCallBlocks(msgsBefore)).toHaveLength(0);
+		const blocksBefore = extractToolCallBlocks(msgsBefore);
+		expect(blocksBefore).toHaveLength(1);
+		expect(blocksBefore[0].state).toBe('pending');
 
 		const resumeResult = await agent.resume(
 			'generate',
@@ -202,12 +207,17 @@ describe('tool-call upsert via suspend/resume (in-memory storage)', () => {
 		expect(r1.finishReason).toBe('tool-calls');
 		const { runId, toolCallId } = r1.pendingSuspend![0];
 
-		// The inbound user message is persisted eagerly on receipt, so it survives
-		// even though the turn suspended before completing. No assistant message yet
-		// (the suspended turn never reached its end-of-turn save).
+		// The turn-so-far is persisted on suspend: the inbound user message plus the
+		// assistant message holding the still-pending tool-call. So an abandoned
+		// suspension survives, with the tool-call block left pending until resume.
 		const afterSuspend = await memory.getMessages(threadId);
-		expect(filterLlmMessages(afterSuspend)).toHaveLength(1);
-		expect((afterSuspend[0] as Message).role).toBe('user');
+		const llmAfterSuspend = filterLlmMessages(afterSuspend);
+		expect(llmAfterSuspend).toHaveLength(2);
+		expect(llmAfterSuspend[0].role).toBe('user');
+		expect(llmAfterSuspend[1].role).toBe('assistant');
+		const suspendBlocks = extractToolCallBlocks(afterSuspend);
+		expect(suspendBlocks).toHaveLength(1);
+		expect(suspendBlocks[0].state).toBe('pending');
 
 		// Resume: completes
 		const r2 = await agent.resume('generate', { yes: true }, { runId, toolCallId });

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -703,6 +703,18 @@ describe('AgentRuntime — eager input persistence', () => {
 		return block?.text;
 	}
 
+	function hasToolCall(message: AgentDbMessage, toolCallId: string): boolean {
+		const content = (message as { content?: unknown }).content;
+		if (!Array.isArray(content)) return false;
+		return content.some(
+			(c) =>
+				typeof c === 'object' &&
+				c !== null &&
+				Reflect.get(c, 'type') === 'tool-call' &&
+				Reflect.get(c, 'toolCallId') === toolCallId,
+		);
+	}
+
 	function makeMemoryRuntime() {
 		const memory = new InMemoryMemory();
 		const bus = new AgentEventBus();
@@ -777,6 +789,70 @@ describe('AgentRuntime — eager input persistence', () => {
 
 		const afterResume = await memory.getMessages('t1', { resourceId: 'u1' });
 		expect(afterResume.filter((m) => textOf(m) === 'please build it')).toHaveLength(1);
+	});
+
+	it("persists the turn's assistant output when the turn suspends on HITL", async () => {
+		const suspendTool = makeInterruptibleTool();
+		const memory = new InMemoryMemory();
+		const runtime = new AgentRuntime({
+			name: 'test',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'You are a test assistant.',
+			tools: [suspendTool],
+			checkpointStorage: 'memory',
+			memory,
+		});
+
+		// The model calls the interruptible tool, so the run suspends on HITL before
+		// reaching finishComplete — the only path that previously saved the turn.
+		generateText.mockResolvedValueOnce(
+			makeGenerateWithToolCalls([
+				{ toolCallId: 'tc-1', toolName: 'approve', args: { question: 'continue?' } },
+			]),
+		);
+
+		await runtime.generate('please build it', PERSIST);
+
+		// The assistant's tool-call output from the suspended turn is now in memory, so a
+		// later cancel/abandon cannot drop it — the next turn sees the work was done.
+		const persisted = await memory.getMessages('t1', { resourceId: 'u1' });
+		const assistantRows = persisted.filter(
+			(m) => (m as { role?: string }).role === 'assistant' && hasToolCall(m, 'tc-1'),
+		);
+		expect(assistantRows).toHaveLength(1);
+	});
+
+	it('stores exactly one assistant row across a suspend -> resume cycle (idempotent)', async () => {
+		const suspendTool = makeInterruptibleTool();
+		const memory = new InMemoryMemory();
+		const runtime = new AgentRuntime({
+			name: 'test',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'You are a test assistant.',
+			tools: [suspendTool],
+			checkpointStorage: 'memory',
+			memory,
+		});
+
+		generateText.mockResolvedValueOnce(
+			makeGenerateWithToolCalls([
+				{ toolCallId: 'tc-1', toolName: 'approve', args: { question: 'continue?' } },
+			]),
+		);
+		const first = await runtime.generate('please build it', PERSIST);
+		const { runId, toolCallId } = first.pendingSuspend![0];
+
+		// Saved on suspend (pending tool-call).
+		const afterSuspend = await memory.getMessages('t1', { resourceId: 'u1' });
+		expect(afterSuspend.filter((m) => hasToolCall(m, 'tc-1'))).toHaveLength(1);
+
+		// Resume to completion: the end-of-turn save rewrites the same assistant row (now
+		// with the resolved tool-call) under the same id — upsert, not a 2nd row.
+		generateText.mockResolvedValueOnce(makeGenerateSuccess('done'));
+		await runtime.resume('generate', { approved: true }, { runId, toolCallId });
+
+		const afterResume = await memory.getMessages('t1', { resourceId: 'u1' });
+		expect(afterResume.filter((m) => hasToolCall(m, 'tc-1'))).toHaveLength(1);
 	});
 });
 

--- a/packages/@n8n/agents/src/runtime/__tests__/memory-orchestrator-persist-input.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/memory-orchestrator-persist-input.test.ts
@@ -15,6 +15,10 @@ function userMsg(text: string): AgentMessage {
 	return { role: 'user', content: [{ type: 'text', text }] };
 }
 
+function assistantMsg(text: string): AgentMessage {
+	return { role: 'assistant', content: [{ type: 'text', text }] };
+}
+
 function buildOrchestrator(store?: InMemoryMemory): MemoryOrchestrator {
 	const config = { memory: store } as unknown as AgentRuntimeConfig;
 	return new MemoryOrchestrator(config, new BackgroundTaskTracker(), new AgentEventBus());
@@ -110,6 +114,94 @@ describe('MemoryOrchestrator.persistInputMessages', () => {
 		// A transient persistence failure must not abort the turn.
 		await expect(
 			buildOrchestrator(store).persistInputMessages(list, PERSIST),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe('MemoryOrchestrator.persistTurnOnSuspend', () => {
+	it('persists the full turn delta (input + response), not history', async () => {
+		const store = new InMemoryMemory();
+		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
+
+		const list = new AgentMessageList();
+		list.addHistory([{ id: 'h1', createdAt: new Date(2024, 0, 1), ...userMsg('old history') }]);
+		list.addInput([userMsg('please build it')]);
+		list.addResponse([assistantMsg('built the workflow')]);
+
+		await buildOrchestrator(store).persistTurnOnSuspend(list, PERSIST);
+
+		const persisted = await store.getMessages(THREAD_ID, { resourceId: RESOURCE_ID });
+		expect(textsOf(persisted)).toEqual(['please build it', 'built the workflow']);
+	});
+
+	it('is a no-op when no persistence options are provided', async () => {
+		const store = new InMemoryMemory();
+		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
+
+		const list = new AgentMessageList();
+		list.addInput([userMsg('please build it')]);
+		list.addResponse([assistantMsg('built the workflow')]);
+
+		await buildOrchestrator(store).persistTurnOnSuspend(list, undefined);
+
+		const persisted = await store.getMessages(THREAD_ID, { resourceId: RESOURCE_ID });
+		expect(persisted).toEqual([]);
+	});
+
+	it('is a no-op when there is no memory store configured', async () => {
+		const list = new AgentMessageList();
+		list.addInput([userMsg('please build it')]);
+		list.addResponse([assistantMsg('built the workflow')]);
+
+		await expect(
+			buildOrchestrator(undefined).persistTurnOnSuspend(list, PERSIST),
+		).resolves.toBeUndefined();
+	});
+
+	it('is a no-op when the turn delta is empty', async () => {
+		const store = new InMemoryMemory();
+		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
+
+		const list = new AgentMessageList();
+		list.addHistory([{ id: 'h1', createdAt: new Date(2024, 0, 1), ...userMsg('old history') }]);
+
+		await buildOrchestrator(store).persistTurnOnSuspend(list, PERSIST);
+
+		const persisted = await store.getMessages(THREAD_ID, { resourceId: RESOURCE_ID });
+		expect(persisted).toEqual([]);
+	});
+
+	it('is idempotent with the end-of-turn save — one row per message id', async () => {
+		const store = new InMemoryMemory();
+		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
+
+		const list = new AgentMessageList();
+		list.addInput([userMsg('please build it')]);
+		list.addResponse([assistantMsg('built the workflow')]);
+
+		const orchestrator = buildOrchestrator(store);
+		// Save on suspend, then the end-of-turn save of the same delta after resume.
+		await orchestrator.persistTurnOnSuspend(list, PERSIST);
+		await orchestrator.saveToMemory(list, PERSIST);
+
+		const persisted = await store.getMessages(THREAD_ID, { resourceId: RESOURCE_ID });
+		expect(textsOf(persisted)).toEqual(['please build it', 'built the workflow']);
+		const responseId = list.responseDelta()[0].id;
+		expect(persisted.filter((m) => m.id === responseId)).toHaveLength(1);
+	});
+
+	it('does not throw when the underlying save fails (best-effort)', async () => {
+		const store = new InMemoryMemory();
+		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
+		vi.spyOn(store, 'saveMessages').mockRejectedValue(new Error('db down'));
+
+		const list = new AgentMessageList();
+		list.addInput([userMsg('please build it')]);
+		list.addResponse([assistantMsg('built the workflow')]);
+
+		// A transient persistence failure must not abort the suspend flow.
+		await expect(
+			buildOrchestrator(store).persistTurnOnSuspend(list, PERSIST),
 		).resolves.toBeUndefined();
 	});
 });

--- a/packages/@n8n/agents/src/runtime/loop/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/loop/agent-runtime.ts
@@ -752,8 +752,9 @@ export class AgentRuntime {
 	}
 
 	/**
-	 * Persist a suspended run state and update the current state snapshot.
-	 * Returns the runtime's runId.
+	 * Persist a suspended run state and update the current state snapshot, and durably
+	 * save the turn-so-far to thread memory so a suspended turn that is later cancelled or
+	 * abandoned still leaves its assistant work behind. Returns the runtime's runId.
 	 */
 	private async persistSuspension(
 		pendingToolCalls: Record<string, PendingToolCall>,
@@ -781,6 +782,8 @@ export class AgentRuntime {
 		};
 		await this.runState.suspend(this.runId, state);
 		this.updateState({ status: 'suspended', pendingToolCalls, messageList: list.serialize() });
+		await this.memory.persistTurnOnSuspend(list, options);
+
 		return this.runId;
 	}
 

--- a/packages/@n8n/agents/src/runtime/memory/memory-orchestrator.ts
+++ b/packages/@n8n/agents/src/runtime/memory/memory-orchestrator.ts
@@ -188,6 +188,41 @@ export class MemoryOrchestrator {
 		}
 	}
 
+	/**
+	 * Persist the turn-so-far when the run suspends (HITL), before the turn completes.
+	 * Saves the full `turnDelta()` (input + accumulated response) so a suspended turn that
+	 * is later cancelled or abandoned still leaves its assistant work — the built workflow,
+	 * resolved tool results — in memory. Like `persistInputMessages`, it skips the
+	 * observation-log / episodic-memory / title jobs that `saveToMemory` schedules; those
+	 * stay at end-of-turn. Idempotent with the end-of-turn save: the message list is
+	 * serialized into the checkpoint and deserialized on resume preserving ids, so both
+	 * writes target the same rows and TypeORM upserts (pending tool-call → resolved in place).
+	 */
+	async persistTurnOnSuspend(
+		list: AgentMessageList,
+		options: (RunOptions & ExecutionOptions) | undefined,
+	): Promise<void> {
+		if (!this.config.memory || !options?.persistence) return;
+		const delta = list.turnDelta();
+		if (delta.length === 0) return;
+		try {
+			await saveMessagesToThread(
+				this.config.memory,
+				options.persistence.threadId,
+				options.persistence.resourceId,
+				delta,
+			);
+		} catch (error) {
+			// Best-effort: a completed turn's end-of-turn save still persists this delta,
+			// so a transient failure here must not abort the suspend flow. Only a turn that
+			// suspends and is then abandoned, whose save here also failed, loses its output.
+			logger.warn('Failed to persist turn on suspend', {
+				error,
+				threadId: options.persistence.threadId,
+			});
+		}
+	}
+
 	/** Persist the current-turn delta to memory and schedule background indexing. */
 	async saveToMemory(
 		list: AgentMessageList,


### PR DESCRIPTION
## Summary

A turn's assistant output (text, resolved tool results, the built workflow) was only persisted by the SDK's end-of-turn save in finishComplete. A turn that suspends on a HITL card and is then cancelled or abandoned never reached finishComplete, so its work was lost from thread memory — the next turn loaded a history missing it and rebuilt from scratch.

Persist the turn-so-far (turnDelta) leanly at suspend time, mirroring the input-on-receipt fix. The save skips the observation-log / episodic-memory / title jobs (those stay at end-of-turn) and is best-effort. It is idempotent with the end-of-turn save: the list is serialized into the checkpoint and deserialized on resume preserving ids, so both writes upsert the same rows. An abandoned turn's pending HITL tool-call is stripped on the next load while resolved results survive.

Practical benefit of this is if user stops the agent while it's suspended on HITL it knows what happeend on the turn so far when resumed, and doesn't end up losing the context from previous turn and for instance building a new workflow if users asks it to "set up credentials" again after stopping on the setup panel.

## How to test

- Have this branch built and running
- On instance AI ask it to build a workflow (that uses credentials), when it stops to setup panel having built the WF check the DB, there should now be AI messages saved already at this stage (and not only at the end of the turn after suspend continues)
- Instead of answering the HITL stop the turn by aborting the message with the stop button on the chat prompt
- Now ask the AI to do something with the WF it just built / ask it to finish setting it up or something
- AI should not be confused on context and it should not build a new workflow, it should know it already built one

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-646/cancelledabandoned-hitl-suspended-turn-drops-its-assistant-output

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32958">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

