### PR TITLE
feat(core): Make external-facing rate limits configurable

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
@@ -8,10 +8,38 @@ describe('AiConfig', () => {
 		vi.clearAllMocks();
 	});
 
+	afterEach(() => {
+		delete process.env.N8N_AI_RATE_LIMIT;
+	});
+
 	it('should not poison openAiDefaultHeaders object globally when modified', () => {
 		const { openAiDefaultHeaders } = Container.get(AiConfig);
 		openAiDefaultHeaders.test = 'ok';
 		expect(openAiDefaultHeaders.test).toBe('ok');
 		expect(Container.get(AiConfig).openAiDefaultHeaders.test).toBeFalsy();
+	});
+
+	describe('rateLimit', () => {
+		it('applies the documented default limit', () => {
+			expect(Container.get(AiConfig).rateLimit).toBe(100);
+		});
+
+		it('reads the limit from its environment variable', () => {
+			process.env.N8N_AI_RATE_LIMIT = '500';
+			expect(Container.get(AiConfig).rateLimit).toBe(500);
+		});
+
+		it('accepts 0 to disable rate limiting for the AI endpoints', () => {
+			process.env.N8N_AI_RATE_LIMIT = '0';
+			expect(Container.get(AiConfig).rateLimit).toBe(0);
+		});
+
+		it.each(['-5', 'abc', '1.5'])(
+			'falls back to the default when given an invalid value (%s)',
+			(value) => {
+				process.env.N8N_AI_RATE_LIMIT = value;
+				expect(Container.get(AiConfig).rateLimit).toBe(100);
+			},
+		);
 	});
 });

--- a/packages/@n8n/config/src/configs/__tests__/diagnostics.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/diagnostics.config.test.ts
@@ -1,0 +1,43 @@
+import { Container } from '@n8n/di';
+
+import { DiagnosticsConfig } from '../diagnostics.config';
+
+describe('DiagnosticsConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+	});
+
+	afterEach(() => {
+		delete process.env.N8N_TELEMETRY_RATE_LIMIT;
+		delete process.env.N8N_TELEMETRY_SOURCE_RATE_LIMIT;
+	});
+
+	describe('telemetry rate limits', () => {
+		it('applies the documented defaults', () => {
+			const config = Container.get(DiagnosticsConfig);
+			expect(config.telemetryRateLimit).toBe(100);
+			expect(config.telemetrySourceRateLimit).toBe(50);
+		});
+
+		it('reads the limits from their environment variables', () => {
+			process.env.N8N_TELEMETRY_RATE_LIMIT = '500';
+			process.env.N8N_TELEMETRY_SOURCE_RATE_LIMIT = '200';
+			const config = Container.get(DiagnosticsConfig);
+			expect(config.telemetryRateLimit).toBe(500);
+			expect(config.telemetrySourceRateLimit).toBe(200);
+		});
+
+		it('accepts 0 to disable rate limiting', () => {
+			process.env.N8N_TELEMETRY_RATE_LIMIT = '0';
+			expect(Container.get(DiagnosticsConfig).telemetryRateLimit).toBe(0);
+		});
+
+		it.each(['-5', 'abc', '1.5'])(
+			'falls back to the default when given an invalid value (%s)',
+			(value) => {
+				process.env.N8N_TELEMETRY_RATE_LIMIT = value;
+				expect(Container.get(DiagnosticsConfig).telemetryRateLimit).toBe(100);
+			},
+		);
+	});
+});

--- a/packages/@n8n/config/src/configs/__tests__/rate-limit.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/rate-limit.config.test.ts
@@ -1,0 +1,46 @@
+import { Container } from '@n8n/di';
+
+import { RateLimitConfig } from '../rate-limit.config';
+
+describe('RateLimitConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+	});
+
+	afterEach(() => {
+		delete process.env.N8N_RATE_LIMIT_MULTIPLIER;
+		delete process.env.N8N_RATE_LIMIT_DISABLED;
+	});
+
+	describe('multiplier', () => {
+		it('defaults to 1 (no scaling)', () => {
+			expect(Container.get(RateLimitConfig).multiplier).toBe(1);
+		});
+
+		it('reads the multiplier from its environment variable', () => {
+			process.env.N8N_RATE_LIMIT_MULTIPLIER = '3';
+			expect(Container.get(RateLimitConfig).multiplier).toBe(3);
+		});
+
+		it('accepts fractional multipliers', () => {
+			process.env.N8N_RATE_LIMIT_MULTIPLIER = '2.5';
+			expect(Container.get(RateLimitConfig).multiplier).toBe(2.5);
+		});
+
+		it.each(['0', '-2', 'abc'])('falls back to 1 when given an invalid value (%s)', (value) => {
+			process.env.N8N_RATE_LIMIT_MULTIPLIER = value;
+			expect(Container.get(RateLimitConfig).multiplier).toBe(1);
+		});
+	});
+
+	describe('disabled', () => {
+		it('defaults to false', () => {
+			expect(Container.get(RateLimitConfig).disabled).toBe(false);
+		});
+
+		it('reads the flag from its environment variable', () => {
+			process.env.N8N_RATE_LIMIT_DISABLED = 'true';
+			expect(Container.get(RateLimitConfig).disabled).toBe(true);
+		});
+	});
+});

--- a/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
@@ -64,4 +64,35 @@ describe('UserManagementConfig', () => {
 
 		consoleWarnSpy.mockRestore();
 	});
+
+	describe('invitation rate limits', () => {
+		it('applies the documented defaults', () => {
+			const config = Container.get(UserManagementConfig);
+			expect(config.invitationRateLimit).toBe(10);
+			expect(config.invitationAcceptRateLimit).toBe(100);
+		});
+
+		it('reads the limits from their environment variables', () => {
+			process.env = {
+				N8N_INVITATION_RATE_LIMIT: '25',
+				N8N_INVITATION_ACCEPT_RATE_LIMIT: '300',
+			};
+			const config = Container.get(UserManagementConfig);
+			expect(config.invitationRateLimit).toBe(25);
+			expect(config.invitationAcceptRateLimit).toBe(300);
+		});
+
+		it('accepts 0 to disable rate limiting', () => {
+			process.env = { N8N_INVITATION_RATE_LIMIT: '0' };
+			expect(Container.get(UserManagementConfig).invitationRateLimit).toBe(0);
+		});
+
+		it.each(['-5', 'abc', '1.5'])(
+			'falls back to the default when given an invalid value (%s)',
+			(value) => {
+				process.env = { N8N_INVITATION_RATE_LIMIT: value };
+				expect(Container.get(UserManagementConfig).invitationRateLimit).toBe(10);
+			},
+		);
+	});
 });

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -1,12 +1,17 @@
 import { Time } from '@n8n/constants';
 
 import { Config, Env } from '../decorators';
+import { nonnegativeIntSchema } from '../schemas';
 
 @Config
 export class AiConfig {
 	/** Whether AI features (such as AI nodes and AI assistant) are enabled globally. */
 	@Env('N8N_AI_ENABLED')
 	enabled: boolean = false;
+
+	/** Maximum number of requests per IP per 5 minutes to the AI assistant endpoints (build, chat, sessions). */
+	@Env('N8N_AI_RATE_LIMIT', nonnegativeIntSchema)
+	rateLimit: number = 100;
 
 	/**
 	 * Maximum time in milliseconds to wait for an HTTP response from an AI service.

--- a/packages/@n8n/config/src/configs/diagnostics.config.ts
+++ b/packages/@n8n/config/src/configs/diagnostics.config.ts
@@ -1,4 +1,5 @@
 import { Config, Env, Nested } from '../decorators';
+import { nonnegativeIntSchema } from '../schemas';
 
 @Config
 class PostHogConfig {
@@ -27,4 +28,12 @@ export class DiagnosticsConfig {
 
 	@Nested
 	posthogConfig: PostHogConfig;
+
+	/** Max requests per IP per minute to the identify/track telemetry proxy routes (`0` disables). */
+	@Env('N8N_TELEMETRY_RATE_LIMIT', nonnegativeIntSchema)
+	telemetryRateLimit: number = 100;
+
+	/** Max requests per IP per minute to the page and Rudderstack source-config routes (`0` disables). */
+	@Env('N8N_TELEMETRY_SOURCE_RATE_LIMIT', nonnegativeIntSchema)
+	telemetrySourceRateLimit: number = 50;
 }

--- a/packages/@n8n/config/src/configs/rate-limit.config.ts
+++ b/packages/@n8n/config/src/configs/rate-limit.config.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+import { Config, Env } from '../decorators';
+
+/** An invalid multiplier (0, negative or non-numeric) falls back to `1`, i.e. no scaling. */
+const multiplierSchema = z.number({ coerce: true }).positive();
+
+/**
+ * Global escape hatch for IP-based (Layer 1) rate limiting. Keyed (Layer 2) limiters
+ * are deliberately unaffected, so auth-flow protection holds when IP limits are relaxed.
+ */
+@Config
+export class RateLimitConfig {
+	/** Scales the count of every IP rate limit (window unchanged). Default `1` = no scaling. */
+	@Env('N8N_RATE_LIMIT_MULTIPLIER', multiplierSchema)
+	multiplier: number = 1;
+
+	/** When `true`, IP-based rate limiting is skipped entirely. Keyed (auth) limiters still apply. */
+	@Env('N8N_RATE_LIMIT_DISABLED')
+	disabled: boolean = false;
+}

--- a/packages/@n8n/config/src/configs/user-management.config.ts
+++ b/packages/@n8n/config/src/configs/user-management.config.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { Config, Env, Nested } from '../decorators';
+import { nonnegativeIntSchema } from '../schemas';
 import { PasswordConfig } from './password.config';
 
 @Config
@@ -135,6 +136,14 @@ export class UserManagementConfig {
 	 */
 	@Env('N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS')
 	jwtRefreshTimeoutHours: number = 0;
+
+	/** Max requests per IP per 5 minutes to create invitations (`0` disables). */
+	@Env('N8N_INVITATION_RATE_LIMIT', nonnegativeIntSchema)
+	invitationRateLimit: number = 10;
+
+	/** Max requests per IP per minute to accept an invitation (`0` disables). */
+	@Env('N8N_INVITATION_ACCEPT_RATE_LIMIT', nonnegativeIntSchema)
+	invitationAcceptRateLimit: number = 100;
 
 	sanitize() {
 		if (this.jwtRefreshTimeoutHours >= this.jwtSessionDurationHours) {

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -35,6 +35,7 @@ import { MultiMainSetupConfig } from './configs/multi-main-setup.config';
 import { NodesConfig } from './configs/nodes.config';
 import { PersonalizationConfig } from './configs/personalization.config';
 import { PublicApiConfig } from './configs/public-api.config';
+import { RateLimitConfig } from './configs/rate-limit.config';
 import { RedisConfig } from './configs/redis.config';
 import { TaskRunnersConfig } from './configs/runners.config';
 import { ScalingModeConfig } from './configs/scaling-mode.config';
@@ -87,6 +88,8 @@ export { PasswordConfig } from './configs/password.config';
 export { AgentsConfig } from './configs/agents.config';
 export { CompressionNodeConfig } from './configs/compression.config';
 export { RedisConfig } from './configs/redis.config';
+export { RateLimitConfig } from './configs/rate-limit.config';
+export { nonnegativeIntSchema } from './schemas';
 export { EndpointsConfig, PrometheusMetricsConfig };
 
 const protocolSchema = z.enum(['http', 'https']);
@@ -293,4 +296,7 @@ export class GlobalConfig {
 
 	@Nested
 	instanceSettingsLoader: InstanceSettingsLoaderConfig;
+
+	@Nested
+	rateLimit: RateLimitConfig;
 }

--- a/packages/@n8n/config/src/schemas.ts
+++ b/packages/@n8n/config/src/schemas.ts
@@ -1,3 +1,6 @@
 import { z } from 'zod';
 
 export const positiveIntSchema = z.number({ coerce: true }).int().positive();
+
+/** For rate-limit counts where `0` is a valid value meaning "disable the limit". */
+export const nonnegativeIntSchema = z.number({ coerce: true }).int().nonnegative();

--- a/packages/cli/src/__tests__/controller.registry.test.ts
+++ b/packages/cli/src/__tests__/controller.registry.test.ts
@@ -35,7 +35,10 @@ import type { SuperAgentTest } from '@test-integration/types';
 describe('ControllerRegistry', () => {
 	const license = mock<License>();
 	const authService = mock<AuthService>();
-	const globalConfig = mock<GlobalConfig>({ endpoints: { rest: 'rest' } });
+	const globalConfig = mock<GlobalConfig>({
+		endpoints: { rest: 'rest' },
+		rateLimit: { multiplier: 1, disabled: false },
+	});
 	const metadata = Container.get(ControllerRegistryMetadata);
 	const lastActiveAtService = mock<LastActiveAtService>();
 	let agent: SuperAgentTest;
@@ -52,7 +55,7 @@ describe('ControllerRegistry', () => {
 			globalConfig,
 			metadata,
 			lastActiveAtService,
-			new RateLimitService(),
+			new RateLimitService(globalConfig.rateLimit),
 		).activate(app);
 		agent = testAgent(app);
 	});

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -156,8 +156,9 @@ export class ControllerRegistry {
 	): RequestHandler[] {
 		const middlewares: RequestHandler[] = [];
 
-		// LAYER 1: IP-based rate limiting (always before auth)
-		if (inProduction && route.ipRateLimit) {
+		// LAYER 1: IP-based rate limiting (always before auth). N8N_RATE_LIMIT_DISABLED
+		// skips only this layer; keyed (Layer 2) limiters below stay active.
+		if (inProduction && route.ipRateLimit && !this.globalConfig.rateLimit.disabled) {
 			middlewares.push(this.rateLimitService.createIpRateLimitMiddleware(route.ipRateLimit));
 		}
 

--- a/packages/cli/src/controllers/ai.controller.ts
+++ b/packages/cli/src/controllers/ai.controller.ts
@@ -1,4 +1,3 @@
-import { FREE_AI_CREDITS_CREDENTIAL_NAME, STREAM_SEPARATOR } from '@/constants';
 import type {
 	AiGatewayConfigDto,
 	AiGatewayUsageResponse,
@@ -16,14 +15,26 @@ import {
 	AiClearSessionRequestDto,
 	AiGatewayUsageQueryDto,
 } from '@n8n/api-types';
+import { AiConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Body, Get, Licensed, Post, Query, RestController, GlobalScope } from '@n8n/decorators';
+import {
+	Body,
+	createIpRateLimit,
+	Get,
+	Licensed,
+	Post,
+	Query,
+	RestController,
+	GlobalScope,
+} from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { type AiAssistantSDK, APIResponseError } from '@n8n_io/ai-assistant-sdk';
 import { Response } from 'express';
 import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
 import { strict as assert } from 'node:assert';
 import { WritableStream } from 'node:stream/web';
 
+import { FREE_AI_CREDITS_CREDENTIAL_NAME, STREAM_SEPARATOR } from '@/constants';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
@@ -36,6 +47,9 @@ import { AiService } from '@/services/ai.service';
 import { UserService } from '@/services/user.service';
 
 export type FlushableResponse = Response & { flush: () => void };
+
+// Read at class-load so the configured limit is baked into the route decorator.
+const aiRateLimit = createIpRateLimit(Container.get(AiConfig).rateLimit);
 
 @RestController('/ai')
 export class AiController {
@@ -52,7 +66,7 @@ export class AiController {
 	// "Cannot set headers after they are sent" error for streaming responses.
 	// This ensures errors during streaming are handled within the stream itself.
 	@Licensed('feat:aiBuilder')
-	@Post('/build', { ipRateLimit: { limit: 100 }, usesTemplates: true })
+	@Post('/build', { ipRateLimit: aiRateLimit, usesTemplates: true })
 	async build(
 		req: AuthenticatedRequest,
 		res: FlushableResponse,
@@ -135,7 +149,7 @@ export class AiController {
 		}
 	}
 
-	@Post('/chat', { ipRateLimit: { limit: 100 } })
+	@Post('/chat', { ipRateLimit: aiRateLimit })
 	async chat(req: AuthenticatedRequest, res: FlushableResponse, @Body payload: AiChatRequestDto) {
 		try {
 			const abortController = new AbortController();
@@ -244,7 +258,7 @@ export class AiController {
 	}
 
 	@Licensed('feat:aiBuilder')
-	@Post('/sessions', { ipRateLimit: { limit: 100 } })
+	@Post('/sessions', { ipRateLimit: aiRateLimit })
 	async getSessions(
 		req: AuthenticatedRequest,
 		_: Response,
@@ -315,7 +329,7 @@ export class AiController {
 	}
 
 	@Licensed('feat:aiBuilder')
-	@Post('/build/truncate-messages', { ipRateLimit: { limit: 100 } })
+	@Post('/build/truncate-messages', { ipRateLimit: aiRateLimit })
 	async truncateMessages(
 		req: AuthenticatedRequest,
 		_: Response,
@@ -336,7 +350,7 @@ export class AiController {
 	}
 
 	@Licensed('feat:aiBuilder')
-	@Post('/build/clear-session', { ipRateLimit: { limit: 100 } })
+	@Post('/build/clear-session', { ipRateLimit: aiRateLimit })
 	async clearSession(
 		req: AuthenticatedRequest,
 		_: Response,

--- a/packages/cli/src/controllers/invitation.controller.ts
+++ b/packages/cli/src/controllers/invitation.controller.ts
@@ -1,8 +1,11 @@
 import { AcceptInvitationRequestDto, InviteUsersRequestDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import type { User } from '@n8n/db';
 import { UserRepository, AuthenticatedRequest } from '@n8n/db';
-import { Post, GlobalScope, RestController, Body } from '@n8n/decorators';
+import { createIpRateLimit, Post, GlobalScope, RestController, Body } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { Response } from 'express';
 
 import { AuthService } from '@/auth/auth.service';
@@ -14,11 +17,18 @@ import { ExternalHooks } from '@/external-hooks';
 import { License } from '@/license';
 import { PostHogClient } from '@/posthog';
 import { AuthlessRequest } from '@/requests';
+import { OwnershipService } from '@/services/ownership.service';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
-import { OwnershipService } from '@/services/ownership.service';
 import { isSsoCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
-import { Time } from '@n8n/constants';
+
+// Read at class-load so the configured limit is baked into the route decorator.
+const userManagementConfig = Container.get(GlobalConfig).userManagement;
+const inviteRateLimit = createIpRateLimit(userManagementConfig.invitationRateLimit);
+const acceptRateLimit = createIpRateLimit(
+	userManagementConfig.invitationAcceptRateLimit,
+	1 * Time.minutes.toMilliseconds,
+);
 
 @RestController('/invitations')
 export class InvitationController {
@@ -39,7 +49,7 @@ export class InvitationController {
 	 * Send email invite(s) to one or multiple users and create user shell(s).
 	 */
 
-	@Post('/', { ipRateLimit: { limit: 10 } })
+	@Post('/', { ipRateLimit: inviteRateLimit })
 	@GlobalScope('user:create')
 	async inviteUser(
 		req: AuthenticatedRequest,
@@ -157,9 +167,8 @@ export class InvitationController {
 	 */
 	@Post('/accept', {
 		skipAuth: true,
-		// Two layered rate limit to ensure multiple users can accept an invitation from
-		// the same IP address but aggressive per inviteeId limit.
-		ipRateLimit: { limit: 100, windowMs: 1 * Time.minutes.toMilliseconds },
+		// Higher limit on a short window so multiple users behind one IP can accept.
+		ipRateLimit: acceptRateLimit,
 	})
 	async acceptInvitationWithToken(
 		req: AuthlessRequest,

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -1,14 +1,15 @@
 import { OutboundHttp } from '@n8n/backend-network';
 import { GlobalConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
 import { AuthenticatedRequest } from '@n8n/db';
 import { createIpRateLimit, Get, Options, Post, RestController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { NextFunction, Response } from 'express';
 import { createProxyMiddleware, fixRequestBody } from 'http-proxy-middleware';
 
-// Window is fixed at 60s; only the count is configurable. Read at class-load so the
+// Window is fixed; only the count is configurable. Read at class-load so the
 // limit is baked into the route decorator.
-const TELEMETRY_WINDOW_MS = 60_000;
+const TELEMETRY_WINDOW_MS = 1 * Time.minutes.toMilliseconds;
 const diagnosticsConfig = Container.get(GlobalConfig).diagnostics;
 const telemetryRateLimit = createIpRateLimit(
 	diagnosticsConfig.telemetryRateLimit,

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -1,9 +1,23 @@
 import { OutboundHttp } from '@n8n/backend-network';
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Get, Options, Post, RestController } from '@n8n/decorators';
+import { createIpRateLimit, Get, Options, Post, RestController } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { NextFunction, Response } from 'express';
 import { createProxyMiddleware, fixRequestBody } from 'http-proxy-middleware';
+
+// Window is fixed at 60s; only the count is configurable. Read at class-load so the
+// limit is baked into the route decorator.
+const TELEMETRY_WINDOW_MS = 60_000;
+const diagnosticsConfig = Container.get(GlobalConfig).diagnostics;
+const telemetryRateLimit = createIpRateLimit(
+	diagnosticsConfig.telemetryRateLimit,
+	TELEMETRY_WINDOW_MS,
+);
+const telemetrySourceRateLimit = createIpRateLimit(
+	diagnosticsConfig.telemetrySourceRateLimit,
+	TELEMETRY_WINDOW_MS,
+);
 
 @RestController('/telemetry')
 export class TelemetryController {
@@ -68,7 +82,7 @@ export class TelemetryController {
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Options('/proxy/:version/:action', {
 		skipAuth: true,
-		ipRateLimit: { limit: 100, windowMs: 60_000 },
+		ipRateLimit: telemetryRateLimit,
 	})
 	proxyPreflight(req: AuthenticatedRequest, res: Response) {
 		this.applyCors(req, res);
@@ -77,7 +91,7 @@ export class TelemetryController {
 
 	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
-	@Post('/proxy/:version/track', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
+	@Post('/proxy/:version/track', { skipAuth: true, ipRateLimit: telemetryRateLimit })
 	async track(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		this.applyCors(req, res);
 		await this.proxy(req, res, next);
@@ -87,7 +101,7 @@ export class TelemetryController {
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/identify', {
 		skipAuth: true,
-		ipRateLimit: { limit: 100, windowMs: 60_000 },
+		ipRateLimit: telemetryRateLimit,
 	})
 	async identify(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		this.applyCors(req, res);
@@ -96,7 +110,7 @@ export class TelemetryController {
 
 	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
-	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
+	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: telemetrySourceRateLimit })
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		this.applyCors(req, res);
 		await this.proxy(req, res, next);
@@ -106,7 +120,7 @@ export class TelemetryController {
 	// the instance write key server-side and returns only the SDK config.
 	@Options('/rudderstack/sourceConfig', {
 		skipAuth: true,
-		ipRateLimit: { limit: 50, windowMs: 60_000 },
+		ipRateLimit: telemetrySourceRateLimit,
 		usesTemplates: true,
 	})
 	sourceConfigPreflight(req: AuthenticatedRequest, res: Response) {
@@ -118,7 +132,7 @@ export class TelemetryController {
 	// the instance write key server-side and returns only the SDK config.
 	@Get('/rudderstack/sourceConfig', {
 		skipAuth: true,
-		ipRateLimit: { limit: 50, windowMs: 60_000 },
+		ipRateLimit: telemetrySourceRateLimit,
 		usesTemplates: true,
 	})
 	async sourceConfig(req: AuthenticatedRequest, res: Response) {

--- a/packages/cli/src/modules/mcp/mcp.config.ts
+++ b/packages/cli/src/modules/mcp/mcp.config.ts
@@ -1,5 +1,4 @@
-import { Config, Env } from '@n8n/config';
-import { z } from 'zod';
+import { Config, Env, nonnegativeIntSchema } from '@n8n/config';
 
 /** Configuration for the instance MCP server module. */
 @Config
@@ -8,6 +7,6 @@ export class McpConfig {
 	 * Maximum number of requests to the MCP server endpoint (`/mcp-server/http`)
 	 * per IP per 5 minutes. Set to `0` to disable IP rate limiting for the endpoint.
 	 */
-	@Env('N8N_MCP_SERVER_RATE_LIMIT', z.number({ coerce: true }).int().nonnegative())
+	@Env('N8N_MCP_SERVER_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitServer: number = 100;
 }

--- a/packages/cli/src/modules/oauth-server/oauth-server.config.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.config.ts
@@ -1,34 +1,31 @@
-import { Config, Env } from '@n8n/config';
-import { z } from 'zod';
-
-// Each limit accepts `0` to disable IP rate limiting for its endpoint.
-const rateLimitSchema = z.number({ coerce: true }).int().nonnegative();
+import { Config, Env, nonnegativeIntSchema } from '@n8n/config';
 
 /**
- * IP rate limits for the OAuth server endpoints.
+ * IP rate limits for the OAuth server endpoints. Each limit accepts `0` to
+ * disable IP rate limiting for its endpoint.
  */
 @Config
 export class OAuthServerConfig {
 	/** Maximum number of client registration requests per IP per 5 minutes. */
-	@Env('N8N_OAUTH_SERVER_REGISTER_RATE_LIMIT', rateLimitSchema)
+	@Env('N8N_OAUTH_SERVER_REGISTER_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitRegister: number = 10;
 
 	/** Maximum number of authorize requests per IP per 5 minutes. */
-	@Env('N8N_OAUTH_SERVER_AUTHORIZE_RATE_LIMIT', rateLimitSchema)
+	@Env('N8N_OAUTH_SERVER_AUTHORIZE_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitAuthorize: number = 50;
 
 	/** Maximum number of token requests per IP per 5 minutes. */
-	@Env('N8N_OAUTH_SERVER_TOKEN_RATE_LIMIT', rateLimitSchema)
+	@Env('N8N_OAUTH_SERVER_TOKEN_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitToken: number = 20;
 
 	/** Maximum number of revoke requests per IP per 5 minutes. */
-	@Env('N8N_OAUTH_SERVER_REVOKE_RATE_LIMIT', rateLimitSchema)
+	@Env('N8N_OAUTH_SERVER_REVOKE_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitRevoke: number = 30;
 
 	/**
 	 * Maximum number of OAuth metadata discovery requests (the `.well-known/*`
 	 * endpoints) per IP per 5 minutes.
 	 */
-	@Env('N8N_OAUTH_SERVER_WELL_KNOWN_RATE_LIMIT', rateLimitSchema)
+	@Env('N8N_OAUTH_SERVER_WELL_KNOWN_RATE_LIMIT', nonnegativeIntSchema)
 	rateLimitWellKnown: number = 100;
 }

--- a/packages/cli/src/services/__tests__/rate-limit.service.test.ts
+++ b/packages/cli/src/services/__tests__/rate-limit.service.test.ts
@@ -1,0 +1,53 @@
+import type { RateLimitConfig } from '@n8n/config';
+import type { Options } from 'express-rate-limit';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
+import { mock } from 'jest-mock-extended';
+
+import { RateLimitService } from '../rate-limit.service';
+
+jest.mock('express-rate-limit', () => ({
+	rateLimit: jest.fn(() => jest.fn()),
+}));
+
+const expressRateLimitMock = expressRateLimit as unknown as jest.Mock<unknown, [Options]>;
+
+const lastOptions = (): Options => expressRateLimitMock.mock.calls.at(-1)![0];
+
+describe('RateLimitService - global multiplier', () => {
+	beforeEach(() => {
+		expressRateLimitMock.mockClear();
+	});
+
+	const buildService = (multiplier: number, disabled = false) =>
+		new RateLimitService(mock<RateLimitConfig>({ multiplier, disabled }));
+
+	it('does not change the limit when multiplier is 1', () => {
+		buildService(1).createIpRateLimitMiddleware({ limit: 100 });
+		expect(lastOptions().limit).toBe(100);
+	});
+
+	it('scales the IP limit by the multiplier', () => {
+		buildService(3).createIpRateLimitMiddleware({ limit: 100 });
+		expect(lastOptions().limit).toBe(300);
+	});
+
+	it('rounds a fractionally-scaled limit up', () => {
+		buildService(2.5).createIpRateLimitMiddleware({ limit: 5 });
+		expect(lastOptions().limit).toBe(13); // ceil(5 * 2.5) = 13
+	});
+
+	it('scales the default limit when ipRateLimit is `true`', () => {
+		buildService(2).createIpRateLimitMiddleware(true);
+		expect(lastOptions().limit).toBe(10); // default 5 * 2
+	});
+
+	it('leaves the window unchanged (count-only)', () => {
+		buildService(4).createIpRateLimitMiddleware({ limit: 10, windowMs: 60_000 });
+		expect(lastOptions().windowMs).toBe(60_000);
+	});
+
+	it('does not apply the multiplier to user-keyed (Layer 2) limiters', () => {
+		buildService(5).createUserKeyedRateLimitMiddleware({ source: 'user', limit: 10 });
+		expect(lastOptions().limit).toBe(10);
+	});
+});

--- a/packages/cli/src/services/rate-limit.service.ts
+++ b/packages/cli/src/services/rate-limit.service.ts
@@ -1,4 +1,7 @@
+import type { ZodClass } from '@n8n/api-types';
+import { RateLimitConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
+import { AuthenticatedRequest } from '@n8n/db';
 import type { RateLimiterLimits, UserKeyedRateLimiterConfig } from '@n8n/decorators';
 import { BodyKeyedRateLimiterConfig } from '@n8n/decorators';
 import { Service } from '@n8n/di';
@@ -6,8 +9,6 @@ import type { Request, RequestHandler } from 'express';
 import { rateLimit as expressRateLimit } from 'express-rate-limit';
 import assert from 'node:assert';
 import type { ZodTypeAny } from 'zod';
-import type { ZodClass } from '@n8n/api-types';
-import { AuthenticatedRequest } from '@n8n/db';
 
 const defaultLimits: Required<RateLimiterLimits> = {
 	limit: 5,
@@ -24,15 +25,22 @@ const defaultLimits: Required<RateLimiterLimits> = {
  */
 @Service()
 export class RateLimitService {
+	constructor(private readonly rateLimitConfig: RateLimitConfig) {}
+
 	/**
 	 * Creates Layer 1: IP-based rate limit middleware
 	 * Always runs BEFORE authentication.
+	 *
+	 * The global `N8N_RATE_LIMIT_MULTIPLIER` scales the count of every IP limit
+	 * (the window is never scaled). It applies on top of any per-route config.
 	 */
 	createIpRateLimitMiddleware(rateLimit: boolean | RateLimiterLimits): RequestHandler {
 		if (typeof rateLimit === 'boolean') rateLimit = {};
 
+		const baseLimit = rateLimit.limit ?? defaultLimits.limit;
+
 		return expressRateLimit({
-			limit: rateLimit.limit ?? defaultLimits.limit,
+			limit: Math.ceil(baseLimit * this.rateLimitConfig.multiplier),
 			windowMs: rateLimit.windowMs ?? defaultLimits.windowMs,
 			message: { message: 'Too many requests' },
 		});


### PR DESCRIPTION
## Summary

Follow-up to [CAT-2986](https://linear.app/n8n/issue/CAT-2986) ([#32203](https://github.com/n8n-io/n8n/pull/32203)), which made only the MCP + OAuth-server IP rate limits configurable. This makes the **remaining** external-facing IP rate limits configurable, with defaults equal to the previous hard-coded values, so the default security posture is unchanged.

**Per-route counts** (each accepts `0` to disable IP rate limiting for that route):

| Env var | Default | Endpoint(s) |
| -- | -- | -- |
| `N8N_AI_RATE_LIMIT` | 100 | AI assistant (`/ai/build`, `/chat`, `/sessions`, `/build/truncate-messages`, `/build/clear-session`) |
| `N8N_TELEMETRY_RATE_LIMIT` | 100 | telemetry proxy identify/track (+OPTIONS) |
| `N8N_TELEMETRY_SOURCE_RATE_LIMIT` | 50 | telemetry proxy page + Rudderstack source-config |
| `N8N_INVITATION_RATE_LIMIT` | 10 | `POST /invitations` |
| `N8N_INVITATION_ACCEPT_RATE_LIMIT` | 100 | `POST /invitations/accept` |

**Global escape hatch** (for shared-NAT / office-IP deployments):

| Env var | Default | Effect |
| -- | -- | -- |
| `N8N_RATE_LIMIT_MULTIPLIER` | 1 | Scales the count of every IP rate limit (window unchanged) |
| `N8N_RATE_LIMIT_DISABLED` | false | Skips IP-based rate limiting entirely |

Both global switches affect **IP (Layer 1) limits only** — keyed (Layer 2) limiters such as the per-email login limit and per-user MFA limit are deliberately unaffected, so brute-force / credential-stuffing protection holds even when IP limits are relaxed. Auth, login, password-reset and MFA limits are left intentionally fixed and out of scope.

Counts use a shared `nonnegativeIntSchema` (invalid values fall back to the default); the `oauth-server` and `mcp` module configs from the hotfix were migrated onto it too. Windows stay fixed per route (count-only configuration).

## How to test

With `NODE_ENV=production`:
- Set `N8N_AI_RATE_LIMIT=2` → the 3rd request to `/rest/ai/chat` within the window returns `429 {"message":"Too many requests"}`.
- Set `N8N_RATE_LIMIT_MULTIPLIER=3` → effective limits triple.
- Set `N8N_RATE_LIMIT_DISABLED=true` → IP routes stop returning 429, but the per-email login limiter still fires.
- Set `N8N_TELEMETRY_RATE_LIMIT=0` → telemetry identify/track is no longer IP rate limited.

Unit tests cover config parsing/defaults/fallback and the multiplier's IP-only scaling.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3411

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- follow-up docs PR to add the new env vars + note that 0 fully removes the IP bound on the unauthenticated telemetry/invitation routes -->
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33139">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->