### PR TITLE
feat: Introduce reusable blob storage layer

### DIFF
--- a/packages/cli/src/blob-storage/__tests__/fs-byte-store.integration.test.ts
+++ b/packages/cli/src/blob-storage/__tests__/fs-byte-store.integration.test.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { mockInstance } from '@n8n/backend-test-utils';
+import { Container } from '@n8n/di';
+import { ErrorReporter, StorageConfig } from 'n8n-core';
+import { UnexpectedError } from 'n8n-workflow';
+import fs, { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { FsByteStore } from '../fs-byte-store';
+
+jest.unmock('node:fs/promises');
+
+let store: FsByteStore;
+let storagePath: string;
+let errorReporter: ErrorReporter;
+
+const body = Buffer.from('hello-bytes', 'utf-8');
+
+beforeAll(async () => {
+	storagePath = await mkdtemp(join(tmpdir(), 'n8n-fs-byte-store-test-'));
+	mockInstance(StorageConfig, { storagePath });
+	errorReporter = mockInstance(ErrorReporter);
+	store = Container.get(FsByteStore);
+});
+
+beforeEach(async () => {
+	jest.mocked(errorReporter.error).mockClear();
+	for (const entry of await fs.readdir(storagePath)) {
+		await rm(join(storagePath, entry), { recursive: true, force: true });
+	}
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+afterAll(async () => {
+	await rm(storagePath, { recursive: true, force: true });
+});
+
+describe('init', () => {
+	it('creates the storage dir if absent', async () => {
+		const customPath = join(storagePath, 'custom-init');
+		const custom = new FsByteStore({ storagePath: customPath } as StorageConfig, errorReporter);
+
+		await custom.init();
+
+		expect((await fs.stat(customPath)).isDirectory()).toBe(true);
+	});
+});
+
+describe('write', () => {
+	it('writes bytes at the key path, creating parent dirs, and returns the byte count', async () => {
+		const bytes = await store.write('a/b/c/blob.json', body);
+
+		const onDisk = await fs.readFile(join(storagePath, 'a/b/c/blob.json'));
+		expect(onDisk.equals(body)).toBe(true);
+		expect(bytes).toBe(body.length);
+	});
+
+	it('overwrites an existing key', async () => {
+		await store.write('a/blob.json', body);
+		const updated = Buffer.from('updated', 'utf-8');
+
+		await store.write('a/blob.json', updated);
+
+		expect((await store.read('a/blob.json'))!.equals(updated)).toBe(true);
+	});
+
+	it('rethrows on write failure and cleans up the temp file', async () => {
+		jest.spyOn(fs, 'rename').mockRejectedValueOnce(new Error('EACCES: permission denied'));
+
+		await expect(store.write('a/blob.json', body)).rejects.toThrow('EACCES');
+
+		const files = await fs.readdir(join(storagePath, 'a'));
+		expect(files.filter((f) => f.includes('.tmp.'))).toHaveLength(0);
+	});
+});
+
+describe('read', () => {
+	it('returns the stored bytes', async () => {
+		await store.write('a/blob.json', body);
+
+		expect((await store.read('a/blob.json'))!.equals(body)).toBe(true);
+	});
+
+	it('returns null for a missing key', async () => {
+		expect(await store.read('a/missing.json')).toBeNull();
+	});
+
+	it('rethrows a systemic (non-ENOENT) read error', async () => {
+		await store.write('a/blob.json', body);
+		const eacces = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+		jest.spyOn(fs, 'readFile').mockRejectedValueOnce(eacces);
+
+		await expect(store.read('a/blob.json')).rejects.toBe(eacces);
+	});
+});
+
+describe('delete', () => {
+	it('removes the keyed files', async () => {
+		await store.write('a/one.json', body);
+		await store.write('a/two.json', body);
+
+		await store.delete(['a/one.json']);
+
+		expect(await store.read('a/one.json')).toBeNull();
+		expect(await store.read('a/two.json')).not.toBeNull();
+	});
+
+	it('prunes empty ancestor dirs up to (not including) the storage root', async () => {
+		await store.write('pa/pb/pc/blob.json', body);
+
+		await store.delete(['pa/pb/pc/blob.json']);
+
+		await expect(fs.stat(join(storagePath, 'pa'))).rejects.toThrow();
+		expect((await fs.stat(storagePath)).isDirectory()).toBe(true);
+	});
+
+	it('stops pruning at the first non-empty ancestor', async () => {
+		await store.write('shared/x/f1.json', body);
+		await store.write('shared/y/f2.json', body);
+
+		await store.delete(['shared/x/f1.json']);
+
+		await expect(fs.stat(join(storagePath, 'shared/x'))).rejects.toThrow();
+		expect((await fs.stat(join(storagePath, 'shared'))).isDirectory()).toBe(true);
+		expect(await store.read('shared/y/f2.json')).not.toBeNull();
+	});
+
+	it('does not throw on deleting a missing key', async () => {
+		await expect(store.delete(['a/missing.json'])).resolves.toBeUndefined();
+	});
+});
+
+describe('path traversal guard', () => {
+	it('rejects a key that escapes the storage root', async () => {
+		await expect(store.write('../escape.json', body)).rejects.toThrow(UnexpectedError);
+		await expect(store.read('../../escape.json')).rejects.toThrow(UnexpectedError);
+	});
+
+	it('rejects a key that resolves to the storage root itself', async () => {
+		for (const key of ['', '.', 'a/..']) {
+			await expect(store.write(key, body)).rejects.toThrow(UnexpectedError);
+			await expect(store.delete([key])).rejects.toThrow(UnexpectedError);
+		}
+	});
+});

--- a/packages/cli/src/blob-storage/__tests__/json-store.test.ts
+++ b/packages/cli/src/blob-storage/__tests__/json-store.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable n8n-local-rules/no-uncaught-json-parse */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { JsonStore } from '../json-store';
+import type { ByteStore, ByteStoreKey, StorageLocation } from '../types';
+
+type TestRef = { id: string };
+type TestPayload = { value: string };
+
+class InMemoryByteStore implements ByteStore {
+	readonly objects = new Map<ByteStoreKey, Buffer>();
+
+	/** Force a non-ENOENT (systemic) failure on read for these keys. */
+	readonly failingKeys = new Set<ByteStoreKey>();
+
+	async write(key: ByteStoreKey, body: Buffer) {
+		this.objects.set(key, body);
+		return body.length;
+	}
+
+	async read(key: ByteStoreKey): Promise<Buffer | null> {
+		if (this.failingKeys.has(key)) throw new Error('disk on fire');
+		return this.objects.get(key) ?? null;
+	}
+
+	async delete(keys: ByteStoreKey[]): Promise<void> {
+		for (const key of keys) this.objects.delete(key);
+	}
+}
+
+const VERSION = 1;
+
+function makeStore(byteStores: Partial<Record<StorageLocation, ByteStore>>) {
+	const reportError = jest.fn();
+	const store = new JsonStore<TestRef, TestPayload>({
+		byteStores,
+		version: VERSION,
+		key: (ref) => `objects/${ref.id}.json`,
+		getId: (ref) => ref.id,
+		createWriteError: (ref, cause) => new Error(`write failed for ${ref.id}: ${String(cause)}`),
+		createCorruptedError: (ref, cause) => new Error(`corrupt ${ref.id}: ${String(cause)}`),
+		reportError,
+	});
+	return { store, reportError };
+}
+
+describe('JsonStore', () => {
+	describe('write + read', () => {
+		it('serializes with a version stamp and reads it back', async () => {
+			const fs = new InMemoryByteStore();
+			const { store } = makeStore({ fs });
+
+			const bytes = await store.write({ id: 'a' }, { value: 'hello' }, 'fs');
+			expect(bytes).toBeGreaterThan(0);
+
+			const stored = JSON.parse(fs.objects.get('objects/a.json')!.toString('utf-8'));
+			expect(stored).toEqual({ value: 'hello', version: VERSION });
+
+			const bundle = await store.read({ id: 'a' }, 'fs');
+			expect(bundle).toEqual({ value: 'hello', version: VERSION });
+		});
+
+		it('returns null when the bundle is missing', async () => {
+			const { store } = makeStore({ fs: new InMemoryByteStore() });
+			expect(await store.read({ id: 'missing' }, 'fs')).toBeNull();
+		});
+
+		it('throws a corrupted error on unparseable bytes', async () => {
+			const fs = new InMemoryByteStore();
+			fs.objects.set('objects/a.json', Buffer.from('{not json', 'utf-8'));
+			const { store } = makeStore({ fs });
+
+			await expect(store.read({ id: 'a' }, 'fs')).rejects.toThrow('corrupt a');
+		});
+
+		it('throws a corrupted error on a version mismatch', async () => {
+			const fs = new InMemoryByteStore();
+			fs.objects.set('objects/a.json', Buffer.from(JSON.stringify({ value: 'x', version: 99 })));
+			const { store } = makeStore({ fs });
+
+			await expect(store.read({ id: 'a' }, 'fs')).rejects.toThrow('corrupt a');
+		});
+	});
+
+	describe('routing', () => {
+		it('writes and reads against the byte store for the given location', async () => {
+			const fs = new InMemoryByteStore();
+			const s3 = new InMemoryByteStore();
+			const { store } = makeStore({ fs, s3 });
+
+			await store.write({ id: 'a' }, { value: 'on-fs' }, 'fs');
+			await store.write({ id: 'b' }, { value: 'on-s3' }, 's3');
+
+			expect(fs.objects.has('objects/a.json')).toBe(true);
+			expect(fs.objects.has('objects/b.json')).toBe(false);
+			expect(s3.objects.has('objects/b.json')).toBe(true);
+		});
+
+		it('throws when writing to an unconfigured location', async () => {
+			const { store } = makeStore({ fs: new InMemoryByteStore() });
+			await expect(store.write({ id: 'a' }, { value: 'x' }, 's3')).rejects.toThrow(
+				'not configured',
+			);
+		});
+
+		it('uses a lazily registered byte store', async () => {
+			const { store } = makeStore({ fs: new InMemoryByteStore() });
+			expect(store.hasLocation('s3')).toBe(false);
+
+			const s3 = new InMemoryByteStore();
+			store.registerByteStore('s3', s3);
+			expect(store.hasLocation('s3')).toBe(true);
+
+			await store.write({ id: 'a' }, { value: 'x' }, 's3');
+			expect(s3.objects.has('objects/a.json')).toBe(true);
+		});
+	});
+
+	describe('readMany', () => {
+		it('partitions by storedAt and returns bundles keyed by id', async () => {
+			const fs = new InMemoryByteStore();
+			const s3 = new InMemoryByteStore();
+			const { store } = makeStore({ fs, s3 });
+			await store.write({ id: 'a' }, { value: 'a' }, 'fs');
+			await store.write({ id: 'b' }, { value: 'b' }, 's3');
+
+			const bundles = await store.readMany([
+				{ id: 'a', storedAt: 'fs' },
+				{ id: 'b', storedAt: 's3' },
+			]);
+
+			expect(bundles.get('a')).toEqual({ value: 'a', version: VERSION });
+			expect(bundles.get('b')).toEqual({ value: 'b', version: VERSION });
+		});
+
+		it('omits missing bundles without throwing', async () => {
+			const fs = new InMemoryByteStore();
+			const { store } = makeStore({ fs });
+			await store.write({ id: 'a' }, { value: 'a' }, 'fs');
+
+			const bundles = await store.readMany([
+				{ id: 'a', storedAt: 'fs' },
+				{ id: 'gone', storedAt: 'fs' },
+			]);
+
+			expect(bundles.has('a')).toBe(true);
+			expect(bundles.has('gone')).toBe(false);
+			expect(bundles.size).toBe(1);
+		});
+
+		it('reports and omits a corrupt bundle but keeps the rest, without throwing', async () => {
+			const fs = new InMemoryByteStore();
+			fs.objects.set('objects/bad.json', Buffer.from('{nope', 'utf-8'));
+			const { store, reportError } = makeStore({ fs });
+			await store.write({ id: 'ok' }, { value: 'ok' }, 'fs');
+
+			const bundles = await store.readMany([
+				{ id: 'ok', storedAt: 'fs' },
+				{ id: 'bad', storedAt: 'fs' },
+			]);
+
+			expect(bundles.has('ok')).toBe(true);
+			expect(bundles.has('bad')).toBe(false);
+			expect(reportError).toHaveBeenCalledTimes(1);
+		});
+
+		it('propagates a systemic byte-store failure', async () => {
+			const fs = new InMemoryByteStore();
+			fs.failingKeys.add('objects/a.json');
+			const { store } = makeStore({ fs });
+
+			await expect(store.readMany([{ id: 'a', storedAt: 'fs' }])).rejects.toThrow('disk on fire');
+		});
+	});
+
+	describe('delete', () => {
+		it('partitions deletes by location', async () => {
+			const fs = new InMemoryByteStore();
+			const s3 = new InMemoryByteStore();
+			const { store } = makeStore({ fs, s3 });
+			await store.write({ id: 'a' }, { value: 'a' }, 'fs');
+			await store.write({ id: 'b' }, { value: 'b' }, 's3');
+
+			await store.delete([
+				{ id: 'a', storedAt: 'fs' },
+				{ id: 'b', storedAt: 's3' },
+			]);
+
+			expect(fs.objects.size).toBe(0);
+			expect(s3.objects.size).toBe(0);
+		});
+
+		it('reports and skips deletes for an unconfigured location instead of throwing', async () => {
+			const { store, reportError } = makeStore({ fs: new InMemoryByteStore() });
+
+			await expect(store.delete([{ id: 'a', storedAt: 's3' }])).resolves.toBeUndefined();
+			expect(reportError).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/cli/src/blob-storage/azure-byte-store.ee.ts
+++ b/packages/cli/src/blob-storage/azure-byte-store.ee.ts
@@ -1,0 +1,40 @@
+import { Service } from '@n8n/di';
+import chunk from 'lodash/chunk';
+import { AzureBlobService } from 'n8n-core/dist/binary-data/azure-blob/azure-blob.service.ee';
+import { ensureError } from 'n8n-workflow';
+
+import type { ByteStore, ByteStoreKey } from './types';
+
+const MAX_DELETE_CONCURRENCY = 50;
+
+@Service()
+export class AzureByteStore implements ByteStore {
+	constructor(private readonly azureBlob: AzureBlobService) {}
+
+	async write(key: ByteStoreKey, body: Buffer, contentType?: string) {
+		await this.azureBlob.put(key, body, { mimeType: contentType ?? 'application/octet-stream' });
+		return body.length;
+	}
+
+	async read(key: ByteStoreKey): Promise<Buffer | null> {
+		try {
+			return await this.azureBlob.get(key, { mode: 'buffer' });
+		} catch (error) {
+			if (this.isNotFound(error)) return null;
+			throw error;
+		}
+	}
+
+	async delete(keys: ByteStoreKey[]): Promise<void> {
+		for (const batch of chunk(keys, MAX_DELETE_CONCURRENCY)) {
+			await Promise.all(batch.map(async (key) => await this.azureBlob.delete(key)));
+		}
+	}
+
+	private isNotFound(error: unknown) {
+		const original = ensureError(error).cause ?? error;
+		if (typeof original !== 'object' || original === null) return false;
+		const code = 'code' in original ? original.code : undefined;
+		return code === 'BlobNotFound';
+	}
+}

--- a/packages/cli/src/blob-storage/fs-byte-store.ts
+++ b/packages/cli/src/blob-storage/fs-byte-store.ts
@@ -1,0 +1,92 @@
+import { assertDir } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { ErrorReporter, StorageConfig } from 'n8n-core';
+import { UnexpectedError } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { ByteStore, ByteStoreKey } from './types';
+
+@Service()
+export class FsByteStore implements ByteStore {
+	constructor(
+		private readonly config: StorageConfig,
+		private readonly reporter: ErrorReporter,
+	) {}
+
+	async init() {
+		await assertDir(this.config.storagePath);
+	}
+
+	async write(key: ByteStoreKey, body: Buffer) {
+		const writePath = this.resolvePath(key);
+		await assertDir(path.dirname(writePath));
+		const tempPath = `${writePath}.tmp.${process.pid}.${randomUUID()}`;
+
+		let success = false;
+
+		try {
+			await fs.writeFile(tempPath, body);
+			await fs.rename(tempPath, writePath);
+			success = true;
+			return body.length;
+		} finally {
+			if (!success) {
+				await fs.rm(tempPath, { force: true }).catch((error) => this.reporter.error(error));
+			}
+		}
+	}
+
+	async read(key: ByteStoreKey) {
+		const readPath = this.resolvePath(key);
+		try {
+			return await fs.readFile(readPath);
+		} catch (error) {
+			if (this.isFileNotFound(error)) return null;
+			throw error;
+		}
+	}
+
+	async delete(keys: ByteStoreKey[]) {
+		const deletePaths = keys.map((key) => this.resolvePath(key));
+		await Promise.all(deletePaths.map(async (p) => await fs.rm(p, { force: true })));
+		const dirs = [...new Set(deletePaths.map((p) => path.dirname(p)))];
+		await Promise.all(dirs.map(async (dir) => await this.removeEmptyAncestors(dir)));
+	}
+
+	// private methods
+
+	private async removeEmptyAncestors(dir: string) {
+		const storagePath = path.resolve(this.config.storagePath);
+		let current = dir;
+		while (current.startsWith(storagePath) && current !== storagePath) {
+			try {
+				await fs.rmdir(current);
+			} catch {
+				return; // non-empty (ENOTEMPTY) or already gone (ENOENT)
+			}
+			current = path.dirname(current);
+		}
+	}
+
+	private resolvePath(key: ByteStoreKey) {
+		const storagePath = path.resolve(this.config.storagePath);
+		const resolvedPath = path.resolve(storagePath, key);
+		const relativePath = path.relative(storagePath, resolvedPath);
+
+		if (relativePath === '' || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+			throw new UnexpectedError(
+				'Byte store key must resolve to a location inside the storage path',
+			);
+		}
+
+		return resolvedPath;
+	}
+
+	private isFileNotFound(error: unknown): error is NodeJS.ErrnoException {
+		return (
+			error !== null && typeof error === 'object' && 'code' in error && error.code === 'ENOENT'
+		);
+	}
+}

--- a/packages/cli/src/blob-storage/json-store.ts
+++ b/packages/cli/src/blob-storage/json-store.ts
@@ -1,0 +1,140 @@
+import chunk from 'lodash/chunk';
+import { jsonParse, jsonStringify, UnexpectedError } from 'n8n-workflow';
+
+import { SkippedEntryDeletionError } from './skipped-entry-deletion.error';
+import type { ByteStore, JsonEntry, JsonStoreOptions, StorageLocation, Stored } from './types';
+
+const CORRUPT_ENTRY = Symbol('corruptEntry');
+
+const MAX_READ_CONCURRENCY = 50;
+
+/** Stores JSON entries as blobs using pluggable backends. */
+export class JsonStore<Ref, Payload extends object> {
+	private readonly byteStores = new Map<StorageLocation, ByteStore>();
+
+	constructor(private readonly options: JsonStoreOptions<Ref>) {
+		for (const [loc, store] of Object.entries(options.byteStores)) {
+			if (store) this.byteStores.set(loc as StorageLocation, store);
+		}
+	}
+
+	registerByteStore(loc: StorageLocation, store: ByteStore) {
+		this.byteStores.set(loc, store);
+	}
+
+	hasLocation(loc: StorageLocation) {
+		return this.byteStores.has(loc);
+	}
+
+	async write(ref: Ref, payload: Payload, loc: StorageLocation) {
+		const store = this.getByteStore(loc);
+		try {
+			const body = Buffer.from(
+				jsonStringify({ ...payload, version: this.options.version }),
+				'utf-8',
+			);
+			return await store.write(this.options.key(ref), body, 'application/json');
+		} catch (error) {
+			throw this.options.createWriteError(ref, error);
+		}
+	}
+
+	async read(ref: Ref, loc: StorageLocation) {
+		const store = this.getByteStore(loc);
+		const key = this.options.key(ref);
+		const bytes = await store.read(key);
+		if (!bytes) return null;
+		return this.parse(ref, bytes);
+	}
+
+	async readMany(refs: Array<Stored<Ref>>) {
+		const entries = new Map<string, JsonEntry<Payload>>();
+		if (refs.length === 0) return entries;
+
+		await Promise.all(
+			[...this.groupByLocation(refs)].map(async ([loc, group]) => {
+				const store = this.getByteStore(loc);
+				for (const batch of chunk(group, MAX_READ_CONCURRENCY)) {
+					const results = await Promise.all(
+						batch.map(async (ref) => await this.tryRead(ref, store)),
+					);
+					results.forEach((entry, idx) => {
+						if (entry) entries.set(this.options.getId(batch[idx]), entry);
+					});
+				}
+			}),
+		);
+
+		return entries;
+	}
+
+	async delete(refs: Array<Stored<Ref>>) {
+		if (refs.length === 0) return;
+
+		await Promise.all(
+			[...this.groupByLocation(refs)].map(async ([loc, group]) => {
+				const store = this.byteStores.get(loc);
+				if (!store) {
+					this.options.reportError(new SkippedEntryDeletionError(loc, group.length));
+					return;
+				}
+				await store.delete(group.map((ref) => this.options.key(ref)));
+			}),
+		);
+	}
+
+	// private methods
+
+	private groupByLocation(refs: Array<Stored<Ref>>) {
+		const groups = new Map<StorageLocation, Ref[]>();
+		for (const ref of refs) {
+			const group = groups.get(ref.storedAt) ?? [];
+			group.push(ref);
+			groups.set(ref.storedAt, group);
+		}
+		return groups;
+	}
+
+	private async tryRead(ref: Ref, store: ByteStore) {
+		try {
+			const bytes = await store.read(this.options.key(ref));
+			if (!bytes) return null;
+			return this.parse(ref, bytes);
+		} catch (error) {
+			if (this.isCorruptEntryError(error)) {
+				this.options.reportError(error);
+				return null;
+			}
+			throw error;
+		}
+	}
+
+	private parse(ref: Ref, bytes: Buffer) {
+		try {
+			const entry = jsonParse<JsonEntry<Payload>>(bytes.toString('utf-8'));
+			if (entry.version !== this.options.version) {
+				throw new Error(`Unsupported entry version: ${String(entry.version)}`);
+			}
+			return entry;
+		} catch (error) {
+			throw this.markCorrupt(this.options.createCorruptedError(ref, error));
+		}
+	}
+
+	private getByteStore(loc: StorageLocation): ByteStore {
+		const store = this.byteStores.get(loc);
+		if (!store) {
+			throw new UnexpectedError(`JSON store for location "${loc}" is not configured.`);
+		}
+		return store;
+	}
+
+	private markCorrupt<E extends Error>(error: E): E {
+		Object.defineProperty(error, CORRUPT_ENTRY, { value: true });
+		return error;
+	}
+
+	private isCorruptEntryError(error: unknown): error is Error {
+		return error instanceof Error && CORRUPT_ENTRY in error;
+	}
+}

--- a/packages/cli/src/blob-storage/s3-byte-store.ee.ts
+++ b/packages/cli/src/blob-storage/s3-byte-store.ee.ts
@@ -1,0 +1,38 @@
+import { Service } from '@n8n/di';
+import { ObjectStoreService } from 'n8n-core/dist/binary-data/object-store/object-store.service.ee';
+import { ensureError } from 'n8n-workflow';
+
+import type { ByteStore, ByteStoreKey } from './types';
+
+@Service()
+export class S3ByteStore implements ByteStore {
+	constructor(private readonly objectStore: ObjectStoreService) {}
+
+	async write(key: ByteStoreKey, body: Buffer, contentType?: string) {
+		await this.objectStore.put(key, body, { mimeType: contentType ?? 'application/octet-stream' });
+		return body.length;
+	}
+
+	async read(key: ByteStoreKey) {
+		try {
+			return await this.objectStore.get(key, { mode: 'buffer' });
+		} catch (error) {
+			if (this.isNotFound(error)) return null;
+			throw error;
+		}
+	}
+
+	async delete(keys: ByteStoreKey[]): Promise<void> {
+		if (keys.length === 0) return;
+		await this.objectStore.deleteByKeys(keys);
+	}
+
+	// private methods
+
+	private isNotFound(error: unknown) {
+		const original = ensureError(error).cause ?? error;
+		if (typeof original !== 'object' || original === null) return false;
+		const name = 'name' in original ? original.name : undefined;
+		return name === 'NoSuchKey' || name === 'NotFound';
+	}
+}

--- a/packages/cli/src/blob-storage/skipped-entry-deletion.error.ts
+++ b/packages/cli/src/blob-storage/skipped-entry-deletion.error.ts
@@ -1,0 +1,11 @@
+import { UnexpectedError } from 'n8n-workflow';
+
+import type { StorageLocation } from './types';
+
+export class SkippedEntryDeletionError extends UnexpectedError {
+	constructor(loc: StorageLocation, count: number) {
+		super(`Skipped deleting entries - "${loc}" store is not configured`, {
+			extra: { count },
+		});
+	}
+}

--- a/packages/cli/src/blob-storage/skipped-entry-deletion.error.ts
+++ b/packages/cli/src/blob-storage/skipped-entry-deletion.error.ts
@@ -1,8 +1,8 @@
-import { UnexpectedError } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
 import type { StorageLocation } from './types';
 
-export class SkippedEntryDeletionError extends UnexpectedError {
+export class SkippedEntryDeletionError extends OperationalError {
 	constructor(loc: StorageLocation, count: number) {
 		super(`Skipped deleting entries - "${loc}" store is not configured`, {
 			extra: { count },

--- a/packages/cli/src/blob-storage/types.ts
+++ b/packages/cli/src/blob-storage/types.ts
@@ -1,0 +1,46 @@
+export type StorageLocation = 'fs' | 's3' | 'az';
+
+export type ByteStoreKey = string;
+
+/** A raw byte store addressed by an opaque key. */
+export interface ByteStore {
+	init?(): Promise<void>;
+
+	/** Returns the number of bytes written. */
+	write(key: ByteStoreKey, body: Buffer, contentType?: string): Promise<number>;
+
+	/** Returns `null` when no object exists for `key`. */
+	read(key: ByteStoreKey): Promise<Buffer | null>;
+
+	delete(keys: ByteStoreKey[]): Promise<void>;
+}
+
+/** A stored JSON entry. */
+export type JsonEntry<Payload extends object> = Payload & { version: number };
+
+/** A stored JSON entry identifier. */
+export type Stored<Ref> = Ref & { storedAt: StorageLocation };
+
+/** Per-domain configuration for a {@link JsonStore}. */
+export interface JsonStoreOptions<Ref> {
+	/** Byte store per location. `fs` is always present. Externals e.g. `s3` and `az` are registered when configured. */
+	byteStores: Partial<Record<StorageLocation, ByteStore>>;
+
+	/** Schema version stamped on write and verified on read. */
+	version: number;
+
+	/** Maps a ref to the byte-store key (path) where the entry is stored at. */
+	key: (ref: Ref) => string;
+
+	/** Identity used to key `readMany` results. */
+	getId: (ref: Ref) => string;
+
+	/** Wraps a write failure as a domain error. */
+	createWriteError: (ref: Ref, cause: unknown) => Error;
+
+	/** Wraps an unparseable or version-mismatched entry as a domain error. */
+	createCorruptedError: (ref: Ref, cause: unknown) => Error;
+
+	/** Reports a non-fatal error, e.g. a skipped delete. */
+	reportError: (error: unknown) => void;
+}


### PR DESCRIPTION
This PR adds a domain-agnostic layer for storing JSON entries as blobs using pluggable backends: `fs`, `s3`, `az`. 

`ByteStore` handles raw bytes by key. `JsonStore` adds serialization, versioning, location routing, and per-entry fault tolerance on batch reads. Standalone and not yet connected.

In future we need to connect this to:
- Execution data
- Agent logs
- Binary data tied to executions
- Binary data unrelated to executions


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->