### PR TITLE
test(core): Make instance-ai sandbox-setup mocks parallel-safe (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -1,20 +1,35 @@
-const { packWorkspaceSdkMockState, resolveMockWorkspaceRoot } = vi.hoisted(() => ({
-	packWorkspaceSdkMockState: {
-		isEnabled: false,
-		packWorkspaceSdk: vi.fn(),
-	},
-	resolveMockWorkspaceRoot: async (workspace: {
-		filesystem?: { basePath?: string };
-	}): Promise<string> => {
-		await Promise.resolve();
-		const basePath = workspace.filesystem?.basePath;
-		if (typeof basePath === 'string' && basePath.length > 0) {
-			return basePath;
-		}
+const { packWorkspaceSdkMockState, resolveMockWorkspaceRoot, sandboxFsMockState } = vi.hoisted(
+	() => ({
+		packWorkspaceSdkMockState: {
+			isEnabled: false,
+			packWorkspaceSdk: vi.fn(),
+		},
+		resolveMockWorkspaceRoot: async (workspace: {
+			filesystem?: { basePath?: string };
+		}): Promise<string> => {
+			await Promise.resolve();
+			const basePath = workspace.filesystem?.basePath;
+			if (typeof basePath === 'string' && basePath.length > 0) {
+				return basePath;
+			}
 
-		return '/home/daytona/workspace';
-	},
-}));
+			return '/home/daytona/workspace';
+		},
+		// Mutable mock state for `../sandbox-fs`. A top-level `vi.mock` (below)
+		// delegates to these, so each test swaps behaviour by assigning here —
+		// no per-test `vi.resetModules()` + dynamic `import`, which races and
+		// flakes when many vitest processes run concurrently (e.g. CI).
+		sandboxFsMockState: {
+			runInSandbox:
+				vi.fn<
+					(
+						...args: [SandboxWorkspace, string, string?]
+					) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+				>(),
+			readFileViaSandbox: vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>(),
+		},
+	}),
+);
 
 vi.mock('../pack-workspace-sdk', () => ({
 	isLinkWorkspaceSdkEnabled: () => packWorkspaceSdkMockState.isEnabled,
@@ -29,6 +44,20 @@ vi.mock('@n8n/agents/sandbox', async (importOriginal) => {
 	};
 });
 
+vi.mock('../sandbox-fs', () => ({
+	runInSandbox: async (...args: [SandboxWorkspace, string, string?]) =>
+		await sandboxFsMockState.runInSandbox(...args),
+	readFileViaSandbox: async (...args: [SandboxWorkspace, string]) =>
+		await sandboxFsMockState.readFileViaSandbox(...args),
+	writeFileViaSandbox: async (workspace: SandboxWorkspace, path: string) => {
+		const result = await sandboxFsMockState.runInSandbox(workspace, `write '${path}'`);
+		if (result.exitCode !== 0) {
+			throw new Error(`Failed to write file ${path}: ${result.stderr}`);
+		}
+	},
+	escapeSingleQuotes: (value: string) => value.replace(/'/g, "'\\''"),
+}));
+
 import { jsonParse } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 
@@ -36,12 +65,12 @@ import { makeBuilderTemplatesTarGz } from '../../knowledge-base/__tests__/builde
 import type { InstanceAiContext, SearchableNodeDescription } from '../../types';
 import type { BuilderTemplatesBundle } from '../builder-templates-service';
 import type { SandboxWorkspace } from '../sandbox-fs';
-import type {
-	formatNodeCatalogLine as formatNodeCatalogLineFunction,
-	setupSandboxWorkspace as setupSandboxWorkspaceFunction,
+import {
+	setupSandboxWorkspace,
+	type formatNodeCatalogLine as formatNodeCatalogLineFunction,
 } from '../sandbox-setup';
 
-type SetupSandboxWorkspace = typeof setupSandboxWorkspaceFunction;
+type SetupSandboxWorkspace = typeof setupSandboxWorkspace;
 type FormatNodeCatalogLine = typeof formatNodeCatalogLineFunction;
 type LinkWorkspaceSdkIfEnabled = (
 	workspace: SandboxWorkspace,
@@ -149,30 +178,15 @@ function createLocalWorkspace(
 	};
 }
 
-async function loadSetupSandboxWorkspaceWithFsMocks(
+function loadSetupSandboxWorkspaceWithFsMocks(
 	runInSandbox: RunInSandboxMock,
 	readFileViaSandbox: ReadFileViaSandboxMock,
-): Promise<SetupSandboxWorkspace> {
+): SetupSandboxWorkspace {
 	packWorkspaceSdkMockState.isEnabled = false;
 	packWorkspaceSdkMockState.packWorkspaceSdk.mockReset();
-	vi.resetModules();
-	vi.doMock('../sandbox-fs', () => ({
-		runInSandbox,
-		readFileViaSandbox,
-		writeFileViaSandbox: async (workspace: SandboxWorkspace, path: string) => {
-			const result = await runInSandbox(workspace, `write '${path}'`);
-			if (result.exitCode !== 0) {
-				throw new Error(`Failed to write file ${path}: ${result.stderr}`);
-			}
-		},
-		escapeSingleQuotes: (value: string) => value.replace(/'/g, "'\\''"),
-	}));
-
-	const sandboxSetup = (await import('../sandbox-setup')) as {
-		setupSandboxWorkspace: SetupSandboxWorkspace;
-	};
-
-	return sandboxSetup.setupSandboxWorkspace;
+	sandboxFsMockState.runInSandbox = runInSandbox;
+	sandboxFsMockState.readFileViaSandbox = readFileViaSandbox;
+	return setupSandboxWorkspace;
 }
 
 async function loadLinkWorkspaceSdkWithMocks(
@@ -267,7 +281,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -297,7 +311,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -338,7 +352,7 @@ describe('setupSandboxWorkspace', () => {
 			}
 			return null;
 		});
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -382,7 +396,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -417,7 +431,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -448,7 +462,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -478,7 +492,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);
@@ -516,7 +530,7 @@ describe('setupSandboxWorkspace', () => {
 		const readFileViaSandbox: ReadFileViaSandboxMock =
 			vi.fn<(...args: [SandboxWorkspace, string]) => Promise<string | null>>();
 		readFileViaSandbox.mockResolvedValue(null);
-		const setupSandboxWorkspace = await loadSetupSandboxWorkspaceWithFsMocks(
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
 			runInSandbox,
 			readFileViaSandbox,
 		);


### PR DESCRIPTION
## Summary

`packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts` mocked `../sandbox-fs` **per test** via `vi.resetModules()` + `vi.doMock()` + dynamic `import('../sandbox-setup')`. That mutates global vitest module state on every test and **races when many vitest processes run concurrently** — e.g. CI's "Backend Unit Tests" job, which runs every backend package's suite at once. Under that load it occasionally binds the *real* `../sandbox-fs` instead of the mock, so the marker-write fallback tests flake with `expected false to be true` / `promise resolved "true" instead of rejecting`.

It's a long-standing latent flake (the tests date to early May); it only surfaces on PRs that touch `instance-ai`, because master's other commits path-filter the suite out of CI.

**Fix:** replace the per-test dynamic-import pattern with the idiom this file already uses for `pack-workspace-sdk` — a hoisted mutable `sandboxFsMockState` + one **top-level** `vi.mock('../sandbox-fs')` that delegates to it, plus a **static** import of `setupSandboxWorkspace`. Each test swaps behaviour by assigning to the state; there's no `resetModules`/dynamic-import, so the mock binding is established once at load and is stable under concurrency. The `SDK-link` and `PACKAGE_JSON` describes keep their dynamic import (they genuinely need per-test module resets for the `sdkTarballPromise` cache and the env-derived `PACKAGE_JSON` constant).

Test-only change — no production code touched.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm exec vitest run src/workspace/__tests__/sandbox-setup.test.ts   # 18/18
pnpm exec vitest run                                                 # full suite green
```
The real check is CI: the "Backend Unit Tests" job (which previously flaked on `sandbox-setup` under concurrent load) should now stay green across re-runs. Locally verified: 18/18 file, 2495/2495 full suite, lint + typecheck clean. The flake reproduces only under multi-process concurrency (CI), so this PR is the experiment.

## Related Linear tickets, Github issues, and Community forum posts

Surfaced while running instance-ai eval-harness changes through CI; no Linear ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- test-only -->
- [x] Tests included. <!-- this *is* the test change -->
- [ ] PR Labeled with backport (if urgent fix needs backporting)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32982">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->