### PR TITLE
test: Add authorization coverage for instance custom roles (no-changelog)

### DIFF
--- a/packages/cli/test/integration/access-control/instance-roles.test.ts
+++ b/packages/cli/test/integration/access-control/instance-roles.test.ts
@@ -1,0 +1,182 @@
+import { mockInstance, randomCredentialPayload, testDb } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { GLOBAL_MEMBER_ROLE } from '@n8n/db';
+import type { User } from '@n8n/db';
+
+import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
+import { SecuritySettingsService } from '@/services/security-settings.service';
+
+import { createGlobalRoleUser } from './shared-setup';
+import { saveCredential } from '../shared/db/credentials';
+import { cleanupRolesAndScopes, createCustomRoleWithScopeSlugs } from '../shared/db/roles';
+import { createOwner } from '../shared/db/users';
+import { initCredentialsTypes, setupTestServer } from '../shared/utils';
+
+/**
+ * Authorization safety net for *instance* (global) custom roles.
+ *
+ * The project-level matrix in this directory proves scope-driven access for
+ * `roleType: 'project'` roles. These tests do the same for `roleType: 'global'`
+ * roles, guarding that instance-level gates flow through scope checks
+ * (`@GlobalScope` / `hasGlobalScope`) rather than literal role-slug equality.
+ * Each behavior gets a positive (has scope -> allowed) and a negative
+ * (lacks scope -> 403 / restricted) case, both driven by a custom global role.
+ */
+describe('Instance (global) custom role authorization', () => {
+	// Mocked so the security-settings handler returns deterministically once the
+	// scope gate is passed; authorization itself runs through the real middleware.
+	mockInstance(SecuritySettingsService);
+	mockInstance(InstanceRedactionEnforcementService);
+	mockInstance(InstanceSettingsLoaderConfig, { securityPolicyManagedByEnv: false });
+
+	const testServer = setupTestServer({
+		endpointGroups: ['credentials', 'role', 'security-settings'],
+		enabledFeatures: ['feat:sharing', 'feat:customRoles', 'feat:personalSpacePolicy'],
+	});
+
+	beforeAll(async () => {
+		await initCredentialsTypes();
+	});
+
+	afterEach(async () => {
+		// Users hold FK refs to the custom roles, so truncate them before the role
+		// cleanup (which deletes by FK-respecting `repository.delete`). Runs in
+		// `afterEach` because the DI `Connection` is only live during test hooks.
+		await testDb.truncate(['SharedCredentials', 'CredentialsEntity', 'ProjectRelation', 'User']);
+		await cleanupRolesAndScopes();
+	});
+
+	describe('credential listing — all vs own (credential:list)', () => {
+		let owner: User;
+
+		beforeEach(async () => {
+			await testDb.truncate(['SharedCredentials', 'CredentialsEntity']);
+			owner = await createOwner();
+		});
+
+		test('a custom global role with credential:list sees every credential', async () => {
+			const { user, agent } = await createGlobalRoleUser(
+				testServer,
+				['credential:read', 'credential:list'],
+				'Global Credential Lister',
+			);
+
+			const ownerCredential = await saveCredential(randomCredentialPayload(), {
+				user: owner,
+				role: 'credential:owner',
+			});
+			const ownCredential = await saveCredential(randomCredentialPayload(), {
+				user,
+				role: 'credential:owner',
+			});
+
+			const response = await agent.get('/credentials').expect(200);
+			const ids = response.body.data.map((c: { id: string }) => c.id);
+
+			expect(ids).toContain(ownerCredential.id);
+			expect(ids).toContain(ownCredential.id);
+		});
+
+		test('a custom global role without credential:list sees only its own credentials', async () => {
+			// A role lacking any global credential scope must not see other users'
+			// credentials — only the ones it owns.
+			const { user, agent } = await createGlobalRoleUser(
+				testServer,
+				['workflow:list'],
+				'Global Non-Credential Role',
+			);
+
+			const ownerCredential = await saveCredential(randomCredentialPayload(), {
+				user: owner,
+				role: 'credential:owner',
+			});
+			const ownCredential = await saveCredential(randomCredentialPayload(), {
+				user,
+				role: 'credential:owner',
+			});
+
+			const response = await agent.get('/credentials').expect(200);
+			const ids = response.body.data.map((c: { id: string }) => c.id);
+
+			expect(ids).toContain(ownCredential.id);
+			expect(ids).not.toContain(ownerCredential.id);
+		});
+	});
+
+	describe('role administration (role:manage / role:read)', () => {
+		test('a custom global role with role:manage can create, read assignments for, and delete roles', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['role:manage'],
+				'Global Role Manager',
+			);
+
+			const created = await agent
+				.post('/roles')
+				.send({ displayName: 'Created By Custom', roleType: 'project', scopes: ['workflow:read'] })
+				.expect(200);
+
+			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/assignments`).expect(200);
+			await agent.delete(`/roles/${created.body.data.slug}`).expect(200);
+		});
+
+		test('a custom global role without role:manage cannot create, read assignments for, or delete roles', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['workflow:list'],
+				'Global Role Outsider',
+			);
+			const target = await createCustomRoleWithScopeSlugs(['workflow:read'], {
+				roleType: 'project',
+				displayName: 'Delete Target',
+			});
+
+			await agent
+				.post('/roles')
+				.send({ displayName: 'Forbidden Role', roleType: 'project', scopes: ['workflow:read'] })
+				.expect(403);
+			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/assignments`).expect(403);
+			await agent.delete(`/roles/${target.slug}`).expect(403);
+		});
+
+		test('a custom global role with role:read can list a role’s members', async () => {
+			const { agent } = await createGlobalRoleUser(testServer, ['role:read'], 'Global Role Reader');
+
+			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/members`).expect(200);
+		});
+
+		test('a custom global role without role:read cannot list a role’s members', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['workflow:list'],
+				'Global Members Outsider',
+			);
+
+			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/members`).expect(403);
+		});
+	});
+
+	describe('security settings (securitySettings:manage)', () => {
+		test('a custom global role with securitySettings:manage can read and update security settings', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['securitySettings:manage'],
+				'Global Settings Manager',
+			);
+
+			await agent.get('/settings/security').expect(200);
+			await agent.post('/settings/security').send({}).expect(200);
+		});
+
+		test('a custom global role without securitySettings:manage gets 403', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['workflow:list'],
+				'Global Settings Outsider',
+			);
+
+			await agent.get('/settings/security').expect(403);
+			await agent.post('/settings/security').send({}).expect(403);
+		});
+	});
+});

--- a/packages/cli/test/integration/access-control/shared-setup.ts
+++ b/packages/cli/test/integration/access-control/shared-setup.ts
@@ -10,7 +10,7 @@ import { GLOBAL_MEMBER_ROLE, GLOBAL_OWNER_ROLE } from '@n8n/db';
 import { UserManagementMailer } from '@/user-management/email';
 
 import { createCustomRoleWithScopeSlugs, cleanupRolesAndScopes } from '../shared/db/roles';
-import { createAdmin, createOwner, createMember } from '../shared/db/users';
+import { createAdmin, createOwner, createMember, createUser } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
 
@@ -221,6 +221,24 @@ export async function setupTestContext(): Promise<TestContext> {
  */
 export async function cleanupTestContext(): Promise<void> {
 	await cleanupRolesAndScopes();
+}
+
+/**
+ * Creates a user holding a custom *instance* (global) role that grants exactly
+ * `scopeSlugs`, and returns the user alongside its authenticated agent. Used to
+ * prove that instance-level authorization is driven by scope, not role name.
+ */
+export async function createGlobalRoleUser(
+	testServer: ReturnType<typeof utils.setupTestServer>,
+	scopeSlugs: string[],
+	displayName: string,
+): Promise<{ user: User; agent: SuperAgentTest }> {
+	const role = await createCustomRoleWithScopeSlugs(scopeSlugs, {
+		roleType: 'global',
+		displayName,
+	});
+	const user = await createUser({ role });
+	return { user, agent: testServer.authAgentFor(user) };
 }
 
 /**


### PR DESCRIPTION
## Summary

Custom **instance** (global) roles let admins grant arbitrary global-scope subsets. Authorization for these roles must flow through scope checks (`hasGlobalScope` / `userHasScopes` / `@GlobalScope`), never through literal role-slug equality (`global:owner`, `global:admin`, …) — otherwise a custom role that was granted the equivalent scope is silently excluded.

The existing access-control integration suite (`packages/cli/test/integration/access-control/`) only covered `roleType: 'project'` custom roles. This PR adds the equivalent safety net for `roleType: 'global'` roles, so that removing or weakening a global scope gate turns a test red.

It adds **8 integration tests** (`instance-roles.test.ts`), each with a positive (has scope → allowed) and a negative (lacks scope → 403 / restricted) case, all driven by a **custom global role** rather than a built-in one:

- **Credential listing — "all vs own"** (`credential:list`): a global role with `credential:list` sees every credential; a global role without it sees only the ones it owns. This is the highest-value case — it proves the ownership branch in `credentials.service.ts` is keyed on scope, not role name.
- **Role administration** (`role:manage`, `role:read`): a global role with `role:manage` can create/delete roles and read assignments; with `role:read` it can list a role's members; without the scope each endpoint returns 403.
- **Security settings** (`securitySettings:manage`): a global role with the scope can read/update security settings; without it gets 403.

It also extends `shared-setup.ts` with a small reusable helper, `createGlobalRoleUser(testServer, scopeSlugs, displayName)`, which mints a user holding a custom global role granting exactly the given scopes and returns `{ user, agent }`.

### Why

Part of the role-slug → scope migration (IAM-850). The goal is a test safety net so the migration can't regress silently: every gate the feature touches should have both a positive and a negative authorization test, and at least one test must prove the behavior for a custom role — not only built-in ones — to confirm access is driven by scope.

Scope of this PR is deliberately a **high-value subset** (credential ownership, role admin, security settings) tested against current behavior. Member-listing detail-visibility, invitations, and the API-key empty-state are noted as follow-ups. The remaining intentional literal-slug checks (e.g. owner-deletion protection, owner/admin role-change hierarchy) are out of scope and left untouched.


## Related Linear tickets, Github issues, and Community forum posts

closes  https://linear.app/n8n/issue/IAM-850

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

