### PR TITLE
build: Bump n8n base image to Alpine 3.24 and unpin graphicsmagick

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -2,8 +2,8 @@ ARG NODE_VERSION=24.16.0
 
 # Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # Bump the digest together with the tag when updating the base image.
-# Digest pins to dhi.io/node:24.16.0-alpine3.22-dev (Node 24.16.0, Alpine 3.22, DHI dev variant).
-FROM dhi.io/node:24.16.0-alpine3.22-dev@sha256:67906dda1e458153488aecb9a7a5a926cb03cf1e8890eb8602a86a78162b2556
+# Digest pins to dhi.io/node:24.16.0-alpine3.24-dev (Node 24.16.0, Alpine 3.24, DHI dev variant).
+FROM dhi.io/node:24.16.0-alpine3.24-dev@sha256:0fda302d7d6f2436b27edc9392bd6a4f8ae9ce86e9837c2b8676abdf26a4a7fb
 
 ARG NODE_VERSION
 
@@ -22,7 +22,7 @@ RUN apk add --no-cache busybox-binsh && \
     # libs Node uses (the openssl CLI binary isn't needed at runtime).
     apk add --no-cache \
         openssh \
-        graphicsmagick=1.3.45-r0 `# pinned to avoid ghostscript-fonts (GPL-2.0); see SEC-398 + NODE-4184` \
+        graphicsmagick `# unpinned to float with the Alpine base; OS-layer copyleft (ghostscript-fonts GPL-2.0, libheif LGPL-3.0) is non-in-force per security/sca/README.md. NODE-4184 migrates gm->sharp` \
         tini \
         tzdata \
         ca-certificates \

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -1,11 +1,7 @@
-ARG NODE_VERSION=24.16.0
-
-# Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
-# Bump the digest together with the tag when updating the base image.
-# Digest pins to dhi.io/node:24.16.0-alpine3.24-dev (Node 24.16.0, Alpine 3.24, DHI dev variant).
+# Pinned to a multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
+# The tag is the human-readable version; Docker resolves by the digest. Bump the tag and
+# digest together when updating the base image.
 FROM dhi.io/node:24.16.0-alpine3.24-dev@sha256:0fda302d7d6f2436b27edc9392bd6a4f8ae9ce86e9837c2b8676abdf26a4a7fb
-
-ARG NODE_VERSION
 
 # Install all dependencies in a single layer to minimize image size
 RUN apk add --no-cache busybox-binsh && \
@@ -22,7 +18,7 @@ RUN apk add --no-cache busybox-binsh && \
     # libs Node uses (the openssl CLI binary isn't needed at runtime).
     apk add --no-cache \
         openssh \
-        graphicsmagick `# unpinned to track the base image; the GPL fonts it pulls are an OS-layer dependency and do not affect n8n's own license` \
+        graphicsmagick \
         tini \
         tzdata \
         ca-certificates \

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -27,6 +27,10 @@ RUN apk add --no-cache busybox-binsh && \
     rm -rf /tmp/* /root/.npm /root/.cache/node /opt/yarn* && \
     apk del apk-tools
 
+# Alpine 3.24 ships node at /usr/bin; symlink it to /usr/local/bin so the path
+# matches what the cloud launch and AppArmor profile expect.
+RUN mkdir -p /usr/local/bin && ln -sf /usr/bin/node /usr/local/bin/node
+
 WORKDIR /home/node
 # This base image installs global npm modules under /usr/local; set NODE_PATH
 # so packages added via `npm install -g` are require()-able at runtime.

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache busybox-binsh && \
     # libs Node uses (the openssl CLI binary isn't needed at runtime).
     apk add --no-cache \
         openssh \
-        graphicsmagick `# unpinned to float with the Alpine base; OS-layer copyleft (ghostscript-fonts GPL-2.0, libheif LGPL-3.0) is non-in-force per security/sca/README.md. NODE-4184 migrates gm->sharp` \
+        graphicsmagick `# unpinned to track the base image; the GPL fonts it pulls are an OS-layer dependency and do not affect n8n's own license` \
         tini \
         tzdata \
         ca-certificates \
@@ -32,7 +32,7 @@ RUN apk add --no-cache busybox-binsh && \
     apk del apk-tools
 
 WORKDIR /home/node
-# DHI images use a non-standard global npm path, so we need to set NODE_PATH
-# to allow externally installed npm packages to be found by require()
-ENV NODE_PATH=/opt/nodejs/node-v${NODE_VERSION}/lib/node_modules
+# This base image installs global npm modules under /usr/local; set NODE_PATH
+# so packages added via `npm install -g` are require()-able at runtime.
+ENV NODE_PATH=/usr/local/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -42,7 +42,9 @@ WORKDIR /home/node
 COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
-RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
+# The Alpine 3.24 base has no /usr/local/bin (node lives in /usr/bin); create it for the symlink.
+RUN mkdir -p /usr/local/bin && \
+    ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \
     rm -rf /root/.npm /tmp/*

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -4,8 +4,8 @@ ARG N8N_VERSION=snapshot
 # Builder stage exists because the runtime base image has no toolchain.
 # Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # Bump the digest together with the tag when updating the base image.
-# Digest pins to node:24.16.0-alpine3.22 (Node 24.16.0, Alpine 3.22).
-FROM node:24.16.0-alpine3.22@sha256:191c9f0080fcbbc6547a85dc0ff7988072214a355aabdc1d2ec55a7dae5eea8a AS builder
+# Digest pins to node:24.16.0-alpine3.24 (Node 24.16.0, Alpine 3.24).
+FROM node:24.16.0-alpine3.24@sha256:21f403ab171f2dc89bad4dd69d7721bfd15f084ccb46cdd225f31f2bc59b5c9a AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN apk add --no-cache python3 make g++ && \
     cd /usr/local/lib/node_modules/n8n && \
@@ -28,8 +28,8 @@ RUN apk add --no-cache python3 make g++ && \
 # base change, so a base rebuild does not reach this image until the digest is
 # manually re-pinned here. Bump the digest together with the tag whenever the base
 # image is intentionally updated.
-# Digest pins to n8nio/base:24.16.0 (Node 24.16.0, Alpine 3.22).
-FROM n8nio/base:24.16.0@sha256:a1aa4005e4faebd6da3ba51ec28180a3fb421243d921fa0efbba2d21395012f0
+# Digest pins to n8nio/base:24.16.0 (Node 24.16.0, Alpine 3.24).
+FROM n8nio/base:24.16.0@sha256:d822b9c6edde370c2fe289be835aa5e64d9851276f1421908c90ef0e2dd73d8b
 
 ARG N8N_VERSION
 ARG N8N_RELEASE_TYPE=dev

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache python3 make g++ && \
 # manually re-pinned here. Bump the digest together with the tag whenever the base
 # image is intentionally updated.
 # Digest pins to n8nio/base:24.16.0 (Node 24.16.0, Alpine 3.24).
-FROM n8nio/base:24.16.0@sha256:d822b9c6edde370c2fe289be835aa5e64d9851276f1421908c90ef0e2dd73d8b
+FROM n8nio/base:24.16.0@sha256:25e5671a1b3e11cd576bc9a4409ebf962baea993a4bc7414168dfd357e85a7e8
 
 ARG N8N_VERSION
 ARG N8N_RELEASE_TYPE=dev


### PR DESCRIPTION
## Summary

Bumps the runtime base image (`docker/images/n8n-base/Dockerfile`) from the pinned Alpine 3.22 DHI digest to **Alpine 3.24**, removes the strict `graphicsmagick` version pin so it floats with the base, and re-pins the n8n image (`docker/images/n8n/Dockerfile`) onto the new 3.24 base.

The 3.22 hold (and the gm pin at `1.3.45-r0`) predate available OS-package patches. On 3.24 the closure carries up-to-date `graphicsmagick` / `libheif` / `libde265` / `openssh` / `libcurl`. Note `graphicsmagick` 1.3.46+ hard-depends `ghostscript-fonts` (GPL-2.0) — a transitive that can no longer be avoided by pinning below 1.3.46. Per `security/sca/README.md`, GPL/LGPL in unmodified OS packages is non-in-force for n8n's licensing; full removal of graphicsmagick is tracked under NODE-4184 (graphicsmagick → sharp).

> [!NOTE]
> **Single PR — base republish and n8n re-pin together.** Merging republishes `n8nio/base:24.16.0` on Alpine 3.24 **and** re-pins `docker/images/n8n/Dockerfile` onto it: the base `FROM` moves to the new 3.24 digest (`:32`) and the builder stage is bumped from `node:…-alpine3.22` to `node:…-alpine3.24` (`:8`) in lockstep. Both must move together — native modules (`isolated-vm`, `sqlite3`) are compiled in the builder and must match the runtime base's musl ABI. `runners` and `engine` images are not touched here.

## Verification

Local no-cache builds on Alpine 3.24:

- **Base** (`docker/images/n8n-base/Dockerfile`): `trivy` (OS) **0 vulnerabilities** at CRITICAL/HIGH/MEDIUM; `trivy --scanners license` shows copyleft is GPL-2.0 / LGPL-2.x / LGPL-3.0 only — **no AGPL**; `graphicsmagick` resolves to MIT.
- **Full `n8nio/n8n` image** (built on the 3.24 base): `trivy` (OS) **0 vulnerabilities** at CRITICAL/HIGH — the five OS-package CVEs flagged on the 3.22 image are cleared. E2E ran green against this image (pre-existing AI-test failures only; nothing in the OS / image-processing / native-module path).

## How to test

```bash
# Build the base on 3.24 (no cache) and scan it
docker build --no-cache -f docker/images/n8n-base/Dockerfile -t n8nio/base:3.24-check docker/images/n8n-base
trivy image --scanners vuln --pkg-types os n8nio/base:3.24-check     # expect 0
trivy image --scanners license n8nio/base:3.24-check | grep -i agpl  # expect no matches

# Build the full image on the new base and scan it
docker build --no-cache -f docker/images/n8n/Dockerfile -t n8nio/n8n:3.24-check .
trivy image --scanners vuln --pkg-types os n8nio/n8n:3.24-check      # expect 0 HIGH/CRITICAL
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-556

Related: https://linear.app/n8n/issue/NODE-4184 (graphicsmagick → sharp migration — the strategic fix this bump bridges toward)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
