### PR TITLE
fix(core): Report IAI agent background failures to Sentry

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -888,7 +888,10 @@ describe('AgentRuntime.stream() — fallback error observability', () => {
 				finishReason: 'error',
 			}),
 		);
-		expect(errorEvents).toHaveLength(1);
+		// The post-loop persistence failure surfaces as a sourceless error event. (The
+		// eager input persist also fails against this memory mock and emits its own
+		// source-tagged event, which has dedicated coverage elsewhere.)
+		expect(errorEvents.filter((e) => !(e as { source?: string }).source)).toHaveLength(1);
 		expect(runtime.getState().status).toBe('failed');
 	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/memory-orchestrator-persist-input.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/memory-orchestrator-persist-input.test.ts
@@ -1,3 +1,5 @@
+import { AgentEvent } from '../../types/runtime/event';
+import type { AgentEventData } from '../../types/runtime/event';
 import type { RunOptions } from '../../types/sdk/agent';
 import type { AgentDbMessage, AgentMessage } from '../../types/sdk/message';
 import type { AgentRuntimeConfig } from '../loop/agent-runtime';
@@ -19,9 +21,12 @@ function assistantMsg(text: string): AgentMessage {
 	return { role: 'assistant', content: [{ type: 'text', text }] };
 }
 
-function buildOrchestrator(store?: InMemoryMemory): MemoryOrchestrator {
+function buildOrchestrator(
+	store?: InMemoryMemory,
+	bus: AgentEventBus = new AgentEventBus(),
+): MemoryOrchestrator {
 	const config = { memory: store } as unknown as AgentRuntimeConfig;
-	return new MemoryOrchestrator(config, new BackgroundTaskTracker(), new AgentEventBus());
+	return new MemoryOrchestrator(config, new BackgroundTaskTracker(), bus);
 }
 
 function textsOf(messages: AgentDbMessage[]): string[] {
@@ -103,18 +108,23 @@ describe('MemoryOrchestrator.persistInputMessages', () => {
 		expect(persisted.filter((m) => m.id === inputId)).toHaveLength(1);
 	});
 
-	it('does not throw when the underlying save fails (best-effort)', async () => {
+	it('does not throw, and emits AgentEvent.Error, when the underlying save fails (best-effort)', async () => {
 		const store = new InMemoryMemory();
 		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
 		vi.spyOn(store, 'saveMessages').mockRejectedValue(new Error('db down'));
+		const bus = new AgentEventBus();
+		const errors: AgentEventData[] = [];
+		bus.on(AgentEvent.Error, (event) => errors.push(event));
 
 		const list = new AgentMessageList();
 		list.addInput([userMsg('the user prompt')]);
 
-		// A transient persistence failure must not abort the turn.
+		// A transient persistence failure must not abort the turn, but is reported.
 		await expect(
-			buildOrchestrator(store).persistInputMessages(list, PERSIST),
+			buildOrchestrator(store, bus).persistInputMessages(list, PERSIST),
 		).resolves.toBeUndefined();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ type: AgentEvent.Error, source: 'input-persistence' });
 	});
 });
 
@@ -190,18 +200,23 @@ describe('MemoryOrchestrator.persistTurnOnSuspend', () => {
 		expect(persisted.filter((m) => m.id === responseId)).toHaveLength(1);
 	});
 
-	it('does not throw when the underlying save fails (best-effort)', async () => {
+	it('does not throw, and emits AgentEvent.Error, when the underlying save fails (best-effort)', async () => {
 		const store = new InMemoryMemory();
 		await store.saveThread({ id: THREAD_ID, resourceId: RESOURCE_ID });
 		vi.spyOn(store, 'saveMessages').mockRejectedValue(new Error('db down'));
+		const bus = new AgentEventBus();
+		const errors: AgentEventData[] = [];
+		bus.on(AgentEvent.Error, (event) => errors.push(event));
 
 		const list = new AgentMessageList();
 		list.addInput([userMsg('please build it')]);
 		list.addResponse([assistantMsg('built the workflow')]);
 
-		// A transient persistence failure must not abort the suspend flow.
+		// A transient persistence failure must not abort the suspend flow, but is reported.
 		await expect(
-			buildOrchestrator(store).persistTurnOnSuspend(list, PERSIST),
+			buildOrchestrator(store, bus).persistTurnOnSuspend(list, PERSIST),
 		).resolves.toBeUndefined();
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ type: AgentEvent.Error, source: 'turn-suspend-persistence' });
 	});
 });

--- a/packages/@n8n/agents/src/runtime/memory/memory-orchestrator.ts
+++ b/packages/@n8n/agents/src/runtime/memory/memory-orchestrator.ts
@@ -185,6 +185,12 @@ export class MemoryOrchestrator {
 				error,
 				threadId: options.persistence.threadId,
 			});
+			this.eventBus.emit({
+				type: AgentEvent.Error,
+				message: 'Failed to eagerly persist input messages',
+				error,
+				source: 'input-persistence',
+			});
 		}
 	}
 
@@ -219,6 +225,12 @@ export class MemoryOrchestrator {
 			logger.warn('Failed to persist turn on suspend', {
 				error,
 				threadId: options.persistence.threadId,
+			});
+			this.eventBus.emit({
+				type: AgentEvent.Error,
+				message: 'Failed to persist turn on suspend',
+				error,
+				source: 'turn-suspend-persistence',
 			});
 		}
 	}

--- a/packages/@n8n/agents/src/types/runtime/event.ts
+++ b/packages/@n8n/agents/src/types/runtime/event.ts
@@ -64,7 +64,12 @@ export type AgentEventData =
 			type: AgentEvent.Error;
 			message: string;
 			error: unknown;
-			source?: 'observer' | 'reflector' | 'episodic-memory';
+			source?:
+				| 'observer'
+				| 'reflector'
+				| 'episodic-memory'
+				| 'input-persistence'
+				| 'turn-suspend-persistence';
 	  };
 
 export type AgentEventHandler = (data: AgentEventData) => void;

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1,4 +1,5 @@
-import type { Message, Workspace, ScopedMemoryTaskEvent } from '@n8n/agents';
+import { AgentEvent } from '@n8n/agents';
+import type { Message, Workspace, ScopedMemoryTaskEvent, AgentEventData } from '@n8n/agents';
 import {
 	applyBranchReadOnlyOverrides,
 	buildProxyHeaders,
@@ -722,6 +723,30 @@ export class InstanceAiService {
 			};
 			this.logger.info(`Observational memory task ${event.type}`, logContext);
 		};
+	}
+
+	/**
+	 * Surface the agent's background/best-effort failures to Sentry. The SDK emits
+	 * `AgentEvent.Error` for these but nothing consumed it, so they were lost: memory
+	 * observer/reflector/episodic indexing and the eager input / turn-on-suspend
+	 * persists all fail silently while the run itself succeeds. We report only the
+	 * `source`-tagged events — the main agentic-loop errors (no source) already reach
+	 * Sentry via the errored run/stream result, so reporting them here would only
+	 * re-tag the same (deduped) error.
+	 */
+	private subscribeToAgentErrors(
+		agent: Awaited<ReturnType<typeof createInstanceAgent>>,
+		threadId: string,
+		runId: string,
+	): void {
+		agent.on(AgentEvent.Error, (event: AgentEventData) => {
+			if (event.type !== AgentEvent.Error || !event.source) return;
+			this.reportInstanceAiError(event.error, {
+				component: `instance-ai-${event.source}`,
+				threadId,
+				runId,
+			});
+		});
 	}
 
 	private reportInstanceAiError(
@@ -2997,6 +3022,7 @@ export class InstanceAiService {
 				onMemoryTaskEvent: this.memoryTaskObserverFor(threadId),
 				thinkingEnabled: this.instanceAiConfig.thinkingEnabled,
 			});
+			this.subscribeToAgentErrors(agent, threadId, runId);
 
 			const streamOptions = this.buildOrchestratorAgentStreamOptions(user, threadId, runId, signal);
 
@@ -3693,6 +3719,7 @@ export class InstanceAiService {
 				onMemoryTaskEvent: this.memoryTaskObserverFor(orphan.threadId),
 				thinkingEnabled: this.instanceAiConfig.thinkingEnabled,
 			});
+			this.subscribeToAgentErrors(agent, orphan.threadId, orphan.runId);
 		} catch (error: unknown) {
 			return { kind: 'agent-failure', error };
 		}


### PR DESCRIPTION
## Summary

The agents SDK emits AgentEvent.Error for background/best-effort failures that don't fail the run - observational-memory observer/reflector and episodic indexing, and the eager input / turn-on-suspend persists - but Instance AI never subscribed to that event, so these failed silently (only a logger.warn). The main agentic-loop errors were unaffected: they already reach Sentry via the errored run/stream result.

Tag each best-effort memory-persist failure with a `source` on AgentEvent.Error, and subscribe to AgentEvent.Error in InstanceAiService, routing source-tagged events to reportInstanceAiError (Sentry) with thread/run context. Sourceless main-loop errors are left to their existing result-path reporting to avoid double-tagging the same error.

This was originally a followup to the comment https://github.com/n8n-io/n8n/pull/32958#discussion_r3468414898 to make us capture memory write errors to sentry, but made it a bit more generic instead.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/pull/32958

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32972">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

