### PR TITLE
fix(core): Agents session page search bar include tool results in search (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/session-timeline.utils.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/session-timeline.utils.spec.ts
@@ -8,6 +8,7 @@ import {
 	formatDuration,
 	IDLE_THRESHOLD_MS,
 	flattenExecutionsToTimelineItems,
+	matchesSearch,
 } from '../session-timeline.utils';
 import type { TimelineItem } from '../session-timeline.types';
 
@@ -105,6 +106,27 @@ describe('kindColorToken', () => {
 		expect(kindColorToken('tool')).toBe('var(--color--success)');
 		expect(kindColorToken('workflow')).toBe('var(--color--primary)');
 		expect(kindColorToken('suspension')).toBe('var(--color--warning)');
+	});
+});
+
+describe('matchesSearch', () => {
+	const labelForKey = (key: string) => key;
+
+	it('matches tool call input and output values', () => {
+		const toolItem = item({
+			kind: 'tool',
+			toolName: 'fetch_urlscan_results',
+			toolInput: {
+				url: 'https://urlscan.io/api/v1/search/?q=domain%3Aapp.n8n.cloud',
+			},
+			toolOutput: {
+				domain: 'monicasue.app.n8n.cloud',
+				stats: { uniqIPs: 1 },
+			},
+		});
+
+		expect(matchesSearch(toolItem, 'monicasue', labelForKey)).toBe(true);
+		expect(matchesSearch(toolItem, 'uniqIPs', labelForKey)).toBe(true);
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/session-timeline.utils.ts
@@ -39,6 +39,21 @@ export function itemFilterKey(item: TimelineItem): string {
 
 export type TimelineLabelResolver = (key: string) => string;
 
+function searchableValueText(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+	if (value === null) return 'null';
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+		return String(value);
+	}
+
+	try {
+		return JSON.stringify(value) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
 export function timelineItemSearchText(
 	item: TimelineItem,
 	labelForKey: TimelineLabelResolver,
@@ -59,6 +74,8 @@ export function timelineItemSearchText(
 		item.workflowName,
 		item.nodeDisplayName,
 		item.subAgentName,
+		searchableValueText(item.toolInput),
+		searchableValueText(item.toolOutput),
 	);
 	if (item.toolName) parts.push(formatToolNameForDisplay(item.toolName));
 


### PR DESCRIPTION
## Summary

Before this update any search in the session log page would just include the timeline item names in the search rather than actually including their results - this is a simple change to fix that.

Addresses: https://linear.app/n8n/issue/AGENT-268/bug-search-bar-in-trace-does-not-match-on-tool-input-or-output

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

