### PR TITLE
test(ai-builder): Render full judge text for eval failures, warn only on barely-passed units (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
@@ -379,8 +379,8 @@ describe('formatComparisonMarkdown', () => {
 			slugByTestCase: slugMap(evalWithFailures, ['cross-team-linear-report']),
 		});
 
-		expect(md).toMatch(/<summary>Failure details<\/summary>/);
-		expect(md).toMatch(/\*\*`cross-team-linear-report\/no-cross-team-issues`\*\* — 3 failed/);
+		expect(md).toMatch(/<summary>Failures \(1\)<\/summary>/);
+		expect(md).toMatch(/\*\*`cross-team-linear-report\/no-cross-team-issues`\*\* — passed 0\/3/);
 	});
 
 	it('attaches per-scenario failures to the right file slug when names collide', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
@@ -10,8 +10,13 @@ import type {
 
 interface CaseSpec {
 	slug: string;
-	scenarios?: Array<{ name: string; passes: boolean[]; failureCategory?: string }>;
-	expectations?: Array<{ text: string; verdicts: Array<boolean | 'incomplete'> }>;
+	scenarios?: Array<{
+		name: string;
+		passes: boolean[];
+		failureCategory?: string;
+		reasoning?: string;
+	}>;
+	expectations?: Array<{ text: string; verdicts: Array<boolean | 'incomplete'>; reason?: string }>;
 }
 
 /** Build a MultiRunEvaluation + slug map matching the shape gate.ts/format.ts read. */
@@ -47,7 +52,7 @@ function makeEval(totalRuns: number, cases: CaseSpec[]) {
 						scenario,
 						success: p,
 						score: p ? 1 : 0,
-						reasoning: '',
+						reasoning: p ? '' : (sa.reasoning ?? `judge: ${sa.name} failed`),
 						failureCategory: !p ? sa.failureCategory : undefined,
 					}),
 				),
@@ -58,7 +63,11 @@ function makeEval(totalRuns: number, cases: CaseSpec[]) {
 			const runs: BuildExpectationResult[] = e.verdicts.map((v) =>
 				v === 'incomplete'
 					? { expectation: e.text, pass: false, reason: '', incomplete: true }
-					: { expectation: e.text, pass: v, reason: '' },
+					: {
+							expectation: e.text,
+							pass: v,
+							reason: v ? '' : (e.reason ?? 'judge: expectation failed'),
+						},
 			);
 			const evaluated = runs.filter((r) => !r.incomplete);
 			const passCount = evaluated.filter((r) => r.pass).length;
@@ -207,7 +216,7 @@ describe('formatComparisonMarkdown — gate mode', () => {
 		expect(md).not.toMatch(/#### Not green/);
 	});
 
-	it('renders a red CAUTION verdict with a Not-green table for failing units', () => {
+	it("renders a red CAUTION verdict and the failing unit's full judge text", () => {
 		const { evaluation, slugByTestCase } = makeEval(3, [
 			{
 				slug: 'rest-api-data-pipeline',
@@ -217,6 +226,7 @@ describe('formatComparisonMarkdown — gate mode', () => {
 						name: 'empty-response',
 						passes: [false, false, false],
 						failureCategory: 'builder_issue',
+						reasoning: 'No Slack message was posted for the empty array.',
 					},
 				],
 			},
@@ -226,19 +236,24 @@ describe('formatComparisonMarkdown — gate mode', () => {
 
 		expect(md).toMatch(/> \[!CAUTION\]/);
 		expect(md).toMatch(/🔴 1 of 2 units not green over 3 runs/);
-		expect(md).toMatch(/#### Not green/);
-		expect(md).toMatch(
-			/`rest-api-data-pipeline\/empty-response` \| 0\/3 \(0%\) \| 3× builder_issue/,
-		);
+		expect(md).toMatch(/<details open><summary>Failures \(1\)<\/summary>/);
+		expect(md).toMatch(/`rest-api-data-pipeline\/empty-response`\*\* — passed 0\/3/);
+		expect(md).toMatch(/_\[builder_issue\]_ No Slack message was posted for the empty array\./);
+		expect(md).not.toMatch(/#### Not green/);
 	});
 
-	it('renders a yellow WARNING when all units pass@k but one had a failing run', () => {
+	it('renders a yellow WARNING when a unit barely passed (failed the majority)', () => {
 		const { evaluation, slugByTestCase } = makeEval(3, [
 			{
 				slug: 'notification-router',
 				scenarios: [
 					{ name: 'low', passes: [true, true, true] },
-					{ name: 'high', passes: [true, false, true], failureCategory: 'builder_issue' },
+					{
+						name: 'high',
+						passes: [true, false, false], // 1/3 — passed the minority
+						failureCategory: 'builder_issue',
+						reasoning: 'Teams message omitted the Server Down title.',
+					},
 				],
 			},
 		]);
@@ -247,11 +262,60 @@ describe('formatComparisonMarkdown — gate mode', () => {
 
 		expect(gate.green).toBe(true); // pass@k still met
 		expect(md).toMatch(/> \[!WARNING\]/);
-		expect(md).toMatch(/🟡 All 2 units green over 3 runs, but 1 had a failing run/);
-		expect(md).toMatch(/#### Passed with failures/);
-		expect(md).toMatch(/`notification-router\/high` \| 2\/3 \(67%\) \| 1× builder_issue/);
-		expect(md).not.toMatch(/#### Not green/);
+		expect(md).toMatch(/🟡 All 2 units green over 3 runs, but 1 barely passed/);
+		expect(md).toMatch(/`notification-router\/high`\*\* — passed 1\/3/);
+		expect(md).toMatch(/_\[builder_issue\]_ Teams message omitted the Server Down title\./);
 		expect(md).not.toMatch(/> \[!CAUTION\]/);
+	});
+
+	it('stays a green TIP for a single flaky run (2/3) but still lists it', () => {
+		const { evaluation, slugByTestCase } = makeEval(3, [
+			{
+				slug: 'notification-router',
+				scenarios: [
+					{ name: 'low', passes: [true, true, true] },
+					{
+						name: 'high',
+						passes: [true, false, true], // 2/3 — one flaky miss, still majority-pass
+						failureCategory: 'mock_issue',
+						reasoning: 'Transient mock hiccup on run 2.',
+					},
+				],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+		const md = formatComparisonMarkdown(evaluation, undefined, { slugByTestCase, gate });
+
+		expect(md).toMatch(/> \[!TIP\]/);
+		expect(md).toMatch(/🟢 All 2 units green over 3 runs; 1 flaky/);
+		expect(md).not.toMatch(/> \[!WARNING\]/);
+		// the flaky run is still surfaced, with its judge text
+		expect(md).toMatch(/`notification-router\/high`\*\* — passed 2\/3/);
+		expect(md).toMatch(/Transient mock hiccup on run 2\./);
+	});
+
+	it('renders the judge text for a failing build expectation, not just scenarios', () => {
+		const { evaluation, slugByTestCase } = makeEval(3, [
+			{
+				slug: 'notification-router',
+				scenarios: [{ name: 'happy', passes: [true, true, true] }],
+				expectations: [
+					{
+						text: 'asked a clarifying question before building',
+						verdicts: [true, false, false], // 1/3 — barely passed
+						reason: 'The agent started building without asking anything.',
+					},
+				],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+		const md = formatComparisonMarkdown(evaluation, undefined, { slugByTestCase, gate });
+
+		// the build-expectation failure is surfaced with its full reason (previously omitted)
+		expect(md).toMatch(/notification-router :: asked a clarifying question/);
+		expect(md).toMatch(/passed 1\/3/);
+		expect(md).toMatch(/The agent started building without asking anything\./);
+		expect(md).toMatch(/> \[!WARNING\]/); // a 1/3 build expectation is "barely passed"
 	});
 
 	it('renders the gate even if a comparison outcome is also passed (gate wins)', () => {
@@ -302,7 +366,7 @@ describe('formatComparisonTerminal — gate mode', () => {
 		expect(out).not.toMatch(/\| /);
 	});
 
-	it('marks green-but-flaky units as FLAKY in the gate summary', () => {
+	it('marks green-but-flaky units in the terminal gate summary', () => {
 		const { evaluation, slugByTestCase } = makeEval(3, [
 			{
 				slug: 'notification-router',
@@ -315,7 +379,7 @@ describe('formatComparisonTerminal — gate mode', () => {
 		const gate = evaluateGate(evaluation, { slugByTestCase });
 		const out = formatComparisonTerminal(evaluation, undefined, { slugByTestCase, gate });
 
-		expect(out).toMatch(/▶ GATE: all 2 units green over 3 runs, 1 with a failing run/);
-		expect(out).toMatch(/FLAKY +notification-router\/high +2\/3/);
+		expect(out).toMatch(/▶ GATE: all 2 units green over 3 runs, 1 flaky/);
+		expect(out).toMatch(/flaky +notification-router\/high +2\/3/);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -29,12 +29,7 @@ import {
 import type { GateCriterion, GateResult, GateUnit } from './gate';
 import { aggregateWorkflowChecks } from '../binaryChecks/aggregate';
 import { CHECK_DIMENSIONS } from '../binaryChecks/types';
-import type {
-	MultiRunEvaluation,
-	TestCaseAggregation,
-	WorkflowTestCase,
-	WorkflowTestCaseResult,
-} from '../types';
+import type { MultiRunEvaluation, TestCaseAggregation, WorkflowTestCase } from '../types';
 import { caseDisplayPrompt } from '../utils/conversation-text';
 
 interface FormatOptions {
@@ -74,6 +69,9 @@ export function formatComparisonMarkdown(
 		lines.push(formatGateAlertMarkdown(gate));
 		lines.push('');
 		lines.push(...renderGateSummaryMarkdown(gate));
+		// Failures (full judge text) go right under the verdict in gate mode — the point
+		// is to see what failed at a glance, not hunt for it at the bottom of the comment.
+		lines.push(...renderFailureDetails(evaluation, options.slugByTestCase));
 	} else {
 		lines.push(formatTopAlert(outcome));
 		lines.push('');
@@ -152,7 +150,8 @@ export function formatComparisonMarkdown(
 		if (otherFindings.length > 0) lines.push(...otherFindings);
 	}
 
-	const failureDetails = renderFailureDetails(evaluation, options.slugByTestCase);
+	// Gate mode already rendered the Failures section under the verdict (above).
+	const failureDetails = gate ? [] : renderFailureDetails(evaluation, options.slugByTestCase);
 	if (failureDetails.length > 0) lines.push(...failureDetails);
 
 	return lines.join('\n');
@@ -179,32 +178,50 @@ function gateFailuresCell(unit: GateUnit): string {
 		.join(', ');
 }
 
-// Units that pass@k but failed at least one run (e.g. 2/3) — green, but worth surfacing.
+// A green unit that failed ≥1 run (e.g. 2/3) — passes the gate, still worth listing.
 function degradedUnits(gate: GateResult): GateUnit[] {
 	return gate.units.filter((u) => u.green && u.passCount < u.total);
 }
 
+// A green unit that failed the *majority* of its runs (passed <50%, e.g. 1/3) — it
+// barely cleared pass@k, one bad run from red. Pass-rate based so it scales across k
+// (3 on PRs, 10 on baselines); a single flaky miss (2/3) is not "barely passed".
+function barelyPassedUnits(gate: GateResult): GateUnit[] {
+	return gate.units.filter((u) => u.green && u.total > 0 && u.passCount / u.total < 0.5);
+}
+
+function pluralUnits(c: number): string {
+	return `${c} unit${c === 1 ? '' : 's'}`;
+}
+
 function formatGateAlertMarkdown(gate: GateResult): string {
 	const n = gate.units.length;
-	const k = gate.totalRuns;
-	const over = `over ${k} run${k === 1 ? '' : 's'}`;
+	const over = `over ${gate.totalRuns} run${gate.totalRuns === 1 ? '' : 's'}`;
 	// Key off failing, not gate.green: under minAggregatePassRate gate.green can be
 	// true via the pooled rate while individual units fail.
 	if (gate.failing.length > 0) {
 		return [
 			'> [!CAUTION]',
-			`> 🔴 ${gate.failing.length} of ${n} unit${n === 1 ? '' : 's'} not green ${over}.`,
+			`> 🔴 ${gate.failing.length} of ${pluralUnits(n)} not green ${over}.`,
 		].join('\n');
 	}
-	// All units pass@k. Distinguish a clean sweep from green-but-flaky so a 2/3 stays visible.
-	const degraded = degradedUnits(gate);
-	if (degraded.length > 0) {
+	// All units pass@k. Only warn when a unit *barely* passed (failed most of its runs);
+	// a single flaky miss stays green but is still listed in Failures below.
+	const barely = barelyPassedUnits(gate).length;
+	if (barely > 0) {
 		return [
 			'> [!WARNING]',
-			`> 🟡 All ${n} unit${n === 1 ? '' : 's'} green ${over}, but ${degraded.length} had a failing run — see below.`,
+			`> 🟡 All ${pluralUnits(n)} green ${over}, but ${barely} barely passed (failed most runs) — see Failures below.`,
 		].join('\n');
 	}
-	return ['> [!TIP]', `> 🟢 All ${n} unit${n === 1 ? '' : 's'} green ${over} (clean).`].join('\n');
+	const flaky = degradedUnits(gate).length;
+	if (flaky > 0) {
+		return [
+			'> [!TIP]',
+			`> 🟢 All ${pluralUnits(n)} green ${over}; ${flaky} flaky — see Failures below.`,
+		].join('\n');
+	}
+	return ['> [!TIP]', `> 🟢 All ${pluralUnits(n)} green ${over} (clean).`].join('\n');
 }
 
 function renderGateSummaryMarkdown(gate: GateResult): string[] {
@@ -217,34 +234,27 @@ function renderGateSummaryMarkdown(gate: GateResult): string[] {
 		lines.push(`_${gate.excluded.length} unit(s) not gated (no judge verdict)._`);
 	}
 	lines.push('');
-	const unitTable = (heading: string, units: GateUnit[]): void => {
-		if (units.length === 0) return;
-		lines.push(`#### ${heading}`, '', '| Unit | Pass | Failures |', '|---|---|---|');
-		for (const u of units) {
-			const rateU = u.total > 0 ? Math.round(u.passRate * 100) : 0;
-			lines.push(
-				`| \`${u.slug}\` | ${u.passCount}/${u.total} (${rateU}%) | ${gateFailuresCell(u)} |`,
-			);
-		}
-		lines.push('');
-	};
-	unitTable('Not green', gate.failing);
-	unitTable('Passed with failures', degradedUnits(gate));
+	// Failing / flaky units (with their full judge text) are rendered by the Failures
+	// section below — not a per-unit table here. Build expectations carry no failure
+	// category, which left the old table's Failures column blank.
 	return lines;
 }
 
 function formatTerminalGateLine(gate: GateResult): string {
 	const n = gate.units.length;
-	const k = gate.totalRuns;
-	const over = `over ${k} run${k === 1 ? '' : 's'}`;
+	const over = `over ${gate.totalRuns} run${gate.totalRuns === 1 ? '' : 's'}`;
 	if (gate.failing.length > 0) {
-		return `▶ GATE: ${gate.failing.length} of ${n} unit${n === 1 ? '' : 's'} NOT green ${over}`;
+		return `▶ GATE: ${gate.failing.length} of ${pluralUnits(n)} NOT green ${over}`;
 	}
-	const degraded = degradedUnits(gate).length;
-	if (degraded > 0) {
-		return `▶ GATE: all ${n} unit${n === 1 ? '' : 's'} green ${over}, ${degraded} with a failing run`;
+	const barely = barelyPassedUnits(gate).length;
+	if (barely > 0) {
+		return `▶ GATE: all ${pluralUnits(n)} green ${over}, ${barely} barely passed`;
 	}
-	return `▶ GATE: all ${n} unit${n === 1 ? '' : 's'} green ${over} (clean)`;
+	const flaky = degradedUnits(gate).length;
+	if (flaky > 0) {
+		return `▶ GATE: all ${pluralUnits(n)} green ${over}, ${flaky} flaky`;
+	}
+	return `▶ GATE: all ${pluralUnits(n)} green ${over} (clean)`;
 }
 
 function formatTerminalGateSummary(gate: GateResult): string[] {
@@ -264,7 +274,8 @@ function formatTerminalGateSummary(gate: GateResult): string[] {
 	}
 	for (const u of degradedUnits(gate)) {
 		const cats = u.failureCategories ? `  [${gateFailuresCell(u)}]` : '';
-		lines.push(TERMINAL_INDENT + `  FLAKY      ${u.slug}  ${u.passCount}/${u.total}${cats}`);
+		const label = u.total > 0 && u.passCount / u.total < 0.5 ? 'BARELY   ' : 'flaky    ';
+		lines.push(TERMINAL_INDENT + `  ${label}  ${u.slug}  ${u.passCount}/${u.total}${cats}`);
 	}
 	return lines;
 }
@@ -666,44 +677,63 @@ function renderFailureDetails(
 	evaluation: MultiRunEvaluation,
 	slugByTestCase?: Map<WorkflowTestCase, string>,
 ): string[] {
-	const failed: Array<{
-		tc: WorkflowTestCaseResult;
-		fileSlug: string | undefined;
-		scenarioName: string;
-		failedRuns: Array<{ category?: string; reasoning: string }>;
-	}> = [];
+	interface FailedUnit {
+		slug: string;
+		passCount: number;
+		total: number;
+		runs: Array<{ category?: string; text: string }>;
+	}
+	const units: FailedUnit[] = [];
 	for (const tc of evaluation.testCases) {
-		const fileSlug = slugByTestCase?.get(tc.testCase);
+		const prefix =
+			slugByTestCase?.get(tc.testCase) ?? caseDisplayPrompt(tc.testCase).slice(0, 50).trim();
 		for (const sa of tc.executionScenarios) {
-			const failedRuns = sa.runs
-				.filter((r) => !r.success)
-				.map((r) => ({ category: r.failureCategory, reasoning: r.reasoning }));
+			const failedRuns = sa.runs.filter((r) => !r.success);
 			if (failedRuns.length > 0) {
-				failed.push({ tc: tc.runs[0], fileSlug, scenarioName: sa.scenario.name, failedRuns });
+				units.push({
+					slug: `${prefix}/${sa.scenario.name}`,
+					passCount: sa.passCount,
+					total: sa.runs.length,
+					runs: failedRuns.map((r) => ({ category: r.failureCategory, text: r.reasoning })),
+				});
+			}
+		}
+		for (const ea of tc.buildExpectations) {
+			// Only evaluated verdicts count; `incomplete` runs have no judge text to show.
+			const failedRuns = ea.runs.filter((r) => !r.incomplete && !r.pass);
+			if (failedRuns.length > 0) {
+				units.push({
+					slug: `${prefix} :: ${ea.expectation.slice(0, 60)}`,
+					passCount: ea.passCount,
+					total: ea.evaluatedCount,
+					runs: failedRuns.map((r) => ({ text: r.reason })),
+				});
 			}
 		}
 	}
-	if (failed.length === 0) return [];
+	if (units.length === 0) return [];
 
-	const lines: string[] = [];
-	lines.push('<details><summary>Failure details</summary>');
-	lines.push('');
-	for (const { tc, fileSlug, scenarioName, failedRuns } of failed) {
-		const slug = fileSlug
-			? `${fileSlug}/${scenarioName}`
-			: `${caseDisplayPrompt(tc.testCase).slice(0, 50).trim()} / ${scenarioName}`;
-		lines.push(`**\`${slug}\`** — ${failedRuns.length} failed`);
-		for (const fr of failedRuns) {
-			const tag = fr.category ? ` [${fr.category}]` : '';
-			// Show the full reasoning (generous cap for pathological cases); keep any
-			// newlines inside the blockquote so the detail stays readable.
-			const reason = fr.reasoning.length > 1500 ? `${fr.reasoning.slice(0, 1500)}…` : fr.reasoning;
-			lines.push(`> Run${tag}: ${reason.replace(/\n+/g, '\n> ')}`);
+	// Full judge text for every failed run — scenarios and build expectations alike —
+	// so it's easy to see exactly what failed. Open by default but collapsible.
+	const lines: string[] = [`<details open><summary>Failures (${units.length})</summary>`, ''];
+	for (const u of units) {
+		lines.push(`**\`${u.slug}\`** — passed ${u.passCount}/${u.total}`, '');
+		// Collapse identical reasonings — a unit usually fails the same way each run.
+		const byText = new Map<string, { category?: string; text: string; count: number }>();
+		for (const r of u.runs) {
+			const key = `${r.category ?? ''}::${r.text}`;
+			const existing = byText.get(key);
+			if (existing) existing.count++;
+			else byText.set(key, { ...r, count: 1 });
 		}
-		lines.push('');
+		for (const r of byText.values()) {
+			const tag = r.category ? `_[${r.category}]_ ` : '';
+			const mult = r.count > 1 ? ` _(×${r.count})_` : '';
+			const text = (r.text.trim() || '_(judge returned no text)_').replace(/\n+/g, '\n> ');
+			lines.push(`> ${tag}${text}${mult}`, '');
+		}
 	}
-	lines.push('</details>');
-	lines.push('');
+	lines.push('</details>', '');
 	return lines;
 }
 


### PR DESCRIPTION
## Summary

The pr-tier eval comment buried failures in a table whose **Failures column was always blank for build expectations** (they carry no failure category), and it **never rendered build-expectation judge text at all** — so when a build expectation failed, you couldn't see why. The comment was also hard to read.

This reworks the gate comment's failure rendering:

- **Full judge text for every failed run** — execution scenarios *and* build expectations — in a `Failures` section placed **directly under the verdict** (not buried at the bottom of the comment). No truncation; identical reasonings collapse to `(×N)`.
- **Dropped the broken "Passed with failures" / "Not green" tables** (the empty-column bug).
- **Smarter yellow:** 🟡 now means a unit *barely passed* — it failed the **majority** of its runs (pass rate < 50%, e.g. `1/3` at k=3). A single flaky miss (`2/3`) stays 🟢 and is still listed, just not alarming. Pass-rate based, so it scales to the k=10 baseline runs too.

Verdict ladder: 🟢 clean · 🟢 + flaky note · 🟡 barely passed · 🔴 a unit failed every run.

This is **comment-rendering only** — gate logic, the pass@k criterion, and CI gating are unchanged.

## How to test

- `cd packages/@n8n/instance-ai && pnpm vitest run evaluations/__tests__/comparison-gate.test.ts evaluations/__tests__/comparison-format.test.ts` — 35 pass, incl. new yellow / green-flaky / build-expectation-judge-text cases.
- To see it live: this PR touches `evaluations/**`, so marking it **ready for review** (or dispatching **CI: Instance AI Evals** on this branch) runs the pr-tier eval and posts the reworked comment.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->