### PR TITLE
fix(Copper Node): Fix getAll pagination not incrementing page_number

### DIFF
--- a/packages/nodes-base/nodes/Copper/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Copper/GenericFunctions.ts
@@ -137,6 +137,8 @@ export const adjustTaskFields = flow(adjustLeadFields, adjustProjectIds);
 
 /**
  * Make an authenticated API request to Copper and return all items.
+ * Copper uses page_number (1-indexed) in the request body to paginate.
+ * Without incrementing it, every iteration fetches the same first page.
  */
 export async function copperApiRequestAllItems(
 	this: IHookFunctions | ILoadOptionsFunctions | IExecuteFunctions,
@@ -148,15 +150,25 @@ export async function copperApiRequestAllItems(
 	option: IDataObject = {},
 ) {
 	let responseData;
-	qs.page_size = 200;
-	let totalItems = 0;
+	const pageSize = 200;
+	let pageNumber = 1;
 	const returnData: IDataObject[] = [];
 
 	do {
-		responseData = await copperApiRequest.call(this, method, resource, body, qs, uri, option);
-		totalItems = responseData.headers['x-pw-total'];
-		returnData.push(...(responseData.body as IDataObject[]));
-	} while (totalItems > returnData.length);
+		responseData = await copperApiRequest.call(
+			this,
+			method,
+			resource,
+			{ ...body, page_size: pageSize, page_number: pageNumber },
+			qs,
+			uri,
+			option,
+		);
+		const pageItems = responseData.body as IDataObject[];
+		returnData.push(...pageItems);
+		pageNumber++;
+		// Stop when the API returns fewer records than the page size — that is the last page.
+	} while ((responseData.body as IDataObject[]).length === pageSize);
 
 	return returnData;
 }

--- a/packages/nodes-base/nodes/Copper/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Copper/test/GenericFunctions.test.ts
@@ -1,0 +1,179 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { copperApiRequestAllItems } from '../GenericFunctions';
+
+describe('copperApiRequestAllItems', () => {
+	const mockRequestWithAuthentication = vi.fn();
+
+	const mockContext = {
+		helpers: {
+			requestWithAuthentication: mockRequestWithAuthentication,
+		},
+		getNode: vi.fn().mockReturnValue({ name: 'Copper' }),
+	} as unknown as IExecuteFunctions;
+
+	beforeEach(() => {
+		mockRequestWithAuthentication.mockClear();
+	});
+
+	it('should return all items from a single page when total is less than page size', async () => {
+		// Single page with 3 items (less than page_size of 200)
+		const page1Items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+		mockRequestWithAuthentication.mockResolvedValueOnce({
+			headers: { 'x-pw-total': 3 },
+			body: page1Items,
+		});
+
+		const result = await copperApiRequestAllItems.call(
+			mockContext,
+			'POST',
+			'/companies/search',
+			{},
+			{},
+			'',
+			{ resolveWithFullResponse: true },
+		);
+
+		expect(result).toEqual(page1Items);
+		// Should call the API exactly once with page_number: 1
+		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
+		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ page_size: 200, page_number: 1 }),
+			}),
+		);
+	});
+
+	it('should fetch multiple pages by incrementing page_number', async () => {
+		// Simulate exactly 200 items on page 1 (full page) and 50 on page 2 (partial = last page)
+		const page1Items = Array.from({ length: 200 }, (_, i) => ({ id: i + 1 }));
+		const page2Items = Array.from({ length: 50 }, (_, i) => ({ id: i + 201 }));
+
+		mockRequestWithAuthentication
+			.mockResolvedValueOnce({ headers: { 'x-pw-total': 250 }, body: page1Items })
+			.mockResolvedValueOnce({ headers: { 'x-pw-total': 250 }, body: page2Items });
+
+		const result = await copperApiRequestAllItems.call(
+			mockContext,
+			'POST',
+			'/companies/search',
+			{},
+			{},
+			'',
+			{ resolveWithFullResponse: true },
+		);
+
+		expect(result).toHaveLength(250);
+		expect(result).toEqual([...page1Items, ...page2Items]);
+
+		// Should make exactly 2 API calls
+		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(2);
+
+		// First call must send page_number: 1
+		expect(mockRequestWithAuthentication).toHaveBeenNthCalledWith(
+			1,
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ page_size: 200, page_number: 1 }),
+			}),
+		);
+
+		// Second call must send page_number: 2
+		expect(mockRequestWithAuthentication).toHaveBeenNthCalledWith(
+			2,
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ page_size: 200, page_number: 2 }),
+			}),
+		);
+	});
+
+	it('should fetch three pages when needed', async () => {
+		// 200 + 200 + 1 = 401 total items over 3 pages
+		const page1Items = Array.from({ length: 200 }, (_, i) => ({ id: i + 1 }));
+		const page2Items = Array.from({ length: 200 }, (_, i) => ({ id: i + 201 }));
+		const page3Items = [{ id: 401 }];
+
+		mockRequestWithAuthentication
+			.mockResolvedValueOnce({ headers: {}, body: page1Items })
+			.mockResolvedValueOnce({ headers: {}, body: page2Items })
+			.mockResolvedValueOnce({ headers: {}, body: page3Items });
+
+		const result = await copperApiRequestAllItems.call(
+			mockContext,
+			'POST',
+			'/companies/search',
+			{ name: 'test' }, // extra body filter
+			{},
+			'',
+			{ resolveWithFullResponse: true },
+		);
+
+		expect(result).toHaveLength(401);
+		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(3);
+
+		// page_number should progress 1 → 2 → 3
+		expect(mockRequestWithAuthentication).toHaveBeenNthCalledWith(
+			1,
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ name: 'test', page_size: 200, page_number: 1 }),
+			}),
+		);
+		expect(mockRequestWithAuthentication).toHaveBeenNthCalledWith(
+			2,
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ name: 'test', page_size: 200, page_number: 2 }),
+			}),
+		);
+		expect(mockRequestWithAuthentication).toHaveBeenNthCalledWith(
+			3,
+			'copperApi',
+			expect.objectContaining({
+				body: expect.objectContaining({ name: 'test', page_size: 200, page_number: 3 }),
+			}),
+		);
+	});
+
+	it('should return an empty array when the first page has no items', async () => {
+		mockRequestWithAuthentication.mockResolvedValueOnce({
+			headers: { 'x-pw-total': 0 },
+			body: [],
+		});
+
+		const result = await copperApiRequestAllItems.call(
+			mockContext,
+			'POST',
+			'/companies/search',
+			{},
+			{},
+			'',
+			{ resolveWithFullResponse: true },
+		);
+
+		expect(result).toEqual([]);
+		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not mutate the caller-provided body object', async () => {
+		const originalBody = { name: 'Acme' };
+		const bodyCopy = { ...originalBody };
+
+		mockRequestWithAuthentication.mockResolvedValueOnce({ headers: {}, body: [{ id: 1 }] });
+
+		await copperApiRequestAllItems.call(
+			mockContext,
+			'POST',
+			'/companies/search',
+			originalBody,
+			{},
+			'',
+			{ resolveWithFullResponse: true },
+		);
+
+		// The original body object must not have been mutated with page_size / page_number
+		expect(originalBody).toEqual(bodyCopy);
+	});
+});


### PR DESCRIPTION
The copperApiRequestAllItems function used qs.page_size but never set or incremented page_number in the request body. As a result, every loop iteration fetched the same first page of results, producing an infinite loop of duplicated records whenever the total count exceeded the page size (200).

Fix: remove the x-pw-total header comparison and instead use the standard Copper API pagination strategy — pass page_number (1-indexed) in the request body and stop when a page returns fewer records than page_size, indicating the last page has been reached.

Also use object spread ({ ...body, page_size, page_number }) so the caller-provided body object is never mutated.

Fixes #26201

## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->