### PR TITLE
refactor(core): Expose AWS credentials via a proper n8n-nodes-base sub-path (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
@@ -1,13 +1,14 @@
 import { getNodeProxyAgent } from '@n8n/ai-utilities';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
-import { type AWSRegion, getAwsDomain } from 'n8n-nodes-base/dist/credentials/common/aws/regions';
-import type {
-	AwsAssumeRoleCredentialsType,
-	AwsIamCredentialsType,
-} from 'n8n-nodes-base/dist/credentials/common/aws/types';
-import { getSystemCredentials } from 'n8n-nodes-base/dist/credentials/common/aws/system-credentials-utils';
-import { assertSupportedAwsRegion } from 'n8n-nodes-base/dist/credentials/common/aws/utils';
+import {
+	type AWSRegion,
+	getAwsDomain,
+	type AwsAssumeRoleCredentialsType,
+	type AwsIamCredentialsType,
+	getSystemCredentials,
+	assertSupportedAwsRegion,
+} from 'n8n-nodes-base/aws-credentials';
 import { UserError, type ISupplyDataFunctions } from 'n8n-workflow';
 
 export type ResolvedAwsCredentials = {

--- a/packages/@n8n/nodes-langchain/utils/aws/test/resolveAwsCredentials.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/test/resolveAwsCredentials.test.ts
@@ -1,3 +1,4 @@
+import type * as AwsCredentialsModule from 'n8n-nodes-base/aws-credentials';
 import { UserError, type ISupplyDataFunctions, type INode } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -14,7 +15,8 @@ vi.mock('@aws-sdk/credential-providers', () => ({
 	}),
 }));
 
-vi.mock('n8n-nodes-base/dist/credentials/common/aws/system-credentials-utils', () => ({
+vi.mock('n8n-nodes-base/aws-credentials', async (importOriginal) => ({
+	...(await importOriginal<typeof AwsCredentialsModule>()),
 	getSystemCredentials: vi.fn(),
 }));
 
@@ -23,7 +25,7 @@ vi.mock('@n8n/ai-utilities', () => ({
 }));
 
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
-import { getSystemCredentials } from 'n8n-nodes-base/dist/credentials/common/aws/system-credentials-utils';
+import { getSystemCredentials } from 'n8n-nodes-base/aws-credentials';
 import { getNodeProxyAgent } from '@n8n/ai-utilities';
 
 import { resolveAwsCredentials } from '../resolveAwsCredentials';

--- a/packages/nodes-base/aws-credentials.js
+++ b/packages/nodes-base/aws-credentials.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/credentials/common/aws/index.js');

--- a/packages/nodes-base/credentials/common/aws/index.ts
+++ b/packages/nodes-base/credentials/common/aws/index.ts
@@ -1,0 +1,4 @@
+export { type AWSRegion, getAwsDomain } from './regions';
+export type { AwsAssumeRoleCredentialsType, AwsIamCredentialsType } from './types';
+export { getSystemCredentials } from './system-credentials-utils';
+export { assertSupportedAwsRegion } from './utils';

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -3,6 +3,11 @@
   "version": "2.28.0",
   "description": "Base nodes of n8n",
   "main": "index.js",
+  "typesVersions": {
+    "*": {
+      "aws-credentials": ["dist/credentials/common/aws/index.d.ts"]
+    }
+  },
   "scripts": {
     "clean": "rimraf dist .turbo",
     "copy-nodes-json": "node scripts/copy-nodes-json.js .",
@@ -22,7 +27,8 @@
     "test:integration:skip": "vitest run --config vitest.integration.config.ts"
   },
   "files": [
-    "dist"
+    "dist",
+    "aws-credentials.js"
   ],
   "n8n": {
     "credentials": [


### PR DESCRIPTION
## Summary

The langchain package imported AWS credential types and helpers directly from
`n8n-nodes-base/dist/...`, coupling it to another package's compiled output layout.
This adds a stable entry point, `n8n-nodes-base/aws-credentials`, and points the
single langchain consumer at it.

The entry point is three small pieces:
- a barrel (`credentials/common/aws/index.ts`) that compiles into `dist` with the rest of the package,
- a one-line runtime re-export at the package root (`aws-credentials.js`),
- a `typesVersions` mapping so TypeScript resolves the generated `.d.ts`.

No `exports` map is added to `nodes-base`, so its existing deep imports keep
resolving as before.

## How to test

```bash
pnpm --filter n8n-nodes-base build
pnpm --filter @n8n/n8n-nodes-langchain typecheck
pushd packages/@n8n/nodes-langchain && pnpm test && popd
```

The existing `resolveAwsCredentials.test.ts` suite (13 tests) still passes; only its
import and mock path changed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-68

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI