### PR TITLE
fix(core): Generate representative mock data for simulated nodes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/simulation-fixtures/cases.ts
+++ b/packages/@n8n/instance-ai/evaluations/simulation-fixtures/cases.ts
@@ -1,0 +1,197 @@
+// ---------------------------------------------------------------------------
+// Graded eval cases for simulation-fixture generation (INS-668)
+//
+// Each case is a minimal workflow with one or more `simulate`-verdict nodes.
+// The grader (see runner.ts) calls the real fixture generator and checks that
+// every simulated node gets NON-EMPTY, schema-appropriate mock output — never
+// the `{}` placeholder the fallback produces.
+//
+// Node types are chosen to stress the failure modes: thin-output operations
+// (deletes), no-obvious-shape nodes, and multi-node batches that tempt the
+// model to omit entries.
+// ---------------------------------------------------------------------------
+
+import type { IConnections } from 'n8n-workflow';
+
+export interface SimulatedNodeSpec {
+	name: string;
+	type: string;
+	parameters?: Record<string, unknown>;
+}
+
+export interface FixtureCase {
+	/** Stable id for filtering / reporting. */
+	id: string;
+	description: string;
+	nodes: SimulatedNodeSpec[];
+	connections?: IConnections;
+	/** Node names to mark `simulate`; the rest are `execute`. */
+	simulate: string[];
+	/**
+	 * Per simulated node: at least one of these keys (case-insensitive) must
+	 * appear in the generated item for it to count as schema-appropriate.
+	 */
+	expectedKeys: Record<string, string[]>;
+}
+
+const chain = (...names: string[]): IConnections =>
+	Object.fromEntries(
+		names
+			.slice(0, -1)
+			.map((from, i) => [from, { main: [[{ node: names[i + 1], type: 'main', index: 0 }]] }]),
+	);
+
+export const FIXTURE_CASES: FixtureCase[] = [
+	{
+		id: 'slack-post',
+		description: 'Slack post message returns the delivered message envelope',
+		nodes: [
+			{
+				name: 'Send Slack',
+				type: 'n8n-nodes-base.slack',
+				parameters: {
+					resource: 'message',
+					operation: 'post',
+					channelId: 'C0ALERTS',
+					text: 'Deploy finished',
+				},
+			},
+		],
+		simulate: ['Send Slack'],
+		expectedKeys: { 'Send Slack': ['ts', 'channel', 'ok', 'message'] },
+	},
+	{
+		id: 'gmail-send',
+		description: 'Gmail send returns the created message id',
+		nodes: [
+			{
+				name: 'Send Email',
+				type: 'n8n-nodes-base.gmail',
+				parameters: {
+					resource: 'message',
+					operation: 'send',
+					to: 'user@example.com',
+					subject: 'Receipt',
+				},
+			},
+		],
+		simulate: ['Send Email'],
+		expectedKeys: { 'Send Email': ['id', 'threadId', 'messageId', 'labelIds'] },
+	},
+	{
+		id: 'sheets-append',
+		description: 'Google Sheets append echoes the appended row columns',
+		nodes: [
+			{
+				name: 'Append Row',
+				type: 'n8n-nodes-base.googleSheets',
+				parameters: {
+					resource: 'sheet',
+					operation: 'append',
+					columns: { value: { Name: 'Ada Lovelace', Email: 'ada@example.com', Status: 'active' } },
+				},
+			},
+		],
+		simulate: ['Append Row'],
+		// Either the echoed row columns or the Sheets append update metadata is acceptable.
+		expectedKeys: {
+			'Append Row': [
+				'Name',
+				'Email',
+				'Status',
+				'row',
+				'updatedRange',
+				'updatedCells',
+				'spreadsheetId',
+			],
+		},
+	},
+	{
+		id: 'postgres-insert',
+		description: 'Postgres insert returns the new row including its id',
+		nodes: [
+			{
+				name: 'Insert Order',
+				type: 'n8n-nodes-base.postgres',
+				parameters: { operation: 'insert', table: 'orders', columns: 'customer,amount' },
+			},
+		],
+		simulate: ['Insert Order'],
+		expectedKeys: { 'Insert Order': ['id', 'customer', 'amount'] },
+	},
+	{
+		id: 'http-post',
+		description: 'HTTP POST to an API returns a plausible JSON body',
+		nodes: [
+			{
+				name: 'Create Ticket',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: { method: 'POST', url: 'https://api.example.com/tickets', sendBody: true },
+			},
+		],
+		simulate: ['Create Ticket'],
+		expectedKeys: { 'Create Ticket': ['id', 'status', 'url', 'createdAt', 'data'] },
+	},
+	{
+		id: 'http-delete',
+		description: 'A delete operation still emits a non-empty status (thin-output stress)',
+		nodes: [
+			{
+				name: 'Delete Record',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: { method: 'DELETE', url: 'https://api.example.com/records/42' },
+			},
+		],
+		simulate: ['Delete Record'],
+		expectedKeys: {
+			'Delete Record': ['id', 'success', 'deleted', 'status', 'statusCode', 'statusMessage'],
+		},
+	},
+	{
+		id: 'form-submit',
+		description: 'Mid-workflow Form emits the submitted field values',
+		nodes: [
+			{
+				name: 'Collect Details',
+				type: 'n8n-nodes-base.form',
+				parameters: {
+					formFields: {
+						values: [
+							{ fieldLabel: 'fullName', fieldType: 'text' },
+							{ fieldLabel: 'email', fieldType: 'email' },
+						],
+					},
+				},
+			},
+		],
+		simulate: ['Collect Details'],
+		expectedKeys: { 'Collect Details': ['fullName', 'email', 'submittedAt'] },
+	},
+	{
+		id: 'multi-node-batch',
+		description: 'Two simulated nodes in one batch — neither may be omitted',
+		nodes: [
+			{
+				name: 'Create Contact',
+				type: 'n8n-nodes-base.hubspot',
+				parameters: { resource: 'contact', operation: 'create', email: 'lead@example.com' },
+			},
+			{
+				name: 'Notify Channel',
+				type: 'n8n-nodes-base.slack',
+				parameters: {
+					resource: 'message',
+					operation: 'post',
+					channelId: 'C0SALES',
+					text: 'New lead',
+				},
+			},
+		],
+		connections: chain('Create Contact', 'Notify Channel'),
+		simulate: ['Create Contact', 'Notify Channel'],
+		expectedKeys: {
+			'Create Contact': ['id', 'vid', 'email', 'properties'],
+			'Notify Channel': ['ts', 'channel', 'ok', 'message'],
+		},
+	},
+];

--- a/packages/@n8n/instance-ai/evaluations/simulation-fixtures/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/simulation-fixtures/cli.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// CLI for the simulation-fixture graded eval (INS-668)
+//
+// Usage:
+//   pnpm eval:simulation-fixtures
+//   pnpm eval:simulation-fixtures --filter slack --verbose
+//   pnpm eval:simulation-fixtures --threshold 0.9
+//
+// Needs a model API key in the environment (ANTHROPIC_API_KEY / N8N_AI_ANTHROPIC_KEY).
+// Exits non-zero when the overall pass fraction is below the threshold.
+// ---------------------------------------------------------------------------
+
+import { FIXTURE_CASES } from './cases';
+import { gradeCase, type CaseResult } from './runner';
+
+interface CliArgs {
+	filter?: string;
+	verbose: boolean;
+	threshold: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	// 0.8 cleanly separates the bug (0%) from a healthy run (~100%) while
+	// tolerating occasional single-node schema variance from the model.
+	const args: CliArgs = { verbose: false, threshold: 0.8 };
+	for (let i = 0; i < argv.length; i++) {
+		switch (argv[i]) {
+			case '--verbose':
+			case '-v':
+				args.verbose = true;
+				break;
+			case '--filter':
+				args.filter = argv[++i];
+				break;
+			case '--threshold':
+				args.threshold = Number(argv[++i]);
+				break;
+			default:
+				break;
+		}
+	}
+	return args;
+}
+
+function printCase(result: CaseResult, verbose: boolean): void {
+	const mark = result.pass ? '✓' : '✗';
+	console.log(`${mark} ${result.id} — ${result.description}`);
+	if (result.error) console.log(`    error: ${result.error}`);
+	for (const node of result.nodes) {
+		if (node.pass && !verbose) continue;
+		const flags = [
+			node.nonEmpty ? 'non-empty' : 'EMPTY',
+			node.schemaAppropriate ? 'schema-ok' : `missing any of [${node.missingFrom.join(', ')}]`,
+		].join(', ');
+		console.log(`    ${node.pass ? '·' : '✗'} ${node.nodeName}: ${flags}`);
+		if (verbose) console.log(`      keys: ${JSON.stringify(Object.keys(node.item))}`);
+	}
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const cases = args.filter
+		? FIXTURE_CASES.filter((c) => c.id.includes(args.filter as string))
+		: FIXTURE_CASES;
+
+	if (cases.length === 0) {
+		console.error(`No cases match filter "${args.filter ?? ''}"`);
+		process.exit(1);
+	}
+
+	const results = await Promise.all(cases.map(gradeCase));
+	results.forEach((r) => printCase(r, args.verbose));
+
+	const allNodes = results.flatMap((r) => r.nodes);
+	const passedNodes = allNodes.filter((n) => n.pass).length;
+	const passedCases = results.filter((r) => r.pass).length;
+	const score = allNodes.length > 0 ? passedNodes / allNodes.length : 0;
+
+	console.log('');
+	console.log(
+		`Cases: ${passedCases}/${results.length} passed · Nodes: ${passedNodes}/${allNodes.length} passed · Score: ${(score * 100).toFixed(1)}% (threshold ${(args.threshold * 100).toFixed(0)}%)`,
+	);
+
+	if (score < args.threshold) {
+		console.log('RED: below threshold');
+		process.exit(1);
+	}
+	console.log('GREEN: at or above threshold');
+}
+
+void main();

--- a/packages/@n8n/instance-ai/evaluations/simulation-fixtures/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/simulation-fixtures/runner.ts
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------
+// Grader for simulation-fixture generation (INS-668)
+//
+// For each case: build a minimal workflow, mark the listed nodes `simulate`,
+// call the REAL fixture generator (hits the configured model), then grade
+// every simulated node on two metrics:
+//   - non_empty:          the item has at least one field (catches the `{}` bug)
+//   - schema_appropriate:  at least one expected key is present for the node type
+// A node passes only when both hold. Case/overall score is the pass fraction.
+// ---------------------------------------------------------------------------
+
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import type { FixtureCase } from './cases';
+import { generateSimulationFixtures } from '../../src/tools/workflows/generate-simulation-fixtures.service';
+import type { NodeSimulationVerdict } from '../../src/workflow-loop/workflow-loop-state';
+
+export interface NodeGrade {
+	nodeName: string;
+	nonEmpty: boolean;
+	schemaAppropriate: boolean;
+	pass: boolean;
+	item: Record<string, unknown>;
+	missingFrom: string[];
+}
+
+export interface CaseResult {
+	id: string;
+	description: string;
+	nodes: NodeGrade[];
+	pass: boolean;
+	error?: string;
+}
+
+function toWorkflow(testCase: FixtureCase): WorkflowJSON {
+	return {
+		name: testCase.id,
+		nodes: testCase.nodes.map((n, i) => ({
+			id: `id-${i}`,
+			name: n.name,
+			type: n.type,
+			typeVersion: 1,
+			position: [i * 200, 0],
+			parameters: n.parameters ?? {},
+		})),
+		connections: testCase.connections ?? {},
+		pinData: {},
+		settings: {},
+	} as unknown as WorkflowJSON;
+}
+
+function toPlan(testCase: FixtureCase): NodeSimulationVerdict[] {
+	const simulate = new Set(testCase.simulate);
+	return testCase.nodes.map((n) => ({
+		nodeName: n.name,
+		verdict: simulate.has(n.name) ? 'simulate' : 'execute',
+		reason: 'Performs an external side effect',
+		confidence: 'high',
+		source: 'deterministic',
+	}));
+}
+
+const hasKey = (item: Record<string, unknown>, key: string): boolean =>
+	Object.keys(item).some((k) => k.toLowerCase() === key.toLowerCase());
+
+export async function gradeCase(testCase: FixtureCase): Promise<CaseResult> {
+	let fixtures;
+	try {
+		fixtures = await generateSimulationFixtures({
+			workflow: toWorkflow(testCase),
+			plan: toPlan(testCase),
+		});
+	} catch (error) {
+		return {
+			id: testCase.id,
+			description: testCase.description,
+			nodes: [],
+			pass: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	const nodes: NodeGrade[] = testCase.simulate.map((nodeName) => {
+		const item = fixtures[nodeName]?.[0] ?? {};
+		const expected = testCase.expectedKeys[nodeName] ?? [];
+		const nonEmpty = Object.keys(item).length > 0;
+		const present = expected.filter((k) => hasKey(item, k));
+		const schemaAppropriate = expected.length === 0 ? nonEmpty : present.length > 0;
+		return {
+			nodeName,
+			nonEmpty,
+			schemaAppropriate,
+			pass: nonEmpty && schemaAppropriate,
+			item,
+			missingFrom: present.length > 0 ? [] : expected,
+		};
+	});
+
+	return {
+		id: testCase.id,
+		description: testCase.description,
+		nodes,
+		pass: nodes.length > 0 && nodes.every((n) => n.pass),
+	};
+}

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -21,6 +21,7 @@
     "eval:subagent": "tsx evaluations/subagent/cli.ts",
     "eval:computer-use": "tsx evaluations/computer-use/cli.ts",
     "eval:discovery": "tsx evaluations/discovery/cli.ts",
+    "eval:simulation-fixtures": "tsx evaluations/simulation-fixtures/cli.ts",
     "prompts:print": "tsx scripts/print-prompts.ts"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -28,6 +28,12 @@ describe('applyAgentThinking', () => {
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
 	});
 
+	it('skips adaptive thinking for Anthropic Haiku models', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'anthropic/claude-haiku-4-5-20251001');
+		expect(mockAgentInstances[0]?.thinking).not.toHaveBeenCalled();
+	});
+
 	it('enables OpenAI reasoning for supported models', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openai/gpt-5.5');

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -37,6 +37,9 @@ export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {
 	}
 
 	if (provider === 'anthropic') {
+		// Haiku models reject adaptive thinking (400), which silently fails the
+		// call and degrades dependent output (e.g. empty simulation fixtures).
+		if (resolveModelId(modelId)?.includes('haiku')) return;
 		agent.thinking('anthropic', { mode: 'adaptive' });
 		return;
 	}


### PR DESCRIPTION
## Summary

Verification runs were pinning **simulated nodes with empty `{}` output** instead of representative mock data (INS-668).

**Root cause:** the eval-agent factory (`applyAgentThinking`) applied adaptive thinking to *every* Anthropic model, but **Haiku 4.5 rejects adaptive thinking with a `400` (`adaptive thinking is not supported on this model`)**. The simulation-fixture generator uses Haiku, so every call errored and fell back to empty fixtures. CI never caught it because recorded expectations replay canned responses; the live API on the stage env did not, so it returned `{}`.

This was not fixture-specific: **every** `createEvalAgent` call on Haiku was 400ing against the real API.

**Fix:** skip adaptive thinking for Haiku models (it isn't needed for this JSON-shaping task anyway). The Haiku call now succeeds and produces non-empty, schema-appropriate mock output.

**Eval (EDD, red → green):** adds a graded eval over a set of node types (Slack, Gmail, Sheets, Postgres, HTTP POST/DELETE, Form, multi-node batch) asserting every simulated node gets non-empty, schema-appropriate output.

| | Score | Non-empty nodes |
|---|---|---|
| Before fix | **0.0% (RED)** | 0/9 — every node `{}` |
| After fix | **~89% (GREEN)** | 9/9 |

## How to test

```bash
cd packages/@n8n/instance-ai
# unit guard (deterministic, CI-safe)
pnpm test src/agent/__tests__/apply-agent-thinking.test.ts
# graded eval (needs ANTHROPIC_API_KEY / N8N_AI_ANTHROPIC_KEY)
pnpm eval:simulation-fixtures --verbose
```

Reverting the one-line change in `apply-agent-thinking.ts` returns the eval to 0% (RED).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-668

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33036">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->