### PR TITLE
feat(editor): Add AI disclaimer to Instance AI chat

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5909,6 +5909,7 @@
 	"instanceAi.canvasActionPopover.title": "Try new AI Assistant",
 	"instanceAi.canvasActionPopover.body": "Building, questions, and debugging with AI now happen in the AI Assistant.",
 	"instanceAi.canvasActionPopover.action": "Open AI Assistant",
+	"instanceAi.input.disclaimer": "AI can make mistakes. Check important info.",
 	"instanceAi.input.placeholder": "Ask anything...",
 	"instanceAi.input.suspendedPlaceholder": "Complete or skip the setup above to continue",
 	"instanceAi.input.workflowBuilderUnavailablePlaceholder": "Workflow builder unavailable",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -805,6 +805,9 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 												/>
 											</Transition>
 										</div>
+										<p :class="$style.disclaimer">
+											{{ i18n.baseText('instanceAi.input.disclaimer') }}
+										</p>
 									</div>
 								</div>
 							</div>
@@ -1155,6 +1158,14 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--xs);
+}
+
+.disclaimer {
+	margin: 0;
+	text-align: center;
+	color: var(--color--text--tint-1);
+	font-size: var(--font-size--3xs);
+	line-height: var(--line-height--md);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Adds a persistent, muted disclaimer below the Instance AI chat composer noting that AI can make mistakes, for compliance. Matches the convention used by ChatGPT, Gemini, and Claude (short, low-emphasis, centered under the input).

- New i18n string `instanceAi.input.disclaimer`: "AI can make mistakes. Check important info."
- Rendered under the composer in `InstanceAiThreadView.vue` with a muted style using semantic design tokens.

Scoped to the active chat thread (not the empty state), since the empty view already uses the input `#footer` slot for the project selector, and the disclaimer reads best alongside live responses.
<img width="786" height="239" alt="Screenshot 2026-06-26 at 12 14 57" src="https://github.com/user-attachments/assets/19db39c3-f4a9-4759-9690-c0c942f16b0f" />


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33101">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->