### PR TITLE
feat(Microsoft To Do Node): Add Service Principal (app-only) authentication

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -41,17 +41,18 @@ export function getToDoCredentialType(
 // intact, so shape validation (not encoding) is what keeps the value safe to interpolate
 // into a Graph URL path. Validation messages are static, so the id is never echoed back.
 //
-// NOTE: this user-only app-only kernel mirrors a reduced form of the OneDrive/Excel nodes —
-// keep the user regexes + validation in sync until ENT-92 lifts a shared helper.
+// NOTE: To Do is user-only, like the Microsoft Outlook node — a Graph `/users/{id}` is only
+// a user object ID (GUID) or a UPN (has `@`); there is no bare host/domain form. Keep these
+// regexes in sync with Outlook's `validateMailbox` until ENT-92 lifts a shared helper.
 const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-const USER_TARGET_UPN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$/;
-const USER_TARGET_HOST = /^[A-Za-z0-9.-]+$/;
+// Local part allows apostrophes (e.g. o'connor@…) and excludes `%`, so an encoded-traversal
+// payload like `..%2f..%2fx@y.com` is rejected outright.
+const USER_TARGET_UPN = /^[A-Za-z0-9._+'-]+@[A-Za-z0-9.-]+$/;
 
 /**
  * Validates an app-only user target id before it is encoded and used to compose a Graph
  * URL. Throws a `NodeOperationError` with a fully static message (never interpolating the
- * id). Empty / dots-only are rejected first, then the accepted user shapes (GUID / UPN /
- * bare host).
+ * id). Empty / dots-only are rejected first, then the accepted user shapes (GUID / UPN).
  */
 export function validateUserTargetId(id: string, node: INode): void {
 	if (id === '') {
@@ -65,7 +66,7 @@ export function validateUserTargetId(id: string, node: INode): void {
 			description: 'A target ID cannot consist only of dots.',
 		});
 	}
-	const valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id) || USER_TARGET_HOST.test(id);
+	const valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id);
 	if (!valid) {
 		throw new NodeOperationError(node, 'The target ID is not valid', {
 			description: 'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
@@ -126,6 +127,7 @@ export async function microsoftApiRequest(
 	).replace(/\/+$/, '');
 
 	// App-only Service Principal has no `/me`; rebase the request onto the chosen user.
+	// `userTarget` is a per-node setting resolved once here (item 0), not per input item.
 	// Only page-1 (relative) requests are scoped — paginated follow-ups pass an absolute
 	// `@odata.nextLink` as `uri`, which is used verbatim.
 	let uriToUse = uri || `${baseUrl}/v1.0/me${resource}`;

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -2,13 +2,18 @@ import type {
 	IExecuteFunctions,
 	IDataObject,
 	ILoadOptionsFunctions,
+	INode,
+	INodeParameterResourceLocator,
 	JsonObject,
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
-export type ToDoCredentialType = 'microsoftToDoOAuth2Api' | 'microsoftOAuth2Api';
+export type ToDoCredentialType =
+	| 'microsoftToDoOAuth2Api'
+	| 'microsoftOAuth2Api'
+	| 'microsoftEntraServicePrincipalApi';
 
 /**
  * Resolves which credential type the node is configured to use. Defaults to the
@@ -21,10 +26,84 @@ export function getToDoCredentialType(
 ): ToDoCredentialType {
 	// `0` is the execute item index; in load-options getNodeParameter has no itemIndex
 	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form. Anything
-	// other than the generic value (incl. legacy nodes) resolves to the To Do credential.
-	return this.getNodeParameter('authentication', 0) === 'microsoftOAuth2Api'
-		? 'microsoftOAuth2Api'
-		: 'microsoftToDoOAuth2Api';
+	// other than these two non-default values (incl. legacy nodes) resolves to the To Do
+	// credential.
+	const selected = this.getNodeParameter('authentication', 0);
+	if (selected === 'microsoftOAuth2Api' || selected === 'microsoftEntraServicePrincipalApi') {
+		return selected;
+	}
+	return 'microsoftToDoOAuth2Api';
+}
+
+// App-only Microsoft Graph has no `/me`, and To Do lists/tasks belong to a user, so under
+// the Service Principal credential the request is addressed under an explicit `/users/{id}`
+// root. The user id shape is validated BEFORE encoding — `encodeURIComponent` leaves `..`
+// intact, so shape validation (not encoding) is what keeps the value safe to interpolate
+// into a Graph URL path. Validation messages are static, so the id is never echoed back.
+//
+// NOTE: this user-only app-only kernel mirrors a reduced form of the OneDrive/Excel nodes —
+// keep the user regexes + validation in sync until ENT-92 lifts a shared helper.
+const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+const USER_TARGET_UPN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$/;
+const USER_TARGET_HOST = /^[A-Za-z0-9.-]+$/;
+
+/**
+ * Validates an app-only user target id before it is encoded and used to compose a Graph
+ * URL. Throws a `NodeOperationError` with a fully static message (never interpolating the
+ * id). Empty / dots-only are rejected first, then the accepted user shapes (GUID / UPN /
+ * bare host).
+ */
+export function validateUserTargetId(id: string, node: INode): void {
+	if (id === '') {
+		throw new NodeOperationError(node, 'A target ID is required for the Service Principal', {
+			description:
+				'Set the User ID under "Access As" — app-only Microsoft Graph has no personal context to default to.',
+		});
+	}
+	if (/^\.+$/.test(id)) {
+		throw new NodeOperationError(node, 'The target ID is not valid', {
+			description: 'A target ID cannot consist only of dots.',
+		});
+	}
+	const valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id) || USER_TARGET_HOST.test(id);
+	if (!valid) {
+		throw new NodeOperationError(node, 'The target ID is not valid', {
+			description: 'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
+		});
+	}
+}
+
+/**
+ * Builds the `/users/{id}` Graph root for an app-only request. The id is validated before
+ * `encodeURIComponent` so a malformed id throws (and is not echoed back).
+ */
+export function getServicePrincipalResourceRoot(rawId: string, node: INode): string {
+	const id = String(rawId ?? '').trim();
+	validateUserTargetId(id, node);
+	return `/users/${encodeURIComponent(id)}`;
+}
+
+/**
+ * Resolves the app-only `/users/{id}` root for the current node context, or `undefined`
+ * for the OAuth2 credentials (which use the `/me` path). The `userTarget` RLC value is
+ * extracted manually (not via `{ extractValue: true }`) so the single call shape works in
+ * both execute (`0` = itemIndex) and load-options (`0` = ignored fallback) contexts; an
+ * unpersisted/empty target coalesces to `''`, which yields the intended "target ID
+ * required" error rather than a malformed `/users/` URL.
+ */
+export function resolveScopeRoot(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	itemIndex = 0,
+): string | undefined {
+	if (getToDoCredentialType.call(this) !== 'microsoftEntraServicePrincipalApi') {
+		return undefined;
+	}
+	const raw = this.getNodeParameter('userTarget', itemIndex, '');
+	const id =
+		typeof raw === 'string'
+			? raw
+			: String((raw as INodeParameterResourceLocator | undefined)?.value ?? '');
+	return getServicePrincipalResourceRoot(id, this.getNode());
 }
 
 export async function microsoftApiRequest(
@@ -38,12 +117,25 @@ export async function microsoftApiRequest(
 	option: IDataObject = { json: true },
 ) {
 	const credentialType = getToDoCredentialType.call(this);
+	const isServicePrincipal = credentialType === 'microsoftEntraServicePrincipalApi';
 	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
+
+	// App-only Service Principal has no `/me`; rebase the request onto the chosen user.
+	// Only page-1 (relative) requests are scoped — paginated follow-ups pass an absolute
+	// `@odata.nextLink` as `uri`, which is used verbatim.
+	let uriToUse = uri || `${baseUrl}/v1.0/me${resource}`;
+	if (!uri && isServicePrincipal) {
+		const scopeRoot = resolveScopeRoot.call(this);
+		if (scopeRoot) {
+			uriToUse = `${baseUrl}/v1.0${scopeRoot}${resource}`;
+		}
+	}
+
 	const options: IRequestOptions = {
 		headers: {
 			'Content-Type': 'application/json',
@@ -51,7 +143,7 @@ export async function microsoftApiRequest(
 		method,
 		body,
 		qs,
-		uri: uri || `${baseUrl}/v1.0/me${resource}`,
+		uri: uriToUse,
 	};
 	try {
 		Object.assign(options, option);
@@ -60,6 +152,12 @@ export async function microsoftApiRequest(
 		}
 		if (Object.keys(body).length === 0) {
 			delete options.body;
+		}
+		// SP is not an `oAuth2Api` parent type, so it must route through
+		// `requestWithAuthentication` (client_credentials token mint + Bearer attach + core's
+		// single 401-retry). OAuth2 credentials keep `requestOAuth2`.
+		if (isServicePrincipal) {
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -127,9 +127,9 @@ export async function microsoftApiRequest(
 	).replace(/\/+$/, '');
 
 	// App-only Service Principal has no `/me`; rebase the request onto the chosen user.
-	// `userTarget` is a per-node setting resolved once here (item 0), not per input item.
-	// Only page-1 (relative) requests are scoped — paginated follow-ups pass an absolute
-	// `@odata.nextLink` as `uri`, which is used verbatim.
+	// `userTarget` is `noDataExpression` (a node-level value, identical for every item), so
+	// resolving it once here is correct. Only page-1 (relative) requests are scoped —
+	// paginated follow-ups pass an absolute `@odata.nextLink` as `uri`, used verbatim.
 	let uriToUse = uri || `${baseUrl}/v1.0/me${resource}`;
 	if (!uri && isServicePrincipal) {
 		const scopeRoot = resolveScopeRoot.call(this);

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -41,13 +41,16 @@ export function getToDoCredentialType(
 // intact, so shape validation (not encoding) is what keeps the value safe to interpolate
 // into a Graph URL path. Validation messages are static, so the id is never echoed back.
 //
-// NOTE: To Do is user-only, like the Microsoft Outlook node — a Graph `/users/{id}` is only
-// a user object ID (GUID) or a UPN (has `@`); there is no bare host/domain form. Keep these
-// regexes in sync with Outlook's `validateMailbox` until ENT-92 lifts a shared helper.
+// NOTE: To Do is user-only — a Graph `/users/{id}` is only a user object ID (GUID) or a UPN
+// (has `@`); there is no bare host/domain form. The UPN character set follows Entra's
+// documented userPrincipalName policy; ENT-92 should lift a shared helper and bring the
+// Outlook node's `validateMailbox` to the same set.
 const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-// Local part allows apostrophes (e.g. o'connor@…) and excludes `%`, so an encoded-traversal
-// payload like `..%2f..%2fx@y.com` is rejected outright.
-const USER_TARGET_UPN = /^[A-Za-z0-9._+'-]+@[A-Za-z0-9.-]+$/;
+// Local part = Entra's documented userPrincipalName set (A-Z a-z 0-9 ' . - _ ! # ^ ~) plus
+// `+`, and covers B2B guest UPNs (`user_contoso.com#EXT#@tenant.onmicrosoft.com`). It excludes
+// `%`, so an encoded-traversal payload like `..%2f..%2fx@y.com` is rejected; for the rest,
+// `encodeURIComponent` makes `#`/`^` path-safe (`%23`/`%5E`) before they reach the URL.
+const USER_TARGET_UPN = /^[A-Za-z0-9._+'!#^~-]+@[A-Za-z0-9.-]+$/;
 
 /**
  * Validates an app-only user target id before it is encoded and used to compose a Graph

--- a/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
@@ -10,6 +10,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
+import { targetDescription } from './descriptions/TargetDescription';
 import { microsoftApiRequest, microsoftApiRequestAllItems } from './GenericFunctions';
 import { linkedResourceFields, linkedResourceOperations } from './LinkedResourceDescription';
 import { listFields, listOperations } from './ListDescription';
@@ -50,6 +51,15 @@ export class MicrosoftToDo implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'microsoftEntraServicePrincipalApi',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftEntraServicePrincipalApi'],
+					},
+				},
+			},
 		],
 		properties: [
 			{
@@ -68,9 +78,16 @@ export class MicrosoftToDo implements INodeType {
 						description:
 							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Tasks.ReadWrite) on the credential.',
 					},
+					{
+						name: 'Microsoft Entra Service Principal (App-Only)',
+						value: 'microsoftEntraServicePrincipalApi',
+						description:
+							'App-only access via a Microsoft Entra app registration. Choose which user to act on.',
+					},
 				],
 				default: 'microsoftToDoOAuth2Api',
 			},
+			...targetDescription,
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -1,0 +1,39 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+/**
+ * App-only target selector for the Service Principal credential. App-only Microsoft
+ * Graph has no `/me`, and To Do lists/tasks belong to a user, so the node must be told
+ * which user to act on. This is a STATIC `INodeProperties` only — the runtime resolution
+ * lives in `resolveScopeRoot` in `GenericFunctions.ts`.
+ *
+ * To Do is strictly user-scoped (no drive or site), so unlike the OneDrive/Excel nodes
+ * there is no "Access As" selector — just a single required user target. The RLC uses ID
+ * mode only (no `searchListMethod`) so rendering needs no Directory.Read.All — the user
+ * pastes the id. The param name `userTarget` is kept identical to the sibling Microsoft
+ * nodes so the transport reads it generically and workflow JSON stays portable.
+ */
+export const userTargetRLC: INodeProperties = {
+	displayName: 'User',
+	name: 'userTarget',
+	type: 'resourceLocator',
+	default: { mode: 'id', value: '' },
+	required: true,
+	modes: [
+		{
+			displayName: 'By ID',
+			name: 'id',
+			type: 'string',
+			placeholder: 'e.g. jane@contoso.com or a user object ID',
+			hint: 'The user principal name (UPN) or object ID of the user whose To Do lists and tasks to act on',
+		},
+	],
+	description: 'The user whose To Do lists and tasks the Service Principal should act on',
+	displayOptions: {
+		show: {
+			authentication: ['microsoftEntraServicePrincipalApi'],
+		},
+	},
+};
+
+/** The app-only target params, spread into the node after the auth selector (user-only). */
+export const targetDescription: INodeProperties[] = [userTargetRLC];

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -16,6 +16,10 @@ export const userTargetRLC: INodeProperties = {
 	displayName: 'User',
 	name: 'userTarget',
 	type: 'resourceLocator',
+	// Node-level target, not per-item: `noDataExpression` keeps it a fixed value for the whole
+	// run, so the transport resolving it once (item 0) can never silently target the wrong user
+	// from a per-item expression like `={{ $json.user }}`.
+	noDataExpression: true,
 	default: { mode: 'id', value: '' },
 	required: true,
 	modes: [
@@ -28,7 +32,7 @@ export const userTargetRLC: INodeProperties = {
 		},
 	],
 	description:
-		'The user whose To Do lists and tasks the Service Principal should act on. Applies to the whole node — set once, not evaluated per input item.',
+		'The user whose To Do lists and tasks the Service Principal should act on. Applies to the whole node (every item in the execution).',
 	displayOptions: {
 		show: {
 			authentication: ['microsoftEntraServicePrincipalApi'],

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -27,7 +27,8 @@ export const userTargetRLC: INodeProperties = {
 			hint: 'The user principal name (UPN) or object ID of the user whose To Do lists and tasks to act on',
 		},
 	],
-	description: 'The user whose To Do lists and tasks the Service Principal should act on',
+	description:
+		'The user whose To Do lists and tasks the Service Principal should act on. Applies to the whole node — set once, not evaluated per input item.',
 	displayOptions: {
 		show: {
 			authentication: ['microsoftEntraServicePrincipalApi'],

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -429,6 +429,28 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			expect(message).toBe('The target ID is not valid');
 			expect(message).not.toContain('secret');
 		});
+
+		it("accepts a UPN containing an apostrophe (e.g. o'connor)", () => {
+			expect(getServicePrincipalResourceRoot("o'connor@contoso.com", mockNode)).toBe(
+				"/users/o'connor%40contoso.com",
+			);
+		});
+
+		it('accepts a UPN with "+" sub-addressing', () => {
+			expect(() => validateUserTargetId('jane+test@contoso.com', mockNode)).not.toThrow();
+		});
+
+		it('rejects a bare host/domain (not a valid /users/{id})', () => {
+			expect(() => validateUserTargetId('contoso.com', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+			expect(() => validateUserTargetId('jane', mockNode)).toThrow('The target ID is not valid');
+		});
+
+		it('rejects backslash and encoded-traversal ids', () => {
+			expect(() => validateUserTargetId('a\\b', mockNode)).toThrow('The target ID is not valid');
+			expect(() => validateUserTargetId('%2e%2e', mockNode)).toThrow('The target ID is not valid');
+		});
 	});
 
 	describe('resolveScopeRoot', () => {

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -1,8 +1,20 @@
-import type { IExecuteFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import {
+	NodeApiError,
+	NodeOperationError,
+	type IExecuteFunctions,
+	type ILoadOptionsFunctions,
+	type INode,
+} from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
-import { getToDoCredentialType, microsoftApiRequest } from '../GenericFunctions';
+import {
+	getServicePrincipalResourceRoot,
+	getToDoCredentialType,
+	microsoftApiRequest,
+	resolveScopeRoot,
+	validateUserTargetId,
+} from '../GenericFunctions';
 import { MicrosoftToDo } from '../MicrosoftToDo.node';
 
 describe('Microsoft ToDo GenericFunctions', () => {
@@ -286,6 +298,158 @@ describe('Microsoft ToDo GenericFunctions', () => {
 
 			expect(getToDoCredentialType.call(mockExecuteFunctions)).toBe('microsoftOAuth2Api');
 		});
+
+		it('should return microsoftEntraServicePrincipalApi when the Service Principal is selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftEntraServicePrincipalApi');
+
+			expect(getToDoCredentialType.call(mockExecuteFunctions)).toBe(
+				'microsoftEntraServicePrincipalApi',
+			);
+		});
+	});
+
+	describe('Service Principal (app-only) routing', () => {
+		const baseUrl = 'https://graph.microsoft.com';
+		let mockRequestWithAuthentication: Mock;
+
+		const setSpParams = (overrides: Record<string, unknown> = {}) => {
+			const params: Record<string, unknown> = {
+				authentication: 'microsoftEntraServicePrincipalApi',
+				userTarget: { value: 'jane@contoso.com' },
+				...overrides,
+			};
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(name, _itemIndex, fallback) =>
+					(name in params ? params[name as string] : fallback) as never,
+			);
+		};
+
+		beforeEach(() => {
+			mockRequestWithAuthentication = vi.fn().mockResolvedValue({ value: [] });
+			mockExecuteFunctions.helpers.requestWithAuthentication = mockRequestWithAuthentication;
+			mockExecuteFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+			setSpParams();
+		});
+
+		it('routes through requestWithAuthentication, never requestOAuth2', async () => {
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+			);
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.anything(),
+			);
+			expect(mockRequestOAuth2).not.toHaveBeenCalled();
+		});
+
+		it('rebases /me onto /users/{id} for the user target', async () => {
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({ uri: `${baseUrl}/v1.0/users/jane%40contoso.com/todo/lists` }),
+			);
+		});
+
+		it('honors a sovereign graphApiBaseUrl', async () => {
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				graphApiBaseUrl: 'https://graph.microsoft.us',
+			});
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.us/v1.0/users/jane%40contoso.com/todo/lists',
+				}),
+			);
+		});
+
+		it('uses an absolute @odata.nextLink uri verbatim (pagination bypasses scoping)', async () => {
+			const nextLink =
+				'https://graph.microsoft.com/v1.0/users/jane%40contoso.com/todo/lists?$skiptoken=abc';
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', {}, {}, nextLink);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({ uri: nextLink }),
+			);
+		});
+
+		it('throws a clear error when the user target is missing', async () => {
+			setSpParams({ userTarget: { value: '' } });
+
+			await expect(
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists'),
+			).rejects.toThrow('A target ID is required for the Service Principal');
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('wraps a transport failure as NodeApiError', async () => {
+			mockRequestWithAuthentication.mockRejectedValue(new Error('boom'));
+
+			await expect(
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists'),
+			).rejects.toThrow(NodeApiError);
+		});
+	});
+
+	describe('getServicePrincipalResourceRoot / validateUserTargetId', () => {
+		it('builds the user root with an encoded UPN', () => {
+			expect(getServicePrincipalResourceRoot('jane@contoso.com', mockNode)).toBe(
+				'/users/jane%40contoso.com',
+			);
+		});
+
+		it('accepts a GUID object id', () => {
+			expect(
+				getServicePrincipalResourceRoot('00000000-0000-0000-0000-000000000000', mockNode),
+			).toBe('/users/00000000-0000-0000-0000-000000000000');
+		});
+
+		it('rejects an empty id', () => {
+			expect(() => validateUserTargetId('', mockNode)).toThrow(NodeOperationError);
+		});
+
+		it('rejects a dots-only id', () => {
+			expect(() => validateUserTargetId('..', mockNode)).toThrow('The target ID is not valid');
+		});
+
+		it('rejects an id with a slash (path injection) and never echoes it', () => {
+			let message = '';
+			try {
+				validateUserTargetId('jane/../secret', mockNode);
+			} catch (error) {
+				message = (error as Error).message;
+			}
+			expect(message).toBe('The target ID is not valid');
+			expect(message).not.toContain('secret');
+		});
+	});
+
+	describe('resolveScopeRoot', () => {
+		it('returns undefined for the OAuth2 credential', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
+
+			expect(resolveScopeRoot.call(mockExecuteFunctions)).toBeUndefined();
+		});
+
+		it('resolves the user root for the Service Principal credential', () => {
+			const params: Record<string, unknown> = {
+				authentication: 'microsoftEntraServicePrincipalApi',
+				userTarget: { value: 'jane@contoso.com' },
+			};
+			mockExecuteFunctions.getNodeParameter.mockImplementation(
+				(name, _itemIndex, fallback) =>
+					(name in params ? params[name as string] : fallback) as never,
+			);
+
+			expect(resolveScopeRoot.call(mockExecuteFunctions)).toBe('/users/jane%40contoso.com');
+		});
 	});
 
 	describe('loadOptions credential routing', () => {
@@ -321,6 +485,31 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				'microsoftToDoOAuth2Api',
 				expect.anything(),
 			);
+		});
+
+		it('routes getTaskLists through requestWithAuthentication under the Service Principal', async () => {
+			const loadOptionsRequestWithAuth = vi.fn().mockResolvedValue({ value: [] });
+			mockLoadOptions.helpers.requestWithAuthentication = loadOptionsRequestWithAuth;
+			const params: Record<string, unknown> = {
+				authentication: 'microsoftEntraServicePrincipalApi',
+				userTarget: { value: 'jane@contoso.com' },
+			};
+			mockLoadOptions.getNodeParameter.mockImplementation(
+				(name, fallback) => (name in params ? params[name as string] : fallback) as never,
+			);
+
+			await new MicrosoftToDo().methods.loadOptions.getTaskLists.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+			);
+			expect(loadOptionsRequestWithAuth).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/users/jane%40contoso.com/todo/lists',
+				}),
+			);
+			expect(loadOptionsRequestOAuth2).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -440,6 +440,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			expect(() => validateUserTargetId('jane+test@contoso.com', mockNode)).not.toThrow();
 		});
 
+		it('accepts a B2B guest UPN (#EXT#) and encodes it path-safely', () => {
+			expect(
+				getServicePrincipalResourceRoot('user_contoso.com#EXT#@tenant.onmicrosoft.com', mockNode),
+			).toBe('/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com');
+		});
+
+		it('accepts the documented Entra UPN special characters (! # ^ ~)', () => {
+			expect(() => validateUserTargetId('joe^smith@contoso.com', mockNode)).not.toThrow();
+			expect(() => validateUserTargetId('o!brien@contoso.com', mockNode)).not.toThrow();
+		});
+
 		it('rejects a bare host/domain (not a valid /users/{id})', () => {
 			expect(() => validateUserTargetId('contoso.com', mockNode)).toThrow(
 				'The target ID is not valid',

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
@@ -18,7 +18,11 @@ describe('MicrosoftToDo authentication descriptor', () => {
 		const optionValues = (authentication?.options as INodePropertyOptions[]).map(
 			(option) => option.value,
 		);
-		expect(optionValues).toEqual(['microsoftToDoOAuth2Api', 'microsoftOAuth2Api']);
+		expect(optionValues).toEqual([
+			'microsoftToDoOAuth2Api',
+			'microsoftOAuth2Api',
+			'microsoftEntraServicePrincipalApi',
+		]);
 	});
 
 	it('defaults to the To Do credential and gates it on that value (backward compatibility)', () => {
@@ -34,5 +38,22 @@ describe('MicrosoftToDo authentication descriptor', () => {
 	it('gates the generic credential behind the generic option', () => {
 		expect(genericCredential?.required).toBe(true);
 		expect(genericCredential?.displayOptions?.show?.authentication).toEqual(['microsoftOAuth2Api']);
+	});
+
+	it('gates the Service Principal credential and its user target behind the SP option', () => {
+		const spCredential = credentials?.find(
+			(cred) => cred.name === 'microsoftEntraServicePrincipalApi',
+		);
+		expect(spCredential?.required).toBe(true);
+		expect(spCredential?.displayOptions?.show?.authentication).toEqual([
+			'microsoftEntraServicePrincipalApi',
+		]);
+
+		const userTarget = properties.find((property) => property.name === 'userTarget');
+		expect(userTarget?.displayOptions?.show?.authentication).toEqual([
+			'microsoftEntraServicePrincipalApi',
+		]);
+		// To Do is user-only: no "Access As" selector and no drive/site targets.
+		expect(properties.find((property) => property.name === 'resourceTarget')).toBeUndefined();
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
@@ -53,6 +53,8 @@ describe('MicrosoftToDo authentication descriptor', () => {
 		expect(userTarget?.displayOptions?.show?.authentication).toEqual([
 			'microsoftEntraServicePrincipalApi',
 		]);
+		// Node-level target: no per-item expression, so item-0 resolution can't misroute.
+		expect(userTarget?.noDataExpression).toBe(true);
 		// To Do is user-only: no "Access As" selector and no drive/site targets.
 		expect(properties.find((property) => property.name === 'resourceTarget')).toBeUndefined();
 	});

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/credentials.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/credentials.ts
@@ -1,0 +1,15 @@
+// Credential fixtures for the Microsoft To Do harness (workflow) tests. The
+// NodeTestHarness preAuthentication is a no-op, so the Service Principal token POST never
+// fires — the credential's `authenticate` attaches `Bearer <accessToken>` straight from
+// this fixture. Supply `accessToken` directly and nock only the scoped Graph endpoint
+// (with the Bearer header), never login.microsoftonline.com.
+export const credentials = {
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'test-access-token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.test.ts
@@ -1,0 +1,26 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from './credentials';
+
+// Smoke test for the app-only Service Principal path through NodeTestHarness. The harness
+// preAuthentication is a no-op, so the token POST never fires — we nock ONLY the scoped
+// Graph endpoint and require the Bearer header the credential's `authenticate` attaches.
+// The request is rebased from `/me/todo/lists` onto `/users/{upn}/todo/lists`, proving the
+// app-only routing end to end. login.microsoftonline.com is deliberately NOT nocked.
+describe('Test MicrosoftToDo, Service Principal list:getAll smoke', () => {
+	nock('https://graph.microsoft.com/v1.0')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get('/users/jane%40contoso.com/todo/lists')
+		.query(true)
+		.reply(200, {
+			value: [
+				{ id: 'AAMkAExampleListId=', displayName: 'Tasks', wellknownListName: 'defaultList' },
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['list.getAll.sp.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.workflow.json
@@ -1,0 +1,57 @@
+{
+	"name": "microsoft to do - list getAll (service principal)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "1a000000-0000-4000-8000-000000000001",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"userTarget": {
+					"__rl": true,
+					"value": "jane@contoso.com",
+					"mode": "id"
+				},
+				"resource": "list",
+				"operation": "getAll",
+				"returnAll": false,
+				"limit": 50
+			},
+			"id": "1a000000-0000-4000-8000-000000000002",
+			"name": "Microsoft To Do",
+			"type": "n8n-nodes-base.microsoftToDo",
+			"typeVersion": 1,
+			"position": [260, 0],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Microsoft To Do": [
+			{
+				"json": {
+					"id": "AAMkAExampleListId=",
+					"displayName": "Tasks",
+					"wellknownListName": "defaultList"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Microsoft To Do", "type": "main", "index": 0 }]]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"tags": []
+}


### PR DESCRIPTION
## Summary

Adds Microsoft Entra **Service Principal (app-only)** authentication to the Microsoft To Do node, alongside its existing OAuth2 credentials (`microsoftToDoOAuth2Api` / `microsoftOAuth2Api`). It reuses the shared `microsoftEntraServicePrincipalApi` credential, consistent with the OneDrive (reference) and Excel rollouts of the app-only epic (ENT-82).

App-only Microsoft Graph has no `/me`, and To Do lists/tasks belong to a user — so a required **User** target (UPN or object ID, ID-mode only, no extra Graph permissions to render) selects whose lists and tasks to act on. The node's central transport (`microsoftApiRequest`) rebases each request from `/me/todo/…` onto `/users/{id}/todo/…` and routes app-only requests through `requestWithAuthentication` instead of `requestOAuth2`.

**User-only by design:** To Do is a user-scoped API, so — unlike OneDrive/Excel — there is **no "Access As" drive/site selector**, just the single user target. (OneDrive itself recently dropped Site; To Do never needs drive/site.)

**Backward compatible:** the `authentication` selector defaults to `microsoftToDoOAuth2Api`; saved workflows and legacy nodes keep hitting `/me` via `requestOAuth2`, byte-identical.

Implementation notes:
- Scope-root resolution lives in the central transport, so every operation and the `getTaskLists` picker inherit app-only targeting with no per-operation edits.
- The user target ID is shape-validated **before** `encodeURIComponent` (rejects path-injection); error messages never echo the ID.
- Certificate sign-in is **out of scope** (ENT-86).

## How to test

**Automated:**
```
cd packages/nodes-base && pnpm test nodes/Microsoft/ToDo
```
38 tests — SP transport routing (`/me`→`/users/{id}`), the `requestWithAuthentication` vs `requestOAuth2` branch lock, user-ID validation/path-injection, the `getTaskLists` picker under SP, a NodeTestHarness `list:getAll` smoke, and the unchanged OAuth2 regressions.

**Manual (real tenant — required by AC):**
1. Register an Entra app; grant the **application** permission **`Tasks.ReadWrite.All`** (+ `Organization.Read.All` so the credential's connection test passes); **grant admin consent**; create a client secret.
2. Create a **Microsoft Entra Service Principal** credential and run its connection test.
3. In the To Do node pick **Microsoft Entra Service Principal (App-Only)**, set **User** to a target UPN, and verify: list/create/get task lists, and create/get/update/delete tasks (and linked resources) for that user.
4. Confirm an existing OAuth2 To Do workflow still runs unchanged.

## Screenshots

### Able to list tasks for a user via the app only credentials

<img width="1063" height="613" alt="image" src="https://github.com/user-attachments/assets/31783ddd-353f-4a5a-abc7-6d2d1ab6391d" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-84

Follows the OneDrive reference node and the Microsoft Excel rollout (#33014). Certificate auth tracked separately in ENT-86; docs in ENT-88.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- docs tracked in ENT-88 -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33081">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

