### PR TITLE
fix(editor): Include base path in View sub-execution links

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.test.ts
@@ -140,30 +140,50 @@ describe('useExecutionHelpers()', () => {
 	});
 
 	describe('resolveRelatedExecutionUrl', () => {
+		// Standard deployment (no N8N_PATH): href and fullPath are identical.
+		const executionUrl = '/workflow/xyz/executions/123';
+
 		it('resolves sub execution url', () => {
-			const fullPath = 'test.com';
-			resolve.mockReturnValue({ fullPath });
+			resolve.mockReturnValue({ href: executionUrl, fullPath: executionUrl });
 			const { resolveRelatedExecutionUrl } = useExecutionHelpers();
 
 			expect(
 				resolveRelatedExecutionUrl({ subExecution: { executionId: '123', workflowId: 'xyz' } }),
-			).toEqual(fullPath);
+			).toEqual(executionUrl);
 		});
 
 		it('resolves parent execution url', () => {
-			const fullPath = 'test.com';
-			resolve.mockReturnValue({ fullPath });
+			resolve.mockReturnValue({ href: executionUrl, fullPath: executionUrl });
 			const { resolveRelatedExecutionUrl } = useExecutionHelpers();
 
 			expect(
 				resolveRelatedExecutionUrl({ parentExecution: { executionId: '123', workflowId: 'xyz' } }),
-			).toEqual(fullPath);
+			).toEqual(executionUrl);
 		});
 
 		it('returns empty if no related execution url', () => {
 			const { resolveRelatedExecutionUrl } = useExecutionHelpers();
 
 			expect(resolveRelatedExecutionUrl({})).toEqual('');
+		});
+
+		// Edge case: under a sub-path (N8N_PATH=/n8n/), the link is a real
+		// `<a href target="_blank">`, so it must use router.resolve(...).href
+		// (base-included), not .fullPath - else the opened tab drops the prefix and 404s.
+		describe('subpath deployment (e.g. N8N_PATH=/n8n/)', () => {
+			it('includes the base path in the link (href, not fullPath)', () => {
+				resolve.mockReturnValue({
+					href: `/n8n${executionUrl}`,
+					fullPath: executionUrl,
+				});
+				const { resolveRelatedExecutionUrl } = useExecutionHelpers();
+
+				const result = resolveRelatedExecutionUrl({
+					subExecution: { executionId: '123', workflowId: 'xyz' },
+				});
+				expect(result).toEqual(`/n8n${executionUrl}`);
+				expect(result).not.toEqual(executionUrl);
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionHelpers.ts
@@ -95,10 +95,13 @@ export function useExecutionHelpers() {
 
 		const { workflowId, executionId } = info;
 
+		// Rendered as a real `<a href target="_blank">`, so the URL must include the
+		// router base (N8N_PATH). Use `.href` (base-included), not `.fullPath`, else the
+		// base is dropped and the link 404s under a sub-path (cf. openExecutionInNewTab).
 		return router.resolve({
 			name: VIEWS.EXECUTION_PREVIEW,
 			params: { workflowId, executionId },
-		}).fullPath;
+		}).href;
 	}
 
 	function trackOpeningRelatedExecution(


### PR DESCRIPTION
Fixes #19437 (the "missing base path" half).

## Summary

The "View sub-execution" / "View parent execution" links shown on subworkflow
calls in execution/run data drop the configured base path (`N8N_PATH`). With
`N8N_PATH=/n8n/`, the link points at `/workflow/<id>/executions/<id>` instead of
`/n8n/workflow/<id>/executions/<id>`, so opening it 404s (or lands outside n8n).

**Cause:** `resolveRelatedExecutionUrl` (in `useExecutionHelpers.ts`) returns
`router.resolve(...).fullPath`. In Vue Router 4, `.fullPath` is **base-relative**
— it does not include the router base. But the value is consumed only as a real
`<a href target="_blank">` anchor (in `ViewSubExecution.vue` and twice in
`RunDataTable.vue`), i.e. genuine browser navigation that needs the full,
base-included path. The sibling helper `openExecutionInNewTab` already uses
`.href` (base-included) for the same `EXECUTION_PREVIEW` view.

**Fix:** return `.href` instead of `.fullPath`. One-line change, plus the unit
test updated to assert the base-included href is returned (guards the regression).

> Note: this is the mirror image of the folder-navigation bug in #15240 — there
> a base-included `.href` was wrongly fed back into the router (doubling the
> base); here a base-relative `.fullPath` is wrongly used as a real anchor href
> (dropping the base). Rule of thumb: `.href` for real anchors / `window.open`,
> `.fullPath` (or a location object) for `router.push` / `RouterLink :to`.

## How to test

1. Start n8n with `N8N_PATH=/n8n/` behind a reverse proxy serving it at `/n8n/`.
2. Run a workflow that calls a sub-workflow (Execute Sub-workflow node).
3. Open the execution, find the "View sub-execution" link on the node's output.
4. The link href is `/n8n/workflow/<id>/executions/<id>` and opens correctly,
   instead of `/workflow/<id>/executions/<id>` which 404s.
5. Regression check: with no `N8N_PATH`, the link still works.

## Note on tests

I'm not fully up to speed on n8n's conventions for contributing tests, so I've
followed the patterns in the surrounding spec (the existing `vue-router` mock and
the `resolveRelatedExecutionUrl` cases). The standard no-`N8N_PATH` cases keep
asserting the resolved URL, and the subpath behaviour is isolated as an edge case.
Happy to restructure or adjust the coverage to match your preferences.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. (`useExecutionHelpers.test.ts` updated to assert the base-included href.)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33069">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

