### PR TITLE
fix(core): Track builder workflow telemetry when execution fails to launch

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2688,6 +2688,7 @@ describe('createExecutionAdapter run()', () => {
 			expect.objectContaining({
 				workflow_id: 'wf-1',
 				status: 'error',
+				error: 'boom',
 			}),
 		);
 	});
@@ -2715,6 +2716,7 @@ describe('createExecutionAdapter run()', () => {
 			expect.objectContaining({
 				workflow_id: 'wf-1',
 				status: 'error',
+				error: expect.stringContaining('timed out'),
 			}),
 		);
 	});
@@ -2740,6 +2742,7 @@ describe('createExecutionAdapter run()', () => {
 			expect.objectContaining({
 				workflow_id: 'wf-1',
 				status: 'error',
+				error: 'Failed to run workflow due to missing execution data',
 			}),
 		);
 	});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2719,6 +2719,31 @@ describe('createExecutionAdapter run()', () => {
 		);
 	});
 
+	it('tracks error status when an execution fails to launch', async () => {
+		const { adapter, mockTelemetry, mockWorkflowRunner } = createRunAdapterForTests(
+			{
+				id: 'wf-1',
+				nodes: [],
+			},
+			{
+				threadId: 'thread-1',
+			},
+		);
+
+		const launchError = new Error('Failed to run workflow due to missing execution data');
+		mockWorkflowRunner.run.mockRejectedValueOnce(launchError);
+
+		await expect(adapter.run('wf-1')).rejects.toThrow(launchError);
+
+		expect(mockTelemetry.track).toHaveBeenCalledWith(
+			'Builder executed workflow',
+			expect.objectContaining({
+				workflow_id: 'wf-1',
+				status: 'error',
+			}),
+		);
+	});
+
 	it('populates runnable executionData for a trigger run with no input', async () => {
 		const { adapter, mockWorkflowRunner } = createRunAdapterForTests({
 			id: 'wf-1',

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1018,87 +1018,95 @@ export class InstanceAiAdapterService {
 					});
 				};
 
-				const executionId = await workflowRunner.run(runData);
+				try {
+					const executionId = await workflowRunner.run(runData);
 
-				// Wait for completion with timeout protection
-				const timeoutMs = Math.min(options?.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
+					// Wait for completion with timeout protection
+					const timeoutMs = Math.min(options?.timeout ?? DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
 
-				if (activeExecutions.has(executionId)) {
-					let timeoutId: NodeJS.Timeout | undefined;
-					const timeoutPromise = new Promise<never>((_, reject) => {
-						timeoutId = setTimeout(() => {
-							reject(new Error(`Execution timed out after ${timeoutMs}ms`));
-						}, timeoutMs);
-					});
+					if (activeExecutions.has(executionId)) {
+						let timeoutId: NodeJS.Timeout | undefined;
+						const timeoutPromise = new Promise<never>((_, reject) => {
+							timeoutId = setTimeout(() => {
+								reject(new Error(`Execution timed out after ${timeoutMs}ms`));
+							}, timeoutMs);
+						});
 
-					try {
-						await Promise.race([
-							activeExecutions.getPostExecutePromise(executionId),
-							timeoutPromise,
-						]);
-						clearTimeout(timeoutId);
-					} catch (error) {
-						clearTimeout(timeoutId);
-						// On timeout, cancel the execution
-						if (error instanceof Error && error.message.includes('timed out')) {
-							try {
-								activeExecutions.stopExecution(
+						try {
+							await Promise.race([
+								activeExecutions.getPostExecutePromise(executionId),
+								timeoutPromise,
+							]);
+							clearTimeout(timeoutId);
+						} catch (error) {
+							clearTimeout(timeoutId);
+							// On timeout, cancel the execution
+							if (error instanceof Error && error.message.includes('timed out')) {
+								try {
+									activeExecutions.stopExecution(
+										executionId,
+										new TimeoutExecutionCancelledError(executionId),
+									);
+								} catch {
+									// Execution may have completed between timeout and cancel
+								}
+								const result = {
 									executionId,
-									new TimeoutExecutionCancelledError(executionId),
+									status: 'error',
+									error: `Execution timed out after ${timeoutMs}ms and was cancelled`,
+								} satisfies ExecutionResult;
+								trackBuilderExecutedWorkflow(result.status);
+								return result;
+							}
+							throw error;
+						}
+					}
+
+					// Persist the simulation map onto the saved execution so the editor
+					// can label simulated node outputs. Only nodes that actually ran are
+					// recorded — an execution that dead-ends early must not claim
+					// simulations that never happened. Post-completion update: works in
+					// queue mode too (plain DB write), and the final save has already
+					// happened once the post-execute promise resolves. Best-effort — a
+					// failure must not mask the execution result.
+					if (options?.simulation && Object.keys(options.simulation).length > 0) {
+						try {
+							const execution = await executionRepository.findSingleExecution(executionId, {
+								includeData: true,
+								unflattenData: true,
+							});
+							if (execution?.data) {
+								const runData = execution.data.resultData.runData ?? {};
+								const simulation = Object.fromEntries(
+									Object.entries(options.simulation).filter(([nodeName]) =>
+										Object.hasOwn(runData, nodeName),
+									),
 								);
-							} catch {
-								// Execution may have completed between timeout and cancel
+								if (Object.keys(simulation).length > 0) {
+									execution.data.resultData.simulation = simulation;
+									await executionRepository.updateExistingExecution(executionId, {
+										data: execution.data,
+									});
+								}
 							}
-							const result = {
+						} catch (error) {
+							logger.warn('Failed to persist simulation metadata on execution', {
 								executionId,
-								status: 'error',
-								error: `Execution timed out after ${timeoutMs}ms and was cancelled`,
-							} satisfies ExecutionResult;
-							trackBuilderExecutedWorkflow(result.status);
-							return result;
+								error: error instanceof Error ? error.message : String(error),
+							});
 						}
-						throw error;
 					}
-				}
 
-				// Persist the simulation map onto the saved execution so the editor
-				// can label simulated node outputs. Only nodes that actually ran are
-				// recorded — an execution that dead-ends early must not claim
-				// simulations that never happened. Post-completion update: works in
-				// queue mode too (plain DB write), and the final save has already
-				// happened once the post-execute promise resolves. Best-effort — a
-				// failure must not mask the execution result.
-				if (options?.simulation && Object.keys(options.simulation).length > 0) {
-					try {
-						const execution = await executionRepository.findSingleExecution(executionId, {
-							includeData: true,
-							unflattenData: true,
-						});
-						if (execution?.data) {
-							const runData = execution.data.resultData.runData ?? {};
-							const simulation = Object.fromEntries(
-								Object.entries(options.simulation).filter(([nodeName]) =>
-									Object.hasOwn(runData, nodeName),
-								),
-							);
-							if (Object.keys(simulation).length > 0) {
-								execution.data.resultData.simulation = simulation;
-								await executionRepository.updateExistingExecution(executionId, {
-									data: execution.data,
-								});
-							}
-						}
-					} catch (error) {
-						logger.warn('Failed to persist simulation metadata on execution', {
-							executionId,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
+					const result = await extractExecutionResult(executionId, allowSendingParameterValues);
+					trackBuilderExecutedWorkflow(result.status);
+					return result;
+				} catch (error) {
+					// A failure to launch (or any other unsettled error) is still an
+					// errored builder run — track it before rethrowing so it isn't
+					// silently dropped from telemetry.
+					trackBuilderExecutedWorkflow('error');
+					throw error;
 				}
-
-				const result = await extractExecutionResult(executionId, allowSendingParameterValues);
-				trackBuilderExecutedWorkflow(result.status);
-				return result;
 			},
 
 			async getStatus(executionId: string) {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1005,7 +1005,10 @@ export class InstanceAiAdapterService {
 					mockDataSources,
 				};
 
-				const trackBuilderExecutedWorkflow = (status: ExecutionResult['status']) => {
+				const trackBuilderExecutedWorkflow = (
+					status: ExecutionResult['status'],
+					error?: string,
+				) => {
 					if (!threadId) return;
 
 					telemetry.track('Builder executed workflow', {
@@ -1015,6 +1018,7 @@ export class InstanceAiAdapterService {
 						pinned_node_count: Object.keys(runData.pinData ?? {}).length,
 						exec_type: runData.executionMode,
 						status,
+						...(error ? { error } : {}),
 					});
 				};
 
@@ -1055,7 +1059,7 @@ export class InstanceAiAdapterService {
 									status: 'error',
 									error: `Execution timed out after ${timeoutMs}ms and was cancelled`,
 								} satisfies ExecutionResult;
-								trackBuilderExecutedWorkflow(result.status);
+								trackBuilderExecutedWorkflow(result.status, result.error);
 								return result;
 							}
 							throw error;
@@ -1098,13 +1102,16 @@ export class InstanceAiAdapterService {
 					}
 
 					const result = await extractExecutionResult(executionId, allowSendingParameterValues);
-					trackBuilderExecutedWorkflow(result.status);
+					trackBuilderExecutedWorkflow(result.status, result.error);
 					return result;
 				} catch (error) {
 					// A failure to launch (or any other unsettled error) is still an
 					// errored builder run — track it before rethrowing so it isn't
 					// silently dropped from telemetry.
-					trackBuilderExecutedWorkflow('error');
+					trackBuilderExecutedWorkflow(
+						'error',
+						error instanceof Error ? error.message : String(error),
+					);
 					throw error;
 				}
 			},


### PR DESCRIPTION
## Summary

The `Builder executed workflow` telemetry event (warehouse: `builder_executed_workflow`) was not fired when an AI-builder workflow execution failed to **launch**. Such runs were invisible in telemetry — counted as neither a success nor a tracked error.

In the Instance AI execution adapter's `run()` method (`packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts`), the `trackBuilderExecutedWorkflow(status)` helper was only reached on the two settle paths (normal completion and timeout). The launch call `await workflowRunner.run(runData)` was not wrapped in try/catch, so a synchronous throw (e.g. the engine rejecting on missing execution data) propagated out of `run()` before any telemetry fired.

This PR wraps the launch + wait + extract block in a `try/catch`. The catch calls `trackBuilderExecutedWorkflow('error')` and rethrows the original error, so launch-time failures are now tracked as errored executions without changing caller behavior.

| Outcome | Event fires before | Event fires after |
| -- | -- | -- |
| Execution starts, then fails at runtime | ✅ `error` | ✅ `error` |
| Execution times out | ✅ `error` | ✅ `error` |
| Execution **fails to launch** | ❌ no event | ✅ `error` |

The success and timeout paths `return` before reaching the new catch, so the two existing telemetry calls are unchanged (no double-tracking).

## How to test

This is internal telemetry behavior. Covered by unit tests in `packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts`:

```bash
cd packages/cli && pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
```

A new test asserts that when `workflowRunner.run` rejects (launch failure), the `Builder executed workflow` event fires with `status: 'error'` and the original error still propagates. Existing success/error/timeout telemetry tests continue to pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-654

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33003">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

