### PR TITLE
fix(editor): Redirect to project home after archiving or deleting a workflow

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -2,7 +2,6 @@ import WorkflowDetails from '@/app/components/MainHeader/WorkflowDetails.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import { createTestWorkflow } from '@/__tests__/mocks';
-import type { IWorkflowDb } from '@/Interface';
 import {
 	EnterpriseEditionFeature,
 	MODAL_CONFIRM,
@@ -23,7 +22,7 @@ import { useProjectsStore } from '@/features/collaboration/projects/projects.sto
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import type { SourceControlPreferences } from '@/features/integrations/sourceControl.ee/sourceControl.types';
-import type { Project } from '@/features/collaboration/projects/projects.types';
+import type { Project, ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { shallowRef, computed } from 'vue';
 import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
 import {
@@ -506,16 +505,11 @@ describe('WorkflowDetails', () => {
 
 		it("should navigate to team project workflows page on 'Archive' for team project workflow", async () => {
 			const teamProjectId = 'team-project-123';
-			const teamWorkflow = {
-				...workflow,
-				homeProject: {
-					id: teamProjectId,
-					name: 'Team Project',
-					type: 'team',
-				},
-			};
-
-			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as IWorkflowDb);
+			workflowDocumentStoreRef.value?.setHomeProject({
+				id: teamProjectId,
+				name: 'Team Project',
+				type: 'team',
+			} as ProjectSharingData);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			workflowDocumentStoreRef.value?.setScopes(['workflow:delete']);
@@ -529,7 +523,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-archive'));
 
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(teamWorkflow.id, 'test-checksum');
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.PROJECTS_WORKFLOWS,
 				params: { projectId: teamProjectId },
@@ -537,16 +531,11 @@ describe('WorkflowDetails', () => {
 		});
 
 		it("should navigate to personal workflows page on 'Archive' for personal project workflow", async () => {
-			const personalWorkflow = {
-				...workflow,
-				homeProject: {
-					id: 'personal-project-123',
-					name: 'Personal Project',
-					type: 'personal',
-				},
-			};
-
-			workflowsListStore.getWorkflowById.mockReturnValue(personalWorkflow as IWorkflowDb);
+			workflowDocumentStoreRef.value?.setHomeProject({
+				id: 'personal-project-123',
+				name: 'Personal Project',
+				type: 'personal',
+			} as ProjectSharingData);
 			workflowsStore.archiveWorkflow.mockResolvedValue(undefined);
 
 			workflowDocumentStoreRef.value?.setScopes(['workflow:delete']);
@@ -560,10 +549,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-archive'));
 
-			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(
-				personalWorkflow.id,
-				'test-checksum',
-			);
+			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
 			});
@@ -667,17 +653,11 @@ describe('WorkflowDetails', () => {
 
 		it("should navigate to team project workflows page on 'Delete' for team project workflow", async () => {
 			const teamProjectId = 'team-project-456';
-			const teamWorkflow = {
-				...workflow,
-				isArchived: true,
-				homeProject: {
-					id: teamProjectId,
-					name: 'Team Project',
-					type: 'team',
-				},
-			};
-
-			workflowsListStore.getWorkflowById.mockReturnValue(teamWorkflow as IWorkflowDb);
+			workflowDocumentStoreRef.value?.setHomeProject({
+				id: teamProjectId,
+				name: 'Team Project',
+				type: 'team',
+			} as ProjectSharingData);
 			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			workflowDocumentStoreRef.value?.setScopes(['workflow:delete']);
@@ -691,7 +671,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-delete'));
 
-			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(teamWorkflow.id);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(workflow.id);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.PROJECTS_WORKFLOWS,
 				params: { projectId: teamProjectId },
@@ -699,17 +679,11 @@ describe('WorkflowDetails', () => {
 		});
 
 		it("should navigate to personal workflows page on 'Delete' for personal project workflow", async () => {
-			const personalWorkflow = {
-				...workflow,
-				isArchived: true,
-				homeProject: {
-					id: 'personal-project-456',
-					name: 'Personal Project',
-					type: 'personal',
-				},
-			};
-
-			workflowsListStore.getWorkflowById.mockReturnValue(personalWorkflow as IWorkflowDb);
+			workflowDocumentStoreRef.value?.setHomeProject({
+				id: 'personal-project-456',
+				name: 'Personal Project',
+				type: 'personal',
+			} as ProjectSharingData);
 			workflowsListStore.deleteWorkflow.mockResolvedValue(undefined);
 
 			workflowDocumentStoreRef.value?.setScopes(['workflow:delete']);
@@ -723,7 +697,7 @@ describe('WorkflowDetails', () => {
 			await userEvent.click(getByTestId('workflow-menu'));
 			await userEvent.click(getByTestId('workflow-menu-item-delete'));
 
-			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(personalWorkflow.id);
+			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(workflow.id);
 			expect(router.push).toHaveBeenCalledWith({
 				name: VIEWS.WORKFLOWS,
 			});

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -530,9 +530,10 @@ describe('WorkflowDetails', () => {
 			});
 		});
 
-		it("should navigate to personal workflows page on 'Archive' for personal project workflow", async () => {
+		it("should navigate to personal project workflows page on 'Archive' for personal project workflow", async () => {
+			const personalProjectId = 'personal-project-123';
 			workflowDocumentStoreRef.value?.setHomeProject({
-				id: 'personal-project-123',
+				id: personalProjectId,
 				name: 'Personal Project',
 				type: 'personal',
 			} as ProjectSharingData);
@@ -551,7 +552,8 @@ describe('WorkflowDetails', () => {
 
 			expect(workflowsStore.archiveWorkflow).toHaveBeenCalledWith(workflow.id, 'test-checksum');
 			expect(router.push).toHaveBeenCalledWith({
-				name: VIEWS.WORKFLOWS,
+				name: VIEWS.PROJECTS_WORKFLOWS,
+				params: { projectId: personalProjectId },
 			});
 		});
 
@@ -678,9 +680,10 @@ describe('WorkflowDetails', () => {
 			});
 		});
 
-		it("should navigate to personal workflows page on 'Delete' for personal project workflow", async () => {
+		it("should navigate to personal project workflows page on 'Delete' for personal project workflow", async () => {
+			const personalProjectId = 'personal-project-456';
 			workflowDocumentStoreRef.value?.setHomeProject({
-				id: 'personal-project-456',
+				id: personalProjectId,
 				name: 'Personal Project',
 				type: 'personal',
 			} as ProjectSharingData);
@@ -699,7 +702,8 @@ describe('WorkflowDetails', () => {
 
 			expect(workflowsListStore.deleteWorkflow).toHaveBeenCalledWith(workflow.id);
 			expect(router.push).toHaveBeenCalledWith({
-				name: VIEWS.WORKFLOWS,
+				name: VIEWS.PROJECTS_WORKFLOWS,
+				params: { projectId: personalProjectId },
 			});
 		});
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -274,11 +274,11 @@ async function handleArchiveWorkflow() {
 	});
 
 	// Navigate to the appropriate project's workflow list
-	const workflow = workflowsListStore.getWorkflowById(props.id);
-	if (workflow?.homeProject?.type === ProjectTypes.Team) {
+	const homeProject = workflowDocumentStore?.value?.homeProject;
+	if (homeProject?.type === ProjectTypes.Team) {
 		await router.push({
 			name: VIEWS.PROJECTS_WORKFLOWS,
-			params: { projectId: workflow.homeProject.id },
+			params: { projectId: homeProject.id },
 		});
 	} else {
 		await router.push({ name: VIEWS.WORKFLOWS });
@@ -352,9 +352,9 @@ async function handleDeleteWorkflow() {
 		return;
 	}
 
-	// Get workflow before deletion to know which project to navigate to
-	const workflow = workflowsListStore.getWorkflowById(props.id);
-	const isTeamProject = workflow?.homeProject?.type === ProjectTypes.Team;
+	// Get workflow's home project before deletion to know which project to navigate to
+	const homeProject = workflowDocumentStore?.value?.homeProject;
+	const isTeamProject = homeProject?.type === ProjectTypes.Team;
 
 	try {
 		await workflowsListStore.deleteWorkflow(props.id);
@@ -373,10 +373,10 @@ async function handleDeleteWorkflow() {
 	});
 
 	// Navigate to the appropriate project's workflow list
-	if (isTeamProject && workflow?.homeProject) {
+	if (isTeamProject && homeProject) {
 		await router.push({
 			name: VIEWS.PROJECTS_WORKFLOWS,
-			params: { projectId: workflow.homeProject.id },
+			params: { projectId: homeProject.id },
 		});
 	} else {
 		await router.push({ name: VIEWS.WORKFLOWS });

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -19,7 +19,6 @@ import { nodeViewEventBus } from '@/app/event-bus';
 import type { IWorkflowDb } from '@/Interface';
 import type { FolderShortInfo } from '@/features/core/folders/folders.types';
 import { useFoldersStore } from '@/features/core/folders/folders.store';
-import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
 import type { PathItem } from '@n8n/design-system/components/N8nBreadcrumbs/Breadcrumbs.vue';
 import WorkflowHeaderDraftPublishActions from '@/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue';
 import { useI18n } from '@n8n/i18n';
@@ -273,9 +272,9 @@ async function handleArchiveWorkflow() {
 		type: 'success',
 	});
 
-	// Navigate to the appropriate project's workflow list
+	// Navigate to the home of the workflow's context (personal or team project)
 	const homeProject = workflowDocumentStore?.value?.homeProject;
-	if (homeProject?.type === ProjectTypes.Team) {
+	if (homeProject) {
 		await router.push({
 			name: VIEWS.PROJECTS_WORKFLOWS,
 			params: { projectId: homeProject.id },
@@ -354,7 +353,6 @@ async function handleDeleteWorkflow() {
 
 	// Get workflow's home project before deletion to know which project to navigate to
 	const homeProject = workflowDocumentStore?.value?.homeProject;
-	const isTeamProject = homeProject?.type === ProjectTypes.Team;
 
 	try {
 		await workflowsListStore.deleteWorkflow(props.id);
@@ -372,8 +370,8 @@ async function handleDeleteWorkflow() {
 		type: 'success',
 	});
 
-	// Navigate to the appropriate project's workflow list
-	if (isTeamProject && homeProject) {
+	// Navigate to the home of the workflow's context (personal or team project)
+	if (homeProject) {
 		await router.push({
 			name: VIEWS.PROJECTS_WORKFLOWS,
 			params: { projectId: homeProject.id },


### PR DESCRIPTION
## Summary

Archiving or deleting a workflow from the canvas `…` menu always redirected the user to **Overview**, even when the workflow lived in a team project. The redirect read the workflow's `homeProject` from the workflows-**list** store, whose cache is only populated by the Workflows/Overview views — so when a workflow is opened directly on the canvas the lookup returned `undefined` and the handlers fell through to the Overview route. This now reads `homeProject` from the workflow document store (populated on canvas load), so a workflow in Project A correctly returns to that project's workflow list.

## How to test

1. Open a workflow that lives inside a team project (directly via its URL / canvas).
2. From the canvas `…` menu, archive it (or delete an already-archived workflow).
3. You should be redirected to that project's workflow list (`/projects/{id}/workflows`), not to Overview. Personal-space workflows still land on the Overview home.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-102

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

