### PR TITLE
fix(WooCommerce Node): Validate resource ID and isolate query params per item

### DIFF
--- a/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
@@ -7,6 +7,7 @@ import {
 	type INodeType,
 	type INodeTypeDescription,
 	NodeConnectionTypes,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 import { customerFields, customerOperations } from './descriptions';
@@ -29,6 +30,19 @@ import type {
 } from './OrderInterface';
 import { productFields, productOperations } from './ProductDescription';
 import type { IDimension, IImage, IProduct } from './ProductInterface';
+
+function assertResourceId(
+	context: IExecuteFunctions,
+	id: unknown,
+	displayName: string,
+	itemIndex: number,
+): void {
+	if (id === undefined || id === null || String(id).trim() === '') {
+		throw new NodeOperationError(context.getNode(), `${displayName} must not be empty`, {
+			itemIndex,
+		});
+	}
+}
 
 export class WooCommerce implements INodeType {
 	description: INodeTypeDescription = {
@@ -127,463 +141,496 @@ export class WooCommerce implements INodeType {
 		const returnData: INodeExecutionData[] = [];
 		const length = items.length;
 		let responseData;
-		const qs: IDataObject = {};
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
 
 		for (let i = 0; i < length; i++) {
-			if (resource === 'customer') {
-				// **********************************************************************
-				//                                customer
-				// **********************************************************************
+			const qs: IDataObject = {};
+			try {
+				if (resource === 'customer') {
+					// **********************************************************************
+					//                                customer
+					// **********************************************************************
 
-				// https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#customer-properties
+					// https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#customer-properties
 
-				if (operation === 'create') {
-					// ----------------------------------------
-					//             customer: create
-					// ----------------------------------------
+					if (operation === 'create') {
+						// ----------------------------------------
+						//             customer: create
+						// ----------------------------------------
 
-					// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#create-a-customer
+						// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#create-a-customer
 
-					const body = {
-						email: this.getNodeParameter('email', i),
-					} as IDataObject;
+						const body = {
+							email: this.getNodeParameter('email', i),
+						} as IDataObject;
 
-					const additionalFields = this.getNodeParameter('additionalFields', i);
+						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-					if (Object.keys(additionalFields).length) {
-						Object.assign(body, adjustMetadata(additionalFields));
+						if (Object.keys(additionalFields).length) {
+							Object.assign(body, adjustMetadata(additionalFields));
+						}
+
+						responseData = await woocommerceApiRequest.call(this, 'POST', '/customers', body);
+					} else if (operation === 'delete') {
+						// ----------------------------------------
+						//             customer: delete
+						// ----------------------------------------
+
+						// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#delete-a-customer
+
+						const customerId = this.getNodeParameter('customerId', i);
+						assertResourceId(this, customerId, 'Customer ID', i);
+
+						qs.force = true; // required, customers do not support trashing
+
+						const endpoint = `/customers/${customerId}`;
+						responseData = await woocommerceApiRequest.call(this, 'DELETE', endpoint, {}, qs);
+					} else if (operation === 'get') {
+						// ----------------------------------------
+						//              customer: get
+						// ----------------------------------------
+
+						// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#retrieve-a-customer
+
+						const customerId = this.getNodeParameter('customerId', i);
+						assertResourceId(this, customerId, 'Customer ID', i);
+
+						const endpoint = `/customers/${customerId}`;
+						responseData = await woocommerceApiRequest.call(this, 'GET', endpoint);
+					} else if (operation === 'getAll') {
+						// ----------------------------------------
+						//             customer: getAll
+						// ----------------------------------------
+
+						// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#list-all-customers
+
+						const filters = this.getNodeParameter('filters', i);
+						const returnAll = this.getNodeParameter('returnAll', i);
+
+						if (Object.keys(filters).length) {
+							Object.assign(qs, filters);
+						}
+
+						if (returnAll) {
+							responseData = await woocommerceApiRequestAllItems.call(
+								this,
+								'GET',
+								'/customers',
+								{},
+								{},
+							);
+						} else {
+							qs.per_page = this.getNodeParameter('limit', i);
+							responseData = await woocommerceApiRequest.call(this, 'GET', '/customers', {}, qs);
+						}
+					} else if (operation === 'update') {
+						// ----------------------------------------
+						//             customer: update
+						// ----------------------------------------
+
+						// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#update-a-customer
+
+						const body = {} as IDataObject;
+						const updateFields = this.getNodeParameter('updateFields', i);
+
+						if (Object.keys(updateFields).length) {
+							Object.assign(body, adjustMetadata(updateFields));
+						}
+
+						const customerId = this.getNodeParameter('customerId', i);
+						assertResourceId(this, customerId, 'Customer ID', i);
+
+						const endpoint = `/customers/${customerId}`;
+						responseData = await woocommerceApiRequest.call(this, 'PUT', endpoint, body);
 					}
+				} else if (resource === 'product') {
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product
+					if (operation === 'create') {
+						const name = this.getNodeParameter('name', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const body: IProduct = {
+							name,
+						};
 
-					responseData = await woocommerceApiRequest.call(this, 'POST', '/customers', body);
-				} else if (operation === 'delete') {
-					// ----------------------------------------
-					//             customer: delete
-					// ----------------------------------------
+						setFields(additionalFields, body);
 
-					// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#delete-a-customer
+						if (additionalFields.categories) {
+							body.categories = (additionalFields.categories as string[]).map((category) => ({
+								id: parseInt(category, 10),
+							})) as unknown as IDataObject[];
+						}
 
-					const customerId = this.getNodeParameter('customerId', i);
-
-					qs.force = true; // required, customers do not support trashing
-
-					const endpoint = `/customers/${customerId}`;
-					responseData = await woocommerceApiRequest.call(this, 'DELETE', endpoint, {}, qs);
-				} else if (operation === 'get') {
-					// ----------------------------------------
-					//              customer: get
-					// ----------------------------------------
-
-					// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#retrieve-a-customer
-
-					const customerId = this.getNodeParameter('customerId', i);
-
-					const endpoint = `/customers/${customerId}`;
-					responseData = await woocommerceApiRequest.call(this, 'GET', endpoint);
-				} else if (operation === 'getAll') {
-					// ----------------------------------------
-					//             customer: getAll
-					// ----------------------------------------
-
-					// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#list-all-customers
-
-					const filters = this.getNodeParameter('filters', i);
-					const returnAll = this.getNodeParameter('returnAll', i);
-
-					if (Object.keys(filters).length) {
-						Object.assign(qs, filters);
+						const images = (this.getNodeParameter('imagesUi', i) as IDataObject)
+							.imagesValues as IImage[];
+						if (images) {
+							body.images = images;
+						}
+						const dimension = (this.getNodeParameter('dimensionsUi', i) as IDataObject)
+							.dimensionsValues as IDimension;
+						if (dimension) {
+							body.dimensions = dimension;
+						}
+						const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
+							.metadataValues as IDataObject[];
+						if (metadata) {
+							body.meta_data = metadata;
+						}
+						responseData = await woocommerceApiRequest.call(this, 'POST', '/products', body);
 					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#update-a-product
+					if (operation === 'update') {
+						const productId = this.getNodeParameter('productId', i) as string;
+						assertResourceId(this, productId, 'Product ID', i);
+						const updateFields = this.getNodeParameter('updateFields', i);
+						const body: IProduct = {};
 
-					if (returnAll) {
-						responseData = await woocommerceApiRequestAllItems.call(
+						setFields(updateFields, body);
+
+						const images = (this.getNodeParameter('imagesUi', i) as IDataObject)
+							.imagesValues as IImage[];
+						if (images) {
+							body.images = images;
+						}
+						const dimension = (this.getNodeParameter('dimensionsUi', i) as IDataObject)
+							.dimensionsValues as IDimension;
+						if (dimension) {
+							body.dimensions = dimension;
+						}
+						const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
+							.metadataValues as IDataObject[];
+						if (metadata) {
+							body.meta_data = metadata;
+						}
+						responseData = await woocommerceApiRequest.call(
 							this,
-							'GET',
-							'/customers',
-							{},
-							{},
+							'PUT',
+							`/products/${productId}`,
+							body,
 						);
-					} else {
-						qs.per_page = this.getNodeParameter('limit', i);
-						responseData = await woocommerceApiRequest.call(this, 'GET', '/customers', {}, qs);
 					}
-				} else if (operation === 'update') {
-					// ----------------------------------------
-					//             customer: update
-					// ----------------------------------------
-
-					// https://woocommerce.github.io/woocommerce-rest-api-docs/?javascript#update-a-customer
-
-					const body = {} as IDataObject;
-					const updateFields = this.getNodeParameter('updateFields', i);
-
-					if (Object.keys(updateFields).length) {
-						Object.assign(body, adjustMetadata(updateFields));
-					}
-
-					const customerId = this.getNodeParameter('customerId', i);
-
-					const endpoint = `/customers/${customerId}`;
-					responseData = await woocommerceApiRequest.call(this, 'PUT', endpoint, body);
-				}
-			} else if (resource === 'product') {
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-product
-				if (operation === 'create') {
-					const name = this.getNodeParameter('name', i) as string;
-					const additionalFields = this.getNodeParameter('additionalFields', i);
-					const body: IProduct = {
-						name,
-					};
-
-					setFields(additionalFields, body);
-
-					if (additionalFields.categories) {
-						body.categories = (additionalFields.categories as string[]).map((category) => ({
-							id: parseInt(category, 10),
-						})) as unknown as IDataObject[];
-					}
-
-					const images = (this.getNodeParameter('imagesUi', i) as IDataObject)
-						.imagesValues as IImage[];
-					if (images) {
-						body.images = images;
-					}
-					const dimension = (this.getNodeParameter('dimensionsUi', i) as IDataObject)
-						.dimensionsValues as IDimension;
-					if (dimension) {
-						body.dimensions = dimension;
-					}
-					const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
-						.metadataValues as IDataObject[];
-					if (metadata) {
-						body.meta_data = metadata;
-					}
-					responseData = await woocommerceApiRequest.call(this, 'POST', '/products', body);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#update-a-product
-				if (operation === 'update') {
-					const productId = this.getNodeParameter('productId', i) as string;
-					const updateFields = this.getNodeParameter('updateFields', i);
-					const body: IProduct = {};
-
-					setFields(updateFields, body);
-
-					const images = (this.getNodeParameter('imagesUi', i) as IDataObject)
-						.imagesValues as IImage[];
-					if (images) {
-						body.images = images;
-					}
-					const dimension = (this.getNodeParameter('dimensionsUi', i) as IDataObject)
-						.dimensionsValues as IDimension;
-					if (dimension) {
-						body.dimensions = dimension;
-					}
-					const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
-						.metadataValues as IDataObject[];
-					if (metadata) {
-						body.meta_data = metadata;
-					}
-					responseData = await woocommerceApiRequest.call(
-						this,
-						'PUT',
-						`/products/${productId}`,
-						body,
-					);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-a-product
-				if (operation === 'get') {
-					const productId = this.getNodeParameter('productId', i) as string;
-					responseData = await woocommerceApiRequest.call(
-						this,
-						'GET',
-						`/products/${productId}`,
-						{},
-						qs,
-					);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products
-				if (operation === 'getAll') {
-					const returnAll = this.getNodeParameter('returnAll', i);
-					const options = this.getNodeParameter('options', i);
-					if (options.after) {
-						qs.after = options.after as string;
-					}
-					if (options.before) {
-						qs.before = options.before as string;
-					}
-					if (options.category) {
-						qs.category = options.category as string;
-					}
-					if (options.context) {
-						qs.context = options.context as string;
-					}
-					if (options.featured) {
-						qs.featured = options.featured as boolean;
-					}
-					if (options.maxPrice) {
-						qs.max_price = options.maxPrice as string;
-					}
-					if (options.minPrice) {
-						qs.max_price = options.minPrice as string;
-					}
-					if (options.order) {
-						qs.order = options.order as string;
-					}
-					if (options.orderBy) {
-						qs.orderby = options.orderBy as string;
-					}
-					if (options.search) {
-						qs.search = options.search as string;
-					}
-					if (options.sku) {
-						qs.sku = options.sku as string;
-					}
-					if (options.slug) {
-						qs.slug = options.slug as string;
-					}
-					if (options.status) {
-						qs.status = options.status as string;
-					}
-					if (options.stockStatus) {
-						qs.stock_status = options.stockStatus as string;
-					}
-					if (options.tag) {
-						qs.tag = options.tag as string;
-					}
-					if (options.taxClass) {
-						qs.tax_class = options.taxClass as string;
-					}
-					if (options.type) {
-						qs.type = options.type as string;
-					}
-					if (returnAll) {
-						responseData = await woocommerceApiRequestAllItems.call(
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-a-product
+					if (operation === 'get') {
+						const productId = this.getNodeParameter('productId', i) as string;
+						assertResourceId(this, productId, 'Product ID', i);
+						responseData = await woocommerceApiRequest.call(
 							this,
 							'GET',
-							'/products',
+							`/products/${productId}`,
 							{},
 							qs,
 						);
-					} else {
-						qs.per_page = this.getNodeParameter('limit', i);
-						responseData = await woocommerceApiRequest.call(this, 'GET', '/products', {}, qs);
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-products
+					if (operation === 'getAll') {
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i);
+						if (options.after) {
+							qs.after = options.after as string;
+						}
+						if (options.before) {
+							qs.before = options.before as string;
+						}
+						if (options.category) {
+							qs.category = options.category as string;
+						}
+						if (options.context) {
+							qs.context = options.context as string;
+						}
+						if (options.featured) {
+							qs.featured = options.featured as boolean;
+						}
+						if (options.maxPrice) {
+							qs.max_price = options.maxPrice as string;
+						}
+						if (options.minPrice) {
+							qs.max_price = options.minPrice as string;
+						}
+						if (options.order) {
+							qs.order = options.order as string;
+						}
+						if (options.orderBy) {
+							qs.orderby = options.orderBy as string;
+						}
+						if (options.search) {
+							qs.search = options.search as string;
+						}
+						if (options.sku) {
+							qs.sku = options.sku as string;
+						}
+						if (options.slug) {
+							qs.slug = options.slug as string;
+						}
+						if (options.status) {
+							qs.status = options.status as string;
+						}
+						if (options.stockStatus) {
+							qs.stock_status = options.stockStatus as string;
+						}
+						if (options.tag) {
+							qs.tag = options.tag as string;
+						}
+						if (options.taxClass) {
+							qs.tax_class = options.taxClass as string;
+						}
+						if (options.type) {
+							qs.type = options.type as string;
+						}
+						if (returnAll) {
+							responseData = await woocommerceApiRequestAllItems.call(
+								this,
+								'GET',
+								'/products',
+								{},
+								qs,
+							);
+						} else {
+							qs.per_page = this.getNodeParameter('limit', i);
+							responseData = await woocommerceApiRequest.call(this, 'GET', '/products', {}, qs);
+						}
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-a-product
+					if (operation === 'delete') {
+						const productId = this.getNodeParameter('productId', i) as string;
+						assertResourceId(this, productId, 'Product ID', i);
+						responseData = await woocommerceApiRequest.call(
+							this,
+							'DELETE',
+							`/products/${productId}`,
+							{},
+							{ force: true },
+						);
 					}
 				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-a-product
-				if (operation === 'delete') {
-					const productId = this.getNodeParameter('productId', i) as string;
-					responseData = await woocommerceApiRequest.call(
-						this,
-						'DELETE',
-						`/products/${productId}`,
-						{},
-						{ force: true },
-					);
+				if (resource === 'order') {
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#create-an-order
+					if (operation === 'create') {
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const body: IOrder = {};
+
+						setFields(additionalFields, body);
+
+						const billing = (this.getNodeParameter('billingUi', i) as IDataObject)
+							.billingValues as IAddress;
+						if (billing !== undefined) {
+							body.billing = billing;
+							toSnakeCase(billing as IDataObject);
+						}
+						const shipping = (this.getNodeParameter('shippingUi', i) as IDataObject)
+							.shippingValues as IAddress;
+						if (shipping !== undefined) {
+							body.shipping = shipping;
+							toSnakeCase(shipping as IDataObject);
+						}
+						const couponLines = (this.getNodeParameter('couponLinesUi', i) as IDataObject)
+							.couponLinesValues as ICouponLine[];
+						if (couponLines) {
+							body.coupon_lines = couponLines;
+							setMetadata(couponLines);
+							toSnakeCase(couponLines);
+						}
+						const feeLines = (this.getNodeParameter('feeLinesUi', i) as IDataObject)
+							.feeLinesValues as IFeeLine[];
+						if (feeLines) {
+							body.fee_lines = feeLines;
+							setMetadata(feeLines);
+							toSnakeCase(feeLines);
+						}
+						const lineItems = (this.getNodeParameter('lineItemsUi', i) as IDataObject)
+							.lineItemsValues as ILineItem[];
+						if (lineItems) {
+							body.line_items = lineItems;
+							setMetadata(lineItems);
+							toSnakeCase(lineItems);
+						}
+						const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
+							.metadataValues as IDataObject[];
+						if (metadata) {
+							body.meta_data = metadata;
+						}
+						const shippingLines = (this.getNodeParameter('shippingLinesUi', i) as IDataObject)
+							.shippingLinesValues as IShoppingLine[];
+						if (shippingLines) {
+							body.shipping_lines = shippingLines;
+							setMetadata(shippingLines);
+							toSnakeCase(shippingLines);
+						}
+						responseData = await woocommerceApiRequest.call(this, 'POST', '/orders', body);
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#update-an-order
+					if (operation === 'update') {
+						const orderId = this.getNodeParameter('orderId', i) as string;
+						assertResourceId(this, orderId, 'Order ID', i);
+						const updateFields = this.getNodeParameter('updateFields', i);
+						const body: IOrder = {};
+
+						if (updateFields.currency) {
+							body.currency = updateFields.currency as string;
+						}
+						if (updateFields.customerId) {
+							body.customer_id = parseInt(updateFields.customerId as string, 10);
+						}
+						if (updateFields.customerNote) {
+							body.customer_note = updateFields.customerNote as string;
+						}
+						if (updateFields.parentId) {
+							body.parent_id = parseInt(updateFields.parentId as string, 10);
+						}
+						if (updateFields.paymentMethodId) {
+							body.payment_method = updateFields.paymentMethodId as string;
+						}
+						if (updateFields.paymentMethodTitle) {
+							body.payment_method_title = updateFields.paymentMethodTitle as string;
+						}
+
+						if (updateFields.status) {
+							body.status = updateFields.status as string;
+						}
+						if (updateFields.transactionID) {
+							body.transaction_id = updateFields.transactionID as string;
+						}
+						const billing = (this.getNodeParameter('billingUi', i) as IDataObject)
+							.billingValues as IAddress;
+						if (billing !== undefined) {
+							body.billing = billing;
+							toSnakeCase(billing as IDataObject);
+						}
+						const shipping = (this.getNodeParameter('shippingUi', i) as IDataObject)
+							.shippingValues as IAddress;
+						if (shipping !== undefined) {
+							body.shipping = shipping;
+							toSnakeCase(shipping as IDataObject);
+						}
+						const couponLines = (this.getNodeParameter('couponLinesUi', i) as IDataObject)
+							.couponLinesValues as ICouponLine[];
+						if (couponLines) {
+							body.coupon_lines = couponLines;
+							setMetadata(couponLines);
+							toSnakeCase(couponLines);
+						}
+						const feeLines = (this.getNodeParameter('feeLinesUi', i) as IDataObject)
+							.feeLinesValues as IFeeLine[];
+						if (feeLines) {
+							body.fee_lines = feeLines;
+							setMetadata(feeLines);
+							toSnakeCase(feeLines);
+						}
+						const lineItems = (this.getNodeParameter('lineItemsUi', i) as IDataObject)
+							.lineItemsValues as ILineItem[];
+						if (lineItems) {
+							body.line_items = lineItems;
+							setMetadata(lineItems);
+							toSnakeCase(lineItems);
+						}
+						const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
+							.metadataValues as IDataObject[];
+						if (metadata) {
+							body.meta_data = metadata;
+						}
+						const shippingLines = (this.getNodeParameter('shippingLinesUi', i) as IDataObject)
+							.shippingLinesValues as IShoppingLine[];
+						if (shippingLines) {
+							body.shipping_lines = shippingLines;
+							setMetadata(shippingLines);
+							toSnakeCase(shippingLines);
+						}
+
+						responseData = await woocommerceApiRequest.call(
+							this,
+							'PUT',
+							`/orders/${orderId}`,
+							body,
+						);
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-an-order
+					if (operation === 'get') {
+						const orderId = this.getNodeParameter('orderId', i) as string;
+						assertResourceId(this, orderId, 'Order ID', i);
+						responseData = await woocommerceApiRequest.call(
+							this,
+							'GET',
+							`/orders/${orderId}`,
+							{},
+							qs,
+						);
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-orders
+					if (operation === 'getAll') {
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i);
+						if (options.after) {
+							qs.after = options.after as string;
+						}
+						if (options.before) {
+							qs.before = options.before as string;
+						}
+						if (options.category) {
+							qs.category = options.category as string;
+						}
+						if (options.customer) {
+							qs.customer = parseInt(options.customer as string, 10);
+						}
+						if (options.decimalPoints) {
+							qs.dp = options.decimalPoints as number;
+						}
+						if (options.product) {
+							qs.product = parseInt(options.product as string, 10);
+						}
+						if (options.order) {
+							qs.order = options.order as string;
+						}
+						if (options.orderBy) {
+							qs.orderby = options.orderBy as string;
+						}
+						if (options.search) {
+							qs.search = options.search as string;
+						}
+						if (options.status) {
+							qs.status = options.status as string;
+						}
+						if (returnAll) {
+							responseData = await woocommerceApiRequestAllItems.call(
+								this,
+								'GET',
+								'/orders',
+								{},
+								qs,
+							);
+						} else {
+							qs.per_page = this.getNodeParameter('limit', i);
+							responseData = await woocommerceApiRequest.call(this, 'GET', '/orders', {}, qs);
+						}
+					}
+					//https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-an-order
+					if (operation === 'delete') {
+						const orderId = this.getNodeParameter('orderId', i) as string;
+						assertResourceId(this, orderId, 'Order ID', i);
+						responseData = await woocommerceApiRequest.call(
+							this,
+							'DELETE',
+							`/orders/${orderId}`,
+							{},
+							{ force: true },
+						);
+					}
 				}
+				const executionData = this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					{ itemData: { item: i } },
+				);
+				returnData.push(...executionData);
+			} catch (error) {
+				if (this.continueOnFail()) {
+					returnData.push(
+						...this.helpers.constructExecutionMetaData(
+							this.helpers.returnJsonArray({ error: (error as Error).message }),
+							{ itemData: { item: i } },
+						),
+					);
+					continue;
+				}
+				throw error;
 			}
-			if (resource === 'order') {
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#create-an-order
-				if (operation === 'create') {
-					const additionalFields = this.getNodeParameter('additionalFields', i);
-					const body: IOrder = {};
-
-					setFields(additionalFields, body);
-
-					const billing = (this.getNodeParameter('billingUi', i) as IDataObject)
-						.billingValues as IAddress;
-					if (billing !== undefined) {
-						body.billing = billing;
-						toSnakeCase(billing as IDataObject);
-					}
-					const shipping = (this.getNodeParameter('shippingUi', i) as IDataObject)
-						.shippingValues as IAddress;
-					if (shipping !== undefined) {
-						body.shipping = shipping;
-						toSnakeCase(shipping as IDataObject);
-					}
-					const couponLines = (this.getNodeParameter('couponLinesUi', i) as IDataObject)
-						.couponLinesValues as ICouponLine[];
-					if (couponLines) {
-						body.coupon_lines = couponLines;
-						setMetadata(couponLines);
-						toSnakeCase(couponLines);
-					}
-					const feeLines = (this.getNodeParameter('feeLinesUi', i) as IDataObject)
-						.feeLinesValues as IFeeLine[];
-					if (feeLines) {
-						body.fee_lines = feeLines;
-						setMetadata(feeLines);
-						toSnakeCase(feeLines);
-					}
-					const lineItems = (this.getNodeParameter('lineItemsUi', i) as IDataObject)
-						.lineItemsValues as ILineItem[];
-					if (lineItems) {
-						body.line_items = lineItems;
-						setMetadata(lineItems);
-						toSnakeCase(lineItems);
-					}
-					const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
-						.metadataValues as IDataObject[];
-					if (metadata) {
-						body.meta_data = metadata;
-					}
-					const shippingLines = (this.getNodeParameter('shippingLinesUi', i) as IDataObject)
-						.shippingLinesValues as IShoppingLine[];
-					if (shippingLines) {
-						body.shipping_lines = shippingLines;
-						setMetadata(shippingLines);
-						toSnakeCase(shippingLines);
-					}
-					responseData = await woocommerceApiRequest.call(this, 'POST', '/orders', body);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#update-an-order
-				if (operation === 'update') {
-					const orderId = this.getNodeParameter('orderId', i) as string;
-					const updateFields = this.getNodeParameter('updateFields', i);
-					const body: IOrder = {};
-
-					if (updateFields.currency) {
-						body.currency = updateFields.currency as string;
-					}
-					if (updateFields.customerId) {
-						body.customer_id = parseInt(updateFields.customerId as string, 10);
-					}
-					if (updateFields.customerNote) {
-						body.customer_note = updateFields.customerNote as string;
-					}
-					if (updateFields.parentId) {
-						body.parent_id = parseInt(updateFields.parentId as string, 10);
-					}
-					if (updateFields.paymentMethodId) {
-						body.payment_method = updateFields.paymentMethodId as string;
-					}
-					if (updateFields.paymentMethodTitle) {
-						body.payment_method_title = updateFields.paymentMethodTitle as string;
-					}
-
-					if (updateFields.status) {
-						body.status = updateFields.status as string;
-					}
-					if (updateFields.transactionID) {
-						body.transaction_id = updateFields.transactionID as string;
-					}
-					const billing = (this.getNodeParameter('billingUi', i) as IDataObject)
-						.billingValues as IAddress;
-					if (billing !== undefined) {
-						body.billing = billing;
-						toSnakeCase(billing as IDataObject);
-					}
-					const shipping = (this.getNodeParameter('shippingUi', i) as IDataObject)
-						.shippingValues as IAddress;
-					if (shipping !== undefined) {
-						body.shipping = shipping;
-						toSnakeCase(shipping as IDataObject);
-					}
-					const couponLines = (this.getNodeParameter('couponLinesUi', i) as IDataObject)
-						.couponLinesValues as ICouponLine[];
-					if (couponLines) {
-						body.coupon_lines = couponLines;
-						setMetadata(couponLines);
-						toSnakeCase(couponLines);
-					}
-					const feeLines = (this.getNodeParameter('feeLinesUi', i) as IDataObject)
-						.feeLinesValues as IFeeLine[];
-					if (feeLines) {
-						body.fee_lines = feeLines;
-						setMetadata(feeLines);
-						toSnakeCase(feeLines);
-					}
-					const lineItems = (this.getNodeParameter('lineItemsUi', i) as IDataObject)
-						.lineItemsValues as ILineItem[];
-					if (lineItems) {
-						body.line_items = lineItems;
-						setMetadata(lineItems);
-						toSnakeCase(lineItems);
-					}
-					const metadata = (this.getNodeParameter('metadataUi', i) as IDataObject)
-						.metadataValues as IDataObject[];
-					if (metadata) {
-						body.meta_data = metadata;
-					}
-					const shippingLines = (this.getNodeParameter('shippingLinesUi', i) as IDataObject)
-						.shippingLinesValues as IShoppingLine[];
-					if (shippingLines) {
-						body.shipping_lines = shippingLines;
-						setMetadata(shippingLines);
-						toSnakeCase(shippingLines);
-					}
-
-					responseData = await woocommerceApiRequest.call(this, 'PUT', `/orders/${orderId}`, body);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#retrieve-an-order
-				if (operation === 'get') {
-					const orderId = this.getNodeParameter('orderId', i) as string;
-					responseData = await woocommerceApiRequest.call(
-						this,
-						'GET',
-						`/orders/${orderId}`,
-						{},
-						qs,
-					);
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-orders
-				if (operation === 'getAll') {
-					const returnAll = this.getNodeParameter('returnAll', i);
-					const options = this.getNodeParameter('options', i);
-					if (options.after) {
-						qs.after = options.after as string;
-					}
-					if (options.before) {
-						qs.before = options.before as string;
-					}
-					if (options.category) {
-						qs.category = options.category as string;
-					}
-					if (options.customer) {
-						qs.customer = parseInt(options.customer as string, 10);
-					}
-					if (options.decimalPoints) {
-						qs.dp = options.decimalPoints as number;
-					}
-					if (options.product) {
-						qs.product = parseInt(options.product as string, 10);
-					}
-					if (options.order) {
-						qs.order = options.order as string;
-					}
-					if (options.orderBy) {
-						qs.orderby = options.orderBy as string;
-					}
-					if (options.search) {
-						qs.search = options.search as string;
-					}
-					if (options.status) {
-						qs.status = options.status as string;
-					}
-					if (returnAll) {
-						responseData = await woocommerceApiRequestAllItems.call(this, 'GET', '/orders', {}, qs);
-					} else {
-						qs.per_page = this.getNodeParameter('limit', i);
-						responseData = await woocommerceApiRequest.call(this, 'GET', '/orders', {}, qs);
-					}
-				}
-				//https://woocommerce.github.io/woocommerce-rest-api-docs/#delete-an-order
-				if (operation === 'delete') {
-					const orderId = this.getNodeParameter('orderId', i) as string;
-					responseData = await woocommerceApiRequest.call(
-						this,
-						'DELETE',
-						`/orders/${orderId}`,
-						{},
-						{ force: true },
-					);
-				}
-			}
-			const executionData = this.helpers.constructExecutionMetaData(
-				this.helpers.returnJsonArray(responseData as IDataObject[]),
-				{ itemData: { item: i } },
-			);
-			returnData.push(...executionData);
 		}
 		return [returnData];
 	}

--- a/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
+++ b/packages/nodes-base/nodes/WooCommerce/WooCommerce.node.ts
@@ -344,7 +344,7 @@ export class WooCommerce implements INodeType {
 							qs.max_price = options.maxPrice as string;
 						}
 						if (options.minPrice) {
-							qs.max_price = options.minPrice as string;
+							qs.min_price = options.minPrice as string;
 						}
 						if (options.order) {
 							qs.order = options.order as string;

--- a/packages/nodes-base/nodes/WooCommerce/__tests__/WooCommerce.node.test.ts
+++ b/packages/nodes-base/nodes/WooCommerce/__tests__/WooCommerce.node.test.ts
@@ -1,0 +1,161 @@
+import { NodeOperationError } from 'n8n-workflow';
+import type { IDataObject } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+
+import * as GenericFunctions from '../GenericFunctions';
+import type * as _importType0 from '../GenericFunctions';
+import { WooCommerce } from '../WooCommerce.node';
+
+vi.mock('../GenericFunctions', async () => ({
+	...(await vi.importActual<typeof _importType0>('../GenericFunctions')),
+	woocommerceApiRequest: vi.fn(),
+	woocommerceApiRequestAllItems: vi.fn(),
+}));
+
+const woocommerceApiRequestMock = GenericFunctions.woocommerceApiRequest as Mock;
+
+type ParamMap = Record<string, unknown>;
+
+/** Builds a mocked IExecuteFunctions for the given resource/operation and per-item params. */
+function createMockExecuteFunctions(resource: string, operation: string, items: ParamMap[]) {
+	return {
+		getInputData: vi.fn().mockReturnValue(items.map((json) => ({ json }))),
+		getNodeParameter: vi
+			.fn()
+			.mockImplementation((name: string, itemIndex: number, fallback?: unknown) => {
+				if (name === 'resource') return resource;
+				if (name === 'operation') return operation;
+				const value = items[itemIndex]?.[name];
+				return value === undefined ? fallback : value;
+			}),
+		getNode: vi.fn().mockReturnValue({ name: 'WooCommerce' }),
+		continueOnFail: vi.fn().mockReturnValue(false),
+		helpers: {
+			returnJsonArray: vi
+				.fn()
+				.mockImplementation((data: IDataObject | IDataObject[]) =>
+					(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+				),
+			constructExecutionMetaData: vi.fn().mockImplementation((data: unknown[]) => data),
+		},
+	} as any;
+}
+
+describe('WooCommerce Node', () => {
+	beforeEach(() => {
+		woocommerceApiRequestMock.mockReset();
+	});
+
+	describe('Order: Get operation', () => {
+		it('returns exactly one item per input item when each Order ID is valid', async () => {
+			woocommerceApiRequestMock.mockImplementation(async (_method: string, endpoint: string) => ({
+				id: endpoint.split('/').pop(),
+			}));
+
+			const items = [{ orderId: '14' }, { orderId: '15' }, { orderId: '16' }];
+			const mockThis = createMockExecuteFunctions('order', 'get', items);
+
+			const result = await new WooCommerce().execute.call(mockThis);
+
+			expect(result[0]).toHaveLength(3);
+			// Single-resource calls only — never the list endpoint.
+			for (const call of woocommerceApiRequestMock.mock.calls) {
+				expect(call[1]).toMatch(/^\/orders\/\d+$/);
+			}
+		});
+
+		it('does not send query parameters on a single-resource get', async () => {
+			woocommerceApiRequestMock.mockResolvedValue({ id: 14 });
+
+			const mockThis = createMockExecuteFunctions('order', 'get', [{ orderId: '14' }]);
+			await new WooCommerce().execute.call(mockThis);
+
+			const qs = woocommerceApiRequestMock.mock.calls[0][3];
+			expect(qs).toEqual({});
+		});
+
+		it('throws when the Order ID is empty instead of falling back to the list endpoint', async () => {
+			// Mirror the real WooCommerce API: GET /orders/ returns a paginated list.
+			woocommerceApiRequestMock.mockResolvedValue(
+				Array.from({ length: 20 }, (_v, i) => ({ id: i + 1 })),
+			);
+
+			const mockThis = createMockExecuteFunctions('order', 'get', [{ orderId: '' }]);
+
+			await expect(new WooCommerce().execute.call(mockThis)).rejects.toBeInstanceOf(
+				NodeOperationError,
+			);
+			expect(woocommerceApiRequestMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe.each([
+		{ operation: 'update', extra: { updateFields: {} } },
+		{ operation: 'delete', extra: {} },
+	])('Order: $operation operation', ({ operation, extra }) => {
+		it('throws on an empty Order ID instead of issuing a request to the collection endpoint', async () => {
+			const mockThis = createMockExecuteFunctions('order', operation, [{ orderId: '', ...extra }]);
+
+			await expect(new WooCommerce().execute.call(mockThis)).rejects.toBeInstanceOf(
+				NodeOperationError,
+			);
+			expect(woocommerceApiRequestMock).not.toHaveBeenCalled();
+		});
+	});
+
+	// Order is covered above; this locks the same guard on customer and product.
+	describe.each([
+		{ resource: 'customer', idParam: 'customerId' },
+		{ resource: 'product', idParam: 'productId' },
+	])('$resource single-resource operations', ({ resource, idParam }) => {
+		it.each(['get', 'update', 'delete'])(
+			'throws on an empty ID for the %s operation',
+			async (operation) => {
+				const mockThis = createMockExecuteFunctions(resource, operation, [
+					{ [idParam]: '', updateFields: {} },
+				]);
+
+				await expect(new WooCommerce().execute.call(mockThis)).rejects.toBeInstanceOf(
+					NodeOperationError,
+				);
+				expect(woocommerceApiRequestMock).not.toHaveBeenCalled();
+			},
+		);
+	});
+
+	describe('continueOnFail', () => {
+		it('collects the guard error as item output instead of aborting the run', async () => {
+			const mockThis = createMockExecuteFunctions('order', 'get', [
+				{ orderId: '14' },
+				{ orderId: '' },
+			]);
+			mockThis.continueOnFail.mockReturnValue(true);
+			woocommerceApiRequestMock.mockResolvedValue({ id: 14 });
+
+			const result = await new WooCommerce().execute.call(mockThis);
+
+			expect(result[0]).toHaveLength(2);
+			expect(result[0][1].json).toHaveProperty('error', 'Order ID must not be empty');
+			// Only the valid item reached the API.
+			expect(woocommerceApiRequestMock).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Order: Get All operation', () => {
+		it('does not leak query parameters between input items', async () => {
+			woocommerceApiRequestMock.mockResolvedValue([{ id: 1 }]);
+
+			const items = [
+				{ returnAll: false, limit: 50, options: { status: 'completed' } },
+				{ returnAll: false, limit: 50, options: {} },
+			];
+			const mockThis = createMockExecuteFunctions('order', 'getAll', items);
+
+			await new WooCommerce().execute.call(mockThis);
+
+			const secondCallQs = woocommerceApiRequestMock.mock.calls[1][3] as IDataObject;
+			expect(secondCallQs.status).toBeUndefined();
+			expect(secondCallQs).toEqual({ per_page: 50 });
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The WooCommerce node's `get`/`update`/`delete` operations build their URL as `/<resource>/${id}`. When the ID parameter resolved to empty (e.g. an unresolved expression like `{{ $json.orderNum }} -> undefined`), the request fell through to the **collection** endpoint (`GET /orders/`) and the API returned a whole page of items. So a single `order:get` returned ~20 items per input item instead of one (the community report: 18 inputs → 360 outputs).

This PR:

- **Validates the resource ID** for `get`/`update`/`delete` on order, customer, and product. An empty/whitespace ID now throws a clear `NodeOperationError` (`"<X> ID must not be empty"`) instead of silently acting on the whole collection.
- **Scopes the `qs` query object per input item** (moved inside the execute loop). Previously it was shared across iterations, so `getAll` filters from one item could leak into the next item's request.
- **Honors Continue On Fail**: the per-item loop is now wrapped so a failing item is emitted as an error item instead of aborting the whole execution.

Note on the diff: wrapping the loop body in `try/catch` reindented the whole `execute` block, so `WooCommerce.node.ts` shows a large diff that is mostly mechanical.

### Behavior change

For the same input, an empty ID used to silently return a list and now returns a clear error. This turns a silent wrong-result into an actionable error; the node stays on `version: 1` (no new version, as this corrects clearly-broken behavior rather than changing a valid use case).

## How to test

Automated:

\`\`\`bash
cd packages/nodes-base && pnpm test WooCommerce
\`\`\`

Manual against a real store — spin up a local WordPress + WooCommerce using this guide: [Local WordPress + WooCommerce for manual testing](https://www.notion.so/n8n/Local-WordPress-WooCommerce-for-manual-testing-34c5b6e0c94f81ebaaa4eafec3aa6ee2). Then:

1. Create a few orders and a WooCommerce API credential in n8n pointing at the local store.
2. Import the workflow below (set the WooCommerce node's credential after import).
3. Run it with the Code node's `USE_VALID = false` (empty IDs): **before** this fix the WooCommerce node returns N × (page size) items; **after** it fails with `"Order ID must not be empty"` (or, with Continue On Fail on, emits an error item per affected input).
4. Flip `USE_VALID = true` (valid IDs): it returns exactly one item per input.

<details>
<summary>Reproduction workflow (import into n8n)</summary>

\`\`\`json
{
  "name": "NODE-4566 WooCommerce order:get repro",
  "nodes": [
    {
      "parameters": {},
      "id": "11111111-1111-1111-1111-111111111111",
      "name": "When clicking Test workflow",
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [0, 0]
    },
    {
      "parameters": {
        "jsType": "javaScript",
        "jsCode": "// 3 input items. Flip USE_VALID to compare:\n//   false -> orderNum empty  => reproduces the bug (list fallback)\n//   true  -> orderNum valid  => correct behavior (1 item each)\nconst USE_VALID = false;\nconst validIds = ['14', '15', '16'];\nreturn validIds.map((id, i) => ({ json: { orderNum: USE_VALID ? id : '' } }));"
      },
      "id": "22222222-2222-2222-2222-222222222222",
      "name": "Generate 3 items",
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [220, 0]
    },
    {
      "parameters": {
        "resource": "order",
        "operation": "get",
        "orderId": "={{ $json.orderNum }}"
      },
      "id": "33333333-3333-3333-3333-333333333333",
      "name": "WooCommerce order:get",
      "type": "n8n-nodes-base.wooCommerce",
      "typeVersion": 1,
      "position": [440, 0],
      "credentials": {
        "wooCommerceApi": {
          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
          "name": "WooCommerce local"
        }
      }
    }
  ],
  "connections": {
    "When clicking Test workflow": {
      "main": [[{ "node": "Generate 3 items", "type": "main", "index": 0 }]]
    },
    "Generate 3 items": {
      "main": [[{ "node": "WooCommerce order:get", "type": "main", "index": 0 }]]
    }
  },
  "settings": {},
  "active": false
}
\`\`\`

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4566

closes #26569

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI