### PR TITLE
fix(core): Serialize OAuth2 credential refresh to prevent rotating refresh-token invalidation

### DIFF
--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -14,4 +14,8 @@ export { CliParser } from './cli-parser';
 export { TypedEmitter } from './typed-emitter';
 
 export { LockService } from './locking/lock.service';
-export { type ILockService, LockNamespace } from './locking/lock-service.interface';
+export {
+	type ILockService,
+	LockNamespace,
+	LockAcquisitionTimeoutError,
+} from './locking/lock-service.interface';

--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -12,3 +12,6 @@ export { assertDir, exists } from './utils/fs';
 export { parseFlatted } from './utils/parse-flatted';
 export { CliParser } from './cli-parser';
 export { TypedEmitter } from './typed-emitter';
+
+export { LockService } from './locking/lock.service';
+export { type ILockService, LockNamespace } from './locking/lock-service.interface';

--- a/packages/@n8n/backend-common/src/locking/__tests__/in-process-lock.service.test.ts
+++ b/packages/@n8n/backend-common/src/locking/__tests__/in-process-lock.service.test.ts
@@ -1,0 +1,216 @@
+import { OperationalError } from 'n8n-workflow';
+
+import { InProcessLockService } from '../in-process-lock.service';
+import { LockNamespace } from '../lock-service.interface';
+
+const NS = LockNamespace.CREDENTIALS;
+
+describe('InProcessLockService', () => {
+	let service: InProcessLockService;
+
+	beforeEach(() => {
+		service = new InProcessLockService();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should serialize concurrent withLease calls for the same namespace + key', async () => {
+		const executionOrder: string[] = [];
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			executionOrder.push('fn1-start');
+			await firstBlocking;
+			executionOrder.push('fn1-end');
+			return 'first';
+		});
+		const fn2 = vi.fn(async () => {
+			executionOrder.push('fn2-start');
+			await Promise.resolve();
+			return 'second';
+		});
+
+		const p1 = service.withLease(NS, 'k', fn1);
+		const p2 = service.withLease(NS, 'k', fn2);
+
+		await new Promise((r) => setImmediate(r));
+		expect(fn1).toHaveBeenCalled();
+		expect(fn2).not.toHaveBeenCalled();
+
+		resolveFirst();
+		const [r1, r2] = await Promise.all([p1, p2]);
+
+		expect(r1).toBe('first');
+		expect(r2).toBe('second');
+		expect(executionOrder).toEqual(['fn1-start', 'fn1-end', 'fn2-start']);
+	});
+
+	it('should not block on different keys within the same namespace', async () => {
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			await firstBlocking;
+			return 'first';
+		});
+		const fn2 = vi.fn().mockResolvedValue('second');
+
+		const p1 = service.withLease(NS, 'k1', fn1);
+		const p2 = service.withLease(NS, 'k2', fn2);
+
+		await new Promise((r) => setImmediate(r));
+		expect(fn1).toHaveBeenCalled();
+		expect(fn2).toHaveBeenCalled();
+
+		resolveFirst();
+		expect(await Promise.all([p1, p2])).toEqual(['first', 'second']);
+	});
+
+	it('should not block on the same key across different namespaces', async () => {
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			await firstBlocking;
+			return 'first';
+		});
+		const fn2 = vi.fn().mockResolvedValue('second');
+
+		const p1 = service.withLease(LockNamespace.CREDENTIALS, 'same', fn1);
+		const p2 = service.withLease(LockNamespace.KNOWN_LOCKS, 'same', fn2);
+
+		await new Promise((r) => setImmediate(r));
+		expect(fn1).toHaveBeenCalled();
+		expect(fn2).toHaveBeenCalled();
+
+		resolveFirst();
+		expect(await Promise.all([p1, p2])).toEqual(['first', 'second']);
+	});
+
+	it('should reject with OperationalError when waitTimeoutMs expires', async () => {
+		vi.useFakeTimers();
+
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			await firstBlocking;
+			return 'first';
+		});
+		const fn2 = vi.fn().mockResolvedValue('second');
+
+		const p1 = service.withLease(NS, 'k', fn1);
+		const p2 = service.withLease(NS, 'k', fn2, { waitTimeoutMs: 100 });
+
+		vi.advanceTimersByTime(100);
+
+		await expect(p2).rejects.toThrow(OperationalError);
+		await expect(p2).rejects.toThrow(/Timed out waiting for lock '.*' after 100ms/);
+		expect(fn2).not.toHaveBeenCalled();
+
+		resolveFirst();
+		await p1;
+	});
+
+	it('should release the lock when fn throws', async () => {
+		const fn1 = vi.fn().mockRejectedValue(new Error('fn1 failed'));
+		const fn2 = vi.fn().mockResolvedValue('second');
+
+		await expect(service.withLease(NS, 'k', fn1)).rejects.toThrow('fn1 failed');
+
+		expect(await service.withLease(NS, 'k', fn2)).toBe('second');
+	});
+
+	it('should execute 3+ waiters in FIFO order', async () => {
+		const executionOrder: string[] = [];
+		let resolve1!: () => void;
+		let resolve2!: () => void;
+		const blocking1 = new Promise<void>((r) => {
+			resolve1 = r;
+		});
+		const blocking2 = new Promise<void>((r) => {
+			resolve2 = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			executionOrder.push('fn1');
+			await blocking1;
+			return 'first';
+		});
+		const fn2 = vi.fn(async () => {
+			executionOrder.push('fn2');
+			await blocking2;
+			return 'second';
+		});
+		const fn3 = vi.fn(async () => {
+			executionOrder.push('fn3');
+			await Promise.resolve();
+			return 'third';
+		});
+
+		const p1 = service.withLease(NS, 'k', fn1);
+		const p2 = service.withLease(NS, 'k', fn2);
+		const p3 = service.withLease(NS, 'k', fn3);
+
+		await new Promise((r) => setImmediate(r));
+		expect(executionOrder).toEqual(['fn1']);
+
+		resolve1();
+		await p1;
+		await new Promise((r) => setImmediate(r));
+		expect(executionOrder).toEqual(['fn1', 'fn2']);
+
+		resolve2();
+		const [r2, r3] = await Promise.all([p2, p3]);
+
+		expect(r2).toBe('second');
+		expect(r3).toBe('third');
+		expect(executionOrder).toEqual(['fn1', 'fn2', 'fn3']);
+	});
+
+	it('should treat double-release as a safe no-op', async () => {
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+
+		const fn1 = vi.fn(async () => {
+			await firstBlocking;
+			return 'first';
+		});
+		const fn2 = vi.fn().mockResolvedValue('second');
+		const fn3 = vi.fn().mockResolvedValue('third');
+
+		const p1 = service.withLease(NS, 'k', fn1);
+		const p2 = service.withLease(NS, 'k', fn2);
+
+		await new Promise((r) => setImmediate(r));
+
+		resolveFirst();
+		await Promise.all([p1, p2]);
+
+		// If the p1 release had corrupted state, fn3 would deadlock or fail.
+		expect(await service.withLease(NS, 'k', fn3)).toBe('third');
+	});
+
+	it('should abort the signal after fn settles', async () => {
+		let captured!: AbortSignal;
+		await service.withLease(NS, 'k', async (signal) => {
+			captured = signal;
+			expect(signal.aborted).toBe(false);
+			await Promise.resolve();
+		});
+		expect(captured.aborted).toBe(true);
+	});
+});

--- a/packages/@n8n/backend-common/src/locking/__tests__/lock.service.test.ts
+++ b/packages/@n8n/backend-common/src/locking/__tests__/lock.service.test.ts
@@ -1,0 +1,48 @@
+import { mock } from 'vitest-mock-extended';
+
+import { InProcessLockService } from '../in-process-lock.service';
+import type { ILockService } from '../lock-service.interface';
+import { LockNamespace } from '../lock-service.interface';
+import { LockService } from '../lock.service';
+
+const NS = LockNamespace.CREDENTIALS;
+
+describe('LockService', () => {
+	it('defaults to the in-process provider and serializes same-key calls', async () => {
+		const service = new LockService(new InProcessLockService());
+
+		let resolveFirst!: () => void;
+		const firstBlocking = new Promise<void>((r) => {
+			resolveFirst = r;
+		});
+		const fn1 = vi.fn(async () => {
+			await firstBlocking;
+			return 'first';
+		});
+		const fn2 = vi.fn().mockResolvedValue('second');
+
+		const p1 = service.withLease(NS, 'k', fn1);
+		const p2 = service.withLease(NS, 'k', fn2);
+
+		await new Promise((r) => setImmediate(r));
+		expect(fn1).toHaveBeenCalled();
+		expect(fn2).not.toHaveBeenCalled();
+
+		resolveFirst();
+		expect(await Promise.all([p1, p2])).toEqual(['first', 'second']);
+	});
+
+	it('forwards withLease to the active provider after setProvider', async () => {
+		const service = new LockService(new InProcessLockService());
+		const provider = mock<ILockService>();
+		provider.withLease.mockResolvedValue('from-provider');
+		service.setProvider(provider);
+
+		const fn = vi.fn();
+		const options = { waitTimeoutMs: 10, leaseTtlMs: 20 };
+		const result = await service.withLease(NS, 'k', fn, options);
+
+		expect(result).toBe('from-provider');
+		expect(provider.withLease).toHaveBeenCalledWith(NS, 'k', fn, options);
+	});
+});

--- a/packages/@n8n/backend-common/src/locking/in-process-lock.service.ts
+++ b/packages/@n8n/backend-common/src/locking/in-process-lock.service.ts
@@ -1,0 +1,111 @@
+import { Service } from '@n8n/di';
+import { OperationalError } from 'n8n-workflow';
+
+import type { ILockService, LockNamespace } from './lock-service.interface';
+
+type ReleaseFn = () => void;
+/**
+ * Opaque ownership token created on lock acquisition. The release function
+ * captures this token and only releases if it still matches `held`, which
+ * prevents a stale release (from acquisition A) from corrupting a later
+ * acquisition B's lock state.
+ */
+type OwnerToken = symbol;
+
+interface LockState {
+	held: OwnerToken | null;
+	queue: Array<(token: OwnerToken) => void>;
+}
+
+@Service()
+export class InProcessLockService implements ILockService {
+	private locks: Map<string, LockState> = new Map();
+
+	private getOrCreateLockState(lockId: string): LockState {
+		let lockState = this.locks.get(lockId);
+		if (!lockState) {
+			lockState = { held: null, queue: [] };
+			this.locks.set(lockId, lockState);
+		}
+		return lockState;
+	}
+
+	private createReleaseFn(lockId: string, lockState: LockState, token: OwnerToken): ReleaseFn {
+		return () => {
+			if (lockState.held !== token) return;
+
+			const next = lockState.queue.shift();
+			if (next) {
+				const nextToken: OwnerToken = Symbol();
+				lockState.held = nextToken;
+				next(nextToken);
+			} else {
+				lockState.held = null;
+				this.locks.delete(lockId);
+			}
+		};
+	}
+
+	private async acquireLock(lockId: string, timeoutMs?: number): Promise<ReleaseFn> {
+		const lockState = this.getOrCreateLockState(lockId);
+
+		if (!lockState.held) {
+			const token: OwnerToken = Symbol();
+			lockState.held = token;
+			return this.createReleaseFn(lockId, lockState, token);
+		}
+
+		// Race the lock-release signal against an optional timeout.
+		//
+		// Node.js is single-threaded: `resolver` (called by releaseLock) and
+		// the setTimeout callback each run to completion before the other can
+		// start. Only one of them will settle the Promise first; the second
+		// call to resolve/reject on an already-settled Promise is a no-op per
+		// the Promise spec. clearTimeout on an already-fired timer is likewise
+		// a harmless no-op.
+		const token = await new Promise<OwnerToken>((resolve, reject) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+
+			const resolver = (ownerToken: OwnerToken) => {
+				if (timer !== undefined) clearTimeout(timer);
+				resolve(ownerToken);
+			};
+
+			lockState.queue.push(resolver);
+
+			if (timeoutMs !== undefined) {
+				timer = setTimeout(() => {
+					const idx = lockState.queue.indexOf(resolver);
+					if (idx !== -1) {
+						lockState.queue.splice(idx, 1);
+					}
+					reject(
+						new OperationalError(`Timed out waiting for lock '${lockId}' after ${timeoutMs}ms`),
+					);
+				}, timeoutMs);
+			}
+		});
+
+		return this.createReleaseFn(lockId, lockState, token);
+	}
+
+	buildLockKey(ns: LockNamespace, key: string): string {
+		return `${ns}:${key}`;
+	}
+
+	async withLease<T>(
+		ns: LockNamespace,
+		key: string,
+		fn: (signal: AbortSignal) => Promise<T>,
+		options?: { waitTimeoutMs?: number; leaseTtlMs?: number },
+	): Promise<T> {
+		const release = await this.acquireLock(this.buildLockKey(ns, key), options?.waitTimeoutMs);
+		const abortController = new AbortController();
+		try {
+			return await fn(abortController.signal);
+		} finally {
+			abortController.abort();
+			release();
+		}
+	}
+}

--- a/packages/@n8n/backend-common/src/locking/in-process-lock.service.ts
+++ b/packages/@n8n/backend-common/src/locking/in-process-lock.service.ts
@@ -1,7 +1,10 @@
 import { Service } from '@n8n/di';
-import { OperationalError } from 'n8n-workflow';
 
-import type { ILockService, LockNamespace } from './lock-service.interface';
+import {
+	LockAcquisitionTimeoutError,
+	type ILockService,
+	type LockNamespace,
+} from './lock-service.interface';
 
 type ReleaseFn = () => void;
 /**
@@ -80,7 +83,9 @@ export class InProcessLockService implements ILockService {
 						lockState.queue.splice(idx, 1);
 					}
 					reject(
-						new OperationalError(`Timed out waiting for lock '${lockId}' after ${timeoutMs}ms`),
+						new LockAcquisitionTimeoutError(
+							`Timed out waiting for lock '${lockId}' after ${timeoutMs}ms`,
+						),
 					);
 				}, timeoutMs);
 			}

--- a/packages/@n8n/backend-common/src/locking/lock-service.interface.ts
+++ b/packages/@n8n/backend-common/src/locking/lock-service.interface.ts
@@ -1,0 +1,44 @@
+/**
+ * Lock namespaces. A `const` object rather than an `enum`: `const enum` erases
+ * to `undefined` for cross-package callers under `isolatedModules`, and a plain
+ * `enum` is disallowed by lint (runtime overhead). This pattern is both.
+ */
+export const LockNamespace = {
+	KNOWN_LOCKS: 1,
+	CREDENTIALS: 2,
+} as const;
+
+export type LockNamespace = (typeof LockNamespace)[keyof typeof LockNamespace];
+
+export interface ILockService {
+	/**
+	 * Run `fn` while holding a lease on `ns`/`key`, releasing it when `fn` settles.
+	 *
+	 * This is an **efficiency primitive**, not a correctness one: the lease can expire
+	 * while `fn` is still running (on the Redis backend, via TTL; under failover or a
+	 * watchdog renewal failure), so two holders may briefly run concurrently. Safe for
+	 * idempotent or self-fencing work (e.g. OAuth refresh against a rotating-token IdP).
+	 * If you need mutual exclusion that survives holder stalls, the protected resource
+	 * must enforce a fence — a lease alone cannot provide that.
+	 *
+	 * @param fn Receives an `AbortSignal` that fires if the lease is lost mid-execution
+	 *   (Redis backend only — see below). Honor it for long critical sections; abort is
+	 *   cooperative, so ignoring the signal reopens the concurrent-holder window.
+	 * @param options.waitTimeoutMs Max time to wait to acquire before throwing
+	 *   `OperationalError`. Omit to wait indefinitely.
+	 * @param options.leaseTtlMs Lease backstop for the **Redis backend only**. The lease
+	 *   auto-expires after this window if not renewed (the watchdog renews every
+	 *   `leaseTtlMs / 3`), so a crashed holder can't block the key forever. Must exceed
+	 *   the Redis command timeout. Defaults to 30s.
+	 *   **Ignored by the in-process backend**, which holds the lease until `fn` settles
+	 *   and never aborts the signal during execution — there is no orphaned-holder risk
+	 *   within a single process. Do not rely on `leaseTtlMs` for liveness on the default
+	 *   (in-process) backend.
+	 */
+	withLease<T>(
+		ns: LockNamespace,
+		key: string,
+		fn: (signal: AbortSignal) => Promise<T>,
+		options?: { waitTimeoutMs?: number; leaseTtlMs?: number },
+	): Promise<T>;
+}

--- a/packages/@n8n/backend-common/src/locking/lock-service.interface.ts
+++ b/packages/@n8n/backend-common/src/locking/lock-service.interface.ts
@@ -1,3 +1,5 @@
+import { OperationalError } from 'n8n-workflow';
+
 /**
  * Lock namespaces. A `const` object rather than an `enum`: `const enum` erases
  * to `undefined` for cross-package callers under `isolatedModules`, and a plain
@@ -9,6 +11,9 @@ export const LockNamespace = {
 } as const;
 
 export type LockNamespace = (typeof LockNamespace)[keyof typeof LockNamespace];
+
+/** Thrown by `withLease` when the lease cannot be acquired within `waitTimeoutMs`. */
+export class LockAcquisitionTimeoutError extends OperationalError {}
 
 export interface ILockService {
 	/**

--- a/packages/@n8n/backend-common/src/locking/lock.service.ts
+++ b/packages/@n8n/backend-common/src/locking/lock.service.ts
@@ -1,0 +1,26 @@
+import { Service } from '@n8n/di';
+
+import { InProcessLockService } from './in-process-lock.service';
+import { ILockService, LockNamespace } from './lock-service.interface';
+
+@Service()
+export class LockService implements ILockService {
+	private provider: ILockService;
+
+	constructor(inProcessLockService: InProcessLockService) {
+		this.provider = inProcessLockService;
+	}
+
+	setProvider(provider: ILockService) {
+		this.provider = provider;
+	}
+
+	async withLease<T>(
+		ns: LockNamespace,
+		key: string,
+		fn: (signal: AbortSignal) => Promise<T>,
+		options?: { waitTimeoutMs?: number; leaseTtlMs?: number },
+	): Promise<T> {
+		return await this.provider.withLease(ns, key, fn, options);
+	}
+}

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -3,6 +3,7 @@ import {
 	inDevelopment,
 	inTest,
 	LicenseState,
+	LockService,
 	Logger,
 	ModuleRegistry,
 	ModulesConfig,
@@ -130,6 +131,15 @@ export abstract class BaseCommand<F = never> {
 		this.nodeTypes = Container.get(NodeTypes);
 
 		await Container.get(LoadNodesAndCredentials).init();
+
+		const useRedisForLocking =
+			this.globalConfig.executions.mode === 'queue' ||
+			this.globalConfig.multiMainSetup.enabled ||
+			this.globalConfig.cache.backend === 'redis';
+		if (useRedisForLocking) {
+			const { RedisLockService } = await import('@/scaling/redis-lock.service');
+			Container.get(LockService).setProvider(Container.get(RedisLockService));
+		}
 
 		await this.dbConnection
 			.init()

--- a/packages/cli/src/scaling/__tests__/redis-lock.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/redis-lock.service.test.ts
@@ -1,0 +1,158 @@
+import { LockNamespace } from '@n8n/backend-common';
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { GlobalConfig } from '@n8n/config';
+import type { Redis as SingleNodeClient } from 'ioredis';
+import { mock } from 'jest-mock-extended';
+import { OperationalError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+
+import type { RedisClientService } from '@/services/redis-client.service';
+
+import { RedisLockService } from '../redis-lock.service';
+
+const PREFIX = 'n8n';
+const NS = LockNamespace.CREDENTIALS;
+
+const expectedKey = (key: string) =>
+	`${PREFIX}:lock:${NS}:${createHash('sha256').update(key).digest('hex')}`;
+
+const flush = async () => await Promise.resolve();
+
+describe('RedisLockService', () => {
+	const client = mock<SingleNodeClient>();
+	const logger = mockLogger();
+	const globalConfig = mock<GlobalConfig>({ redis: { prefix: PREFIX } });
+	const redisClientService = mock<RedisClientService>();
+	redisClientService.toValidPrefix.mockImplementation((prefix) => prefix);
+	redisClientService.createClient.mockReturnValue(client);
+
+	let service: RedisLockService;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		service = new RedisLockService(logger, globalConfig, redisClientService);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	describe('constructor', () => {
+		it('should create a dedicated lock client with a command timeout', () => {
+			expect(redisClientService.createClient).toHaveBeenCalledWith({
+				type: 'lock(n8n)',
+				extraOptions: { commandTimeout: 5_000 },
+			});
+		});
+	});
+
+	describe('withLease', () => {
+		it('should acquire with NX/PX, run fn, then release with the owner token', async () => {
+			client.set.mockResolvedValue('OK');
+			client.eval.mockResolvedValue(1);
+			const fn = jest.fn().mockResolvedValue('result');
+
+			const result = await service.withLease(NS, 'my-key', fn);
+
+			expect(result).toBe('result');
+
+			const [key, token, px, ttl, nx] = client.set.mock.calls[0];
+			expect(key).toBe(expectedKey('my-key'));
+			expect(typeof token).toBe('string');
+			expect([px, ttl, nx]).toEqual(['PX', 30_000, 'NX']);
+
+			expect(fn).toHaveBeenCalledTimes(1);
+			expect(client.eval).toHaveBeenCalledWith(
+				expect.stringContaining('del'),
+				1,
+				expectedKey('my-key'),
+				token,
+			);
+		});
+
+		it('should use a caller-supplied leaseTtlMs', async () => {
+			client.set.mockResolvedValue('OK');
+			client.eval.mockResolvedValue(1);
+
+			await service.withLease(NS, 'k', jest.fn(), { leaseTtlMs: 5_000 });
+
+			expect(client.set).toHaveBeenCalledWith(
+				expectedKey('k'),
+				expect.any(String),
+				'PX',
+				5_000,
+				'NX',
+			);
+		});
+
+		it('should throw OperationalError and never run fn when waiting times out', async () => {
+			client.set.mockResolvedValue(null); // never acquired
+			const fn = jest.fn();
+
+			await expect(service.withLease(NS, 'k', fn, { waitTimeoutMs: 50 })).rejects.toThrow(
+				OperationalError,
+			);
+			expect(fn).not.toHaveBeenCalled();
+		});
+
+		it('should release the lock when fn throws and propagate the error', async () => {
+			client.set.mockResolvedValue('OK');
+			client.eval.mockResolvedValue(1);
+			const fn = jest.fn().mockRejectedValue(new Error('boom'));
+
+			await expect(service.withLease(NS, 'k', fn)).rejects.toThrow('boom');
+			expect(client.eval).toHaveBeenCalledWith(
+				expect.stringContaining('del'),
+				1,
+				expect.any(String),
+				expect.any(String),
+			);
+		});
+
+		it('should still return fn result when release fails (best-effort)', async () => {
+			client.set.mockResolvedValue('OK');
+			client.eval.mockRejectedValue(new Error('redis down'));
+			const fn = jest.fn().mockResolvedValue('result');
+
+			expect(await service.withLease(NS, 'k', fn)).toBe('result');
+			expect(logger.warn).toHaveBeenCalled();
+		});
+
+		it('should renew the lease via watchdog and abort the signal when the lock is lost', async () => {
+			jest.useFakeTimers();
+			client.set.mockResolvedValue('OK');
+
+			// Distinguish renewal (PEXPIRE) from release (del): renew succeeds once, then loses.
+			let renewals = 0;
+			client.eval.mockImplementation(async (script: unknown) => {
+				if (typeof script === 'string' && script.includes('PEXPIRE')) {
+					renewals += 1;
+					return renewals >= 2 ? 0 : 1;
+				}
+				return 1; // release
+			});
+
+			let signal!: AbortSignal;
+			let resolveFn!: (v: string) => void;
+			const fn = jest.fn(async (s: AbortSignal) => {
+				signal = s;
+				return await new Promise<string>((r) => {
+					resolveFn = r;
+				});
+			});
+
+			// leaseTtlMs 300 => watchdog interval 100ms
+			const p = service.withLease(NS, 'k', fn, { leaseTtlMs: 300 });
+			await flush(); // let acquire resolve and fn run
+
+			await jest.advanceTimersByTimeAsync(100); // renewal #1 -> ok
+			expect(signal.aborted).toBe(false);
+
+			await jest.advanceTimersByTimeAsync(100); // renewal #2 -> lost
+			expect(signal.aborted).toBe(true);
+
+			resolveFn('done');
+			expect(await p).toBe('done');
+		});
+	});
+});

--- a/packages/cli/src/scaling/redis-lock.service.ts
+++ b/packages/cli/src/scaling/redis-lock.service.ts
@@ -6,6 +6,7 @@ import { ensureError, OperationalError } from 'n8n-workflow';
 import { createHash, randomUUID } from 'node:crypto';
 
 import { RedisClientService } from '@/services/redis-client.service';
+import { OnShutdown } from '@n8n/decorators';
 
 const COMMAND_TIMEOUT_MS = 5_000;
 
@@ -164,5 +165,11 @@ export class RedisLockService implements ILockService {
 
 			await new Promise((resolve) => setTimeout(resolve, 50 + jitter)); // Wait before retrying
 		}
+	}
+
+	/** Disconnect the underlying Redis client. */
+	@OnShutdown()
+	destroy() {
+		this.redisClient.disconnect();
 	}
 }

--- a/packages/cli/src/scaling/redis-lock.service.ts
+++ b/packages/cli/src/scaling/redis-lock.service.ts
@@ -1,8 +1,13 @@
-import { type ILockService, type LockNamespace, Logger } from '@n8n/backend-common';
+import {
+	type ILockService,
+	type LockNamespace,
+	LockAcquisitionTimeoutError,
+	Logger,
+} from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { Cluster, Redis } from 'ioredis';
-import { ensureError, OperationalError } from 'n8n-workflow';
+import { ensureError } from 'n8n-workflow';
 import { createHash, randomUUID } from 'node:crypto';
 
 import { RedisClientService } from '@/services/redis-client.service';
@@ -156,7 +161,7 @@ export class RedisLockService implements ILockService {
 			}
 
 			if (options?.waitTimeoutMs !== undefined && Date.now() - startTime > options.waitTimeoutMs) {
-				throw new OperationalError(
+				throw new LockAcquisitionTimeoutError(
 					`Timed out waiting for lock '${key}' in namespace '${ns}' after ${options.waitTimeoutMs}ms`,
 				);
 			}

--- a/packages/cli/src/scaling/redis-lock.service.ts
+++ b/packages/cli/src/scaling/redis-lock.service.ts
@@ -1,0 +1,168 @@
+import { type ILockService, type LockNamespace, Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import type { Cluster, Redis } from 'ioredis';
+import { ensureError, OperationalError } from 'n8n-workflow';
+import { createHash, randomUUID } from 'node:crypto';
+
+import { RedisClientService } from '@/services/redis-client.service';
+
+const COMMAND_TIMEOUT_MS = 5_000;
+
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+	return redis.call("del", KEYS[1])
+else
+	return 0
+end
+`;
+
+const EXTENDED_RELEASE_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+    return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+else
+    return 0
+end
+`;
+
+@Service()
+export class RedisLockService implements ILockService {
+	private readonly redisClient: Redis | Cluster;
+
+	private readonly lockPrefix: string;
+
+	constructor(
+		private readonly logger: Logger,
+		globalConfig: GlobalConfig,
+		redisClientService: RedisClientService,
+	) {
+		const prefix = redisClientService.toValidPrefix(globalConfig.redis.prefix);
+		this.lockPrefix = prefix + ':lock';
+
+		this.redisClient = redisClientService.createClient({
+			type: 'lock(n8n)',
+			extraOptions: { commandTimeout: COMMAND_TIMEOUT_MS },
+		});
+	}
+
+	private buildLockKey(ns: LockNamespace, key: string): string {
+		const hash = createHash('sha256').update(key).digest('hex');
+		return `${this.lockPrefix}:${ns}:${hash}`;
+	}
+
+	async withLease<T>(
+		ns: LockNamespace,
+		key: string,
+		fn: (signal: AbortSignal) => Promise<T>,
+		options?: { waitTimeoutMs?: number; leaseTtlMs?: number },
+	): Promise<T> {
+		const abortController = new AbortController();
+		const lockKey = this.buildLockKey(ns, key);
+		const lockValue = randomUUID();
+		const lease = options?.leaseTtlMs ?? 30_000;
+
+		let acquireErrorLogged = false;
+		const acquireLock = async (): Promise<boolean> => {
+			try {
+				const result = await this.redisClient.set(lockKey, lockValue, 'PX', lease, 'NX');
+				return result === 'OK';
+			} catch (error) {
+				if (!acquireErrorLogged) {
+					this.logger.warn('Failed to acquire lock; retrying', { key, error: ensureError(error) });
+					acquireErrorLogged = true;
+				}
+				return false;
+			}
+		};
+
+		const releaseLock = async (): Promise<void> => {
+			try {
+				const result = await this.redisClient.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, lockValue);
+				if (result !== 1) {
+					// We didn't hold it at release time — lease expired and possibly another
+					// worker has the lock. Means fn() ran longer than the lease could be renewed.
+					this.logger.warn('Lock was no longer held at release time', { key });
+				}
+			} catch (error) {
+				// Best-effort: the lease (PX) expires on its own. Never let a release
+				// error overwrite a successful fn() result.
+				this.logger.warn('Failed to release lock; relying on lease expiry', {
+					key,
+					error: ensureError(error),
+				});
+			}
+		};
+
+		const startWatchdog = (): NodeJS.Timeout => {
+			let lastRenewedAt = Date.now();
+			const timer = setInterval(
+				() => {
+					void (async () => {
+						try {
+							const result = await this.redisClient.eval(
+								EXTENDED_RELEASE_LOCK_SCRIPT,
+								1,
+								lockKey,
+								lockValue,
+								lease,
+							);
+							if (result === 1) {
+								lastRenewedAt = Date.now();
+								return;
+							}
+							// Lost the lock: expired before renewal, or another worker took it.
+							// Can't cancel fn(), so just stop renewing and warn.
+							this.logger.warn('Lost lock during execution; stopping renewal', { key });
+							clearInterval(timer);
+							abortController.abort();
+						} catch (error) {
+							// Transient error: keep retrying, but only while the lease could still
+							// be alive. Past that point another worker may hold the lock.
+							if (Date.now() - lastRenewedAt >= lease) {
+								this.logger.warn('Lock renewal failing past lease window; aborting', {
+									key,
+									error: ensureError(error),
+								});
+								clearInterval(timer);
+								abortController.abort();
+							} else {
+								this.logger.warn('Lock renewal failed; will retry', {
+									key,
+									error: ensureError(error),
+								});
+							}
+						}
+					})();
+				},
+				Math.max(1, Math.floor(lease / 3)),
+			);
+
+			timer.unref(); // never keep the process alive just for renewal
+			return timer;
+		};
+
+		const startTime = Date.now();
+		while (true) {
+			if (await acquireLock()) {
+				const watchdog = startWatchdog();
+				try {
+					return await fn(abortController.signal);
+				} finally {
+					clearInterval(watchdog);
+					abortController.abort();
+					await releaseLock();
+				}
+			}
+
+			if (options?.waitTimeoutMs !== undefined && Date.now() - startTime > options.waitTimeoutMs) {
+				throw new OperationalError(
+					`Timed out waiting for lock '${key}' in namespace '${ns}' after ${options.waitTimeoutMs}ms`,
+				);
+			}
+
+			const jitter = Math.floor(Math.random() * 50); // Random jitter to avoid thundering herd
+
+			await new Promise((resolve) => setTimeout(resolve, 50 + jitter)); // Wait before retrying
+		}
+	}
+}

--- a/packages/cli/src/scaling/redis/redis.types.ts
+++ b/packages/cli/src/scaling/redis/redis.types.ts
@@ -12,7 +12,8 @@ type N8nRedisClientType =
 	| 'publisher(n8n)'
 	| 'cache(n8n)'
 	| 'registry(n8n)'
-	| 'leader(n8n)';
+	| 'leader(n8n)'
+	| 'lock(n8n)';
 
 /**
  * Redis client used internally by Bull. Suffixed with `(bull)` at `ScalingService.setupQueue`.

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -1061,6 +1061,10 @@ describe('requestOAuth2 - concurrent refresh serialization', () => {
 			LockNamespace.CREDENTIALS,
 			'cred-id',
 			expect.any(Function),
+			expect.objectContaining({
+				waitTimeoutMs: expect.any(Number),
+				leaseTtlMs: expect.any(Number),
+			}),
 		);
 		withLeaseSpy.mockRestore();
 	});

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -1,4 +1,11 @@
-import type { IAllExecuteFunctions, INode, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import { LockNamespace, LockService } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
+import type {
+	IAllExecuteFunctions,
+	ICredentialDataDecryptedObject,
+	INode,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
 import { OperationalError, UserError } from 'n8n-workflow';
 import nock from 'nock';
 import { mockDeep } from 'vitest-mock-extended';
@@ -30,6 +37,13 @@ describe('refreshOAuth2Token', () => {
 	beforeEach(() => {
 		nock.cleanAll();
 		vi.resetAllMocks();
+		// A successful refresh mutates `credentials.oauthTokenData` in place, and some
+		// tests pass this shared object by reference — reset it so each test starts from
+		// the same stored token.
+		mockCredentialData.oauthTokenData = {
+			access_token: 'old-token',
+			refresh_token: 'old-refresh-token',
+		};
 		mockNode.name = 'test-node-name';
 		mockNode.credentials = {
 			'test-credentials-type': {
@@ -37,6 +51,11 @@ describe('refreshOAuth2Token', () => {
 				name: 'test-credentials-name',
 			},
 		};
+		// Recheck re-reads the credential; return the same access token so it
+		// detects "unchanged" and proceeds to the real refresh.
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: { access_token: 'old-token' },
+		} as unknown as ICredentialDataDecryptedObject);
 	});
 
 	test('should refresh the OAuth2 token with pkce grant type', async () => {
@@ -187,9 +206,11 @@ describe('refreshOAuth2Token', () => {
 			refresh_token: 'new-refresh-token',
 		});
 
+		// Without a credential id the refresh can't be keyed/persisted, so it fails fast
+		// before any network call (same error the persist path raises).
 		await expect(
 			refreshOAuth2Token.call(mockThis, 'test-credentials-type', mockNode, mockAdditionalData),
-		).rejects.toThrow('Node does not have credential type');
+		).rejects.toThrow('Found credential with no ID.');
 		expect(
 			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
 		).not.toHaveBeenCalled();
@@ -281,6 +302,9 @@ describe('refreshOAuth2Token', () => {
 			mockNode.credentials = {
 				'test-credentials-type': { id: 'test-credentials-id', name: 'test-credentials-name' },
 			};
+			mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+				oauthTokenData: { access_token: 'old-token' },
+			} as unknown as ICredentialDataDecryptedObject);
 		});
 
 		test('decrypts the refreshed token via the proxy when present', async () => {
@@ -409,6 +433,9 @@ describe('requestOAuth2 - tokenExpiredStatusCode', () => {
 				name: 'cred-name',
 			},
 		};
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: { access_token: 'expired-token' },
+		} as unknown as ICredentialDataDecryptedObject);
 	});
 
 	test('should retry on 401 by default (isN8nRequest path)', async () => {
@@ -724,6 +751,9 @@ describe('requestOAuth2 - preAuthentication', () => {
 		mockNode.credentials = {
 			testOAuth2: { id: 'cred-id', name: 'cred-name' },
 		};
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: { access_token: 'raw-token' },
+		} as unknown as ICredentialDataDecryptedObject);
 	});
 
 	test('initial path: signs request with token transformed by preAuthentication', async () => {
@@ -904,5 +934,134 @@ describe('requestOAuth2 - preAuthentication', () => {
 			}),
 			mockAdditionalData,
 		);
+	});
+});
+
+describe('requestOAuth2 - concurrent refresh serialization', () => {
+	const baseUrl = 'https://api.example.com';
+	const tokenUrl = 'https://auth.example.com';
+	const mockThis = mockDeep<IAllExecuteFunctions>();
+	const mockNode = mockDeep<INode>();
+	const mockAdditionalData = mockDeep<IWorkflowExecuteAdditionalData>();
+	(mockAdditionalData as unknown as Record<string, unknown>)['oauth-jwe'] = undefined;
+
+	const credentialData = () => ({
+		clientId: 'test-client-id',
+		clientSecret: 'test-client-secret',
+		grantType: 'clientCredentials',
+		accessTokenUrl: `${tokenUrl}/token`,
+		authentication: 'body',
+		scope: 'read',
+		oauthTokenData: { access_token: 'expired-token', token_type: 'bearer' },
+	});
+
+	const error401 = () => Object.assign(new Error('401'), { response: { status: 401 } });
+
+	const call = async () =>
+		await requestOAuth2.call(
+			mockThis,
+			'testOAuth2',
+			{ method: 'GET', url: `${baseUrl}/data` },
+			mockNode,
+			mockAdditionalData,
+			undefined,
+			true,
+		);
+
+	beforeEach(() => {
+		nock.cleanAll();
+		vi.resetAllMocks();
+		mockNode.name = 'test-node';
+		mockNode.credentials = { testOAuth2: { id: 'cred-id', name: 'cred-name' } };
+		mockThis.getCredentials.mockResolvedValue(credentialData());
+		// Recheck reads the stored token; unchanged by default so the refresh proceeds.
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: { access_token: 'expired-token', token_type: 'bearer' },
+		} as unknown as ICredentialDataDecryptedObject);
+	});
+
+	test('coalesces concurrent refreshes of the same credential into one network call', async () => {
+		// Single interceptor IS the assertion: a second refresh finds none and rejects.
+		const tokenScope = nock(tokenUrl)
+			.post('/token')
+			.reply(200, { access_token: 'new-token', token_type: 'bearer' });
+
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		const [r1, r2] = await Promise.all([call(), call()]);
+
+		expect(r1).toEqual({ success: true });
+		expect(r2).toEqual({ success: true });
+		expect(tokenScope.isDone()).toBe(true);
+		expect(
+			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+		).toHaveBeenCalledTimes(1);
+	});
+
+	test('adopts the stored token without a network refresh when it already rotated', async () => {
+		// No /token interceptor: a network refresh would throw on an unmatched request.
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: { access_token: 'rotated-elsewhere', token_type: 'bearer' },
+		} as unknown as ICredentialDataDecryptedObject);
+
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		const result = await call();
+
+		expect(result).toEqual({ success: true });
+		expect(
+			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+		).not.toHaveBeenCalled();
+		expect(mockThis.helpers.httpRequest).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				headers: expect.objectContaining({ Authorization: 'Bearer rotated-elsewhere' }),
+			}),
+		);
+	});
+
+	test('rejects all waiters on a failed refresh and clears the map for a later retry', async () => {
+		const failScope = nock(tokenUrl).post('/token').reply(500, { error: 'server_error' });
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockRejectedValueOnce(error401());
+
+		const results = await Promise.allSettled([call(), call()]);
+
+		expect(results[0].status).toBe('rejected');
+		expect(results[1].status).toBe('rejected');
+		expect(failScope.isDone()).toBe(true);
+
+		// Map cleared on settle → a fresh attempt re-refreshes and succeeds.
+		nock(tokenUrl).post('/token').reply(200, { access_token: 'new-token', token_type: 'bearer' });
+		mockThis.helpers.httpRequest.mockReset();
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		await expect(call()).resolves.toEqual({ success: true });
+	});
+
+	test('wraps the refresh in LockService.withLease keyed by the credential id', async () => {
+		// In-process the coalescing map masks the lock, so this is the only proof the
+		// (cross-process) lock path is actually wired.
+		const withLeaseSpy = vi.spyOn(Container.get(LockService), 'withLease');
+		nock(tokenUrl).post('/token').reply(200, { access_token: 'new-token', token_type: 'bearer' });
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		await call();
+
+		expect(withLeaseSpy).toHaveBeenCalledWith(
+			LockNamespace.CREDENTIALS,
+			'cred-id',
+			expect.any(Function),
+		);
+		withLeaseSpy.mockRestore();
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -1024,6 +1024,94 @@ describe('requestOAuth2 - concurrent refresh serialization', () => {
 		);
 	});
 
+	test('refreshes when oAuth2Options.property resolves to an unchanged nested token', async () => {
+		// Slack-style credential: the signing token comes from a nested path, not the
+		// top-level access_token. The fencing check must compare the same nested value,
+		// otherwise it always reports "rotated elsewhere" and never refreshes.
+		const property = 'authed_user.access_token';
+		const storedTokenData = {
+			access_token: 'bot-token',
+			authed_user: { access_token: 'user-token' },
+			token_type: 'bearer',
+		};
+		mockThis.getCredentials.mockResolvedValue({
+			...credentialData(),
+			oauthTokenData: storedTokenData,
+		});
+		// Post-lease re-read returns the same nested token: no concurrent refresh happened.
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: storedTokenData,
+		} as unknown as ICredentialDataDecryptedObject);
+
+		const tokenScope = nock(tokenUrl)
+			.post('/token')
+			.reply(200, { access_token: 'new-token', token_type: 'bearer' });
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		const result = await requestOAuth2.call(
+			mockThis,
+			'testOAuth2',
+			{ method: 'GET', url: `${baseUrl}/data` },
+			mockNode,
+			mockAdditionalData,
+			{ tokenType: 'Bearer', property },
+			true,
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(tokenScope.isDone()).toBe(true);
+		expect(
+			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+		).toHaveBeenCalledTimes(1);
+	});
+
+	test('adopts the stored token when oAuth2Options.property nested token already rotated', async () => {
+		// Same Slack-style credential, but the nested token changed between reads → another
+		// process refreshed it. No /token interceptor: a network refresh would throw.
+		const property = 'authed_user.access_token';
+		mockThis.getCredentials.mockResolvedValue({
+			...credentialData(),
+			oauthTokenData: {
+				access_token: 'bot-token',
+				authed_user: { access_token: 'user-token' },
+				token_type: 'bearer',
+			},
+		});
+		mockAdditionalData.credentialsHelper.getDecrypted.mockResolvedValue({
+			oauthTokenData: {
+				access_token: 'bot-token',
+				authed_user: { access_token: 'user-token-rotated' },
+				token_type: 'bearer',
+			},
+		} as unknown as ICredentialDataDecryptedObject);
+
+		mockThis.helpers.httpRequest
+			.mockRejectedValueOnce(error401())
+			.mockResolvedValue({ success: true });
+
+		const result = await requestOAuth2.call(
+			mockThis,
+			'testOAuth2',
+			{ method: 'GET', url: `${baseUrl}/data` },
+			mockNode,
+			mockAdditionalData,
+			{ tokenType: 'Bearer', property },
+			true,
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(
+			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+		).not.toHaveBeenCalled();
+		expect(mockThis.helpers.httpRequest).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				headers: expect.objectContaining({ Authorization: 'Bearer user-token-rotated' }),
+			}),
+		);
+	});
+
 	test('rejects all waiters on a failed refresh and clears the map for a later retry', async () => {
 		const failScope = nock(tokenUrl).post('/token').reply(500, { error: 'server_error' });
 		mockThis.helpers.httpRequest

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { LockNamespace, LockService } from '@n8n/backend-common';
+import { LockNamespace, LockAcquisitionTimeoutError, LockService } from '@n8n/backend-common';
 import { removeEmptyBody } from '@n8n/backend-network';
 import type {
 	ClientOAuth2Options,
@@ -136,13 +136,11 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 		});
 	}
 
-	// From here till the setting of a new promise in the map, we are in a critical section.
-	// If two processes reach this point at the same time, they will both try to refresh the token.
-	// The first one to set the promise in the map will be the one that actually does the refresh,
-	// while the second one will just wait for the first one to finish and return its result.
-	// Therefore other than awaiting the existing promise we cannot yield the execution to the event loop,
-	// otherwise we risk that the first process finishes and removes the promise from the map before the
-	// second process sets it, leading to both processes refreshing the token concurrently.
+	// Critical section from here until the in-flight promise is stored in the map.
+	// This map is process-LOCAL: it coalesces concurrent refreshes *within this instance*
+	// so they share one network call. Cross-instance serialization is handled by the lease below.
+	// We must not yield to the event loop before `inFlightRefreshes.set(...)`, or a second concurrent
+	// caller could pass the `has` check before the promise is registered and trigger a duplicate refresh.
 	if (inFlightRefreshes.has(credentialId)) {
 		return await inFlightRefreshes.get(credentialId)!;
 	}
@@ -270,7 +268,24 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 	};
 
 	const promise = Container.get(LockService)
-		.withLease(LockNamespace.CREDENTIALS, credentialId, runRefresh)
+		.withLease(LockNamespace.CREDENTIALS, credentialId, runRefresh, {
+			waitTimeoutMs: 10_000,
+			leaseTtlMs: 30_000,
+		})
+		.catch(async (error) => {
+			if (error instanceof LockAcquisitionTimeoutError) {
+				// The lease is an efficiency primitive, not a correctness one. If the lock
+				// backend is unavailable/contended, refresh without cross-process coordination
+				// rather than stalling the execution; runRefresh's read-back check still avoids
+				// a redundant network call when another holder already rotated the token.
+				ctx.logger.warn(
+					`Could not acquire refresh lock for credential "${credentialId}"; refreshing without cross-process coordination`,
+					{ error },
+				);
+				return await runRefresh();
+			}
+			throw error;
+		})
 		.finally(() => inFlightRefreshes.delete(credentialId));
 	inFlightRefreshes.set(credentialId, promise);
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+import { LockNamespace, LockService } from '@n8n/backend-common';
 import { removeEmptyBody } from '@n8n/backend-network';
 import type {
 	ClientOAuth2Options,
@@ -13,6 +14,7 @@ import type {
 	OAuth2CredentialData,
 } from '@n8n/client-oauth2';
 import { AuthError, ClientOAuth2 } from '@n8n/client-oauth2';
+import { Container } from '@n8n/di';
 import type { AxiosError } from 'axios';
 import { createHmac } from 'crypto';
 import get from 'lodash/get';
@@ -25,9 +27,16 @@ import type {
 	IOAuth2Options,
 	IRequestOptions,
 	IWorkflowExecuteAdditionalData,
+	WorkflowExecuteMode,
 	Logger as WorkflowLogger,
 } from 'n8n-workflow';
-import { OperationalError, jsonParse, NodeOperationError, UserError } from 'n8n-workflow';
+import {
+	OperationalError,
+	jsonParse,
+	NodeOperationError,
+	UserError,
+	UnexpectedError,
+} from 'n8n-workflow';
 import type { Token } from 'oauth-1.0a';
 import clientOAuth1 from 'oauth-1.0a';
 
@@ -79,6 +88,7 @@ interface RefreshOAuth2TokenContext {
 	additionalData: IWorkflowExecuteAdditionalData;
 	oAuth2Options?: IOAuth2Options;
 	logger: WorkflowLogger;
+	mode: WorkflowExecuteMode;
 	helpers: IAllExecuteFunctions['helpers'];
 }
 
@@ -113,109 +123,158 @@ function buildOAuth2ReconnectError(node: INode, credentialsType: string): NodeOp
 	);
 }
 
+const inFlightRefreshes = new Map<string, Promise<ClientOAuth2Token>>();
+
 async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<ClientOAuth2Token> {
-	const {
-		credentials,
-		token,
-		credentialsType,
-		node,
-		additionalData,
-		oAuth2Options,
-		logger,
-		helpers,
-	} = ctx;
-	const tokenRefreshOptions: IDataObject = {};
-	if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
-		const body: IDataObject = {
-			client_id: credentials.clientId,
-			...(credentials.grantType === 'authorizationCode' && {
-				client_secret: credentials.clientSecret as string,
-			}),
-		};
-		tokenRefreshOptions.body = body;
-		tokenRefreshOptions.headers = { Authorization: '' };
-	}
+	const nodeCredentials = ctx.node.credentials?.[ctx.credentialsType];
+	const credentialId = nodeCredentials?.id;
 
-	logger.debug(
-		`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Revalidating.`,
-	);
-
-	const refreshResource = credentials.oauthTokenData?.resource;
-	if (typeof refreshResource === 'string' && refreshResource.length > 0) {
-		tokenRefreshOptions.resource = refreshResource;
-	}
-
-	let newToken;
-	try {
-		if (credentials.grantType === 'clientCredentials') {
-			newToken = await token.client.credentials.getToken();
-		} else {
-			newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
-		}
-	} catch (error) {
-		if (isRevokedOAuth2GrantError(error)) {
-			throw buildOAuth2ReconnectError(node, credentialsType);
-		}
-		throw error;
-	}
-
-	logger.debug(
-		`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
-	);
-
-	// Merge old and new token data so fields that the authorization server
-	// does not echo back on refresh (e.g. `resource`) are preserved from the
-	// original token response.
-	const newOAuthTokenData = { ...token.data, ...newToken.data };
-
-	// If the server doesn't echo the resource back, restore it from the
-	// previous token data to ensure it's not lost on refresh.
-	if (!newOAuthTokenData.resource && token.data.resource) {
-		newOAuthTokenData.resource = token.data.resource;
-	}
-
-	const refreshedTokenData = await decryptOAuth2TokenDataIfConfigured(
-		additionalData,
-		newOAuthTokenData,
-		credentials.jweEnabled === true,
-	);
-
-	credentials.oauthTokenData = refreshedTokenData as typeof credentials.oauthTokenData;
-
-	// Apply preAuthentication so custom credential types extending oAuth2Api can transform
-	// refreshed token data (e.g. extracting a claim from a decrypted JWE/JWT) before signing.
-	// runPreAuthentication runs on every refresh without persisting — the transformed
-	// oauthTokenData is persisted by the updateCredentialsOauthTokenData call below.
-	const preAuthData = await additionalData.credentialsHelper.runPreAuthentication(
-		{ helpers },
-		credentials as unknown as ICredentialDataDecryptedObject,
-		credentialsType,
-	);
-	let signingToken = newToken;
-	if (preAuthData) {
-		Object.assign(credentials, preAuthData);
-		signingToken = buildSigningToken(
-			token.client,
-			credentials.oauthTokenData as ClientOAuth2TokenData,
-			oAuth2Options,
-		);
-	}
-
-	if (!node.credentials?.[credentialsType]) {
-		throw new UserError('Node does not have credential type', {
-			extra: { nodeName: node.name, credentialType: credentialsType },
+	if (!credentialId) {
+		throw new UnexpectedError('Found credential with no ID.', {
+			extra: { credentialName: nodeCredentials?.name },
+			tags: { credentialType: ctx.credentialsType },
 		});
 	}
 
-	const nodeCredentials = node.credentials[credentialsType];
-	await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
-		nodeCredentials,
-		credentialsType,
-		credentials as unknown as ICredentialDataDecryptedObject,
-		additionalData,
-	);
+	// From here till the setting of a new promise in the map, we are in a critical section.
+	// If two processes reach this point at the same time, they will both try to refresh the token.
+	// The first one to set the promise in the map will be the one that actually does the refresh,
+	// while the second one will just wait for the first one to finish and return its result.
+	// Therefore other than awaiting the existing promise we cannot yield the execution to the event loop,
+	// otherwise we risk that the first process finishes and removes the promise from the map before the
+	// second process sets it, leading to both processes refreshing the token concurrently.
+	if (inFlightRefreshes.has(credentialId)) {
+		return await inFlightRefreshes.get(credentialId)!;
+	}
 
-	return signingToken;
+	const runRefresh = async () => {
+		const {
+			credentials,
+			token,
+			credentialsType,
+			node,
+			additionalData,
+			oAuth2Options,
+			logger,
+			helpers,
+		} = ctx;
+		const currentCredential = (await additionalData.credentialsHelper.getDecrypted(
+			additionalData,
+			nodeCredentials,
+			ctx.credentialsType,
+			ctx.mode,
+			undefined,
+			true,
+		)) as unknown as OAuth2CredentialData;
+
+		// if the access token value changed, the refresh already happend in another process, so we can just return the new token
+		if (currentCredential?.oauthTokenData?.access_token !== token.accessToken) {
+			return buildSigningToken(
+				token.client,
+				currentCredential?.oauthTokenData as ClientOAuth2TokenData,
+				oAuth2Options,
+			);
+		}
+
+		const tokenRefreshOptions: IDataObject = {};
+		if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
+			const body: IDataObject = {
+				client_id: credentials.clientId,
+				...(credentials.grantType === 'authorizationCode' && {
+					client_secret: credentials.clientSecret as string,
+				}),
+			};
+			tokenRefreshOptions.body = body;
+			tokenRefreshOptions.headers = { Authorization: '' };
+		}
+
+		logger.debug(
+			`OAuth2 token for "${credentialsType}" used by node "${node.name}" expired. Revalidating.`,
+		);
+
+		const refreshResource = credentials.oauthTokenData?.resource;
+		if (typeof refreshResource === 'string' && refreshResource.length > 0) {
+			tokenRefreshOptions.resource = refreshResource;
+		}
+
+		let newToken;
+		try {
+			if (credentials.grantType === 'clientCredentials') {
+				newToken = await token.client.credentials.getToken();
+			} else {
+				newToken = await token.refresh(tokenRefreshOptions as unknown as ClientOAuth2Options);
+			}
+		} catch (error) {
+			if (isRevokedOAuth2GrantError(error)) {
+				throw buildOAuth2ReconnectError(node, credentialsType);
+			}
+			throw error;
+		}
+
+		logger.debug(
+			`OAuth2 token for "${credentialsType}" used by node "${node.name}" has been renewed.`,
+		);
+
+		// Merge old and new token data so fields that the authorization server
+		// does not echo back on refresh (e.g. `resource`) are preserved from the
+		// original token response.
+		const newOAuthTokenData = { ...token.data, ...newToken.data };
+
+		// If the server doesn't echo the resource back, restore it from the
+		// previous token data to ensure it's not lost on refresh.
+		if (!newOAuthTokenData.resource && token.data.resource) {
+			newOAuthTokenData.resource = token.data.resource;
+		}
+
+		const refreshedTokenData = await decryptOAuth2TokenDataIfConfigured(
+			additionalData,
+			newOAuthTokenData,
+			credentials.jweEnabled === true,
+		);
+
+		credentials.oauthTokenData = refreshedTokenData as typeof credentials.oauthTokenData;
+
+		// Apply preAuthentication so custom credential types extending oAuth2Api can transform
+		// refreshed token data (e.g. extracting a claim from a decrypted JWE/JWT) before signing.
+		// runPreAuthentication runs on every refresh without persisting — the transformed
+		// oauthTokenData is persisted by the updateCredentialsOauthTokenData call below.
+		const preAuthData = await additionalData.credentialsHelper.runPreAuthentication(
+			{ helpers },
+			credentials as unknown as ICredentialDataDecryptedObject,
+			credentialsType,
+		);
+		let signingToken = newToken;
+		if (preAuthData) {
+			Object.assign(credentials, preAuthData);
+			signingToken = buildSigningToken(
+				token.client,
+				credentials.oauthTokenData as ClientOAuth2TokenData,
+				oAuth2Options,
+			);
+		}
+
+		if (!node.credentials?.[credentialsType]) {
+			throw new UserError('Node does not have credential type', {
+				extra: { nodeName: node.name, credentialType: credentialsType },
+			});
+		}
+
+		await additionalData.credentialsHelper.updateCredentialsOauthTokenData(
+			nodeCredentials,
+			credentialsType,
+			credentials as unknown as ICredentialDataDecryptedObject,
+			additionalData,
+		);
+
+		return signingToken;
+	};
+
+	const promise = Container.get(LockService)
+		.withLease(LockNamespace.CREDENTIALS, credentialId, runRefresh)
+		.finally(() => inFlightRefreshes.delete(credentialId));
+	inFlightRefreshes.set(credentialId, promise);
+
+	return await promise;
 }
 
 function resolveTokenExpiredStatusCode(
@@ -335,6 +394,7 @@ export async function requestOAuth2(
 		oAuth2Options,
 		logger: this.logger,
 		helpers: this.helpers,
+		mode: this.getMode?.() ?? 'internal',
 	};
 
 	const retryWithNewToken = async (
@@ -484,6 +544,7 @@ export async function refreshOAuth2Token(
 		oAuth2Options,
 		logger: this.logger,
 		helpers: this.helpers,
+		mode: this.getMode?.() ?? 'internal',
 	});
 
 	return newToken.data;

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -165,8 +165,15 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 			true,
 		)) as unknown as OAuth2CredentialData;
 
+		// Resolve the stored token through the same property path used to build `token`,
+		// otherwise the comparison misfires for nodes using `oAuth2Options.property` (e.g. Slack),
+		// where `token.accessToken` is a nested value rather than the top-level `access_token`.
+		const currentAccessToken =
+			get(currentCredential?.oauthTokenData, oAuth2Options?.property as string) ||
+			currentCredential?.oauthTokenData?.access_token;
+
 		// if the access token value changed, the refresh already happend in another process, so we can just return the new token
-		if (currentCredential?.oauthTokenData?.access_token !== token.accessToken) {
+		if (currentAccessToken !== token.accessToken) {
 			return buildSigningToken(
 				token.client,
 				currentCredential?.oauthTokenData as ClientOAuth2TokenData,


### PR DESCRIPTION
## Summary

When several items or executions refresh the **same** OAuth2 credential at the same time, each parallel refresh spends the current refresh token. With identity providers that **rotate** refresh tokens, only one of those concurrent refreshes wins — the rest present an already-consumed token and the credential is invalidated, forcing the user to reconnect.

This PR serializes OAuth2 token refresh per credential so concurrent refreshes share a single result instead of racing. It does so in two layers and introduces a reusable lock/lease primitive to support the cross-process layer:

1. **Process-local coalescing** — an in-flight map keyed by credential ID so concurrent refreshes *within one instance* await a single network call.
2. **Cross-instance lease** — a new `LockService.withLease(...)` serializes refreshes *across* main/worker/webhook processes, without pinning a DB connection across the refresh HTTP round-trip.

### Why

Implements IAM-889. A Postgres advisory lock is connection-bound; holding it across the refresh network call would pin a pooled DB connection for the whole round-trip and drain the pool at execution/item scale. A Redis key with a TTL pins nothing between acquire and release, so the coordination primitive here is a **lease**, not a DB lock.

The lease is also the IAM-890 foundation slice: a general-purpose, DI-registered `LockService` that behaves the same in single-instance and multi-process deployments. Callers never branch on deployment mode and the service is never rebound in DI.

### How it works

`refreshOrFetchToken` (in `packages/core/.../request-helpers/oauth.ts`) now:

- Returns an in-flight refresh promise if one already exists for the credential (process-local coalescing; the map is populated synchronously before any `await` to close the check-then-set race).
- Otherwise runs the refresh inside `Container.get(LockService).withLease(LockNamespace.CREDENTIALS, credentialId, runRefresh, { waitTimeoutMs: 10_000, leaseTtlMs: 30_000 })`.
- **Read-back after acquiring the lease:** re-reads the decrypted credential; if the access token already changed, another holder rotated it, so it returns the new token without a redundant refresh call.
- **Graceful fallback:** on `LockAcquisitionTimeoutError` (lock backend unavailable or heavily contended) it logs a warning and refreshes *without* cross-process coordination rather than stalling the execution — correct because the lease is an efficiency primitive and the read-back still avoids redundant work.

The `LockService` itself:

- **In-process default** (`InProcessLockService`) — per-key FIFO mutex adapted from `DbLockService`'s SQLite path (opaque owner token, atomic hand-off, double-release-safe). Holds the lease until `fn` settles; `leaseTtlMs` is ignored (no orphaned-holder risk in one process).
- **Redis backend** (`RedisLockService`, cli) — `SET key <token> NX PX <ttl>` to acquire (retry with jittered backoff until `waitTimeoutMs`), owner-token compare-and-delete release via Lua, and a watchdog that renews the lease every `leaseTtlMs / 3` and fires the `fn`'s `AbortSignal` if the lease is lost.
- **Wiring** — `BaseCommand.init()` swaps in `RedisLockService` via the explicit, greppable `setProvider(...)` (never a `Container.set` rebind) when `executions.mode === 'queue'`, multi-main is enabled, or `cache.backend === 'redis'`. All process types share one backend; single-instance keeps the in-process default.

### Key implementation decisions

- **Lease, not lock.** The public method is `withLease`: the Redis backend is an efficiency primitive, not a correctness one (TTL/failover/renewal-failure can let two holders run briefly). OAuth refresh is safe under this because it is idempotent against a rotating-token IdP and self-fences via the read-back check. `LockAcquisitionTimeoutError` (a typed `OperationalError` subclass) lets the consumer distinguish "couldn't coordinate" and fall back cleanly.
- **Two layers on purpose.** Process-local coalescing avoids even hitting Redis for the common same-instance burst; the lease handles the rarer cross-process case. Either alone is insufficient.
- **Wiring is topology-based, broader than CacheService.** Locking correctness depends on process count, not the cache backend, so a multi-process deployment with an in-memory cache still gets the Redis backend.
- **`LockNamespace` is a `const` object + union type**, not an `enum` — a `const enum` erases to `undefined` for cross-package callers under `isolatedModules`, and a plain `enum` is disallowed by lint.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-693
closes https://linear.app/n8n/issue/IAM-889
closes https://linear.app/n8n/issue/IAM-890
closes #30345



## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->