### PR TITLE
fix(core): Settle failed workflow verification instead of looping (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-failed-loop-repro.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-verification-failed-loop-repro.json
@@ -1,0 +1,37 @@
+{
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"First create a plan and wait for my approval before building. Do not skip the plan approval step.",
+				"",
+				"After I approve, build a workflow named \"workflow verification failed loop repro\" with exactly this shape:",
+				"",
+				"Manual Trigger",
+				"→ Code node named \"Fails at runtime\" whose body is exactly `throw new Error('Simulated upstream failure');`",
+				"→ HTTP Request node named \"Unreached POST\" configured as POST to https://example.com/repro with a small JSON body",
+				"→ Edit Fields node named \"After post\"",
+				"",
+				"This Code node is meant to fail at runtime on purpose — it simulates an upstream system error we cannot fix from inside the workflow. Do NOT change the Code node to succeed, do NOT wrap it in try/catch or add error-handling/continue-on-fail, do NOT add fallback branches, and do NOT remove the HTTP POST or the downstream node.",
+				"After saving, verify the workflow automatically."
+			]
+		}
+	],
+	"complexity": "medium",
+	"tags": ["behaviour", "verification", "orchestration", "regression"],
+	"executionScenarios": [
+		{
+			"name": "runtime-error-stops-before-post",
+			"description": "The Code node throws at runtime, so the execution errors out and the HTTP POST and downstream Edit Fields node are never reached.",
+			"dataSetup": "Manual trigger input can be an empty item. HTTP requests are mocked; however, the workflow should error at the Code node before the HTTP Request node runs, because the Code node throws.",
+			"successCriteria": "The workflow execution fails at the Code node with a runtime error. The HTTP POST is not executed, the downstream nodes are not reached, and the agent reports the concrete failure (and that downstream nodes were not verified) instead of repeatedly re-running verification."
+		}
+	],
+	"description": "Regression case for the post-build workflow-verification loop when automatic verification FAILS (success=false) with readiness=ready and no required setup. Without an off-ramp for failed evidence the obligation re-derives to ready_to_verify forever and the planned orchestrator re-issues verification endlessly. Mirror of workflow-verification-loop-repro.json, which covers the success=true partial-coverage variant.",
+	"processExpectations": [
+		"The agent does not repeatedly re-enter workflow verification for the same saved workflow after a failed verification; it verifies once or twice at most, then surfaces the concrete runtime failure to the user (or reports manual/partial verification) instead of looping."
+	],
+	"triggerType": "manual",
+	"messageBudget": 20,
+	"datasets": ["behaviour", "verification", "full"]
+}

--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/verification-obligation.test.ts
@@ -135,6 +135,33 @@ describe('deriveWorkflowVerificationObligation', () => {
 		expect(obligation.blockingReason).toContain('Send Email');
 	});
 
+	it('settles failed verification evidence as a manual completion instead of looping', () => {
+		const obligation = deriveWorkflowVerificationObligation('thread-1', {
+			state: makeState(),
+			attempts: [makeAttempt()],
+			lastBuildOutcome: makeOutcome({
+				// Readiness "ready" + setup "not_required" is the production shape that
+				// previously fell through to ready_to_verify and re-issued forever.
+				verificationReadiness: { status: 'ready' },
+				setupRequirement: { status: 'not_required' },
+				verification: {
+					attempted: true,
+					success: false,
+					executionId: 'exec-1',
+					status: 'error',
+					failureSignature:
+						'Error in sub-node Google Gemini — Node does not have any credentials set',
+					evidence: { nodesNotReached: ['Send Bug Report Email'] },
+				},
+			}),
+		});
+
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.policy).toBe('manual');
+		expect(obligation.blockingReason).toContain('Node does not have any credentials set');
+		expect(obligation.blockingReason).toContain('Send Bug Report Email');
+	});
+
 	it('treats not-verifiable outcomes as manual warning completions', () => {
 		const obligation = deriveWorkflowVerificationObligation('thread-1', {
 			state: makeState(),
@@ -290,6 +317,29 @@ describe('deriveWorkflowVerificationObligationFromOutcome', () => {
 		expect(obligation.status).toBe('not_verifiable');
 		expect(obligation.policy).toBe('manual');
 		expect(obligation.blockingReason).toContain('Send Email');
+	});
+
+	it('settles failed verification evidence as manual from outcome-only records', () => {
+		const obligation = deriveWorkflowVerificationObligationFromOutcome(
+			'thread-1',
+			makeOutcome({
+				verificationReadiness: { status: 'ready' },
+				setupRequirement: { status: 'not_required' },
+				verification: {
+					attempted: true,
+					success: false,
+					executionId: 'exec-1',
+					status: 'error',
+					failureSignature: 'Sheet with name Registrations not found',
+				},
+			}),
+			{ source: 'planned', plannedTaskId: 'task-1' },
+		);
+
+		expect(obligation.status).toBe('not_verifiable');
+		expect(obligation.policy).toBe('manual');
+		expect(obligation.blockingReason).toContain('Sheet with name Registrations not found');
+		expect(obligation.plannedTaskId).toBe('task-1');
 	});
 
 	it('marks setup-blocked failed evidence as needs setup from outcome-only records', () => {

--- a/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/verification-obligation.ts
@@ -76,6 +76,13 @@ function deriveStatus(
 	if (hasSuccessfulEvidence(outcome)) return 'verified';
 	if (hasSetupBlockingEvidence(state, outcome)) return 'needs_setup';
 	if (hasPartialSuccessfulCoverageEvidence(outcome)) return 'not_verifiable';
+	// A verification that was attempted and failed has already run end-to-end and
+	// produced a concrete error (e.g. a missing credential or a runtime error).
+	// Re-issuing it just replays the same failure, so once setup-blocking and
+	// partial-success cases are ruled out above, settle it as a manual outcome.
+	// Without this the switch below falls through to `ready_to_verify` and the
+	// planned orchestrator re-issues verification forever.
+	if (hasFailedEvidence(outcome)) return 'not_verifiable';
 
 	switch (outcome.verificationReadiness?.status) {
 		case 'already_verified':
@@ -121,6 +128,16 @@ function deriveBlockingReason(
 	if (hasPartialSuccessfulCoverageEvidence(outcome)) {
 		const nodesNotReached = outcome.verification?.evidence?.nodesNotReached ?? [];
 		return `Automatic verification only covered part of the workflow. Unreached nodes need manual testing: ${nodesNotReached.join(', ')}.`;
+	}
+	if (hasFailedEvidence(outcome) && !hasSetupBlockingEvidence(state, outcome)) {
+		const failure =
+			outcome.verification?.failureSignature ??
+			outcome.verification?.evidence?.errorMessage ??
+			'an error during execution';
+		const nodesNotReached = outcome.verification?.evidence?.nodesNotReached ?? [];
+		const unreached =
+			nodesNotReached.length > 0 ? ` Nodes not reached: ${nodesNotReached.join(', ')}.` : '';
+		return `Automatic verification failed with: ${failure}. Re-running it will reproduce the same failure — explain this blocker to the user and have them resolve it (e.g. configure credentials or fix the data) before verifying manually.${unreached}`;
 	}
 	const outcomeRemediation = outcome.remediation;
 	if (outcomeRemediation && setupRemediationBlocksVerification(outcomeRemediation, outcome)) {


### PR DESCRIPTION
## Summary

Fixes a second infinite workflow-verification loop, a follow-up to #32979.

PR #32979 stopped the loop when verification **succeeded** with partial coverage (`nodesNotReached > 0`). But a verification that was **attempted and failed** (`success: false`) with `readiness: ready` and `setupRequirement: not_required` had no terminal branch in `deriveStatus`: it fell through the switch to `ready_to_verify`, which is an *unsettled* status, so the planned-task orchestrator re-issued `<workflow-verification-follow-up>` endlessly.

Two production users on 2.28 (which already had #32979) hit this — their verifications failed on errors the agent can't fix by rebuilding (a sub-node credential error on a Gemini/LM node, and a "Sheet not found" data error), both reported as a hard runtime `error` rather than `needs_setup`. One thread re-issued verification **78 times**.

### The fix (`verification-obligation.ts`)

- `deriveStatus`: after the existing setup-blocking and partial-success checks, an attempted-and-failed verification now settles as `not_verifiable` (→ `manual` policy). Re-running it just replays the same failure. Setup-blocking failures still route to `needs_setup` (the check sits after `hasSetupBlockingEvidence`).
- `deriveBlockingReason`: surfaces the concrete failure signature + any unreached nodes (guarded so setup guidance still wins) so the agent explains the blocker to the user instead of looping.

## How to test

```
pnpm eval:instance-ai \
  --base-url http://localhost:5678 --iterations 1 --verbose \
  --filter workflow-verification-failed-loop-repro --keep-workflows
```

The new eval (`workflow-verification-failed-loop-repro`) is the `success: false` sibling of `workflow-verification-loop-repro`. Verified end-to-end against a live instance + Daytona sandbox:

| | Verification resumes | Result |
|---|---|---|
| Unfixed | **100+** (infinite loop) | 🔴 |
| With fix | 3 runs, then settled | ✅ 100% pass |

Unit coverage added in `verification-obligation.test.ts` (the deepaknaidu sub-node-credential and tandingarab sheet-not-found shapes).

## Related

https://linear.app/n8n/issue/INS-678

## Review / Merge checklist

- [x] Tests included.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

