### PR TITLE
fix(core): Route split in batches chains through loop output

### DIFF
--- a/packages/@n8n/workflow-sdk/src/workflow-builder.integration.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.integration.test.ts
@@ -681,6 +681,36 @@ describe('New SDK API', () => {
 			// Process Item loops back to Split In Batches via nextBatch()
 			expect(json.connections['Process Item'].main[0]![0].node).toBe('Process Batches');
 		});
+
+		it('chains nodes after a bare splitInBatches builder from the loop output', () => {
+			const t = createTrigger('Start');
+			const defineScenarios = createNode('Define Scenarios');
+			const loop = splitInBatches({
+				version: 3,
+				config: {
+					name: 'Loop Each Item',
+					parameters: { batchSize: 1, options: {} },
+				},
+			});
+			const generatePrompt = createNode('Generate Prompt');
+			const extractPrompt = createNode('Extract Prompt');
+			const logResult = createNode('Log Result');
+
+			const wf = workflow('test', 'Agentic AI Image Generator')
+				.add(t)
+				.to(defineScenarios)
+				.to(loop)
+				.to(generatePrompt)
+				.to(extractPrompt)
+				.to(logResult)
+				.to(nextBatch(loop));
+
+			const json = wf.toJSON();
+
+			expect(json.connections['Loop Each Item'].main[0] ?? []).toEqual([]);
+			expect(json.connections['Loop Each Item'].main[1]![0].node).toBe('Generate Prompt');
+			expect(json.connections['Log Result'].main[0]![0].node).toBe('Loop Each Item');
+		});
 	});
 
 	describe('API Integration: Complete Workflow Examples', () => {

--- a/packages/@n8n/workflow-sdk/src/workflow-builder.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder.ts
@@ -345,8 +345,9 @@ class WorkflowBuilderImpl implements WorkflowBuilder {
 				}
 			}
 
-			this._currentNode = headName;
-			this._currentOutput = 0;
+			const continuation = thenHandler.handleThen?.(nodeOrComposite, headName, 0, ctx);
+			this._currentNode = continuation?.currentNode ?? headName;
+			this._currentOutput = continuation?.currentOutput ?? 0;
 			return this;
 		}
 

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/composite-handlers/split-in-batches-handler.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/plugins/composite-handlers/split-in-batches-handler.ts
@@ -130,7 +130,29 @@ export const splitInBatchesHandler: CompositeHandlerPlugin<SplitInBatchesBuilder
 			processingSibBuilders.delete(input);
 		}
 	},
+
+	handleThen(
+		input: SplitInBatchesBuilderShape,
+		currentNode: string,
+	): {
+		currentNode: string;
+		currentOutput: number;
+	} {
+		return {
+			currentNode,
+			currentOutput: hasConfiguredTargets(input) ? 0 : 1,
+		};
+	},
 };
+
+function hasConfiguredTargets(input: SplitInBatchesBuilderShape): boolean {
+	return (
+		'_doneTarget' in input ||
+		'_eachTarget' in input ||
+		(input._doneBatches !== undefined && input._doneBatches.length > 0) ||
+		(input._eachBatches !== undefined && input._eachBatches.length > 0)
+	);
+}
 
 /**
  * Process named syntax: splitInBatches(sibNode, { done: ..., each: ... })


### PR DESCRIPTION
## Summary

Routes fluent chaining after a bare `splitInBatches(...)` builder through the loop output instead of the done output.

Adds a regression test for the builder-generated shape:
`workflow.add(trigger).to(loop).to(process).to(nextBatch(loop))`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-632

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32968">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->