### PR TITLE
fix: Correct document processing output key guidance (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/document-processing.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/best-practices/guides/document-processing.ts
@@ -174,7 +174,7 @@ Critical: ALWAYS check file type first with an IF or Switch before and select th
 Critical: If the user requests handling of multiple file types (PDF, CSV, JSON, etc) then a Switch (n8n-nodes-base.switch) node should be used
 to check the file type before text extraction. Multiple text extraction nodes should be used to handle each of the different file types. For example,
 if the workflow contains a form trigger node which receives a file, then a Switch node MUST be used to split the different options out to different extraction nodes.
-Output: Extracted text is returned under the "text" key in JSON (e.g., access with {{ $json.text }})
+Output: Extracted text is returned under the "data" key in JSON by default (e.g., access with {{ $json.data }}). Configure destinationKey if you need a different output key.
 Pitfalls:
 - Returns empty for scanned documents - always check and fallback to OCR; Using wrong operation causes errors
 - If connecting to a document upload form (n8n-nodes-base.formTrigger) use a File field type and then connect it to the extract from file node using the field name.

--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts
@@ -90,6 +90,20 @@ describe('get-workflow-best-practices MCP tool', () => {
 		);
 	});
 
+	test('documents the default Extract from File output key for document processing', async () => {
+		const tool = createTool();
+		const result = await tool.handler(
+			{ technique: WorkflowTechnique.DOCUMENT_PROCESSING },
+			{} as never,
+		);
+
+		const documentation = result.structuredContent?.documentation;
+
+		expect(documentation).toContain('access with {{ $json.data }}');
+		expect(documentation).toContain('destinationKey');
+		expect(documentation).not.toContain('access with {{ $json.text }}');
+	});
+
 	test('returns a friendly message for a known technique without documentation', async () => {
 		const tool = createTool();
 		const result = await tool.handler({ technique: WorkflowTechnique.MONITORING }, {} as never);


### PR DESCRIPTION
## Summary

Correct the MCP `document_processing` best-practices guidance for Extract from File output.

The guide now points to the default `data` output key and mentions `destinationKey` for custom keys. This is guidance-only and does not change runtime behavior.

## How to test

- `pnpm run test:win -- src/modules/mcp/__tests__/get-workflow-best-practices.tool.test.ts`
- `pnpm run typecheck` in `packages/@n8n/workflow-sdk`
- `pnpm run lint` in `packages/@n8n/workflow-sdk`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm run lint` in `packages/cli`

Note: `pnpm run typecheck` in `packages/cli` currently fails on unrelated upstream cross-package type errors around Azure binary data, role members, and task-runner shared types.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #32854

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

