### PR TITLE
fix(core): Narrow mcp apps frame domains (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-apps/README.md
+++ b/packages/@n8n/mcp-apps/README.md
@@ -85,11 +85,13 @@ URL handling is locked down by `isAllowedWorkflowUrl` in
 host are accepted, both when reading the tool result and right before calling
 `openLink`. This is defense in depth on top of the host's own validation.
 
-The workflow preview iframe uses a server-provided `previewUrl` when available.
-Otherwise it uses the existing n8n preview service because instance routes are
-commonly blocked or unreachable from MCP hosts. The resource metadata declares
-broad `frameDomains` for `http` and `https` so hosts that enforce MCP Apps CSP
-can load instance-specific or configured preview URLs. The framed n8n server's
+The workflow preview iframe loads the shared n8n preview service
+(`WORKFLOW_PREVIEW_ORIGIN`). The preview is instance-agnostic: the workflow
+graph is pushed into the iframe via `postMessage` rather than fetched from the
+instance, so a single origin renders both cloud and self-hosted workflows. The
+resource metadata therefore declares exactly one `frameDomains` entry — the
+preview-service origin. Keep this list narrow: MCP hosts (e.g. the ChatGPT
+connector review) reject broad or wildcard frame domains. The framed server's
 own frame policy still applies, so the app falls back to the open-workflow
 button when the preview cannot load.
 

--- a/packages/@n8n/mcp-apps/src/server/constants.ts
+++ b/packages/@n8n/mcp-apps/src/server/constants.ts
@@ -3,9 +3,9 @@ export const RESOURCE_URI_META_KEY = 'ui/resourceUri';
 
 export const WORKFLOW_PREVIEW_APP_URI = 'ui://workflow-preview/workflow-preview.html';
 export const WORKFLOW_PREVIEW_ORIGIN = 'https://n8n-preview-service.internal.n8n.cloud';
-export const WORKFLOW_PREVIEW_FRAME_DOMAINS = [
-	WORKFLOW_PREVIEW_ORIGIN,
-	'https://*',
-	'http://localhost:*',
-	'http://127.0.0.1:*',
-] as const;
+// Scoped to the single preview-service origin (CSP `frame-src`). The preview is
+// instance-agnostic: workflow data is pushed into the iframe via postMessage, so
+// the same origin renders cloud and self-hosted workflows without needing the
+// instance origin framed. Keep this narrow — MCP hosts reject broad/wildcard
+// frame domains.
+export const WORKFLOW_PREVIEW_FRAME_DOMAINS = [WORKFLOW_PREVIEW_ORIGIN] as const;


### PR DESCRIPTION
## Summary
Only use essential frame domains (n8n preview) instance for mcp apps, removing wildcard and local urls.

## How to test
Create test instance from this branch (make sure to use `N8N_MCP_APPS_ENABLED=true`) and try creating workflows trough mcp -> preview app should still work


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33123">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->