### PR TITLE
feat(Microsoft Teams Node): Add Service Principal (app-only) authentication

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
@@ -209,7 +209,10 @@ export class MicrosoftTeamsTrigger implements INodeType {
 				displayOptions: {
 					show: {
 						event: ['newChannel', 'newChannelMessage', 'newTeamMember'],
-						watchAllTeams: [false],
+						// `_cnd: { not: true }` matches both `false` and `undefined`. Under SP the
+						// watch-all toggle is hidden (SP_HIDE) and resolves to `undefined`; a plain
+						// `[false]` would not match, so this picker would wrongly disappear.
+						watchAllTeams: [{ _cnd: { not: true } }],
 					},
 				},
 			},
@@ -270,8 +273,10 @@ export class MicrosoftTeamsTrigger implements INodeType {
 				displayOptions: {
 					show: {
 						event: ['newChannelMessage'],
-						watchAllTeams: [false],
-						watchAllChannels: [false],
+						// `_cnd: { not: true }` matches `false` and the `undefined` that the SP-hidden
+						// watch-all toggles resolve to, so the channel picker still renders under SP.
+						watchAllTeams: [{ _cnd: { not: true } }],
+						watchAllChannels: [{ _cnd: { not: true } }],
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
@@ -100,7 +100,7 @@ export class MicrosoftTeamsTrigger implements INodeType {
 						name: 'Service Principal (App-Only)',
 						value: SERVICE_PRINCIPAL_AUTH,
 						description:
-							'App-only access via a Microsoft Entra app registration. App-only Graph cannot subscribe to a signed-in user’s chats, so chat triggers are unavailable. Grant the relevant application permissions (e.g. ChannelMessage.Read.All) and admin consent on the credential.',
+							'App-only access via a Microsoft Entra app registration. App-only Graph cannot subscribe to the chats of a signed-in user, so chat triggers are unavailable. Grant the relevant application permissions (e.g. ChannelMessage.Read.All) and admin consent on the credential.',
 					},
 				],
 				default: 'microsoftTeamsOAuth2Api',
@@ -141,7 +141,7 @@ export class MicrosoftTeamsTrigger implements INodeType {
 			},
 			{
 				displayName:
-					'Chat triggers (New Chat, New Chat Message) are not available with the Service Principal credential. App-only Microsoft Graph cannot subscribe to a signed-in user’s chats; use an OAuth2 credential for chat triggers.',
+					'Chat triggers (New Chat, New Chat Message) are not available with the Service Principal credential. App-only Microsoft Graph cannot subscribe to the chats of a signed-in user; use an OAuth2 credential for chat triggers.',
 				name: 'chatTriggerServicePrincipalNotice',
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
@@ -20,7 +20,12 @@ import {
 	verifyWebhook,
 } from './v2/helpers/utils-trigger';
 import { listSearch } from './v2/methods';
-import { microsoftApiRequest, microsoftApiRequestAllItems } from './v2/transport';
+import {
+	microsoftApiRequest,
+	microsoftApiRequestAllItems,
+	SERVICE_PRINCIPAL_AUTH,
+	SP_HIDE,
+} from './v2/transport';
 
 export class MicrosoftTeamsTrigger implements INodeType {
 	description: INodeTypeDescription = {
@@ -54,6 +59,15 @@ export class MicrosoftTeamsTrigger implements INodeType {
 					},
 				},
 			},
+			{
+				name: SERVICE_PRINCIPAL_AUTH,
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: [SERVICE_PRINCIPAL_AUTH],
+					},
+				},
+			},
 		],
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
@@ -81,6 +95,12 @@ export class MicrosoftTeamsTrigger implements INodeType {
 						value: 'microsoftOAuth2Api',
 						description:
 							'Generic Microsoft Graph credential. Add the Teams change-notification scopes (e.g. ChannelMessage.Read.All, Chat.Read, Subscription.Read.All) and grant admin consent on the credential. See the docs for the full scope string.',
+					},
+					{
+						name: 'Service Principal (App-Only)',
+						value: SERVICE_PRINCIPAL_AUTH,
+						description:
+							'App-only access via a Microsoft Entra app registration. App-only Graph cannot subscribe to a signed-in user’s chats, so chat triggers are unavailable. Grant the relevant application permissions (e.g. ChannelMessage.Read.All) and admin consent on the credential.',
 					},
 				],
 				default: 'microsoftTeamsOAuth2Api',
@@ -120,6 +140,19 @@ export class MicrosoftTeamsTrigger implements INodeType {
 				description: 'Select the event to trigger the workflow',
 			},
 			{
+				displayName:
+					'Chat triggers (New Chat, New Chat Message) are not available with the Service Principal credential. App-only Microsoft Graph cannot subscribe to a signed-in user’s chats; use an OAuth2 credential for chat triggers.',
+				name: 'chatTriggerServicePrincipalNotice',
+				type: 'notice',
+				default: '',
+				displayOptions: {
+					show: {
+						event: ['newChat', 'newChatMessage'],
+						authentication: [SERVICE_PRINCIPAL_AUTH],
+					},
+				},
+			},
+			{
 				displayName: 'Watch All Teams',
 				name: 'watchAllTeams',
 				type: 'boolean',
@@ -128,6 +161,9 @@ export class MicrosoftTeamsTrigger implements INodeType {
 				displayOptions: {
 					show: {
 						event: ['newChannel', 'newChannelMessage', 'newTeamMember'],
+					},
+					hide: {
+						...SP_HIDE,
 					},
 				},
 			},
@@ -188,6 +224,9 @@ export class MicrosoftTeamsTrigger implements INodeType {
 						event: ['newChannelMessage'],
 						watchAllTeams: [false],
 					},
+					hide: {
+						...SP_HIDE,
+					},
 				},
 			},
 			{
@@ -246,6 +285,9 @@ export class MicrosoftTeamsTrigger implements INodeType {
 					show: {
 						event: ['newChatMessage'],
 					},
+					hide: {
+						...SP_HIDE,
+					},
 				},
 			},
 			{
@@ -290,6 +332,9 @@ export class MicrosoftTeamsTrigger implements INodeType {
 					show: {
 						event: ['newChatMessage'],
 						watchAllChats: [false],
+					},
+					hide: {
+						...SP_HIDE,
 					},
 				},
 			},

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
@@ -67,7 +67,9 @@ describe.each(cases)('$name authentication selector', ({ properties, credentials
 	});
 
 	it('should gate the Service Principal credential behind its authentication value', () => {
-		const spCredential = credentials.find((credential) => credential.name === SERVICE_PRINCIPAL_AUTH);
+		const spCredential = credentials.find(
+			(credential) => credential.name === SERVICE_PRINCIPAL_AUTH,
+		);
 
 		expect(spCredential?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
 		expect(spCredential?.required).toBe(true);

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
@@ -2,6 +2,7 @@ import type { INodeCredentialDescription, INodeProperties } from 'n8n-workflow';
 
 import { MicrosoftTeamsTrigger } from '../MicrosoftTeamsTrigger.node';
 import { versionDescription } from '../v2/actions/versionDescription';
+import { SERVICE_PRINCIPAL_AUTH } from '../v2/transport';
 
 /**
  * These tests pin the backward-compatibility contract introduced alongside the
@@ -36,12 +37,13 @@ describe.each(cases)('$name authentication selector', ({ properties, credentials
 		expect(authProperty?.noDataExpression).toBe(true);
 	});
 
-	it('should offer both the Teams and the generic Microsoft credential', () => {
+	it('should offer the Teams, generic Microsoft, and Service Principal credentials', () => {
 		const values = (authProperty?.options ?? []).map((option) =>
 			'value' in option ? option.value : undefined,
 		);
 		expect(values).toContain('microsoftTeamsOAuth2Api');
 		expect(values).toContain('microsoftOAuth2Api');
+		expect(values).toContain(SERVICE_PRINCIPAL_AUTH);
 	});
 
 	it('should default to the Teams credential (backward compatibility)', () => {
@@ -62,6 +64,13 @@ describe.each(cases)('$name authentication selector', ({ properties, credentials
 		expect(genericCredential?.displayOptions?.show?.authentication).toEqual(['microsoftOAuth2Api']);
 		expect(teamsCredential?.required).toBe(true);
 		expect(genericCredential?.required).toBe(true);
+	});
+
+	it('should gate the Service Principal credential behind its authentication value', () => {
+		const spCredential = credentials.find((credential) => credential.name === SERVICE_PRINCIPAL_AUTH);
+
+		expect(spCredential?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		expect(spCredential?.required).toBe(true);
 	});
 
 	it('should keep the default aligned with the Teams credential gate value', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/credentials.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/credentials.ts
@@ -1,8 +1,21 @@
+// Credential fixtures for the Teams harness (workflow) tests. The NodeTestHarness
+// no-ops preAuthentication but still calls authenticate, so the Service Principal
+// token POST never fires — the credential's `authenticate` attaches
+// `Bearer <accessToken>` straight from this fixture. Supply `accessToken` inline
+// and nock ONLY the Graph endpoint, never login.microsoftonline.com.
 export const credentials = {
 	microsoftTeamsOAuth2Api: {
 		scope: 'openid',
 		oauthTokenData: {
 			access_token: 'token',
 		},
+	},
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
 	},
 };

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/MicrosoftTeamTrigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/MicrosoftTeamTrigger.test.ts
@@ -3,15 +3,23 @@ import { mock } from 'vitest-mock-extended';
 import { MicrosoftTeamsTrigger } from '../../MicrosoftTeamsTrigger.node';
 import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../v2/transport';
 import type { Mock } from 'vitest';
+import type * as _transport from '../../v2/transport';
 
-vi.mock('../../v2/transport', () => ({
-	microsoftApiRequest: {
-		call: vi.fn(),
-	},
-	microsoftApiRequestAllItems: {
-		call: vi.fn(),
-	},
-}));
+// Preserve the real transport exports (the node description references
+// SERVICE_PRINCIPAL_AUTH/SP_HIDE at construction, and getResourcePath uses the real
+// credential resolver); only stub the network helpers.
+vi.mock('../../v2/transport', async () => {
+	const actual = await vi.importActual<typeof _transport>('../../v2/transport');
+	return {
+		...actual,
+		microsoftApiRequest: {
+			call: vi.fn(),
+		},
+		microsoftApiRequestAllItems: {
+			call: vi.fn(),
+		},
+	};
+});
 
 describe('Microsoft Teams Trigger Node', () => {
 	let mockWebhookFunctions: any;

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -97,6 +97,17 @@ describe('Microsoft Teams Helpers Functions', () => {
 				'Failed to fetch channels',
 			);
 		});
+
+		it('rejects a crafted teamId under SP via buildTeamsPath (non-bypassable defense-in-depth)', async () => {
+			mockHookFunctions.getNodeParameter.mockImplementation((name: string) =>
+				name === 'authentication' ? SERVICE_PRINCIPAL_AUTH : undefined,
+			);
+
+			await expect(fetchAllChannels.call(mockHookFunctions, 'x/../../groups/abc')).rejects.toThrow(
+				'The ID is not valid',
+			);
+			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('createSubscription', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -426,6 +426,27 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
 		});
 
+		// Regression: under SP the watch-all toggles are hidden (SP_HIDE) and absent, so the
+		// reads must fall back to `false` WITHOUT `{ extractValue: true }` — extractValue on a
+		// hidden param throws a raw "Could not find property" before the channel path is built.
+		it('composes the channel path when watch-all toggles are absent, and reads them without extractValue', async () => {
+			setSpParams({ teamId: '1111-2222', channelId: '19:abc@thread.tacv2' });
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
+
+			expect(result).toBe('/teams/1111-2222/channels/19:abc@thread.tacv2/messages');
+			expect(mockHookFunctions.getNodeParameter).not.toHaveBeenCalledWith(
+				'watchAllTeams',
+				expect.anything(),
+				expect.objectContaining({ extractValue: true }),
+			);
+			expect(mockHookFunctions.getNodeParameter).not.toHaveBeenCalledWith(
+				'watchAllChannels',
+				expect.anything(),
+				expect.objectContaining({ extractValue: true }),
+			);
+		});
+
 		it('passes a colon channelId RAW for newChannelMessage (same shape as OAuth2, not encoded)', async () => {
 			setSpParams({
 				watchAllTeams: false,

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -470,6 +470,20 @@ describe('Microsoft Teams Helpers Functions', () => {
 			);
 		});
 
+		it('throws a friendly error (not a raw URIError) for a malformed percent-encoded channelId under SP', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: '1111-2222',
+				watchAllChannels: false,
+				// `%zz` is not valid percent-encoding; an unguarded decodeURIComponent throws a raw URIError.
+				channelId: '19%zzabc',
+			});
+
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannelMessage')).rejects.toThrow(
+				'The ID is not valid',
+			);
+		});
+
 		it('rejects a crafted (separator) channelId for newChannelMessage', async () => {
 			setSpParams({
 				watchAllTeams: false,

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -403,7 +403,7 @@ describe('Microsoft Teams Helpers Functions', () => {
 			},
 		);
 
-		it('encodes the teamId for newChannel (no decode round-trip, fetchAllTeams not called)', async () => {
+		it('interpolates the teamId RAW for newChannel (no decode round-trip, fetchAllTeams not called)', async () => {
 			setSpParams({ watchAllTeams: false, teamId: 'team_id-123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannel');
@@ -411,7 +411,20 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
 		});
 
-		it('encodes teamId + channelId for newChannelMessage and rejects a crafted channelId', async () => {
+		it('passes a colon channelId RAW for newChannelMessage (same shape as OAuth2, not encoded)', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: '1111-2222',
+				watchAllChannels: false,
+				channelId: '19:abc@thread.tacv2',
+			});
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
+			expect(result).toBe('/teams/1111-2222/channels/19:abc@thread.tacv2/messages');
+			expect(result).not.toContain('%3A');
+		});
+
+		it('rejects a crafted (separator) channelId for newChannelMessage', async () => {
 			setSpParams({
 				watchAllTeams: false,
 				teamId: 'team123',
@@ -424,11 +437,39 @@ describe('Microsoft Teams Helpers Functions', () => {
 			);
 		});
 
-		it('encodes the teamId for newTeamMember', async () => {
+		it('interpolates the teamId RAW for newTeamMember', async () => {
 			setSpParams({ watchAllTeams: false, teamId: 'team123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
 			expect(result).toBe('/teams/team123/members');
+		});
+
+		// Watch-all is UI-hidden under SP, but a hand-edited workflow can still set it.
+		// The runtime guard must fire before any fan-out (fetchAllTeams/fetchAllChannels),
+		// which would otherwise send a crafted teamId raw under the org-wide token.
+		it.each(['newChannel', 'newChannelMessage', 'newTeamMember'])(
+			'blocks watchAllTeams under SP for %s before any request (crafted teamId)',
+			async (event) => {
+				setSpParams({ watchAllTeams: true, teamId: 'x/../../groups/abc' });
+
+				await expect(getResourcePath.call(mockHookFunctions, event)).rejects.toThrow(
+					'Watching all teams/channels is not available with the Service Principal credential',
+				);
+				expect(microsoftApiRequest.call).not.toHaveBeenCalled();
+			},
+		);
+
+		it('blocks watchAllChannels under SP for newChannelMessage before any request (crafted teamId)', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: 'x/../../groups/abc',
+				watchAllChannels: true,
+			});
+
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannelMessage')).rejects.toThrow(
+				'Watching all teams/channels is not available with the Service Principal credential',
+			);
+			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -302,9 +302,8 @@ describe('Microsoft Teams Helpers Functions', () => {
 		// Resolve getNodeParameter by NAME so a leading authentication read (the SP
 		// resolver) doesn't shift the assertion. `authentication` defaults to OAuth2.
 		const setParams = (params: Record<string, unknown>) => {
-			mockHookFunctions.getNodeParameter.mockImplementation(
-				(name: string, fallback?: unknown) =>
-					name in params ? params[name] : fallback,
+			mockHookFunctions.getNodeParameter.mockImplementation((name: string, fallback?: unknown) =>
+				name in params ? params[name] : fallback,
 			);
 		};
 
@@ -348,7 +347,12 @@ describe('Microsoft Teams Helpers Functions', () => {
 		});
 
 		it('should return the correct resource path for newChannelMessage event with a specific team and channel', async () => {
-			setParams({ watchAllTeams: false, teamId: 'team123', watchAllChannels: false, channelId: 'channel123' });
+			setParams({
+				watchAllTeams: false,
+				teamId: 'team123',
+				watchAllChannels: false,
+				channelId: 'channel123',
+			});
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
 			expect(result).toBe('/teams/team123/channels/channel123/messages');

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -10,14 +10,22 @@ import {
 	getResourcePath,
 	verifyWebhook,
 } from '../../v2/helpers/utils-trigger';
-import { microsoftApiRequest } from '../../v2/transport';
+import { microsoftApiRequest, SERVICE_PRINCIPAL_AUTH } from '../../v2/transport';
 import type { Mock } from 'vitest';
+import type * as _transport from '../../v2/transport';
 
-vi.mock('../../v2/transport', () => ({
-	microsoftApiRequest: {
-		call: vi.fn(),
-	},
-}));
+// Keep the real credential-resolution + path helpers (getTeamsCredentialType,
+// joinedTeamsEndpoint, buildTeamsPath) so the SP-gated trigger branches are
+// exercised; only stub the network helper.
+vi.mock('../../v2/transport', async () => {
+	const actual = await vi.importActual<typeof _transport>('../../v2/transport');
+	return {
+		...actual,
+		microsoftApiRequest: {
+			call: vi.fn(),
+		},
+	};
+});
 
 describe('Microsoft Teams Helpers Functions', () => {
 	let mockLoadOptionsFunctions: any;
@@ -291,74 +299,77 @@ describe('Microsoft Teams Helpers Functions', () => {
 	});
 
 	describe('getResourcePath', () => {
+		// Resolve getNodeParameter by NAME so a leading authentication read (the SP
+		// resolver) doesn't shift the assertion. `authentication` defaults to OAuth2.
+		const setParams = (params: Record<string, unknown>) => {
+			mockHookFunctions.getNodeParameter.mockImplementation(
+				(name: string, fallback?: unknown) =>
+					name in params ? params[name] : fallback,
+			);
+		};
+
 		it('should return the correct resource path for newChat event', async () => {
+			setParams({});
 			const result = await getResourcePath.call(mockHookFunctions, 'newChat');
 			expect(result).toBe('/me/chats');
 		});
 
 		it('should return the correct resource path for newChatMessage event with watchAllChats', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(true);
+			setParams({ watchAllChats: true });
 			const result = await getResourcePath.call(mockHookFunctions, 'newChatMessage');
 			expect(result).toBe('/me/chats/getAllMessages');
 		});
 
 		it('should return the correct resource path for newChatMessage event with chatId', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(false).mockReturnValueOnce('chat123');
+			setParams({ watchAllChats: false, chatId: 'chat123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChatMessage');
 			expect(result).toBe('/chats/chat123/messages');
 		});
 
 		it('should return the correct resource path for newChatMessage event with chatId missing', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(false);
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(undefined);
+			setParams({ watchAllChats: false, chatId: undefined });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChatMessage');
 			expect(result).toBe('/chats/undefined/messages');
 		});
 		it('should return the correct resource path for newChannel event', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(false);
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce('team123');
+			setParams({ watchAllTeams: false, teamId: 'team123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannel');
 			expect(result).toBe('/teams/team123/channels');
 		});
 
 		it('should return the correct resource path for newChannel event with teamId missing', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(undefined);
+			setParams({ watchAllTeams: false, teamId: undefined });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannel');
 			expect(result).toBe('/teams/undefined/channels');
 		});
 
 		it('should return the correct resource path for newChannelMessage event with a specific team and channel', async () => {
-			mockHookFunctions.getNodeParameter
-				.mockReturnValueOnce(false)
-				.mockReturnValueOnce('team123')
-				.mockReturnValueOnce(false)
-				.mockReturnValueOnce('channel123');
+			setParams({ watchAllTeams: false, teamId: 'team123', watchAllChannels: false, channelId: 'channel123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
 			expect(result).toBe('/teams/team123/channels/channel123/messages');
 		});
 
 		it('should return the correct resource path for newTeamMember event', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(false);
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce('team123');
+			setParams({ watchAllTeams: false, teamId: 'team123' });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
 			expect(result).toBe('/teams/team123/members');
 		});
 
 		it('should return the correct resource path for newTeamMember event with teamId missing', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(undefined);
+			setParams({ watchAllTeams: false, teamId: undefined });
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
 			expect(result).toBe('/teams/undefined/members');
 		});
 
 		it('should return the correct resource path for newTeamMember event with watchAllTeams', async () => {
-			mockHookFunctions.getNodeParameter.mockReturnValueOnce(true);
+			setParams({ watchAllTeams: true });
 
 			(microsoftApiRequest.call as Mock).mockResolvedValueOnce({
 				value: [
@@ -369,6 +380,55 @@ describe('Microsoft Teams Helpers Functions', () => {
 
 			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
 			expect(result).toEqual(['/teams/team1/members', '/teams/team2/members']);
+		});
+	});
+
+	describe('getResourcePath under the Service Principal credential', () => {
+		const setSpParams = (params: Record<string, unknown>) => {
+			mockHookFunctions.getNodeParameter.mockImplementation((name: string, fallback?: unknown) => {
+				if (name === 'authentication') return SERVICE_PRINCIPAL_AUTH;
+				return name in params ? params[name] : fallback;
+			});
+		};
+
+		it.each(['newChat', 'newChatMessage'])(
+			'throws a static error for %s and never composes a /me path',
+			async (event) => {
+				setSpParams({ watchAllChats: false, chatId: 'chat123' });
+
+				await expect(getResourcePath.call(mockHookFunctions, event)).rejects.toThrow(
+					'Chat triggers are not available with the Service Principal credential',
+				);
+				expect(microsoftApiRequest.call).not.toHaveBeenCalled();
+			},
+		);
+
+		it('encodes the teamId for newChannel (no decode round-trip, fetchAllTeams not called)', async () => {
+			setSpParams({ watchAllTeams: false, teamId: 'team_id-123' });
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannel');
+			expect(result).toBe('/teams/team_id-123/channels');
+			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
+		});
+
+		it('encodes teamId + channelId for newChannelMessage and rejects a crafted channelId', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: 'team123',
+				watchAllChannels: false,
+				channelId: 'c/../../groups/abc',
+			});
+
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannelMessage')).rejects.toThrow(
+				'The ID is not valid',
+			);
+		});
+
+		it('encodes the teamId for newTeamMember', async () => {
+			setSpParams({ watchAllTeams: false, teamId: 'team123' });
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
+			expect(result).toBe('/teams/team123/members');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -440,6 +440,36 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(result).not.toContain('%40');
 		});
 
+		it('decodes a By-URL (percent-encoded) channelId for newChannelMessage under SP (parity with OAuth2)', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: '1111-2222',
+				watchAllChannels: false,
+				// The By-URL mode extracts the channel id percent-encoded (19%3A...%40thread.tacv2).
+				channelId: '19%3Aabc%40thread.tacv2',
+			});
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
+			// Decoded to the raw id Graph matches against, identical to the OAuth2 path.
+			expect(result).toBe('/teams/1111-2222/channels/19:abc@thread.tacv2/messages');
+			expect(result).not.toContain('%3A');
+			expect(result).not.toContain('%40');
+		});
+
+		it('rejects a percent-encoded traversal channelId for newChannelMessage under SP (decoded before validation)', async () => {
+			setSpParams({
+				watchAllTeams: false,
+				teamId: 'team123',
+				watchAllChannels: false,
+				// %2F decodes to `/`; validation runs on the decoded value and rejects the traversal.
+				channelId: 'c%2F..%2F..%2Fgroups%2Fabc',
+			});
+
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannelMessage')).rejects.toThrow(
+				'The ID is not valid',
+			);
+		});
+
 		it('rejects a crafted (separator) channelId for newChannelMessage', async () => {
 			setSpParams({
 				watchAllTeams: false,

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -422,6 +422,7 @@ describe('Microsoft Teams Helpers Functions', () => {
 			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
 			expect(result).toBe('/teams/1111-2222/channels/19:abc@thread.tacv2/messages');
 			expect(result).not.toContain('%3A');
+			expect(result).not.toContain('%40');
 		});
 
 		it('rejects a crafted (separator) channelId for newChannelMessage', async () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.servicePrincipal.test.ts
@@ -1,0 +1,46 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// App-only (Service Principal) channel:getAll. The harness no-ops preAuthentication
+// but calls authenticate, so the Bearer comes straight from the inline accessToken
+// fixture — nock ONLY the Graph endpoint, never login.microsoftonline.com. The exact
+// path is pinned (no doubled segment, no /me) so a transport regression is caught.
+describe('Test MicrosoftTeamsV2, channel => getAll (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/teams/1111-2222-3333/channels')
+		.reply(200, {
+			value: [
+				{
+					id: '19:8662cdf2d8ff49eabdcf6364bc0fe3a2@thread.tacv2',
+					createdDateTime: '2022-03-26T17:18:30Z',
+					displayName: 'Sales East',
+					description: 'Description of Sales East',
+					isFavoriteByDefault: null,
+					email: null,
+					tenantId: 'tenantId-111-222-333',
+					webUrl:
+						'https://teams.microsoft.com/l/channel/19%3A8662cdf2d8ff49eabdcf6364bc0fe3a2%40thread.tacv2/Sales%20East?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False',
+					membershipType: 'standard',
+				},
+				{
+					id: '19:a95209ede91f4d5595ac944aeb172124@thread.tacv2',
+					createdDateTime: '2022-03-26T17:18:16Z',
+					displayName: 'General',
+					description: 'Description of U.S. Sales',
+					isFavoriteByDefault: null,
+					email: 'U.S.Sales@5w1hb7.onmicrosoft.com',
+					tenantId: 'tenantId-111-222-333',
+					webUrl:
+						'https://teams.microsoft.com/l/channel/19%3Aa95209ede91f4d5595ac944aeb172124%40thread.tacv2/U.S.%20Sales?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False',
+					membershipType: 'standard',
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAll.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/channel/getAll.servicePrincipal.workflow.json
@@ -1,0 +1,108 @@
+{
+  "name": "Teams channel getAll (Service Principal)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "6666-9999-77777",
+      "name": "When clicking \"Execute Workflow\"",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [880, 380]
+    },
+    {
+      "parameters": {
+        "authentication": "microsoftEntraServicePrincipalApi",
+        "operation": "getAll",
+        "teamId": {
+          "__rl": true,
+          "value": "1111-2222-3333",
+          "mode": "list",
+          "cachedResultName": "U.S. Sales"
+        }
+      },
+      "id": "6666-5555-77777",
+      "name": "Microsoft Teams",
+      "type": "n8n-nodes-base.microsoftTeams",
+      "typeVersion": 2,
+      "position": [1100, 380],
+      "credentials": {
+        "microsoftEntraServicePrincipalApi": {
+          "id": "spCredId",
+          "name": "Microsoft Entra Service Principal account"
+        }
+      }
+    },
+    {
+      "parameters": {},
+      "id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+      "name": "No Operation, do nothing",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [1400, 380]
+    }
+  ],
+  "pinData": {
+    "No Operation, do nothing": [
+      {
+        "json": {
+          "id": "19:8662cdf2d8ff49eabdcf6364bc0fe3a2@thread.tacv2",
+          "createdDateTime": "2022-03-26T17:18:30Z",
+          "displayName": "Sales East",
+          "description": "Description of Sales East",
+          "isFavoriteByDefault": null,
+          "email": null,
+          "tenantId": "tenantId-111-222-333",
+          "webUrl": "https://teams.microsoft.com/l/channel/19%3A8662cdf2d8ff49eabdcf6364bc0fe3a2%40thread.tacv2/Sales%20East?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False",
+          "membershipType": "standard"
+        }
+      },
+      {
+        "json": {
+          "id": "19:a95209ede91f4d5595ac944aeb172124@thread.tacv2",
+          "createdDateTime": "2022-03-26T17:18:16Z",
+          "displayName": "General",
+          "description": "Description of U.S. Sales",
+          "isFavoriteByDefault": null,
+          "email": "U.S.Sales@5w1hb7.onmicrosoft.com",
+          "tenantId": "tenantId-111-222-333",
+          "webUrl": "https://teams.microsoft.com/l/channel/19%3Aa95209ede91f4d5595ac944aeb172124%40thread.tacv2/U.S.%20Sales?groupId=1111-2222-3333&tenantId=tenantId-111-222-333&allowXTenantAccess=False",
+          "membershipType": "standard"
+        }
+      }
+    ]
+  },
+  "connections": {
+    "When clicking \"Execute Workflow\"": {
+      "main": [
+        [
+          {
+            "node": "Microsoft Teams",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Microsoft Teams": {
+      "main": [
+        [
+          {
+            "node": "No Operation, do nothing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "08f365b7-a03d-4d38-979e-edca8194d046",
+  "id": "i3NYGF0LXV4qDFVA",
+  "meta": {
+    "instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+  },
+  "tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -235,4 +235,81 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			},
 		);
 	});
+
+	describe('task body-ID validation under SP (defense-in-depth)', () => {
+		it.each([
+			['planId', { resource: 'task', operation: 'create', planId: 'p/../x', bucketId: 'b1' }],
+			['bucketId', { resource: 'task', operation: 'create', planId: 'p1', bucketId: 'b/../x' }],
+		])('task:create rejects a crafted %s before any request', async (_label, params) => {
+			selectSp({ ...params, title: 'x', options: {} });
+
+			await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		});
+
+		it('task:update rejects a crafted planId in the update body before any request', async () => {
+			// task:update reads updateFields, then per-key reads updateFields.<key>; the body
+			// validation runs before the GET/PATCH.
+			ctx.getNodeParameter.mockImplementation(
+				(name: string, _i?: number, fallback?: unknown): NodeParameterValueType => {
+					if (name === 'authentication') return SERVICE_PRINCIPAL_AUTH;
+					if (name === 'resource') return 'task';
+					if (name === 'operation') return 'update';
+					if (name === 'taskId') return 'valid-task-id';
+					if (name === 'updateFields') return { planId: 'p/../x' };
+					if (name === 'updateFields.planId') return 'p/../x';
+					return fallback as NodeParameterValueType;
+				},
+			);
+
+			await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('empty-ID validation under SP', () => {
+		it('channel:get with an empty channelId throws "A required ID is empty" before any request', async () => {
+			selectSp({
+				resource: 'channel',
+				operation: 'get',
+				teamId: '1111-2222-3333',
+				channelId: '',
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow('A required ID is empty');
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('channelMessage:getAll under SP with returnAll:false', () => {
+		it('hits the same /beta/.../messages endpoint (limit path)', async () => {
+			(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([
+				{ id: 'm1' },
+				{ id: 'm2' },
+			]);
+			ctx.helpers.returnJsonArray = vi.fn((data) =>
+				(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+			) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+			ctx.helpers.constructExecutionMetaData = vi.fn(
+				(data) => data,
+			) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+			selectSp({
+				resource: 'channelMessage',
+				operation: 'getAll',
+				teamId: '1111-2222-3333',
+				channelId: '19:abc@thread.tacv2',
+				returnAll: false,
+				limit: 1,
+			});
+
+			await node.execute.call(ctx);
+
+			expect(transport.microsoftApiRequestAllItems).toHaveBeenCalledWith(
+				'value',
+				'GET',
+				'/beta/teams/1111-2222-3333/channels/19:abc@thread.tacv2/messages',
+				{},
+			);
+		});
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -265,6 +265,43 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
 			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 		});
+
+		it('task:create with a By-ID assignee builds the app-only assignment from the user id', async () => {
+			(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'task-1' });
+			ctx.helpers.returnJsonArray = vi.fn((data) =>
+				(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+			) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+			ctx.helpers.constructExecutionMetaData = vi.fn(
+				(data) => data,
+			) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+			selectSp({
+				resource: 'task',
+				operation: 'create',
+				planId: 'plan-1',
+				bucketId: 'bucket-1',
+				title: 'My task',
+				options: { assignedTo: 'user-guid-123' },
+				'options.assignedTo': 'user-guid-123',
+			});
+
+			await node.execute.call(ctx);
+
+			expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/v1.0/planner/tasks',
+				expect.objectContaining({
+					planId: 'plan-1',
+					bucketId: 'bucket-1',
+					title: 'My task',
+					assignments: {
+						'user-guid-123': {
+							'@odata.type': 'microsoft.graph.plannerAssignment',
+							orderHint: ' !',
+						},
+					},
+				}),
+			);
+		});
 	});
 
 	describe('empty-ID validation under SP', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -1,0 +1,160 @@
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type { Mock } from 'vitest';
+import {
+	SEND_AND_WAIT_OPERATION,
+	type IExecuteFunctions,
+	type INode,
+	type NodeParameterValueType,
+} from 'n8n-workflow';
+
+import { versionDescription } from '../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../v2/MicrosoftTeamsV2.node';
+import { SERVICE_PRINCIPAL_AUTH } from '../../../v2/transport';
+import * as transport from '../../../v2/transport';
+import type * as _importType0 from '../../../v2/transport';
+
+// Real transport except for the network helper, so the real getTeamsCredentialType
+// (and thus the SP runtime guards) are exercised; only microsoftApiRequest /
+// microsoftApiRequestAllItems are stubbed to assert they are NOT called.
+vi.mock('../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
+	};
+});
+
+describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// Drives `getNodeParameter` so `authentication` resolves to the SP credential and
+	// other reads come from `params` (falling back to the provided fallback arg).
+	// `failOnTasksFor` proves the operation never reads `tasksFor` under SP.
+	const selectSp = (params: Record<string, unknown>, failOnTasksFor = false) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType => {
+				if (name === 'authentication') return SERVICE_PRINCIPAL_AUTH;
+				if (failOnTasksFor && name === 'tasksFor') {
+					throw new Error('tasksFor must not be read under the Service Principal credential');
+				}
+				return (name in params ? params[name] : fallback) as NodeParameterValueType;
+			},
+		);
+	};
+
+	it.each([
+		['create', 'create'],
+		['get', 'get'],
+		['getAll', 'getAll'],
+	])('chatMessage:%s throws a static error and issues no request under SP', async (_label, op) => {
+		selectSp({ resource: 'chatMessage', operation: op, chatId: 'chatID', returnAll: true });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Chat messages are not available with the Service Principal credential',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+	});
+
+	it('chatMessage:sendAndWait throws under SP and NEVER calls putExecutionToWait', async () => {
+		selectSp({
+			resource: 'chatMessage',
+			operation: SEND_AND_WAIT_OPERATION,
+			chatId: 'chatID',
+			message: 'hi',
+			'approvalOptions.values': {},
+			responseType: 'approval',
+			'options.limitWaitTime.values': {},
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Chat messages are not available with the Service Principal credential',
+		);
+		expect(ctx.putExecutionToWait).not.toHaveBeenCalled();
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('channelMessage:create throws a static error and issues no request under SP', async () => {
+		selectSp({
+			resource: 'channelMessage',
+			operation: 'create',
+			teamId: 'teamID',
+			channelId: 'channelID',
+			contentType: 'text',
+			message: 'hi',
+			options: {},
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Sending channel messages is not available with the Service Principal credential',
+		);
+		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+	});
+
+	describe('task:getAll under SP', () => {
+		it('forces plan mode, never reads tasksFor, and hits the exact plan-tasks path', async () => {
+			(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([{ id: 't1' }]);
+			// Happy path reaches the router's result assembly, so stub these helpers.
+			ctx.helpers.returnJsonArray = vi.fn((data) =>
+				(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+			) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+			ctx.helpers.constructExecutionMetaData = vi.fn(
+				(data) => data,
+			) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+			selectSp({ resource: 'task', operation: 'getAll', planId: 'plan-123', returnAll: true }, true);
+
+			await node.execute.call(ctx);
+
+			// Called via `.call(this, ...)`, so the recorded args start at the method's
+			// own parameters (the bound `this` is not an argument).
+			expect(transport.microsoftApiRequestAllItems).toHaveBeenCalledWith(
+				'value',
+				'GET',
+				'/v1.0/planner/plans/plan-123/tasks',
+			);
+			// app-only must never hit /me
+			const calledPath = (transport.microsoftApiRequestAllItems as Mock).mock.calls[0][2] as string;
+			expect(calledPath).not.toContain('/me');
+		});
+
+		it('rejects a crafted planId via buildTeamsPath under SP', async () => {
+			selectSp({
+				resource: 'task',
+				operation: 'getAll',
+				planId: 'x/../../groups/abc',
+				returnAll: true,
+			});
+
+			await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+			expect(transport.microsoftApiRequestAllItems).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('task path-id injection under SP', () => {
+		it.each(['get', 'deleteTask'])(
+			'task:%s rejects a crafted taskId via buildTeamsPath',
+			async (op) => {
+				selectSp({ resource: 'task', operation: op, taskId: 'x/../../planner/tasks/evil' });
+
+				await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+				expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+			},
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -146,6 +146,49 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		});
 	});
 
+	describe('channel:get under SP composes the proven raw Graph path', () => {
+		it('interpolates a real colon-bearing channelId RAW (not percent-encoded)', async () => {
+			(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'ch' });
+			ctx.helpers.returnJsonArray = vi.fn((data) =>
+				(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+			) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+			ctx.helpers.constructExecutionMetaData = vi.fn(
+				(data) => data,
+			) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+			selectSp({
+				resource: 'channel',
+				operation: 'get',
+				teamId: '1111-2222-3333',
+				channelId: '19:abc@thread.tacv2',
+			});
+
+			await node.execute.call(ctx);
+
+			expect(transport.microsoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/v1.0/teams/1111-2222-3333/channels/19:abc@thread.tacv2',
+			);
+			const calledPath = (transport.microsoftApiRequest as Mock).mock.calls[0][1] as string;
+			expect(calledPath).not.toContain('%3A');
+			expect(calledPath).not.toContain('%40');
+			expect(calledPath).not.toContain('/me');
+		});
+
+		it('rejects a separator-bearing channelId before any request', async () => {
+			selectSp({
+				resource: 'channel',
+				operation: 'get',
+				teamId: '1111-2222-3333',
+				channelId: 'x/../../groups/abc',
+			});
+
+			// channel:get wraps its body in a try/catch that rethrows a generic message, but
+			// the validator throw (a NodeOperationError) is surfaced before any request.
+			await expect(node.execute.call(ctx)).rejects.toThrow();
+			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('task path-id injection under SP', () => {
 		it.each(['get', 'deleteTask'])(
 			'task:%s rejects a crafted taskId via buildTeamsPath',

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -206,19 +206,22 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			expect(calledPath).not.toContain('/me');
 		});
 
-		it('rejects a separator-bearing channelId before any request', async () => {
-			selectSp({
-				resource: 'channel',
-				operation: 'get',
-				teamId: '1111-2222-3333',
-				channelId: 'x/../../groups/abc',
-			});
+		it.each(['get', 'deleteChannel'])(
+			'channel:%s rejects a separator-bearing channelId before any request',
+			async (op) => {
+				selectSp({
+					resource: 'channel',
+					operation: op,
+					teamId: '1111-2222-3333',
+					channelId: 'x/../../groups/abc',
+				});
 
-			// channel:get wraps its body in a try/catch that rethrows a generic message, but
-			// the validator throw (a NodeOperationError) is surfaced before any request.
-			await expect(node.execute.call(ctx)).rejects.toThrow();
-			expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
-		});
+				// The path (and its validation) is built outside the op's try/catch, so the
+				// validator's specific message surfaces instead of the generic "doesn't exist" one.
+				await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+				expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
+			},
+		);
 	});
 
 	describe('task path-id injection under SP', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -107,6 +107,35 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 		expect(transport.microsoftApiRequest).not.toHaveBeenCalled();
 	});
 
+	it('channelMessage:getAll under SP hits the exact raw /beta path (colon id, not encoded, no /me)', async () => {
+		(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([{ id: 'm1' }]);
+		ctx.helpers.returnJsonArray = vi.fn((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+		ctx.helpers.constructExecutionMetaData = vi.fn(
+			(data) => data,
+		) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+		selectSp({
+			resource: 'channelMessage',
+			operation: 'getAll',
+			teamId: '1111-2222-3333',
+			channelId: '19:abc@thread.tacv2',
+			returnAll: true,
+		});
+
+		await node.execute.call(ctx);
+
+		expect(transport.microsoftApiRequestAllItems).toHaveBeenCalledWith(
+			'value',
+			'GET',
+			'/beta/teams/1111-2222-3333/channels/19:abc@thread.tacv2/messages',
+		);
+		const calledPath = (transport.microsoftApiRequestAllItems as Mock).mock.calls[0][2] as string;
+		expect(calledPath).not.toContain('%3A');
+		// no `/me` user-scope segment (the `me` in `/messages` is not a segment)
+		expect(calledPath).not.toMatch(/\/me(\/|$)/);
+	});
+
 	describe('task:getAll under SP', () => {
 		it('forces plan mode, never reads tasksFor, and hits the exact plan-tasks path', async () => {
 			(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([{ id: 't1' }]);

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/servicePrincipal.test.ts
@@ -146,7 +146,10 @@ describe('Microsoft Teams V2 — Service Principal runtime guards', () => {
 			ctx.helpers.constructExecutionMetaData = vi.fn(
 				(data) => data,
 			) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
-			selectSp({ resource: 'task', operation: 'getAll', planId: 'plan-123', returnAll: true }, true);
+			selectSp(
+				{ resource: 'task', operation: 'getAll', planId: 'plan-123', returnAll: true },
+				true,
+			);
 
 			await node.execute.call(ctx);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.memberMode.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.memberMode.test.ts
@@ -1,0 +1,77 @@
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+import type { Mock } from 'vitest';
+import type { IExecuteFunctions, INode, NodeParameterValueType } from 'n8n-workflow';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+// OAuth2 task:getAll member-mode regression lock. Mirrors the SP "forces plan, never
+// reads tasksFor" test: under OAuth2 with tasksFor='member' the operation MUST read
+// `tasksFor`, resolve the signed-in user via /v1.0/me, then list that user's tasks.
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+		microsoftApiRequestAllItems: vi.fn(),
+	};
+});
+
+describe('Test MicrosoftTeamsV2, task => getAll (OAuth2 member mode)', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+
+	beforeEach(() => {
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray = vi.fn((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		) as unknown as IExecuteFunctions['helpers']['returnJsonArray'];
+		ctx.helpers.constructExecutionMetaData = vi.fn(
+			(data) => data,
+		) as unknown as IExecuteFunctions['helpers']['constructExecutionMetaData'];
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('reads tasksFor and composes the member-mode endpoint under OAuth2', async () => {
+		(transport.microsoftApiRequest as Mock).mockResolvedValue({ id: 'me-123' });
+		(transport.microsoftApiRequestAllItems as Mock).mockResolvedValue([{ id: 't1' }]);
+
+		const params: Record<string, unknown> = {
+			resource: 'task',
+			operation: 'getAll',
+			authentication: 'microsoftTeamsOAuth2Api',
+			tasksFor: 'member',
+			returnAll: true,
+		};
+		let readTasksFor = false;
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _i?: number, fallback?: unknown): NodeParameterValueType => {
+				if (name === 'tasksFor') readTasksFor = true;
+				return (name in params ? params[name] : fallback) as NodeParameterValueType;
+			},
+		);
+
+		await node.execute.call(ctx);
+
+		// the OAuth2 member path MUST read tasksFor (the mirror of the SP "never reads it")
+		expect(readTasksFor).toBe(true);
+		// resolves the signed-in user, then lists that user's tasks
+		expect(transport.microsoftApiRequest).toHaveBeenCalledWith('GET', '/v1.0/me');
+		expect(transport.microsoftApiRequestAllItems).toHaveBeenCalledWith(
+			'value',
+			'GET',
+			'/v1.0/users/me-123/planner/tasks',
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.servicePrincipal.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.servicePrincipal.test.ts
@@ -1,0 +1,38 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+// App-only (Service Principal) task:getAll. Under the SP credential the operation is
+// forced to plan mode (no /me), so it must hit the exact plan-tasks path. The harness
+// no-ops preAuthentication but calls authenticate (Bearer from the inline accessToken
+// fixture) — nock ONLY the Graph endpoint, never login.microsoftonline.com.
+describe('Test MicrosoftTeamsV2, task => getAll (Service Principal)', () => {
+	nock('https://graph.microsoft.com')
+		.get('/v1.0/planner/plans/coJdCqzqNUKULQtTRWDa6pgACTln/tasks')
+		.reply(200, {
+			value: [
+				{
+					'@odata.etag': 'W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAZCc="',
+					planId: 'coJdCqzqNUKULQtTRWDa6pgACTln',
+					bucketId: null,
+					title: 'tada',
+					percentComplete: 10,
+					id: '1KgwUqOmbU2C9mZWiqxiv5gAPp8Q',
+				},
+				{
+					'@odata.etag': 'W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="',
+					planId: 'coJdCqzqNUKULQtTRWDa6pgACTln',
+					bucketId: '2avE1BwPmEKp7Lxh0E-EmZgALF72',
+					title: '1',
+					percentComplete: 0,
+					id: 'J3MLUgtmJ06YJgenyujiYpgANMF1',
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAll.servicePrincipal.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.servicePrincipal.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/task/getAll.servicePrincipal.workflow.json
@@ -1,0 +1,103 @@
+{
+  "name": "Teams task getAll (Service Principal)",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "6666-9999-77777",
+      "name": "When clicking \"Execute Workflow\"",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [880, 380]
+    },
+    {
+      "parameters": {
+        "authentication": "microsoftEntraServicePrincipalApi",
+        "resource": "task",
+        "operation": "getAll",
+        "planId": {
+          "__rl": true,
+          "value": "coJdCqzqNUKULQtTRWDa6pgACTln",
+          "mode": "id"
+        },
+        "returnAll": true
+      },
+      "id": "6666-5555-77777",
+      "name": "Microsoft Teams",
+      "type": "n8n-nodes-base.microsoftTeams",
+      "typeVersion": 2,
+      "position": [1100, 380],
+      "credentials": {
+        "microsoftEntraServicePrincipalApi": {
+          "id": "spCredId",
+          "name": "Microsoft Entra Service Principal account"
+        }
+      }
+    },
+    {
+      "parameters": {},
+      "id": "9d1a2e59-c71c-486c-b3ac-dec6adbc26b3",
+      "name": "No Operation, do nothing",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [1400, 380]
+    }
+  ],
+  "pinData": {
+    "No Operation, do nothing": [
+      {
+        "json": {
+          "@odata.etag": "W/\"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAZCc=\"",
+          "planId": "coJdCqzqNUKULQtTRWDa6pgACTln",
+          "bucketId": null,
+          "title": "tada",
+          "percentComplete": 10,
+          "id": "1KgwUqOmbU2C9mZWiqxiv5gAPp8Q"
+        }
+      },
+      {
+        "json": {
+          "@odata.etag": "W/\"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc=\"",
+          "planId": "coJdCqzqNUKULQtTRWDa6pgACTln",
+          "bucketId": "2avE1BwPmEKp7Lxh0E-EmZgALF72",
+          "title": "1",
+          "percentComplete": 0,
+          "id": "J3MLUgtmJ06YJgenyujiYpgANMF1"
+        }
+      }
+    ]
+  },
+  "connections": {
+    "When clicking \"Execute Workflow\"": {
+      "main": [
+        [
+          {
+            "node": "Microsoft Teams",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Microsoft Teams": {
+      "main": [
+        [
+          {
+            "node": "No Operation, do nothing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "34bcdc66-9dad-4c93-8456-4019f94c2f89",
+  "id": "i3NYGF0LXV4qDFVB",
+  "meta": {
+    "instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+  },
+  "tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -139,6 +139,65 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 		});
 	});
 
+	describe('task:create — By-ID plan/bucket under SP, group hidden', () => {
+		const fields = actionProps.filter(
+			(p) =>
+				p.displayOptions?.show?.resource?.includes('task') &&
+				p.displayOptions?.show?.operation?.includes('create'),
+		);
+
+		it('the OAuth2 group picker is hidden under SP', () => {
+			const group = byName(fields, 'groupId').find((p) => isSpHidden(p));
+			expect(group).toBeDefined();
+		});
+
+		it.each(['planId', 'bucketId'])(
+			'an SP-shown By-ID %s picker exists (no list, no deps)',
+			(name) => {
+				const spCopy = byName(fields, name).find((p) => isSpShown(p));
+				expect(spCopy).toBeDefined();
+				expect((spCopy?.default as { mode?: string })?.mode).toBe('id');
+				expect(spCopy?.modes?.some((m) => m.name === 'list')).toBe(false);
+				expect(spCopy?.typeOptions?.loadOptionsDependsOn).toBeUndefined();
+			},
+		);
+
+		it.each(['planId', 'bucketId'])('the OAuth2 list-mode %s picker is hidden under SP', (name) => {
+			const oauthCopy = byName(fields, name).find((p) => isSpHidden(p));
+			expect(oauthCopy).toBeDefined();
+		});
+	});
+
+	describe('task:update — By-ID plan/bucket under SP inside updateFields, group hidden', () => {
+		const updateFields = actionProps.find(
+			(p) =>
+				p.name === 'updateFields' &&
+				p.displayOptions?.show?.resource?.includes('task') &&
+				p.displayOptions?.show?.operation?.includes('update'),
+		);
+		const options = (updateFields?.options ?? []) as INodeProperties[];
+		const byOptName = (name: string) => options.filter((o) => o.name === name);
+
+		it('the OAuth2 group picker is hidden under SP', () => {
+			expect(byOptName('groupId').some((p) => isSpHidden(p))).toBe(true);
+		});
+
+		it.each(['planId', 'bucketId'])(
+			'an SP-shown By-ID %s picker exists (no list, no deps)',
+			(name) => {
+				const spCopy = byOptName(name).find((p) => isSpShown(p));
+				expect(spCopy).toBeDefined();
+				expect((spCopy?.default as { mode?: string })?.mode).toBe('id');
+				expect(spCopy?.modes?.some((m) => m.name === 'list')).toBe(false);
+				expect(spCopy?.typeOptions?.loadOptionsDependsOn).toBeUndefined();
+			},
+		);
+
+		it.each(['planId', 'bucketId'])('the OAuth2 list-mode %s picker is hidden under SP', (name) => {
+			expect(byOptName(name).some((p) => isSpHidden(p))).toBe(true);
+		});
+	});
+
 	describe('trigger — watch-all and chat fields hidden under SP', () => {
 		it.each(['watchAllTeams', 'watchAllChannels'])('%s carries hide["/authentication"]', (name) => {
 			const field = triggerProps.find((p) => p.name === name);

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -237,5 +237,21 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			const field = triggerProps.find((p) => p.name === name);
 			expect(isSpHidden(field)).toBe(true);
 		});
+
+		// Regression: the watch-all toggles are hidden under SP, so they resolve to `undefined`.
+		// The dependent pickers must gate on `_cnd: { not: true }` (matches `false` AND `undefined`),
+		// not a plain `[false]` — otherwise the Team/Channel pickers disappear under SP.
+		it.each(['teamId', 'channelId'])(
+			'the %s picker gates watchAllTeams with _cnd:{not:true} (renders under SP)',
+			(name) => {
+				const field = triggerProps.find((p) => p.name === name);
+				expect(field?.displayOptions?.show?.watchAllTeams).toEqual([{ _cnd: { not: true } }]);
+			},
+		);
+
+		it('the channelId picker gates watchAllChannels with _cnd:{not:true} (renders under SP)', () => {
+			const channel = triggerProps.find((p) => p.name === 'channelId');
+			expect(channel?.displayOptions?.show?.watchAllChannels).toEqual([{ _cnd: { not: true } }]);
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -166,6 +166,23 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			const oauthCopy = byName(fields, name).find((p) => isSpHidden(p));
 			expect(oauthCopy).toBeDefined();
 		});
+
+		// `assignedTo` (member RLC) lives inside the `options` collection.
+		const optionFields = (fields.find((p) => p.name === 'options')?.options ??
+			[]) as INodeProperties[];
+		const assignedToCopies = optionFields.filter((o) => o.name === 'assignedTo');
+
+		it('an SP-shown By-ID assignedTo picker exists (no list, no deps)', () => {
+			const spCopy = assignedToCopies.find((p) => isSpShown(p));
+			expect(spCopy).toBeDefined();
+			expect((spCopy?.default as { mode?: string })?.mode).toBe('id');
+			expect(spCopy?.modes?.some((m) => m.name === 'list')).toBe(false);
+			expect(spCopy?.typeOptions?.loadOptionsDependsOn).toBeUndefined();
+		});
+
+		it('the OAuth2 list-mode assignedTo picker is hidden under SP', () => {
+			expect(assignedToCopies.some((p) => isSpHidden(p))).toBe(true);
+		});
 	});
 
 	describe('task:update — By-ID plan/bucket under SP inside updateFields, group hidden', () => {
@@ -195,6 +212,18 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 
 		it.each(['planId', 'bucketId'])('the OAuth2 list-mode %s picker is hidden under SP', (name) => {
 			expect(byOptName(name).some((p) => isSpHidden(p))).toBe(true);
+		});
+
+		it('an SP-shown By-ID assignedTo picker exists (no list, no deps)', () => {
+			const spCopy = byOptName('assignedTo').find((p) => isSpShown(p));
+			expect(spCopy).toBeDefined();
+			expect((spCopy?.default as { mode?: string })?.mode).toBe('id');
+			expect(spCopy?.modes?.some((m) => m.name === 'list')).toBe(false);
+			expect(spCopy?.typeOptions?.loadOptionsDependsOn).toBeUndefined();
+		});
+
+		it('the OAuth2 list-mode assignedTo picker is hidden under SP', () => {
+			expect(byOptName('assignedTo').some((p) => isSpHidden(p))).toBe(true);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -126,6 +126,17 @@ describe('Microsoft Teams Service Principal displayOptions contract', () => {
 			const planCopies = byName(taskGetAllFields, 'planId');
 			expect(planCopies.some((p) => isSpShown(p))).toBe(true);
 		});
+
+		it('the SP-shown plan picker defaults to By-ID mode with no auto-firing list', () => {
+			const spPlan = byName(taskGetAllFields, 'planId').find((p) => isSpShown(p));
+			expect(spPlan).toBeDefined();
+			// By-ID default so the dropdown never auto-fires getPlans with an empty groupId
+			// (which would hit the SP empty-id validation error).
+			expect((spPlan?.default as { mode?: string })?.mode).toBe('id');
+			// no list mode, and no group dependency that would trigger a load.
+			expect(spPlan?.modes?.some((m) => m.name === 'list')).toBe(false);
+			expect(spPlan?.typeOptions?.loadOptionsDependsOn).toBeUndefined();
+		});
 	});
 
 	describe('trigger — watch-all and chat fields hidden under SP', () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/servicePrincipalDisplayOptions.test.ts
@@ -1,0 +1,142 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import { MicrosoftTeamsTrigger } from '../../MicrosoftTeamsTrigger.node';
+import { versionDescription } from '../../v2/actions/versionDescription';
+import { SERVICE_PRINCIPAL_AUTH } from '../../v2/transport';
+
+const actionProps = versionDescription.properties;
+const triggerProps = new MicrosoftTeamsTrigger().description.properties;
+
+/** All resolved copies of a field (by name) — there can be several (RLC variants). */
+const byName = (props: INodeProperties[], name: string) =>
+	props.filter((property) => property.name === name);
+
+const isSpHidden = (property?: INodeProperties) =>
+	Array.isArray(property?.displayOptions?.hide?.['/authentication']) &&
+	property?.displayOptions?.hide?.['/authentication']?.includes(SERVICE_PRINCIPAL_AUTH);
+
+const isSpShown = (property?: INodeProperties) =>
+	property?.displayOptions?.show?.['/authentication']?.includes(SERVICE_PRINCIPAL_AUTH) === true;
+
+describe('Microsoft Teams Service Principal displayOptions contract', () => {
+	describe('credential entry uses the un-prefixed show.authentication key', () => {
+		it.each([
+			['action node', versionDescription.credentials ?? []],
+			['trigger node', new MicrosoftTeamsTrigger().description.credentials ?? []],
+		])('%s gates the SP credential with show.authentication (no slash prefix)', (_l, creds) => {
+			const spCredential = creds.find((c) => c.name === SERVICE_PRINCIPAL_AUTH);
+			expect(spCredential?.required).toBe(true);
+			expect(spCredential?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+			// the credential entry must NOT use the slash-prefixed field-level key
+			expect(spCredential?.displayOptions?.show?.['/authentication']).toBeUndefined();
+		});
+	});
+
+	describe('chatMessage — hidden under SP via the slash-prefixed field-level key', () => {
+		it('operation selector carries hide["/authentication"] = [SP]', () => {
+			const op = actionProps.find(
+				(p) => p.name === 'operation' && p.displayOptions?.show?.resource?.includes('chatMessage'),
+			);
+			expect(isSpHidden(op)).toBe(true);
+			// distinct from the un-prefixed credential gate
+			expect(op?.displayOptions?.hide?.authentication).toBeUndefined();
+		});
+
+		it('every chatMessage field copy is hidden under SP', () => {
+			const chatFields = actionProps.filter((p) =>
+				p.displayOptions?.show?.resource?.includes('chatMessage'),
+			);
+			// the chatId RLC, message, contentType, options, messageId, send-and-wait props…
+			const gatedFields = chatFields.filter((p) => p.type !== 'notice' && p.name !== 'operation');
+			expect(gatedFields.length).toBeGreaterThan(0);
+			for (const field of gatedFields) {
+				expect(isSpHidden(field)).toBe(true);
+			}
+		});
+
+		it('shows an SP notice for the chatMessage resource', () => {
+			const notice = actionProps.find(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.resource?.includes('chatMessage') &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			expect(notice).toBeDefined();
+			expect(notice?.displayOptions?.show?.authentication).toEqual([SERVICE_PRINCIPAL_AUTH]);
+		});
+	});
+
+	describe('channelMessage — only create hidden under SP', () => {
+		it('create fields are hidden, getAll fields are shown', () => {
+			const createFields = actionProps.filter(
+				(p) =>
+					p.type !== 'notice' &&
+					p.displayOptions?.show?.resource?.includes('channelMessage') &&
+					p.displayOptions?.show?.operation?.includes('create'),
+			);
+			expect(createFields.length).toBeGreaterThan(0);
+			for (const field of createFields) {
+				expect(isSpHidden(field)).toBe(true);
+			}
+
+			const getAllFields = actionProps.filter(
+				(p) =>
+					p.type !== 'notice' &&
+					p.displayOptions?.show?.resource?.includes('channelMessage') &&
+					p.displayOptions?.show?.operation?.includes('getAll'),
+			);
+			expect(getAllFields.length).toBeGreaterThan(0);
+			for (const field of getAllFields) {
+				expect(isSpHidden(field)).toBe(false);
+			}
+		});
+
+		it('has both the create and the getAll SP notices', () => {
+			const notices = actionProps.filter(
+				(p) =>
+					p.type === 'notice' &&
+					p.displayOptions?.show?.resource?.includes('channelMessage') &&
+					p.displayOptions?.show?.authentication?.includes(SERVICE_PRINCIPAL_AUTH),
+			);
+			const operations = notices.flatMap((n) => n.displayOptions?.show?.operation ?? []);
+			expect(operations).toContain('create');
+			expect(operations).toContain('getAll');
+		});
+	});
+
+	describe('task:getAll — plan picker shown, member-mode hidden under SP', () => {
+		const taskGetAllFields = actionProps.filter(
+			(p) =>
+				p.displayOptions?.show?.resource?.includes('task') &&
+				p.displayOptions?.show?.operation?.includes('getAll'),
+		);
+
+		it('tasksFor is hidden under SP', () => {
+			const tasksFor = taskGetAllFields.find((p) => p.name === 'tasksFor');
+			expect(isSpHidden(tasksFor)).toBe(true);
+		});
+
+		it('the member-mode group picker (first groupId) is hidden under SP', () => {
+			const groupCopies = byName(taskGetAllFields, 'groupId');
+			expect(groupCopies.length).toBeGreaterThan(0);
+			expect(isSpHidden(groupCopies[0])).toBe(true);
+		});
+
+		it('an SP-shown plan picker exists', () => {
+			const planCopies = byName(taskGetAllFields, 'planId');
+			expect(planCopies.some((p) => isSpShown(p))).toBe(true);
+		});
+	});
+
+	describe('trigger — watch-all and chat fields hidden under SP', () => {
+		it.each(['watchAllTeams', 'watchAllChannels'])('%s carries hide["/authentication"]', (name) => {
+			const field = triggerProps.find((p) => p.name === name);
+			expect(isSpHidden(field)).toBe(true);
+		});
+
+		it.each(['watchAllChats', 'chatId'])('chat field %s is hidden under SP', (name) => {
+			const field = triggerProps.find((p) => p.name === name);
+			expect(isSpHidden(field)).toBe(true);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/create.operation.ts
@@ -3,7 +3,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { teamRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	teamRLC,
@@ -79,5 +79,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	if (options.type) {
 		body.membershipType = options.type as string;
 	}
-	return await microsoftApiRequest.call(this, 'POST', `/v1.0/teams/${teamId}/channels`, body);
+	return await microsoftApiRequest.call(
+		this,
+		'POST',
+		buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels']),
+		body,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/deleteChannel.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/deleteChannel.operation.ts
@@ -19,15 +19,19 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions, i: number) {
 	//https://docs.microsoft.com/en-us/graph/api/channel-delete?view=graph-rest-beta&tabs=http
 
-	try {
-		const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
-		const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
+	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	// Build (and validate) the path outside the try so an invalid-ID error surfaces
+	// with its specific message instead of the generic "channel doesn't exist" below.
+	const endpoint = buildTeamsPath.call(this, [
+		'/v1.0/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+	]);
 
-		await microsoftApiRequest.call(
-			this,
-			'DELETE',
-			buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels/', { id: channelId }]),
-		);
+	try {
+		await microsoftApiRequest.call(this, 'DELETE', endpoint);
 		return { success: true };
 	} catch (error) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/deleteChannel.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/deleteChannel.operation.ts
@@ -3,7 +3,7 @@ import { type INodeProperties, type IExecuteFunctions, NodeOperationError } from
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { channelRLC, teamRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [teamRLC, channelRLC];
 
@@ -23,7 +23,11 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
 		const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
 
-		await microsoftApiRequest.call(this, 'DELETE', `/v1.0/teams/${teamId}/channels/${channelId}`);
+		await microsoftApiRequest.call(
+			this,
+			'DELETE',
+			buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels/', { id: channelId }]),
+		);
 		return { success: true };
 	} catch (error) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/get.operation.ts
@@ -19,15 +19,19 @@ export const description = updateDisplayOptions(displayOptions, properties);
 export async function execute(this: IExecuteFunctions, i: number) {
 	//https://docs.microsoft.com/en-us/graph/api/channel-get?view=graph-rest-beta&tabs=http
 
-	try {
-		const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
-		const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
+	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
+	// Build (and validate) the path outside the try so an invalid-ID error surfaces
+	// with its specific message instead of the generic "channel doesn't exist" below.
+	const endpoint = buildTeamsPath.call(this, [
+		'/v1.0/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+	]);
 
-		return await microsoftApiRequest.call(
-			this,
-			'GET',
-			buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels/', { id: channelId }]),
-		);
+	try {
+		return await microsoftApiRequest.call(this, 'GET', endpoint);
 	} catch (error) {
 		throw new NodeOperationError(
 			this.getNode(),

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/get.operation.ts
@@ -3,7 +3,7 @@ import { type INodeProperties, type IExecuteFunctions, NodeOperationError } from
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { channelRLC, teamRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [teamRLC, channelRLC];
 
@@ -26,7 +26,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		return await microsoftApiRequest.call(
 			this,
 			'GET',
-			`/v1.0/teams/${teamId}/channels/${channelId}`,
+			buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels/', { id: channelId }]),
 		);
 	} catch (error) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/getAll.operation.ts
@@ -4,7 +4,7 @@ import { returnAllOrLimit } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { teamRLC } from '../../descriptions';
-import { microsoftApiRequestAllItems } from '../../transport';
+import { buildTeamsPath, microsoftApiRequestAllItems } from '../../transport';
 
 const properties: INodeProperties[] = [teamRLC, ...returnAllOrLimit];
 
@@ -22,22 +22,12 @@ export async function execute(this: IExecuteFunctions, i: number) {
 
 	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
 	const returnAll = this.getNodeParameter('returnAll', i);
+	const endpoint = buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels']);
 	if (returnAll) {
-		return await microsoftApiRequestAllItems.call(
-			this,
-			'value',
-			'GET',
-			`/v1.0/teams/${teamId}/channels`,
-		);
+		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
 	} else {
 		const limit = this.getNodeParameter('limit', i);
-		const responseData = await microsoftApiRequestAllItems.call(
-			this,
-			'value',
-			'GET',
-			`/v1.0/teams/${teamId}/channels`,
-			{},
-		);
+		const responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint, {});
 		return responseData.splice(0, limit);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channel/update.operation.ts
@@ -3,7 +3,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { channelRLC, teamRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	teamRLC,
@@ -64,7 +64,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	await microsoftApiRequest.call(
 		this,
 		'PATCH',
-		`/v1.0/teams/${teamId}/channels/${channelId}`,
+		buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels/', { id: channelId }]),
 		body,
 	);
 	return { success: true };

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/create.operation.ts
@@ -1,10 +1,21 @@
-import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workflow';
+import {
+	NodeOperationError,
+	type INodeProperties,
+	type IExecuteFunctions,
+	type IDataObject,
+} from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { channelRLC, teamRLC } from '../../descriptions';
 import { prepareMessage } from '../../helpers/utils';
-import { microsoftApiRequest } from '../../transport';
+import {
+	buildTeamsPath,
+	getTeamsCredentialType,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+	SP_HIDE,
+} from '../../transport';
 
 const properties: INodeProperties[] = [
 	teamRLC,
@@ -71,6 +82,9 @@ const displayOptions = {
 		resource: ['channelMessage'],
 		operation: ['create'],
 	},
+	hide: {
+		...SP_HIDE,
+	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
@@ -83,6 +97,20 @@ export async function execute(
 ) {
 	//https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-beta&tabs=http
 	//https://docs.microsoft.com/en-us/graph/api/channel-post-messagereply?view=graph-rest-beta&tabs=http
+
+	// App-only Graph exposes channel-message posting only via migration import, so
+	// it has no usable form here; fail before any request for hand-edited workflows.
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Sending channel messages is not available with the Service Principal credential',
+			{
+				itemIndex: i,
+				description:
+					'App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to post messages.',
+			},
+		);
+	}
 
 	const teamId = this.getNodeParameter('teamId', i, '', { extractValue: true }) as string;
 	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
@@ -108,14 +136,28 @@ export async function execute(
 		return await microsoftApiRequest.call(
 			this,
 			'POST',
-			`/beta/teams/${teamId}/channels/${channelId}/messages/${replyToId}/replies`,
+			buildTeamsPath.call(this, [
+				'/beta/teams/',
+				{ id: teamId },
+				'/channels/',
+				{ id: channelId },
+				'/messages/',
+				{ id: replyToId },
+				'/replies',
+			]),
 			body,
 		);
 	} else {
 		return await microsoftApiRequest.call(
 			this,
 			'POST',
-			`/beta/teams/${teamId}/channels/${channelId}/messages`,
+			buildTeamsPath.call(this, [
+				'/beta/teams/',
+				{ id: teamId },
+				'/channels/',
+				{ id: channelId },
+				'/messages',
+			]),
 			body,
 		);
 	}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/getAll.operation.ts
@@ -4,7 +4,7 @@ import { returnAllOrLimit } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { channelRLC, teamRLC } from '../../descriptions';
-import { microsoftApiRequestAllItems } from '../../transport';
+import { buildTeamsPath, microsoftApiRequestAllItems } from '../../transport';
 
 const properties: INodeProperties[] = [teamRLC, channelRLC, ...returnAllOrLimit];
 
@@ -24,22 +24,19 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	const channelId = this.getNodeParameter('channelId', i, '', { extractValue: true }) as string;
 	const returnAll = this.getNodeParameter('returnAll', i);
 
+	const endpoint = buildTeamsPath.call(this, [
+		'/beta/teams/',
+		{ id: teamId },
+		'/channels/',
+		{ id: channelId },
+		'/messages',
+	]);
+
 	if (returnAll) {
-		return await microsoftApiRequestAllItems.call(
-			this,
-			'value',
-			'GET',
-			`/beta/teams/${teamId}/channels/${channelId}/messages`,
-		);
+		return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
 	} else {
 		const limit = this.getNodeParameter('limit', i);
-		const responseData = await microsoftApiRequestAllItems.call(
-			this,
-			'value',
-			'GET',
-			`/beta/teams/${teamId}/channels/${channelId}/messages`,
-			{},
-		);
+		const responseData = await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint, {});
 		return responseData.splice(0, limit);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/channelMessage/index.ts
@@ -2,6 +2,7 @@ import type { INodeProperties } from 'n8n-workflow';
 
 import * as create from './create.operation';
 import * as getAll from './getAll.operation';
+import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
 
 export { create, getAll };
 
@@ -31,6 +32,34 @@ export const description: INodeProperties[] = [
 			},
 		],
 		default: 'create',
+	},
+	{
+		displayName:
+			'Sending channel messages is not available with the Service Principal credential (app-only Graph supports only migration import). Use an OAuth2 credential to post messages.',
+		name: 'channelMessageCreateServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['channelMessage'],
+				operation: ['create'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
+	{
+		displayName:
+			'Reading channel messages with the Service Principal credential uses the metered Microsoft Teams API, which may require billing/eval-model configuration on the tenant.',
+		name: 'channelMessageGetAllServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['channelMessage'],
+				operation: ['getAll'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
 	},
 
 	...create.description,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
@@ -91,5 +91,7 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 		instanceId,
 	);
 
+	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
+	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
 	return await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
@@ -4,7 +4,8 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
 import { prepareMessage } from '../../helpers/utils';
-import { microsoftApiRequest } from '../../transport';
+import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [
 	chatRLC,
@@ -62,12 +63,18 @@ const displayOptions = {
 		resource: ['chatMessage'],
 		operation: ['create'],
 	},
+	hide: {
+		...SP_HIDE,
+	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number, instanceId: string) {
 	// https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http
+
+	// App-only Graph cannot post chat messages; fail before any request.
+	throwIfChatUnsupported.call(this);
 
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 	const contentType = this.getNodeParameter('contentType', i) as string;

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
@@ -42,6 +42,8 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 		const messageId = this.getNodeParameter('messageId', i) as string;
 
+		// OAuth2-only path (chat is hidden + guarded under SP), so `chatId` is
+		// interpolated raw without buildTeamsPath by design.
 		return await microsoftApiRequest.call(
 			this,
 			'GET',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
@@ -3,7 +3,8 @@ import { type INodeProperties, type IExecuteFunctions, NodeOperationError } from
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [
 	chatRLC,
@@ -23,12 +24,19 @@ const displayOptions = {
 		resource: ['chatMessage'],
 		operation: ['get'],
 	},
+	hide: {
+		...SP_HIDE,
+	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://docs.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http
+
+	// App-only Graph cannot read chats; fail before the request (and before the
+	// catch below, so the static SP message is surfaced, not the generic one).
+	throwIfChatUnsupported.call(this);
 
 	try {
 		const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -27,6 +27,8 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	// App-only Graph cannot read chats; fail before any request.
 	throwIfChatUnsupported.call(this);
 
+	// OAuth2-only path (chat is hidden + guarded under SP), so `chatId` below is
+	// interpolated raw without buildTeamsPath by design.
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 	const returnAll = this.getNodeParameter('returnAll', i);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -4,7 +4,8 @@ import { returnAllOrLimit } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequestAllItems } from '../../transport';
+import { microsoftApiRequestAllItems, SP_HIDE } from '../../transport';
+import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [chatRLC, ...returnAllOrLimit];
 
@@ -13,12 +14,18 @@ const displayOptions = {
 		resource: ['chatMessage'],
 		operation: ['getAll'],
 	},
+	hide: {
+		...SP_HIDE,
+	},
 };
 
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
 	// https://docs.microsoft.com/en-us/graph/api/chat-list-messages?view=graph-rest-1.0&tabs=http
+
+	// App-only Graph cannot read chats; fail before any request.
+	throwIfChatUnsupported.call(this);
 
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 	const returnAll = this.getNodeParameter('returnAll', i);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/index.ts
@@ -4,10 +4,24 @@ import * as create from './create.operation';
 import * as get from './get.operation';
 import * as getAll from './getAll.operation';
 import * as sendAndWait from './sendAndWait.operation';
+import { SERVICE_PRINCIPAL_AUTH, SP_HIDE } from '../../transport';
 
 export { create, get, getAll, sendAndWait };
 
 export const description: INodeProperties[] = [
+	{
+		displayName:
+			'Chat messages are not available with the Service Principal credential. App-only Microsoft Graph has no signed-in user; use an OAuth2 credential for chat actions.',
+		name: 'chatMessageServicePrincipalNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['chatMessage'],
+				authentication: [SERVICE_PRINCIPAL_AUTH],
+			},
+		},
+	},
 	{
 		displayName: 'Operation',
 		name: 'operation',
@@ -16,6 +30,9 @@ export const description: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['chatMessage'],
+			},
+			hide: {
+				...SP_HIDE,
 			},
 		},
 		options: [

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
@@ -57,5 +57,7 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 		},
 	};
 
+	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
+	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
 	return await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
@@ -6,7 +6,8 @@ import {
 } from '../../../../../../utils/sendAndWait/utils';
 import { createUtmCampaignLink } from '../../../../../../utils/utilities';
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { throwIfChatUnsupported } from './sharedGuard';
 
 export const description: INodeProperties[] = getSendAndWaitProperties(
 	[chatRLC],
@@ -17,9 +18,24 @@ export const description: INodeProperties[] = getSendAndWaitProperties(
 		defaultApproveLabel: '✓ Approve',
 		defaultDisapproveLabel: '✗ Decline',
 	},
-).filter((p) => p.name !== 'subject');
+)
+	.filter((p) => p.name !== 'subject')
+	.map((property) => ({
+		...property,
+		displayOptions: {
+			...property.displayOptions,
+			hide: {
+				...property.displayOptions?.hide,
+				...SP_HIDE,
+			},
+		},
+	}));
 
 export async function execute(this: IExecuteFunctions, i: number, instanceId: string) {
+	// App-only Graph cannot post chat messages. Dispatched from the router before the
+	// item loop, so this guard fires before any putExecutionToWait.
+	throwIfChatUnsupported.call(this);
+
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 	const config = getSendAndWaitConfig(this);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sharedGuard.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sharedGuard.ts
@@ -1,0 +1,24 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { getTeamsCredentialType, SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Throws a static `NodeOperationError` when the node is configured with the
+ * app-only (Service Principal) credential. Chat messages have no usable app-only
+ * form (app-only Graph has no signed-in user), so every chatMessage operation
+ * guards on this BEFORE any request — covering hand-edited workflows that bypass
+ * the hidden UI. For `sendAndWait` it fires before any `putExecutionToWait`.
+ */
+export function throwIfChatUnsupported(this: IExecuteFunctions): void {
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Chat messages are not available with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user. Use an OAuth2 credential for chat actions.',
+			},
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
@@ -4,26 +4,8 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
-import {
-	microsoftApiRequest,
-	SERVICE_PRINCIPAL_AUTH,
-	SP_HIDE,
-	validateTaskBodyIdsUnderSp,
-} from '../../transport';
-
-// SP-shown By-ID copy of an RLC: app-only has no group-scoped list to depend on, so
-// drop list mode + `loadOptionsDependsOn` and default to By-ID, mirroring task:getAll.
-const byIdUnderSp = (rlc: INodeProperties): INodeProperties => ({
-	...rlc,
-	default: { mode: 'id', value: '' },
-	modes: (rlc.modes ?? []).filter((mode) => mode.name === 'id'),
-	typeOptions: undefined,
-	displayOptions: {
-		show: {
-			'/authentication': [SERVICE_PRINCIPAL_AUTH],
-		},
-	},
-});
+import { microsoftApiRequest, SP_HIDE, validateTaskBodyIdsUnderSp } from '../../transport';
+import { byIdUnderSp } from './helpers';
 
 const properties: INodeProperties[] = [
 	// OAuth2 pickers: list mode with group/plan dependency — hidden under SP.
@@ -59,6 +41,8 @@ const properties: INodeProperties[] = [
 		default: {},
 		placeholder: 'Add option',
 		options: [
+			// OAuth2 assignee picker (list, scoped by the group) — hidden under SP, which
+			// uses the By-ID copy below (the group picker it depends on is hidden under SP).
 			{
 				...memberRLC,
 				displayName: 'Assigned To',
@@ -67,7 +51,14 @@ const properties: INodeProperties[] = [
 				typeOptions: {
 					loadOptionsDependsOn: ['groupId.value'],
 				},
+				displayOptions: { hide: { ...SP_HIDE } },
 			},
+			// SP assignee picker: By-ID (Planner assignment is app-only-capable with a user ID).
+			byIdUnderSp(memberRLC, {
+				displayName: 'Assigned To',
+				name: 'assignedTo',
+				description: 'Who the task should be assigned to',
+			}),
 			{
 				displayName: 'Due Date Time',
 				name: 'dueDateTime',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
@@ -5,16 +5,44 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
 import {
-	getTeamsCredentialType,
 	microsoftApiRequest,
 	SERVICE_PRINCIPAL_AUTH,
-	validateTeamsId,
+	SP_HIDE,
+	validateTaskBodyIdsUnderSp,
 } from '../../transport';
 
+// SP-shown By-ID copy of an RLC: app-only has no group-scoped list to depend on, so
+// drop list mode + `loadOptionsDependsOn` and default to By-ID, mirroring task:getAll.
+const byIdUnderSp = (rlc: INodeProperties): INodeProperties => ({
+	...rlc,
+	default: { mode: 'id', value: '' },
+	modes: (rlc.modes ?? []).filter((mode) => mode.name === 'id'),
+	typeOptions: undefined,
+	displayOptions: {
+		show: {
+			'/authentication': [SERVICE_PRINCIPAL_AUTH],
+		},
+	},
+});
+
 const properties: INodeProperties[] = [
-	groupRLC,
-	planRLC,
-	bucketRLC,
+	// OAuth2 pickers: list mode with group/plan dependency — hidden under SP.
+	{
+		...groupRLC,
+		displayOptions: { hide: { ...SP_HIDE } },
+	},
+	{
+		...planRLC,
+		displayOptions: { hide: { ...SP_HIDE } },
+	},
+	{
+		...bucketRLC,
+		displayOptions: { hide: { ...SP_HIDE } },
+	},
+	// SP pickers: By-ID plan + bucket (group is not needed once By-ID). `groupRLC` is
+	// hidden under SP above.
+	byIdUnderSp(planRLC),
+	byIdUnderSp(bucketRLC),
 	{
 		displayName: 'Title',
 		name: 'title',
@@ -37,7 +65,7 @@ const properties: INodeProperties[] = [
 				name: 'assignedTo',
 				description: 'Who the task should be assigned to',
 				typeOptions: {
-					loadOptionsDependsOn: ['groupId.balue'],
+					loadOptionsDependsOn: ['groupId.value'],
 				},
 			},
 			{
@@ -81,15 +109,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	const planId = this.getNodeParameter('planId', i, '', { extractValue: true }) as string;
 	const bucketId = this.getNodeParameter('bucketId', i, '', { extractValue: true }) as string;
 
-	// `planId`/`bucketId` go into the JSON body (not a path), so JSON encoding handles
-	// escaping. Under the app-only credential, still shape-validate them as
-	// defense-in-depth (a malformed id is a bad request) — this is NOT the
-	// path-injection fix (that is `buildTeamsPath` on path-interpolated ids).
-	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
-		const node = this.getNode();
-		validateTeamsId(planId, node);
-		validateTeamsId(bucketId, node);
-	}
+	validateTaskBodyIdsUnderSp.call(this, { planId, bucketId });
 
 	const title = this.getNodeParameter('title', i) as string;
 	const options = this.getNodeParameter('options', i);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/create.operation.ts
@@ -4,7 +4,12 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import {
+	getTeamsCredentialType,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+	validateTeamsId,
+} from '../../transport';
 
 const properties: INodeProperties[] = [
 	groupRLC,
@@ -75,6 +80,16 @@ export async function execute(this: IExecuteFunctions, i: number) {
 
 	const planId = this.getNodeParameter('planId', i, '', { extractValue: true }) as string;
 	const bucketId = this.getNodeParameter('bucketId', i, '', { extractValue: true }) as string;
+
+	// `planId`/`bucketId` go into the JSON body (not a path), so JSON encoding handles
+	// escaping. Under the app-only credential, still shape-validate them as
+	// defense-in-depth (a malformed id is a bad request) — this is NOT the
+	// path-injection fix (that is `buildTeamsPath` on path-interpolated ids).
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		const node = this.getNode();
+		validateTeamsId(planId, node);
+		validateTeamsId(bucketId, node);
+	}
 
 	const title = this.getNodeParameter('title', i) as string;
 	const options = this.getNodeParameter('options', i);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/deleteTask.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/deleteTask.operation.ts
@@ -2,7 +2,7 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	{
@@ -29,15 +29,10 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	//https://docs.microsoft.com/en-us/graph/api/plannertask-delete?view=graph-rest-1.0&tabs=http
 
 	const taskId = this.getNodeParameter('taskId', i) as string;
-	const task = await microsoftApiRequest.call(this, 'GET', `/v1.0/planner/tasks/${taskId}`);
-	await microsoftApiRequest.call(
-		this,
-		'DELETE',
-		`/v1.0/planner/tasks/${taskId}`,
-		{},
-		{},
-		undefined,
-		{ 'If-Match': task['@odata.etag'] },
-	);
+	const taskPath = buildTeamsPath.call(this, ['/v1.0/planner/tasks/', { id: taskId }]);
+	const task = await microsoftApiRequest.call(this, 'GET', taskPath);
+	await microsoftApiRequest.call(this, 'DELETE', taskPath, {}, {}, undefined, {
+		'If-Match': task['@odata.etag'],
+	});
 	return { success: true };
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/get.operation.ts
@@ -2,7 +2,7 @@ import type { INodeProperties, IExecuteFunctions } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	{
@@ -29,5 +29,9 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	//https://docs.microsoft.com/en-us/graph/api/plannertask-get?view=graph-rest-1.0&tabs=http
 
 	const taskId = this.getNodeParameter('taskId', i) as string;
-	return await microsoftApiRequest.call(this, 'GET', `/v1.0/planner/tasks/${taskId}`);
+	return await microsoftApiRequest.call(
+		this,
+		'GET',
+		buildTeamsPath.call(this, ['/v1.0/planner/tasks/', { id: taskId }]),
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -12,6 +12,7 @@ import {
 	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
 } from '../../transport';
+import { byIdUnderSp } from './helpers';
 
 const properties: INodeProperties[] = [
 	{
@@ -64,23 +65,10 @@ const properties: INodeProperties[] = [
 			},
 		},
 	},
-	{
-		// Plan picker shown under the Service Principal credential (which has no
-		// `tasksFor` selector). The group-scoped list mode depends on `groupId`, which is
-		// hidden under SP — so default to By-ID mode and drop the list/`loadOptionsDependsOn`
-		// so the dropdown never auto-fires `getPlans` with an empty group id (which would
-		// hit the SP empty-id validation error). The By-ID value still routes through
-		// `buildTeamsPath` in execute. Plan mode is forced in execute.
-		...planRLC,
-		default: { mode: 'id', value: '' },
-		modes: (planRLC.modes ?? []).filter((mode) => mode.name === 'id'),
-		typeOptions: undefined,
-		displayOptions: {
-			show: {
-				'/authentication': [SERVICE_PRINCIPAL_AUTH],
-			},
-		},
-	},
+	// Plan picker shown under the Service Principal credential (which has no `tasksFor`
+	// selector). By-ID — plan mode is forced in execute and the value routes through
+	// `buildTeamsPath`. (See `byIdUnderSp` for why list mode is dropped under SP.)
+	byIdUnderSp(planRLC),
 	...returnAllOrLimit,
 ];
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -4,7 +4,14 @@ import { returnAllOrLimit } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { groupRLC, planRLC } from '../../descriptions';
-import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../transport';
+import {
+	buildTeamsPath,
+	getTeamsCredentialType,
+	microsoftApiRequest,
+	microsoftApiRequestAllItems,
+	SERVICE_PRINCIPAL_AUTH,
+	SP_HIDE,
+} from '../../transport';
 
 const properties: INodeProperties[] = [
 	{
@@ -26,13 +33,45 @@ const properties: INodeProperties[] = [
 				description: 'Tasks in group plan',
 			},
 		],
+		// App-only Graph has no `/me`, so "Group Member" mode (which reads /v1.0/me)
+		// has no app-only form — hidden under the Service Principal credential, which
+		// is forced to plan mode in execute.
+		displayOptions: {
+			hide: {
+				...SP_HIDE,
+			},
+		},
 	},
-	groupRLC,
+	{
+		// The group picker (member mode, and the dependency for the OAuth2 plan picker)
+		// is part of the member-mode flow that has no app-only form — hidden under the
+		// Service Principal credential, which is forced to plan mode in execute.
+		...groupRLC,
+		displayOptions: {
+			hide: {
+				...SP_HIDE,
+			},
+		},
+	},
 	{
 		...planRLC,
 		displayOptions: {
 			show: {
 				tasksFor: ['plan'],
+			},
+			hide: {
+				...SP_HIDE,
+			},
+		},
+	},
+	{
+		// Plan picker shown under the Service Principal credential (which has no
+		// `tasksFor` selector). The group-scoped list needs Group.Read.All; otherwise
+		// pick the plan by ID. Plan mode is forced in execute.
+		...planRLC,
+		displayOptions: {
+			show: {
+				'/authentication': [SERVICE_PRINCIPAL_AUTH],
 			},
 		},
 	},
@@ -49,7 +88,10 @@ const displayOptions = {
 export const description = updateDisplayOptions(displayOptions, properties);
 
 export async function execute(this: IExecuteFunctions, i: number) {
-	const tasksFor = this.getNodeParameter('tasksFor', i) as string;
+	// App-only Graph has no `/me`, so "Group Member" mode is unavailable; force plan
+	// mode (and never read the hidden `tasksFor`) under the Service Principal credential.
+	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
+	const tasksFor = isServicePrincipal ? 'plan' : (this.getNodeParameter('tasksFor', i) as string);
 	const returnAll = this.getNodeParameter('returnAll', i);
 
 	if (tasksFor === 'member') {
@@ -77,20 +119,16 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	} else {
 		//https://docs.microsoft.com/en-us/graph/api/plannerplan-list-tasks?view=graph-rest-1.0&tabs=http
 		const planId = this.getNodeParameter('planId', i, '', { extractValue: true }) as string;
+		const endpoint = buildTeamsPath.call(this, ['/v1.0/planner/plans/', { id: planId }, '/tasks']);
 		if (returnAll) {
-			return await microsoftApiRequestAllItems.call(
-				this,
-				'value',
-				'GET',
-				`/v1.0/planner/plans/${planId}/tasks`,
-			);
+			return await microsoftApiRequestAllItems.call(this, 'value', 'GET', endpoint);
 		} else {
 			const limit = this.getNodeParameter('limit', i);
 			const responseData = await microsoftApiRequestAllItems.call(
 				this,
 				'value',
 				'GET',
-				`/v1.0/planner/plans/${planId}/tasks`,
+				endpoint,
 				{},
 			);
 			return responseData.splice(0, limit);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/getAll.operation.ts
@@ -66,9 +66,15 @@ const properties: INodeProperties[] = [
 	},
 	{
 		// Plan picker shown under the Service Principal credential (which has no
-		// `tasksFor` selector). The group-scoped list needs Group.Read.All; otherwise
-		// pick the plan by ID. Plan mode is forced in execute.
+		// `tasksFor` selector). The group-scoped list mode depends on `groupId`, which is
+		// hidden under SP — so default to By-ID mode and drop the list/`loadOptionsDependsOn`
+		// so the dropdown never auto-fires `getPlans` with an empty group id (which would
+		// hit the SP empty-id validation error). The By-ID value still routes through
+		// `buildTeamsPath` in execute. Plan mode is forced in execute.
 		...planRLC,
+		default: { mode: 'id', value: '' },
+		modes: (planRLC.modes ?? []).filter((mode) => mode.name === 'id'),
+		typeOptions: undefined,
 		displayOptions: {
 			show: {
 				'/authentication': [SERVICE_PRINCIPAL_AUTH],

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/helpers.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/helpers.ts
@@ -1,0 +1,28 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import { SERVICE_PRINCIPAL_AUTH } from '../../transport';
+
+/**
+ * Builds the SP-shown By-ID copy of a Planner RLC (plan/bucket/member). App-only
+ * Graph has no group-scoped list to depend on (the group picker is hidden under SP),
+ * so a list-mode picker would auto-fire its `loadOptionsMethod` against an empty
+ * group and hit the SP empty-id validation error. This copy defaults to By-ID and
+ * drops list mode + `typeOptions` (incl. `loadOptionsDependsOn`), and is shown only
+ * under the Service Principal credential. Shared by `task:create`/`update`/`getAll`
+ * so the rule lives in one place (OAuth2 list pickers are untouched).
+ */
+export const byIdUnderSp = (
+	rlc: INodeProperties,
+	overrides: Partial<INodeProperties> = {},
+): INodeProperties => ({
+	...rlc,
+	...overrides,
+	default: { mode: 'id', value: '' },
+	modes: (rlc.modes ?? []).filter((mode) => mode.name === 'id'),
+	typeOptions: undefined,
+	displayOptions: {
+		show: {
+			'/authentication': [SERVICE_PRINCIPAL_AUTH],
+		},
+	},
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
@@ -4,7 +4,32 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
-import { buildTeamsPath, microsoftApiRequest } from '../../transport';
+import {
+	buildTeamsPath,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+	SP_HIDE,
+	validateTaskBodyIdsUnderSp,
+} from '../../transport';
+
+// SP-shown By-ID copy of an RLC inside the updateFields collection: app-only has no
+// group-scoped list to depend on, so drop list mode + `loadOptionsDependsOn` and
+// default to By-ID, mirroring task:getAll / task:create.
+const byIdUnderSp = (
+	rlc: INodeProperties,
+	overrides: Partial<INodeProperties> = {},
+): INodeProperties => ({
+	...rlc,
+	...overrides,
+	default: { mode: 'id', value: '' },
+	modes: (rlc.modes ?? []).filter((mode) => mode.name === 'id'),
+	typeOptions: undefined,
+	displayOptions: {
+		show: {
+			'/authentication': [SERVICE_PRINCIPAL_AUTH],
+		},
+	},
+});
 
 const properties: INodeProperties[] = [
 	{
@@ -34,13 +59,17 @@ const properties: INodeProperties[] = [
 					loadOptionsDependsOn: ['updateFields.groupId.value'],
 				},
 			},
+			// OAuth2 bucket picker (list, depends on plan) — hidden under SP.
 			{
 				...bucketRLC,
 				required: false,
 				typeOptions: {
 					loadOptionsDependsOn: ['updateFields.planId.value'],
 				},
+				displayOptions: { hide: { ...SP_HIDE } },
 			},
+			// SP bucket picker: By-ID.
+			byIdUnderSp(bucketRLC, { required: false }),
 			{
 				displayName: 'Due Date Time',
 				name: 'dueDateTime',
@@ -50,12 +79,15 @@ const properties: INodeProperties[] = [
 				description:
 					'Date and time at which the task is due. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time.',
 			},
+			// Group picker is OAuth2-only (used to scope the plan/bucket lists); hidden
+			// under SP, which uses By-ID plan/bucket.
 			{
 				...groupRLC,
 				required: false,
 				typeOptions: {
 					loadOptionsDependsOn: ['/groupSource'],
 				},
+				displayOptions: { hide: { ...SP_HIDE } },
 			},
 			{
 				displayName: 'Percent Complete',
@@ -70,6 +102,7 @@ const properties: INodeProperties[] = [
 				description:
 					'Percentage of task completion. When set to 100, the task is considered completed.',
 			},
+			// OAuth2 plan picker (list, depends on group) — hidden under SP.
 			{
 				...planRLC,
 				required: false,
@@ -77,7 +110,10 @@ const properties: INodeProperties[] = [
 				typeOptions: {
 					loadOptionsDependsOn: ['updateFields.groupId.value'],
 				},
+				displayOptions: { hide: { ...SP_HIDE } },
 			},
+			// SP plan picker: By-ID.
+			byIdUnderSp(planRLC, { required: false }),
 			{
 				displayName: 'Title',
 				name: 'title',
@@ -137,6 +173,13 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			updateFields.dueDateTime = updateFields.dueDateTime.toISO();
 		}
 	}
+
+	// `planId`/`bucketId` are written into the PATCH body; shape-validate them under SP
+	// (defense-in-depth, same as task:create).
+	validateTaskBodyIdsUnderSp.call(this, {
+		planId: updateFields.planId as string | undefined,
+		bucketId: updateFields.bucketId as string | undefined,
+	});
 
 	const body: IDataObject = {};
 	Object.assign(body, updateFields);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
@@ -7,29 +7,10 @@ import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
 import {
 	buildTeamsPath,
 	microsoftApiRequest,
-	SERVICE_PRINCIPAL_AUTH,
 	SP_HIDE,
 	validateTaskBodyIdsUnderSp,
 } from '../../transport';
-
-// SP-shown By-ID copy of an RLC inside the updateFields collection: app-only has no
-// group-scoped list to depend on, so drop list mode + `loadOptionsDependsOn` and
-// default to By-ID, mirroring task:getAll / task:create.
-const byIdUnderSp = (
-	rlc: INodeProperties,
-	overrides: Partial<INodeProperties> = {},
-): INodeProperties => ({
-	...rlc,
-	...overrides,
-	default: { mode: 'id', value: '' },
-	modes: (rlc.modes ?? []).filter((mode) => mode.name === 'id'),
-	typeOptions: undefined,
-	displayOptions: {
-		show: {
-			'/authentication': [SERVICE_PRINCIPAL_AUTH],
-		},
-	},
-});
+import { byIdUnderSp } from './helpers';
 
 const properties: INodeProperties[] = [
 	{
@@ -48,6 +29,8 @@ const properties: INodeProperties[] = [
 		default: {},
 		placeholder: 'Add Field',
 		options: [
+			// OAuth2 assignee picker (list, scoped by the group) — hidden under SP, which
+			// uses the By-ID copy below (the group picker it depends on is hidden under SP).
 			{
 				...memberRLC,
 				displayName: 'Assigned To',
@@ -58,7 +41,15 @@ const properties: INodeProperties[] = [
 				typeOptions: {
 					loadOptionsDependsOn: ['updateFields.groupId.value'],
 				},
+				displayOptions: { hide: { ...SP_HIDE } },
 			},
+			// SP assignee picker: By-ID (Planner assignment is app-only-capable with a user ID).
+			byIdUnderSp(memberRLC, {
+				displayName: 'Assigned To',
+				name: 'assignedTo',
+				description: 'Who the task should be assigned to',
+				required: false,
+			}),
 			// OAuth2 bucket picker (list, depends on plan) — hidden under SP.
 			{
 				...bucketRLC,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/task/update.operation.ts
@@ -4,7 +4,7 @@ import type { INodeProperties, IExecuteFunctions, IDataObject } from 'n8n-workfl
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { bucketRLC, groupRLC, memberRLC, planRLC } from '../../descriptions';
-import { microsoftApiRequest } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	{
@@ -141,17 +141,13 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	const body: IDataObject = {};
 	Object.assign(body, updateFields);
 
-	const task = await microsoftApiRequest.call(this, 'GET', `/v1.0/planner/tasks/${taskId}`);
+	const taskPath = buildTeamsPath.call(this, ['/v1.0/planner/tasks/', { id: taskId }]);
 
-	await microsoftApiRequest.call(
-		this,
-		'PATCH',
-		`/v1.0/planner/tasks/${taskId}`,
-		body,
-		{},
-		undefined,
-		{ 'If-Match': task['@odata.etag'] },
-	);
+	const task = await microsoftApiRequest.call(this, 'GET', taskPath);
+
+	await microsoftApiRequest.call(this, 'PATCH', taskPath, body, {}, undefined, {
+		'If-Match': task['@odata.etag'],
+	});
 
 	return { success: true };
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -7,6 +7,7 @@ import * as chatMessage from './chatMessage';
 import * as task from './task';
 import { sendAndWaitWebhooksDescription } from '../../../../../utils/sendAndWait/descriptions';
 import { SEND_AND_WAIT_WAITING_TOOLTIP } from '../../../../../utils/sendAndWait/utils';
+import { SERVICE_PRINCIPAL_AUTH } from '../transport';
 
 export const versionDescription: INodeTypeDescription = {
 	displayName: 'Microsoft Teams',
@@ -40,6 +41,15 @@ export const versionDescription: INodeTypeDescription = {
 				},
 			},
 		},
+		{
+			name: SERVICE_PRINCIPAL_AUTH,
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: [SERVICE_PRINCIPAL_AUTH],
+				},
+			},
+		},
 	],
 	waitingNodeTooltip: SEND_AND_WAIT_WAITING_TOOLTIP,
 	webhooks: sendAndWaitWebhooksDescription,
@@ -59,6 +69,12 @@ export const versionDescription: INodeTypeDescription = {
 					value: 'microsoftOAuth2Api',
 					description:
 						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All) and grant admin consent on the credential. See the docs for the full scope string.',
+				},
+				{
+					name: 'Service Principal (App-Only)',
+					value: SERVICE_PRINCIPAL_AUTH,
+					description:
+						'App-only access via a Microsoft Entra app registration. App-only Graph cannot act as a signed-in user, so chat actions and chat triggers are unavailable. Grant the relevant application permissions (e.g. Team.ReadBasic.All, Channel.ReadBasic.All, Tasks.ReadWrite.All) and admin consent on the credential.',
 				},
 			],
 			default: 'microsoftTeamsOAuth2Api',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -116,9 +116,7 @@ export async function getResourcePath(
 		case 'newChatMessage': {
 			if (isServicePrincipal) throwChatTriggerUnsupported.call(this);
 
-			const watchAllChats = this.getNodeParameter('watchAllChats', false, {
-				extractValue: true,
-			}) as boolean;
+			const watchAllChats = this.getNodeParameter('watchAllChats', false) as boolean;
 
 			if (watchAllChats) {
 				return '/me/chats/getAllMessages';
@@ -129,9 +127,10 @@ export async function getResourcePath(
 		}
 
 		case 'newChannel': {
-			const watchAllTeams = this.getNodeParameter('watchAllTeams', false, {
-				extractValue: true,
-			}) as boolean;
+			// No `extractValue` for booleans: it triggers a property-descriptor lookup that
+			// throws "Could not find property" when the toggle is hidden under SP. The 2-arg
+			// form returns the `false` fallback cleanly when hidden.
+			const watchAllTeams = this.getNodeParameter('watchAllTeams', false) as boolean;
 
 			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
 
@@ -148,9 +147,10 @@ export async function getResourcePath(
 		}
 
 		case 'newChannelMessage': {
-			const watchAllTeams = this.getNodeParameter('watchAllTeams', false, {
-				extractValue: true,
-			}) as boolean;
+			// No `extractValue` for booleans: it triggers a property-descriptor lookup that
+			// throws "Could not find property" when the toggle is hidden under SP. The 2-arg
+			// form returns the `false` fallback cleanly when hidden.
+			const watchAllTeams = this.getNodeParameter('watchAllTeams', false) as boolean;
 
 			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
 
@@ -165,9 +165,7 @@ export async function getResourcePath(
 				return teamChannels.flat();
 			} else {
 				const teamId = this.getNodeParameter('teamId', undefined, { extractValue: true }) as string;
-				const watchAllChannels = this.getNodeParameter('watchAllChannels', false, {
-					extractValue: true,
-				}) as boolean;
+				const watchAllChannels = this.getNodeParameter('watchAllChannels', false) as boolean;
 
 				if (isServicePrincipal && watchAllChannels) throwWatchAllUnsupported.call(this);
 
@@ -197,9 +195,10 @@ export async function getResourcePath(
 		}
 
 		case 'newTeamMember': {
-			const watchAllTeams = this.getNodeParameter('watchAllTeams', false, {
-				extractValue: true,
-			}) as boolean;
+			// No `extractValue` for booleans: it triggers a property-descriptor lookup that
+			// throws "Could not find property" when the toggle is hidden under SP. The 2-arg
+			// form returns the `false` fallback cleanly when hidden.
+			const watchAllTeams = this.getNodeParameter('watchAllTeams', false) as boolean;
 
 			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -179,7 +179,7 @@ export async function getResourcePath(
 						extractValue: true,
 					}) as string;
 					if (isServicePrincipal) {
-						// SP path: validate + encode, and DO NOT decodeURIComponent.
+						// SP path: validate + interpolate raw (no decode, no encode).
 						return buildTeamsPath.call(this, [
 							'/teams/',
 							{ id: teamId },

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -29,10 +29,12 @@ export async function fetchAllChannels(
 	this: IHookFunctions,
 	teamId: string,
 ): Promise<ChannelResponse[]> {
+	// Route through buildTeamsPath so `teamId` is validated under SP (non-bypassable
+	// defense-in-depth — watch-all is also guarded in getResourcePath); verbatim under OAuth2.
 	const { value: channels } = (await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/v1.0/teams/${teamId}/channels`,
+		buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels']),
 	)) as { value: ChannelResponse[] };
 	return channels;
 }
@@ -98,9 +100,11 @@ export async function getResourcePath(
 	event: string,
 ): Promise<string | string[]> {
 	// App-only Graph has no signed-in user. On the SP-reachable branches the
-	// path-interpolated teamId/channelId are validated + encoded via buildTeamsPath
-	// (which also drops the OAuth2-only decodeURIComponent on the SP path). The OAuth2
-	// branches below are byte-for-byte unchanged (incl. the pre-existing decode).
+	// path-interpolated teamId/channelId are validated and interpolated RAW via
+	// buildTeamsPath (which also drops the OAuth2-only decodeURIComponent on the SP
+	// path). Watch-all is disabled under SP (UI-hidden + the runtime guards below, since
+	// fetchAllTeams/fetchAllChannels fan out an org-wide-token request). The OAuth2
+	// branches are byte-for-byte unchanged (incl. the pre-existing decode).
 	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
 
 	switch (event) {
@@ -129,6 +133,8 @@ export async function getResourcePath(
 				extractValue: true,
 			}) as boolean;
 
+			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
+
 			if (watchAllTeams) {
 				const teams = await fetchAllTeams.call(this);
 				return teams.map((team) => `/teams/${team.id}/channels`);
@@ -146,6 +152,8 @@ export async function getResourcePath(
 				extractValue: true,
 			}) as boolean;
 
+			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
+
 			if (watchAllTeams) {
 				const teams = await fetchAllTeams.call(this);
 				const teamChannels = await Promise.all(
@@ -160,6 +168,8 @@ export async function getResourcePath(
 				const watchAllChannels = this.getNodeParameter('watchAllChannels', false, {
 					extractValue: true,
 				}) as boolean;
+
+				if (isServicePrincipal && watchAllChannels) throwWatchAllUnsupported.call(this);
 
 				if (watchAllChannels) {
 					const channels = await fetchAllChannels.call(this, teamId);
@@ -187,6 +197,8 @@ export async function getResourcePath(
 			const watchAllTeams = this.getNodeParameter('watchAllTeams', false, {
 				extractValue: true,
 			}) as boolean;
+
+			if (isServicePrincipal && watchAllTeams) throwWatchAllUnsupported.call(this);
 
 			if (watchAllTeams) {
 				const teams = await fetchAllTeams.call(this);
@@ -220,7 +232,24 @@ function throwChatTriggerUnsupported(this: IHookFunctions): never {
 		'Chat triggers are not available with the Service Principal credential',
 		{
 			description:
-				'App-only Microsoft Graph cannot subscribe to a signed-in user’s chats. Use an OAuth2 credential for chat triggers.',
+				'App-only Microsoft Graph cannot subscribe to the chats of a signed-in user. Use an OAuth2 credential for chat triggers.',
+		},
+	);
+}
+
+/**
+ * Watch-all fans out one subscription per team/channel via fetchAllTeams/
+ * fetchAllChannels under the org-wide app token, which the plan disables under SP
+ * (option b). The UI hides the toggles; this guard backs that at runtime for
+ * hand-edited workflows, throwing a static error before any fan-out request.
+ */
+function throwWatchAllUnsupported(this: IHookFunctions): never {
+	throw new NodeOperationError(
+		this.getNode(),
+		'Watching all teams/channels is not available with the Service Principal credential',
+		{
+			description:
+				'Select a specific team and channel. App-only fan-out across all teams/channels is disabled for the Service Principal credential.',
 		},
 	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -179,14 +179,15 @@ export async function getResourcePath(
 						extractValue: true,
 					}) as string;
 					if (isServicePrincipal) {
-						// `channelId` is percent-encoded when selected By URL; decode it first so
-						// validation runs on the decoded value and the subscription resource carries
-						// the raw channel id Graph matches against (parity with the OAuth2 path below).
+						// `channelId` is percent-encoded when selected By URL; decode it first (via the
+						// guarded helper, so a malformed `%` yields a NodeOperationError not a raw
+						// URIError) so validation runs on the decoded value and the subscription resource
+						// carries the raw channel id Graph matches against (parity with the OAuth2 path).
 						return buildTeamsPath.call(this, [
 							'/teams/',
 							{ id: teamId },
 							'/channels/',
-							{ id: decodeURIComponent(channelId) },
+							{ id: decodeChannelId.call(this, channelId) },
 							'/messages',
 						]);
 					}
@@ -254,4 +255,21 @@ function throwWatchAllUnsupported(this: IHookFunctions): never {
 				'Select a specific team and channel. App-only fan-out across all teams/channels is disabled for the Service Principal credential.',
 		},
 	);
+}
+
+/**
+ * Decodes a By-URL channel id (percent-encoded, e.g. `19%3A...%40thread.tacv2`) before it is
+ * validated and interpolated under SP. A malformed `%` sequence makes `decodeURIComponent` throw a
+ * raw `URIError`; convert it to a static `NodeOperationError` so the SP path never surfaces a raw
+ * decode error (the OAuth2 path keeps its pre-existing unguarded decode).
+ */
+function decodeChannelId(this: IHookFunctions, channelId: string): string {
+	try {
+		return decodeURIComponent(channelId);
+	} catch {
+		throw new NodeOperationError(this.getNode(), 'The ID is not valid', {
+			description:
+				'The channel ID could not be decoded. Re-select the channel from the list or by URL.',
+		});
+	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -4,7 +4,13 @@ import { NodeOperationError } from 'n8n-workflow';
 
 import type { TeamResponse, ChannelResponse, SubscriptionResponse } from './types';
 import { verifySignature as verifySignatureGeneric } from '../../../../../utils/webhook-signature-verification';
-import { microsoftApiRequest } from '../transport';
+import {
+	buildTeamsPath,
+	getTeamsCredentialType,
+	joinedTeamsEndpoint,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+} from '../transport';
 
 export function generateClientState(): string {
 	return randomBytes(32).toString('hex');
@@ -14,7 +20,7 @@ export async function fetchAllTeams(this: IHookFunctions): Promise<TeamResponse[
 	const { value: teams } = (await microsoftApiRequest.call(
 		this,
 		'GET',
-		'/v1.0/me/joinedTeams',
+		joinedTeamsEndpoint.call(this),
 	)) as { value: TeamResponse[] };
 	return teams;
 }
@@ -91,12 +97,21 @@ export async function getResourcePath(
 	this: IHookFunctions,
 	event: string,
 ): Promise<string | string[]> {
+	// App-only Graph has no signed-in user. On the SP-reachable branches the
+	// path-interpolated teamId/channelId are validated + encoded via buildTeamsPath
+	// (which also drops the OAuth2-only decodeURIComponent on the SP path). The OAuth2
+	// branches below are byte-for-byte unchanged (incl. the pre-existing decode).
+	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
+
 	switch (event) {
 		case 'newChat': {
+			if (isServicePrincipal) throwChatTriggerUnsupported.call(this);
 			return '/me/chats';
 		}
 
 		case 'newChatMessage': {
+			if (isServicePrincipal) throwChatTriggerUnsupported.call(this);
+
 			const watchAllChats = this.getNodeParameter('watchAllChats', false, {
 				extractValue: true,
 			}) as boolean;
@@ -119,6 +134,9 @@ export async function getResourcePath(
 				return teams.map((team) => `/teams/${team.id}/channels`);
 			} else {
 				const teamId = this.getNodeParameter('teamId', undefined, { extractValue: true }) as string;
+				if (isServicePrincipal) {
+					return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/channels']);
+				}
 				return `/teams/${teamId}/channels`;
 			}
 		}
@@ -150,6 +168,16 @@ export async function getResourcePath(
 					const channelId = this.getNodeParameter('channelId', undefined, {
 						extractValue: true,
 					}) as string;
+					if (isServicePrincipal) {
+						// SP path: validate + encode, and DO NOT decodeURIComponent.
+						return buildTeamsPath.call(this, [
+							'/teams/',
+							{ id: teamId },
+							'/channels/',
+							{ id: channelId },
+							'/messages',
+						]);
+					}
 					return `/teams/${teamId}/channels/${decodeURIComponent(channelId)}/messages`;
 				}
 			}
@@ -165,6 +193,9 @@ export async function getResourcePath(
 				return teams.map((team) => `/teams/${team.id}/members`);
 			} else {
 				const teamId = this.getNodeParameter('teamId', undefined, { extractValue: true }) as string;
+				if (isServicePrincipal) {
+					return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/members']);
+				}
 				return `/teams/${teamId}/members`;
 			}
 		}
@@ -176,4 +207,20 @@ export async function getResourcePath(
 			});
 		}
 	}
+}
+
+/**
+ * Chat triggers subscribe to `/me/chats[...]`, which has no app-only equivalent.
+ * Throws a static `NodeOperationError` before composing any `/me` path under the
+ * Service Principal credential.
+ */
+function throwChatTriggerUnsupported(this: IHookFunctions): never {
+	throw new NodeOperationError(
+		this.getNode(),
+		'Chat triggers are not available with the Service Principal credential',
+		{
+			description:
+				'App-only Microsoft Graph cannot subscribe to a signed-in user’s chats. Use an OAuth2 credential for chat triggers.',
+		},
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -100,11 +100,11 @@ export async function getResourcePath(
 	event: string,
 ): Promise<string | string[]> {
 	// App-only Graph has no signed-in user. On the SP-reachable branches the
-	// path-interpolated teamId/channelId are validated and interpolated RAW via
-	// buildTeamsPath (which also drops the OAuth2-only decodeURIComponent on the SP
-	// path). Watch-all is disabled under SP (UI-hidden + the runtime guards below, since
-	// fetchAllTeams/fetchAllChannels fan out an org-wide-token request). The OAuth2
-	// branches are byte-for-byte unchanged (incl. the pre-existing decode).
+	// path-interpolated ids are validated + interpolated via buildTeamsPath. A By-URL
+	// channel id arrives percent-encoded, so newChannelMessage decodes it first (parity
+	// with the OAuth2 path) so validation runs on the decoded value. Watch-all is disabled
+	// under SP (UI-hidden + the runtime guards below, since fetchAllTeams/fetchAllChannels
+	// fan out an org-wide-token request). The OAuth2 branches are byte-for-byte unchanged.
 	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
 
 	switch (event) {
@@ -179,12 +179,14 @@ export async function getResourcePath(
 						extractValue: true,
 					}) as string;
 					if (isServicePrincipal) {
-						// SP path: validate + interpolate raw (no decode, no encode).
+						// `channelId` is percent-encoded when selected By URL; decode it first so
+						// validation runs on the decoded value and the subscription resource carries
+						// the raw channel id Graph matches against (parity with the OAuth2 path below).
 						return buildTeamsPath.call(this, [
 							'/teams/',
 							{ id: teamId },
 							'/channels/',
-							{ id: channelId },
+							{ id: decodeURIComponent(channelId) },
 							'/messages',
 						]);
 					}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -8,12 +8,32 @@ import {
 } from 'n8n-workflow';
 
 import { filterSortSearchListItems } from '../helpers/utils';
-import { microsoftApiRequest } from '../transport';
+import {
+	buildTeamsPath,
+	getTeamsCredentialType,
+	joinedTeamsEndpoint,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+} from '../transport';
 
 export async function getChats(
 	this: ILoadOptionsFunctions,
 	filter?: string,
 ): Promise<INodeListSearchResult> {
+	// App-only Microsoft Graph has no signed-in user, so `/v1.0/chats` (which is
+	// `/me`-scoped) cannot be listed. Fail fast with a static message before any
+	// request — chat resources are hidden under the Service Principal credential.
+	if (getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Chats are not available with the Service Principal credential',
+			{
+				description:
+					'App-only Microsoft Graph has no signed-in user to read chats for. Use an OAuth2 credential for chat actions.',
+			},
+		);
+	}
+
 	const returnData: INodeListSearchItems[] = [];
 	const qs: IDataObject = {
 		$expand: 'members',
@@ -78,7 +98,11 @@ export async function getTeams(
 	filter?: string,
 ): Promise<INodeListSearchResult> {
 	const returnData: INodeListSearchItems[] = [];
-	const { value } = await microsoftApiRequest.call(this, 'GET', '/v1.0/me/joinedTeams');
+	const { value } = await microsoftApiRequest.call(
+		this,
+		'GET',
+		joinedTeamsEndpoint.call(this),
+	);
 
 	for (const team of value) {
 		const teamName = team.displayName;
@@ -128,7 +152,11 @@ export async function getChannels(
 
 	if (resource === 'channel') excludeGeneralChannel.push('update');
 
-	const { value } = await microsoftApiRequest.call(this, 'GET', `/v1.0/teams/${teamId}/channels`);
+	const { value } = await microsoftApiRequest.call(
+		this,
+		'GET',
+		buildTeamsPath.call(this, ['/v1.0/teams/', { id: teamId }, '/channels']),
+	);
 
 	for (const channel of value) {
 		if (channel.displayName === 'General' && excludeGeneralChannel.includes(operation)) {
@@ -202,7 +230,7 @@ export async function getPlans(
 	const { value } = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/v1.0/groups/${groupId}/planner/plans`,
+		buildTeamsPath.call(this, ['/v1.0/groups/', { id: groupId }, '/planner/plans']),
 	);
 	for (const plan of value) {
 		returnData.push({
@@ -236,7 +264,7 @@ export async function getBuckets(
 	const { value } = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/v1.0/planner/plans/${planId}/buckets`,
+		buildTeamsPath.call(this, ['/v1.0/planner/plans/', { id: planId }, '/buckets']),
 	);
 	for (const bucket of value) {
 		returnData.push({
@@ -266,7 +294,11 @@ export async function getMembers(
 			extractValue: true,
 		}) as string;
 	}
-	const { value } = await microsoftApiRequest.call(this, 'GET', `/v1.0/groups/${groupId}/members`);
+	const { value } = await microsoftApiRequest.call(
+		this,
+		'GET',
+		buildTeamsPath.call(this, ['/v1.0/groups/', { id: groupId }, '/members']),
+	);
 
 	for (const member of value) {
 		returnData.push({

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -13,6 +13,7 @@ import {
 	getTeamsCredentialType,
 	joinedTeamsEndpoint,
 	microsoftApiRequest,
+	microsoftApiRequestAllItems,
 	SERVICE_PRINCIPAL_AUTH,
 } from '../transport';
 
@@ -98,8 +99,12 @@ export async function getTeams(
 	filter?: string,
 ): Promise<INodeListSearchResult> {
 	const returnData: INodeListSearchItems[] = [];
-	const { value } = await microsoftApiRequest.call(
+	// `/v1.0/teams` (SP) and `/v1.0/me/joinedTeams` (OAuth2) are both Graph-paginated
+	// collections — page through `@odata.nextLink` so all org teams are returned, not
+	// just the first ~100. `microsoftApiRequestAllItems` returns the flattened `value`.
+	const value = await microsoftApiRequestAllItems.call(
 		this,
+		'value',
 		'GET',
 		joinedTeamsEndpoint.call(this),
 	);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -400,16 +400,28 @@ describe('Microsoft Teams Transport', () => {
 					async (statusCode, code, expectedMessage) => {
 						mockRequestWithAuthentication.mockRejectedValue(rawBody(statusCode, code));
 
-						const error = await microsoftApiRequest
+						const error = (await microsoftApiRequest
 							.call(mockExecuteFunctions, 'GET', '/v1.0/teams')
-							.catch((e: Error) => e);
+							.catch((e: Error) => e)) as Error & { messages?: string[] };
 
 						expect(error.constructor.name).toBe('NodeApiError');
 						expect(error.message).toBe(expectedMessage);
+						// The raw body must not leak through the surfaced message…
 						expect(error.message).not.toContain('request-id');
-						expect(error.message).not.toContain('client-request-id');
 						expect(error.message).not.toContain('token=');
 						expect(error.message).not.toContain('injected');
+						// …nor through the error's `messages` array…
+						for (const m of error.messages ?? []) {
+							expect(m).not.toContain('request-id');
+							expect(m).not.toContain('token=');
+							expect(m).not.toContain('injected');
+						}
+						// …nor anywhere in the serialized error object.
+						const serialized = JSON.stringify(error);
+						expect(serialized).not.toContain('request-id');
+						expect(serialized).not.toContain('client-request-id');
+						expect(serialized).not.toContain('token=');
+						expect(serialized).not.toContain('injected');
 					},
 				);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -512,9 +512,7 @@ describe('Microsoft Teams Transport', () => {
 
 	describe('validateTeamsId', () => {
 		it('accepts a GUID and a Planner-style id', () => {
-			expect(() =>
-				validateTeamsId('1111-2222-3333-4444-555566667777', mockNode),
-			).not.toThrow();
+			expect(() => validateTeamsId('1111-2222-3333-4444-555566667777', mockNode)).not.toThrow();
 			expect(() => validateTeamsId('rl1HYb0cUEiHPc7zgB_KWWUAA7Of', mockNode)).not.toThrow();
 		});
 
@@ -717,7 +715,10 @@ describe('Microsoft Teams Transport', () => {
 
 		it('getTeams pages through @odata.nextLink under SP (all org teams, not just page 1)', async () => {
 			mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
-			mockLoadOptions.getCredentials.mockResolvedValue({ accessToken: 'token', graphApiBaseUrl: '' });
+			mockLoadOptions.getCredentials.mockResolvedValue({
+				accessToken: 'token',
+				graphApiBaseUrl: '',
+			});
 			// page 1 carries @odata.nextLink → the paginator must follow it to page 2.
 			loadOptionsRequestWithAuthentication
 				.mockResolvedValueOnce({

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -593,6 +593,31 @@ describe('Microsoft Teams Transport', () => {
 			expect(path).not.toContain('%40');
 		});
 
+		// A node expression like `={{ 123 }}` resolves to a non-string at runtime; the
+		// call sites' `as string` is compile-time only. The SP path must coerce before
+		// `.trim()` or it throws a raw `TypeError` (regression guard).
+		it('coerces a non-string id under SP without throwing', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			const path = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/planner/tasks/',
+				{ id: 123 as unknown as string },
+			]);
+
+			expect(path).toBe('/v1.0/planner/tasks/123');
+		});
+
+		it('stringifies a non-string id under OAuth2 (join coercion, no throw)', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+
+			const path = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/planner/tasks/',
+				{ id: 123 as unknown as string },
+			]);
+
+			expect(path).toBe('/v1.0/planner/tasks/123');
+		});
+
 		it.each(['x/../../groups/abc', 'abc?$expand=foo', 'a\\b', 'a#frag'])(
 			'throws on a crafted separator/injection id (%s) under the Service Principal credential',
 			(craftedId) => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -3,18 +3,35 @@ import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import { MicrosoftTeamsTrigger } from '../../../MicrosoftTeamsTrigger.node';
-import { getTeams } from '../../methods/listSearch';
-import { getTeamsCredentialType, microsoftApiRequest } from '../../transport/index';
+import {
+	getBuckets,
+	getChannels,
+	getChats,
+	getMembers,
+	getPlans,
+	getTeams,
+} from '../../methods/listSearch';
+import {
+	buildTeamsPath,
+	getTeamsCredentialType,
+	joinedTeamsEndpoint,
+	microsoftApiRequest,
+	SERVICE_PRINCIPAL_AUTH,
+	validateTeamsId,
+} from '../../transport/index';
 
 describe('Microsoft Teams Transport', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
 	let mockNode: INode;
 	let mockRequestOAuth2: Mock;
+	let mockRequestWithAuthentication: Mock;
 
 	beforeEach(() => {
 		mockExecuteFunctions = mockDeep<IExecuteFunctions>();
 		mockRequestOAuth2 = vi.fn();
+		mockRequestWithAuthentication = vi.fn();
 		mockExecuteFunctions.helpers.requestOAuth2 = mockRequestOAuth2;
+		mockExecuteFunctions.helpers.requestWithAuthentication = mockRequestWithAuthentication;
 
 		mockNode = {
 			id: 'test-node',
@@ -229,6 +246,8 @@ describe('Microsoft Teams Transport', () => {
 					'microsoftTeamsOAuth2Api',
 					expect.anything(),
 				);
+				// dual-branch lock: the OAuth2 path must never reach requestWithAuthentication
+				expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
 			it('should use microsoftTeamsOAuth2Api when explicitly selected', async () => {
@@ -241,6 +260,7 @@ describe('Microsoft Teams Transport', () => {
 					'microsoftTeamsOAuth2Api',
 					expect.anything(),
 				);
+				expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
 			it('should use microsoftOAuth2Api when the generic credential is selected', async () => {
@@ -250,6 +270,7 @@ describe('Microsoft Teams Transport', () => {
 
 				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
 				expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+				expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
 			it('should resolve the credential name from the authentication parameter at index 0', async () => {
@@ -274,6 +295,143 @@ describe('Microsoft Teams Transport', () => {
 				);
 			});
 		});
+
+		describe('service principal authentication', () => {
+			beforeEach(() => {
+				mockRequestWithAuthentication.mockResolvedValue({ data: 'test' });
+				// Drive selection by parameter NAME, not a flat return value, so the
+				// resolver's `getNodeParameter('authentication', 0)` resolves to SP while
+				// other reads (resource, etc.) fall through to undefined.
+				mockExecuteFunctions.getNodeParameter.mockImplementation((name: string) =>
+					name === 'authentication' ? SERVICE_PRINCIPAL_AUTH : undefined,
+				);
+				// SP credential carries a minted accessToken, NOT oauthTokenData.
+				mockExecuteFunctions.getCredentials.mockResolvedValue({
+					accessToken: 'token',
+					graphApiBaseUrl: 'https://graph.microsoft.com',
+				});
+			});
+
+			it('routes the request through requestWithAuthentication (NOT requestOAuth2)', async () => {
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/v1.0/teams');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(SERVICE_PRINCIPAL_AUTH);
+				expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+					SERVICE_PRINCIPAL_AUTH,
+					expect.objectContaining({
+						method: 'GET',
+						uri: 'https://graph.microsoft.com/v1.0/teams',
+					}),
+				);
+				// dual-branch lock: the SP path must never reach requestOAuth2
+				expect(mockRequestOAuth2).not.toHaveBeenCalled();
+			});
+
+			it('never composes a /me path under the Service Principal credential', async () => {
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/v1.0/teams');
+
+				const calledUri = mockRequestWithAuthentication.mock.calls[0][1].uri as string;
+				expect(calledUri).not.toContain('/me');
+			});
+
+			it('honors a sovereign graphApiBaseUrl', async () => {
+				mockExecuteFunctions.getCredentials.mockResolvedValue({
+					accessToken: 'token',
+					graphApiBaseUrl: 'https://graph.microsoft.us',
+				});
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/v1.0/teams');
+
+				expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+					SERVICE_PRINCIPAL_AUTH,
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.us/v1.0/teams',
+					}),
+				);
+			});
+
+			describe('error suppression (no raw Graph body leaks at any status)', () => {
+				// A raw Graph error body carrying a correlation id + reflected input. Under
+				// SP NONE of this may reach the surfaced message at ANY status.
+				const rawBody = (statusCode: number, code: string) => ({
+					statusCode,
+					error: {
+						error: {
+							code,
+							message:
+								'request-id: 11111111-2222-3333-4444-555555555555; client-request-id: aaaa; token=eyJ0eParrotedSecret; resource /teams/19:injected@thread.tacv2',
+						},
+					},
+				});
+
+				it.each([
+					[
+						401,
+						'InvalidAuthenticationToken',
+						"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.",
+					],
+					[
+						402,
+						'PaymentRequired',
+						'This operation requires a metered Microsoft Teams API to be enabled on the tenant.',
+					],
+					[
+						403,
+						'Forbidden',
+						'The app registration is missing a consented application permission for this operation. Grant the required Graph application permission and admin consent, then retry.',
+					],
+					[
+						400,
+						'BadRequest',
+						"Microsoft Graph rejected the request (HTTP 400). Check the operation's inputs and the app registration's permissions.",
+					],
+					[
+						429,
+						'TooManyRequests',
+						"Microsoft Graph rejected the request (HTTP 429). Check the operation's inputs and the app registration's permissions.",
+					],
+					[
+						503,
+						'ServiceUnavailable',
+						"Microsoft Graph rejected the request (HTTP 503). Check the operation's inputs and the app registration's permissions.",
+					],
+				])(
+					'maps HTTP %i to a static message and never leaks the raw body',
+					async (statusCode, code, expectedMessage) => {
+						mockRequestWithAuthentication.mockRejectedValue(rawBody(statusCode, code));
+
+						const error = await microsoftApiRequest
+							.call(mockExecuteFunctions, 'GET', '/v1.0/teams')
+							.catch((e: Error) => e);
+
+						expect(error.constructor.name).toBe('NodeApiError');
+						expect(error.message).toBe(expectedMessage);
+						expect(error.message).not.toContain('request-id');
+						expect(error.message).not.toContain('client-request-id');
+						expect(error.message).not.toContain('token=');
+						expect(error.message).not.toContain('injected');
+					},
+				);
+
+				it('rewrites a NotFound body to the static "{Resource} not found" message', async () => {
+					mockExecuteFunctions.getNodeParameter.mockImplementation((name: string) => {
+						if (name === 'authentication') return SERVICE_PRINCIPAL_AUTH;
+						if (name === 'resource') return 'channel';
+						return undefined;
+					});
+					mockRequestWithAuthentication.mockRejectedValue({
+						statusCode: 404,
+						error: { error: { code: 'NotFound', message: 'Resource not found' } },
+					});
+
+					const error = await microsoftApiRequest
+						.call(mockExecuteFunctions, 'GET', '/v1.0/teams/x/channels/y')
+						.catch((e: Error) => e);
+
+					expect(error.message).toBe('Channel not found');
+				});
+			});
+		});
 	});
 
 	describe('getTeamsCredentialType', () => {
@@ -294,16 +452,156 @@ describe('Microsoft Teams Transport', () => {
 
 			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftOAuth2Api');
 		});
+
+		it('should return the Service Principal credential when selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe(SERVICE_PRINCIPAL_AUTH);
+		});
+	});
+
+	describe('joinedTeamsEndpoint', () => {
+		it('returns /v1.0/teams under the Service Principal credential', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			expect(joinedTeamsEndpoint.call(mockExecuteFunctions)).toBe('/v1.0/teams');
+		});
+
+		it('returns /v1.0/me/joinedTeams under OAuth2 (default)', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			expect(joinedTeamsEndpoint.call(mockExecuteFunctions)).toBe('/v1.0/me/joinedTeams');
+		});
+	});
+
+	describe('validateTeamsId', () => {
+		it('accepts a GUID and a colon-free Planner-style id', () => {
+			expect(() =>
+				validateTeamsId('1111-2222-3333-4444-555566667777', mockNode),
+			).not.toThrow();
+			expect(() => validateTeamsId('rl1HYb0cUEiHPc7zgB_KWWUAA7Of', mockNode)).not.toThrow();
+		});
+
+		it.each(['', '   '])('rejects empty / whitespace-only ids', (id) => {
+			expect(() => validateTeamsId(id, mockNode)).toThrow();
+		});
+
+		it.each(['.', '..', '...'])('rejects dots-only ids', (id) => {
+			expect(() => validateTeamsId(id, mockNode)).toThrow();
+		});
+
+		it.each(['a/b', 'a\\b', '19:abc@thread.tacv2', 'a?b', 'a#b'])(
+			'rejects path-escaping ids (%s)',
+			(id) => {
+				expect(() => validateTeamsId(id, mockNode)).toThrow();
+			},
+		);
+
+		it('throws a static message that never echoes the rejected id', () => {
+			const error = (() => {
+				try {
+					validateTeamsId('x/../../groups/secretInjected', mockNode);
+					return undefined;
+				} catch (e) {
+					return e as Error;
+				}
+			})();
+
+			expect(error).toBeDefined();
+			expect(error?.message).not.toContain('secretInjected');
+			expect(error?.message).not.toContain('groups');
+			expect(error?.message).not.toContain('..');
+		});
+	});
+
+	describe('buildTeamsPath', () => {
+		it('passes ids verbatim under OAuth2 (no validate, no encode)', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+
+			const path = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/teams/',
+				{ id: '19:abc@thread.tacv2' },
+				'/channels',
+			]);
+
+			expect(path).toBe('/v1.0/teams/19:abc@thread.tacv2/channels');
+		});
+
+		it('validates then encodes each id once under the Service Principal credential', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			const path = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/planner/plans/',
+				{ id: 'plan_id-123' },
+				'/tasks',
+			]);
+
+			expect(path).toBe('/v1.0/planner/plans/plan_id-123/tasks');
+		});
+
+		it('encodes an @ exactly once under the Service Principal credential', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			const path = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/groups/',
+				{ id: 'jane@contoso.com' },
+				'/members',
+			]);
+
+			expect(path).toBe('/v1.0/groups/jane%40contoso.com/members');
+		});
+
+		it('throws on a crafted traversal id under the Service Principal credential', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			expect(() =>
+				buildTeamsPath.call(mockExecuteFunctions, [
+					'/v1.0/teams/',
+					{ id: 'x/../../groups/abc' },
+					'/channels',
+				]),
+			).toThrow();
+		});
+	});
+
+	describe('OAuth2 back-compat lock (byte-for-byte unchanged)', () => {
+		it('composes the legacy raw uri for a colon-bearing channelId that SP would reject', async () => {
+			// Default OAuth2 selected. A realistic colon-bearing channel id flows through
+			// buildTeamsPath verbatim — no throw, no encoding — proving OAuth2 URL shapes
+			// are unchanged (the SP validator would reject this exact id).
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+			mockExecuteFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+
+			const resource = buildTeamsPath.call(mockExecuteFunctions, [
+				'/v1.0/teams/',
+				{ id: '1111-2222' },
+				'/channels/',
+				{ id: '19:abc@thread.tacv2' },
+			]);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', resource);
+
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftTeamsOAuth2Api',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/teams/1111-2222/channels/19:abc@thread.tacv2',
+				}),
+			);
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('listSearch credential routing', () => {
 		let mockLoadOptions: Mocked<ILoadOptionsFunctions>;
 		let loadOptionsRequestOAuth2: Mock;
+		let loadOptionsRequestWithAuthentication: Mock;
 
 		beforeEach(() => {
 			mockLoadOptions = mockDeep<ILoadOptionsFunctions>();
 			loadOptionsRequestOAuth2 = vi.fn().mockResolvedValue({ value: [] });
+			loadOptionsRequestWithAuthentication = vi.fn().mockResolvedValue({ value: [] });
 			mockLoadOptions.helpers.requestOAuth2 = loadOptionsRequestOAuth2;
+			mockLoadOptions.helpers.requestWithAuthentication = loadOptionsRequestWithAuthentication;
 			mockLoadOptions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
 		});
 
@@ -317,6 +615,7 @@ describe('Microsoft Teams Transport', () => {
 				'microsoftOAuth2Api',
 				expect.anything(),
 			);
+			expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 		});
 
 		it('should default list-search requests to the Teams credential', async () => {
@@ -329,17 +628,92 @@ describe('Microsoft Teams Transport', () => {
 				'microsoftTeamsOAuth2Api',
 				expect.anything(),
 			);
+			expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
+		it('getTeams hits /v1.0/teams (not /me/joinedTeams) through requestWithAuthentication under SP', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			mockLoadOptions.getCredentials.mockResolvedValue({
+				accessToken: 'token',
+				graphApiBaseUrl: '',
+			});
+
+			await getTeams.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith(SERVICE_PRINCIPAL_AUTH);
+			expect(loadOptionsRequestWithAuthentication).toHaveBeenCalledWith(
+				SERVICE_PRINCIPAL_AUTH,
+				expect.objectContaining({ uri: 'https://graph.microsoft.com/v1.0/teams' }),
+			);
+			const calledUri = loadOptionsRequestWithAuthentication.mock.calls[0][1].uri as string;
+			expect(calledUri).not.toContain('/me/joinedTeams');
+			expect(loadOptionsRequestOAuth2).not.toHaveBeenCalled();
+		});
+
+		it('getChats throws a static error under SP and never issues a request', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+			await expect(getChats.call(mockLoadOptions)).rejects.toThrow(
+				'Chats are not available with the Service Principal credential',
+			);
+			expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			expect(loadOptionsRequestOAuth2).not.toHaveBeenCalled();
+		});
+
+		// MAJOR B hard gate: every SP-reachable listSearch method that interpolates an id
+		// must reject a crafted traversal id via buildTeamsPath, before any request.
+		describe('SP id-injection gate (enumerated)', () => {
+			const craftedId = 'x/../../groups/abc';
+
+			beforeEach(() => {
+				mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+				mockLoadOptions.getCredentials.mockResolvedValue({
+					accessToken: 'token',
+					graphApiBaseUrl: '',
+				});
+			});
+
+			it('getChannels rejects a crafted teamId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+
+				await expect(getChannels.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
+				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			});
+
+			it('getPlans rejects a crafted groupId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+
+				await expect(getPlans.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
+				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			});
+
+			it('getBuckets rejects a crafted (unvalidated) planId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+
+				await expect(getBuckets.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
+				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			});
+
+			it('getMembers rejects a crafted groupId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+
+				await expect(getMembers.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
+				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+			});
 		});
 	});
 
 	describe('microsoftApiRequest under a webhook hook (IHookFunctions) context', () => {
 		let mockHookFunctions: Mocked<IHookFunctions>;
 		let hookRequestOAuth2: Mock;
+		let hookRequestWithAuthentication: Mock;
 
 		beforeEach(() => {
 			mockHookFunctions = mockDeep<IHookFunctions>();
 			hookRequestOAuth2 = vi.fn().mockResolvedValue({ value: [] });
+			hookRequestWithAuthentication = vi.fn().mockResolvedValue({ value: [] });
 			mockHookFunctions.helpers.requestOAuth2 = hookRequestOAuth2;
+			mockHookFunctions.helpers.requestWithAuthentication = hookRequestWithAuthentication;
 			mockHookFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
 			mockHookFunctions.getNode.mockReturnValue(mockNode);
 		});
@@ -351,6 +725,7 @@ describe('Microsoft Teams Transport', () => {
 
 			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
 			expect(hookRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+			expect(hookRequestWithAuthentication).not.toHaveBeenCalled();
 		});
 
 		it('should default to the Teams credential', async () => {
@@ -360,6 +735,7 @@ describe('Microsoft Teams Transport', () => {
 
 			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
 			expect(hookRequestOAuth2).toHaveBeenCalledWith('microsoftTeamsOAuth2Api', expect.anything());
+			expect(hookRequestWithAuthentication).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -1,4 +1,11 @@
-import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import type {
+	IExecuteFunctions,
+	IHookFunctions,
+	ILoadOptionsFunctions,
+	INode,
+	JsonObject,
+} from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
@@ -351,18 +358,27 @@ describe('Microsoft Teams Transport', () => {
 			});
 
 			describe('error suppression (no raw Graph body leaks at any status)', () => {
-				// A raw Graph error body carrying a correlation id + reflected input. Under
-				// SP NONE of this may reach the surfaced message at ANY status.
-				const rawBody = (statusCode: number, code: string) => ({
-					statusCode,
-					error: {
-						error: {
-							code,
-							message:
-								'request-id: 11111111-2222-3333-4444-555555555555; client-request-id: aaaa; token=eyJ0eParrotedSecret; resource /teams/19:injected@thread.tacv2',
+				// The REAL error shape: `requestWithAuthentication` wraps the underlying
+				// request error in a `NodeApiError`. The underlying (legacy-request) error
+				// carries `statusCode` + an `error` body + a `message` of the form
+				// `"<status> - <json>"`, and NodeApiError surfaces the status on `httpCode`
+				// (string) and copies that raw message into `messages`. A correlation id +
+				// reflected input ride the raw body — none of it may reach the surfaced
+				// message at ANY status.
+				const rawLeak =
+					'request-id: 11111111-2222-3333-4444-555555555555; client-request-id: aaaa; token=eyJ0eParrotedSecret; resource /teams/19:injected@thread.tacv2';
+				const realError = (statusCode: number, code: string) => {
+					const underlying = Object.assign(
+						new Error(`${statusCode} - {"error":{"code":"${code}","message":"${rawLeak}"}}`),
+						{
+							statusCode,
+							status: statusCode,
+							error: { error: { code, message: rawLeak } },
+							response: { status: statusCode, statusText: code, headers: {} },
 						},
-					},
-				});
+					);
+					return new NodeApiError(mockNode, underlying as unknown as JsonObject);
+				};
 
 				it.each([
 					[
@@ -398,13 +414,15 @@ describe('Microsoft Teams Transport', () => {
 				])(
 					'maps HTTP %i to a static message and never leaks the raw body',
 					async (statusCode, code, expectedMessage) => {
-						mockRequestWithAuthentication.mockRejectedValue(rawBody(statusCode, code));
+						mockRequestWithAuthentication.mockRejectedValue(realError(statusCode, code));
 
 						const error = (await microsoftApiRequest
 							.call(mockExecuteFunctions, 'GET', '/v1.0/teams')
 							.catch((e: Error) => e)) as Error & { messages?: string[] };
 
 						expect(error.constructor.name).toBe('NodeApiError');
+						// proves the SPECIFIC 401/402/403 messages fire in production (the status
+						// is read from NodeApiError.httpCode, not the absent statusCode/error.error)
 						expect(error.message).toBe(expectedMessage);
 						// The raw body must not leak through the surfaced message…
 						expect(error.message).not.toContain('request-id');
@@ -425,16 +443,13 @@ describe('Microsoft Teams Transport', () => {
 					},
 				);
 
-				it('rewrites a NotFound body to the static "{Resource} not found" message', async () => {
+				it('rewrites a 404 to the static "{Resource} not found" message', async () => {
 					mockExecuteFunctions.getNodeParameter.mockImplementation((name: string) => {
 						if (name === 'authentication') return SERVICE_PRINCIPAL_AUTH;
 						if (name === 'resource') return 'channel';
 						return undefined;
 					});
-					mockRequestWithAuthentication.mockRejectedValue({
-						statusCode: 404,
-						error: { error: { code: 'NotFound', message: 'Resource not found' } },
-					});
+					mockRequestWithAuthentication.mockRejectedValue(realError(404, 'NotFound'));
 
 					const error = await microsoftApiRequest
 						.call(mockExecuteFunctions, 'GET', '/v1.0/teams/x/channels/y')
@@ -449,6 +464,15 @@ describe('Microsoft Teams Transport', () => {
 	describe('getTeamsCredentialType', () => {
 		it('should default to microsoftTeamsOAuth2Api when authentication is undefined', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftTeamsOAuth2Api');
+		});
+
+		it('should default to microsoftTeamsOAuth2Api when the fallback value 0 is returned (load-options/hook legacy node)', () => {
+			// In load-options/hook contexts getNodeParameter treats the 2nd arg as the
+			// FALLBACK, so a legacy node with no stored authentication returns the literal
+			// `0`. The allow-list must map it to Teams (a `?? default` would keep `0`).
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(0);
 
 			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftTeamsOAuth2Api');
 		});
@@ -656,6 +680,22 @@ describe('Microsoft Teams Transport', () => {
 			expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 		});
 
+		it('should resolve a legacy node to Teams when getNodeParameter returns the fallback 0 (never getCredentials(0))', async () => {
+			// load-options getNodeParameter('authentication', 0) returns the literal fallback
+			// `0` for a legacy node — must resolve to Teams, never reach getCredentials(0).
+			mockLoadOptions.getNodeParameter.mockReturnValue(0);
+
+			await getTeams.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+			expect(mockLoadOptions.getCredentials).not.toHaveBeenCalledWith(0);
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftTeamsOAuth2Api',
+				expect.anything(),
+			);
+			expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
+		});
+
 		it('getTeams hits /v1.0/teams (not /me/joinedTeams) through requestWithAuthentication under SP', async () => {
 			mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
 			mockLoadOptions.getCredentials.mockResolvedValue({
@@ -673,6 +713,31 @@ describe('Microsoft Teams Transport', () => {
 			const calledUri = loadOptionsRequestWithAuthentication.mock.calls[0][1].uri as string;
 			expect(calledUri).not.toContain('/me/joinedTeams');
 			expect(loadOptionsRequestOAuth2).not.toHaveBeenCalled();
+		});
+
+		it('getTeams pages through @odata.nextLink under SP (all org teams, not just page 1)', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+			mockLoadOptions.getCredentials.mockResolvedValue({ accessToken: 'token', graphApiBaseUrl: '' });
+			// page 1 carries @odata.nextLink → the paginator must follow it to page 2.
+			loadOptionsRequestWithAuthentication
+				.mockResolvedValueOnce({
+					value: [{ id: 't1', displayName: 'Team 1' }],
+					'@odata.nextLink': 'https://graph.microsoft.com/v1.0/teams?$skiptoken=p2',
+				})
+				.mockResolvedValueOnce({ value: [{ id: 't2', displayName: 'Team 2' }] });
+
+			const { results } = await getTeams.call(mockLoadOptions);
+
+			expect(loadOptionsRequestWithAuthentication).toHaveBeenCalledTimes(2);
+			// page 2 fetched via the absolute nextLink uri
+			expect(loadOptionsRequestWithAuthentication).toHaveBeenNthCalledWith(
+				2,
+				SERVICE_PRINCIPAL_AUTH,
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/teams?$skiptoken=p2',
+				}),
+			);
+			expect(results.map((r) => r.value)).toEqual(['t1', 't2']);
 		});
 
 		it('getChats throws a static error under SP and never issues a request', async () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -487,11 +487,15 @@ describe('Microsoft Teams Transport', () => {
 	});
 
 	describe('validateTeamsId', () => {
-		it('accepts a GUID and a colon-free Planner-style id', () => {
+		it('accepts a GUID and a Planner-style id', () => {
 			expect(() =>
 				validateTeamsId('1111-2222-3333-4444-555566667777', mockNode),
 			).not.toThrow();
 			expect(() => validateTeamsId('rl1HYb0cUEiHPc7zgB_KWWUAA7Of', mockNode)).not.toThrow();
+		});
+
+		it('accepts a real colon-bearing channel id (`:` and `@` are allowed)', () => {
+			expect(() => validateTeamsId('19:abc@thread.tacv2', mockNode)).not.toThrow();
 		});
 
 		it.each(['', '   '])('rejects empty / whitespace-only ids', (id) => {
@@ -502,8 +506,8 @@ describe('Microsoft Teams Transport', () => {
 			expect(() => validateTeamsId(id, mockNode)).toThrow();
 		});
 
-		it.each(['a/b', 'a\\b', '19:abc@thread.tacv2', 'a?b', 'a#b'])(
-			'rejects path-escaping ids (%s)',
+		it.each(['a/b', 'a\\b', 'a?b', 'a#b', 'x/../../groups/abc', 'abc?$expand=foo'])(
+			'rejects path-escape / query-injection ids (%s)',
 			(id) => {
 				expect(() => validateTeamsId(id, mockNode)).toThrow();
 			},
@@ -539,7 +543,7 @@ describe('Microsoft Teams Transport', () => {
 			expect(path).toBe('/v1.0/teams/19:abc@thread.tacv2/channels');
 		});
 
-		it('validates then encodes each id once under the Service Principal credential', () => {
+		it('validates and interpolates each id RAW under the Service Principal credential', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
 
 			const path = buildTeamsPath.call(mockExecuteFunctions, [
@@ -551,36 +555,45 @@ describe('Microsoft Teams Transport', () => {
 			expect(path).toBe('/v1.0/planner/plans/plan_id-123/tasks');
 		});
 
-		it('encodes an @ exactly once under the Service Principal credential', () => {
+		it('passes a colon/at-bearing id RAW under SP (same shape as OAuth2, not encoded)', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
 
 			const path = buildTeamsPath.call(mockExecuteFunctions, [
-				'/v1.0/groups/',
-				{ id: 'jane@contoso.com' },
-				'/members',
+				'/v1.0/teams/',
+				{ id: '1111-2222' },
+				'/channels/',
+				{ id: '19:abc@thread.tacv2' },
 			]);
 
-			expect(path).toBe('/v1.0/groups/jane%40contoso.com/members');
+			expect(path).toBe('/v1.0/teams/1111-2222/channels/19:abc@thread.tacv2');
+			// proven raw Graph shape — never percent-encoded
+			expect(path).not.toContain('%3A');
+			expect(path).not.toContain('%40');
 		});
 
-		it('throws on a crafted traversal id under the Service Principal credential', () => {
-			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+		it.each(['x/../../groups/abc', 'abc?$expand=foo', 'a\\b', 'a#frag'])(
+			'throws on a crafted separator/injection id (%s) under the Service Principal credential',
+			(craftedId) => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
 
-			expect(() =>
-				buildTeamsPath.call(mockExecuteFunctions, [
-					'/v1.0/teams/',
-					{ id: 'x/../../groups/abc' },
-					'/channels',
-				]),
-			).toThrow();
-		});
+				expect(() =>
+					buildTeamsPath.call(mockExecuteFunctions, [
+						'/v1.0/teams/',
+						{ id: craftedId },
+						'/channels',
+					]),
+				).toThrow();
+			},
+		);
 	});
 
 	describe('OAuth2 back-compat lock (byte-for-byte unchanged)', () => {
-		it('composes the legacy raw uri for a colon-bearing channelId that SP would reject', async () => {
+		it('composes the legacy raw uri for a colon-bearing channelId', async () => {
 			// Default OAuth2 selected. A realistic colon-bearing channel id flows through
 			// buildTeamsPath verbatim — no throw, no encoding — proving OAuth2 URL shapes
-			// are unchanged (the SP validator would reject this exact id).
+			// are unchanged. SP composes the SAME raw shape for this valid id (see the
+			// buildTeamsPath SP test); the two paths differ only in that SP rejects the
+			// separator/query-injection vectors.
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
 			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
 			mockExecuteFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -13,9 +13,9 @@ import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 import { capitalize } from '../../../../../utils/utilities';
 
 /**
- * Credential-name literal of the shared app-only (Service Principal) credential.
- * Used as the `authentication` selector value AND the credential type, so a rename
- * stays in one place (mirrors the OneDrive reference scheme).
+ * Credential-name literal of the shared `microsoftEntraServicePrincipalApi`
+ * (app-only) credential. Used as both the `authentication` selector value and the
+ * credential type, so a rename stays in one place.
  */
 export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
 
@@ -116,14 +116,9 @@ type TeamsPathSegment = string | { id: string };
 /**
  * Single, non-bypassable path builder for every Graph path that interpolates a
  * user-supplied id. `segments` is an ordered mix of literal strings and id parts
- * (`{ id: value }`). Under the Service Principal credential each `{ id }` is
- * validated (`validateTeamsId`) — the tenant-wide app token makes a path-escape
- * org-wide, so rejecting `/ \ ? #` + control is the path-injection guard. The id is
- * then interpolated RAW (no `encodeURIComponent`), sending the identical proven
- * OAuth2 URL shape byte-for-byte (encoding `:`→`%3A` would be an unverified Graph
- * shape). Under OAuth2 the id is passed through verbatim with no validation, so the
- * SP path sends the same raw shape while being strictly more locked-down. The SP gate
- * is read once here.
+ * (`{ id: value }`). Under SP each `{ id }` is validated then interpolated RAW;
+ * under OAuth2 it is passed through verbatim. See `validateTeamsId` /
+ * `TEAMS_ID_REJECT` for why validation (not encoding) is the guard.
  */
 export function buildTeamsPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
@@ -139,6 +134,22 @@ export function buildTeamsPath(
 			return segment.id.trim();
 		})
 		.join('');
+}
+
+/**
+ * Shape-validates Planner body IDs (`planId`/`bucketId`) under SP for `task:create`
+ * and `task:update`. These go into the JSON body (not a path), so this is
+ * defense-in-depth — a malformed id is a bad request — NOT the path-injection fix
+ * (that is `buildTeamsPath` on path-interpolated ids). No-op under OAuth2.
+ */
+export function validateTaskBodyIdsUnderSp(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	ids: { planId?: string; bucketId?: string },
+): void {
+	if (getTeamsCredentialType.call(this) !== SERVICE_PRINCIPAL_AUTH) return;
+	const node = this.getNode();
+	if (ids.planId !== undefined) validateTeamsId(ids.planId, node);
+	if (ids.bucketId !== undefined) validateTeamsId(ids.bucketId, node);
 }
 
 export async function microsoftApiRequest(
@@ -198,8 +209,19 @@ export async function microsoftApiRequest(
 				rawCode === undefined || rawCode === null ? undefined : Number(rawCode);
 
 			let message: string;
-			if (httpCode === 404) {
-				const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
+			// `resource` exists on the action node but NOT in the trigger IHookFunctions
+			// context — read it defensively so a 404 in the trigger falls through to the
+			// generic static message instead of "Undefined not found".
+			let nodeResource: string | undefined;
+			try {
+				const resource = this.getNodeParameter('resource', 0) as string | undefined;
+				if (typeof resource === 'string' && resource !== '') {
+					nodeResource = capitalize(resource);
+				}
+			} catch {
+				nodeResource = undefined;
+			}
+			if (httpCode === 404 && nodeResource) {
 				message = `${nodeResource} not found`;
 			} else if (httpCode === 401) {
 				message =

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -39,8 +39,9 @@ export type TeamsCredentialType =
  * allowing the generic `microsoftOAuth2Api` (Graph) credential or the app-only
  * `microsoftEntraServicePrincipalApi` (Service Principal) credential to be selected.
  *
- * Passthrough resolver: any selected value is used verbatim; only an unset value
- * (legacy nodes) falls back to the Teams credential.
+ * Allow-list resolver: only the two known non-default credential names are honored;
+ * anything else (unset/legacy nodes, an unknown value, or the load-options fallback
+ * `0`) falls back to the Teams credential.
  *
  * Shared by the action node (v2), its `listSearch` helpers and the Trigger's
  * webhook hooks, since all of them authenticate through `microsoftApiRequest`.

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -68,19 +68,21 @@ export function joinedTeamsEndpoint(
 		: '/v1.0/me/joinedTeams';
 }
 
-// Reject any id that could escape its Graph path segment. `encodeURIComponent`
-// leaves `..` intact, so shape validation (not encoding) is what keeps a value
-// safe to interpolate — validate BEFORE encoding. Messages are fully static so a
-// rejected id is never echoed back. Rejects control chars and `/ \ : ? #`;
-// hyphens/dots/`@` are kept (GUIDs, UPNs and Planner ids legitimately use them).
+// Reject any id that could escape its Graph path segment or start a query/fragment:
+// path separators (`/` `\`), query/fragment starters (`?` `#`), and control chars
+// (0x00–0x1F). `:` and `@` are ALLOWED — they are structure-neutral inside a single
+// Teams id segment (real channel ids look like `19:...@thread.tacv2`), and the proven
+// OAuth2 URL shape interpolates them raw. Validating the shape (not encoding) is what
+// keeps a value safe to interpolate raw. Messages are static so a rejected id is
+// never echoed back.
 // eslint-disable-next-line no-control-regex
-const TEAMS_ID_REJECT = /[\x00-\x1f\/\\:?#]/;
+const TEAMS_ID_REJECT = /[\x00-\x1f\/\\?#]/;
 
 /**
  * Validates a user-supplied Graph id (already `extractValue`-resolved) before it is
- * encoded and interpolated into a Graph path. Throws a `NodeOperationError` with a
- * fully static message (never echoing the id) on a bad shape. Reused for both path
- * IDs and `task:create` body IDs (the latter validate-only — see `buildTeamsPath`).
+ * interpolated RAW into a Graph path. Throws a `NodeOperationError` with a fully
+ * static message (never echoing the id) on a bad shape. Reused for both path IDs and
+ * `task:create` body IDs (the latter validate-only — see `buildTeamsPath`).
  */
 export function validateTeamsId(id: string, node: INode): void {
 	const value = String(id ?? '').trim();
@@ -96,7 +98,7 @@ export function validateTeamsId(id: string, node: INode): void {
 	}
 	if (TEAMS_ID_REJECT.test(value)) {
 		throw new NodeOperationError(node, 'The ID is not valid', {
-			description: 'Remove any slashes, backslashes, colons, question marks or hashes and try again.',
+			description: 'Remove any slashes, backslashes, question marks or hashes and try again.',
 		});
 	}
 }
@@ -107,10 +109,13 @@ type TeamsPathSegment = string | { id: string };
  * Single, non-bypassable path builder for every Graph path that interpolates a
  * user-supplied id. `segments` is an ordered mix of literal strings and id parts
  * (`{ id: value }`). Under the Service Principal credential each `{ id }` is
- * validated (`validateTeamsId`) then `encodeURIComponent`-ed — the tenant-wide app
- * token makes a path-escape org-wide, so this is the path-injection guard. Under
- * OAuth2 the id is passed through verbatim (no validate, no encode) so OAuth2 URL
- * shapes stay byte-for-byte unchanged. The SP gate is read once here.
+ * validated (`validateTeamsId`) — the tenant-wide app token makes a path-escape
+ * org-wide, so rejecting `/ \ ? #` + control is the path-injection guard. The id is
+ * then interpolated RAW (no `encodeURIComponent`), sending the identical proven
+ * OAuth2 URL shape byte-for-byte (encoding `:`→`%3A` would be an unverified Graph
+ * shape). Under OAuth2 the id is passed through verbatim with no validation, so the
+ * SP path sends the same raw shape while being strictly more locked-down. The SP gate
+ * is read once here.
  */
 export function buildTeamsPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
@@ -123,7 +128,7 @@ export function buildTeamsPath(
 			if (typeof segment === 'string') return segment;
 			if (!isServicePrincipal) return segment.id;
 			validateTeamsId(segment.id, node);
-			return encodeURIComponent(segment.id.trim());
+			return segment.id.trim();
 		})
 		.join('');
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -48,10 +48,17 @@ export type TeamsCredentialType =
 export function getTeamsCredentialType(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 ): TeamsCredentialType {
-	// `0` is the execute item index; in load-options getNodeParameter has no itemIndex
-	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form.
+	// `0` is the execute item index; in load-options/hook contexts getNodeParameter
+	// treats the 2nd arg as the FALLBACK value, so don't switch this to the 3-arg form.
+	// Use an explicit allow-list (not `selected ?? default`): in load-options/hooks a
+	// legacy node with no stored `authentication` returns the literal fallback `0`,
+	// which is not nullish — so `?? default` would resolve to `0` and break
+	// `getCredentials(0)`. Anything other than the two known non-default values
+	// (incl. `0`, `undefined`, legacy nodes) resolves to the Teams credential.
 	const selected = this.getNodeParameter('authentication', 0) as TeamsCredentialType | undefined;
-	return selected ?? 'microsoftTeamsOAuth2Api';
+	return selected === 'microsoftOAuth2Api' || selected === SERVICE_PRINCIPAL_AUTH
+		? selected
+		: 'microsoftTeamsOAuth2Api';
 }
 
 /**
@@ -178,12 +185,19 @@ export async function microsoftApiRequest(
 			// correlation IDs and reflected input. For ANY status, never pass the raw
 			// body to NodeApiError (it would land in `messages`/context); throw a
 			// sanitized error whose only content is a static message + the status code.
-			const httpCode: number | undefined = error?.error?.error?.statusCode ?? error?.statusCode;
-			const graphCode: string | undefined = error?.error?.error?.code;
-			const graphMessage: unknown = error?.error?.error?.message;
+			//
+			// `requestWithAuthentication` wraps the underlying request error in a
+			// `NodeApiError`, which exposes the HTTP status on `httpCode` (a string) — NOT
+			// on `statusCode` / `error.error.statusCode`. Read `httpCode` first; fall back
+			// to `statusCode` for the rare raw-error case. The Graph body/code is not
+			// reliably accessible on the wrapped error, so key the NotFound rewrite off the
+			// numeric 404 rather than the Graph `code`.
+			const rawCode = error?.httpCode ?? error?.statusCode;
+			const httpCode: number | undefined =
+				rawCode === undefined || rawCode === null ? undefined : Number(rawCode);
 
 			let message: string;
-			if (graphCode === 'NotFound' && graphMessage === 'Resource not found') {
+			if (httpCode === 404) {
 				const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
 				message = `${nodeResource} not found`;
 			} else if (httpCode === 401) {
@@ -201,7 +215,7 @@ export async function microsoftApiRequest(
 
 			const sanitizedError: JsonObject = { message };
 			const errorOptions: IDataObject = { message };
-			if (httpCode !== undefined) {
+			if (httpCode !== undefined && !Number.isNaN(httpCode)) {
 				sanitizedError.httpStatusCode = httpCode;
 				errorOptions.httpCode = `${httpCode}`;
 			}

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -6,18 +6,41 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 	IHookFunctions,
+	INode,
 } from 'n8n-workflow';
-import { NodeApiError } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 
 import { capitalize } from '../../../../../utils/utilities';
 
-export type TeamsCredentialType = 'microsoftTeamsOAuth2Api' | 'microsoftOAuth2Api';
+/**
+ * Credential-name literal of the shared app-only (Service Principal) credential.
+ * Used as the `authentication` selector value AND the credential type, so a rename
+ * stays in one place (mirrors the OneDrive reference scheme).
+ */
+export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
+
+/**
+ * Field-level `displayOptions.hide` gate spread onto every operation/event/field
+ * that has no usable app-only form. The slash-prefixed `/authentication` key
+ * addresses the root selector from a nested field (distinct from the un-prefixed
+ * `show.authentication` key used on the credential entries themselves).
+ */
+export const SP_HIDE = { '/authentication': [SERVICE_PRINCIPAL_AUTH] };
+
+export type TeamsCredentialType =
+	| 'microsoftTeamsOAuth2Api'
+	| 'microsoftOAuth2Api'
+	| typeof SERVICE_PRINCIPAL_AUTH;
 
 /**
  * Resolves which credential type the node is configured to use. Defaults to the
  * node-specific `microsoftTeamsOAuth2Api` so existing workflows (and nodes saved
  * before the `authentication` selector existed) keep working unchanged, while
- * allowing the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ * allowing the generic `microsoftOAuth2Api` (Graph) credential or the app-only
+ * `microsoftEntraServicePrincipalApi` (Service Principal) credential to be selected.
+ *
+ * Passthrough resolver: any selected value is used verbatim; only an unset value
+ * (legacy nodes) falls back to the Teams credential.
  *
  * Shared by the action node (v2), its `listSearch` helpers and the Trigger's
  * webhook hooks, since all of them authenticate through `microsoftApiRequest`.
@@ -26,11 +49,83 @@ export function getTeamsCredentialType(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 ): TeamsCredentialType {
 	// `0` is the execute item index; in load-options getNodeParameter has no itemIndex
-	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form. Anything
-	// other than the generic value (incl. legacy nodes) resolves to the Teams credential.
-	return this.getNodeParameter('authentication', 0) === 'microsoftOAuth2Api'
-		? 'microsoftOAuth2Api'
-		: 'microsoftTeamsOAuth2Api';
+	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form.
+	const selected = this.getNodeParameter('authentication', 0) as TeamsCredentialType | undefined;
+	return selected ?? 'microsoftTeamsOAuth2Api';
+}
+
+/**
+ * App-only Microsoft Graph has no `/me`, so the joined-teams listing is fetched
+ * from the org-wide `/v1.0/teams` endpoint under the Service Principal credential
+ * (App `Team.ReadBasic.All`). OAuth2 keeps the per-user `/v1.0/me/joinedTeams`.
+ * Shared by `getTeams` (listSearch) and `fetchAllTeams` (trigger).
+ */
+export function joinedTeamsEndpoint(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+): string {
+	return getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH
+		? '/v1.0/teams'
+		: '/v1.0/me/joinedTeams';
+}
+
+// Reject any id that could escape its Graph path segment. `encodeURIComponent`
+// leaves `..` intact, so shape validation (not encoding) is what keeps a value
+// safe to interpolate — validate BEFORE encoding. Messages are fully static so a
+// rejected id is never echoed back. Rejects control chars and `/ \ : ? #`;
+// hyphens/dots/`@` are kept (GUIDs, UPNs and Planner ids legitimately use them).
+// eslint-disable-next-line no-control-regex
+const TEAMS_ID_REJECT = /[\x00-\x1f\/\\:?#]/;
+
+/**
+ * Validates a user-supplied Graph id (already `extractValue`-resolved) before it is
+ * encoded and interpolated into a Graph path. Throws a `NodeOperationError` with a
+ * fully static message (never echoing the id) on a bad shape. Reused for both path
+ * IDs and `task:create` body IDs (the latter validate-only — see `buildTeamsPath`).
+ */
+export function validateTeamsId(id: string, node: INode): void {
+	const value = String(id ?? '').trim();
+	if (value === '') {
+		throw new NodeOperationError(node, 'A required ID is empty', {
+			description: 'Set the team, channel, plan, bucket or task ID and try again.',
+		});
+	}
+	if (/^\.+$/.test(value)) {
+		throw new NodeOperationError(node, 'The ID is not valid', {
+			description: 'An ID cannot consist only of dots.',
+		});
+	}
+	if (TEAMS_ID_REJECT.test(value)) {
+		throw new NodeOperationError(node, 'The ID is not valid', {
+			description: 'Remove any slashes, backslashes, colons, question marks or hashes and try again.',
+		});
+	}
+}
+
+type TeamsPathSegment = string | { id: string };
+
+/**
+ * Single, non-bypassable path builder for every Graph path that interpolates a
+ * user-supplied id. `segments` is an ordered mix of literal strings and id parts
+ * (`{ id: value }`). Under the Service Principal credential each `{ id }` is
+ * validated (`validateTeamsId`) then `encodeURIComponent`-ed — the tenant-wide app
+ * token makes a path-escape org-wide, so this is the path-injection guard. Under
+ * OAuth2 the id is passed through verbatim (no validate, no encode) so OAuth2 URL
+ * shapes stay byte-for-byte unchanged. The SP gate is read once here.
+ */
+export function buildTeamsPath(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	segments: TeamsPathSegment[],
+): string {
+	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
+	const node = this.getNode();
+	return segments
+		.map((segment) => {
+			if (typeof segment === 'string') return segment;
+			if (!isServicePrincipal) return segment.id;
+			validateTeamsId(segment.id, node);
+			return encodeURIComponent(segment.id.trim());
+		})
+		.join('');
 }
 
 export async function microsoftApiRequest(
@@ -43,6 +138,7 @@ export async function microsoftApiRequest(
 	headers: IDataObject = {},
 ): Promise<any> {
 	const credentialType = getTeamsCredentialType.call(this);
+	const isServicePrincipal = credentialType === SERVICE_PRINCIPAL_AUTH;
 	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
@@ -63,6 +159,13 @@ export async function microsoftApiRequest(
 		if (Object.keys(headers).length !== 0) {
 			options.headers = Object.assign({}, options.headers, headers);
 		}
+		// The Service Principal credential is not an `oAuth2Api` parent type — it
+		// mints a bearer via preAuthentication + attaches it via authenticate, so it
+		// must go through `requestWithAuthentication` (core's single 401-retry re-runs
+		// the token mint). OAuth2 credentials keep using `requestOAuth2`.
+		if (isServicePrincipal) {
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
+		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
 		const errorOptions: IDataObject = {};
@@ -70,11 +173,36 @@ export async function microsoftApiRequest(
 			const httpCode = error.statusCode;
 			error = error.error.error;
 			error.statusCode = httpCode;
-			errorOptions.message = error.message;
 
-			if (error.code === 'NotFound' && error.message === 'Resource not found') {
-				const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
-				errorOptions.message = `${nodeResource} not found`;
+			if (isServicePrincipal) {
+				// App-only runs under a tenant-wide token: a raw Graph error body can
+				// carry correlation IDs and reflected input, so NEVER assign
+				// `error.message` to the surfaced message for ANY status. Map to a
+				// static string instead. 401/402/403 get specific guidance; everything
+				// else (incl. 400 reflected input and 429 throttling) gets a catch-all
+				// that interpolates only the numeric status code.
+				if (error.code === 'NotFound' && error.message === 'Resource not found') {
+					const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
+					errorOptions.message = `${nodeResource} not found`;
+				} else if (httpCode === 401) {
+					errorOptions.message =
+						"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
+				} else if (httpCode === 402) {
+					errorOptions.message =
+						'This operation requires a metered Microsoft Teams API to be enabled on the tenant.';
+				} else if (httpCode === 403) {
+					errorOptions.message =
+						'The app registration is missing a consented application permission for this operation. Grant the required Graph application permission and admin consent, then retry.';
+				} else {
+					errorOptions.message = `Microsoft Graph rejected the request (HTTP ${httpCode}). Check the operation's inputs and the app registration's permissions.`;
+				}
+			} else {
+				errorOptions.message = error.message;
+
+				if (error.code === 'NotFound' && error.message === 'Resource not found') {
+					const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
+					errorOptions.message = `${nodeResource} not found`;
+				}
 			}
 		}
 		throw new NodeApiError(this.getNode(), error as JsonObject, errorOptions);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -168,41 +168,51 @@ export async function microsoftApiRequest(
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
+		if (isServicePrincipal) {
+			// App-only runs under a tenant-wide token: a raw Graph error body can carry
+			// correlation IDs and reflected input. For ANY status, never pass the raw
+			// body to NodeApiError (it would land in `messages`/context); throw a
+			// sanitized error whose only content is a static message + the status code.
+			const httpCode: number | undefined = error?.error?.error?.statusCode ?? error?.statusCode;
+			const graphCode: string | undefined = error?.error?.error?.code;
+			const graphMessage: unknown = error?.error?.error?.message;
+
+			let message: string;
+			if (graphCode === 'NotFound' && graphMessage === 'Resource not found') {
+				const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
+				message = `${nodeResource} not found`;
+			} else if (httpCode === 401) {
+				message =
+					"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
+			} else if (httpCode === 402) {
+				message =
+					'This operation requires a metered Microsoft Teams API to be enabled on the tenant.';
+			} else if (httpCode === 403) {
+				message =
+					'The app registration is missing a consented application permission for this operation. Grant the required Graph application permission and admin consent, then retry.';
+			} else {
+				message = `Microsoft Graph rejected the request (HTTP ${httpCode ?? 'unknown'}). Check the operation's inputs and the app registration's permissions.`;
+			}
+
+			const sanitizedError: JsonObject = { message };
+			const errorOptions: IDataObject = { message };
+			if (httpCode !== undefined) {
+				sanitizedError.httpStatusCode = httpCode;
+				errorOptions.httpCode = `${httpCode}`;
+			}
+			throw new NodeApiError(this.getNode(), sanitizedError, errorOptions);
+		}
+
 		const errorOptions: IDataObject = {};
 		if (error.error?.error) {
 			const httpCode = error.statusCode;
 			error = error.error.error;
 			error.statusCode = httpCode;
+			errorOptions.message = error.message;
 
-			if (isServicePrincipal) {
-				// App-only runs under a tenant-wide token: a raw Graph error body can
-				// carry correlation IDs and reflected input, so NEVER assign
-				// `error.message` to the surfaced message for ANY status. Map to a
-				// static string instead. 401/402/403 get specific guidance; everything
-				// else (incl. 400 reflected input and 429 throttling) gets a catch-all
-				// that interpolates only the numeric status code.
-				if (error.code === 'NotFound' && error.message === 'Resource not found') {
-					const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
-					errorOptions.message = `${nodeResource} not found`;
-				} else if (httpCode === 401) {
-					errorOptions.message =
-						"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
-				} else if (httpCode === 402) {
-					errorOptions.message =
-						'This operation requires a metered Microsoft Teams API to be enabled on the tenant.';
-				} else if (httpCode === 403) {
-					errorOptions.message =
-						'The app registration is missing a consented application permission for this operation. Grant the required Graph application permission and admin consent, then retry.';
-				} else {
-					errorOptions.message = `Microsoft Graph rejected the request (HTTP ${httpCode}). Check the operation's inputs and the app registration's permissions.`;
-				}
-			} else {
-				errorOptions.message = error.message;
-
-				if (error.code === 'NotFound' && error.message === 'Resource not found') {
-					const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
-					errorOptions.message = `${nodeResource} not found`;
-				}
+			if (error.code === 'NotFound' && error.message === 'Resource not found') {
+				const nodeResource = capitalize(this.getNodeParameter('resource', 0) as string);
+				errorOptions.message = `${nodeResource} not found`;
 			}
 		}
 		throw new NodeApiError(this.getNode(), error as JsonObject, errorOptions);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -129,9 +129,12 @@ export function buildTeamsPath(
 	return segments
 		.map((segment) => {
 			if (typeof segment === 'string') return segment;
+			// `as string` at the call sites is compile-time only — an expression can resolve an
+			// id to a non-string (e.g. `={{ 123 }}` → number). OAuth2 passes through and is
+			// stringified by `join()`; the SP path must coerce before `.trim()` or it throws.
 			if (!isServicePrincipal) return segment.id;
 			validateTeamsId(segment.id, node);
-			return segment.id.trim();
+			return String(segment.id).trim();
 		})
 		.join('');
 }


### PR DESCRIPTION
## Summary

Adds the shared **Microsoft Entra Service Principal** credential (`microsoftEntraServicePrincipalApi`, app-only `client_credentials`) as a third **Authentication** option on the Microsoft Teams **v2 action node** and the **Microsoft Teams Trigger** node, alongside the existing Teams OAuth2 (kept as the default) and generic Microsoft Graph OAuth2. This is the Teams sibling of the OneDrive rollout (ENT-91), building on the credential from ENT-85.

App-only Microsoft Graph has no signed-in user (no `/me`), so the node reworks the user-scoped paths and turns off the operations that have no application form:

- **Transport** branches to `requestWithAuthentication` for the Service Principal credential (the credential mints/caches its own bearer via `preAuthentication`/`authenticate`); the two OAuth2 paths keep `requestOAuth2`. `graphApiBaseUrl` (incl. sovereign clouds) is honoured.
- **Works app-only:** listing teams (`GET /v1.0/teams`, paged), all **Channel** operations, all **Task** (Planner) operations, and **Channel Message → Get Many**. Trigger: **New Channel**, **New Channel Message**, **New Team Member** (specific team/channel).
- **Turned off / clearly explained under Service Principal** (hidden fields + an in-NDV notice + a friendly `NodeOperationError` at runtime — never a raw Graph error): the whole **Chat Message** resource, **Channel Message → Create** (app-only channel-message send is migration-only), **Task → Get Many** member mode (forced to plan mode), the **New Chat / New Chat Message** triggers, and **Watch All Teams/Channels**.
- **Back-compat:** the `Authentication` default is unchanged, so existing saved workflows and their pickers/trigger webhooks resolve to the Teams OAuth2 credential exactly as before.
- Graph IDs taken from node parameters are validated and interpolated through a single shared path builder; app-only error responses are mapped to static messages so no raw Graph body reaches the UI.

The OAuth2 request/URL/error behaviour is unchanged byte-for-byte — all new logic is gated on the Service Principal credential.

## How to test

**Setup:** In Microsoft Entra, register an app, add the required **application** permissions, and grant **admin consent** (e.g. `Team.ReadBasic.All`, `Channel.ReadBasic.All`/`ChannelSettings.ReadWrite.All`, `ChannelMessage.Read.All`, `Tasks.ReadWrite.All`, `Group.Read.All`; the credential's connection test also needs `Organization.Read.All`/`Directory.Read.All`). Create a **Microsoft Entra Service Principal** credential (tenant ID, client ID, client secret, cloud).

1. Add a **Microsoft Teams** node → open the credential picker → choose the Service Principal credential. The **Authentication** field shows **Service Principal (App-Only)**.
2. **Channel → Get Many** (pick a team) and **Task → Get Many** (pick a plan) should return data against a real tenant.
3. Switch **Resource** to **Chat Message**: it shows the "not available with the Service Principal credential" notice; selecting it and executing yields a friendly error, not a raw Graph 403.
4. Add a **Microsoft Teams Trigger**, select the Service Principal credential: **New Chat / New Chat Message** and **Watch All** are unavailable/explained; **New Channel Message** for a specific team+channel can create a subscription.
5. Existing OAuth2 Teams workflows continue to work unchanged.

> Automated unit + `NodeTestHarness` coverage is included (Teams suite green: 177 tests). Several app-only paths can only be fully validated on a **licensed M365 tenant** — see the residual checklist below.

**Needs a real tenant to confirm (cannot be mocked):** `Channel Message → Get Many` is a metered Graph API (may need billing/eval-model enabled); `GET /v1.0/teams` returns all org teams (paging/size); app-only change-notification subscription creation for the channel triggers; Planner app-only 2xx; and that the connection test passes (note: the credential caches an expirable token — recreate the credential to force a fresh mint after changing consent/secret).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-89
- Builds on https://linear.app/n8n/issue/ENT-85 (credential) and https://linear.app/n8n/issue/ENT-91 (OneDrive reference node)
- Docs tracked in https://linear.app/n8n/issue/ENT-88

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- tracked in ENT-88 -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->