### PR TITLE
fix(core): Preserve binary data metadata on S3 copy and rename

### DIFF
--- a/packages/core/src/binary-data/__tests__/object-store.manager.test.ts
+++ b/packages/core/src/binary-data/__tests__/object-store.manager.test.ts
@@ -26,8 +26,8 @@ const otherFileId = toFileId(otherWorkflowId, otherExecutionId, otherFileUuid);
 const mockBuffer = Buffer.from('Test data');
 const mockStream = toStream(mockBuffer);
 
-beforeAll(() => {
-	vi.restoreAllMocks();
+beforeEach(() => {
+	vi.resetAllMocks();
 });
 
 describe('store()', () => {
@@ -112,14 +112,27 @@ describe('getMetadata()', () => {
 });
 
 describe('copyByFileId()', () => {
-	it('should copy by file ID and return the file ID', async () => {
+	it('should copy by file ID, forwarding source metadata, and return the file ID', async () => {
+		const mimeType = 'text/plain';
+		const fileName = 'file.txt';
+		objectStoreService.getMetadata.mockResolvedValue(
+			mock<MetadataResponseHeaders>({
+				'content-length': String(mockBuffer.length),
+				'content-type': mimeType,
+				'x-amz-meta-filename': fileName,
+			}),
+		);
+
 		const targetFileId = await objectStoreManager.copyByFileId(
 			{ type: 'execution', workflowId, executionId },
 			fileId,
 		);
 
+		const lastPutCall = objectStoreService.put.mock.lastCall;
 		expect(targetFileId.startsWith(prefix)).toBe(true);
 		expect(objectStoreService.get).toHaveBeenCalledWith(fileId, { mode: 'buffer' });
+		expect(lastPutCall?.[0]).toBe(targetFileId);
+		expect(lastPutCall?.[2]).toEqual(expect.objectContaining({ mimeType, fileName }));
 	});
 });
 
@@ -143,13 +156,26 @@ describe('copyByFilePath()', () => {
 });
 
 describe('rename()', () => {
-	it('should rename a file', async () => {
+	it('should rename a file, forwarding the original metadata', async () => {
+		const mimeType = 'text/plain';
+		const fileName = 'file.txt';
+		objectStoreService.getMetadata.mockResolvedValue(
+			mock<MetadataResponseHeaders>({
+				'content-length': String(mockBuffer.length),
+				'content-type': mimeType,
+				'x-amz-meta-filename': fileName,
+			}),
+		);
+
 		const promise = objectStoreManager.rename(fileId, otherFileId);
 
 		await expect(promise).resolves.not.toThrow();
 
+		const lastPutCall = objectStoreService.put.mock.lastCall;
 		expect(objectStoreService.get).toHaveBeenCalledWith(fileId, { mode: 'buffer' });
 		expect(objectStoreService.getMetadata).toHaveBeenCalledWith(fileId);
+		expect(lastPutCall?.[0]).toBe(otherFileId);
+		expect(lastPutCall?.[2]).toEqual(expect.objectContaining({ mimeType, fileName }));
 		expect(objectStoreService.deleteOne).toHaveBeenCalledWith(fileId);
 	});
 });

--- a/packages/core/src/binary-data/object-store.manager.ts
+++ b/packages/core/src/binary-data/object-store.manager.ts
@@ -59,8 +59,9 @@ export class ObjectStoreManager implements BinaryData.Manager {
 		const targetFileId = this.toFileId(targetLocation);
 
 		const sourceFile = await this.objectStoreService.get(sourceFileId, { mode: 'buffer' });
+		const sourceMetadata = await this.getMetadata(sourceFileId);
 
-		await this.objectStoreService.put(targetFileId, sourceFile);
+		await this.objectStoreService.put(targetFileId, sourceFile, sourceMetadata);
 
 		return targetFileId;
 	}
@@ -83,7 +84,7 @@ export class ObjectStoreManager implements BinaryData.Manager {
 
 	async rename(oldFileId: string, newFileId: string) {
 		const oldFile = await this.objectStoreService.get(oldFileId, { mode: 'buffer' });
-		const oldFileMetadata = await this.objectStoreService.getMetadata(oldFileId);
+		const oldFileMetadata = await this.getMetadata(oldFileId);
 
 		await this.objectStoreService.put(newFileId, oldFile, oldFileMetadata);
 		await this.objectStoreService.deleteOne(oldFileId);


### PR DESCRIPTION
## Summary

Copying (`copyByFileId`) or renaming (`rename`) S3 binary data dropped the blob's content type and filename:

- `copyByFileId` called `put` with no metadata.
- `rename` passed raw response headers (`content-type`, `x-amz-meta-filename`) to `put`, which only reads `mimeType`/`fileName` — so both were `undefined`. It type-checked only because `MetadataResponseHeaders` intersects `PreWriteMetadata`.

Both now forward metadata via the manager's `getMetadata` (S3 headers → `{ fileSize, mimeType, fileName }`), matching the filesystem, database, and Azure managers.

The download/view endpoint masks this (it falls back to the metadata in the execution JSON), but `getBinaryMetadata()` and chat-hub attachments read it directly and got `undefined`.

## How to test

Requires S3 binary mode (`N8N_DEFAULT_BINARY_DATA_MODE=s3`, S3 bucket configured, S3 binary-data license).

1. Run a workflow producing binary data with a known filename + MIME type.
2. Trigger a copy (sub-workflow returning the binary item) or rename path.
3. Confirm the resulting S3 object retains its `Content-Type` and `x-amz-meta-filename`.

Unit: `pnpm --filter=n8n-core test object-store.manager`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3576

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI