### PR TITLE
chore(core): Capture span callback exceptions

### DIFF
--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -210,7 +210,7 @@ export class ErrorReporter {
 				.filter((integrationName) => !!eligibleIntegrations[integrationName])
 				.forEach((integrationName) => enabledIntegrations.add(integrationName));
 
-			this.tracing.setTracingImplementation(new SentryTracing(sentry, this));
+			this.tracing.setTracingImplementation(new SentryTracing(sentry));
 		}
 
 		const isProfilingEnabled = profilesSampleRate > 0;

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -210,7 +210,7 @@ export class ErrorReporter {
 				.filter((integrationName) => !!eligibleIntegrations[integrationName])
 				.forEach((integrationName) => enabledIntegrations.add(integrationName));
 
-			this.tracing.setTracingImplementation(new SentryTracing(sentry));
+			this.tracing.setTracingImplementation(new SentryTracing(sentry, this));
 		}
 
 		const isProfilingEnabled = profilesSampleRate > 0;

--- a/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest';
 import { mock, mockClear } from 'vitest-mock-extended';
 
 import { SentryTracing } from '../sentry-tracing';
+import { SpanStatus, type Span } from '../tracing';
 
 describe('SentryTracing', () => {
 	let sentryTracing: SentryTracing;
@@ -65,7 +66,7 @@ describe('SentryTracing', () => {
 			const callback = vi.fn().mockRejectedValue(error);
 
 			mockSentry.startSpan.mockImplementation(async (_opts, cb) => {
-				return await cb({} as Sentry.Span);
+				return await cb(mock<Span>());
 			});
 
 			await expect(sentryTracing.startSpan(options, callback)).rejects.toThrow('Callback error');
@@ -122,6 +123,58 @@ describe('SentryTracing', () => {
 
 			expect(result).toBe('inner-result');
 			expect(mockSentry.startSpan).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('error handling', () => {
+		let span: Span;
+
+		beforeEach(() => {
+			span = mock<Span>();
+			mockSentry.startSpan.mockImplementation(async (_opts, cb) => await cb(span));
+		});
+
+		it('should record the exception and set error status/attributes when the callback throws', async () => {
+			const error = new TypeError('boom');
+			const callback = vi.fn().mockRejectedValue(error);
+
+			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).rejects.toBe(error);
+
+			expect(span.recordException).toHaveBeenCalledWith(error);
+			expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatus.error, message: 'boom' });
+			expect(span.setAttributes).toHaveBeenCalledWith({
+				'error.type': 'TypeError',
+				'error.message': 'boom',
+			});
+		});
+
+		it('should wrap non-Error throws via ensureError', async () => {
+			const callback = vi.fn().mockRejectedValue('string failure');
+
+			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).rejects.toBe(
+				'string failure',
+			);
+
+			const wrapped = expect.objectContaining({ cause: 'string failure' });
+			expect(span.recordException).toHaveBeenCalledWith(wrapped);
+			expect(span.setStatus).toHaveBeenCalledWith({
+				code: SpanStatus.error,
+				message: 'Error that was not an instance of Error was thrown',
+			});
+			expect(span.setAttributes).toHaveBeenCalledWith({
+				'error.type': 'Error',
+				'error.message': 'Error that was not an instance of Error was thrown',
+			});
+		});
+
+		it('should not touch the span on success', async () => {
+			const callback = vi.fn().mockResolvedValue('ok');
+
+			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).resolves.toBe('ok');
+
+			expect(span.recordException).not.toHaveBeenCalled();
+			expect(span.setStatus).not.toHaveBeenCalled();
+			expect(span.setAttributes).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
@@ -3,19 +3,26 @@ import type Sentry from '@sentry/node';
 import type { Mock } from 'vitest';
 import { mock, mockClear } from 'vitest-mock-extended';
 
-import { SentryTracing } from '../sentry-tracing';
+import { SentryTracing, type TraceErrorReporter } from '../sentry-tracing';
 import { SpanStatus, type Span } from '../tracing';
 
 describe('SentryTracing', () => {
 	let sentryTracing: SentryTracing;
+	const traceContext = {
+		traceId: 'trace-id',
+		spanId: 'span-id',
+		traceFlags: 1,
+	};
 	const mockSentry = mock({
 		startSpan: vi.fn(),
 	});
+	const mockErrorReporter = mock<TraceErrorReporter>();
 
 	beforeEach(() => {
 		mockClear(mockSentry);
+		mockClear(mockErrorReporter);
 
-		sentryTracing = new SentryTracing(mockSentry);
+		sentryTracing = new SentryTracing(mockSentry, mockErrorReporter);
 	});
 
 	describe('startSpan', () => {
@@ -66,7 +73,9 @@ describe('SentryTracing', () => {
 			const callback = vi.fn().mockRejectedValue(error);
 
 			mockSentry.startSpan.mockImplementation(async (_opts, cb) => {
-				return await cb(mock<Span>());
+				const span = mock<Span>();
+				vi.mocked(span.spanContext).mockReturnValue(traceContext);
+				return await cb(span);
 			});
 
 			await expect(sentryTracing.startSpan(options, callback)).rejects.toThrow('Callback error');
@@ -131,20 +140,26 @@ describe('SentryTracing', () => {
 
 		beforeEach(() => {
 			span = mock<Span>();
+			vi.mocked(span.spanContext).mockReturnValue(traceContext);
 			mockSentry.startSpan.mockImplementation(async (_opts, cb) => await cb(span));
 		});
 
-		it('should record the exception and set error status/attributes when the callback throws', async () => {
+		it('should report the exception and set error status/attributes when the callback throws', async () => {
 			const error = new TypeError('boom');
 			const callback = vi.fn().mockRejectedValue(error);
 
 			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).rejects.toBe(error);
 
-			expect(span.recordException).toHaveBeenCalledWith(error);
 			expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatus.error, message: 'boom' });
 			expect(span.setAttributes).toHaveBeenCalledWith({
 				'error.type': 'TypeError',
 				'error.message': 'boom',
+			});
+			expect(mockErrorReporter.error).toHaveBeenCalledWith(error, {
+				shouldBeLogged: false,
+				extra: {
+					trace: traceContext,
+				},
 			});
 		});
 
@@ -156,7 +171,6 @@ describe('SentryTracing', () => {
 			);
 
 			const wrapped = expect.objectContaining({ cause: 'string failure' });
-			expect(span.recordException).toHaveBeenCalledWith(wrapped);
 			expect(span.setStatus).toHaveBeenCalledWith({
 				code: SpanStatus.error,
 				message: 'Error that was not an instance of Error was thrown',
@@ -165,6 +179,12 @@ describe('SentryTracing', () => {
 				'error.type': 'Error',
 				'error.message': 'Error that was not an instance of Error was thrown',
 			});
+			expect(mockErrorReporter.error).toHaveBeenCalledWith(wrapped, {
+				shouldBeLogged: false,
+				extra: {
+					trace: traceContext,
+				},
+			});
 		});
 
 		it('should not touch the span on success', async () => {
@@ -172,9 +192,19 @@ describe('SentryTracing', () => {
 
 			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).resolves.toBe('ok');
 
-			expect(span.recordException).not.toHaveBeenCalled();
 			expect(span.setStatus).not.toHaveBeenCalled();
 			expect(span.setAttributes).not.toHaveBeenCalled();
+			expect(mockErrorReporter.error).not.toHaveBeenCalled();
+		});
+
+		it('should preserve the original callback error when reporting fails', async () => {
+			const error = new Error('boom');
+			const callback = vi.fn().mockRejectedValue(error);
+			mockErrorReporter.error.mockImplementation(() => {
+				throw new Error('reporting failed');
+			});
+
+			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).rejects.toBe(error);
 		});
 	});
 });

--- a/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
@@ -3,26 +3,19 @@ import type Sentry from '@sentry/node';
 import type { Mock } from 'vitest';
 import { mock, mockClear } from 'vitest-mock-extended';
 
-import { SentryTracing, type TraceErrorReporter } from '../sentry-tracing';
+import { SentryTracing } from '../sentry-tracing';
 import { SpanStatus, type Span } from '../tracing';
 
 describe('SentryTracing', () => {
 	let sentryTracing: SentryTracing;
-	const traceContext = {
-		traceId: 'trace-id',
-		spanId: 'span-id',
-		traceFlags: 1,
-	};
 	const mockSentry = mock({
 		startSpan: vi.fn(),
 	});
-	const mockErrorReporter = mock<TraceErrorReporter>();
 
 	beforeEach(() => {
 		mockClear(mockSentry);
-		mockClear(mockErrorReporter);
 
-		sentryTracing = new SentryTracing(mockSentry, mockErrorReporter);
+		sentryTracing = new SentryTracing(mockSentry);
 	});
 
 	describe('startSpan', () => {
@@ -73,9 +66,7 @@ describe('SentryTracing', () => {
 			const callback = vi.fn().mockRejectedValue(error);
 
 			mockSentry.startSpan.mockImplementation(async (_opts, cb) => {
-				const span = mock<Span>();
-				vi.mocked(span.spanContext).mockReturnValue(traceContext);
-				return await cb(span);
+				return await cb(mock<Span>());
 			});
 
 			await expect(sentryTracing.startSpan(options, callback)).rejects.toThrow('Callback error');
@@ -140,11 +131,10 @@ describe('SentryTracing', () => {
 
 		beforeEach(() => {
 			span = mock<Span>();
-			vi.mocked(span.spanContext).mockReturnValue(traceContext);
 			mockSentry.startSpan.mockImplementation(async (_opts, cb) => await cb(span));
 		});
 
-		it('should report the exception and set error status/attributes when the callback throws', async () => {
+		it('should set error status/attributes when the callback throws', async () => {
 			const error = new TypeError('boom');
 			const callback = vi.fn().mockRejectedValue(error);
 
@@ -155,12 +145,6 @@ describe('SentryTracing', () => {
 				'error.type': 'TypeError',
 				'error.message': 'boom',
 			});
-			expect(mockErrorReporter.error).toHaveBeenCalledWith(error, {
-				shouldBeLogged: false,
-				extra: {
-					trace: traceContext,
-				},
-			});
 		});
 
 		it('should wrap non-Error throws via ensureError', async () => {
@@ -170,7 +154,6 @@ describe('SentryTracing', () => {
 				'string failure',
 			);
 
-			const wrapped = expect.objectContaining({ cause: 'string failure' });
 			expect(span.setStatus).toHaveBeenCalledWith({
 				code: SpanStatus.error,
 				message: 'Error that was not an instance of Error was thrown',
@@ -178,12 +161,6 @@ describe('SentryTracing', () => {
 			expect(span.setAttributes).toHaveBeenCalledWith({
 				'error.type': 'Error',
 				'error.message': 'Error that was not an instance of Error was thrown',
-			});
-			expect(mockErrorReporter.error).toHaveBeenCalledWith(wrapped, {
-				shouldBeLogged: false,
-				extra: {
-					trace: traceContext,
-				},
 			});
 		});
 
@@ -194,17 +171,6 @@ describe('SentryTracing', () => {
 
 			expect(span.setStatus).not.toHaveBeenCalled();
 			expect(span.setAttributes).not.toHaveBeenCalled();
-			expect(mockErrorReporter.error).not.toHaveBeenCalled();
-		});
-
-		it('should preserve the original callback error when reporting fails', async () => {
-			const error = new Error('boom');
-			const callback = vi.fn().mockRejectedValue(error);
-			mockErrorReporter.error.mockImplementation(() => {
-				throw new Error('reporting failed');
-			});
-
-			await expect(sentryTracing.startSpan({ name: 'span' }, callback)).rejects.toBe(error);
 		});
 	});
 });

--- a/packages/core/src/observability/tracing/sentry-tracing.ts
+++ b/packages/core/src/observability/tracing/sentry-tracing.ts
@@ -1,28 +1,46 @@
+import type { ReportingOptions } from '@n8n/errors';
 import type Sentry from '@sentry/node';
 import { ensureError } from 'n8n-workflow';
 
 import { SpanStatus, type Span, type StartSpanOpts, type Tracer } from './tracing';
 
+export interface TraceErrorReporter {
+	error(error: unknown, options?: ReportingOptions): void;
+}
+
 /**
  * Tracing implementation that uses Sentry to trace spans
  */
 export class SentryTracing implements Tracer {
-	constructor(private readonly sentry: Pick<typeof Sentry, 'startSpan'>) {}
+	constructor(
+		private readonly sentry: Pick<typeof Sentry, 'startSpan'>,
+		private readonly errorReporter: TraceErrorReporter,
+	) {}
 
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.sentry.startSpan(options, async (span) => {
 			try {
 				return await spanCb(span);
 			} catch (e) {
-				// Attach the exception to the span so failures are diagnosable in Sentry,
-				// then rethrow to preserve the caller's control flow.
 				const error = ensureError(e);
-				span.recordException(error);
-				span.setStatus({ code: SpanStatus.error, message: error.message });
-				span.setAttributes({
-					'error.type': error.constructor.name,
-					'error.message': error.message,
-				});
+				try {
+					const { traceId, spanId, traceFlags } = span.spanContext();
+					span.setStatus({ code: SpanStatus.error, message: error.message });
+					span.setAttributes({
+						'error.type': error.constructor.name,
+						'error.message': error.message,
+					});
+					this.errorReporter.error(error, {
+						shouldBeLogged: false,
+						extra: {
+							trace: {
+								traceId,
+								spanId,
+								traceFlags,
+							},
+						},
+					});
+				} catch {}
 				throw e;
 			}
 		});

--- a/packages/core/src/observability/tracing/sentry-tracing.ts
+++ b/packages/core/src/observability/tracing/sentry-tracing.ts
@@ -1,6 +1,7 @@
 import type Sentry from '@sentry/node';
+import { ensureError } from 'n8n-workflow';
 
-import type { Span, StartSpanOpts, Tracer } from './tracing';
+import { SpanStatus, type Span, type StartSpanOpts, type Tracer } from './tracing';
 
 /**
  * Tracing implementation that uses Sentry to trace spans
@@ -10,7 +11,20 @@ export class SentryTracing implements Tracer {
 
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.sentry.startSpan(options, async (span) => {
-			return await spanCb(span);
+			try {
+				return await spanCb(span);
+			} catch (e) {
+				// Attach the exception to the span so failures are diagnosable in Sentry,
+				// then rethrow to preserve the caller's control flow.
+				const error = ensureError(e);
+				span.recordException(error);
+				span.setStatus({ code: SpanStatus.error, message: error.message });
+				span.setAttributes({
+					'error.type': error.constructor.name,
+					'error.message': error.message,
+				});
+				throw e;
+			}
 		});
 	}
 }

--- a/packages/core/src/observability/tracing/sentry-tracing.ts
+++ b/packages/core/src/observability/tracing/sentry-tracing.ts
@@ -1,21 +1,13 @@
-import type { ReportingOptions } from '@n8n/errors';
 import type Sentry from '@sentry/node';
 import { ensureError } from 'n8n-workflow';
 
 import { SpanStatus, type Span, type StartSpanOpts, type Tracer } from './tracing';
 
-export interface TraceErrorReporter {
-	error(error: unknown, options?: ReportingOptions): void;
-}
-
 /**
  * Tracing implementation that uses Sentry to trace spans
  */
 export class SentryTracing implements Tracer {
-	constructor(
-		private readonly sentry: Pick<typeof Sentry, 'startSpan'>,
-		private readonly errorReporter: TraceErrorReporter,
-	) {}
+	constructor(private readonly sentry: Pick<typeof Sentry, 'startSpan'>) {}
 
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.sentry.startSpan(options, async (span) => {
@@ -23,24 +15,11 @@ export class SentryTracing implements Tracer {
 				return await spanCb(span);
 			} catch (e) {
 				const error = ensureError(e);
-				try {
-					const { traceId, spanId, traceFlags } = span.spanContext();
-					span.setStatus({ code: SpanStatus.error, message: error.message });
-					span.setAttributes({
-						'error.type': error.constructor.name,
-						'error.message': error.message,
-					});
-					this.errorReporter.error(error, {
-						shouldBeLogged: false,
-						extra: {
-							trace: {
-								traceId,
-								spanId,
-								traceFlags,
-							},
-						},
-					});
-				} catch {}
+				span.setStatus({ code: SpanStatus.error, message: error.message });
+				span.setAttributes({
+					'error.type': error.constructor.name,
+					'error.message': error.message,
+				});
 				throw e;
 			}
 		});


### PR DESCRIPTION
## Summary

Capture details from exceptions thrown inside `SentryTracing.startSpan` for better visibility.

Sentry should automatically link errors to spans if the reporting happens inside that span. However if it's not, there's no linkage. Decided against doing the reporting directly here, and instead include minimal details to the span.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3568


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33023">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

