### PR TITLE
fix(expression-runtime): Trim whitespace in toBoolean before comparison

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/__tests__/string-extensions.test.ts
@@ -7,6 +7,8 @@ const extractUrlPath = stringExtensions.functions.extractUrlPath as (
 
 const toSentenceCase = stringExtensions.functions.toSentenceCase as (value: string) => string;
 
+const toBoolean = stringExtensions.functions.toBoolean as (value: string) => boolean;
+
 describe('extractUrlPath (imperative parser, no URL constructor)', () => {
 	it.each([
 		['https://example.com/path', '/path'],
@@ -62,5 +64,41 @@ describe('toSentenceCase', () => {
 		['', ''],
 	])('should return letter-free input %p unchanged', (input, expected) => {
 		expect(toSentenceCase(input)).toBe(expected);
+	});
+});
+
+describe('toBoolean', () => {
+	it.each([
+		['true', true],
+		['yes', true],
+		['1', true],
+		['anything', true],
+		['false', false],
+		['no', false],
+		['0', false],
+		['', false],
+	])('should convert %s to %s', (input, expected) => {
+		expect(toBoolean(input)).toBe(expected);
+	});
+
+	it.each([
+		['FALSE', false],
+		['False', false],
+		['NO', false],
+		['No', false],
+	])('should be case-insensitive: %s → %s', (input, expected) => {
+		expect(toBoolean(input)).toBe(expected);
+	});
+
+	it.each([
+		[' false ', false],
+		[' 0 ', false],
+		[' no ', false],
+		['\tfalse\t', false],
+		['\n0\n', false],
+		[' true ', true],
+		['  ', false],
+	])('should trim whitespace before comparison: %s → %s', (input, expected) => {
+		expect(toBoolean(input)).toBe(expected);
 	});
 });

--- a/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/string-extensions.ts
@@ -432,7 +432,7 @@ function parseJson(value: string): unknown {
 }
 
 function toBoolean(value: string): boolean {
-	const normalized = value.toLowerCase();
+	const normalized = value.trim().toLowerCase();
 	const FALSY = new Set(['false', 'no', '0']);
 	return normalized.length > 0 && !FALSY.has(normalized);
 }

--- a/packages/workflow/src/extensions/string-extensions.ts
+++ b/packages/workflow/src/extensions/string-extensions.ts
@@ -427,7 +427,7 @@ function parseJson(value: string): unknown {
 }
 
 function toBoolean(value: string): boolean {
-	const normalized = value.toLowerCase();
+	const normalized = value.trim().toLowerCase();
 	const FALSY = new Set(['false', 'no', '0']);
 	return normalized.length > 0 && !FALSY.has(normalized);
 }

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -349,6 +349,15 @@ describe('Data Transformation Functions', () => {
 			expect(evaluate('={{ "hello".toBoolean() }}')).toBe(true);
 		});
 
+		test('.toBoolean should trim whitespace before comparison', () => {
+			expect(evaluate('={{ " false ".toBoolean() }}')).toBe(false);
+			expect(evaluate('={{ " 0 ".toBoolean() }}')).toBe(false);
+			expect(evaluate('={{ " no ".toBoolean() }}')).toBe(false);
+			expect(evaluate('={{ "  FALSE  ".toBoolean() }}')).toBe(false);
+			expect(evaluate('={{ "   ".toBoolean() }}')).toBe(false);
+			expect(evaluate('={{ " true ".toBoolean() }}')).toBe(true);
+		});
+
 		test('.base64Encode should work on a string', () => {
 			expect(evaluate('={{ "n8n test".base64Encode() }}')).toBe('bjhuIHRlc3Q=');
 		});


### PR DESCRIPTION
## Summary

`toBoolean()` in both `expression-runtime` and `workflow` runtimes evaluates padded falsy strings like `" false "` or `" 0 "` as `true` because `.toLowerCase()` is called without `.trim()` first. This fix adds `.trim()` before the comparison in both runtimes.

## How to test

```
{{ " false ".toBoolean() }}  // was: true, now: false
{{ " 0 ".toBoolean() }}      // was: true, now: false
{{ " no ".toBoolean() }}     // was: true, now: false
{{ "   ".toBoolean() }}      // was: true, now: false
```

## Related Linear tickets, Github issues, and Community forum posts

None found. Discovered during codebase review.

## Review / Merge checklist

- [x] Tests added for padded falsy/truthy cases in both runtimes
- [x] Cross-runtime parity: fix applied to both `expression-runtime` and `workflow`