### PR TITLE
fix(core): Block deleting a custom role referenced by an SSO mapping rule

### DIFF
--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-deletion-checker.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-deletion-checker.ee.test.ts
@@ -1,0 +1,40 @@
+import type { RoleMappingRuleRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { ProvisioningRoleDeletionChecker } from '../role-deletion-checker.ee';
+
+describe('ProvisioningRoleDeletionChecker', () => {
+	const roleMappingRuleRepository = mock<RoleMappingRuleRepository>();
+	const checker = new ProvisioningRoleDeletionChecker(roleMappingRuleRepository);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('reports no blockers when no mapping rule references the role', async () => {
+		roleMappingRuleRepository.count.mockResolvedValue(0);
+
+		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
+
+		expect(roleMappingRuleRepository.count).toHaveBeenCalledWith({
+			where: { role: { slug: 'global:auditor' } },
+		});
+		expect(blockers).toEqual([]);
+	});
+
+	it('reports a blocker (singular) when one mapping rule references the role', async () => {
+		roleMappingRuleRepository.count.mockResolvedValue(1);
+
+		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
+
+		expect(blockers).toEqual(['referenced by 1 role mapping rule']);
+	});
+
+	it('reports a blocker (plural) when several mapping rules reference the role', async () => {
+		roleMappingRuleRepository.count.mockResolvedValue(3);
+
+		const blockers = await checker.findRoleDeletionBlockers('global:auditor');
+
+		expect(blockers).toEqual(['referenced by 3 role mapping rules']);
+	});
+});

--- a/packages/cli/src/modules/provisioning.ee/__tests__/role-resolver.service.ee.test.ts
+++ b/packages/cli/src/modules/provisioning.ee/__tests__/role-resolver.service.ee.test.ts
@@ -562,6 +562,100 @@ describe('RoleResolverService', () => {
 		});
 	});
 
+	describe('resolveRoles - custom global roles', () => {
+		// The resolver treats the target role as an opaque slug, so custom global
+		// roles resolve exactly like built-in ones. These lock that behavior.
+		const customRole = 'global:auditor';
+
+		it('should resolve a custom global role when its rule matches (SAML attribute)', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $saml.attributes.department === "audit" }}',
+						role: customRole,
+					}),
+				],
+			});
+			const context = makeContext({
+				$provider: 'saml',
+				$saml: { attributes: { department: 'audit' } },
+			});
+
+			const result = await resolveRolesSimple(config, context);
+
+			expect(result.instanceRole).toBe(customRole);
+		});
+
+		it('should resolve a custom global role when its rule matches (OIDC claim)', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $oidc.userInfo.groups.includes("auditors") }}',
+						role: customRole,
+					}),
+				],
+			});
+			const context = makeContext({
+				$provider: 'oidc',
+				$oidc: { idToken: {}, userInfo: { groups: ['auditors'] } },
+			});
+
+			const result = await resolveRolesSimple(config, context);
+
+			expect(result.instanceRole).toBe(customRole);
+		});
+
+		it('should fall back to the default role when no rule matches the attribute', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $claims.department === "audit" }}',
+						role: customRole,
+					}),
+				],
+				fallbackInstanceRole: 'global:member',
+			});
+			const context = makeContext({ $claims: { department: 'sales' } });
+
+			const result = await resolveRolesSimple(config, context);
+
+			expect(result.instanceRole).toBe('global:member');
+		});
+
+		it('should re-resolve to a different role when the attributes change', async () => {
+			const config = makeConfig({
+				instanceRoleRules: [
+					makeRule({
+						id: 'r1',
+						expression: '{{ $claims.department === "audit" }}',
+						role: customRole,
+					}),
+					makeRule({
+						id: 'r2',
+						expression: '{{ $claims.department === "engineering" }}',
+						role: 'global:admin',
+					}),
+				],
+			});
+
+			const first = await resolveRolesSimple(
+				config,
+				makeContext({ $claims: { department: 'audit' } }),
+			);
+			expect(first.instanceRole).toBe(customRole);
+
+			// Same config, changed IdP attributes on a later login → re-resolved role.
+			const second = await resolveRolesSimple(
+				config,
+				makeContext({ $claims: { department: 'engineering' } }),
+			);
+			expect(second.instanceRole).toBe('global:admin');
+		});
+	});
+
 	describe('resolveRoles', () => {
 		it('should return matched rule metadata for instance role', async () => {
 			const config = makeConfig({

--- a/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
+++ b/packages/cli/src/modules/provisioning.ee/provisioning.module.ts
@@ -1,5 +1,6 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 
 @BackendModule({
 	name: 'provisioning',
@@ -10,5 +11,14 @@ export class ProvisioningModule implements ModuleInterface {
 	async init() {
 		await import('./provisioning.controller.ee');
 		await import('./role-mapping-rule.controller.ee');
+
+		// Register the role-deletion checker so the core `RoleService` blocks
+		// deleting a role still targeted by a mapping rule, without importing
+		// this module.
+		const { RoleDeletionCheckProxy } = await import('@/services/role-deletion-check-proxy.service');
+		const { ProvisioningRoleDeletionChecker } = await import('./role-deletion-checker.ee');
+		Container.get(RoleDeletionCheckProxy).registerProvider(
+			Container.get(ProvisioningRoleDeletionChecker),
+		);
 	}
 }

--- a/packages/cli/src/modules/provisioning.ee/role-deletion-checker.ee.ts
+++ b/packages/cli/src/modules/provisioning.ee/role-deletion-checker.ee.ts
@@ -1,0 +1,22 @@
+import { RoleMappingRuleRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import type { RoleDeletionChecker } from '@/services/role-deletion-check-proxy.service';
+
+/**
+ * Blocks deletion of a custom role while it is still targeted by an SSO role
+ * mapping rule. Registered on the core `RoleDeletionCheckProxy` by the
+ * provisioning module so `RoleService` stays decoupled from this module.
+ */
+@Service()
+export class ProvisioningRoleDeletionChecker implements RoleDeletionChecker {
+	constructor(private readonly roleMappingRuleRepository: RoleMappingRuleRepository) {}
+
+	async findRoleDeletionBlockers(roleSlug: string): Promise<string[]> {
+		const count = await this.roleMappingRuleRepository.count({
+			where: { role: { slug: roleSlug } },
+		});
+		if (count === 0) return [];
+		return [`referenced by ${count} role mapping rule${count === 1 ? '' : 's'}`];
+	}
+}

--- a/packages/cli/src/services/__tests__/role-deletion-check-proxy.service.test.ts
+++ b/packages/cli/src/services/__tests__/role-deletion-check-proxy.service.test.ts
@@ -1,0 +1,26 @@
+import { mock } from 'jest-mock-extended';
+
+import {
+	RoleDeletionCheckProxy,
+	type RoleDeletionChecker,
+} from '@/services/role-deletion-check-proxy.service';
+
+describe('RoleDeletionCheckProxy', () => {
+	it('reports no blockers when no provider is registered', async () => {
+		const proxy = new RoleDeletionCheckProxy();
+
+		await expect(proxy.findRoleDeletionBlockers('global:auditor')).resolves.toEqual([]);
+	});
+
+	it('delegates to the registered provider', async () => {
+		const proxy = new RoleDeletionCheckProxy();
+		const provider = mock<RoleDeletionChecker>();
+		provider.findRoleDeletionBlockers.mockResolvedValue(['referenced by 2 role mapping rules']);
+		proxy.registerProvider(provider);
+
+		const blockers = await proxy.findRoleDeletionBlockers('global:auditor');
+
+		expect(provider.findRoleDeletionBlockers).toHaveBeenCalledWith('global:auditor');
+		expect(blockers).toEqual(['referenced by 2 role mapping rules']);
+	});
+});

--- a/packages/cli/src/services/__tests__/role.service.assignments.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.assignments.test.ts
@@ -5,6 +5,7 @@ import { mock } from 'jest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { RoleCacheService } from '@/services/role-cache.service';
+import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
 import { Logger } from '@n8n/backend-common';
 
@@ -14,6 +15,7 @@ describe('RoleService.getRoleAssignments and getRoleProjectMembers', () => {
 	const scopeRepository = mockInstance(ScopeRepository);
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
+	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
 
 	const roleService = new RoleService(
 		licenseState,
@@ -21,6 +23,7 @@ describe('RoleService.getRoleAssignments and getRoleProjectMembers', () => {
 		scopeRepository,
 		roleCacheService,
 		logger,
+		roleDeletionCheckProxy,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
+++ b/packages/cli/src/services/__tests__/role.service.rolesWithScope.test.ts
@@ -4,6 +4,7 @@ import { RoleRepository, ScopeRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import { RoleCacheService } from '@/services/role-cache.service';
+import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
 import { Logger } from '@n8n/backend-common';
 
@@ -13,6 +14,7 @@ describe('RoleService.rolesWithScope', () => {
 	const scopeRepository = mockInstance(ScopeRepository);
 	const roleCacheService = mockInstance(RoleCacheService);
 	const logger = mockInstance(Logger);
+	const roleDeletionCheckProxy = mockInstance(RoleDeletionCheckProxy);
 
 	const roleService = new RoleService(
 		licenseState,
@@ -20,6 +22,7 @@ describe('RoleService.rolesWithScope', () => {
 		scopeRepository,
 		roleCacheService,
 		logger,
+		roleDeletionCheckProxy,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/services/role-deletion-check-proxy.service.ts
+++ b/packages/cli/src/services/role-deletion-check-proxy.service.ts
@@ -1,0 +1,37 @@
+import { Service } from '@n8n/di';
+
+/**
+ * Contract for contributing reasons a custom role cannot be deleted. Optional
+ * modules that reference roles (e.g. SSO provisioning mapping rules) implement
+ * this so the core role service can block deletion without importing them.
+ */
+export interface RoleDeletionChecker {
+	/**
+	 * Returns human-readable blockers preventing deletion of the role. An empty
+	 * array means the contributor has no objection.
+	 */
+	findRoleDeletionBlockers(roleSlug: string): Promise<string[]>;
+}
+
+/**
+ * Proxy through which the core `RoleService` collects role-deletion blockers
+ * from optional modules without importing them directly.
+ *
+ * A module registers its provider on init — same pattern as
+ * `OAuthTokenVerifierProxy`. Until a provider is registered (e.g. the module
+ * is disabled via license/env), there are no external blockers and deletion
+ * proceeds.
+ */
+@Service()
+export class RoleDeletionCheckProxy implements RoleDeletionChecker {
+	private provider: RoleDeletionChecker | null = null;
+
+	registerProvider(provider: RoleDeletionChecker): void {
+		this.provider = provider;
+	}
+
+	async findRoleDeletionBlockers(roleSlug: string): Promise<string[]> {
+		if (!this.provider) return [];
+		return await this.provider.findRoleDeletionBlockers(roleSlug);
+	}
+}

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -44,6 +44,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { isUniqueConstraintError } from '@/response-helper';
 
 import { RoleCacheService } from './role-cache.service';
+import { RoleDeletionCheckProxy } from './role-deletion-check-proxy.service';
 
 @Service()
 export class RoleService {
@@ -53,6 +54,7 @@ export class RoleService {
 		private readonly scopeRepository: ScopeRepository,
 		private readonly roleCacheService: RoleCacheService,
 		private readonly logger: Logger,
+		private readonly roleDeletionCheckProxy: RoleDeletionCheckProxy,
 	) {}
 
 	private dbRoleToRoleDTO(role: Role, usedByUsers?: number, usedByProjects?: number): RoleDTO {
@@ -149,6 +151,13 @@ export class RoleService {
 		const usersWithRole = await this.roleRepository.countUsersWithRole(role);
 		if (usersWithRole > 0) {
 			throw new BadRequestError('Cannot delete role assigned to users');
+		}
+
+		// Let optional modules (e.g. SSO provisioning) veto deletion of a role
+		// they still reference, so it isn't silently orphaned.
+		const blockers = await this.roleDeletionCheckProxy.findRoleDeletionBlockers(slug);
+		if (blockers.length > 0) {
+			throw new BadRequestError(`Cannot delete role: ${blockers.join('; ')}`);
 		}
 
 		await this.roleRepository.removeBySlug(slug);

--- a/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
+++ b/packages/cli/test/integration/oidc/oidc.service.ee.test.ts
@@ -10,6 +10,7 @@ jest.mock('openid-client', () => ({
 }));
 
 import type { OidcConfigDto, ProvisioningConfigDto } from '@n8n/api-types';
+import { LicenseState } from '@n8n/backend-common';
 import { createTeamProject, getProjectRoleForUser, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import { type User, UserRepository, RoleRepository, RoleMappingRuleRepository } from '@n8n/db';
@@ -20,10 +21,12 @@ const real_odic_client = jest.requireActual('openid-client');
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { License } from '@/license';
 import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { OIDC_CLIENT_SECRET_REDACTED_VALUE } from '@/modules/sso-oidc/constants';
 import { OidcService } from '@/modules/sso-oidc/oidc.service.ee';
 import { JwtService } from '@/services/jwt.service';
+import { createCustomRoleWithScopes, createScope } from '@test-integration/db/roles';
 import { createUser } from '@test-integration/db/users';
 
 beforeAll(async () => {
@@ -1154,6 +1157,62 @@ describe('OIDC service', () => {
 						relations: ['role'],
 					});
 					expect(userFromDB!.role.slug).toEqual('global:admin');
+				});
+
+				it('should provision a custom global role with its scopes via expression mapping', async () => {
+					const provisioningService = Container.get(ProvisioningService);
+					// @ts-expect-error - provisioningConfig is private
+					provisioningService.provisioningConfig.scopesUseExpressionMapping = true;
+
+					// Custom roles are license-gated when assigned via provisioning.
+					const licenseState = Container.get(LicenseState);
+					licenseState.setLicenseProvider(Container.get(License));
+					const customRolesLicensed = jest
+						.spyOn(licenseState, 'isCustomRolesLicensed')
+						.mockReturnValue(true);
+
+					// Custom global role with a scope, targeted by an instance rule.
+					const auditScope = await createScope();
+					const customRole = await createCustomRoleWithScopes([auditScope], {
+						slug: 'global:test-auditor',
+						displayName: 'Auditor',
+						roleType: 'global',
+					});
+					await roleMappingRuleRepository.save(
+						roleMappingRuleRepository.create({
+							expression: "{{ $claims.department === 'audit' }}",
+							role: customRole,
+							type: 'instance',
+							order: 0,
+						}),
+					);
+
+					const state = oidcService.generateState();
+					const nonce = oidcService.generateNonce();
+					const callbackUrl = new URL(
+						`http://localhost:5678/rest/sso/oidc/callback?code=valid-code&state=${state.plaintext}`,
+					);
+
+					const mockTokens = createProvisioningMockTokens('oidc-expr-custom-role-sub', {
+						department: 'audit',
+					});
+					authorizationCodeGrantMock.mockResolvedValueOnce(mockTokens);
+					fetchUserInfoMock.mockResolvedValueOnce({
+						email_verified: true,
+						email: 'oidc-expr-custom-role@example.com',
+					});
+
+					const user = await oidcService.loginUser(callbackUrl, state.signed, nonce.signed);
+					expect(user).toBeDefined();
+
+					const userFromDB = await userRepository.findOne({
+						where: { id: user.id },
+						relations: ['role', 'role.scopes'],
+					});
+					expect(userFromDB!.role.slug).toEqual('global:test-auditor');
+					expect(userFromDB!.role.scopes.map((s) => s.slug)).toContain(auditScope.slug);
+
+					customRolesLicensed.mockRestore();
 				});
 
 				it('should provision project role via expression mapping', async () => {

--- a/packages/cli/test/integration/services/role.service.test.ts
+++ b/packages/cli/test/integration/services/role.service.test.ts
@@ -2,14 +2,16 @@ import type { CreateRoleDto, UpdateRoleDto } from '@n8n/api-types';
 import { LicenseState } from '@n8n/backend-common';
 import { testDb } from '@n8n/backend-test-utils';
 import { ProjectRepository } from '@n8n/db';
-import { RoleRepository, UserRepository } from '@n8n/db';
+import { RoleMappingRuleRepository, RoleRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { ALL_ROLES } from '@n8n/permissions';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { License } from '@/license';
+import { ProvisioningRoleDeletionChecker } from '@/modules/provisioning.ee/role-deletion-checker.ee';
 import { ProjectService } from '@/services/project.service.ee';
+import { RoleDeletionCheckProxy } from '@/services/role-deletion-check-proxy.service';
 import { RoleService } from '@/services/role.service';
 
 import {
@@ -1370,6 +1372,68 @@ describe('RoleService', () => {
 			await expect(roleService.removeCustomRole(roleInUse.slug)).rejects.toThrow(
 				'Cannot delete role assigned to users',
 			);
+		});
+
+		describe('when referenced by an SSO role mapping rule', () => {
+			let roleMappingRuleRepository: RoleMappingRuleRepository;
+
+			beforeAll(() => {
+				roleMappingRuleRepository = Container.get(RoleMappingRuleRepository);
+				// Mirror how the provisioning module registers its checker on init,
+				// so the core guard can see mapping-rule references.
+				Container.get(RoleDeletionCheckProxy).registerProvider(
+					Container.get(ProvisioningRoleDeletionChecker),
+				);
+			});
+
+			afterEach(async () => {
+				await roleMappingRuleRepository.delete({});
+			});
+
+			it('should block deletion of a role still targeted by a mapping rule', async () => {
+				//
+				// ARRANGE
+				//
+				const role = await createRole({
+					displayName: 'Mapped Role',
+					roleType: 'global',
+					systemRole: false,
+				});
+				await roleMappingRuleRepository.save(
+					roleMappingRuleRepository.create({
+						expression: "{{ $claims.department === 'audit' }}",
+						role,
+						type: 'instance',
+						order: 0,
+					}),
+				);
+
+				//
+				// ACT & ASSERT
+				//
+				await expect(roleService.removeCustomRole(role.slug)).rejects.toThrow(BadRequestError);
+				await expect(roleService.removeCustomRole(role.slug)).rejects.toThrow(
+					'Cannot delete role: referenced by 1 role mapping rule',
+				);
+
+				// Role is preserved, not silently orphaned.
+				const stillExists = await roleRepository.findBySlug(role.slug);
+				expect(stillExists).not.toBeNull();
+			});
+
+			it('should allow deletion once no mapping rule references the role', async () => {
+				const role = await createRole({
+					displayName: 'Unmapped Role',
+					roleType: 'global',
+					systemRole: false,
+				});
+
+				const result = await roleService.removeCustomRole(role.slug);
+
+				expect(result.slug).toEqual(role.slug);
+				const deletedRole = await roleRepository.findBySlug(role.slug);
+				expect(deletedRole).toBeNull();
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

Custom global roles already provision end-to-end through SSO, but deleting a custom role still targeted by an SSO role mapping rule silently cascade-deleted that rule, breaking provisioning without warning. This PR blocks such deletions with a clear error, surfaced through a new `RoleDeletionCheckProxy` so the core `RoleService` collects blockers from the provisioning module without importing it (same proxy/provider pattern as `OAuthTokenVerifierProxy`). It also adds tests that lock custom-role provisioning via an instance mapping rule and verify IdP attribute → mapping rule → role resolution (match, no-match fallback, and re-evaluation) across both the SAML and OIDC attribute paths.

## How to test

This requires the `provisioning` module (an SSO license: `feat:oidc`/`feat:saml`/`feat:ldap`) and custom roles enabled.

1. Create a custom global role and a SAML/OIDC instance role mapping rule targeting it.
2. Log in via SSO with an attribute that matches the rule → the user is assigned the custom role and its scopes; with no matching rule it falls back to the default role.
3. Try to delete the custom role while the mapping rule exists → request is rejected with `Cannot delete role: referenced by N role mapping rule(s)`; delete the rule first, then deletion succeeds.

Automated: `pnpm --filter n8n test src/services/__tests__/role-deletion-check-proxy.service.test.ts src/modules/provisioning.ee/__tests__/role-deletion-checker.ee.test.ts src/modules/provisioning.ee/__tests__/role-resolver.service.ee.test.ts test/integration/services/role.service.test.ts test/integration/oidc/oidc.service.ee.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-843

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33004">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

