### PR TITLE
fix(core): Align markdown task list items

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/markdown.scss
+++ b/packages/frontend/@n8n/design-system/src/css/markdown.scss
@@ -259,6 +259,27 @@ body[data-theme='dark'] {
 		}
 	}
 
+	ul[data-type='taskList'] {
+		padding-left: 0;
+		list-style: none;
+
+		li {
+			display: flex;
+			align-items: flex-start;
+			gap: var(--spacing--2xs);
+		}
+
+		li > label {
+			flex: 0 0 auto;
+			user-select: none;
+		}
+
+		li > div {
+			flex: 1 1 auto;
+			min-width: 0;
+		}
+	}
+
 	ul ul,
 	ol ol,
 	ul ol,


### PR DESCRIPTION
## Summary

- Fixes N8nMarkdownEditor task lists so checkboxes and text stay on the same row.
- Adds shared markdown CSS for TipTap task-list output, covering the agents task modal and other editor usages.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-264/bug-task-list-in-agents-editor-doesnt-format-correctly

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->