### PR TITLE
feat(Microsoft SharePoint Node): Add Service Principal (app-only) authentication

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/MicrosoftSharePoint.node.ts
@@ -27,12 +27,45 @@ export class MicrosoftSharePoint implements INodeType {
 			{
 				name: 'microsoftSharePointOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftSharePointOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftEntraServicePrincipalApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftEntraServicePrincipalApi'],
+					},
+				},
 			},
 		],
 		requestDefaults: {
-			baseURL: '=https://{{ $credentials.subdomain }}.sharepoint.com/_api/v2.0/',
+			baseURL:
+				'={{ $credentials.graphApiBaseUrl ? ($credentials.graphApiBaseUrl + "/v1.0") : ("https://" + $credentials.subdomain + ".sharepoint.com/_api/v2.0") }}',
 		},
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'SharePoint OAuth2',
+						value: 'microsoftSharePointOAuth2Api',
+					},
+					{
+						name: 'Microsoft Entra Service Principal (App-Only)',
+						value: 'microsoftEntraServicePrincipalApi',
+						description: 'App-only access via a Microsoft Entra app registration',
+					},
+				],
+				default: 'microsoftSharePointOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/helpers/utils.ts
@@ -10,7 +10,7 @@ import type {
 import { jsonParse, NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import type { IErrorResponse } from './interfaces';
-import { microsoftSharePointApiRequest } from '../transport';
+import { getSharePointCredentialType, microsoftSharePointApiRequest } from '../transport';
 
 export const escapeFilterValue = (value: string) => value.replaceAll("'", "''");
 
@@ -127,6 +127,7 @@ export async function itemColumnsPreSend(
 		if (!mapperValue.matchingColumns.includes('id')) {
 			const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
 			const list = this.getNodeParameter('list', undefined, { extractValue: true }) as string;
+			const credentialType = getSharePointCredentialType.call(this);
 
 			const response = await microsoftSharePointApiRequest.call(
 				this,
@@ -141,6 +142,8 @@ export async function itemColumnsPreSend(
 				{
 					Prefer: 'HonorNonIndexedQueriesWarningMayFailRandomly',
 				},
+				undefined,
+				credentialType,
 			);
 			if (response.value?.length === 1) {
 				mapperValue.matchingColumns.push('id');

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/methods/listSearch.ts
@@ -7,7 +7,7 @@ import type {
 
 import type { IDriveItem, IList, IListItem, ISite } from '../helpers/interfaces';
 import { escapeFilterValue } from '../helpers/utils';
-import { microsoftSharePointApiRequest } from '../transport';
+import { getSharePointCredentialType, microsoftSharePointApiRequest } from '../transport';
 
 export async function getFiles(
 	this: ILoadOptionsFunctions,
@@ -16,6 +16,7 @@ export async function getFiles(
 ): Promise<INodeListSearchResult> {
 	const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
 	const folder = this.getNodeParameter('folder', undefined, { extractValue: true }) as string;
+	const credentialType = getSharePointCredentialType.call(this);
 
 	let response: any;
 	if (paginationToken) {
@@ -27,6 +28,7 @@ export async function getFiles(
 			undefined,
 			undefined,
 			paginationToken,
+			credentialType,
 		);
 	} else {
 		// File filter not supported
@@ -43,6 +45,9 @@ export async function getFiles(
 			`/sites/${site}/drive/items/${folder}/children`,
 			{},
 			qs,
+			undefined,
+			undefined,
+			credentialType,
 		);
 	}
 
@@ -67,6 +72,7 @@ export async function getFolders(
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
 	const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
+	const credentialType = getSharePointCredentialType.call(this);
 
 	let response: any;
 	if (paginationToken) {
@@ -78,6 +84,7 @@ export async function getFolders(
 			undefined,
 			undefined,
 			paginationToken,
+			credentialType,
 		);
 	} else {
 		const qs: IDataObject = {
@@ -92,6 +99,9 @@ export async function getFolders(
 			`/sites/${site}/drive/items`,
 			{},
 			qs,
+			undefined,
+			undefined,
+			credentialType,
 		);
 	}
 
@@ -117,6 +127,7 @@ export async function getItems(
 ): Promise<INodeListSearchResult> {
 	const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
 	const list = this.getNodeParameter('list', undefined, { extractValue: true }) as string;
+	const credentialType = getSharePointCredentialType.call(this);
 
 	let response: any;
 	if (paginationToken) {
@@ -128,6 +139,7 @@ export async function getItems(
 			undefined,
 			undefined,
 			paginationToken,
+			credentialType,
 		);
 	} else {
 		const qs: IDataObject = {
@@ -143,6 +155,9 @@ export async function getItems(
 			`/sites/${site}/lists/${list}/items`,
 			{},
 			qs,
+			undefined,
+			undefined,
+			credentialType,
 		);
 	}
 
@@ -166,6 +181,7 @@ export async function getLists(
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
 	const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
+	const credentialType = getSharePointCredentialType.call(this);
 
 	let response: any;
 	if (paginationToken) {
@@ -177,6 +193,7 @@ export async function getLists(
 			undefined,
 			undefined,
 			paginationToken,
+			credentialType,
 		);
 	} else {
 		const qs: IDataObject = {
@@ -191,6 +208,9 @@ export async function getLists(
 			`/sites/${site}/lists`,
 			{},
 			qs,
+			undefined,
+			undefined,
+			credentialType,
 		);
 	}
 
@@ -213,6 +233,8 @@ export async function getSites(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
+	const credentialType = getSharePointCredentialType.call(this);
+
 	let response: any;
 	if (paginationToken) {
 		response = await microsoftSharePointApiRequest.call(
@@ -223,6 +245,7 @@ export async function getSites(
 			undefined,
 			undefined,
 			paginationToken,
+			credentialType,
 		);
 	} else {
 		const qs: IDataObject = {
@@ -232,7 +255,16 @@ export async function getSites(
 		if (filter) {
 			qs.$search = filter;
 		}
-		response = await microsoftSharePointApiRequest.call(this, 'GET', '/sites', {}, qs);
+		response = await microsoftSharePointApiRequest.call(
+			this,
+			'GET',
+			'/sites',
+			{},
+			qs,
+			undefined,
+			undefined,
+			credentialType,
+		);
 	}
 
 	const sites: ISite[] = response.value;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/methods/resourceMapping.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/methods/resourceMapping.ts
@@ -6,7 +6,7 @@ import type {
 } from 'n8n-workflow';
 
 import type { IListColumnType } from '../helpers/interfaces';
-import { microsoftSharePointApiRequest } from '../transport';
+import { getSharePointCredentialType, microsoftSharePointApiRequest } from '../transport';
 
 const unsupportedFields = ['geoLocation', 'location', 'term', 'url'];
 const fieldTypeMapping: Partial<Record<FieldType, string[]>> = {
@@ -39,6 +39,7 @@ export async function getMappingColumns(
 	const site = this.getNodeParameter('site', undefined, { extractValue: true }) as string;
 	const list = this.getNodeParameter('list', undefined, { extractValue: true }) as string;
 	const operation = this.getNodeParameter('operation') as string;
+	const credentialType = getSharePointCredentialType.call(this);
 
 	const response = await microsoftSharePointApiRequest.call(
 		this,
@@ -46,6 +47,9 @@ export async function getMappingColumns(
 		`/sites/${site}/lists/${list}/contentTypes`,
 		{},
 		{ expand: 'columns' },
+		undefined,
+		undefined,
+		credentialType,
 	);
 
 	const columns: IListColumnType[] = response.value[0].columns;

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/credentials.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/credentials.ts
@@ -1,4 +1,16 @@
+// NodeTestHarness preAuthentication is a no-op, so the Service Principal token POST to
+// login.microsoftonline.com never fires — the credential's `authenticate` attaches
+// `Bearer <accessToken>` straight from this fixture. Supply `accessToken` directly and
+// nock only the scoped Graph endpoint (with the Bearer header), never login.microsoftonline.com.
 export const credentials = {
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'test-access-token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
 	microsoftSharePointOAuth2Api: {
 		grantType: 'authorizationCode',
 		authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/item/get.sp.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/item/get.sp.test.ts
@@ -1,0 +1,31 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+
+import { credentials } from '../credentials';
+
+describe('Microsoft SharePoint Node, Service Principal item:get smoke', () => {
+	const harness = new NodeTestHarness();
+
+	harness.setupTests({
+		credentials,
+		workflowFiles: ['get.sp.workflow.json'],
+		nock: {
+			baseUrl: 'https://graph.microsoft.com',
+			mocks: [
+				{
+					method: 'get',
+					path: '/v1.0/sites/site1/lists/list1/items/item1?%24select=id%2CcreatedDateTime%2ClastModifiedDateTime%2CwebUrl&%24expand=fields%28select%3DTitle%29',
+					statusCode: 200,
+					responseBody: {
+						id: 'item1',
+						createdDateTime: '2025-03-12T22:18:18Z',
+						lastModifiedDateTime: '2025-03-12T22:18:18Z',
+						webUrl: 'https://mydomain.sharepoint.com/sites/site1/Lists/name%20list/1_.000',
+						fields: {
+							Title: 'Item 1',
+						},
+					},
+				},
+			],
+		},
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/item/get.sp.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/item/get.sp.workflow.json
@@ -1,0 +1,77 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "d8d29d0a-bb31-4094-a252-8008932f5425",
+			"name": "When clicking 'Test workflow'"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "item",
+				"operation": "get",
+				"site": {
+					"__rl": true,
+					"value": "site1",
+					"mode": "list",
+					"cachedResultName": "site1"
+				},
+				"list": {
+					"__rl": true,
+					"value": "list1",
+					"mode": "list",
+					"cachedResultName": "list1"
+				},
+				"item": {
+					"__rl": true,
+					"value": "item1",
+					"mode": "list",
+					"cachedResultName": "item1"
+				},
+				"requestOptions": {}
+			},
+			"type": "n8n-nodes-base.microsoftSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "0e19be10-9d94-4654-89e9-432daa8102cb",
+			"name": "Microsoft SharePoint",
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "cXXnMCWyk397M5qJ",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking 'Test workflow'": {
+			"main": [
+				[
+					{
+						"node": "Microsoft SharePoint",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft SharePoint": [
+			{
+				"json": {
+					"id": "item1",
+					"createdDateTime": "2025-03-12T22:18:18Z",
+					"lastModifiedDateTime": "2025-03-12T22:18:18Z",
+					"webUrl": "https://mydomain.sharepoint.com/sites/site1/Lists/name%20list/1_.000",
+					"fields": {
+						"Title": "Item 1"
+					}
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/transport/index.test.ts
@@ -1,0 +1,142 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { getSharePointCredentialType, microsoftSharePointApiRequest } from '../../transport';
+import { credentials } from '../credentials';
+
+describe('Microsoft SharePoint Transport', () => {
+	let executeFunctions: Mocked<IExecuteFunctions>;
+	let mockHttpRequestWithAuthentication: Mock;
+
+	beforeEach(() => {
+		executeFunctions = mockDeep<IExecuteFunctions>();
+		mockHttpRequestWithAuthentication = vi.fn();
+		executeFunctions.helpers.httpRequestWithAuthentication = mockHttpRequestWithAuthentication;
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	describe('getSharePointCredentialType', () => {
+		it('defaults to OAuth2 when authentication parameter is not set', () => {
+			executeFunctions.getNodeParameter.mockReturnValue(undefined as any);
+			const result = getSharePointCredentialType.call(executeFunctions);
+			expect(result).toBe('microsoftSharePointOAuth2Api');
+		});
+
+		it('returns OAuth2 when authentication is set to OAuth2', () => {
+			executeFunctions.getNodeParameter.mockReturnValue('microsoftSharePointOAuth2Api');
+			const result = getSharePointCredentialType.call(executeFunctions);
+			expect(result).toBe('microsoftSharePointOAuth2Api');
+		});
+
+		it('returns Service Principal when authentication is set to SP', () => {
+			executeFunctions.getNodeParameter.mockReturnValue('microsoftEntraServicePrincipalApi');
+			const result = getSharePointCredentialType.call(executeFunctions);
+			expect(result).toBe('microsoftEntraServicePrincipalApi');
+		});
+	});
+
+	describe('microsoftSharePointApiRequest', () => {
+		it('OAuth2 path uses SharePoint host and OAuth2 credential — regression guard', async () => {
+			executeFunctions.getCredentials.mockResolvedValue(credentials.microsoftSharePointOAuth2Api);
+			mockHttpRequestWithAuthentication.mockResolvedValue({ value: [] });
+
+			await microsoftSharePointApiRequest.call(
+				executeFunctions,
+				'GET',
+				'/sites/site1/lists',
+				{},
+				{},
+				{},
+				undefined,
+				'microsoftSharePointOAuth2Api',
+			);
+
+			expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftSharePointOAuth2Api',
+				expect.objectContaining({
+					url: 'https://mydomain.sharepoint.com/_api/v2.0/sites/site1/lists',
+				}),
+			);
+		});
+
+		it('Service Principal path uses graph host and SP credential', async () => {
+			executeFunctions.getCredentials.mockResolvedValue(
+				credentials.microsoftEntraServicePrincipalApi,
+			);
+			mockHttpRequestWithAuthentication.mockResolvedValue({ value: [] });
+
+			await microsoftSharePointApiRequest.call(
+				executeFunctions,
+				'GET',
+				'/sites/site1/lists',
+				{},
+				{},
+				{},
+				undefined,
+				'microsoftEntraServicePrincipalApi',
+			);
+
+			expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					url: 'https://graph.microsoft.com/v1.0/sites/site1/lists',
+				}),
+			);
+		});
+
+		it('Service Principal respects a custom graphApiBaseUrl', async () => {
+			executeFunctions.getCredentials.mockResolvedValue({
+				...credentials.microsoftEntraServicePrincipalApi,
+				graphApiBaseUrl: 'https://graph.microsoft.us',
+			});
+			mockHttpRequestWithAuthentication.mockResolvedValue({ value: [] });
+
+			await microsoftSharePointApiRequest.call(
+				executeFunctions,
+				'GET',
+				'/sites/site1/lists',
+				{},
+				{},
+				{},
+				undefined,
+				'microsoftEntraServicePrincipalApi',
+			);
+
+			expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					url: 'https://graph.microsoft.us/v1.0/sites/site1/lists',
+				}),
+			);
+		});
+
+		it('absolute url passthrough bypasses base URL construction (pagination)', async () => {
+			executeFunctions.getCredentials.mockResolvedValue(
+				credentials.microsoftEntraServicePrincipalApi,
+			);
+			mockHttpRequestWithAuthentication.mockResolvedValue({ value: [] });
+			const absoluteUrl = 'https://graph.microsoft.com/v1.0/sites?$skiptoken=abc123';
+
+			await microsoftSharePointApiRequest.call(
+				executeFunctions,
+				'GET',
+				'/sites',
+				{},
+				{},
+				{},
+				absoluteUrl,
+				'microsoftEntraServicePrincipalApi',
+			);
+
+			expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({ url: absoluteUrl }),
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/transport/index.ts
@@ -7,6 +7,25 @@ import type {
 	ILoadOptionsFunctions,
 } from 'n8n-workflow';
 
+export type SharePointCredentialType =
+	| 'microsoftSharePointOAuth2Api'
+	| 'microsoftEntraServicePrincipalApi';
+
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftSharePointOAuth2Api` so existing workflows keep working
+ * unchanged, while allowing the app-only `microsoftEntraServicePrincipalApi`
+ * (Service Principal) credential to be selected.
+ */
+export function getSharePointCredentialType(
+	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
+): SharePointCredentialType {
+	// `0` acts as itemIndex in execute context and as fallback in loadOptions/execute-single
+	// context — `|| default` ensures both contexts return the OAuth2 type when unset.
+	const selected = this.getNodeParameter('authentication', 0) as SharePointCredentialType;
+	return selected || 'microsoftSharePointOAuth2Api';
+}
+
 export async function microsoftSharePointApiRequest(
 	this: IExecuteFunctions | IExecuteSingleFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -15,23 +34,31 @@ export async function microsoftSharePointApiRequest(
 	qs?: IDataObject,
 	headers?: IDataObject,
 	url?: string,
+	credentialType: SharePointCredentialType = 'microsoftSharePointOAuth2Api',
 ): Promise<any> {
-	const credentials: { subdomain: string } = await this.getCredentials(
-		'microsoftSharePointOAuth2Api',
-	);
+	let baseUrl: string;
+
+	if (credentialType === 'microsoftEntraServicePrincipalApi') {
+		const credentials = await this.getCredentials('microsoftEntraServicePrincipalApi');
+		baseUrl = (
+			typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
+				? credentials.graphApiBaseUrl
+				: 'https://graph.microsoft.com'
+		).replace(/\/+$/, '');
+		baseUrl = `${baseUrl}/v1.0`;
+	} else {
+		const credentials = await this.getCredentials('microsoftSharePointOAuth2Api');
+		baseUrl = `https://${credentials.subdomain as string}.sharepoint.com/_api/v2.0`;
+	}
 
 	const options: IHttpRequestOptions = {
 		method,
-		url: url ?? `https://${credentials.subdomain}.sharepoint.com/_api/v2.0${endpoint}`,
+		url: url ?? `${baseUrl}${endpoint}`,
 		json: true,
 		headers,
 		body,
 		qs,
 	};
 
-	return await this.helpers.httpRequestWithAuthentication.call(
-		this,
-		'microsoftSharePointOAuth2Api',
-		options,
-	);
+	return await this.helpers.httpRequestWithAuthentication.call(this, credentialType, options);
 }


### PR DESCRIPTION
## Summary

Adds Microsoft Entra **Service Principal (app-only)** authentication to the Microsoft SharePoint node, alongside its existing SharePoint OAuth2 credential. Builders can now connect SharePoint with an Entra app registration (client credentials) instead of a user sign-in, which suits unattended, server-to-server automations. An "Authentication" selector picks the credential; existing OAuth2 workflows keep working unchanged and OAuth2 stays the default.

It reuses the shared `microsoftEntraServicePrincipalApi` credential introduced for the OneDrive and Excel rollouts, so the pattern stays consistent across Microsoft nodes. Unlike those nodes, SharePoint needs no "Access As" target selector: every operation is already scoped to a chosen site.

## How to test

**Automated:**
```
cd packages/nodes-base && pnpm test SharePoint
```
49 tests pass, including SP transport unit tests (host composition per credential, custom Graph base URL, pagination passthrough), an SP `item:get` end-to-end harness smoke, and the unchanged OAuth2 regressions.

**Manual (real tenant):**
1. Register an Entra app; grant **application** Graph permissions `Organization.Read.All` (credential test), `Sites.Read.All` / `Sites.ReadWrite.All` (items), `Files.ReadWrite.All` (files); **grant admin consent**; create a client secret.
2. Create a **Microsoft Entra Service Principal** credential and run its test.
3. In the SharePoint node pick **Microsoft Entra Service Principal (App-Only)**, then verify the Site/List/Item dropdowns populate and run an item op and a file op.
4. Confirm an existing OAuth2 SharePoint workflow still runs unchanged.

## Related Linear tickets, Github issues

https://linear.app/n8n/issue/ENT-92

Reuses the shared credential (#32759). Sibling rollouts: OneDrive (#32911), Excel (#33014). Docs tracked in ENT-88.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- docs tracked in ENT-88 -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->