### PR TITLE
fix(core): Parse OAuth2 token responses with non-standard content types

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -131,29 +131,22 @@ export class ClientOAuth2 {
 		const contentType = (response.headers['content-type'] as string) ?? '';
 		const body = response.data as string;
 
-		if (contentType.startsWith('application/json')) {
-			try {
-				return JSON.parse(body) as T;
-			} catch {
-				const preview = body.length > 100 ? body.slice(0, 100) + '...' : body;
-				throw new ResponseError(
-					response.status,
-					body,
-					undefined,
-					`Expected JSON response from OAuth2 token endpoint but received: ${preview}`,
-				);
-			}
-		}
-
 		if (contentType.startsWith('application/x-www-form-urlencoded')) {
 			return qs.parse(body) as T;
 		}
 
-		throw new ResponseError(
-			response.status,
-			body,
-			undefined,
-			`Unsupported content type: ${contentType}`,
-		);
+		// RFC 6749 §5.1 mandates a JSON body, not a JSON content-type header.
+		// Parse by body shape so providers that mislabel JSON (e.g. text/plain) still work.
+		try {
+			return JSON.parse(body) as T;
+		} catch {
+			const preview = body.length > 100 ? body.slice(0, 100) + '...' : body;
+			throw new ResponseError(
+				response.status,
+				body,
+				undefined,
+				`Expected JSON response from OAuth2 token endpoint (content-type: ${contentType || 'none'}) but received: ${preview}`,
+			);
+		}
 	}
 }

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -128,16 +128,50 @@ describe('ClientOAuth2', () => {
 				contentType: 'text/plain',
 				body: 'Hello, world!',
 			},
-		])('should reject content type $contentType', async ({ contentType, body }) => {
+		])(
+			'should report a body preview for non-JSON content type $contentType',
+			async ({ contentType, body }) => {
+				mockTokenResponse({
+					status: 200,
+					headers: { 'Content-Type': contentType },
+					body,
+				});
+
+				const result = await makeTokenCall().catch((err) => err);
+				expect(result).toBeInstanceOf(ResponseError);
+				expect(result.message).toContain('Expected JSON response from OAuth2 token endpoint');
+				expect(result.message).toContain(`(content-type: ${contentType})`);
+			},
+		);
+
+		it('should parse a JSON body served with a non-JSON content type', async () => {
 			mockTokenResponse({
 				status: 200,
-				headers: { 'Content-Type': contentType },
-				body,
+				headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+				body: JSON.stringify({
+					access_token: config.accessToken,
+					refresh_token: config.refreshToken,
+				}),
+			});
+
+			const response = await makeTokenCall();
+
+			expect(response).toEqual({
+				access_token: config.accessToken,
+				refresh_token: config.refreshToken,
+			});
+		});
+
+		it('should surface auth errors served with a non-JSON content type', async () => {
+			mockTokenResponse({
+				status: 400,
+				headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+				body: JSON.stringify({ error: 'invalid_grant' }),
 			});
 
 			const result = await makeTokenCall().catch((err) => err);
-			expect(result).toBeInstanceOf(Error);
-			expect(result.message).toEqual(`Unsupported content type: ${contentType}`);
+			expect(result).toBeInstanceOf(AuthError);
+			expect(result.body).toEqual({ error: 'invalid_grant' });
 		});
 
 		it('should throw ResponseError when application/json response contains invalid JSON', async () => {
@@ -152,9 +186,8 @@ describe('ClientOAuth2', () => {
 			expect(result).toBeInstanceOf(ResponseError);
 			expect(result.status).toBe(200);
 			expect(result.body).toBe(htmlBody);
-			expect(result.message).toContain(
-				'Expected JSON response from OAuth2 token endpoint but received:',
-			);
+			expect(result.message).toContain('Expected JSON response from OAuth2 token endpoint');
+			expect(result.message).toContain('(content-type: application/json)');
 			expect(result.message).toContain('<!DOCTYPE html>');
 		});
 


### PR DESCRIPTION
## Summary

The OAuth2 client rejected any token-endpoint response whose `Content Type` was not `application/json` or `application/x-www-form-urlencoded`, throwing `Unsupported content type: …`. Some providers (e.g. Jobber) return a valid JSON token body under `text/plain; charset=utf-8`, which broke token refresh entirely.

This PR makes `ClientOAuth2.parseResponseBody` parse the token-endpoint body by **shape** rather than trusting the `Content-Type` header: the form-urlencoded fast path is unchanged, and everything else is parsed as JSON, falling back to a clearer, body-previewing error only when the body is genuinely not JSON.

**Why this matters (the failure it fixes):** with a provider that rotates refresh tokens, the broken path silently bricks the credential. On refresh, the provider's server *succeeds* — it issues a new access token, rotates the refresh token, and invalidates the old one — but n8n rejected the `text/plain` response before merging (`client-oauth2-token.ts`) or persisting (`request-helpers/oauth.ts` → `updateCredentialsOauthTokenData`) the rotated token. n8n's DB kept the *old* refresh token, which the provider had already invalidated, so every subsequent refresh failed with a 401 and the only recovery was a manual "reconnect" (which works for ~1h, until the first refresh, then breaks again). RFC 6749 §5.1 mandates a JSON *body*, not a specific `Content-Type` header, so trusting the header was the defect.

### Out of scope

A separate, larger concurrency/rotation-safety issue exists, this will help with surfacing errors or fix the problem in some cases, but not all. A follow up ticket will be created to centralized the refreshing of oAuth2 tokens.

## Related Links

- closes https://linear.app/n8n/issue/IAM-693

This should help surface the underlying problem for #30345

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

