### PR TITLE
test(core): Add eval ensuring builder decides technical choices instead of asking (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/dont-ask-technical-implementation-choice.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/dont-ask-technical-implementation-choice.json
@@ -1,0 +1,42 @@
+{
+	"description": "INS-666: When a built-in node can't supply a needed field, the agent must pick the implementation itself (e.g. fall back to an HTTP Request to the service's API) instead of asking the user to approve a technical/node-choice decision. The built-in Linear node's 'Get many issues' doesn't return labels or the issue description, so filtering by the 'bug' label and including descriptions forces an implementation fork the agent should resolve on its own — not surface as a 'is this approach acceptable?' question.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Every weekday at 9am, fetch all my Linear issues that have the 'bug' label, including each issue's description, and post a summary of them to Slack #bugs."
+		},
+		{
+			"role": "assistant",
+			"text": "I'll build that for you now."
+		},
+		{
+			"role": "user",
+			"text": "[You are a non-technical user. You don't know n8n's nodes or APIs and won't make build decisions. If the agent asks you to choose or approve anything technical — which node to use, whether to use an HTTP Request vs a built-in node, which API or endpoint (e.g. a GraphQL API), data formats — do not answer it: reply 'You're the expert — just decide for me.' and never pick. Only answer normally if it asks about what you want (your goal, schedule, channel, which Linear team/project).]"
+		}
+	],
+	"messageBudget": 4,
+	"complexity": "medium",
+	"tags": [
+		"behaviour",
+		"clarification",
+		"question-tool",
+		"technical-decision",
+		"schedule",
+		"linear",
+		"slack"
+	],
+	"triggerType": "schedule",
+	"datasets": ["behaviour", "full"],
+	"processExpectations": [
+		"The agent did not ask the user to approve or choose a technical implementation detail — for example which node type or API to use, whether to use the built-in Linear node or an HTTP Request to Linear's API (e.g. its GraphQL API), or which endpoint. It made any such decision itself.",
+		"Any questions the agent did ask were about the user's goal or desired outcome, never about how to build the workflow technically. The agent never described an implementation approach and asked whether it was acceptable."
+	],
+	"executionScenarios": [
+		{
+			"name": "happy-path",
+			"description": "Linear returns a couple of issues labeled 'bug' with descriptions; a summary is posted to Slack",
+			"dataSetup": "The Linear source returns 2 issues labeled 'bug': 'Login button unresponsive' and 'Export times out', each with a one-sentence description. The Slack postMessage call returns { \"ok\": true, \"ts\": \"1700000000.000100\" }.",
+			"successCriteria": "Judge only the built workflow's structure, not the conversation. A pass is a weekday 9am schedule trigger that retrieves Linear issues filtered to the 'bug' label (including their descriptions) and posts a summary to Slack #bugs. Because no credentials are provided, empty/placeholder values (e.g. an unset Linear team or Slack channel) that cause a validation failure before any request is made are acceptable and count as a pass — they are values to fill in at setup, not build mistakes. If values are set and the run succeeds, that is also a pass."
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Adds a workflow-eval regression guard for INS-666: when a built-in node can't supply a needed field, the builder should resolve the technical/implementation choice itself (e.g. falling back to an HTTP Request to the service's API) rather than asking the user to approve it.

**Notably, the reported behavior, the builder asking *"should I use an HTTP Request calling Linear's GraphQL API instead of the built-in node? [Yes (recommended) / No / Something else]"* — **does not reproduce on master**. Across `opus-4-8` and `sonnet-4-5`, multiple iterations each, the agent reliably makes the call itself (one judge quote: *"As the technical decision-maker, I'll go with that approach … and never asked the user"*).** The reported instance was built from a `test-ins-657-builder-fail` staging branch, so this appears already fixed / branch-specific on master. TBF I also could not force the agent to ask even with an injected "you MUST ask first" instruction ... the "decide, don't ask" behavior is strongly enforced by the planning + workflow-builder skills and the `ask-user` tool description.

The new case (`dont-ask-technical-implementation-choice.json`) is a multi-turn Linear scenario (filter by the `bug` label + include descriptions — fields the built-in Linear node can't return, which forces the node-vs-HTTP fork). Its `processExpectations` assert the agent decides the implementation itself and never surfaces a technical approval question. Green on master (behavior 6/6 across 3 builds).

**No prompt change** is included: master already behaves correctly, and the relevant guidance ("don't ask for implementation details when a sensible default exists" in the planning skill; "ask only when a choice changes intent or topology" in the workflow-builder skill) is already in place.

> Note: the headline scenario pass-rate is dragged down by execution flakiness (credential-less build + GraphQL mocking is a known suite limitation). The `processExpectations` are the behavior signal under test here.

## How to test

Requires a running n8n instance with Instance AI enabled and a working sandbox.

```bash
cd packages/@n8n/instance-ai
pnpm eval:instance-ai --filter dont-ask-technical-implementation-choice --iterations 3 --verbose
```

The two `processExpectations` (asking-vs-deciding) should pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-666

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->