### PR TITLE
ci: Sanitize workflow inputs

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -244,9 +244,11 @@ jobs:
 
       - name: Create Docker Hub manifests
         if: needs.determine-build-context.outputs.push_to_docker == 'true'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
           VERSION="${{ needs.determine-build-context.outputs.n8n_version }}"
-          DOCKER_BASE="${{ secrets.DOCKER_USERNAME }}"
+          DOCKER_BASE="$DOCKER_USERNAME"
 
           # Create manifests for each image type
           declare -A images=(

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -62,11 +62,12 @@ jobs:
           N8N_VERSION: ${{ inputs.n8n_version }}
           RELEASE_TYPE: ${{ inputs.release_type }}
           PUSH_ENABLED: ${{ inputs.push_enabled }}
+          GITHUB_REF: ${{ github.ref_name }}
         run: |
           node .github/scripts/docker/docker-config.mjs \
             --event "${{ github.event_name }}" \
             --pr "${{ github.event.pull_request.number }}" \
-            --branch "${{ github.ref_name }}" \
+            --branch "$GITHUB_REF" \
             --version "$N8N_VERSION" \
             --release-type "$RELEASE_TYPE" \
             --push-enabled "$PUSH_ENABLED"

--- a/.github/workflows/release-publish-new-package.yml
+++ b/.github/workflows/release-publish-new-package.yml
@@ -47,7 +47,9 @@ jobs:
           echo "Package '$PACKAGE_NAME' does not exist on NPM yet. Proceeding with publish."
 
       - name: Configure NPM token
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_DIST_TAG_AND_INITIAL_PUBLISH_TOKEN }}" > ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_DIST_TAG_AND_INITIAL_PUBLISH_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
       - name: Publish package
         working-directory: ${{ github.event.inputs.package-path }}

--- a/.github/workflows/release-push-to-channel.yml
+++ b/.github/workflows/release-push-to-channel.yml
@@ -169,6 +169,8 @@ jobs:
     needs: [validate-inputs, release-to-npm, release-to-docker-hub]
     timeout-minutes: 2
     environment: release
+    env:
+      WEBHOOK_PASSWORD: ${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }}
     steps:
       - continue-on-error: true
-        run: curl --connect-timeout 10 --max-time 30 -u docsWorkflows:${{ secrets.N8N_WEBHOOK_DOCS_PASSWORD }} --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'
+        run: curl --connect-timeout 10 --max-time 30 -u "docsWorkflows:$WEBHOOK_PASSWORD" --request GET 'https://internal.users.n8n.cloud/webhook/update-latest-next'

--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -114,13 +114,14 @@ jobs:
           BRANCH: ${{ inputs.branch || 'master' }}
           SPEC_REPETITIONS: ${{ inputs.spec_repetitions || '1' }}
           SPEC_JUDGES: ${{ inputs.spec_judges || '1' }}
+          GITHUB_REF: ${{ github.ref_name }}
         run: |
           EVENT_NAME="${{ github.event_name }}"
 
           if [ "$EVENT_NAME" = "push" ]; then
             # Merge to master: spec evals use 1 rep, 1 judge
             {
-              echo "branch=${{ github.ref_name }}"
+              echo "branch=$GITHUB_REF"
               echo "spec_repetitions=1"
               echo "spec_judges=1"
               echo "experiment_prefix="

--- a/.github/workflows/util-sync-api-docs.yml
+++ b/.github/workflows/util-sync-api-docs.yml
@@ -82,11 +82,12 @@ jobs:
         if: steps.verify_file.outputs.file_exists == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REF: ${{ github.ref_name }}
         run: |
           echo "Finding last successful workflow run..."
           LAST_SUCCESS_SHA=$(gh run list \
             --workflow "${{ github.workflow }}" \
-            --branch "${{ github.ref_name }}" \
+            --branch "$GITHUB_REF" \
             --status "success" \
             --json "headSha" \
             --jq '.[0].headSha // empty' \


### PR DESCRIPTION
## Summary

Sanitizes multiple workflows inputs by using env variables.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-567

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

