### PR TITLE
fix(core): Broken workflow verification loop in iAI (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-loop-repro.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-loop-repro.json
@@ -28,7 +28,7 @@
 		}
 	],
 	"description": "Regression case for repeated post-build workflow-verification follow-ups when verification succeeds with partial coverage or never settles.",
-	"buildExpectations": [
+	"processExpectations": [
 		"The agent does not repeatedly re-enter workflow verification for the same saved workflow; it verifies once or twice at most, then reports partial/manual verification if downstream nodes cannot be reached."
 	],
 	"triggerType": "manual",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-loop-repro.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-loop-repro.json
@@ -1,0 +1,37 @@
+{
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"First create a plan and wait for my approval before building. Do not skip the plan approval step.",
+				"",
+				"After I approve, build a workflow named \"workflow verification loop repro\" with exactly this shape:",
+				"",
+				"Manual Trigger",
+				"→ Code node named \"Return no items\" that returns an empty array",
+				"→ HTTP Request node named \"Unreached POST\" configured as POST to https://example.com/repro with a small JSON body",
+				"→ Edit Fields node named \"After post\"",
+				"",
+				"Do not add fallback branches, do not seed data, do not change the Code node to return items, and do not remove the HTTP POST.",
+				"After saving, verify the workflow automatically."
+			]
+		}
+	],
+	"complexity": "medium",
+	"tags": ["behaviour", "verification", "orchestration", "regression"],
+	"executionScenarios": [
+		{
+			"name": "empty-output-stops-before-post",
+			"description": "The code node returns no items, so the HTTP POST and downstream Edit Fields node are not reached.",
+			"dataSetup": "Manual trigger input can be an empty item. HTTP requests are mocked; however, the workflow should stop before the HTTP Request node because the Code node returns an empty array.",
+			"successCriteria": "The workflow execution stops after the Code node returns no items. The HTTP POST is not actually executed and the agent reports that downstream nodes were not verified instead of repeatedly re-running verification."
+		}
+	],
+	"description": "Regression case for repeated post-build workflow-verification follow-ups when verification succeeds with partial coverage or never settles.",
+	"buildExpectations": [
+		"The agent does not repeatedly re-enter workflow verification for the same saved workflow; it verifies once or twice at most, then reports partial/manual verification if downstream nodes cannot be reached."
+	],
+	"triggerType": "manual",
+	"messageBudget": 20,
+	"datasets": ["behaviour", "verification", "full"]
+}

--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
@@ -115,7 +115,7 @@ describe('deriveWorkflowVerificationObligation', () => {
 		expect(obligation.evidence?.executionId).toBe('exec-1');
 	});
 
-	it('does not mark partial-coverage evidence as verified', () => {
+	it('treats partial-coverage evidence as a manual warning completion', () => {
 		const obligation = deriveWorkflowVerificationObligation('thread-1', {
 			state: makeState(),
 			attempts: [makeAttempt()],
@@ -130,7 +130,9 @@ describe('deriveWorkflowVerificationObligation', () => {
 			}),
 		});
 
-		expect(obligation.status).toBe('ready_to_verify');
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.policy).toBe('manual');
+		expect(obligation.blockingReason).toContain('Send Email');
 	});
 
 	it('treats not-verifiable outcomes as manual warning completions', () => {
@@ -270,7 +272,7 @@ describe('deriveWorkflowVerificationObligationFromOutcome', () => {
 		expect(obligation.evidence?.executionId).toBe('exec-1');
 	});
 
-	it('does not mark already-verified outcomes as verified when evidence is partial', () => {
+	it('treats partial already-verified outcomes as manual warning completions', () => {
 		const obligation = deriveWorkflowVerificationObligationFromOutcome(
 			'thread-1',
 			makeOutcome({
@@ -285,7 +287,9 @@ describe('deriveWorkflowVerificationObligationFromOutcome', () => {
 			}),
 		);
 
-		expect(obligation.status).toBe('ready_to_verify');
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.policy).toBe('manual');
+		expect(obligation.blockingReason).toContain('Send Email');
 	});
 
 	it('marks setup-blocked failed evidence as needs setup from outcome-only records', () => {

--- a/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
@@ -43,8 +43,12 @@ function hasSuccessfulEvidence(outcome: WorkflowBuildOutcome): boolean {
 	);
 }
 
-function hasPartialCoverageEvidence(outcome: WorkflowBuildOutcome): boolean {
-	return (outcome.verification?.evidence?.nodesNotReached?.length ?? 0) > 0;
+function hasPartialSuccessfulCoverageEvidence(outcome: WorkflowBuildOutcome): boolean {
+	return (
+		outcome.verification?.attempted === true &&
+		outcome.verification.success &&
+		(outcome.verification.evidence?.nodesNotReached?.length ?? 0) > 0
+	);
 }
 
 function hasFailedEvidence(outcome: WorkflowBuildOutcome): boolean {
@@ -71,10 +75,10 @@ function deriveStatus(
 	if (!outcome.submitted) return 'blocked';
 	if (hasSuccessfulEvidence(outcome)) return 'verified';
 	if (hasSetupBlockingEvidence(state, outcome)) return 'needs_setup';
+	if (hasPartialSuccessfulCoverageEvidence(outcome)) return 'not_verifiable';
 
 	switch (outcome.verificationReadiness?.status) {
 		case 'already_verified':
-			if (hasPartialCoverageEvidence(outcome)) return 'ready_to_verify';
 			return 'verified';
 		case 'needs_setup':
 			return 'needs_setup';
@@ -113,6 +117,10 @@ function deriveBlockingReason(
 	}
 	if (outcome.verificationReadiness?.status === 'needs_setup') {
 		return outcome.verificationReadiness.guidance;
+	}
+	if (hasPartialSuccessfulCoverageEvidence(outcome)) {
+		const nodesNotReached = outcome.verification?.evidence?.nodesNotReached ?? [];
+		return `Automatic verification only covered part of the workflow. Unreached nodes need manual testing: ${nodesNotReached.join(', ')}.`;
 	}
 	const outcomeRemediation = outcome.remediation;
 	if (outcomeRemediation && setupRemediationBlocksVerification(outcomeRemediation, outcome)) {


### PR DESCRIPTION
## Summary

Fixes the infinite workflow verify loop that is caused due to the workflow verify tool returning a state that would end up calling itself again in a loop. 

## How to test

Run this on master and the current branch:

```
pnpm eval:instance-ai \
  --base-url http://localhost:5678 --iterations 3 --verbose \
  --filter workflow-verification-loop-repro --keep-workflows
```

infinite loop should resolve in the current branch.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32979">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->