### PR TITLE
build: Declare missing tsx devDependency in test/eval packages (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/package.json
+++ b/packages/@n8n/ai-workflow-builder.ee/package.json
@@ -96,6 +96,7 @@
     "cli-progress": "^3.12.0",
     "cli-table3": "^0.6.3",
     "madge": "^8.0.0",
+    "tsx": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:"
   },

--- a/packages/@n8n/mcp-browser/package.json
+++ b/packages/@n8n/mcp-browser/package.json
@@ -46,6 +46,7 @@
     "@types/ws": "catalog:",
     "@types/yargs-parser": "21.0.0",
     "@vitest/coverage-v8": "catalog:",
+    "tsx": "catalog:",
     "vitest": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"

--- a/packages/testing/containers/package.json
+++ b/packages/testing/containers/package.json
@@ -42,5 +42,8 @@
     "kafkajs": "catalog:",
     "testcontainers": "catalog:",
     "undici": "catalog:undici-v7"
+  },
+  "devDependencies": {
+    "tsx": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,6 +1239,9 @@ importers:
       madge:
         specifier: ^8.0.0
         version: 8.0.0(typescript@6.0.2)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -2625,6 +2628,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.1(vitest@4.1.1)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5847,6 +5847,10 @@ importers:
       undici:
         specifier: catalog:undici-v7
         version: 7.28.0
+    devDependencies:
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
 
   packages/testing/janitor:
     dependencies:


### PR DESCRIPTION
## Summary

Several packages invoke a bare `tsx …` in their npm scripts but never declared `tsx` as a dependency — they relied on pnpm's `shamefully-hoist` surfacing `tsx` at the root `node_modules/.bin`. **#32569 ("Remove shamefully-hoist")** removed that, so on a clean install `tsx` is unresolvable for them (`sh: 1: tsx: not found` / `spawn ENOENT`).

Most visibly this breaks the **Instance AI eval CI** — the `Start sandbox service` step (`pnpm --filter n8n-containers services`) fails before the eval runs. The same latent gap affects two more packages whose tsx scripts simply haven't run since #32569.

Declare `tsx` (`catalog:`) in the affected packages, matching the sibling test packages that already do (`testing/playwright`, `testing/janitor`, …):

- **`n8n-containers`** — `stack`/`stack:*`/`services` (eval-CI blocker + local container dev)
- **`@n8n/ai-workflow-builder.ee`** — `eval`/`eval:langsmith`/… (its eval CLI; that workflow hasn't run since #32569, so the break is latent)
- **`@n8n/mcp-browser`** — `dev`

> `@n8n/workflow-sdk` has tsx scripts too but uses `npx tsx` (self-fetches if missing), so it isn't broken and is intentionally left out.

## How to test

- Clean install then `pnpm --filter n8n-containers stack:help` resolves `tsx` instead of `tsx: not found`.
- `pnpm install --frozen-lockfile` passes.
- The Instance AI eval CI's "Start sandbox service" step starts the container instead of failing at `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`.

## Related Linear tickets, Github issues, and Community forum posts

N/A — fallout from #32569 (remove shamefully-hoist).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with backport labels (if applicable).

🤖 PR Summary generated by AI