### PR TITLE
feat(editor): Show node execution time on canvas

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -121,6 +121,7 @@ export interface CanvasNodeData {
 		waiting?: string;
 		running: boolean;
 		waitingForNext?: boolean;
+		executionTime?: number;
 	};
 	runData: {
 		outputMap?: ExecutionOutputMap;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
@@ -6,6 +6,7 @@ import {
 	createCanvasProvide,
 } from '@/features/workflows/canvas/__tests__/utils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { createTestingPinia } from '@pinia/testing';
 import { fireEvent } from '@testing-library/vue';
 import { NodeConnectionTypes, type IPinData } from 'n8n-workflow';
@@ -13,6 +14,7 @@ import { computed, type ComputedRef } from 'vue';
 import { setActivePinia } from 'pinia';
 import type * as actualVueRouter from 'vue-router';
 import { type RouteLocationNormalizedLoadedGeneric, useRoute } from 'vue-router';
+import type { FrontendSettings, N8nEnvFeatFlags } from '@n8n/api-types';
 import {
 	CanvasConnectionMode,
 	CanvasNodeRenderType,
@@ -66,6 +68,7 @@ const renderComponent = createComponentRenderer(CanvasNodeDefault, {
 });
 
 let nodeTypesStore: MockedStore<typeof useNodeTypesStore>;
+let settingsStore: MockedStore<typeof useSettingsStore>;
 const mockedUseRoute = vi.mocked(useRoute);
 
 beforeEach(() => {
@@ -81,6 +84,8 @@ beforeEach(() => {
 	const pinia = createTestingPinia();
 	setActivePinia(pinia);
 	nodeTypesStore = mockedStore(useNodeTypesStore);
+	settingsStore = mockedStore(useSettingsStore);
+	settingsStore.settings = { envFeatureFlags: {} } as FrontendSettings;
 	mockedUseRoute.mockReturnValue({} as RouteLocationNormalizedLoadedGeneric);
 });
 
@@ -566,6 +571,94 @@ describe('CanvasNodeDefault', () => {
 			await fireEvent.click(getByText('Test Node'));
 
 			expect(emitted()).not.toHaveProperty('replace:node');
+		});
+	});
+
+	describe('execution time display', () => {
+		function enableExecutionTimeFlag() {
+			settingsStore.settings = {
+				envFeatureFlags: {
+					N8N_ENV_FEAT_SHOW_NODE_EXECUTION_TIME: 'true',
+				} as N8nEnvFeatFlags,
+			} as FrontendSettings;
+		}
+
+		it('should display execution time when flag is active, time is defined and node is not running', () => {
+			enableExecutionTimeFlag();
+
+			const { getByTestId } = renderComponent({
+				global: {
+					stubs,
+					provide: {
+						...createCanvasNodeProvide({
+							data: {
+								execution: { running: false, executionTime: 1234 },
+								runData: { outputMap: {}, iterations: 1, visible: true },
+							},
+						}),
+					},
+				},
+			});
+
+			expect(getByTestId('canvas-node-execution-time')).toBeVisible();
+		});
+
+		it('should not display execution time when flag is active but node is running', () => {
+			enableExecutionTimeFlag();
+
+			const { queryByTestId } = renderComponent({
+				global: {
+					stubs,
+					provide: {
+						...createCanvasNodeProvide({
+							data: {
+								execution: { running: true, executionTime: 1234 },
+								runData: { outputMap: {}, iterations: 1, visible: true },
+							},
+						}),
+					},
+				},
+			});
+
+			expect(queryByTestId('canvas-node-execution-time')).toBeNull();
+		});
+
+		it('should not display execution time when flag is inactive', () => {
+			// settingsStore.settings.envFeatureFlags is empty by default in beforeEach
+			const { queryByTestId } = renderComponent({
+				global: {
+					stubs,
+					provide: {
+						...createCanvasNodeProvide({
+							data: {
+								execution: { running: false, executionTime: 1234 },
+								runData: { outputMap: {}, iterations: 1, visible: true },
+							},
+						}),
+					},
+				},
+			});
+
+			expect(queryByTestId('canvas-node-execution-time')).toBeNull();
+		});
+
+		it('should not display execution time when flag is active but executionTime is undefined', () => {
+			enableExecutionTimeFlag();
+
+			const { queryByTestId } = renderComponent({
+				global: {
+					stubs,
+					provide: {
+						...createCanvasNodeProvide({
+							data: {
+								execution: { running: false },
+							},
+						}),
+					},
+				},
+			});
+
+			expect(queryByTestId('canvas-node-execution-time')).toBeNull();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -2,6 +2,7 @@
 import { computed, ref, useCssModule, watch } from 'vue';
 import { useNodeConnections } from '@/app/composables/useNodeConnections';
 import { useI18n } from '@n8n/i18n';
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { useCanvasNode } from '../../../../composables/useCanvasNode';
 import type { CanvasNodeDefaultRender } from '../../../../canvas.types';
 import { injectCanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
@@ -44,10 +45,17 @@ const {
 	executionWaiting,
 	executionWaitingForNext,
 	executionRunning,
+	executionTime,
 	hasRunData,
 	render,
 	isNotInstalledCommunityNode,
 } = useCanvasNode();
+
+const { check } = useEnvFeatureFlag();
+const showNodeExecutionTime = computed(() => check.value('SHOW_NODE_EXECUTION_TIME'));
+const formattedExecutionTime = computed(() =>
+	executionTime.value !== undefined ? i18n.displayTimer(executionTime.value, true) : undefined,
+);
 const renderData = injectCanvasRenderData();
 const inputs = computed(() => renderData.value.nodeInputsByNodeId.get(id.value)?.value ?? []);
 const outputs = computed(() => renderData.value.nodeOutputsByNodeId.get(id.value)?.value ?? []);
@@ -227,6 +235,13 @@ function onActivate(event: MouseEvent) {
 			</div>
 		</div>
 		<CanvasNodeStatusIcons v-if="!isDisabled" :class="$style.statusIcons" />
+		<div
+			v-if="showNodeExecutionTime && formattedExecutionTime && !executionRunning"
+			:class="$style.executionTime"
+			data-test-id="canvas-node-execution-time"
+		>
+			{{ formattedExecutionTime }}
+		</div>
 	</div>
 </template>
 
@@ -437,6 +452,18 @@ function onActivate(event: MouseEvent) {
 	position: absolute;
 	bottom: var(--canvas-node--status-icons--margin);
 	right: var(--canvas-node--status-icons--margin);
+}
+
+.executionTime {
+	position: absolute;
+	bottom: 100%;
+	left: 50%;
+	transform: translateX(-50%);
+	margin-bottom: var(--spacing--2xs);
+	font-size: var(--font-size--xs);
+	color: var(--color--text--tint-1);
+	white-space: nowrap;
+	pointer-events: none;
 }
 
 .icon {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/__snapshots__/CanvasNodeDefault.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/__snapshots__/CanvasNodeDefault.test.ts.snap
@@ -39,6 +39,7 @@ exports[`CanvasNodeDefault > configurable > should render configurable node corr
     </div>
   </div>
   <!--v-if-->
+  <!--v-if-->
 </div>
 `;
 
@@ -73,6 +74,7 @@ exports[`CanvasNodeDefault > configuration > should render configurable configur
     </div>
   </div>
   <!--v-if-->
+  <!--v-if-->
 </div>
 `;
 
@@ -106,6 +108,7 @@ exports[`CanvasNodeDefault > configuration > should render configuration node co
       Test Node Subtitle
     </div>
   </div>
+  <!--v-if-->
   <!--v-if-->
 </div>
 `;
@@ -149,6 +152,7 @@ exports[`CanvasNodeDefault > should render node correctly 1`] = `
     </div>
   </div>
   <!--v-if-->
+  <!--v-if-->
 </div>
 `;
 
@@ -190,6 +194,7 @@ exports[`CanvasNodeDefault > trigger > should render trigger node correctly 1`] 
       Test Node Subtitle
     </div>
   </div>
+  <!--v-if-->
   <!--v-if-->
 </div>
 `;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -162,6 +162,51 @@ describe('useCanvasMapping — mapped nodes', () => {
 		expect(nodes.value[0].data?.execution.waitingForNext).toBe(true);
 	});
 
+	it('maps executionTime from the last runData task', () => {
+		const node = createTestNode({ id: 'a', name: 'Alpha' }) as INodeUi;
+		const rd = createEmptyCanvasRenderData();
+		setRunData(rd, 'a', [
+			{ executionStatus: 'success', executionTime: 500 } as ITaskData,
+			{ executionStatus: 'success', executionTime: 1234 } as ITaskData,
+		]);
+
+		const { nodes } = useCanvasMapping({
+			nodes: ref([node]),
+			connections: ref({}),
+			renderData: shallowRef(rd),
+		});
+
+		// Only the last task's executionTime should be used
+		expect(nodes.value[0].data?.execution.executionTime).toBe(1234);
+	});
+
+	it('sets executionTime to undefined when runData is empty', () => {
+		const node = createTestNode({ id: 'a', name: 'Alpha' }) as INodeUi;
+		const rd = createEmptyCanvasRenderData();
+
+		const { nodes } = useCanvasMapping({
+			nodes: ref([node]),
+			connections: ref({}),
+			renderData: shallowRef(rd),
+		});
+
+		expect(nodes.value[0].data?.execution.executionTime).toBeUndefined();
+	});
+
+	it('sets executionTime to undefined when the last task has no executionTime', () => {
+		const node = createTestNode({ id: 'a', name: 'Alpha' }) as INodeUi;
+		const rd = createEmptyCanvasRenderData();
+		setRunData(rd, 'a', [{ executionStatus: 'success' } as ITaskData]);
+
+		const { nodes } = useCanvasMapping({
+			nodes: ref([node]),
+			connections: ref({}),
+			renderData: shallowRef(rd),
+		});
+
+		expect(nodes.value[0].data?.execution.executionTime).toBeUndefined();
+	});
+
 	it('exposes runData with iterations (excluding canceled) and outputMap', () => {
 		const node = createTestNode({ id: 'a', name: 'Alpha' }) as INodeUi;
 		const rd = createEmptyCanvasRenderData();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -168,6 +168,7 @@ export function useCanvasMapping({
 					waiting: executionSnapshot.waiting,
 					waitingForNext: executionSnapshot.waitingForNext,
 					running: executionSnapshot.running,
+					executionTime: runData?.at(-1)?.executionTime,
 				},
 				runData: {
 					outputMap: rd.executionRunDataOutputMapByNodeId.get(node.id),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
@@ -92,4 +92,72 @@ describe('useCanvasNode', () => {
 		expect(result.executionRunning.value).toBe(true);
 		expect(result.render.value).toBe(node.data.value.render);
 	});
+
+	it('should expose executionTime as undefined when not set in execution data', () => {
+		const node = {
+			data: ref({
+				id: 'node1',
+				name: 'Node 1',
+				subtitle: '',
+				type: 'nodeType1',
+				typeVersion: 1,
+				disabled: false,
+				connections: {
+					[CanvasConnectionMode.Input]: {},
+					[CanvasConnectionMode.Output]: {},
+				},
+				issues: { validation: [], visible: false },
+				execution: { running: false },
+				runData: { outputMap: {}, iterations: 0, visible: false },
+				render: { type: CanvasNodeRenderType.Default, options: {} },
+			} satisfies CanvasNodeData),
+			id: ref('1'),
+			label: ref('Node 1'),
+			selected: ref(false),
+		} satisfies Partial<CanvasNodeInjectionData>;
+
+		vi.mocked(inject).mockReturnValue(node);
+
+		const result = useCanvasNode();
+
+		expect(result.executionTime.value).toBeUndefined();
+	});
+
+	it('should expose executionTime from execution data when set', () => {
+		const node = {
+			data: ref({
+				id: 'node1',
+				name: 'Node 1',
+				subtitle: '',
+				type: 'nodeType1',
+				typeVersion: 1,
+				disabled: false,
+				connections: {
+					[CanvasConnectionMode.Input]: {},
+					[CanvasConnectionMode.Output]: {},
+				},
+				issues: { validation: [], visible: false },
+				execution: { running: false, executionTime: 1234 },
+				runData: { outputMap: {}, iterations: 1, visible: true },
+				render: { type: CanvasNodeRenderType.Default, options: {} },
+			} satisfies CanvasNodeData),
+			id: ref('1'),
+			label: ref('Node 1'),
+			selected: ref(false),
+		} satisfies Partial<CanvasNodeInjectionData>;
+
+		vi.mocked(inject).mockReturnValue(node);
+
+		const result = useCanvasNode();
+
+		expect(result.executionTime.value).toBe(1234);
+	});
+
+	it('should return undefined executionTime when node is not provided', () => {
+		vi.mocked(inject).mockReturnValue(undefined);
+
+		const result = useCanvasNode();
+
+		expect(result.executionTime.value).toBeUndefined();
+	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
@@ -49,6 +49,7 @@ export function useCanvasNode() {
 	const executionWaiting = computed(() => data.value.execution.waiting);
 	const executionWaitingForNext = computed(() => data.value.execution.waitingForNext);
 	const executionRunning = computed(() => data.value.execution.running);
+	const executionTime = computed(() => data.value.execution.executionTime);
 
 	const runDataOutputMap = computed(() => data.value.runData.outputMap);
 	const runDataIterations = computed(() => data.value.runData.iterations);
@@ -86,6 +87,7 @@ export function useCanvasNode() {
 		executionWaiting,
 		executionWaitingForNext,
 		executionRunning,
+		executionTime,
 		render,
 		eventBus,
 		isNotInstalledCommunityNode,


### PR DESCRIPTION
## Summary

Adds a small execution time indicator displayed above each canvas node after it finishes running.

The feature is gated behind the `N8N_ENV_FEAT_SHOW_NODE_EXECUTION_TIME` environment feature flag, so it has zero impact on existing users by default.

**How it works:**
- The last run's `executionTime` is read from `runData` in `useCanvasMapping` and passed through `CanvasNodeData.execution`
- `useCanvasNode` exposes it as a reactive computed
- `CanvasNodeDefault.vue` formats it via `i18n.displayTimer` and renders it above the node when the flag is active, a time is available, and the node is not currently running
<img width="1078" height="268" alt="image" src="https://github.com/user-attachments/assets/02643e25-06d7-4c11-a96c-6595dddd32fb" />


## How to test

1. Start the backend with the feature flag enabled:
   ```bash
   N8N_ENV_FEAT_SHOW_NODE_EXECUTION_TIME=true pnpm dev
   ```
2. Open any workflow in the editor and execute it
3. After execution completes, each node should display its elapsed time (e.g. `142 ms`) above it
4. Verify the indicator is **not** shown while the node is actively running
5. Verify the indicator is **not** shown when the flag is absent or set to `false`

> **Note:** This feature requires the `N8N_ENV_FEAT_SHOW_NODE_EXECUTION_TIME=true` env var on the backend. Without it, nothing changes for existing users.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL if applicable: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.

---

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

