### PR TITLE
fix(core): Avoid new agent structured output parsing error bubbling to Sentry (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -557,4 +557,42 @@ describe('AgentExecutionOrchestratorService', () => {
 		).rejects.toThrow(OperationalError);
 		expect(runtime.agent.structuredOutput).toHaveBeenCalledWith(outputSchema);
 	});
+
+	it('maps structured-output stream reader errors before recording and rethrowing', async () => {
+		const { service, agentRepository, reconstructionService, executionService } = makeService();
+		const outputSchema: JSONSchema7 = {
+			type: 'object',
+			properties: { answer: { type: 'string' } },
+		};
+		const runtime = makeRuntime();
+		runtime.agent.stream.mockResolvedValue({
+			stream: makeFailingStream(new Error('No output generated. Check the stream for errors.')),
+		});
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
+		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
+
+		const execution = service.executeForWorkflow(
+			agentId,
+			'hello',
+			'execution-1',
+			'thread-1',
+			userId,
+			projectId,
+			userId,
+			false,
+			outputSchema,
+		);
+
+		await expect(execution).rejects.toThrow(OperationalError);
+		await expect(execution).rejects.toThrow("Couldn't get structured output matching the schema");
+		await expect(execution).rejects.not.toThrow('Check the stream');
+		expect(executionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				record: expect.objectContaining({
+					error: expect.stringContaining("Couldn't get structured output matching the schema"),
+				}),
+			}),
+		);
+	});
 });

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -143,6 +143,16 @@ export class AgentExecutionOrchestratorService {
 		private readonly integrationMessageContextService: IntegrationMessageContextService,
 	) {}
 
+	private normalizeWorkflowStreamError(error: unknown, outputSchema?: JSONSchema7): Error {
+		const normalizedError = error instanceof Error ? error : new Error(String(error));
+		if (!outputSchema || normalizedError instanceof OperationalError) return normalizedError;
+
+		const structuredOutputError = describeStructuredOutputError(normalizedError.message);
+		if (!structuredOutputError) return normalizedError;
+
+		return new OperationalError(structuredOutputError, { cause: normalizedError });
+	}
+
 	createAgentExecutionCounter({
 		agentId,
 		userId,
@@ -589,9 +599,10 @@ export class AgentExecutionOrchestratorService {
 				}
 			}
 		} catch (error) {
-			recorder.record({ type: 'error', error });
+			const normalizedError = this.normalizeWorkflowStreamError(error, outputSchema);
+			recorder.record({ type: 'error', error: normalizedError });
 			recorder.record({ type: 'finish', finishReason: 'error' });
-			streamError = error instanceof Error ? error : new Error(String(error));
+			streamError = normalizedError;
 		}
 
 		const messageRecord = recorder.getMessageRecord();


### PR DESCRIPTION
## Summary
Fixing an issue where structured output failures were ending up on Sentry - AI SDK errors bubbling up in the stream and causing problems, these are now normalised and hidden.

Addresses: https://linear.app/n8n/issue/AGENT-287/ai-nooutputgeneratederror-no-output-generated-check-the-stream-for

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

