### PR TITLE
fix(core): Handle array-style conversations in mcp evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
@@ -9,7 +9,7 @@ vi.mock('fs', () => ({
 import { readdirSync, readFileSync } from 'fs';
 
 import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
-import { WorkflowTestCaseSchema } from '../data/workflows/schema';
+import { WorkflowTestCaseSchema, conversationTurnTextSchema } from '../data/workflows/schema';
 
 const mockedReaddir = vi.mocked(readdirSync);
 const mockedReadFile = vi.mocked(readFileSync);
@@ -42,6 +42,14 @@ describe('WorkflowTestCaseSchema', () => {
 
 	it('rejects an empty conversation', () => {
 		expect(() => WorkflowTestCaseSchema.parse({ ...validFixture(), conversation: [] })).toThrow();
+	});
+
+	it('normalizes an array-form turn text to a newline-joined string', () => {
+		const parsed = WorkflowTestCaseSchema.parse({
+			...validFixture(),
+			conversation: [{ role: 'user', text: ['line 1', 'line 2'] }],
+		});
+		expect(parsed.conversation[0].text).toBe('line 1\nline 2');
 	});
 
 	it('rejects an empty executionScenarios array', () => {
@@ -210,5 +218,17 @@ describe('loadWorkflowTestCasesWithFiles · file-aware errors', () => {
 		mockedReadFile.mockReturnValue(JSON.stringify({ conversation: [] }));
 		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/demo\.json/);
 		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/executionScenarios/);
+	});
+});
+
+describe('conversationTurnTextSchema', () => {
+	it('passes a plain string through unchanged', () => {
+		expect(conversationTurnTextSchema.parse('one line')).toBe('one line');
+	});
+
+	it('joins an array of lines with newlines', () => {
+		// The mcp-manifest builder reuses this, so the array form must normalize
+		// to a string before its buildPromptFromConversation calls .text.trim().
+		expect(conversationTurnTextSchema.parse(['line 1', 'line 2'])).toBe('line 1\nline 2');
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
@@ -10,7 +10,7 @@ import { homedir, tmpdir } from 'os';
 import { basename, join, resolve } from 'path';
 import { z } from 'zod';
 
-import { DEFAULT_DATASETS } from '../data/workflows/schema';
+import { DEFAULT_DATASETS, conversationTurnTextSchema } from '../data/workflows/schema';
 import { prebuiltManifestSchema, type PrebuiltManifest } from '../harness/prebuilt-workflows';
 import { runWithConcurrency } from '../harness/runner';
 
@@ -379,7 +379,9 @@ interface BuildOutcome {
 
 const testCaseSchema = z
 	.object({
-		conversation: z.array(z.object({ role: z.string(), text: z.string() })).min(1),
+		// Reuse the canonical text normalizer so the array (multi-line) form of a
+		// turn's `text` is accepted and joined here exactly as in the eval harness.
+		conversation: z.array(z.object({ role: z.string(), text: conversationTurnTextSchema })).min(1),
 	})
 	.passthrough();
 

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -6,14 +6,18 @@ import { SUPPORTED_CREDENTIAL_TYPES } from '../../credentials/seeder';
  *  source of truth shared by the loader schema and the mcp-manifest tier reader. */
 export const DEFAULT_DATASETS = ['full'];
 
+/** A conversation turn's `text`: a string, or an array of lines joined with
+ *  newlines. The array form lets long stage directions be authored readably
+ *  (one line per element) in the JSON file; every consumer still receives a
+ *  single string. Exported as the single source of truth so non-harness readers
+ *  (e.g. the mcp-manifest builder) normalize identically. */
+export const conversationTurnTextSchema = z
+	.union([z.string(), z.array(z.string())])
+	.transform((t) => (Array.isArray(t) ? t.join('\n') : t));
+
 const ConversationTurnSchema = z.object({
 	role: z.enum(['user', 'assistant']),
-	// A string, or an array of lines joined with newlines. The array form lets
-	// long stage directions be authored readably (one line per element) in the
-	// JSON file; every consumer still receives a single string.
-	text: z
-		.union([z.string(), z.array(z.string())])
-		.transform((t) => (Array.isArray(t) ? t.join('\n') : t)),
+	text: conversationTurnTextSchema,
 });
 
 const ExecutionScenarioSchema = z.object({


### PR DESCRIPTION
## Summary

`eval:build-mcp-manifest` crashed with a Zod error (`conversation.0.text: Expected string, received array`) when building the full `--tier mcp` cohort.

**What broke:** the manifest builder's local test-case schema only accepted `text: string`, but the canonical eval schema has long accepted `text: string | string[]` (the array form lets long stage directions be authored one line per element). The `mcp` tier includes cases using the array form (e.g. `whatsapp-faq-assistant`, `datatable-exact-spec-schema`), so parsing threw before any workflow was built. Latent since the array form landed; surfaced by the `mcp`
tier added in #32916.

**Fix:** export the canonical text normalizer (`conversationTurnTextSchema`) from the eval schema and reuse it in the manifest builder, so array-form `text` is accepted and joined into a single string — identical to the eval harness.


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33013">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

