### PR TITLE
fix(core): Ensure project variables override same-key global variables

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -35,15 +35,17 @@ describe('workflow-helpers', () => {
 	beforeAll(() => {
 		mockInstance(VariablesService, {
 			async getAllCached() {
+				// Project VAR2 is listed before its global twin so resolution must
+				// be order-independent: the project value still has to win.
 				return [
 					{ id: '1', key: 'VAR1', value: 'value1' },
-					{ id: '2', key: 'VAR2', value: 'value2' },
 					{
 						id: '3',
 						key: 'VAR2',
 						value: 'value1Project',
 						project: { id: '1', name: 'project1' } as Project,
 					},
+					{ id: '2', key: 'VAR2', value: 'value2' },
 					{
 						id: '4',
 						key: 'VAR4',
@@ -86,6 +88,11 @@ describe('workflow-helpers', () => {
 		it('should prioritize passed of projectId over workflowId', async () => {
 			const variables = await getVariables('1', '2');
 			expect(variables).toEqual({ VAR1: 'value1', VAR2: 'value2', VAR5: 'value5' });
+		});
+
+		it('should let a project variable override a same-key global regardless of order', async () => {
+			const variables = await getVariables(undefined, '1');
+			expect(variables.VAR2).toBe('value1Project');
 		});
 	});
 });

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -6,6 +6,7 @@ import {
 	formatWorkflowStructureIssuePath,
 	isSafeObjectProperty,
 	resolveNodeWebhookId,
+	resolveVariables,
 	safeParseWorkflowStructure,
 	validateNodeSelectionForGrouping,
 	type IDataObject,
@@ -497,18 +498,7 @@ export async function getVariables(workflowId?: string, projectId?: string): Pro
 	// Either projectId passed or use project from workflow
 	const projectIdToUse = projectId ?? project?.id;
 
-	return Object.freeze(
-		variables.reduce((acc, curr) => {
-			if (!curr.project) {
-				// always set globals
-				acc[curr.key] = curr.value;
-			} else if (projectIdToUse && curr.project.id === projectIdToUse) {
-				// project variables override globals
-				acc[curr.key] = curr.value;
-			}
-			return acc;
-		}, {} as IDataObject),
-	);
+	return Object.freeze(resolveVariables(variables, projectIdToUse));
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/settings/environments.ee/environments.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/environments.ee/environments.store.ts
@@ -7,7 +7,7 @@ import type {
 } from './environments.types';
 import * as environmentsApi from './environments.api';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { ExpressionError } from 'n8n-workflow';
+import { ExpressionError, resolveVariables } from 'n8n-workflow';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 
 export const useEnvironmentsStore = defineStore('environments', () => {
@@ -77,13 +77,7 @@ export const useEnvironmentsStore = defineStore('environments', () => {
 	}
 
 	const variablesAsObject = computed(() => {
-		const asObject = scopedVariables.value.reduce<Record<string, string | boolean | number>>(
-			(acc, variable) => {
-				acc[variable.key] = variable.value;
-				return acc;
-			},
-			{},
-		);
+		const asObject = resolveVariables(scopedVariables.value, projectId.value);
 
 		return new Proxy(asObject, {
 			set() {

--- a/packages/frontend/editor-ui/src/features/settings/environments.ee/environments.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/environments.ee/environments.test.ts
@@ -147,3 +147,43 @@ describe('environments.store', () => {
 		});
 	});
 });
+
+describe('environments.store variablesAsObject precedence', () => {
+	let server: ReturnType<typeof setupServer>;
+
+	beforeAll(() => {
+		server = setupServer();
+
+		// Project variable is created before its global twin so the store array
+		// lists it first. Resolution must still let the project value win.
+		server.create('variable', {
+			id: '1',
+			key: 'CONFLICT',
+			value: 'projectValue',
+			project: { id: '1', name: 'Project 1' },
+		});
+
+		server.create('variable', {
+			id: '2',
+			key: 'CONFLICT',
+			value: 'globalValue',
+		});
+	});
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	afterAll(() => {
+		server.shutdown();
+	});
+
+	it('should let a project variable override a same-key global regardless of order', async () => {
+		const environmentsStore = useEnvironmentsStore();
+		await environmentsStore.fetchAllVariables();
+		const projectStore = useProjectsStore();
+		projectStore.setCurrentProject({ id: '1', name: 'Project 1' } as Project);
+
+		expect(environmentsStore.variablesAsObject).toEqual({ CONFLICT: 'projectValue' });
+	});
+});

--- a/packages/workflow/src/common/index.ts
+++ b/packages/workflow/src/common/index.ts
@@ -4,3 +4,4 @@ export * from './get-connected-nodes';
 export * from './get-node-by-name';
 export * from './get-parent-nodes';
 export * from './map-connections-by-destination';
+export * from './resolve-variables';

--- a/packages/workflow/src/common/resolve-variables.ts
+++ b/packages/workflow/src/common/resolve-variables.ts
@@ -1,0 +1,42 @@
+/**
+ * A variable that is either global (no `project`) or scoped to a project.
+ * Structural shape shared by the backend `Variables` entity and the
+ * frontend `EnvironmentVariable` type.
+ */
+export interface ScopedVariable {
+	key: string;
+	value: string | boolean | number;
+	project?: { id: string } | null;
+}
+
+/**
+ * Resolves variables to a flat key→value map.
+ *
+ * Globals are applied first, then variables belonging to `projectId` overwrite
+ * them. This makes project variables win over same-key globals regardless of
+ * the input order, which would otherwise leave the result dependent on
+ * database row or store insertion order.
+ *
+ * @param variables Global and project-scoped variables, in any order
+ * @param projectId Project whose variables take precedence, if any
+ */
+export function resolveVariables(
+	variables: ScopedVariable[],
+	projectId?: string,
+): Record<string, string | boolean | number> {
+	const resolved: Record<string, string | boolean | number> = {};
+
+	for (const variable of variables) {
+		if (!variable.project) {
+			resolved[variable.key] = variable.value;
+		}
+	}
+
+	for (const variable of variables) {
+		if (projectId && variable.project?.id === projectId) {
+			resolved[variable.key] = variable.value;
+		}
+	}
+
+	return resolved;
+}

--- a/packages/workflow/test/resolve-variables.test.ts
+++ b/packages/workflow/test/resolve-variables.test.ts
@@ -1,0 +1,54 @@
+import { resolveVariables, type ScopedVariable } from '../src/common';
+
+describe('resolveVariables', () => {
+	it('returns only globals when no projectId is given', () => {
+		const variables: ScopedVariable[] = [
+			{ key: 'GLOBAL', value: 'global' },
+			{ key: 'PROJECT', value: 'project', project: { id: 'p1' } },
+		];
+
+		expect(resolveVariables(variables)).toEqual({ GLOBAL: 'global' });
+	});
+
+	it('overrides a same-key global with the matching project variable', () => {
+		const variables: ScopedVariable[] = [
+			{ key: 'SHARED', value: 'global' },
+			{ key: 'SHARED', value: 'project', project: { id: 'p1' } },
+		];
+
+		expect(resolveVariables(variables, 'p1')).toEqual({ SHARED: 'project' });
+	});
+
+	it('lets the project variable win regardless of input order', () => {
+		const projectFirst: ScopedVariable[] = [
+			{ key: 'SHARED', value: 'project', project: { id: 'p1' } },
+			{ key: 'SHARED', value: 'global' },
+		];
+
+		expect(resolveVariables(projectFirst, 'p1')).toEqual({ SHARED: 'project' });
+	});
+
+	it('ignores project variables that belong to a different project', () => {
+		const variables: ScopedVariable[] = [
+			{ key: 'SHARED', value: 'global' },
+			{ key: 'SHARED', value: 'other-project', project: { id: 'p2' } },
+		];
+
+		expect(resolveVariables(variables, 'p1')).toEqual({ SHARED: 'global' });
+	});
+
+	it('keeps globals that have no project override and adds project-only keys', () => {
+		const variables: ScopedVariable[] = [
+			{ key: 'GLOBAL_ONLY', value: 'global' },
+			{ key: 'SHARED', value: 'global' },
+			{ key: 'SHARED', value: 'project', project: { id: 'p1' } },
+			{ key: 'PROJECT_ONLY', value: 'project', project: { id: 'p1' } },
+		];
+
+		expect(resolveVariables(variables, 'p1')).toEqual({
+			GLOBAL_ONLY: 'global',
+			SHARED: 'project',
+			PROJECT_ONLY: 'project',
+		});
+	});
+});


### PR DESCRIPTION
## Summary

When a project variable and a global variable shared the same key, the project variable was only meant to win inside that project, but `$vars` resolution was iteration-order dependent so the global value could clobber it depending on the order returned from the backend cache or held in the frontend store. The override logic was also duplicated and had drifted between the two layers. This PR extracts a single, order-independent `resolveVariables` helper in `n8n-workflow` (globals applied first, then project variables) and has both backend runtime execution and frontend expression preview delegate to it.

## How to test

1. In a project, create a project variable: key `n8n_alert_to_email`, value `project@example.com`.
2. Create a global variable with the same key `n8n_alert_to_email`, value `global@example.com`.
3. Open a workflow owned by that project, add an Edit Fields node, and use `{{ $vars.n8n_alert_to_email }}`.
4. Confirm both the expression preview and an actual execution resolve to `project@example.com`, regardless of the order the variables were created in.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-762

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

