### PR TITLE
fix(core): Remove duplicated sub-agent list

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSubAgentsPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentSubAgentsPanel.spec.ts
@@ -9,13 +9,9 @@ import {
 	SUB_AGENT_MAX_CHILDREN_MIN,
 } from '@n8n/api-types';
 
-import { AGENT_SUB_AGENTS_MODAL_KEY } from '../constants';
-import type { AgentJsonConfig, AgentResource } from '../types';
+import type { AgentJsonConfig } from '../types';
 import type { AgentModelSelection } from '../model-providers';
 
-const ensureLoadedMock = vi.fn();
-const projectAgentsListRef = ref<AgentResource[] | null>([]);
-const openModalWithDataMock = vi.fn();
 const showErrorMock = vi.fn();
 const ensureModelCatalogLoadedMock = vi.fn();
 const selectCredentialMock = vi.fn();
@@ -40,9 +36,6 @@ vi.mock('@n8n/i18n', () => ({
 			({
 				'agents.builder.subAgents.title': 'Sub-agents',
 				'agents.builder.subAgents.description': 'Sub-agents description',
-				'agents.builder.subAgents.add': 'Add agent',
-				'agents.builder.subAgents.loadError': 'Could not load project agents',
-				'agents.builder.subAgents.remove': 'Remove {name}',
 				'agents.builder.subAgents.maxChildren.label': 'Max parallel sub-agents',
 				'agents.builder.subAgents.maxChildren.hint': 'Max children hint',
 				'agents.builder.subAgents.modelsByDifficulty.title': 'Inline sub-agent models',
@@ -59,13 +52,6 @@ vi.mock('@n8n/i18n', () => ({
 				'credentials.noResults': 'No credentials',
 				error: 'Error',
 			})[key] ?? key,
-	}),
-}));
-
-vi.mock('../composables/useProjectAgentsList', () => ({
-	useProjectAgentsList: () => ({
-		list: projectAgentsListRef,
-		ensureLoaded: ensureLoadedMock,
 	}),
 }));
 
@@ -117,10 +103,6 @@ vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({ showError: showErrorMock }),
 }));
 
-vi.mock('@/app/stores/ui.store', () => ({
-	useUIStore: () => ({ openModalWithData: openModalWithDataMock }),
-}));
-
 vi.mock('../components/AgentModelSelector.vue', () => ({
 	default: {
 		name: 'AgentModelSelector',
@@ -147,11 +129,6 @@ vi.mock('../components/AgentModelSelector.vue', () => ({
 }));
 
 vi.mock('@n8n/design-system', () => ({
-	N8nCard: {
-		template: '<div><slot name="prepend" /><slot /><slot name="append" /></div>',
-		props: ['variant'],
-	},
-	N8nIcon: { template: '<span />', props: ['icon', 'size'] },
 	N8nIconButton: {
 		template: '<button :disabled="disabled" v-bind="$attrs"><slot /></button>',
 		props: ['disabled', 'ariaLabel', 'icon', 'variant', 'size', 'iconSize'],
@@ -162,16 +139,9 @@ vi.mock('@n8n/design-system', () => ({
 		template:
 			'<input :value="modelValue" :disabled="disabled" :min="min" :max="max" @input="$emit(\'update:modelValue\', Number($event.target.value))" />',
 	},
-	N8nScrollArea: { template: '<div><slot /></div>', props: ['maxHeight', 'type'] },
 	N8nText: { template: '<span><slot /></span>', props: ['tag', 'bold', 'size', 'color'] },
 	N8nTooltip: { template: '<div><slot /><slot name="content" /></div>' },
 }));
-
-const publishedSubAgent: AgentResource = {
-	id: 'agent-2',
-	name: 'Helper Agent',
-	activeVersionId: 'version-2',
-} as AgentResource;
 
 const defaultConfig: AgentJsonConfig = {
 	name: 'Agent',
@@ -218,12 +188,10 @@ describe('AgentSubAgentsPanel', () => {
 		vi.clearAllMocks();
 		agentModelSelectorChangeHandlers.clear();
 		agentModelSelectorCredentialHandlers.clear();
-		projectAgentsListRef.value = [];
 		credentialsByProviderRef.value = {
 			anthropic: 'anthropic-cred',
 			openai: 'openai-cred',
 		};
-		ensureLoadedMock.mockResolvedValue([]);
 		ensureModelCatalogLoadedMock.mockResolvedValue(undefined);
 	});
 
@@ -440,81 +408,7 @@ describe('AgentSubAgentsPanel', () => {
 		expect(selectCredentialMock).not.toHaveBeenCalled();
 	});
 
-	it('opens the sub-agents modal after project agents load successfully', async () => {
-		projectAgentsListRef.value = [publishedSubAgent];
-		const wrapper = await mountPanel();
-		await flushPromises();
-		const callsAfterMount = ensureLoadedMock.mock.calls.length;
-
-		await wrapper.find('[data-testid="agent-sub-agents-open-add-modal"]').trigger('click');
-		await flushPromises();
-
-		expect(ensureLoadedMock.mock.calls.length).toBe(callsAfterMount + 1);
-		expect(openModalWithDataMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				name: AGENT_SUB_AGENTS_MODAL_KEY,
-				data: expect.objectContaining({
-					agents: [{ id: 'agent-2', name: 'Helper Agent' }],
-				}),
-			}),
-		);
-		expect(showErrorMock).not.toHaveBeenCalled();
-	});
-
-	it('shows an error toast and does not open the modal when project agents fail to load', async () => {
-		const wrapper = await mountPanel();
-		await flushPromises();
-		const callsAfterMount = ensureLoadedMock.mock.calls.length;
-
-		const loadError = new Error('network');
-		ensureLoadedMock.mockRejectedValueOnce(loadError);
-
-		await wrapper.find('[data-testid="agent-sub-agents-open-add-modal"]').trigger('click');
-		await flushPromises();
-
-		expect(ensureLoadedMock.mock.calls.length).toBe(callsAfterMount + 1);
-		expect(showErrorMock).toHaveBeenCalledWith(loadError, 'Could not load project agents');
-		expect(openModalWithDataMock).not.toHaveBeenCalled();
-	});
-
-	it('emits update:config when the modal confirms an added agent with useWhen guidance', async () => {
-		projectAgentsListRef.value = [publishedSubAgent];
-		const wrapper = await mountPanel({
-			...defaultConfig,
-			subAgents: { maxChildren: 7 },
-		});
-		await flushPromises();
-
-		await wrapper.find('[data-testid="agent-sub-agents-open-add-modal"]').trigger('click');
-		await flushPromises();
-
-		const modalCall = openModalWithDataMock.mock.calls[0]?.[0] as {
-			data: { onConfirm: (payload: { agentId: string; useWhen?: string }) => void };
-		};
-		modalCall.data.onConfirm({
-			agentId: 'agent-2',
-			useWhen: 'Use for billing escalations.',
-		});
-
-		expect(wrapper.emitted('update:config')?.[0]).toEqual([
-			{
-				subAgents: {
-					maxChildren: 7,
-					agents: [{ agentId: 'agent-2', useWhen: 'Use for billing escalations.' }],
-				},
-			},
-		]);
-	});
-
-	it('removes a selected sub-agent and preserves the remaining refs and maxChildren', async () => {
-		projectAgentsListRef.value = [
-			publishedSubAgent,
-			{
-				id: 'agent-3',
-				name: 'Other Agent',
-				activeVersionId: 'version-3',
-			} as AgentResource,
-		];
+	it('does not render selected sub-agent rows in the settings panel', async () => {
 		const wrapper = await mountPanel({
 			...defaultConfig,
 			subAgents: {
@@ -525,67 +419,8 @@ describe('AgentSubAgentsPanel', () => {
 				],
 			},
 		});
-		await flushPromises();
 
-		const rows = wrapper.findAll('[data-testid="agent-sub-agent-row"]');
-		expect(rows).toHaveLength(2);
-
-		const removeButtons = wrapper.findAll('[data-testid="agent-sub-agent-remove"]');
-		expect(removeButtons).toHaveLength(2);
-		await removeButtons[0].trigger('click');
-
-		expect(wrapper.emitted('update:config')?.[0]).toEqual([
-			{
-				subAgents: {
-					maxChildren: 6,
-					agents: [{ agentId: 'agent-3', useWhen: 'Use for research tasks.' }],
-				},
-			},
-		]);
-	});
-
-	it('opens the configure modal for an existing sub-agent and updates useWhen', async () => {
-		projectAgentsListRef.value = [publishedSubAgent];
-		const wrapper = await mountPanel({
-			...defaultConfig,
-			subAgents: {
-				maxChildren: 6,
-				agents: [{ agentId: 'agent-2', useWhen: 'Use for billing escalations.' }],
-			},
-		});
-		await flushPromises();
-
-		await wrapper.find('[data-testid="agent-sub-agent-row"]').trigger('click');
-
-		const modalCall = openModalWithDataMock.mock.calls[0]?.[0] as {
-			data: {
-				selectedAgent: { id: string; name: string };
-				useWhen?: string;
-				onConfirm: (payload: { agentId: string; useWhen?: string }) => void;
-			};
-		};
-		expect(modalCall).toEqual(
-			expect.objectContaining({
-				name: AGENT_SUB_AGENTS_MODAL_KEY,
-				data: expect.objectContaining({
-					selectedAgent: { id: 'agent-2', name: 'Helper Agent' },
-					useWhen: 'Use for billing escalations.',
-				}),
-			}),
-		);
-
-		modalCall.data.onConfirm({
-			agentId: 'agent-2',
-			useWhen: 'Use for invoices and payment status.',
-		});
-
-		expect(wrapper.emitted('update:config')?.[0]).toEqual([
-			{
-				subAgents: {
-					maxChildren: 6,
-					agents: [{ agentId: 'agent-2', useWhen: 'Use for invoices and payment status.' }],
-				},
-			},
-		]);
+		expect(wrapper.find('[data-testid="agent-sub-agent-row"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-sub-agents-open-add-modal"]').exists()).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentSubAgentsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentSubAgentsPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
 	SUB_AGENT_MAX_CHILDREN_DEFAULT,
 	SUB_AGENT_MAX_CHILDREN_MAX,
@@ -8,23 +8,13 @@ import {
 	type SubAgentTaskDifficulty,
 } from '@n8n/api-types';
 import type { BaseTextKey } from '@n8n/i18n';
-import {
-	N8nCard,
-	N8nIcon,
-	N8nIconButton,
-	N8nInputNumber2,
-	N8nScrollArea,
-	N8nText,
-	N8nTooltip,
-} from '@n8n/design-system';
+import { N8nIconButton, N8nInputNumber2, N8nText, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
-import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 
 import { useAgentModelCredentials } from '../composables/useAgentModelCredentials';
 import { useModelCatalog } from '../composables/useModelCatalog';
-import { useProjectAgentsList } from '../composables/useProjectAgentsList';
 import AgentModelSelector from './AgentModelSelector.vue';
 import {
 	type AgentCredentialsByProvider,
@@ -35,7 +25,6 @@ import {
 	isAgentModelProvider,
 } from '../model-providers';
 import type { AgentJsonConfig } from '../types';
-import { AGENT_SUB_AGENTS_MODAL_KEY } from '../constants';
 import { parseModelString, sanitizeModelId } from '../utils/model-string';
 
 const DIFFICULTY_LABEL_KEYS: Record<SubAgentTaskDifficulty, BaseTextKey> = {
@@ -63,11 +52,7 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const toast = useToast();
-const uiStore = useUIStore();
 const usersStore = useUsersStore();
-const { list: projectAgents, ensureLoaded: ensureProjectAgentsLoaded } = useProjectAgentsList(
-	computed(() => props.projectId),
-);
 const { ensureLoaded, getModelsForPicker, isLoading } = useModelCatalog();
 const projectIdRef = computed(() => props.projectId);
 const { credentialsByProvider } = useAgentModelCredentials(
@@ -78,10 +63,6 @@ const maxChildrenHintInterpolate = {
 	min: String(SUB_AGENT_MAX_CHILDREN_MIN),
 	max: String(SUB_AGENT_MAX_CHILDREN_MAX),
 };
-
-onMounted(() => {
-	void ensureProjectAgentsLoaded().catch(() => {});
-});
 
 watch(
 	projectIdRef,
@@ -107,45 +88,6 @@ watch(
 		maxChildrenModelValue.value = resolveMaxChildrenDisplay(value);
 	},
 );
-
-const selectedSubAgentRefs = computed(() => props.config?.subAgents?.agents ?? []);
-const selectedSubAgentIds = computed(() =>
-	selectedSubAgentRefs.value.map(({ agentId }) => agentId),
-);
-const selectedSubAgentIdSet = computed(() => new Set(selectedSubAgentIds.value));
-const availableSubAgents = computed(() =>
-	(projectAgents.value ?? []).filter(
-		(agent) =>
-			agent.id !== props.agentId &&
-			Boolean(agent.activeVersionId) &&
-			!selectedSubAgentIdSet.value.has(agent.id),
-	),
-);
-const selectedSubAgents = computed(() =>
-	selectedSubAgentRefs.value.map(({ agentId, useWhen }) => {
-		const agent = projectAgents.value?.find((candidate) => candidate.id === agentId);
-		return {
-			id: agentId,
-			name: agent?.name ?? agentId,
-			...(useWhen !== undefined ? { useWhen } : {}),
-		};
-	}),
-);
-
-function buildSubAgentsUpdate(
-	overrides: Partial<NonNullable<AgentJsonConfig['subAgents']>>,
-): Partial<AgentJsonConfig> {
-	return {
-		subAgents: {
-			...(props.config?.subAgents ?? {}),
-			...overrides,
-		},
-	};
-}
-
-function emitSubAgentsAgents(agents: typeof selectedSubAgentRefs.value) {
-	emit('update:config', buildSubAgentsUpdate({ agents }));
-}
 
 function onMaxChildrenChange(n: number) {
 	if (props.disabled) return;
@@ -264,66 +206,6 @@ function clearDifficultyMapping(difficulty: SubAgentTaskDifficulty) {
 
 	emitModelsByDifficulty(difficulty, undefined);
 }
-
-async function onOpenAddSubAgentsModal() {
-	if (props.disabled) return;
-
-	try {
-		await ensureProjectAgentsLoaded();
-	} catch (error) {
-		toast.showError(error, i18n.baseText('agents.builder.subAgents.loadError'));
-		return;
-	}
-
-	uiStore.openModalWithData({
-		name: AGENT_SUB_AGENTS_MODAL_KEY,
-		data: {
-			agents: availableSubAgents.value.map(({ id, name }) => ({
-				id,
-				name,
-			})),
-			onConfirm: ({ agentId, useWhen }: { agentId: string; useWhen?: string }) => {
-				if (selectedSubAgentIdSet.value.has(agentId)) return;
-
-				emitSubAgentsAgents([
-					...selectedSubAgentRefs.value,
-					{ agentId, ...(useWhen ? { useWhen } : {}) },
-				]);
-			},
-		},
-	});
-}
-
-function onOpenEditSubAgentModal(subAgent: { id: string; name: string; useWhen?: string }) {
-	if (props.disabled) return;
-
-	uiStore.openModalWithData({
-		name: AGENT_SUB_AGENTS_MODAL_KEY,
-		data: {
-			selectedAgent: {
-				id: subAgent.id,
-				name: subAgent.name,
-			},
-			...(subAgent.useWhen ? { useWhen: subAgent.useWhen } : {}),
-			onConfirm: ({ agentId, useWhen }: { agentId: string; useWhen?: string }) => {
-				emitSubAgentsAgents(
-					selectedSubAgentRefs.value.map((ref) =>
-						ref.agentId === agentId ? { agentId, ...(useWhen ? { useWhen } : {}) } : ref,
-					),
-				);
-			},
-			onRemove: onRemoveSubAgent,
-		},
-	});
-}
-
-function onRemoveSubAgent(agentId: string) {
-	if (props.disabled) return;
-
-	emitSubAgentsAgents(
-		selectedSubAgentRefs.value.filter((subAgent) => subAgent.agentId !== agentId),
-	);
-}
 </script>
 
 <template>
@@ -336,20 +218,6 @@ function onRemoveSubAgent(agentId: string) {
 				<N8nText size="small" color="text-light">
 					{{ i18n.baseText('agents.builder.subAgents.description') }}
 				</N8nText>
-			</div>
-			<div :class="$style.subAgentsHeaderActions">
-				<N8nTooltip :content="i18n.baseText('agents.builder.subAgents.add')" placement="top">
-					<N8nIconButton
-						icon="plus"
-						variant="ghost"
-						size="small"
-						icon-size="medium"
-						:disabled="disabled"
-						:aria-label="i18n.baseText('agents.builder.subAgents.add')"
-						data-testid="agent-sub-agents-open-add-modal"
-						@click="onOpenAddSubAgentsModal"
-					/>
-				</N8nTooltip>
 			</div>
 		</div>
 
@@ -440,60 +308,6 @@ function onRemoveSubAgent(agentId: string) {
 				</div>
 			</div>
 		</div>
-
-		<hr v-if="selectedSubAgentRefs.length > 0" aria-hidden="true" :class="$style.divider" />
-
-		<div v-if="selectedSubAgents.length > 0" :class="$style.subAgentsContent">
-			<N8nScrollArea
-				max-height="calc((var(--spacing--2xl) + var(--spacing--sm)) * 5)"
-				type="auto"
-				:class="$style.rows"
-			>
-				<div :class="$style.rowList">
-					<N8nCard
-						v-for="subAgent in selectedSubAgents"
-						:key="subAgent.id"
-						:class="$style.row"
-						data-testid="agent-sub-agent-row"
-						@click="onOpenEditSubAgentModal(subAgent)"
-					>
-						<template #prepend>
-							<N8nIcon icon="bot" size="medium" :class="$style.itemIcon" />
-						</template>
-
-						<N8nText size="xsmall" color="text-dark" :bold="true" :class="$style.name">
-							{{ subAgent.name }}
-						</N8nText>
-
-						<template #append>
-							<N8nTooltip
-								:content="
-									i18n.baseText('agents.builder.subAgents.remove', {
-										interpolate: { name: subAgent.name },
-									})
-								"
-								placement="top"
-							>
-								<N8nIconButton
-									icon="trash-2"
-									variant="ghost"
-									size="mini"
-									icon-size="small"
-									:disabled="disabled"
-									:aria-label="
-										i18n.baseText('agents.builder.subAgents.remove', {
-											interpolate: { name: subAgent.name },
-										})
-									"
-									data-testid="agent-sub-agent-remove"
-									@click.stop="onRemoveSubAgent(subAgent.id)"
-								/>
-							</N8nTooltip>
-						</template>
-					</N8nCard>
-				</div>
-			</N8nScrollArea>
-		</div>
 	</div>
 </template>
 
@@ -522,13 +336,6 @@ function onRemoveSubAgent(agentId: string) {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--3xs);
-}
-
-.subAgentsHeaderActions {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing--2xs);
-	flex-shrink: 0;
 }
 
 .settingRow {
@@ -601,48 +408,5 @@ function onRemoveSubAgent(agentId: string) {
 .difficultyControls > :first-child {
 	flex: 1;
 	min-width: calc(var(--spacing--5xl) - var(--spacing--xl));
-}
-
-.divider {
-	border: none;
-	border-top: var(--border);
-	margin: var(--spacing--2xs) 0;
-}
-
-.subAgentsContent {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--sm);
-	width: 100%;
-}
-
-.rowList {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--2xs);
-	padding-right: var(--spacing--xs);
-}
-
-.rows {
-	scrollbar-gutter: stable;
-}
-
-.row {
-	--card--append--width: auto;
-	flex-shrink: 0;
-	cursor: pointer;
-}
-
-.itemIcon {
-	flex-shrink: 0;
-	color: var(--text-color--subtle);
-}
-
-.name {
-	display: block;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	max-width: 100%;
 }
 </style>


### PR DESCRIPTION
## Summary

- Removes the stale sub-agent list and add/edit/remove controls from the Sub-agents settings panel.
- Keeps sub-agent management in the Agent capabilities section, where it was moved.
- Updates the focused panel test to assert selected sub-agent rows no longer render there.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-291/bug-sub-agents-list-is-duplicated

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33015">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->