### PR TITLE
fix(ReadWriteFile): remove escaping of glob metacharacters in file selector

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
@@ -35,10 +35,11 @@ export function errorMapper(
 }
 
 export function escapeSpecialCharacters(str: string) {
-	// Escape parentheses and square brackets (glob metacharacters)
-	str = str.replace(/[()[\]]/g, '\\$&');
-
-	return str;
+  // Return the string as-is since we're passing it to a glob library
+  // and we want glob metacharacters to be interpreted correctly
+  // Users who need to match literal metacharacters should use proper glob escaping
+  // (e.g., [[]] to match a literal [)
+  return str;
 }
 
 export function normalizeFileSelector(fileSelectorRaw: string) {

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
@@ -2,9 +2,9 @@ import { escapeSpecialCharacters, normalizeFileSelector } from '../helpers/utils
 
 describe('Read/Write Files from Disk', () => {
 	describe('escapeSpecialCharacters', () => {
-		it('should escape parentheses in a string', () => {
+		it('should return the string as-is for parentheses', () => {
 			const input = '/home/michael/Desktop/test(1).txt';
-			const expectedOutput = '/home/michael/Desktop/test\\(1\\).txt';
+			const expectedOutput = '/home/michael/Desktop/test(1).txt';
 			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
 		});
 
@@ -14,9 +14,9 @@ describe('Read/Write Files from Disk', () => {
 			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
 		});
 
-		it('should escape square brackets in a string', () => {
+		it('should return the string as-is for square brackets', () => {
 			const input = '/home/michael/Desktop/[release]/test.txt';
-			const expectedOutput = '/home/michael/Desktop/\\[release\\]/test.txt';
+			const expectedOutput = '/home/michael/Desktop/[release]/test.txt';
 			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
 		});
 	});
@@ -24,18 +24,18 @@ describe('Read/Write Files from Disk', () => {
 	describe('normalizeFileSelector', () => {
 		it('should normalize UNIX file selector with parentheses', () => {
 			const input = '/home/michael/Desktop/test(1).txt';
-			const expectedOutput = '/home/michael/Desktop/test\\(1\\).txt';
+			const expectedOutput = '/home/michael/Desktop/test(1).txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 
 		it('should normalize Windows file selector with \\ and parentheses', () => {
-			const input = 'C:\\Users\\michael\\Desktop\\test(1).txt';
-			const expectedOutput = 'C:/Users/michael/Desktop/test\\(1\\).txt';
+			const input = 'C:\\Users\\michael\\Desktop\	est(1).txt';
+			const expectedOutput = 'C:/Users/michael/Desktop/test(1).txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 
-		it('should normalize Windows file selector with \\\\', () => {
-			const input = 'C:\\\\Users\\\\michael\\\\Desktop\\\\test.txt';
+		it('should normalize Windows file selector with \\\\\\\\', () => {
+			const input = 'C:\\\\\\\\Users\\\\\\\\michael\\\\\\\\Desktop\\\\\\\	est.txt';
 			const expectedOutput = 'C:/Users/michael/Desktop/test.txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
@@ -46,17 +46,17 @@ describe('Read/Write Files from Disk', () => {
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 
-		it('should escape square brackets in Windows file selector', () => {
+		it('should return Windows file selector with forward slashes and unescaped brackets', () => {
 			const input =
 				'C:\\Users\\Administrator\\Desktop\\Manga\\Complete\\VTuber Legend [J-Novel Club]\\list.txt';
 			const expectedOutput =
-				'C:/Users/Administrator/Desktop/Manga/Complete/VTuber Legend \\[J-Novel Club\\]/list.txt';
+				'C:/Users/Administrator/Desktop/Manga/Complete/VTuber Legend [J-Novel Club]/list.txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 
-		it('should escape square brackets in UNIX file selector', () => {
+		it('should return UNIX file selector with unescaped brackets', () => {
 			const input = '/home/user/VTuber Legend [J-Novel Club]/list.txt';
-			const expectedOutput = '/home/user/VTuber Legend \\[J-Novel Club\\]/list.txt';
+			const expectedOutput = '/home/user/VTuber Legend [J-Novel Club]/list.txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 	});


### PR DESCRIPTION
This fixes the issue where the Read/Write Files from Disk node was escaping square brackets and parentheses in the file selector, preventing glob patterns like `[01234]*` from working correctly. The fix removes the escaping and updates the tests accordingly.

Fixes #32617

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33051">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

