### PR TITLE
fix(core): Improve external secrets provider replacement

### DIFF
--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -1,13 +1,14 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import { mock } from 'jest-mock-extended';
 
-import { DummyProvider, FailedProvider, MockProviders } from '@test/external-secrets/utils';
+import { DummyProvider, MockProviders } from '@test/external-secrets/utils';
 
 import type { SecretsProviderConnectionRepository } from '@n8n/db';
 import type { Cipher } from 'n8n-core';
 
 import { ExternalSecretsManager } from '../external-secrets-manager.ee';
 import type { ExternalSecretsConfig } from '../external-secrets.config';
+import type { ExternalSecretsProviderConnectionManager } from '../external-secrets-provider-connection-manager.ee';
 import type { ExternalSecretsProviderLifecycle } from '../provider-lifecycle.service';
 import type { ExternalSecretsProviderRegistry } from '../provider-registry.service';
 import type { ExternalSecretsRetryManager } from '../retry-manager.service';
@@ -27,6 +28,7 @@ describe('ExternalSecretsManager', () => {
 	let mockProviderRegistry: jest.Mocked<ExternalSecretsProviderRegistry>;
 	let mockProviderLifecycle: jest.Mocked<ExternalSecretsProviderLifecycle>;
 	let mockRetryManager: jest.Mocked<ExternalSecretsRetryManager>;
+	let mockProviderConnectionManager: jest.Mocked<ExternalSecretsProviderConnectionManager>;
 	let mockSecretsCache: jest.Mocked<ExternalSecretsSecretsCache>;
 	let mockSecretsProviderConnectionRepository: jest.Mocked<SecretsProviderConnectionRepository>;
 	let mockCipher: jest.Mocked<Cipher>;
@@ -85,6 +87,8 @@ describe('ExternalSecretsManager', () => {
 			return result;
 		});
 
+		mockProviderConnectionManager = mock<ExternalSecretsProviderConnectionManager>();
+
 		// Mock SecretsCache
 		mockSecretsCache = mock<ExternalSecretsSecretsCache>();
 		mockSecretsCache.getSecret.mockReturnValue(undefined);
@@ -109,6 +113,7 @@ describe('ExternalSecretsManager', () => {
 			mockProviderRegistry,
 			mockProviderLifecycle,
 			mockRetryManager,
+			mockProviderConnectionManager,
 			mockSecretsCache,
 			mockSecretsProviderConnectionRepository,
 			mockCipher,
@@ -294,12 +299,7 @@ describe('ExternalSecretsManager', () => {
 			setUpdateDate: jest.fn(),
 		};
 
-		it('should replace existing provider, refresh cache, and broadcast', async () => {
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('my-vault', existingProvider);
-			mockProviderRegistry.add.mockClear();
-
+		it('should upsert provider connection, refresh cache, and broadcast', async () => {
 			const decryptedSettings = { key: 'value' };
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(decryptedSettings));
@@ -307,94 +307,63 @@ describe('ExternalSecretsManager', () => {
 			const newProvider = new DummyProvider();
 			await newProvider.init({ connected: true, connectedAt: null, settings: {} });
 			await newProvider.connect();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: newProvider,
+			mockProviderConnectionManager.upsertProviderConnection.mockImplementation(async () => {
+				mockProviderRegistry.add('my-vault', newProvider);
 			});
 
 			await manager.syncProviderConnection('my-vault');
 
-			// Replaces without removing the provider key first
-			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', newProvider);
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-
-			// Sets up new provider with decrypted settings
 			expect(mockCipher.decryptV2).toHaveBeenCalledWith('encrypted-data');
-			expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', {
-				connected: true,
-				connectedAt: null,
-				settings: decryptedSettings,
-			});
-
-			// Refreshes cache for the provider
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'my-vault',
+				'dummy',
+				{
+					connected: true,
+					connectedAt: null,
+					settings: decryptedSettings,
+				},
+			);
 			expect(mockSecretsCache.refreshProvider).toHaveBeenCalledWith('my-vault', newProvider);
-
-			// Broadcasts reload
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
 		});
 
-		it('should only tear down and broadcast when connection no longer exists', async () => {
-			const existingProvider = new DummyProvider();
-			mockProviderRegistry.add('my-vault', existingProvider);
-
+		it('should remove provider connection and broadcast when connection no longer exists', async () => {
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(null);
 
 			await manager.syncProviderConnection('my-vault');
 
-			// Tears down
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
-			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
-
-			// Does NOT set up a new provider
-			expect(mockProviderLifecycle.initialize).not.toHaveBeenCalled();
+			expect(mockProviderConnectionManager.removeProviderConnection).toHaveBeenCalledWith(
+				'my-vault',
+			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).not.toHaveBeenCalled();
 			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
-
-			// Still broadcasts reload
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
 		});
 
-		it('should skip cache refresh when provider initialization fails', async () => {
+		it('should skip cache refresh when provider is not available after upsert', async () => {
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			// Provider initialization fails, so it won't be added to the registry
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: false,
-				error: new Error('Init failed'),
-			});
-
 			await manager.syncProviderConnection('my-vault');
 
-			expect(mockProviderLifecycle.initialize).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalled();
 			expect(mockSecretsCache.refreshProvider).not.toHaveBeenCalled();
-			// Still broadcasts reload
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
 		});
 
-		it('should broadcast reload even when no existing provider to tear down', async () => {
+		it('should broadcast reload when syncing an enabled connection', async () => {
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const newProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: newProvider,
-			});
-
 			await manager.syncProviderConnection('my-vault');
 
-			// No teardown needed (no existing provider)
-			expect(mockProviderLifecycle.disconnect).not.toHaveBeenCalled();
-
-			// Sets up provider and broadcasts
-			expect(mockProviderLifecycle.initialize).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalled();
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
@@ -484,20 +453,16 @@ describe('ExternalSecretsManager', () => {
 
 	describe('setProviderSettings', () => {
 		it('should update settings and reload provider', async () => {
-			const dummyProvider = new DummyProvider();
-			await dummyProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
-
-			mockProviderRegistry.get.mockReturnValue(dummyProvider);
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
-
 			await manager.setProviderSettings('dummy', { key: 'new-value' });
 
 			expect(mockSettingsStore.updateProvider).toHaveBeenCalledWith('dummy', {
 				settings: { key: 'new-value' },
 			});
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'dummy',
+				'dummy',
+				mockSettings.dummy,
+			);
 			expect(mockPublisher.publishCommand).toHaveBeenCalledWith({
 				command: 'reload-external-secrets-providers',
 			});
@@ -507,16 +472,10 @@ describe('ExternalSecretsManager', () => {
 			const dummyProvider = new DummyProvider();
 			await dummyProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
 			jest.spyOn(dummyProvider, 'test').mockResolvedValue([true]);
-
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
+			mockProviderRegistry.get.mockReturnValue(dummyProvider);
 
 			await manager.setProviderSettings('dummy', { key: 'value' }, 'user-123');
 
-			// The registry.add happens during reloadProvider, so provider should be available
-			// Wait for async tracking to complete by flushing all pending promises
 			await Promise.resolve();
 			await Promise.resolve();
 
@@ -533,29 +492,20 @@ describe('ExternalSecretsManager', () => {
 
 	describe('setProviderConnected', () => {
 		it('should connect provider when set to connected', async () => {
-			const dummyProvider = new DummyProvider();
-			await dummyProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
-
-			mockProviderRegistry.get.mockReturnValue(dummyProvider);
-			mockProviderLifecycle.connect.mockResolvedValue({ success: true });
-
 			await manager.setProviderConnected('dummy', true);
 
 			expect(mockSettingsStore.updateProvider).toHaveBeenCalledWith('dummy', { connected: true });
-			expect(mockRetryManager.runWithRetry).toHaveBeenCalled();
+			expect(mockProviderConnectionManager.connectProviderWithRetry).toHaveBeenCalledWith('dummy');
 			expect(mockPublisher.publishCommand).toHaveBeenCalled();
 		});
 
 		it('should disconnect provider when set to disconnected', async () => {
-			const dummyProvider = new DummyProvider();
-			mockProviderRegistry.get.mockReturnValue(dummyProvider);
-
 			await manager.setProviderConnected('dummy', false);
 
 			expect(mockSettingsStore.updateProvider).toHaveBeenCalledWith('dummy', {
 				connected: false,
 			});
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(dummyProvider);
+			expect(mockProviderConnectionManager.disconnectProvider).toHaveBeenCalledWith('dummy');
 			expect(mockPublisher.publishCommand).toHaveBeenCalled();
 		});
 	});
@@ -726,10 +676,7 @@ describe('ExternalSecretsManager', () => {
 			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
 		});
 
-		it('should initialize new providers from settings', async () => {
-			const dummyProvider = new DummyProvider();
-			await dummyProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
-
+		it('should upsert providers from settings', async () => {
 			const newSettings = {
 				dummy: {
 					connected: true,
@@ -740,37 +687,25 @@ describe('ExternalSecretsManager', () => {
 
 			mockSettingsStore.reload.mockResolvedValue(newSettings);
 			mockSettingsStore.getProvider.mockResolvedValue(newSettings.dummy);
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
 
 			await manager.reloadAllProviders();
 
-			expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', {
-				connected: true,
-				connectedAt: expect.any(Date),
-				settings: {},
-			});
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'dummy',
+				'dummy',
+				newSettings.dummy,
+			);
 		});
 
-		it('should replace existing providers from settings without removing them first', async () => {
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
-			mockProviderRegistry.add('dummy', existingProvider);
-			mockProviderRegistry.add.mockClear();
-
-			const replacementProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: replacementProvider,
-			});
-
+		it('should refresh secrets after reloading providers from settings', async () => {
 			await manager.reloadAllProviders();
 
-			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('dummy');
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('dummy', replacementProvider);
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'dummy',
+				'dummy',
+				mockSettings.dummy,
+			);
+			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
 		});
 	});
 
@@ -783,34 +718,6 @@ describe('ExternalSecretsManager', () => {
 	});
 
 	describe('integration scenarios', () => {
-		it('should handle provider connection retry on failure', async () => {
-			const failedProvider = new FailedProvider();
-			await failedProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
-
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: failedProvider,
-			});
-			mockProviderLifecycle.connect.mockResolvedValue({
-				success: false,
-				error: new Error('Connection failed'),
-			});
-
-			// Add the provider to the registry so it can be found during connection
-			mockProviderRegistry.add('dummy', failedProvider);
-
-			let retryOperation: any;
-			mockRetryManager.runWithRetry.mockImplementation(async (_key, operation) => {
-				retryOperation = operation;
-				const result = await operation();
-				return result;
-			});
-
-			await manager.setProviderConnected('dummy', true);
-
-			expect(retryOperation).toBeDefined();
-		});
-
 		it('should handle full lifecycle: init -> update -> shutdown', async () => {
 			await manager.init();
 
@@ -848,6 +755,7 @@ describe('ExternalSecretsManager', () => {
 				mockProviderRegistry,
 				mockProviderLifecycle,
 				mockRetryManager,
+				mockProviderConnectionManager,
 				mockSecretsCache,
 				mockSecretsProviderConnectionRepository,
 				mockCipher,
@@ -874,23 +782,19 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const dummyProvider = new DummyProvider();
-			await dummyProvider.init({ connected: true, connectedAt: null, settings: {} });
-			const disabledProvider = new DummyProvider();
-			await disabledProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('vault-disabled', disabledProvider);
-			mockProviderRegistry.add.mockClear();
-
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
-
 			await managerWithProjectMode.reloadAllProviders();
 
 			expect(mockSecretsProviderConnectionRepository.findAll).toHaveBeenCalled();
 			expect(mockSettingsStore.reload).not.toHaveBeenCalled();
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault-1', dummyProvider);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'my-vault-1',
+				'dummy',
+				{
+					connected: true,
+					connectedAt: null,
+					settings: { key: 'value' },
+				},
+			);
 		});
 
 		it('should remove disabled providers but not re-setup them', async () => {
@@ -923,28 +827,23 @@ describe('ExternalSecretsManager', () => {
 			] as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const dummyProvider = new DummyProvider();
-			await dummyProvider.init({ connected: true, connectedAt: null, settings: {} });
-			const disabledProvider = new DummyProvider();
-			await disabledProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('vault-disabled', disabledProvider);
-			mockProviderRegistry.add.mockClear();
-
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
-
 			await managerWithProjectMode.reloadAllProviders();
 
-			// Disabled providers should be removed directly
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('vault-disabled');
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(disabledProvider);
-			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('vault-disabled');
-			// Only enabled should be set up
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-enabled', dummyProvider);
-			expect(mockProviderRegistry.add).not.toHaveBeenCalledWith(
+			expect(mockProviderConnectionManager.removeProviderConnection).toHaveBeenCalledWith(
 				'vault-disabled',
+			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'vault-enabled',
+				'dummy',
+				{
+					connected: true,
+					connectedAt: null,
+					settings: { key: 'value' },
+				},
+			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).not.toHaveBeenCalledWith(
+				'vault-disabled',
+				expect.anything(),
 				expect.anything(),
 			);
 		});
@@ -978,26 +877,18 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const dummyProvider1 = new DummyProvider();
-			const dummyProvider2 = new DummyProvider();
-			await dummyProvider1.init({ connected: true, connectedAt: null, settings: {} });
-			await dummyProvider2.init({ connected: true, connectedAt: null, settings: {} });
-
-			let callCount = 0;
-			mockProviderLifecycle.initialize.mockImplementation(async () => {
-				callCount++;
-				return {
-					success: true,
-					provider: callCount === 1 ? dummyProvider1 : dummyProvider2,
-				};
-			});
-
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-1', dummyProvider1);
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-2', dummyProvider2);
-			expect(managerWithProjectMode.hasProvider('vault-1')).toBe(true);
-			expect(managerWithProjectMode.hasProvider('vault-2')).toBe(true);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'vault-1',
+				'dummy',
+				expect.objectContaining({ settings: { key: 'value' } }),
+			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'vault-2',
+				'dummy',
+				expect.objectContaining({ settings: { key: 'value' } }),
+			);
 		});
 
 		it('should decrypt settings from connections', async () => {
@@ -1019,78 +910,21 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify(decryptedSettings));
 
-			const dummyProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
-
 			await managerWithProjectMode.reloadAllProviders();
 
 			expect(mockCipher.decryptV2).toHaveBeenCalledWith(encryptedSettings);
-			expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', {
-				connected: true,
-				connectedAt: null,
-				settings: decryptedSettings,
-			});
-		});
-
-		it('should connect all providers', async () => {
-			const mockConnections = [
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'my-vault',
+				'dummy',
 				{
-					id: 1,
-					providerKey: 'provider-a',
-					type: 'dummy',
-					encryptedSettings: 'encrypted-data-1',
-					isEnabled: true,
-					projectAccess: [],
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					setUpdateDate: jest.fn(),
+					connected: true,
+					connectedAt: null,
+					settings: decryptedSettings,
 				},
-				{
-					id: 2,
-					providerKey: 'provider-b',
-					type: 'dummy',
-					encryptedSettings: 'encrypted-data-2',
-					isEnabled: true,
-					projectAccess: [],
-					createdAt: new Date(),
-					updatedAt: new Date(),
-					setUpdateDate: jest.fn(),
-				},
-			];
-
-			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
-			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
-
-			const providerA = new DummyProvider();
-			const providerB = new DummyProvider();
-			await providerA.init({ connected: true, connectedAt: null, settings: {} });
-			await providerB.init({ connected: true, connectedAt: null, settings: {} });
-
-			let callCount = 0;
-			mockProviderLifecycle.initialize.mockImplementation(async () => {
-				callCount++;
-				return {
-					success: true,
-					provider: callCount === 1 ? providerA : providerB,
-				};
-			});
-
-			await managerWithProjectMode.reloadAllProviders();
-
-			expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith(
-				'provider-a',
-				expect.any(Function),
-			);
-			expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith(
-				'provider-b',
-				expect.any(Function),
 			);
 		});
 
-		it('should replace existing providers during reload', async () => {
+		it('should delegate enabled provider connections during reload', async () => {
 			const mockConnection = {
 				id: 1,
 				providerKey: 'my-vault',
@@ -1103,99 +937,16 @@ describe('ExternalSecretsManager', () => {
 				setUpdateDate: jest.fn(),
 			};
 
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('my-vault', existingProvider);
-
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const newProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: newProvider,
-			});
-
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', newProvider);
-		});
-
-		it('should cancel retry and remove existing provider when replacement initialization fails', async () => {
-			const mockConnection = {
-				id: 1,
-				providerKey: 'my-vault',
-				type: 'dummy',
-				encryptedSettings: 'encrypted-data',
-				isEnabled: true,
-				projectAccess: [],
-				createdAt: new Date(),
-				updatedAt: new Date(),
-				setUpdateDate: jest.fn(),
-			};
-
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('my-vault', existingProvider);
-			mockRetryManager.cancelRetry.mockClear();
-			mockProviderLifecycle.disconnect.mockClear();
-
-			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
-			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: false,
-				error: new Error('Init failed'),
-			});
-
-			await managerWithProjectMode.reloadAllProviders();
-
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
-			expect(mockRetryManager.runWithRetry).not.toHaveBeenCalled();
-		});
-
-		it('should register failed replacement without cancelling scheduled retry when connection fails', async () => {
-			const mockConnection = {
-				id: 1,
-				providerKey: 'my-vault',
-				type: 'dummy',
-				encryptedSettings: 'encrypted-data',
-				isEnabled: true,
-				projectAccess: [],
-				createdAt: new Date(),
-				updatedAt: new Date(),
-				setUpdateDate: jest.fn(),
-			};
-
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
-			mockProviderRegistry.add('my-vault', existingProvider);
-			mockProviderRegistry.add.mockClear();
-			mockRetryManager.cancelRetry.mockClear();
-			mockProviderLifecycle.disconnect.mockClear();
-
-			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
-			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
-			const replacementProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: replacementProvider,
-			});
-			mockRetryManager.runWithRetry.mockResolvedValue({
-				success: false,
-				error: new Error('Connection failed'),
-			});
-
-			await managerWithProjectMode.reloadAllProviders();
-
-			expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
-			expect(mockRetryManager.cancelRetry).not.toHaveBeenCalledWith('my-vault');
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
-			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'my-vault',
+				'dummy',
+				expect.objectContaining({ settings: { key: 'value' } }),
+			);
 		});
 
 		it('should handle decryption errors gracefully', async () => {
@@ -1268,12 +1019,6 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const dummyProvider = new DummyProvider();
-			mockProviderLifecycle.initialize.mockResolvedValue({
-				success: true,
-				provider: dummyProvider,
-			});
-
 			mockSecretsCache.refreshAll.mockClear();
 
 			await managerWithProjectMode.reloadAllProviders();
@@ -1310,25 +1055,19 @@ describe('ExternalSecretsManager', () => {
 			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue(mockConnections as any);
 			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
 
-			const dummyProvider1 = new DummyProvider();
-			const dummyProvider2 = new DummyProvider();
-			await dummyProvider1.init({ connected: true, connectedAt: null, settings: {} });
-			await dummyProvider2.init({ connected: true, connectedAt: null, settings: {} });
-
-			let callCount = 0;
-			mockProviderLifecycle.initialize.mockImplementation(async () => {
-				callCount++;
-				return {
-					success: true,
-					provider: callCount === 1 ? dummyProvider1 : dummyProvider2,
-				};
-			});
-
 			await managerWithProjectMode.init();
 
 			expect(managerWithProjectMode.initialized).toBe(true);
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-1', dummyProvider1);
-			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-2', dummyProvider2);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'vault-1',
+				'dummy',
+				expect.objectContaining({ settings: { key: 'value' } }),
+			);
+			expect(mockProviderConnectionManager.upsertProviderConnection).toHaveBeenCalledWith(
+				'vault-2',
+				'dummy',
+				expect.objectContaining({ settings: { key: 'value' } }),
+			);
 			expect(mockSecretsCache.refreshAll).toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -294,10 +294,11 @@ describe('ExternalSecretsManager', () => {
 			setUpdateDate: jest.fn(),
 		};
 
-		it('should tear down existing provider, set up new one, refresh cache, and broadcast', async () => {
+		it('should replace existing provider, refresh cache, and broadcast', async () => {
 			const existingProvider = new DummyProvider();
 			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
 			mockProviderRegistry.add('my-vault', existingProvider);
+			mockProviderRegistry.add.mockClear();
 
 			const decryptedSettings = { key: 'value' };
 			mockSecretsProviderConnectionRepository.findOne.mockResolvedValue(mockConnection as any);
@@ -313,10 +314,10 @@ describe('ExternalSecretsManager', () => {
 
 			await manager.syncProviderConnection('my-vault');
 
-			// Tears down existing provider
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+			// Replaces without removing the provider key first
+			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', newProvider);
 			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
 
 			// Sets up new provider with decrypted settings
 			expect(mockCipher.decryptV2).toHaveBeenCalledWith('encrypted-data');

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -775,79 +775,6 @@ describe('ExternalSecretsManager', () => {
 			managerWithProjectMode?.shutdown();
 		});
 
-		const createManagerWithRealProviderServices = ({
-			providerClass = DummyProvider,
-			connections,
-		}: {
-			providerClass?: new () => SecretsProvider;
-			connections: Array<{
-				providerKey: string;
-				type: string;
-				encryptedSettings: string;
-				isEnabled: boolean;
-			}>;
-		}) => {
-			const providersFactory = new MockProviders();
-			providersFactory.setProviders({ dummy: providerClass });
-
-			const providerRegistry = new ExternalSecretsProviderRegistry();
-			const providerLifecycle = new ExternalSecretsProviderLifecycle(
-				mockLogger(),
-				providersFactory,
-			);
-			const retryManager = new ExternalSecretsRetryManager(mockLogger());
-			const providerConnectionManager = new ExternalSecretsProviderConnectionManager(
-				mockLogger(),
-				providerRegistry,
-				providerLifecycle,
-				retryManager,
-			);
-			const secretsCache = new ExternalSecretsSecretsCache(mockLogger(), providerRegistry);
-
-			const repository = mock<SecretsProviderConnectionRepository>();
-			repository.findAll.mockResolvedValue(connections as never);
-
-			const cipher = mock<Cipher>();
-			cipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
-
-			const managerWithRealServices = new ExternalSecretsManager(
-				mockLogger(),
-				{
-					updateInterval: 60,
-					externalSecretsForProjects: true,
-					externalSecretsMultipleConnections: false,
-				} as ExternalSecretsConfig,
-				providersFactory,
-				mockEventService,
-				mockPublisher,
-				mockSettingsStore,
-				providerRegistry,
-				providerLifecycle,
-				retryManager,
-				providerConnectionManager,
-				secretsCache,
-				repository,
-				cipher,
-			);
-
-			return {
-				managerWithRealServices,
-				providerRegistry,
-			};
-		};
-
-		const addConnectedProviderWithSecrets = async (
-			providerRegistry: ExternalSecretsProviderRegistry,
-			providerKey: string,
-			secrets: Record<string, string>,
-		) => {
-			const existingProvider = new DummyProvider();
-			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
-			await existingProvider.connect();
-			existingProvider.secrets = secrets;
-			providerRegistry.add(providerKey, existingProvider);
-		};
-
 		it('should load providers from repository when flag is enabled', async () => {
 			const mockConnection = {
 				id: 1,
@@ -1109,6 +1036,79 @@ describe('ExternalSecretsManager', () => {
 		});
 
 		describe('provider reload consistency', () => {
+			const createProviderReloadTestManager = ({
+				providerClass = DummyProvider,
+				connections,
+			}: {
+				providerClass?: new () => SecretsProvider;
+				connections: Array<{
+					providerKey: string;
+					type: string;
+					encryptedSettings: string;
+					isEnabled: boolean;
+				}>;
+			}) => {
+				const providersFactory = new MockProviders();
+				providersFactory.setProviders({ dummy: providerClass });
+
+				const providerRegistry = new ExternalSecretsProviderRegistry();
+				const providerLifecycle = new ExternalSecretsProviderLifecycle(
+					mockLogger(),
+					providersFactory,
+				);
+				const retryManager = new ExternalSecretsRetryManager(mockLogger());
+				const providerConnectionManager = new ExternalSecretsProviderConnectionManager(
+					mockLogger(),
+					providerRegistry,
+					providerLifecycle,
+					retryManager,
+				);
+				const secretsCache = new ExternalSecretsSecretsCache(mockLogger(), providerRegistry);
+
+				const repository = mock<SecretsProviderConnectionRepository>();
+				repository.findAll.mockResolvedValue(connections as never);
+
+				const cipher = mock<Cipher>();
+				cipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+
+				const manager = new ExternalSecretsManager(
+					mockLogger(),
+					{
+						updateInterval: 60,
+						externalSecretsForProjects: true,
+						externalSecretsMultipleConnections: false,
+					} as ExternalSecretsConfig,
+					providersFactory,
+					mockEventService,
+					mockPublisher,
+					mockSettingsStore,
+					providerRegistry,
+					providerLifecycle,
+					retryManager,
+					providerConnectionManager,
+					secretsCache,
+					repository,
+					cipher,
+				);
+
+				return {
+					manager,
+					providerRegistry,
+				};
+			};
+
+			const addConnectedProviderWithSecrets = async (
+				providerRegistry: ExternalSecretsProviderRegistry,
+				providerKey: string,
+				secrets: Record<string, string>,
+			) => {
+				const existingProvider = new DummyProvider();
+				await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
+				await existingProvider.connect();
+				existingProvider.secrets = secrets;
+				providerRegistry.add(providerKey, existingProvider);
+			};
+
 			it('should keep serving existing secrets while provider connection reload is in progress', async () => {
 				const connectStarted = createDeferred();
 				const allowConnectToFinish = createDeferred();
@@ -1120,33 +1120,31 @@ describe('ExternalSecretsManager', () => {
 					}
 				}
 
-				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
-					{
-						providerClass: SlowConnectProvider,
-						connections: [
-							{
-								providerKey: 'my-vault',
-								type: 'dummy',
-								encryptedSettings: 'encrypted-data',
-								isEnabled: true,
-							},
-						],
-					},
-				);
+				const { manager, providerRegistry } = createProviderReloadTestManager({
+					providerClass: SlowConnectProvider,
+					connections: [
+						{
+							providerKey: 'my-vault',
+							type: 'dummy',
+							encryptedSettings: 'encrypted-data',
+							isEnabled: true,
+						},
+					],
+				});
 
 				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
 					test1: 'old-value',
 				});
 
-				const reloadPromise = managerWithRealServices.reloadAllProviders();
+				const reloadPromise = manager.reloadAllProviders();
 				await connectStarted.promise;
 
 				try {
-					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBe('old-value');
+					expect(manager.getSecret('my-vault', 'test1')).toBe('old-value');
 				} finally {
 					allowConnectToFinish.resolve();
 					await reloadPromise;
-					managerWithRealServices.shutdown();
+					manager.shutdown();
 				}
 			});
 
@@ -1157,59 +1155,55 @@ describe('ExternalSecretsManager', () => {
 					}
 				}
 
-				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
-					{
-						providerClass: FailingConnectProvider,
-						connections: [
-							{
-								providerKey: 'my-vault',
-								type: 'dummy',
-								encryptedSettings: 'encrypted-data',
-								isEnabled: true,
-							},
-						],
-					},
-				);
+				const { manager, providerRegistry } = createProviderReloadTestManager({
+					providerClass: FailingConnectProvider,
+					connections: [
+						{
+							providerKey: 'my-vault',
+							type: 'dummy',
+							encryptedSettings: 'encrypted-data',
+							isEnabled: true,
+						},
+					],
+				});
 
 				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
 					test1: 'old-value',
 				});
 
 				try {
-					await managerWithRealServices.reloadAllProviders();
+					await manager.reloadAllProviders();
 
-					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBeUndefined();
+					expect(manager.getSecret('my-vault', 'test1')).toBeUndefined();
 					expect(providerRegistry.get('my-vault')?.state).toBe('error');
 				} finally {
-					managerWithRealServices.shutdown();
+					manager.shutdown();
 				}
 			});
 
 			it('should stop serving secrets when a provider connection is disabled', async () => {
-				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
-					{
-						connections: [
-							{
-								providerKey: 'my-vault',
-								type: 'dummy',
-								encryptedSettings: 'encrypted-data',
-								isEnabled: false,
-							},
-						],
-					},
-				);
+				const { manager, providerRegistry } = createProviderReloadTestManager({
+					connections: [
+						{
+							providerKey: 'my-vault',
+							type: 'dummy',
+							encryptedSettings: 'encrypted-data',
+							isEnabled: false,
+						},
+					],
+				});
 
 				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
 					test1: 'old-value',
 				});
 
 				try {
-					await managerWithRealServices.reloadAllProviders();
+					await manager.reloadAllProviders();
 
-					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBeUndefined();
+					expect(manager.getSecret('my-vault', 'test1')).toBeUndefined();
 					expect(providerRegistry.has('my-vault')).toBe(false);
 				} finally {
-					managerWithRealServices.shutdown();
+					manager.shutdown();
 				}
 			});
 		});

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -868,7 +868,7 @@ describe('ExternalSecretsManager', () => {
 			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault-1', dummyProvider);
 		});
 
-		it('should tear down disabled providers but not re-setup them', async () => {
+		it('should remove disabled providers but not re-setup them', async () => {
 			const enabledConnection = {
 				id: 1,
 				providerKey: 'vault-enabled',
@@ -907,8 +907,7 @@ describe('ExternalSecretsManager', () => {
 
 			await managerWithProjectMode.reloadAllProviders();
 
-			// Both should be torn down
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('vault-enabled');
+			// Disabled providers should be removed directly
 			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('vault-disabled');
 			// Only enabled should be set up
 			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-enabled', dummyProvider);
@@ -1059,7 +1058,7 @@ describe('ExternalSecretsManager', () => {
 			);
 		});
 
-		it('should tear down existing providers before reloading', async () => {
+		it('should replace existing providers during reload', async () => {
 			const mockConnection = {
 				id: 1,
 				providerKey: 'my-vault',
@@ -1087,9 +1086,8 @@ describe('ExternalSecretsManager', () => {
 
 			await managerWithProjectMode.reloadAllProviders();
 
-			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
 			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
-			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
 			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', newProvider);
 		});
 

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -856,6 +856,11 @@ describe('ExternalSecretsManager', () => {
 
 			const dummyProvider = new DummyProvider();
 			await dummyProvider.init({ connected: true, connectedAt: null, settings: {} });
+			const disabledProvider = new DummyProvider();
+			await disabledProvider.init({ connected: true, connectedAt: null, settings: {} });
+			mockProviderRegistry.add('vault-disabled', disabledProvider);
+			mockProviderRegistry.add.mockClear();
+
 			mockProviderLifecycle.initialize.mockResolvedValue({
 				success: true,
 				provider: dummyProvider,
@@ -900,6 +905,11 @@ describe('ExternalSecretsManager', () => {
 
 			const dummyProvider = new DummyProvider();
 			await dummyProvider.init({ connected: true, connectedAt: null, settings: {} });
+			const disabledProvider = new DummyProvider();
+			await disabledProvider.init({ connected: true, connectedAt: null, settings: {} });
+			mockProviderRegistry.add('vault-disabled', disabledProvider);
+			mockProviderRegistry.add.mockClear();
+
 			mockProviderLifecycle.initialize.mockResolvedValue({
 				success: true,
 				provider: dummyProvider,
@@ -909,6 +919,8 @@ describe('ExternalSecretsManager', () => {
 
 			// Disabled providers should be removed directly
 			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('vault-disabled');
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(disabledProvider);
+			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('vault-disabled');
 			// Only enabled should be set up
 			expect(mockProviderRegistry.add).toHaveBeenCalledWith('vault-enabled', dummyProvider);
 			expect(mockProviderRegistry.add).not.toHaveBeenCalledWith(
@@ -1089,6 +1101,81 @@ describe('ExternalSecretsManager', () => {
 			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
 			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
 			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', newProvider);
+		});
+
+		it('should cancel retry and remove existing provider when replacement initialization fails', async () => {
+			const mockConnection = {
+				id: 1,
+				providerKey: 'my-vault',
+				type: 'dummy',
+				encryptedSettings: 'encrypted-data',
+				isEnabled: true,
+				projectAccess: [],
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				setUpdateDate: jest.fn(),
+			};
+
+			const existingProvider = new DummyProvider();
+			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
+			mockProviderRegistry.add('my-vault', existingProvider);
+			mockRetryManager.cancelRetry.mockClear();
+			mockProviderLifecycle.disconnect.mockClear();
+
+			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+			mockProviderLifecycle.initialize.mockResolvedValue({
+				success: false,
+				error: new Error('Init failed'),
+			});
+
+			await managerWithProjectMode.reloadAllProviders();
+
+			expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+			expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+			expect(mockRetryManager.runWithRetry).not.toHaveBeenCalled();
+		});
+
+		it('should register failed replacement without cancelling scheduled retry when connection fails', async () => {
+			const mockConnection = {
+				id: 1,
+				providerKey: 'my-vault',
+				type: 'dummy',
+				encryptedSettings: 'encrypted-data',
+				isEnabled: true,
+				projectAccess: [],
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				setUpdateDate: jest.fn(),
+			};
+
+			const existingProvider = new DummyProvider();
+			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
+			mockProviderRegistry.add('my-vault', existingProvider);
+			mockProviderRegistry.add.mockClear();
+			mockRetryManager.cancelRetry.mockClear();
+			mockProviderLifecycle.disconnect.mockClear();
+
+			mockSecretsProviderConnectionRepository.findAll.mockResolvedValue([mockConnection as any]);
+			mockCipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+			const replacementProvider = new DummyProvider();
+			mockProviderLifecycle.initialize.mockResolvedValue({
+				success: true,
+				provider: replacementProvider,
+			});
+			mockRetryManager.runWithRetry.mockResolvedValue({
+				success: false,
+				error: new Error('Connection failed'),
+			});
+
+			await managerWithProjectMode.reloadAllProviders();
+
+			expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
+			expect(mockRetryManager.cancelRetry).not.toHaveBeenCalledWith('my-vault');
+			expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
 		});
 
 		it('should handle decryption errors gracefully', async () => {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -74,7 +74,7 @@ describe('ExternalSecretsManager', () => {
 		mockProviderRegistry.get.mockImplementation((name) => providersMap.get(name));
 		mockProviderRegistry.has.mockImplementation((name) => providersMap.has(name));
 		mockProviderRegistry.getAll.mockImplementation(() => new Map(providersMap));
-		mockProviderRegistry.add.mockImplementation((name, provider) => {
+		mockProviderRegistry.set.mockImplementation((name, provider) => {
 			providersMap.set(name, provider);
 		});
 		mockProviderRegistry.remove.mockImplementation((name) => {
@@ -317,7 +317,7 @@ describe('ExternalSecretsManager', () => {
 			await newProvider.init({ connected: true, connectedAt: null, settings: {} });
 			await newProvider.connect();
 			mockProviderConnectionManager.upsertProviderConnection.mockImplementation(async () => {
-				mockProviderRegistry.add('my-vault', newProvider);
+				mockProviderRegistry.set('my-vault', newProvider);
 			});
 
 			await manager.syncProviderConnection('my-vault');
@@ -1106,7 +1106,7 @@ describe('ExternalSecretsManager', () => {
 				await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
 				await existingProvider.connect();
 				existingProvider.secrets = secrets;
-				providerRegistry.add(providerKey, existingProvider);
+				providerRegistry.set(providerKey, existingProvider);
 			};
 
 			it('should keep serving existing secrets while provider connection reload is in progress', async () => {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -7,14 +7,23 @@ import type { SecretsProviderConnectionRepository } from '@n8n/db';
 import type { Cipher } from 'n8n-core';
 
 import { ExternalSecretsManager } from '../external-secrets-manager.ee';
+import { ExternalSecretsProviderConnectionManager } from '../external-secrets-provider-connection-manager.ee';
 import type { ExternalSecretsConfig } from '../external-secrets.config';
-import type { ExternalSecretsProviderConnectionManager } from '../external-secrets-provider-connection-manager.ee';
-import type { ExternalSecretsProviderLifecycle } from '../provider-lifecycle.service';
-import type { ExternalSecretsProviderRegistry } from '../provider-registry.service';
-import type { ExternalSecretsRetryManager } from '../retry-manager.service';
-import type { ExternalSecretsSecretsCache } from '../secrets-cache.service';
+import { ExternalSecretsProviderLifecycle } from '../provider-lifecycle.service';
+import { ExternalSecretsProviderRegistry } from '../provider-registry.service';
+import { ExternalSecretsRetryManager } from '../retry-manager.service';
+import { ExternalSecretsSecretsCache } from '../secrets-cache.service';
 import type { ExternalSecretsSettingsStore } from '../settings-store.service';
 import type { ExternalSecretsSettings, SecretsProvider } from '../types';
+
+const createDeferred = () => {
+	let resolve!: () => void;
+	const promise = new Promise<void>((res) => {
+		resolve = res;
+	});
+
+	return { promise, resolve };
+};
 
 describe('ExternalSecretsManager', () => {
 	jest.useFakeTimers();
@@ -766,6 +775,79 @@ describe('ExternalSecretsManager', () => {
 			managerWithProjectMode?.shutdown();
 		});
 
+		const createManagerWithRealProviderServices = ({
+			providerClass = DummyProvider,
+			connections,
+		}: {
+			providerClass?: new () => SecretsProvider;
+			connections: Array<{
+				providerKey: string;
+				type: string;
+				encryptedSettings: string;
+				isEnabled: boolean;
+			}>;
+		}) => {
+			const providersFactory = new MockProviders();
+			providersFactory.setProviders({ dummy: providerClass });
+
+			const providerRegistry = new ExternalSecretsProviderRegistry();
+			const providerLifecycle = new ExternalSecretsProviderLifecycle(
+				mockLogger(),
+				providersFactory,
+			);
+			const retryManager = new ExternalSecretsRetryManager(mockLogger());
+			const providerConnectionManager = new ExternalSecretsProviderConnectionManager(
+				mockLogger(),
+				providerRegistry,
+				providerLifecycle,
+				retryManager,
+			);
+			const secretsCache = new ExternalSecretsSecretsCache(mockLogger(), providerRegistry);
+
+			const repository = mock<SecretsProviderConnectionRepository>();
+			repository.findAll.mockResolvedValue(connections as never);
+
+			const cipher = mock<Cipher>();
+			cipher.decryptV2.mockResolvedValue(JSON.stringify({ key: 'value' }));
+
+			const managerWithRealServices = new ExternalSecretsManager(
+				mockLogger(),
+				{
+					updateInterval: 60,
+					externalSecretsForProjects: true,
+					externalSecretsMultipleConnections: false,
+				} as ExternalSecretsConfig,
+				providersFactory,
+				mockEventService,
+				mockPublisher,
+				mockSettingsStore,
+				providerRegistry,
+				providerLifecycle,
+				retryManager,
+				providerConnectionManager,
+				secretsCache,
+				repository,
+				cipher,
+			);
+
+			return {
+				managerWithRealServices,
+				providerRegistry,
+			};
+		};
+
+		const addConnectedProviderWithSecrets = async (
+			providerRegistry: ExternalSecretsProviderRegistry,
+			providerKey: string,
+			secrets: Record<string, string>,
+		) => {
+			const existingProvider = new DummyProvider();
+			await existingProvider.init({ connected: true, connectedAt: null, settings: {} });
+			await existingProvider.connect();
+			existingProvider.secrets = secrets;
+			providerRegistry.add(providerKey, existingProvider);
+		};
+
 		it('should load providers from repository when flag is enabled', async () => {
 			const mockConnection = {
 				id: 1,
@@ -1024,6 +1106,112 @@ describe('ExternalSecretsManager', () => {
 			await managerWithProjectMode.reloadAllProviders();
 
 			expect(mockSecretsCache.refreshAll).toHaveBeenCalledTimes(1);
+		});
+
+		describe('provider reload consistency', () => {
+			it('should keep serving existing secrets while provider connection reload is in progress', async () => {
+				const connectStarted = createDeferred();
+				const allowConnectToFinish = createDeferred();
+
+				class SlowConnectProvider extends DummyProvider {
+					protected override async doConnect(): Promise<void> {
+						connectStarted.resolve();
+						await allowConnectToFinish.promise;
+					}
+				}
+
+				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
+					{
+						providerClass: SlowConnectProvider,
+						connections: [
+							{
+								providerKey: 'my-vault',
+								type: 'dummy',
+								encryptedSettings: 'encrypted-data',
+								isEnabled: true,
+							},
+						],
+					},
+				);
+
+				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
+					test1: 'old-value',
+				});
+
+				const reloadPromise = managerWithRealServices.reloadAllProviders();
+				await connectStarted.promise;
+
+				try {
+					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBe('old-value');
+				} finally {
+					allowConnectToFinish.resolve();
+					await reloadPromise;
+					managerWithRealServices.shutdown();
+				}
+			});
+
+			it('should stop serving stale secrets when replacement connection fails', async () => {
+				class FailingConnectProvider extends DummyProvider {
+					protected override async doConnect(): Promise<void> {
+						throw new Error('Connection failed');
+					}
+				}
+
+				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
+					{
+						providerClass: FailingConnectProvider,
+						connections: [
+							{
+								providerKey: 'my-vault',
+								type: 'dummy',
+								encryptedSettings: 'encrypted-data',
+								isEnabled: true,
+							},
+						],
+					},
+				);
+
+				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
+					test1: 'old-value',
+				});
+
+				try {
+					await managerWithRealServices.reloadAllProviders();
+
+					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBeUndefined();
+					expect(providerRegistry.get('my-vault')?.state).toBe('error');
+				} finally {
+					managerWithRealServices.shutdown();
+				}
+			});
+
+			it('should stop serving secrets when a provider connection is disabled', async () => {
+				const { managerWithRealServices, providerRegistry } = createManagerWithRealProviderServices(
+					{
+						connections: [
+							{
+								providerKey: 'my-vault',
+								type: 'dummy',
+								encryptedSettings: 'encrypted-data',
+								isEnabled: false,
+							},
+						],
+					},
+				);
+
+				await addConnectedProviderWithSecrets(providerRegistry, 'my-vault', {
+					test1: 'old-value',
+				});
+
+				try {
+					await managerWithRealServices.reloadAllProviders();
+
+					expect(managerWithRealServices.getSecret('my-vault', 'test1')).toBeUndefined();
+					expect(providerRegistry.has('my-vault')).toBe(false);
+				} finally {
+					managerWithRealServices.shutdown();
+				}
+			});
 		});
 
 		it('should initialize successfully with project-based providers', async () => {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-manager.ee.test.ts
@@ -752,6 +752,25 @@ describe('ExternalSecretsManager', () => {
 				settings: {},
 			});
 		});
+
+		it('should replace existing providers from settings without removing them first', async () => {
+			const existingProvider = new DummyProvider();
+			await existingProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
+			mockProviderRegistry.add('dummy', existingProvider);
+			mockProviderRegistry.add.mockClear();
+
+			const replacementProvider = new DummyProvider();
+			mockProviderLifecycle.initialize.mockResolvedValue({
+				success: true,
+				provider: replacementProvider,
+			});
+
+			await manager.reloadAllProviders();
+
+			expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('dummy');
+			expect(mockProviderRegistry.add).toHaveBeenCalledWith('dummy', replacementProvider);
+			expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		});
 	});
 
 	describe('updateSecrets', () => {

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
@@ -1,0 +1,152 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import { mock } from 'jest-mock-extended';
+
+import { DummyProvider } from '@test/external-secrets/utils';
+
+import { ExternalSecretsProviderConnectionManager } from '../external-secrets-provider-connection-manager.ee';
+import type { ExternalSecretsProviderLifecycle } from '../provider-lifecycle.service';
+import type { ExternalSecretsProviderRegistry } from '../provider-registry.service';
+import type { ExternalSecretsRetryManager } from '../retry-manager.service';
+import type { SecretsProvider, SecretsProviderSettings } from '../types';
+
+describe('ExternalSecretsProviderConnectionManager', () => {
+	let manager: ExternalSecretsProviderConnectionManager;
+	let mockProviderRegistry: jest.Mocked<ExternalSecretsProviderRegistry>;
+	let mockProviderLifecycle: jest.Mocked<ExternalSecretsProviderLifecycle>;
+	let mockRetryManager: jest.Mocked<ExternalSecretsRetryManager>;
+	let providersMap: Map<string, SecretsProvider>;
+
+	const providerSettings: SecretsProviderSettings = {
+		connected: true,
+		connectedAt: null,
+		settings: { key: 'value' },
+	};
+
+	beforeEach(() => {
+		providersMap = new Map();
+
+		mockProviderRegistry = mock<ExternalSecretsProviderRegistry>();
+		mockProviderRegistry.get.mockImplementation((name) => providersMap.get(name));
+		mockProviderRegistry.has.mockImplementation((name) => providersMap.has(name));
+		mockProviderRegistry.add.mockImplementation((name, provider) => {
+			providersMap.set(name, provider);
+		});
+		mockProviderRegistry.remove.mockImplementation((name) => {
+			providersMap.delete(name);
+		});
+
+		mockProviderLifecycle = mock<ExternalSecretsProviderLifecycle>();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: new DummyProvider(),
+		});
+		mockProviderLifecycle.connect.mockResolvedValue({ success: true });
+
+		mockRetryManager = mock<ExternalSecretsRetryManager>();
+		mockRetryManager.runWithRetry.mockImplementation(async (_key, operation) => {
+			return await operation();
+		});
+
+		manager = new ExternalSecretsProviderConnectionManager(
+			mockLogger(),
+			mockProviderRegistry,
+			mockProviderLifecycle,
+			mockRetryManager,
+		);
+	});
+
+	it('should add new provider and connect with retry', async () => {
+		const provider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({ success: true, provider });
+
+		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+
+		expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', providerSettings);
+		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', provider);
+		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
+		expect(mockProviderLifecycle.connect).toHaveBeenCalledWith(provider);
+	});
+
+	it('should replace provider without removing the registry key first', async () => {
+		const existingProvider = new DummyProvider();
+		mockProviderRegistry.add('my-vault', existingProvider);
+		mockProviderRegistry.add.mockClear();
+
+		const replacementProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+
+		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+
+		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+	});
+
+	it('should cancel retry and remove existing provider when replacement initialization fails', async () => {
+		const existingProvider = new DummyProvider();
+		mockProviderRegistry.add('my-vault', existingProvider);
+		mockRetryManager.cancelRetry.mockClear();
+
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: false,
+			error: new Error('Init failed'),
+		});
+
+		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+
+		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+		expect(mockRetryManager.runWithRetry).not.toHaveBeenCalled();
+	});
+
+	it('should register failed replacement without cancelling scheduled retry when connection fails', async () => {
+		const existingProvider = new DummyProvider();
+		mockProviderRegistry.add('my-vault', existingProvider);
+		mockProviderRegistry.add.mockClear();
+		mockRetryManager.cancelRetry.mockClear();
+
+		const replacementProvider = new DummyProvider();
+		mockProviderLifecycle.initialize.mockResolvedValue({
+			success: true,
+			provider: replacementProvider,
+		});
+		mockProviderLifecycle.connect.mockResolvedValue({
+			success: false,
+			error: new Error('Connection failed'),
+		});
+
+		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
+
+		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
+		expect(mockRetryManager.cancelRetry).not.toHaveBeenCalledWith('my-vault');
+		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+	});
+
+	it('should cancel retry and remove provider', async () => {
+		const existingProvider = new DummyProvider();
+		mockProviderRegistry.add('my-vault', existingProvider);
+
+		await manager.removeProviderConnection('my-vault');
+
+		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(mockProviderRegistry.remove).toHaveBeenCalledWith('my-vault');
+	});
+
+	it('should disconnect provider without removing it', async () => {
+		const existingProvider = new DummyProvider();
+		mockProviderRegistry.add('my-vault', existingProvider);
+
+		await manager.disconnectProvider('my-vault');
+
+		expect(mockRetryManager.cancelRetry).toHaveBeenCalledWith('my-vault');
+		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
+		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
+	});
+});

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/external-secrets-provider-connection-manager.ee.test.ts
@@ -28,7 +28,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		mockProviderRegistry = mock<ExternalSecretsProviderRegistry>();
 		mockProviderRegistry.get.mockImplementation((name) => providersMap.get(name));
 		mockProviderRegistry.has.mockImplementation((name) => providersMap.has(name));
-		mockProviderRegistry.add.mockImplementation((name, provider) => {
+		mockProviderRegistry.set.mockImplementation((name, provider) => {
 			providersMap.set(name, provider);
 		});
 		mockProviderRegistry.remove.mockImplementation((name) => {
@@ -62,15 +62,15 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
 
 		expect(mockProviderLifecycle.initialize).toHaveBeenCalledWith('dummy', providerSettings);
-		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', provider);
+		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', provider);
 		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
 		expect(mockProviderLifecycle.connect).toHaveBeenCalledWith(provider);
 	});
 
 	it('should replace provider without removing the registry key first', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.add('my-vault', existingProvider);
-		mockProviderRegistry.add.mockClear();
+		mockProviderRegistry.set('my-vault', existingProvider);
+		mockProviderRegistry.set.mockClear();
 
 		const replacementProvider = new DummyProvider();
 		mockProviderLifecycle.initialize.mockResolvedValue({
@@ -81,13 +81,13 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 		await manager.upsertProviderConnection('my-vault', 'dummy', providerSettings);
 
 		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
-		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
+		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', replacementProvider);
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
 	});
 
 	it('should cancel retry and remove existing provider when replacement initialization fails', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.add('my-vault', existingProvider);
+		mockProviderRegistry.set('my-vault', existingProvider);
 		mockRetryManager.cancelRetry.mockClear();
 
 		mockProviderLifecycle.initialize.mockResolvedValue({
@@ -105,8 +105,8 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 
 	it('should register failed replacement without cancelling scheduled retry when connection fails', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.add('my-vault', existingProvider);
-		mockProviderRegistry.add.mockClear();
+		mockProviderRegistry.set('my-vault', existingProvider);
+		mockProviderRegistry.set.mockClear();
 		mockRetryManager.cancelRetry.mockClear();
 
 		const replacementProvider = new DummyProvider();
@@ -123,14 +123,14 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 
 		expect(mockRetryManager.runWithRetry).toHaveBeenCalledWith('my-vault', expect.any(Function));
 		expect(mockRetryManager.cancelRetry).not.toHaveBeenCalledWith('my-vault');
-		expect(mockProviderRegistry.add).toHaveBeenCalledWith('my-vault', replacementProvider);
+		expect(mockProviderRegistry.set).toHaveBeenCalledWith('my-vault', replacementProvider);
 		expect(mockProviderLifecycle.disconnect).toHaveBeenCalledWith(existingProvider);
 		expect(mockProviderRegistry.remove).not.toHaveBeenCalledWith('my-vault');
 	});
 
 	it('should cancel retry and remove provider', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.add('my-vault', existingProvider);
+		mockProviderRegistry.set('my-vault', existingProvider);
 
 		await manager.removeProviderConnection('my-vault');
 
@@ -141,7 +141,7 @@ describe('ExternalSecretsProviderConnectionManager', () => {
 
 	it('should disconnect provider without removing it', async () => {
 		const existingProvider = new DummyProvider();
-		mockProviderRegistry.add('my-vault', existingProvider);
+		mockProviderRegistry.set('my-vault', existingProvider);
 
 		await manager.disconnectProvider('my-vault');
 

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
@@ -13,8 +13,8 @@ describe('ProviderRegistry', () => {
 		anotherProvider = new AnotherDummyProvider();
 	});
 
-	describe('add', () => {
-		it('should add a provider to the registry', () => {
+	describe('set', () => {
+		it('should set a provider in the registry', () => {
 			registry.set('dummy', dummyProvider);
 
 			expect(registry.has('dummy')).toBe(true);

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/provider-registry.service.test.ts
@@ -15,7 +15,7 @@ describe('ProviderRegistry', () => {
 
 	describe('add', () => {
 		it('should add a provider to the registry', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			expect(registry.has('dummy')).toBe(true);
 			expect(registry.get('dummy')).toBe(dummyProvider);
@@ -25,8 +25,8 @@ describe('ProviderRegistry', () => {
 			const provider1 = new DummyProvider();
 			const provider2 = new DummyProvider();
 
-			registry.add('dummy', provider1);
-			registry.add('dummy', provider2);
+			registry.set('dummy', provider1);
+			registry.set('dummy', provider2);
 
 			expect(registry.get('dummy')).toBe(provider2);
 		});
@@ -34,7 +34,7 @@ describe('ProviderRegistry', () => {
 
 	describe('remove', () => {
 		it('should remove a provider from the registry', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			expect(registry.has('dummy')).toBe(true);
 
 			registry.remove('dummy');
@@ -49,7 +49,7 @@ describe('ProviderRegistry', () => {
 
 	describe('get', () => {
 		it('should return provider by name', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			const result = registry.get('dummy');
 
@@ -65,7 +65,7 @@ describe('ProviderRegistry', () => {
 
 	describe('has', () => {
 		it('should return true when provider exists', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			expect(registry.has('dummy')).toBe(true);
 		});
@@ -77,8 +77,8 @@ describe('ProviderRegistry', () => {
 
 	describe('getAll', () => {
 		it('should return all providers as a Map', () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getAll();
 
@@ -89,7 +89,7 @@ describe('ProviderRegistry', () => {
 		});
 
 		it('should return a copy of the providers map', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			const result = registry.getAll();
 			result.set('modified', anotherProvider);
@@ -114,8 +114,8 @@ describe('ProviderRegistry', () => {
 			await anotherProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
 			anotherProvider.setState('error', new Error('Test error'));
 
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getConnected();
 
@@ -124,8 +124,8 @@ describe('ProviderRegistry', () => {
 		});
 
 		it('should return empty array when no providers are connected', () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getConnected();
 
@@ -141,8 +141,8 @@ describe('ProviderRegistry', () => {
 			await anotherProvider.init({ connected: true, connectedAt: new Date(), settings: {} });
 			anotherProvider.setState('error', new Error('Test error'));
 
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getConnectedNames();
 
@@ -150,8 +150,8 @@ describe('ProviderRegistry', () => {
 		});
 
 		it('should return empty array when no providers are connected', () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getConnectedNames();
 
@@ -161,8 +161,8 @@ describe('ProviderRegistry', () => {
 
 	describe('getNames', () => {
 		it('should return all provider names', () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const result = registry.getNames();
 
@@ -179,8 +179,8 @@ describe('ProviderRegistry', () => {
 
 	describe('clear', () => {
 		it('should remove all providers', () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 			expect(registry.getNames()).toHaveLength(2);
 
 			registry.clear();
@@ -200,8 +200,8 @@ describe('ProviderRegistry', () => {
 			const disconnectSpy1 = jest.spyOn(dummyProvider, 'disconnect');
 			const disconnectSpy2 = jest.spyOn(anotherProvider, 'disconnect');
 
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			await registry.disconnectAll();
 
@@ -213,7 +213,7 @@ describe('ProviderRegistry', () => {
 			const errorProvider = new DummyProvider();
 			jest.spyOn(errorProvider, 'disconnect').mockRejectedValue(new Error('Disconnect failed'));
 
-			registry.add('error', errorProvider);
+			registry.set('error', errorProvider);
 
 			await expect(registry.disconnectAll()).resolves.not.toThrow();
 		});
@@ -224,8 +224,8 @@ describe('ProviderRegistry', () => {
 
 			const disconnectSpy = jest.spyOn(dummyProvider, 'disconnect');
 
-			registry.add('error', errorProvider);
-			registry.add('dummy', dummyProvider);
+			registry.set('error', errorProvider);
+			registry.set('dummy', dummyProvider);
 
 			await registry.disconnectAll();
 

--- a/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-cache.service.test.ts
+++ b/packages/cli/src/modules/external-secrets.ee/__tests__/secrets-cache.service.test.ts
@@ -74,8 +74,8 @@ describe('SecretsCache', () => {
 
 	describe('refreshAll', () => {
 		it('should refresh all registered providers', async () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const updateSpy1 = jest.spyOn(dummyProvider, 'update');
 			const updateSpy2 = jest.spyOn(anotherProvider, 'update');
@@ -89,8 +89,8 @@ describe('SecretsCache', () => {
 		it('should continue refreshing other providers if one fails', async () => {
 			jest.spyOn(dummyProvider, 'update').mockRejectedValue(new Error('Update failed'));
 
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			const updateSpy = jest.spyOn(anotherProvider, 'update');
 
@@ -106,7 +106,7 @@ describe('SecretsCache', () => {
 
 	describe('getSecret', () => {
 		it('should get secret from provider', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const result = cache.getSecret('dummy', 'test1');
@@ -121,7 +121,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should return undefined for non-existent secret', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const result = cache.getSecret('dummy', 'non-existent');
@@ -130,7 +130,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should delegate to provider getSecret method', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const getSpy = jest.spyOn(dummyProvider, 'getSecret');
@@ -143,7 +143,7 @@ describe('SecretsCache', () => {
 
 	describe('hasSecret', () => {
 		it('should return true when secret exists', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const result = cache.hasSecret('dummy', 'test1');
@@ -158,7 +158,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should return false for non-existent secret', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const result = cache.hasSecret('dummy', 'non-existent');
@@ -167,7 +167,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should delegate to provider hasSecret method', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const hasSpy = jest.spyOn(dummyProvider, 'hasSecret');
@@ -180,7 +180,7 @@ describe('SecretsCache', () => {
 
 	describe('getSecretNames', () => {
 		it('should return secret names from provider', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const result = cache.getSecretNames('dummy');
@@ -195,7 +195,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should return empty array when provider has no secrets', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			// Don't call update, so no secrets are loaded
 
 			const result = cache.getSecretNames('dummy');
@@ -204,7 +204,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should delegate to provider getSecretNames method', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			await dummyProvider.update();
 
 			const getNamesSpy = jest.spyOn(dummyProvider, 'getSecretNames');
@@ -217,8 +217,8 @@ describe('SecretsCache', () => {
 
 	describe('getAllSecretNames', () => {
 		it('should return secret names from all providers', async () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			await dummyProvider.update();
 			await anotherProvider.update();
@@ -238,7 +238,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should include providers with no secrets', () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 			// Don't call update, so no secrets are loaded
 
 			const result = cache.getAllSecretNames();
@@ -249,8 +249,8 @@ describe('SecretsCache', () => {
 		});
 
 		it('should handle mix of providers with and without secrets', async () => {
-			registry.add('dummy', dummyProvider);
-			registry.add('another', anotherProvider);
+			registry.set('dummy', dummyProvider);
+			registry.set('another', anotherProvider);
 
 			await dummyProvider.update();
 			// Don't update anotherProvider
@@ -266,7 +266,7 @@ describe('SecretsCache', () => {
 
 	describe('integration', () => {
 		it('should refresh and retrieve secrets', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			await cache.refreshAll();
 
@@ -276,7 +276,7 @@ describe('SecretsCache', () => {
 		});
 
 		it('should update secrets after refresh', async () => {
-			registry.add('dummy', dummyProvider);
+			registry.set('dummy', dummyProvider);
 
 			await cache.refreshAll();
 			expect(cache.getSecret('dummy', 'test1')).toBe('value1');

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -12,17 +12,13 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import { ExternalSecretsProviders } from './external-secrets-providers.ee';
 import { ExternalSecretsConfig } from './external-secrets.config';
-import {
-	ExternalSecretsProviderLifecycle,
-	ProviderConnectResult,
-} from './provider-lifecycle.service';
+import { ExternalSecretsProviderConnectionManager } from './external-secrets-provider-connection-manager.ee';
+import { ExternalSecretsProviderLifecycle } from './provider-lifecycle.service';
 import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import { ExternalSecretsRetryManager } from './retry-manager.service';
 import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import { ExternalSecretsSettingsStore } from './settings-store.service';
 import type { ExternalSecretsSettings, SecretsProvider, SecretsProviderSettings } from './types';
-
-type ProviderConnectionOperationResult = { success: boolean; error?: Error };
 
 /**
  * Orchestrates external secrets management
@@ -46,6 +42,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		private readonly providerRegistry: ExternalSecretsProviderRegistry,
 		private readonly providerLifecycle: ExternalSecretsProviderLifecycle,
 		private readonly retryManager: ExternalSecretsRetryManager,
+		private readonly providerConnectionManager: ExternalSecretsProviderConnectionManager,
 		private readonly secretsCache: ExternalSecretsSecretsCache,
 		private readonly secretsProviderConnectionRepository: SecretsProviderConnectionRepository,
 		private readonly cipher: Cipher,
@@ -153,19 +150,18 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 				settings,
 			};
 
-			if (this.providerRegistry.has(providerKey)) {
-				await this.replaceProviderConnection(providerKey, connection.type, connectionSettings);
-			} else {
-				await this.addProviderConnection(providerKey, connection.type, connectionSettings);
-			}
+			await this.providerConnectionManager.upsertProviderConnection(
+				providerKey,
+				connection.type,
+				connectionSettings,
+			);
 
 			const provider = this.providerRegistry.get(providerKey);
 			if (provider) {
 				await this.secretsCache.refreshProvider(providerKey, provider);
 			}
 		} else {
-			this.retryManager.cancelRetry(providerKey);
-			await this.removeProviderConnection(providerKey);
+			await this.providerConnectionManager.removeProviderConnection(providerKey);
 		}
 
 		this.broadcastReload();
@@ -230,18 +226,9 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		await this.settingsStore.updateProvider(provider, { connected });
 
 		if (connected) {
-			await this.retryManager.runWithRetry(
-				provider,
-				async () => await this.connectProvider(provider),
-			);
+			await this.providerConnectionManager.connectProviderWithRetry(provider);
 		} else {
-			// Cancel any pending retries when disconnecting
-			this.retryManager.cancelRetry(provider);
-
-			const providerInstance = this.providerRegistry.get(provider);
-			if (providerInstance) {
-				await this.providerLifecycle.disconnect(providerInstance);
-			}
+			await this.providerConnectionManager.disconnectProvider(provider);
 		}
 
 		this.broadcastReload();
@@ -324,8 +311,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 		for (const connection of connections) {
 			if (!connection.isEnabled) {
-				this.retryManager.cancelRetry(connection.providerKey);
-				await this.removeProviderConnection(connection.providerKey);
+				await this.providerConnectionManager.removeProviderConnection(connection.providerKey);
 				continue;
 			}
 
@@ -339,19 +325,11 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 				settings,
 			};
 
-			if (this.providerRegistry.has(connection.providerKey)) {
-				await this.replaceProviderConnection(
-					connection.providerKey,
-					connection.type,
-					connectionSettings,
-				);
-			} else {
-				await this.addProviderConnection(
-					connection.providerKey,
-					connection.type,
-					connectionSettings,
-				);
-			}
+			await this.providerConnectionManager.upsertProviderConnection(
+				connection.providerKey,
+				connection.type,
+				connectionSettings,
+			);
 		}
 
 		await this.secretsCache.refreshAll();
@@ -362,150 +340,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 	// Private - Provider Management
 	// ========================================
 
-	private async addProviderConnection(
-		providerKey: string,
-		providerType: string,
-		config: SecretsProviderSettings,
-	): Promise<void> {
-		this.logger.debug('Adding external secrets provider connection', {
-			providerKey,
-			providerType,
-		});
-
-		const result = await this.providerLifecycle.initialize(providerType, config);
-
-		if (!result.success || !result.provider) {
-			this.logger.error('Failed to initialize external secrets provider connection', {
-				providerKey,
-				providerType,
-				error: result.error,
-			});
-			return;
-		}
-
-		this.providerRegistry.add(providerKey, result.provider);
-
-		if (config.connected) {
-			await this.retryManager.runWithRetry(
-				providerKey,
-				async () => await this.connectProvider(providerKey),
-			);
-		}
-	}
-
-	private async replaceProviderConnection(
-		providerKey: string,
-		providerType: string,
-		config: SecretsProviderSettings,
-	): Promise<void> {
-		this.logger.debug('Replacing external secrets provider connection', {
-			providerKey,
-			providerType,
-		});
-
-		// Initialization validates local config, so retrying it would only repeat deterministic failures.
-		const initResult = await this.providerLifecycle.initialize(providerType, config);
-
-		if (!initResult.success || !initResult.provider) {
-			const error =
-				initResult.error ?? new UnexpectedError(`Failed to initialize provider ${providerKey}`);
-			this.logger.error('Failed to initialize replacement external secrets provider connection', {
-				providerKey,
-				providerType,
-				error,
-			});
-			this.retryManager.cancelRetry(providerKey);
-			await this.removeProviderConnection(providerKey);
-			return;
-		}
-
-		const replacementProvider = initResult.provider;
-		let replacementResult: ProviderConnectionOperationResult;
-		if (config.connected) {
-			// Only connection is retried. A successful retry must also perform the registry swap.
-			replacementResult = await this.retryManager.runWithRetry(
-				providerKey,
-				async () =>
-					await this.connectAndSwapProviderConnection(
-						providerKey,
-						providerType,
-						replacementProvider,
-					),
-			);
-		} else {
-			replacementResult = await this.swapProviderConnection(
-				providerKey,
-				providerType,
-				replacementProvider,
-			);
-		}
-
-		if (!replacementResult.success) {
-			// The replacement reflects the latest config, even if connection failed. Register it
-			// in its error state so executions fail visibly instead of using stale secrets.
-			await this.swapProviderConnection(providerKey, providerType, replacementProvider);
-		}
-	}
-
-	private async connectAndSwapProviderConnection(
-		providerKey: string,
-		providerType: string,
-		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectionOperationResult> {
-		const connectResult = await this.providerLifecycle.connect(replacementProvider);
-		if (!connectResult.success) {
-			this.logger.error('Failed to connect replacement external secrets provider connection', {
-				providerKey,
-				providerType,
-				error: connectResult.error,
-			});
-			return connectResult;
-		}
-
-		return await this.swapProviderConnection(providerKey, providerType, replacementProvider);
-	}
-
-	private async swapProviderConnection(
-		providerKey: string,
-		providerType: string,
-		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectionOperationResult> {
-		const existingProvider = this.providerRegistry.get(providerKey);
-		this.providerRegistry.add(providerKey, replacementProvider);
-
-		if (existingProvider && existingProvider !== replacementProvider) {
-			this.logger.debug('Disconnecting previous external secrets provider connection', {
-				providerKey,
-				providerType,
-			});
-			await this.providerLifecycle.disconnect(existingProvider);
-		}
-
-		return { success: true };
-	}
-
-	private async removeProviderConnection(providerKey: string): Promise<void> {
-		this.logger.debug('Removing external secrets provider connection', {
-			providerKey,
-		});
-
-		const existingProvider = this.providerRegistry.get(providerKey);
-		if (existingProvider) {
-			await this.providerLifecycle.disconnect(existingProvider);
-			this.providerRegistry.remove(providerKey);
-		}
-	}
-
-	private async connectProvider(name: string): Promise<ProviderConnectResult> {
-		const provider = this.providerRegistry.get(name);
-		if (!provider) {
-			this.logger.warn(`Cannot connect provider ${name}: not found in registry`);
-			throw new Error(`Provider ${name} not found in registry`);
-		}
-
-		return await this.providerLifecycle.connect(provider);
-	}
-
 	private async reloadProvider(name: string): Promise<void> {
 		const config = await this.settingsStore.getProvider(name);
 		if (!config) {
@@ -513,11 +347,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			return;
 		}
 
-		if (this.providerRegistry.has(name)) {
-			await this.replaceProviderConnection(name, name, config);
-		} else {
-			await this.addProviderConnection(name, name, config);
-		}
+		await this.providerConnectionManager.upsertProviderConnection(name, name, config);
 	}
 
 	private async decryptSettings(

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -339,6 +339,78 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 	// Private - Provider Management
 	// ========================================
 
+	// @ts-expect-error Staged helper, not wired into callers yet.
+	private async addProviderConnection(
+		providerKey: string,
+		providerType: string,
+		config: SecretsProviderSettings,
+	): Promise<void> {
+		const result = await this.providerLifecycle.initialize(providerType, config);
+
+		if (!result.success || !result.provider) {
+			this.logger.error(`Failed to initialize provider ${providerKey}`, {
+				error: result.error,
+			});
+			return;
+		}
+
+		this.providerRegistry.add(providerKey, result.provider);
+
+		if (config.connected) {
+			await this.retryManager.runWithRetry(
+				providerKey,
+				async () => await this.connectProvider(providerKey),
+			);
+		}
+	}
+
+	// @ts-expect-error Staged helper, not wired into callers yet.
+	private async replaceProviderConnection(
+		providerKey: string,
+		providerType: string,
+		config: SecretsProviderSettings,
+	): Promise<void> {
+		const result = await this.providerLifecycle.initialize(providerType, config);
+
+		if (!result.success || !result.provider) {
+			this.logger.error(`Failed to initialize provider ${providerKey}`, {
+				error: result.error,
+			});
+			await this.removeProviderConnection(providerKey);
+			return;
+		}
+
+		if (config.connected) {
+			const connectResult = await this.providerLifecycle.connect(result.provider);
+			if (!connectResult.success) {
+				this.logger.error(`Failed to connect provider ${providerKey}`, {
+					error: connectResult.error,
+				});
+				await this.providerLifecycle.disconnect(result.provider);
+				await this.removeProviderConnection(providerKey);
+				return;
+			}
+		}
+
+		const existingProvider = this.providerRegistry.get(providerKey);
+		this.providerRegistry.add(providerKey, result.provider);
+
+		if (existingProvider) {
+			this.logger.debug(`Tearing down provider connection: ${providerKey}`);
+			await this.providerLifecycle.disconnect(existingProvider);
+		}
+	}
+
+	private async removeProviderConnection(providerKey: string): Promise<void> {
+		this.retryManager.cancelRetry(providerKey);
+		const existingProvider = this.providerRegistry.get(providerKey);
+		if (existingProvider) {
+			this.logger.debug(`Tearing down provider connection: ${providerKey}`);
+			await this.providerLifecycle.disconnect(existingProvider);
+			this.providerRegistry.remove(providerKey);
+		}
+	}
+
 	private async setupProvider(
 		providerType: string,
 		config: SecretsProviderSettings,

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -312,11 +312,10 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		const connections = await this.secretsProviderConnectionRepository.findAll();
 
 		for (const connection of connections) {
-			// Tear down all connections, including disabled ones that may
-			// still be in the registry from a previous load
-			await this.tearDownProviderConnection(connection.providerKey);
-
-			if (!connection.isEnabled) continue;
+			if (!connection.isEnabled) {
+				await this.removeProviderConnection(connection.providerKey);
+				continue;
+			}
 
 			const settings: SecretsProviderSettings['settings'] = await this.decryptSettings(
 				connection.encryptedSettings,
@@ -328,7 +327,19 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 				settings,
 			};
 
-			await this.setupProvider(connection.type, connectionSettings, connection.providerKey);
+			if (this.providerRegistry.has(connection.providerKey)) {
+				await this.replaceProviderConnection(
+					connection.providerKey,
+					connection.type,
+					connectionSettings,
+				);
+			} else {
+				await this.addProviderConnection(
+					connection.providerKey,
+					connection.type,
+					connectionSettings,
+				);
+			}
 		}
 
 		await this.secretsCache.refreshAll();
@@ -339,7 +350,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 	// Private - Provider Management
 	// ========================================
 
-	// @ts-expect-error Staged helper, not wired into callers yet.
 	private async addProviderConnection(
 		providerKey: string,
 		providerType: string,
@@ -364,7 +374,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		}
 	}
 
-	// @ts-expect-error Staged helper, not wired into callers yet.
 	private async replaceProviderConnection(
 		providerKey: string,
 		providerType: string,

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -308,8 +308,10 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 	}
 
 	private async reloadProvidersFromConnectionsRepo(): Promise<void> {
-		this.logger.debug('Initializing external secrets with project-based providers');
 		const connections = await this.secretsProviderConnectionRepository.findAll();
+		this.logger.debug('Reloading external secrets provider connections from repository', {
+			connectionCount: connections.length,
+		});
 
 		for (const connection of connections) {
 			if (!connection.isEnabled) {
@@ -355,10 +357,17 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		providerType: string,
 		config: SecretsProviderSettings,
 	): Promise<void> {
+		this.logger.debug('Adding external secrets provider connection', {
+			providerKey,
+			providerType,
+		});
+
 		const result = await this.providerLifecycle.initialize(providerType, config);
 
 		if (!result.success || !result.provider) {
-			this.logger.error(`Failed to initialize provider ${providerKey}`, {
+			this.logger.error('Failed to initialize external secrets provider connection', {
+				providerKey,
+				providerType,
 				error: result.error,
 			});
 			return;
@@ -379,10 +388,17 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		providerType: string,
 		config: SecretsProviderSettings,
 	): Promise<void> {
+		this.logger.debug('Replacing external secrets provider connection', {
+			providerKey,
+			providerType,
+		});
+
 		const result = await this.providerLifecycle.initialize(providerType, config);
 
 		if (!result.success || !result.provider) {
-			this.logger.error(`Failed to initialize provider ${providerKey}`, {
+			this.logger.error('Failed to initialize replacement external secrets provider connection', {
+				providerKey,
+				providerType,
 				error: result.error,
 			});
 			await this.removeProviderConnection(providerKey);
@@ -392,7 +408,9 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		if (config.connected) {
 			const connectResult = await this.providerLifecycle.connect(result.provider);
 			if (!connectResult.success) {
-				this.logger.error(`Failed to connect provider ${providerKey}`, {
+				this.logger.error('Failed to connect replacement external secrets provider connection', {
+					providerKey,
+					providerType,
 					error: connectResult.error,
 				});
 				await this.providerLifecycle.disconnect(result.provider);
@@ -405,16 +423,22 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		this.providerRegistry.add(providerKey, result.provider);
 
 		if (existingProvider) {
-			this.logger.debug(`Tearing down provider connection: ${providerKey}`);
+			this.logger.debug('Disconnecting previous external secrets provider connection', {
+				providerKey,
+				providerType,
+			});
 			await this.providerLifecycle.disconnect(existingProvider);
 		}
 	}
 
 	private async removeProviderConnection(providerKey: string): Promise<void> {
+		this.logger.debug('Removing external secrets provider connection', {
+			providerKey,
+		});
+
 		this.retryManager.cancelRetry(providerKey);
 		const existingProvider = this.providerRegistry.get(providerKey);
 		if (existingProvider) {
-			this.logger.debug(`Tearing down provider connection: ${providerKey}`);
 			await this.providerLifecycle.disconnect(existingProvider);
 			this.providerRegistry.remove(providerKey);
 		}

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -139,8 +139,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 	}
 
 	async syncProviderConnection(providerKey: string): Promise<void> {
-		await this.tearDownProviderConnection(providerKey);
-
 		const connection = await this.secretsProviderConnectionRepository.findOne({
 			where: { providerKey },
 		});
@@ -149,16 +147,25 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		// Skip disabled connections — they should not be loaded into the provider registry.
 		if (connection?.isEnabled) {
 			const settings = await this.decryptSettings(connection.encryptedSettings);
-			await this.setupProvider(
-				connection.type,
-				{ connected: true, connectedAt: null, settings },
-				providerKey,
-			);
+			const connectionSettings: SecretsProviderSettings = {
+				connected: true,
+				connectedAt: null,
+				settings,
+			};
+
+			if (this.providerRegistry.has(providerKey)) {
+				await this.replaceProviderConnection(providerKey, connection.type, connectionSettings);
+			} else {
+				await this.addProviderConnection(providerKey, connection.type, connectionSettings);
+			}
 
 			const provider = this.providerRegistry.get(providerKey);
 			if (provider) {
 				await this.secretsCache.refreshProvider(providerKey, provider);
 			}
+		} else {
+			this.retryManager.cancelRetry(providerKey);
+			await this.removeProviderConnection(providerKey);
 		}
 
 		this.broadcastReload();
@@ -489,28 +496,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 		}
 	}
 
-	private async setupProvider(
-		providerType: string,
-		config: SecretsProviderSettings,
-		providerKey?: string,
-	): Promise<void> {
-		const key = providerKey ?? providerType;
-		const result = await this.providerLifecycle.initialize(providerType, config);
-
-		if (!result.success || !result.provider) {
-			this.logger.error(`Failed to initialize provider ${key}`, {
-				error: result.error,
-			});
-			return;
-		}
-
-		this.providerRegistry.add(key, result.provider);
-
-		if (config.connected) {
-			await this.retryManager.runWithRetry(key, async () => await this.connectProvider(key));
-		}
-	}
-
 	private async connectProvider(name: string): Promise<ProviderConnectResult> {
 		const provider = this.providerRegistry.get(name);
 		if (!provider) {
@@ -532,16 +517,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			await this.replaceProviderConnection(name, name, config);
 		} else {
 			await this.addProviderConnection(name, name, config);
-		}
-	}
-
-	private async tearDownProviderConnection(providerKey: string): Promise<void> {
-		this.retryManager.cancelRetry(providerKey);
-		const existingProvider = this.providerRegistry.get(providerKey);
-		if (existingProvider) {
-			this.logger.debug(`Tearing down provider connection: ${providerKey}`);
-			await this.providerLifecycle.disconnect(existingProvider);
-			this.providerRegistry.remove(providerKey);
 		}
 	}
 

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -528,8 +528,11 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			return;
 		}
 
-		await this.tearDownProviderConnection(name);
-		await this.setupProvider(name, config);
+		if (this.providerRegistry.has(name)) {
+			await this.replaceProviderConnection(name, name, config);
+		} else {
+			await this.addProviderConnection(name, name, config);
+		}
 	}
 
 	private async tearDownProviderConnection(providerKey: string): Promise<void> {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -22,6 +22,8 @@ import { ExternalSecretsSecretsCache } from './secrets-cache.service';
 import { ExternalSecretsSettingsStore } from './settings-store.service';
 import type { ExternalSecretsSettings, SecretsProvider, SecretsProviderSettings } from './types';
 
+type ProviderConnectionOperationResult = { success: boolean; error?: Error };
+
 /**
  * Orchestrates external secrets management
  * Delegates to specialized components for clean separation of concerns
@@ -315,6 +317,7 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 		for (const connection of connections) {
 			if (!connection.isEnabled) {
+				this.retryManager.cancelRetry(connection.providerKey);
 				await this.removeProviderConnection(connection.providerKey);
 				continue;
 			}
@@ -393,42 +396,85 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			providerType,
 		});
 
-		const result = await this.providerLifecycle.initialize(providerType, config);
+		// Initialization validates local config, so retrying it would only repeat deterministic failures.
+		const initResult = await this.providerLifecycle.initialize(providerType, config);
 
-		if (!result.success || !result.provider) {
+		if (!initResult.success || !initResult.provider) {
+			const error =
+				initResult.error ?? new UnexpectedError(`Failed to initialize provider ${providerKey}`);
 			this.logger.error('Failed to initialize replacement external secrets provider connection', {
 				providerKey,
 				providerType,
-				error: result.error,
+				error,
 			});
+			this.retryManager.cancelRetry(providerKey);
 			await this.removeProviderConnection(providerKey);
 			return;
 		}
 
+		const replacementProvider = initResult.provider;
+		let replacementResult: ProviderConnectionOperationResult;
 		if (config.connected) {
-			const connectResult = await this.providerLifecycle.connect(result.provider);
-			if (!connectResult.success) {
-				this.logger.error('Failed to connect replacement external secrets provider connection', {
-					providerKey,
-					providerType,
-					error: connectResult.error,
-				});
-				await this.providerLifecycle.disconnect(result.provider);
-				await this.removeProviderConnection(providerKey);
-				return;
-			}
+			// Only connection is retried. A successful retry must also perform the registry swap.
+			replacementResult = await this.retryManager.runWithRetry(
+				providerKey,
+				async () =>
+					await this.connectAndSwapProviderConnection(
+						providerKey,
+						providerType,
+						replacementProvider,
+					),
+			);
+		} else {
+			replacementResult = await this.swapProviderConnection(
+				providerKey,
+				providerType,
+				replacementProvider,
+			);
 		}
 
-		const existingProvider = this.providerRegistry.get(providerKey);
-		this.providerRegistry.add(providerKey, result.provider);
+		if (!replacementResult.success) {
+			// The replacement reflects the latest config, even if connection failed. Register it
+			// in its error state so executions fail visibly instead of using stale secrets.
+			await this.swapProviderConnection(providerKey, providerType, replacementProvider);
+		}
+	}
 
-		if (existingProvider) {
+	private async connectAndSwapProviderConnection(
+		providerKey: string,
+		providerType: string,
+		replacementProvider: SecretsProvider,
+	): Promise<ProviderConnectionOperationResult> {
+		const connectResult = await this.providerLifecycle.connect(replacementProvider);
+		if (!connectResult.success) {
+			this.logger.error('Failed to connect replacement external secrets provider connection', {
+				providerKey,
+				providerType,
+				error: connectResult.error,
+			});
+			return connectResult;
+		}
+
+		return await this.swapProviderConnection(providerKey, providerType, replacementProvider);
+	}
+
+	private async swapProviderConnection(
+		providerKey: string,
+		providerType: string,
+		replacementProvider: SecretsProvider,
+	): Promise<ProviderConnectionOperationResult> {
+		const existingProvider = this.providerRegistry.get(providerKey);
+		this.providerRegistry.add(providerKey, replacementProvider);
+
+		if (existingProvider && existingProvider !== replacementProvider) {
 			this.logger.debug('Disconnecting previous external secrets provider connection', {
 				providerKey,
 				providerType,
 			});
 			await this.providerLifecycle.disconnect(existingProvider);
 		}
+
+		return { success: true };
 	}
 
 	private async removeProviderConnection(providerKey: string): Promise<void> {
@@ -436,7 +482,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 			providerKey,
 		});
 
-		this.retryManager.cancelRetry(providerKey);
 		const existingProvider = this.providerRegistry.get(providerKey);
 		if (existingProvider) {
 			await this.providerLifecycle.disconnect(existingProvider);

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-manager.ee.ts
@@ -305,9 +305,6 @@ export class ExternalSecretsManager implements IExternalSecretsManager {
 
 	private async reloadProvidersFromConnectionsRepo(): Promise<void> {
 		const connections = await this.secretsProviderConnectionRepository.findAll();
-		this.logger.debug('Reloading external secrets provider connections from repository', {
-			connectionCount: connections.length,
-		});
 
 		for (const connection of connections) {
 			if (!connection.isEnabled) {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -171,10 +171,6 @@ export class ExternalSecretsProviderConnectionManager {
 	): Promise<ProviderConnectResult> {
 		const existingProvider = this.providerRegistry.get(providerKey);
 
-		if (existingProvider && existingProvider !== replacementProvider) {
-			await this.delayBeforeProviderSwapForRepro(providerKey);
-		}
-
 		this.providerRegistry.set(providerKey, replacementProvider);
 
 		if (existingProvider && existingProvider !== replacementProvider) {
@@ -186,30 +182,6 @@ export class ExternalSecretsProviderConnectionManager {
 		}
 
 		return { success: true };
-	}
-
-	private async delayBeforeProviderSwapForRepro(providerKey: string): Promise<void> {
-		const delayMs = Number.parseInt(
-			process.env.N8N_EXTERNAL_SECRETS_RELOAD_REPRO_DELAY_MS ?? '0',
-			10,
-		);
-
-		if (!Number.isFinite(delayMs) || delayMs <= 0) return;
-
-		const targetProviderKey = process.env.N8N_EXTERNAL_SECRETS_RELOAD_REPRO_PROVIDER_KEY;
-		if (targetProviderKey && targetProviderKey !== providerKey) return;
-
-		this.logger.warn('External secrets reload repro delay before provider swap', {
-			providerKey,
-			delayMs,
-		});
-
-		await new Promise((resolve) => setTimeout(resolve, delayMs));
-
-		this.logger.warn('External secrets reload repro delay finished', {
-			providerKey,
-			delayMs,
-		});
 	}
 
 	private async connectProvider(providerKey: string): Promise<ProviderConnectResult> {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -29,6 +29,9 @@ export class ExternalSecretsProviderConnectionManager {
 		config: SecretsProviderSettings,
 	): Promise<void> {
 		if (this.providerRegistry.has(providerKey)) {
+			// When there is already a provider registered we want to prepare the replacement before swappin the registry.
+			// We tolerate a small time window where we keep the old provider while the new one is being prepared.
+			// This is important because this avoids executions failing intermittently during the reload phase.
 			await this.replaceProviderConnection(providerKey, providerType, config);
 			return;
 		}
@@ -37,7 +40,11 @@ export class ExternalSecretsProviderConnectionManager {
 	}
 
 	async removeProviderConnection(providerKey: string): Promise<void> {
+		// cancelling retries is needed because we can have previous connections for the same provider key
+		// This is espicially common during the setup phase when initial configurations might be wrong
+		// and there will be several changes to the configuration before settling for a valid one.
 		this.retryManager.cancelRetry(providerKey);
+
 		this.logger.debug('Removing external secrets provider connection', {
 			providerKey,
 		});
@@ -119,10 +126,9 @@ export class ExternalSecretsProviderConnectionManager {
 		}
 
 		const replacementProvider = initResult.provider;
-		let replacementResult: ProviderConnectionOperationResult;
 		if (config.connected) {
 			// Only connection is retried. A successful retry must also perform the registry swap.
-			replacementResult = await this.retryManager.runWithRetry(
+			const replacementResult = await this.retryManager.runWithRetry(
 				providerKey,
 				async () =>
 					await this.connectAndSwapProviderConnection(
@@ -131,17 +137,13 @@ export class ExternalSecretsProviderConnectionManager {
 						replacementProvider,
 					),
 			);
-		} else {
-			replacementResult = await this.swapProviderConnection(
-				providerKey,
-				providerType,
-				replacementProvider,
-			);
-		}
 
-		if (!replacementResult.success) {
-			// The replacement reflects the latest config, even if connection failed. Register it
-			// in its error state so executions fail visibly instead of using stale secrets.
+			if (!replacementResult.success) {
+				// The replacement reflects the latest config, even if connection failed. Register it
+				// in its error state so executions fail visibly instead of using stale secrets.
+				await this.swapProviderConnection(providerKey, providerType, replacementProvider);
+			}
+		} else {
 			await this.swapProviderConnection(providerKey, providerType, replacementProvider);
 		}
 	}

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -93,7 +93,7 @@ export class ExternalSecretsProviderConnectionManager {
 			return;
 		}
 
-		this.providerRegistry.add(providerKey, result.provider);
+		this.providerRegistry.set(providerKey, result.provider);
 
 		if (config.connected) {
 			await this.connectProviderWithRetry(providerKey);
@@ -172,7 +172,12 @@ export class ExternalSecretsProviderConnectionManager {
 		replacementProvider: SecretsProvider,
 	): Promise<ProviderConnectionOperationResult> {
 		const existingProvider = this.providerRegistry.get(providerKey);
-		this.providerRegistry.add(providerKey, replacementProvider);
+
+		if (existingProvider && existingProvider !== replacementProvider) {
+			await this.delayBeforeProviderSwapForRepro(providerKey);
+		}
+
+		this.providerRegistry.set(providerKey, replacementProvider);
 
 		if (existingProvider && existingProvider !== replacementProvider) {
 			this.logger.debug('Disconnecting previous external secrets provider connection', {
@@ -183,6 +188,30 @@ export class ExternalSecretsProviderConnectionManager {
 		}
 
 		return { success: true };
+	}
+
+	private async delayBeforeProviderSwapForRepro(providerKey: string): Promise<void> {
+		const delayMs = Number.parseInt(
+			process.env.N8N_EXTERNAL_SECRETS_RELOAD_REPRO_DELAY_MS ?? '0',
+			10,
+		);
+
+		if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+
+		const targetProviderKey = process.env.N8N_EXTERNAL_SECRETS_RELOAD_REPRO_PROVIDER_KEY;
+		if (targetProviderKey && targetProviderKey !== providerKey) return;
+
+		this.logger.warn('External secrets reload repro delay before provider swap', {
+			providerKey,
+			delayMs,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+		this.logger.warn('External secrets reload repro delay finished', {
+			providerKey,
+			delayMs,
+		});
 	}
 
 	private async connectProvider(providerKey: string): Promise<ProviderConnectResult> {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -10,8 +10,6 @@ import { ExternalSecretsProviderRegistry } from './provider-registry.service';
 import { ExternalSecretsRetryManager } from './retry-manager.service';
 import type { SecretsProvider, SecretsProviderSettings } from './types';
 
-type ProviderConnectionOperationResult = { success: boolean; error?: Error };
-
 @Service()
 export class ExternalSecretsProviderConnectionManager {
 	constructor(
@@ -29,7 +27,7 @@ export class ExternalSecretsProviderConnectionManager {
 		config: SecretsProviderSettings,
 	): Promise<void> {
 		if (this.providerRegistry.has(providerKey)) {
-			// When there is already a provider registered we want to prepare the replacement before swappin the registry.
+			// When there is already a provider registered we want to prepare the replacement before swapping the registry.
 			// We tolerate a small time window where we keep the old provider while the new one is being prepared.
 			// This is important because this avoids executions failing intermittently during the reload phase.
 			await this.replaceProviderConnection(providerKey, providerType, config);
@@ -41,7 +39,7 @@ export class ExternalSecretsProviderConnectionManager {
 
 	async removeProviderConnection(providerKey: string): Promise<void> {
 		// cancelling retries is needed because we can have previous connections for the same provider key
-		// This is espicially common during the setup phase when initial configurations might be wrong
+		// This is especially common during the setup phase when initial configurations might be wrong
 		// and there will be several changes to the configuration before settling for a valid one.
 		this.retryManager.cancelRetry(providerKey);
 
@@ -152,7 +150,7 @@ export class ExternalSecretsProviderConnectionManager {
 		providerKey: string,
 		providerType: string,
 		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectionOperationResult> {
+	): Promise<ProviderConnectResult> {
 		const connectResult = await this.providerLifecycle.connect(replacementProvider);
 		if (!connectResult.success) {
 			this.logger.error('Failed to connect replacement external secrets provider connection', {
@@ -170,7 +168,7 @@ export class ExternalSecretsProviderConnectionManager {
 		providerKey: string,
 		providerType: string,
 		replacementProvider: SecretsProvider,
-	): Promise<ProviderConnectionOperationResult> {
+	): Promise<ProviderConnectResult> {
 		const existingProvider = this.providerRegistry.get(providerKey);
 
 		if (existingProvider && existingProvider !== replacementProvider) {

--- a/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
+++ b/packages/cli/src/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee.ts
@@ -1,0 +1,195 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { UnexpectedError } from 'n8n-workflow';
+
+import {
+	ExternalSecretsProviderLifecycle,
+	type ProviderConnectResult,
+} from './provider-lifecycle.service';
+import { ExternalSecretsProviderRegistry } from './provider-registry.service';
+import { ExternalSecretsRetryManager } from './retry-manager.service';
+import type { SecretsProvider, SecretsProviderSettings } from './types';
+
+type ProviderConnectionOperationResult = { success: boolean; error?: Error };
+
+@Service()
+export class ExternalSecretsProviderConnectionManager {
+	constructor(
+		private readonly logger: Logger,
+		private readonly providerRegistry: ExternalSecretsProviderRegistry,
+		private readonly providerLifecycle: ExternalSecretsProviderLifecycle,
+		private readonly retryManager: ExternalSecretsRetryManager,
+	) {
+		this.logger = this.logger.scoped('external-secrets');
+	}
+
+	async upsertProviderConnection(
+		providerKey: string,
+		providerType: string,
+		config: SecretsProviderSettings,
+	): Promise<void> {
+		if (this.providerRegistry.has(providerKey)) {
+			await this.replaceProviderConnection(providerKey, providerType, config);
+			return;
+		}
+
+		await this.addProviderConnection(providerKey, providerType, config);
+	}
+
+	async removeProviderConnection(providerKey: string): Promise<void> {
+		this.retryManager.cancelRetry(providerKey);
+		this.logger.debug('Removing external secrets provider connection', {
+			providerKey,
+		});
+
+		const existingProvider = this.providerRegistry.get(providerKey);
+		if (existingProvider) {
+			await this.providerLifecycle.disconnect(existingProvider);
+			this.providerRegistry.remove(providerKey);
+		}
+	}
+
+	async connectProviderWithRetry(providerKey: string): Promise<ProviderConnectResult> {
+		return await this.retryManager.runWithRetry(
+			providerKey,
+			async () => await this.connectProvider(providerKey),
+		);
+	}
+
+	async disconnectProvider(providerKey: string): Promise<void> {
+		this.retryManager.cancelRetry(providerKey);
+
+		const provider = this.providerRegistry.get(providerKey);
+		if (provider) {
+			await this.providerLifecycle.disconnect(provider);
+		}
+	}
+
+	private async addProviderConnection(
+		providerKey: string,
+		providerType: string,
+		config: SecretsProviderSettings,
+	): Promise<void> {
+		this.logger.debug('Adding external secrets provider connection', {
+			providerKey,
+			providerType,
+		});
+
+		const result = await this.providerLifecycle.initialize(providerType, config);
+
+		if (!result.success || !result.provider) {
+			this.logger.error('Failed to initialize external secrets provider connection', {
+				providerKey,
+				providerType,
+				error: result.error,
+			});
+			return;
+		}
+
+		this.providerRegistry.add(providerKey, result.provider);
+
+		if (config.connected) {
+			await this.connectProviderWithRetry(providerKey);
+		}
+	}
+
+	private async replaceProviderConnection(
+		providerKey: string,
+		providerType: string,
+		config: SecretsProviderSettings,
+	): Promise<void> {
+		this.logger.debug('Replacing external secrets provider connection', {
+			providerKey,
+			providerType,
+		});
+
+		// Initialization validates local config, so retrying it would only repeat deterministic failures.
+		const initResult = await this.providerLifecycle.initialize(providerType, config);
+
+		if (!initResult.success || !initResult.provider) {
+			const error =
+				initResult.error ?? new UnexpectedError(`Failed to initialize provider ${providerKey}`);
+			this.logger.error('Failed to initialize replacement external secrets provider connection', {
+				providerKey,
+				providerType,
+				error,
+			});
+			await this.removeProviderConnection(providerKey);
+			return;
+		}
+
+		const replacementProvider = initResult.provider;
+		let replacementResult: ProviderConnectionOperationResult;
+		if (config.connected) {
+			// Only connection is retried. A successful retry must also perform the registry swap.
+			replacementResult = await this.retryManager.runWithRetry(
+				providerKey,
+				async () =>
+					await this.connectAndSwapProviderConnection(
+						providerKey,
+						providerType,
+						replacementProvider,
+					),
+			);
+		} else {
+			replacementResult = await this.swapProviderConnection(
+				providerKey,
+				providerType,
+				replacementProvider,
+			);
+		}
+
+		if (!replacementResult.success) {
+			// The replacement reflects the latest config, even if connection failed. Register it
+			// in its error state so executions fail visibly instead of using stale secrets.
+			await this.swapProviderConnection(providerKey, providerType, replacementProvider);
+		}
+	}
+
+	private async connectAndSwapProviderConnection(
+		providerKey: string,
+		providerType: string,
+		replacementProvider: SecretsProvider,
+	): Promise<ProviderConnectionOperationResult> {
+		const connectResult = await this.providerLifecycle.connect(replacementProvider);
+		if (!connectResult.success) {
+			this.logger.error('Failed to connect replacement external secrets provider connection', {
+				providerKey,
+				providerType,
+				error: connectResult.error,
+			});
+			return connectResult;
+		}
+
+		return await this.swapProviderConnection(providerKey, providerType, replacementProvider);
+	}
+
+	private async swapProviderConnection(
+		providerKey: string,
+		providerType: string,
+		replacementProvider: SecretsProvider,
+	): Promise<ProviderConnectionOperationResult> {
+		const existingProvider = this.providerRegistry.get(providerKey);
+		this.providerRegistry.add(providerKey, replacementProvider);
+
+		if (existingProvider && existingProvider !== replacementProvider) {
+			this.logger.debug('Disconnecting previous external secrets provider connection', {
+				providerKey,
+				providerType,
+			});
+			await this.providerLifecycle.disconnect(existingProvider);
+		}
+
+		return { success: true };
+	}
+
+	private async connectProvider(providerKey: string): Promise<ProviderConnectResult> {
+		const provider = this.providerRegistry.get(providerKey);
+		if (!provider) {
+			this.logger.warn(`Cannot connect provider ${providerKey}: not found in registry`);
+			throw new Error(`Provider ${providerKey} not found in registry`);
+		}
+
+		return await this.providerLifecycle.connect(provider);
+	}
+}

--- a/packages/cli/src/modules/external-secrets.ee/provider-registry.service.ts
+++ b/packages/cli/src/modules/external-secrets.ee/provider-registry.service.ts
@@ -10,7 +10,7 @@ import type { SecretsProvider } from './types';
 export class ExternalSecretsProviderRegistry {
 	private providers = new Map<string, SecretsProvider>();
 
-	add(name: string, provider: SecretsProvider): void {
+	set(name: string, provider: SecretsProvider): void {
 		this.providers.set(name, provider);
 	}
 

--- a/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
+++ b/packages/cli/test/integration/external-secrets/external-secrets.api.test.ts
@@ -9,6 +9,7 @@ import type { EventService } from '@/events/event.service';
 import { ExternalSecretsManager } from '@/modules/external-secrets.ee/external-secrets-manager.ee';
 import { ExternalSecretsProviders } from '@/modules/external-secrets.ee/external-secrets-providers.ee';
 import { ExternalSecretsConfig } from '@/modules/external-secrets.ee/external-secrets.config';
+import { ExternalSecretsProviderConnectionManager } from '@/modules/external-secrets.ee/external-secrets-provider-connection-manager.ee';
 import { ExternalSecretsProviderLifecycle } from '@/modules/external-secrets.ee/provider-lifecycle.service';
 import { ExternalSecretsProviderRegistry } from '@/modules/external-secrets.ee/provider-registry.service';
 import { ExternalSecretsRetryManager } from '@/modules/external-secrets.ee/retry-manager.service';
@@ -69,6 +70,7 @@ const resetManager = async () => {
 	const providerRegistry = Container.get(ExternalSecretsProviderRegistry);
 	const providerLifecycle = Container.get(ExternalSecretsProviderLifecycle);
 	const retryManager = Container.get(ExternalSecretsRetryManager);
+	const providerConnectionManager = Container.get(ExternalSecretsProviderConnectionManager);
 	const secretsCache = Container.get(ExternalSecretsSecretsCache);
 	const secretsProviderConnectionRepository = Container.get(SecretsProviderConnectionRepository);
 	const cipher = Container.get(Cipher);
@@ -85,6 +87,7 @@ const resetManager = async () => {
 			providerRegistry,
 			providerLifecycle,
 			retryManager,
+			providerConnectionManager,
 			secretsCache,
 			secretsProviderConnectionRepository,
 			cipher,
@@ -140,6 +143,7 @@ beforeAll(async () => {
 	const providerRegistry = Container.get(ExternalSecretsProviderRegistry);
 	const providerLifecycle = Container.get(ExternalSecretsProviderLifecycle);
 	const retryManager = Container.get(ExternalSecretsRetryManager);
+	const providerConnectionManager = Container.get(ExternalSecretsProviderConnectionManager);
 	const secretsCache = Container.get(ExternalSecretsSecretsCache);
 	const secretsProviderConnectionRepository = Container.get(SecretsProviderConnectionRepository);
 	const cipher = Container.get(Cipher);
@@ -156,6 +160,7 @@ beforeAll(async () => {
 			providerRegistry,
 			providerLifecycle,
 			retryManager,
+			providerConnectionManager,
 			secretsCache,
 			secretsProviderConnectionRepository,
 			cipher,


### PR DESCRIPTION
## Summary

[bug demo video](https://www.loom.com/share/e0d86e4ee7044980b4d73b07c10f276e)
[fix demo video](https://www.loom.com/share/0dbb5eda1386405894cd5277b45c360d)
[code run through](https://www.loom.com/share/49d50545ed214ecf87136e99477787d5)

### Root Cause

During reload, each external secrets provider connection was handled as:

- remove old provider instance from the registry
- create and connect new provider instance
- add new provider instance to the registry
- refresh all secrets

This created a window where the provider key was missing from the registry. Any execution resolving secrets during that window could fail intermittently.

This is not specific to queue mode, but queue mode makes it more visible because provider reloads are propagated across instances and can overlap with worker executions.

### New flow

The reload flow now avoids removing the old provider before preparing the replacement:

- for each provider connection:
  - keep the old provider instance in the registry
  - create a new provider instance
  - attempt to connect the new provider
  - if the first connection attempt succeeds:
    - swap the old provider for the new connected provider
    - disconnect the old provider
  - if the first connection attempt fails:
    - swap the old provider for the new provider in its error state
    - disconnect the old provider
    - keep retrying connection for the new provider
    - when retry eventually succeeds, the registered provider transitions to connected
- refresh all secrets

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-631

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

