### PR TITLE
fix(core): Correctly populate tool_calls array when saving memories

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -76,22 +76,23 @@ export function extractToolCallId(
  */
 export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 	const messages: BaseMessage[] = [];
+	const seenAIMessages = new Set<BaseMessage>();
 
 	for (let i = 0; i < steps.length; i++) {
 		const step = steps[i];
 
-		// Try to extract existing AIMessage and its tool_call ID
+		// Try to extract existing AIMessage
 		const existingAIMessage = step.action.messageLog?.[0];
-		const existingToolCallId = existingAIMessage?.tool_calls?.[0]?.id;
 
-		// Use existing ID if available, otherwise extract from step data
-		const toolCallId =
-			existingToolCallId ?? extractToolCallId(step.action.toolCallId, step.action.tool);
+		// Extract toolCallId from step data (more reliable than taking the first id from AIMessage)
+		const toolCallId = extractToolCallId(step.action.toolCallId, step.action.tool);
 
 		// Use existing AIMessage or create a synthetic one
-		const aiMessage =
-			existingAIMessage ??
-			new AIMessage({
+		if (existingAIMessage && !seenAIMessages.has(existingAIMessage)) {
+			messages.push(existingAIMessage);
+			seenAIMessages.add(existingAIMessage);
+		} else if (!existingAIMessage) {
+			const aiMessage = new AIMessage({
 				content: `Calling ${step.action.tool} with input: ${JSON.stringify(step.action.toolInput)}`,
 				tool_calls: [
 					{
@@ -102,6 +103,8 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 					},
 				],
 			});
+			messages.push(aiMessage);
+		}
 
 		// Create ToolMessage with the observation result
 		const toolMessage = new ToolMessage({
@@ -110,8 +113,7 @@ export function buildMessagesFromSteps(steps: ToolCallData[]): BaseMessage[] {
 			name: step.action.tool,
 		});
 
-		// Add both messages
-		messages.push(aiMessage);
+		// Add tool message
 		messages.push(toolMessage);
 	}
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -433,6 +433,49 @@ describe('memoryManagement', () => {
 			expect(result[2]).toBe(aiMessage2);
 			expect(result[3]).toBeInstanceOf(ToolMessage);
 		});
+		it('should handle multiple tool calls in a single step (deduplicating AIMessage)', () => {
+			const aiMessage = new AIMessage({
+				content: 'Let me do both',
+				tool_calls: [
+					{ id: 'call-1', name: 'weather', args: { location: 'NYC' }, type: 'tool_call' },
+					{ id: 'call-2', name: 'time', args: { timezone: 'EST' }, type: 'tool_call' },
+				],
+			});
+
+			const steps: ToolCallData[] = [
+				{
+					action: {
+						tool: 'weather',
+						toolInput: { location: 'NYC' },
+						log: 'Weather',
+						messageLog: [aiMessage],
+						toolCallId: 'call-1',
+						type: 'tool_call',
+					},
+					observation: 'Sunny, 72°F',
+				},
+				{
+					action: {
+						tool: 'time',
+						toolInput: { timezone: 'EST' },
+						log: 'Time',
+						messageLog: [aiMessage],
+						toolCallId: 'call-2',
+						type: 'tool_call',
+					},
+					observation: '14:30',
+				},
+			];
+
+			const result = buildMessagesFromSteps(steps);
+
+			expect(result).toHaveLength(3);
+			expect(result[0]).toBe(aiMessage);
+			expect(result[1]).toBeInstanceOf(ToolMessage);
+			expect((result[1] as ToolMessage).tool_call_id).toBe('call-1');
+			expect(result[2]).toBeInstanceOf(ToolMessage);
+			expect((result[2] as ToolMessage).tool_call_id).toBe('call-2');
+		});
 
 		it('should return empty array for empty steps', () => {
 			const result = buildMessagesFromSteps([]);


### PR DESCRIPTION
Fixes #14361

### Description
This PR fixes an issue in `packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts` where `buildMessagesFromSteps` incorrectly handled tool calls when generating the conversation sequence for memory nodes. It reused the first `tool_call_id` from the AI message for all tool calls in the same step, causing LLMs to hallucinate due to mismatched tool messages. The AI messages are now deduplicated and the correct `toolCallId` is extracted from each tool action.