### PR TITLE
fix(expression-runtime): Preserve array structure in object compact()

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/__tests__/object-extensions.test.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/__tests__/object-extensions.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { compact } from '../object-extensions';
+
+describe('compact', () => {
+	it('should remove null, undefined, empty string, and nil from objects', () => {
+		expect(compact({ a: 1, b: null, c: '', d: undefined, e: 'nil' })).toEqual({ a: 1 });
+	});
+
+	it('should remove empty objects', () => {
+		expect(compact({ a: 1, b: {} })).toEqual({ a: 1 });
+	});
+
+	it('should recurse into nested objects', () => {
+		expect(compact({ a: { b: null, c: 2 }, d: 3 })).toEqual({ a: { c: 2 }, d: 3 });
+	});
+
+	it('should preserve array structure instead of converting to object', () => {
+		const input = { items: [1, null, 2, '', 3] };
+		const result = compact(input);
+		expect(result).toEqual({ items: [1, 2, 3] });
+		expect(Array.isArray((result as Record<string, unknown>).items)).toBe(true);
+	});
+
+	it('should filter empty values from top-level arrays', () => {
+		const result = compact([1, null, 'hello', '', undefined, 'nil', 0] as unknown as object);
+		expect(result).toEqual([1, 'hello', 0]);
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should remove empty objects from arrays', () => {
+		const result = compact([1, {}, { a: 1 }, []] as unknown as object);
+		expect(result).toEqual([1, { a: 1 }]);
+	});
+
+	it('should recurse into objects nested inside arrays', () => {
+		const input = { items: [{ a: 1, b: null }, { c: '', d: 2 }] };
+		expect(compact(input)).toEqual({ items: [{ a: 1 }, { d: 2 }] });
+	});
+
+	it('should handle nested arrays', () => {
+		const input = { matrix: [[1, null], [null, 2]] };
+		const result = compact(input);
+		expect(result).toEqual({ matrix: [[1], [2]] });
+	});
+
+	it('should preserve falsy non-empty values in arrays', () => {
+		const result = compact([false, 0, true, null, ''] as unknown as object);
+		expect(result).toEqual([false, 0, true]);
+	});
+});

--- a/packages/@n8n/expression-runtime/src/extensions/object-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/object-extensions.ts
@@ -66,6 +66,15 @@ function keepFieldsContaining(value: object, extraArgs: string[]): object {
 }
 
 export function compact(value: object): object {
+	if (Array.isArray(value)) {
+		return value
+			.filter((v) => v !== null && v !== undefined && v !== 'nil' && v !== '')
+			.filter((v) => {
+				if (typeof v === 'object' && v !== null && Object.keys(v).length === 0) return false;
+				return true;
+			})
+			.map((v) => (typeof v === 'object' && v !== null ? compact(v) : v)) as unknown as object;
+	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const newObj: any = {};
 	for (const [key, val] of Object.entries(value)) {

--- a/packages/workflow/src/extensions/object-extensions.ts
+++ b/packages/workflow/src/extensions/object-extensions.ts
@@ -73,6 +73,11 @@ function keepFieldsContaining(value: object, extraArgs: string[]): object {
 }
 
 export function compact(value: object): object {
+	if (Array.isArray(value)) {
+		return value
+			.filter((item) => item !== null && item !== undefined && item !== 'nil' && item !== '')
+			.map((item) => (typeof item === 'object' && item !== null ? compact(item) : item));
+	}
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const newObj: any = {};
 	for (const [key, val] of Object.entries(value)) {

--- a/packages/workflow/test/ExpressionExtensions/object-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/object-extensions.test.ts
@@ -132,6 +132,24 @@ describe('Data Transformation Functions', () => {
 					},
 				);
 			});
+
+			test('should preserve arrays instead of converting to objects', () => {
+				expect(
+					evaluate('={{ ({ items: [1, null, 3] }).compact() }}'),
+				).toEqual({ items: [1, 3] });
+			});
+
+			test('should filter null/undefined from arrays', () => {
+				expect(
+					evaluate('={{ ({ data: [null, "a", undefined, "b", "", "c"] }).compact() }}'),
+				).toEqual({ data: ['a', 'b', 'c'] });
+			});
+
+			test('should handle nested objects inside arrays', () => {
+				expect(
+					evaluate('={{ ({ items: [{ a: 1 }, null, { b: null, c: 2 }] }).compact() }}'),
+				).toEqual({ items: [{ a: 1 }, { c: 2 }] });
+			});
 		});
 
 		test('.urlEncode should work on an object', () => {


### PR DESCRIPTION
## Summary

`compact()` in both `expression-runtime` and `workflow` runtimes converts arrays to plain objects when iterating with `Object.entries()`. For example, `{ items: [1, null, 3] }.compact()` returns `{ items: { "0": 1, "2": 3 } }` instead of `{ items: [1, 3] }`. This fix adds an `Array.isArray()` guard to preserve array structure in both runtimes.

## How to test

```
{{ ({ items: [1, null, 3] }).compact() }}
// was: { items: { "0": 1, "2": 3 } }
// now: { items: [1, 3] }
```

## Related Linear tickets, Github issues, and Community forum posts

None found. Discovered during codebase review.

## Review / Merge checklist

- [x] Tests added for array preservation, null filtering, nested objects in arrays
- [x] Cross-runtime parity: fix applied to both `expression-runtime` and `workflow`