### PR TITLE
test(core): Add e2e for webhook reconciliation during publication (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
+++ b/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
@@ -66,5 +66,53 @@ test.describe(
 			expect(details.data).toContain('Webhook received');
 			expect(details.data).not.toContain('draft-only');
 		});
+
+		// Direct DB access (services.postgres) is only available on the postgres
+		// infra modes, so this test is skipped under sqlite.
+		test('reconciles a webhook that went missing from storage on re-publish', async ({
+			api,
+			services,
+		}) => {
+			test.skip(!services.postgres, 'requires direct postgres access');
+
+			const { workflowId, webhookPath } = await api.workflows.importWorkflowFromFile(
+				'simple-webhook-test.json',
+			);
+
+			const countWebhooks = async () =>
+				Number.parseInt(
+					(
+						await services.postgres.exec(
+							`SELECT COUNT(*) FROM webhook_entity WHERE "workflowId" = '${workflowId}';`,
+						)
+					).trim() || '0',
+					10,
+				);
+
+			// Activation is applied asynchronously by the outbox consumer, so wait for
+			// the webhook to be registered in storage.
+			await expect.poll(countWebhooks, { timeout: 10_000 }).toBe(1);
+
+			// Simulate a missed/partial registration: drop the row while the published
+			// version stays the same, so the next publish has an empty trigger diff.
+			await services.postgres.exec(
+				`DELETE FROM webhook_entity WHERE "workflowId" = '${workflowId}';`,
+			);
+			expect(await countWebhooks()).toBe(0);
+
+			// Re-publishing the same version reconciles the desired webhooks against
+			// stored state and re-registers the missing one.
+			const published = await api.workflows.getWorkflow(workflowId);
+			await api.workflows.activate(workflowId, published.versionId!);
+
+			await expect.poll(countWebhooks, { timeout: 10_000 }).toBe(1);
+
+			// The reconciled webhook is functional end to end.
+			const response = await api.webhooks.trigger(`/webhook/${webhookPath}`, {
+				method: 'POST',
+				data: { message: 'after-reconciliation' },
+			});
+			expect(response.ok()).toBe(true);
+		});
 	},
 );


### PR DESCRIPTION
## Summary

e2e test to verify that we reconcile missing webhook rows. This simulates recovering from a publication where we fail after bumping the version id.

## How to test

Container-only (needs direct Postgres access for the SQL delete):

```bash
pnpm build:docker
pnpm --filter=n8n-playwright test:container:postgres --grep "reconciles a webhook"
```

Verified passing locally against a freshly built `n8nio/n8n:local`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3536

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

