### PR TITLE
refactor: Remove ApplicationError re-export from n8n-workflow (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/src/__tests__/utils/failed-attempt-handler/n8nLlmFailedAttemptHandler.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/failed-attempt-handler/n8nLlmFailedAttemptHandler.test.ts
@@ -1,5 +1,5 @@
 import type { ISupplyDataFunctions } from 'n8n-workflow';
-import { ApplicationError, NodeApiError } from 'n8n-workflow';
+import { NodeApiError, UnexpectedError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { makeN8nLlmFailedAttemptHandler } from 'src/utils/failed-attempt-handler/n8nLlmFailedAttemptHandler';
@@ -25,7 +25,7 @@ describe('makeN8nLlmFailedAttemptHandler', () => {
 
 	it('should throw wrapped exception from custom handler', () => {
 		const customHandler = vi.fn(() => {
-			throw new ApplicationError('Custom handler error');
+			throw new UnexpectedError('Custom handler error');
 		});
 		const handler = makeN8nLlmFailedAttemptHandler(ctx, customHandler);
 

--- a/packages/@n8n/eslint-config/src/rules/no-plain-errors.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-plain-errors.ts
@@ -5,11 +5,11 @@ export const NoPlainErrorsRule = ESLintUtils.RuleCreator.withoutDocs({
 		type: 'problem',
 		docs: {
 			description:
-				'Only `ApplicationError` (from the `workflow` package) or its child classes must be thrown. This ensures the error will be normalized when reported to Sentry, if applicable.',
+				'Only `UserError`, `OperationalError`, `UnexpectedError` (from the `n8n-workflow` package) or their child classes must be thrown. This ensures the error will be normalized when reported to Sentry, if applicable.',
 		},
 		messages: {
-			useApplicationError:
-				'Throw an `ApplicationError` (from the `workflow` package) or its child classes.',
+			useN8nError:
+				'Throw a `UserError`, `OperationalError` or `UnexpectedError` (from the `n8n-workflow` package) or one of their child classes.',
 		},
 		fixable: 'code',
 		schema: [],
@@ -32,12 +32,12 @@ export const NoPlainErrorsRule = ESLintUtils.RuleCreator.withoutDocs({
 
 				if (isNewError || isNewlessError) {
 					return context.report({
-						messageId: 'useApplicationError',
+						messageId: 'useN8nError',
 						node,
 						fix: (fixer) =>
 							fixer.replaceText(
 								node,
-								`throw new ApplicationError(${(node.argument as TSESTree.CallExpression).arguments
+								`throw new UnexpectedError(${(node.argument as TSESTree.CallExpression).arguments
 									.map((arg) => context.sourceCode.getText(arg))
 									.join(', ')})`,
 							),

--- a/packages/cli/src/scaling/__tests__/scaling.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/scaling.service.test.ts
@@ -2,10 +2,10 @@ import { mockLogger, mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { ApplicationError } from '@n8n/errors';
 import * as BullModule from 'bull';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
-import { ApplicationError } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { ExecutionPersistence } from '@/executions/execution-persistence';

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1,9 +1,10 @@
 import type { Logger } from '@n8n/backend-common';
 import type { TaskRunnersConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
+import { ApplicationError } from '@n8n/errors';
 import type { RunnerMessage, TaskResultData } from '@n8n/task-runner';
 import { mock } from 'jest-mock-extended';
-import { ApplicationError, type INodeTypeBaseDescription } from 'n8n-workflow';
+import { type INodeTypeBaseDescription } from 'n8n-workflow';
 
 import type { TaskRunnerLifecycleEvents } from '@/task-runners/task-runner-lifecycle-events';
 

--- a/packages/cli/test/integration/folder/folder.controller.test.ts
+++ b/packages/cli/test/integration/folder/folder.controller.test.ts
@@ -13,6 +13,7 @@ import {
 import type { Project, User } from '@n8n/db';
 import { FolderRepository, ProjectRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { ApplicationError } from '@n8n/errors';
 import type { ProjectRole } from '@n8n/permissions';
 import { PROJECT_EDITOR_ROLE_SLUG, PROJECT_VIEWER_ROLE_SLUG } from '@n8n/permissions';
 import {
@@ -25,7 +26,7 @@ import {
 import { createFolder } from '@test-integration/db/folders';
 import { createTag } from '@test-integration/db/tags';
 import { DateTime } from 'luxon';
-import { ApplicationError, PROJECT_ROOT } from 'n8n-workflow';
+import { PROJECT_ROOT } from 'n8n-workflow';
 
 import { createOwner, createMember, createUser, createAdmin } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';

--- a/packages/core/src/errors/__tests__/error-reporter.test.ts
+++ b/packages/core/src/errors/__tests__/error-reporter.test.ts
@@ -1,8 +1,9 @@
 import type { Logger } from '@n8n/backend-common';
+import { ApplicationError } from '@n8n/errors';
 import { QueryFailedError } from '@n8n/typeorm';
 import type { ErrorEvent } from '@sentry/core';
 import { AxiosError } from 'axios';
-import { ApplicationError, BaseError, ExpressionError, NodeOperationError } from 'n8n-workflow';
+import { BaseError, ExpressionError, NodeOperationError } from 'n8n-workflow';
 import type { INode } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -2,10 +2,10 @@ import { inTest, Logger } from '@n8n/backend-common';
 import { isAxiosError } from '@n8n/backend-network';
 import { type InstanceType } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import type { ReportingOptions } from '@n8n/errors';
+import { ApplicationError, type ReportingOptions } from '@n8n/errors';
 import type { ErrorEvent, EventHint } from '@sentry/core';
 import type { NodeOptions } from '@sentry/node';
-import { ApplicationError, ExecutionCancelledError, BaseError } from 'n8n-workflow';
+import { ExecutionCancelledError, BaseError } from 'n8n-workflow';
 import { createHash } from 'node:crypto';
 
 import {

--- a/packages/core/test/helpers/index.ts
+++ b/packages/core/test/helpers/index.ts
@@ -1,3 +1,4 @@
+import { ApplicationError } from '@n8n/errors';
 import { readdirSync, readFileSync } from 'fs';
 import type {
 	IDataObject,
@@ -12,7 +13,7 @@ import type {
 	WorkflowTestData,
 	INodeTypeData,
 } from 'n8n-workflow';
-import { ApplicationError, NodeHelpers } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import path from 'path';
 import { mock } from 'vitest-mock-extended';
 

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.download.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/node/file.download.test.ts
@@ -1,7 +1,8 @@
+import { ApplicationError } from '@n8n/errors';
 import type { IncomingMessage } from 'http';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
-import { type IHttpRequestMethods, type IExecuteFunctions, ApplicationError } from 'n8n-workflow';
+import { type IHttpRequestMethods, type IExecuteFunctions } from 'n8n-workflow';
 
 import * as genericFunctions from '../../GenericFunctions';
 import { MicrosoftOneDrive } from '../../MicrosoftOneDrive.node';

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -10,7 +10,8 @@ import type {
 	INodeTypeBaseDescription,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { ApplicationError, BaseError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { ApplicationError } from '@n8n/errors';
+import { BaseError, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import { capitalize } from '@utils/utilities';
 

--- a/packages/nodes-base/nodes/Switch/V3/test/switch.node.test.ts
+++ b/packages/nodes-base/nodes/Switch/V3/test/switch.node.test.ts
@@ -1,10 +1,11 @@
+import { ApplicationError } from '@n8n/errors';
 import { mockDeep } from 'vitest-mock-extended';
 import type {
 	IExecuteFunctions,
 	ILoadOptionsFunctions,
 	INodeTypeBaseDescription,
 } from 'n8n-workflow';
-import { NodeOperationError, ApplicationError } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 
 import { SwitchV3 } from '../SwitchV3.node';
 import type { Mocked } from 'vitest';

--- a/packages/workflow/src/errors/index.ts
+++ b/packages/workflow/src/errors/index.ts
@@ -2,7 +2,6 @@ export { BaseError, type BaseErrorOptions } from './base/base.error';
 export { OperationalError, type OperationalErrorOptions } from './base/operational.error';
 export { UnexpectedError, type UnexpectedErrorOptions } from './base/unexpected.error';
 export { UserError, type UserErrorOptions } from './base/user.error';
-export { ApplicationError } from '@n8n/errors';
 export { ExpressionError } from './expression.error';
 export {
 	ExecutionCancelledError,

--- a/packages/workflow/src/type-validation.ts
+++ b/packages/workflow/src/type-validation.ts
@@ -1,7 +1,8 @@
+import { ApplicationError } from '@n8n/errors';
 import isObject from 'lodash/isObject';
 import { DateTime } from 'luxon';
 
-import { ApplicationError, BaseError, UserError } from './errors';
+import { BaseError, UserError } from './errors';
 import type {
 	FieldType,
 	FormFieldsParameter,


### PR DESCRIPTION
## Summary

Removes the deprecated `ApplicationError` re-export from `n8n-workflow`'s public API so new code can no longer reach for it through that package. The class itself stays in `@n8n/errors` since external consumers / community nodes may still depend on it.

Remaining internal references now import `ApplicationError` directly from `@n8n/errors` (or use `UnexpectedError` where a generic error suffices). The `no-plain-errors` ESLint rule now points at `UserError` / `OperationalError` / `UnexpectedError` instead of `ApplicationError`, and its autofix emits `UnexpectedError`.

## How to test

- `pnpm build` across the monorepo passes (catches any remaining import references).
- Lint passes across all packages.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3257

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33119">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

