### PR TITLE
fix(editor): Align trigger compatibility warning with backend (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -10,10 +10,7 @@ import {
 	validateNodeCredentials,
 	isNodeConnected,
 	isTriggerLikeNode,
-	toExecutionContextEstablishmentHookParameter,
-	CHAT_TRIGGER_NODE_TYPE,
-	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
-	MANUAL_TRIGGER_NODE_TYPES,
+	classifyTriggerIdentity,
 } from 'n8n-workflow';
 import { FULL_ACCESS_NODE_TYPES } from 'n8n-core';
 import type {
@@ -25,7 +22,7 @@ import type {
 	ICredentialType,
 } from 'n8n-workflow';
 
-import { MCP_TRIGGER_NODE_TYPE, STARTING_NODES } from '@/constants';
+import { STARTING_NODES } from '@/constants';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
@@ -52,16 +49,6 @@ export interface WorkflowStatus {
 /** Formats credential names as a quoted, comma-separated list for error messages. */
 function formatCredentialNames(credentials: Array<{ name: string }>): string {
 	return credentials.map((c) => `"${c.name}"`).join(', ');
-}
-
-/** Whether a node's parameters declare at least one context establishment hook. */
-function hasContextEstablishmentHook(parameters: INode['parameters']): boolean {
-	const hookParams = toExecutionContextEstablishmentHookParameter(parameters);
-	return (
-		hookParams !== null &&
-		hookParams.success &&
-		hookParams.data.contextEstablishmentHooks.hooks.length > 0
-	);
 }
 
 @Service()
@@ -397,11 +384,8 @@ export class WorkflowValidationService {
 	 * - `hasExternalIdentityTrigger`: external identity (context hook, Chat Hub, sub-workflow).
 	 * - `hasN8nIdentityTrigger`: n8n user identity (manual/chat, Chat Hub, sub-workflow).
 	 *
-	 * This mirrors how the engine establishes identity at runtime: keep it in sync
-	 * with `execution-context.ts` (manual/parent inheritance) and the identity sources
-	 * accepted by the resolvers' identifiers (e.g. `N8NIdentifier`). When a new trigger
-	 * or identity source is added there, it must be reflected here too. A follow-up
-	 * tracks making this declarative instead of hardcoded.
+	 * The per-trigger classification lives in `classifyTriggerIdentity` (n8n-workflow)
+	 * so the editor's trigger-compatibility warning can reuse the exact same rules.
 	 */
 	private classifyTriggerIdentities(
 		nodes: INode[],
@@ -415,29 +399,12 @@ export class WorkflowValidationService {
 			const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 			if (!nodeType || !isTriggerLikeNode(nodeType)) continue;
 
-			// Sub-workflows inherit identity from the parent; Chat Hub injects it.
-			// Both satisfy either family.
-			const isSubWorkflowTrigger = node.type === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE;
-			const isChatHubTrigger =
-				node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true;
-			const isMcpTrigger =
-				node.type === MCP_TRIGGER_NODE_TYPE && node.parameters.authentication === 'n8nOAuth2';
-			if (isSubWorkflowTrigger || isChatHubTrigger || isMcpTrigger) {
-				hasExternalIdentityTrigger = true;
-				hasN8nIdentityTrigger = true;
-				continue;
-			}
-
-			// Manual/chat triggers run with the n8n user identity.
-			if (MANUAL_TRIGGER_NODE_TYPES.includes(node.type)) {
-				hasN8nIdentityTrigger = true;
-				continue;
-			}
-
-			// Any other trigger with a context establishment hook provides external identity.
-			if (hasContextEstablishmentHook(node.parameters)) {
-				hasExternalIdentityTrigger = true;
-			}
+			const { providesExternalIdentity, providesN8nIdentity } = classifyTriggerIdentity(
+				node.type,
+				node.parameters,
+			);
+			hasExternalIdentityTrigger ||= providesExternalIdentity;
+			hasN8nIdentityTrigger ||= providesN8nIdentity;
 		}
 
 		return { hasExternalIdentityTrigger, hasN8nIdentityTrigger };

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3922,7 +3922,7 @@
 	"nodeIssues.credentials.notIdentified": "Credentials with name {name} exist for {type}.",
 	"nodeIssues.credentials.notIdentified.hint": "Credentials are not clearly identified. Please select the correct credentials.",
 	"nodeIssues.credentials.privateNotConnected": "'{name}' private credential is not connected for you. Connect yours to execute this step manually.",
-	"nodeIssues.credentials.privateRequiresManualTrigger": "Private credentials only work in manually triggered workflows. Change the trigger to a Manual trigger, or switch this credential to Static.",
+	"nodeIssues.credentials.privateRequiresManualTrigger": "Private credentials require a trigger that establishes who is running the workflow, such as a Manual, Chat, or Sub-workflow trigger. Change the trigger, or switch this credential to Static.",
 	"nodeIssues.input.missing": "No node connected to required input \"{inputName}\"",
 	"ndv.trigger.moreInfo": "More info",
 	"ndv.trigger.copiedTestUrl": "Test URL copied to clipboard",

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -825,6 +825,7 @@ describe('useNodeHelpers()', () => {
 		const MANUAL_TRIGGER = 'n8n-nodes-base.manualTrigger';
 		const MANUAL_CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.manualChatTrigger';
 		const CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.chatTrigger';
+		const MCP_TRIGGER = '@n8n/n8n-nodes-langchain.mcpTrigger';
 		const WEBHOOK_TRIGGER = 'n8n-nodes-base.webhook';
 		const EXECUTE_WORKFLOW_TRIGGER = 'n8n-nodes-base.executeWorkflowTrigger';
 
@@ -1053,8 +1054,50 @@ describe('useNodeHelpers()', () => {
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
 				expect(result?.credentials?.[NOTION_API]).toEqual([
-					'Private credentials only work in manually triggered workflows. Change the trigger to a Manual trigger, or switch this credential to Static.',
+					'Private credentials require a trigger that establishes who is running the workflow, such as a Manual, Chat, or Sub-workflow trigger. Change the trigger, or switch this credential to Static.',
 				]);
+			});
+
+			it('does not warn when a private credential is used under an MCP trigger', () => {
+				mockConnectedPrivateCred(true);
+				mockDocumentStore.workflowTriggerNodes = [buildTriggerNode(MCP_TRIGGER)];
+
+				const { getNodeCredentialIssues } = useNodeHelpers();
+				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+				expect(result).toBeNull();
+			});
+
+			it('does not warn when a private credential is used under a Chat Trigger with availableInChat', () => {
+				mockConnectedPrivateCred(true);
+				mockDocumentStore.workflowTriggerNodes = [
+					buildTriggerNode(CHAT_TRIGGER, { parameters: { availableInChat: true } }),
+				];
+
+				const { getNodeCredentialIssues } = useNodeHelpers();
+				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+				expect(result).toBeNull();
+			});
+
+			it('warns when a private credential is used under a trigger with only an identity extractor', () => {
+				// A context-establishment hook provides an external identity, not the n8n
+				// user identity the system resolver needs — so private creds still warn,
+				// matching the backend's system-resolver publish check.
+				mockConnectedPrivateCred(true);
+				mockDocumentStore.workflowTriggerNodes = [
+					buildTriggerNode(WEBHOOK_TRIGGER, {
+						parameters: {
+							executionsHooksVersion: 1,
+							contextEstablishmentHooks: { hooks: [{ hookName: 'credentials.bearerToken' }] },
+						},
+					}),
+				];
+
+				const { getNodeCredentialIssues } = useNodeHelpers();
+				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+				expect(result?.credentials?.[NOTION_API]).toBeDefined();
 			});
 
 			it('does not warn when a static (non-resolvable) credential is used under a non-manual trigger', () => {
@@ -1090,7 +1133,9 @@ describe('useNodeHelpers()', () => {
 				expect(result).toBeNull();
 			});
 
-			it('warns when any trigger in a multi-trigger workflow is non-manual', () => {
+			it('does not warn when at least one trigger in a multi-trigger workflow is compatible', () => {
+				// Mirrors the backend: the workflow is compatible as long as one trigger
+				// establishes the n8n user identity, even if others do not.
 				mockConnectedPrivateCred(true);
 				mockDocumentStore.workflowTriggerNodes = [
 					buildTriggerNode(MANUAL_TRIGGER),
@@ -1100,8 +1145,21 @@ describe('useNodeHelpers()', () => {
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
 
+				expect(result).toBeNull();
+			});
+
+			it('warns when no trigger in a multi-trigger workflow is compatible', () => {
+				mockConnectedPrivateCred(true);
+				mockDocumentStore.workflowTriggerNodes = [
+					buildTriggerNode(WEBHOOK_TRIGGER),
+					buildTriggerNode('n8n-nodes-base.scheduleTrigger'),
+				];
+
+				const { getNodeCredentialIssues } = useNodeHelpers();
+				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
 				expect(result?.credentials?.[NOTION_API]?.[0]).toContain(
-					'Private credentials only work in manually triggered workflows',
+					'Private credentials require a trigger that establishes who is running the workflow',
 				);
 			});
 
@@ -1189,7 +1247,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildGenericAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						'Private credentials only work in manually triggered workflows. Change the trigger to a Manual trigger, or switch this credential to Static.',
+						'Private credentials require a trigger that establishes who is running the workflow, such as a Manual, Chat, or Sub-workflow trigger. Change the trigger, or switch this credential to Static.',
 					]);
 				});
 
@@ -1221,7 +1279,7 @@ describe('useNodeHelpers()', () => {
 					const result = getNodeCredentialIssues(buildPredefinedAuthNode(), httpRequestWithSslAuth);
 
 					expect(result?.credentials?.[OAUTH2_API]).toEqual([
-						'Private credentials only work in manually triggered workflows. Change the trigger to a Manual trigger, or switch this credential to Static.',
+						'Private credentials require a trigger that establishes who is running the workflow, such as a Manual, Chat, or Sub-workflow trigger. Change the trigger, or switch this credential to Static.',
 					]);
 				});
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -5,8 +5,7 @@ import { CUSTOM_API_CALL_KEY, EnterpriseEditionFeature } from '@/app/constants';
 import {
 	NodeHelpers,
 	NodeConnectionTypes,
-	MANUAL_TRIGGER_NODE_TYPES,
-	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	classifyTriggerIdentity,
 	nodeIssuesToString,
 } from 'n8n-workflow';
 import type {
@@ -417,14 +416,16 @@ export function useNodeHelpers() {
 	}
 
 	function workflowHasIncompatibleTrigger(): boolean {
-		const triggers = workflowDocumentStore.value.workflowTriggerNodes;
-		return triggers.some(
-			(trigger) =>
-				!trigger.disabled &&
-				!MANUAL_TRIGGER_NODE_TYPES.includes(trigger.type) &&
-				// Sub-workflows inherit the identity context from the parent execution,
-				// so a private credential resolves as long as the parent provides one.
-				trigger.type !== EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+		const triggers = workflowDocumentStore.value.workflowTriggerNodes.filter(
+			(trigger) => !trigger.disabled,
+		);
+		if (triggers.length === 0) return false;
+
+		// Private (self-connected) credentials resolve via the system resolver, which
+		// keys on the n8n user identity. Mirror the backend publish check: the workflow
+		// is compatible as long as at least one trigger establishes that identity.
+		return !triggers.some(
+			(trigger) => classifyTriggerIdentity(trigger.type, trigger.parameters).providesN8nIdentity,
 		);
 	}
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -27,6 +27,7 @@ export * from './node-validation';
 export * from './node-grouping-validation';
 export * from './mcp-helpers';
 export * from './tool-helpers';
+export * from './trigger-identity';
 export * from './node-reference-parser-utils';
 export * from './metadata-utils';
 export * from './highlighted-data';

--- a/packages/workflow/src/trigger-identity.ts
+++ b/packages/workflow/src/trigger-identity.ts
@@ -1,0 +1,73 @@
+import {
+	CHAT_TRIGGER_NODE_TYPE,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPES,
+	MCP_TRIGGER_NODE_TYPE,
+} from './constants';
+import { toExecutionContextEstablishmentHookParameter } from './execution-context-establishment-hooks';
+import type { INodeParameters } from './interfaces';
+
+/**
+ * The identity families a trigger can establish at runtime, used to gate dynamic
+ * (resolvable) credentials:
+ * - `providesN8nIdentity`: the n8n user identity, keyed on by the system resolver
+ *   (private credentials).
+ * - `providesExternalIdentity`: an identity extracted from the trigger data, keyed
+ *   on by custom resolvers (OAuth, Slack, …).
+ */
+export interface TriggerIdentityCapabilities {
+	providesN8nIdentity: boolean;
+	providesExternalIdentity: boolean;
+}
+
+const NO_IDENTITY: TriggerIdentityCapabilities = {
+	providesN8nIdentity: false,
+	providesExternalIdentity: false,
+};
+
+/** Whether a trigger's parameters declare at least one context establishment hook. */
+function hasContextEstablishmentHook(parameters: INodeParameters | undefined): boolean {
+	const hookParams = toExecutionContextEstablishmentHookParameter(parameters);
+	return (
+		hookParams !== null &&
+		hookParams.success &&
+		hookParams.data.contextEstablishmentHooks.hooks.length > 0
+	);
+}
+
+/**
+ * Classifies a single trigger node by the identity it can establish at runtime.
+ *
+ * Shared by the backend publish-time validation (`WorkflowValidationService`) and
+ * the editor's trigger-compatibility warning so the two can't drift. Keep it in
+ * sync with how the engine establishes identity (`execution-context.ts`,
+ * manual/parent inheritance) and the resolvers' identifiers (e.g. `N8NIdentifier`):
+ * when a new trigger or identity source is added there, reflect it here too.
+ */
+export function classifyTriggerIdentity(
+	nodeType: string,
+	parameters: INodeParameters | undefined,
+): TriggerIdentityCapabilities {
+	// Sub-workflows inherit identity from the parent; Chat Hub and MCP-over-n8nOAuth2
+	// inject it. All provide both identity families.
+	const isSubWorkflowTrigger = nodeType === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE;
+	const isChatHubTrigger =
+		nodeType === CHAT_TRIGGER_NODE_TYPE && parameters?.availableInChat === true;
+	const isMcpTrigger =
+		nodeType === MCP_TRIGGER_NODE_TYPE && parameters?.authentication === 'n8nOAuth2';
+	if (isSubWorkflowTrigger || isChatHubTrigger || isMcpTrigger) {
+		return { providesN8nIdentity: true, providesExternalIdentity: true };
+	}
+
+	// Manual/chat/MCP triggers run with the n8n user identity.
+	if (MANUAL_TRIGGER_NODE_TYPES.includes(nodeType)) {
+		return { providesN8nIdentity: true, providesExternalIdentity: false };
+	}
+
+	// Any other trigger with a context establishment hook provides an external identity.
+	if (hasContextEstablishmentHook(parameters)) {
+		return { providesN8nIdentity: false, providesExternalIdentity: true };
+	}
+
+	return NO_IDENTITY;
+}

--- a/packages/workflow/test/trigger-identity.test.ts
+++ b/packages/workflow/test/trigger-identity.test.ts
@@ -1,0 +1,85 @@
+import {
+	CHAT_TRIGGER_NODE_TYPE,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	MANUAL_CHAT_TRIGGER_LANGCHAIN_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPE,
+	MCP_TRIGGER_NODE_TYPE,
+} from '../src/constants';
+import { classifyTriggerIdentity } from '../src/trigger-identity';
+
+const hooksParameters = {
+	executionsHooksVersion: 1,
+	contextEstablishmentHooks: { hooks: [{ hookName: 'credentials.bearerToken' }] },
+};
+
+describe('classifyTriggerIdentity', () => {
+	it.each([MANUAL_TRIGGER_NODE_TYPE, MANUAL_CHAT_TRIGGER_LANGCHAIN_NODE_TYPE])(
+		'classifies %s as providing the n8n identity only',
+		(type) => {
+			expect(classifyTriggerIdentity(type, {})).toEqual({
+				providesN8nIdentity: true,
+				providesExternalIdentity: false,
+			});
+		},
+	);
+
+	it('classifies a sub-workflow trigger as providing both identities', () => {
+		expect(classifyTriggerIdentity(EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE, {})).toEqual({
+			providesN8nIdentity: true,
+			providesExternalIdentity: true,
+		});
+	});
+
+	describe('Chat Trigger', () => {
+		it('provides both identities when availableInChat is true', () => {
+			expect(classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, { availableInChat: true })).toEqual({
+				providesN8nIdentity: true,
+				providesExternalIdentity: true,
+			});
+		});
+
+		it('provides the n8n identity only when availableInChat is not set', () => {
+			expect(classifyTriggerIdentity(CHAT_TRIGGER_NODE_TYPE, {})).toEqual({
+				providesN8nIdentity: true,
+				providesExternalIdentity: false,
+			});
+		});
+	});
+
+	describe('MCP Trigger', () => {
+		it('provides both identities when authentication is n8nOAuth2', () => {
+			expect(
+				classifyTriggerIdentity(MCP_TRIGGER_NODE_TYPE, { authentication: 'n8nOAuth2' }),
+			).toEqual({ providesN8nIdentity: true, providesExternalIdentity: true });
+		});
+
+		it('provides the n8n identity only for other authentication modes', () => {
+			expect(
+				classifyTriggerIdentity(MCP_TRIGGER_NODE_TYPE, { authentication: 'bearerAuth' }),
+			).toEqual({ providesN8nIdentity: true, providesExternalIdentity: false });
+		});
+	});
+
+	describe('other triggers', () => {
+		it('provides the external identity only when a context establishment hook is configured', () => {
+			expect(classifyTriggerIdentity('n8n-nodes-base.webhook', hooksParameters)).toEqual({
+				providesN8nIdentity: false,
+				providesExternalIdentity: true,
+			});
+		});
+
+		it('provides no identity without hooks', () => {
+			expect(classifyTriggerIdentity('n8n-nodes-base.scheduleTrigger', {})).toEqual({
+				providesN8nIdentity: false,
+				providesExternalIdentity: false,
+			});
+		});
+
+		it('provides no identity when parameters are undefined', () => {
+			expect(classifyTriggerIdentity('n8n-nodes-base.webhook', undefined)).toEqual({
+				providesN8nIdentity: false,
+				providesExternalIdentity: false,
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The editor's private-credential "incompatible trigger" warning had drifted from the backend publish check, so it over-warned (e.g. on a workflow that also has a manual trigger). This extracts a shared `classifyTriggerIdentity` helper in `n8n-workflow` that both the backend `WorkflowValidationService` and the editor's `workflowHasIncompatibleTrigger` consume, so the editor now warns only when *no* enabled trigger establishes the n8n user identity (mirroring the backend). The warning copy is reworded to describe the real requirement rather than "manual trigger only".

## How to test

Requires the private-credentials feature enabled (`dynamic-credentials` module + `PRIVATE_CREDENTIALS` or `DYNAMIC_CREDENTIALS` env feature flag). Connect a private (self-connected, resolvable) credential on a node, then change the workflow trigger: a Manual/Chat/MCP/Sub-workflow trigger (or any one of several triggers being compatible) shows no warning, while a workflow whose triggers cannot establish the n8n user identity (e.g. only a Schedule/Webhook trigger) shows the reworded warning. New unit tests cover the helper and the editor/backend behavior (`pnpm --filter n8n-workflow test trigger-identity`, `pnpm --filter n8n-editor-ui test useNodeHelpers`, `pnpm --filter n8n test workflow-validation.service`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-750

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->