### PR TITLE
fix(HTTP Request Node): Produce valid items for primitive array responses

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/user-self-corrects.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/user-self-corrects.json
@@ -1,0 +1,57 @@
+{
+	"description": "The user states one thing, then explicitly changes their mind mid-conversation. The corrected channel and story count must win over the originals. The user pins a raw HTTP Request node against the Hacker News Firebase API, whose /v0/topstories.json is a bare top-level array of IDs, so the build must read every split ID with $input.all(), not $input.first().",
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"Every day, fetch the top story from Hacker News and post its title and URL to Slack #news (C04NEWS0001).",
+				"Use a plain HTTP Request node against the Hacker News Firebase API directly — GET https://hacker-news.firebaseio.com/v0/topstories.json for the story IDs, then GET https://hacker-news.firebaseio.com/v0/item/<id>.json for each story. Do not use any dedicated Hacker News node."
+			]
+		},
+		{
+			"role": "user",
+			"text": [
+				"[Once the agent has shown its plan or built the workflow, change your mind in a single follow-up: tell it you reconsidered and now want the post to go to #engineering (C04ENGINEER1) instead of #news (C04NEWS0001), and the top 3 stories instead of just the top one.",
+				"Phrase it as a natural retraction — \"actually, on second thought…\" — and describe both changes in that one message. Keep the HTTP Request approach against the Firebase API. Once the agent acknowledges or applies the change, you're satisfied: finish the conversation. Don't ask it to rebuild from scratch, don't repeat the request, and don't fall back to the original #news / single-story values.]"
+			]
+		}
+	],
+	"messageBudget": 6,
+	"complexity": "medium",
+	"tags": [
+		"build",
+		"slack",
+		"http",
+		"schedule",
+		"behaviour",
+		"self-correction",
+		"array-normalization"
+	],
+	"triggerType": "schedule",
+	"datasets": ["behaviour", "full"],
+	"outcomeExpectations": [
+		"The user changed their mind during the conversation, and the agent applied the correction rather than the original request — the final workflow targets #engineering (C04ENGINEER1), not #news (C04NEWS0001).",
+		"The corrected story count won: the workflow posts the top 3 stories, not just the single top story from the user's first message.",
+		"The workflow fetches the story IDs with an HTTP Request node against https://hacker-news.firebaseio.com/v0/topstories.json (a bare top-level array of IDs that the HTTP Request node splits into one item per ID). The step that selects the top IDs reads every split item via $input.all() (or by iterating the items), never $input.first().json, which would see only one ID and drop the rest."
+	],
+	"executionScenarios": [
+		{
+			"name": "happy-path-bare-id-array",
+			"description": "topstories.json returns a bare array of IDs; the top 3 stories are fetched and posted to the corrected channel",
+			"dataSetup": "The schedule trigger fires. GET https://hacker-news.firebaseio.com/v0/topstories.json returns Hacker News's REAL shape: a bare JSON array of at least 5 numeric story IDs (e.g. [44001, 44002, 44003, 44004, 44005]) — NOT objects, NOT an envelope. Each GET https://hacker-news.firebaseio.com/v0/item/<id>.json returns that story as an object { id, title, url }, e.g. for 44001 return { \"id\": 44001, \"title\": \"Show HN: A new Rust web framework\", \"url\": \"https://example.com/rust\" }; give every requested id a distinct title and url. The Slack post-message node returns { ok: true }.",
+			"successCriteria": "The workflow executes without errors. The step that picks the top IDs from the topstories array consumes the full split array (via $input.all() or iterating the items), NOT $input.first(); it yields 3 IDs, not one. Exactly the top 3 stories are posted to #engineering (C04ENGINEER1) — the corrected channel — and NOT to #news (C04NEWS0001). Each posted entry includes a title and a URL. A workflow that collapses to a single story (the $input.first() bug) FAILS even if it otherwise completes."
+		},
+		{
+			"name": "bare-array-hidden-by-single-item-assumption",
+			"description": "LOAD-BEARING: the bare-array-of-IDs split must surface the $input.first() vs $input.all() bug.",
+			"dataSetup": "Assume credentials are mocked. GET https://hacker-news.firebaseio.com/v0/topstories.json returns the REAL bare array of exactly 5 numeric IDs [44001, 44002, 44003, 44004, 44005], split by the HTTP Request node into one item per ID. Critically do NOT replay a single-item or object-shaped fixture — inject the bare ID array so any $input.first()/single-item assumption in the ID-selection step is exercised. Each GET https://hacker-news.firebaseio.com/v0/item/<id>.json returns { id, title, url } with a distinct title/url per id. Slack returns { ok: true }.",
+			"successCriteria": "Judge on the ID-selection step's output when the 5-ID array is fed in: it must emit 3 IDs (the corrected count) drawn from the full array, not collapse to a single ID — which is what happens when the node reads $input.first().json instead of $input.all(). A collapsed single-story result is a failure even if the workflow otherwise completes. The 3 fetched stories must reach #engineering (C04ENGINEER1), each with a title and URL."
+		},
+		{
+			"name": "fewer-than-three-stories",
+			"description": "topstories.json returns fewer than 3 IDs",
+			"dataSetup": "The schedule trigger fires. GET https://hacker-news.firebaseio.com/v0/topstories.json returns a bare array of only 2 numeric IDs [44001, 44002]. Each GET https://hacker-news.firebaseio.com/v0/item/<id>.json returns { id, title, url }. The Slack post-message node returns { ok: true }.",
+			"successCriteria": "The workflow handles having fewer than 3 stories gracefully — it posts the 2 available stories to #engineering (C04ENGINEER1) without erroring on the missing third."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -49,6 +49,16 @@ that must process every row, read `$input.all().map(i => i.json)` (or iterate
 the items) instead of mapping over `$input.first().json`, which would only see
 the first record and produce null/empty downstream values.
 
+This also applies to a bare array of primitives (for example Hacker News
+`/v0/topstories.json` returns `[12345, 12346, ...]`). It is still split into one
+item per element, so `$input.first().json` is one ID, and `$input.first().json
+.slice(...)` or `Array.isArray($input.first().json)` will be wrong and silently
+yield zero items. n8n wraps each non-object element under `data` (an item's
+`json` must be an object), so read the IDs with `$input.all().map(i => i.json
+.data)`. For the common two-step list pattern (fetch a list of IDs, then fetch
+each item), take the top N from `$input.all()` and fan them out one item per ID,
+never `$input.first()`.
+
 When a downstream node must reason over the whole collection at once — a single
 AI Agent analysing a series, an indicator/metric computed across all rows, a
 summary, or a structured-output parser expecting one object — first aggregate

--- a/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/HttpRequest/GenericFunctions.ts
@@ -41,6 +41,20 @@ function isObject(obj: unknown): obj is IDataObject {
 	return isPlainObject(obj);
 }
 
+// n8n items require `json` to be an object. Split a top-level array one item per
+// element and wrap non-object elements (bare array of IDs, array of arrays) under `data`.
+export function responseToExecutionItems(
+	response: unknown,
+	itemIndex: number,
+): INodeExecutionData[] {
+	const pairedItem = { item: itemIndex };
+	const toItem = (value: unknown): INodeExecutionData =>
+		isObject(value)
+			? { json: value, pairedItem }
+			: { json: { data: value } as IDataObject, pairedItem };
+	return Array.isArray(response) ? response.map(toItem) : [toItem(response)];
+}
+
 function redactString(str: string, secrets: string[]): string {
 	return secrets.reduce((safe, secret) => safe.split(secret).join(REDACTED), str);
 }

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -40,6 +40,7 @@ import {
 	prepareRequestBody,
 	reduceAsync,
 	replaceNullValues,
+	responseToExecutionItems,
 	sanitizeUiMessage,
 	setAgentOptions,
 	updadeQueryParameterConfig,
@@ -1107,23 +1108,7 @@ export class HttpRequestV3 implements INodeType {
 								}
 							}
 
-							if (Array.isArray(response)) {
-								response.forEach((item) =>
-									returnItems.push({
-										json: item,
-										pairedItem: {
-											item: itemIndex,
-										},
-									}),
-								);
-							} else {
-								returnItems.push({
-									json: response,
-									pairedItem: {
-										item: itemIndex,
-									},
-								});
-							}
+							returnItems.push(...responseToExecutionItems(response, itemIndex));
 						}
 					}
 				}

--- a/packages/nodes-base/nodes/HttpRequest/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/test/GenericFunctions.test.ts
@@ -1,7 +1,54 @@
 import { mock } from 'vitest-mock-extended';
 import type { INode } from 'n8n-workflow';
 
-import { getAllowedDomains, updadeQueryParameterConfig } from '../GenericFunctions';
+import {
+	getAllowedDomains,
+	responseToExecutionItems,
+	updadeQueryParameterConfig,
+} from '../GenericFunctions';
+
+describe('responseToExecutionItems', () => {
+	it('splits an array of objects into one item per element (unchanged behaviour)', () => {
+		expect(responseToExecutionItems([{ a: 1 }, { a: 2 }], 0)).toEqual([
+			{ json: { a: 1 }, pairedItem: { item: 0 } },
+			{ json: { a: 2 }, pairedItem: { item: 0 } },
+		]);
+	});
+
+	it('wraps a bare array of primitives so each json is a valid object', () => {
+		expect(responseToExecutionItems([44001, 44002], 0)).toEqual([
+			{ json: { data: 44001 }, pairedItem: { item: 0 } },
+			{ json: { data: 44002 }, pairedItem: { item: 0 } },
+		]);
+	});
+
+	it('wraps an array of arrays (e.g. Binance klines rows)', () => {
+		expect(
+			responseToExecutionItems(
+				[
+					[1, 2],
+					[3, 4],
+				],
+				2,
+			),
+		).toEqual([
+			{ json: { data: [1, 2] }, pairedItem: { item: 2 } },
+			{ json: { data: [3, 4] }, pairedItem: { item: 2 } },
+		]);
+	});
+
+	it('keeps a single object response as one item', () => {
+		expect(responseToExecutionItems({ a: 1 }, 0)).toEqual([
+			{ json: { a: 1 }, pairedItem: { item: 0 } },
+		]);
+	});
+
+	it('wraps a single primitive response under data', () => {
+		expect(responseToExecutionItems('hello', 1)).toEqual([
+			{ json: { data: 'hello' }, pairedItem: { item: 1 } },
+		]);
+	});
+});
 
 describe('updadeQueryParameterConfig', () => {
 	describe('version < 4.3 (legacy behavior)', () => {


### PR DESCRIPTION
## Summary

Split out from #32981 so the core node change can be reviewed and versioned on its own track.

When an HTTP Request node returns a **top-level JSON array**, it splits the response into one item per element. Non-object elements were pushed as items whose `json` was a primitive (a bare array of IDs, an array of arrays such as Binance klines, or a scalar response), violating n8n's contract that an item's `json` is an object — which crashes downstream with `"A 'json' property isn't an object"`.

This wraps non-object array elements under `data` so every emitted item's `json` is a valid object. **Arrays of objects and single-object responses are unchanged** (the common case); only the previously-invalid primitive/array/scalar cases change.

- New helper `responseToExecutionItems` in `GenericFunctions.ts`, with unit tests.
- `HttpRequestV3.node.ts` now delegates array/scalar handling to the helper.
- KB guidance (`workflow-builder-guardrails.md`) for reading bare-array responses (`$input.all().map(i => i.json.data)`) and an instance-ai eval (`user-self-corrects.json`) exercising the bare-array case end-to-end. These are coupled to the wrapping behaviour and so live here rather than in #32981.

## Open question for review

This is a behaviour change to a heavily-used node, currently applied unconditionally to `typeVersion` `[3, 4, 4.1, 4.2, 4.3, 4.4]`. Workflows that consume bare-array endpoints and read `$json` directly today (primitive) would now read `$json.data`. Consider **gating behind a new `typeVersion`** so existing workflows are untouched, and dropping `no-changelog` for a user-facing node change. Flagging for reviewer decision.

## How to test

```bash
cd packages/nodes-base
pnpm test nodes/HttpRequest/test/GenericFunctions.test.ts nodes/HttpRequest/test/node/HttpRequestV3.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-662

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->