### PR TITLE
feat(core): Allow custom token-expired status codes for non-OAuth credentials

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/authentication.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/authentication.test.ts
@@ -1,0 +1,167 @@
+import type {
+	IAllExecuteFunctions,
+	IHttpRequestOptions,
+	INode,
+	IWorkflowExecuteAdditionalData,
+	Workflow,
+} from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { httpRequestWithAuthentication } from '../authentication';
+import { httpRequest } from '../http-request';
+
+vi.mock('../http-request', () => ({
+	httpRequest: vi.fn(),
+	removeEmptyBody: vi.fn(),
+}));
+
+const mockedHttpRequest = vi.mocked(httpRequest);
+
+describe('httpRequestWithAuthentication - tokenExpiredStatusCodes', () => {
+	const baseUrl = 'https://api.example.com';
+	const credentialsType = 'testApi';
+	const mockThis = mockDeep<IAllExecuteFunctions>();
+	const mockNode = mockDeep<INode>();
+	const mockWorkflow = mockDeep<Workflow>();
+	const mockAdditionalData = mockDeep<IWorkflowExecuteAdditionalData>();
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mockNode.name = 'test-node';
+
+		mockAdditionalData.credentialsHelper.getParentTypes.mockReturnValue([]);
+		mockThis.getCredentials.mockResolvedValue({ token: 'secret' });
+		mockAdditionalData.credentialsHelper.preAuthentication.mockResolvedValue(undefined);
+		mockAdditionalData.credentialsHelper.authenticate.mockImplementation(
+			async (_credentials, _type, options) =>
+				(await Promise.resolve(options)) as IHttpRequestOptions,
+		);
+	});
+
+	test('should retry once on 401 by default', async () => {
+		mockedHttpRequest
+			.mockRejectedValueOnce(Object.assign(new Error('401'), { response: { status: 401 } }))
+			.mockResolvedValueOnce({ success: true });
+
+		await expect(
+			httpRequestWithAuthentication.call(
+				mockThis,
+				credentialsType,
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockWorkflow,
+				mockNode,
+				mockAdditionalData,
+				undefined,
+			),
+		).resolves.toEqual({ success: true });
+
+		expect(mockedHttpRequest).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenLastCalledWith(
+			expect.anything(),
+			expect.anything(),
+			credentialsType,
+			mockNode,
+			true,
+		);
+	});
+
+	test('should retry on a custom tokenExpiredStatusCode', async () => {
+		mockedHttpRequest
+			.mockRejectedValueOnce(Object.assign(new Error('429'), { response: { status: 429 } }))
+			.mockResolvedValueOnce({ success: true });
+
+		await expect(
+			httpRequestWithAuthentication.call(
+				mockThis,
+				credentialsType,
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockWorkflow,
+				mockNode,
+				mockAdditionalData,
+				{ generic: { tokenExpiredStatusCodes: [429] } },
+			),
+		).resolves.toEqual({ success: true });
+
+		expect(mockedHttpRequest).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenLastCalledWith(
+			expect.anything(),
+			expect.anything(),
+			credentialsType,
+			mockNode,
+			true,
+		);
+	});
+
+	test('should retry on any of several custom tokenExpiredStatusCodes', async () => {
+		mockedHttpRequest
+			.mockRejectedValueOnce(Object.assign(new Error('403'), { response: { status: 403 } }))
+			.mockResolvedValueOnce({ success: true });
+
+		await expect(
+			httpRequestWithAuthentication.call(
+				mockThis,
+				credentialsType,
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockWorkflow,
+				mockNode,
+				mockAdditionalData,
+				{ generic: { tokenExpiredStatusCodes: [401, 403] } },
+			),
+		).resolves.toEqual({ success: true });
+
+		expect(mockedHttpRequest).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalledTimes(2);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenLastCalledWith(
+			expect.anything(),
+			expect.anything(),
+			credentialsType,
+			mockNode,
+			true,
+		);
+	});
+
+	test('should NOT retry on 401 when custom codes do not include it', async () => {
+		mockedHttpRequest.mockRejectedValueOnce(
+			Object.assign(new Error('401'), { response: { status: 401 } }),
+		);
+
+		await expect(
+			httpRequestWithAuthentication.call(
+				mockThis,
+				credentialsType,
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockWorkflow,
+				mockNode,
+				mockAdditionalData,
+				{ generic: { tokenExpiredStatusCodes: [429] } },
+			),
+		).rejects.toThrow(NodeApiError);
+
+		expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalledTimes(1);
+	});
+
+	test('should NOT retry on a non-expiry status code by default', async () => {
+		mockedHttpRequest.mockRejectedValueOnce(
+			Object.assign(new Error('500'), { response: { status: 500 } }),
+		);
+
+		await expect(
+			httpRequestWithAuthentication.call(
+				mockThis,
+				credentialsType,
+				{ method: 'GET', url: `${baseUrl}/data` },
+				mockWorkflow,
+				mockNode,
+				mockAdditionalData,
+				undefined,
+			),
+		).rejects.toThrow(NodeApiError);
+
+		expect(mockedHttpRequest).toHaveBeenCalledTimes(1);
+		expect(mockAdditionalData.credentialsHelper.preAuthentication).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/authentication.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/authentication.ts
@@ -19,6 +19,19 @@ import { httpRequest, removeEmptyBody } from './http-request';
 import { proxyRequestToAxios } from './legacy-request-adapter';
 import { requestOAuth1, requestOAuth2 } from './oauth';
 
+const DEFAULT_TOKEN_EXPIRED_STATUS_CODES = [401];
+
+function resolveTokenExpiredStatusCodes(
+	genericOptions?: IAdditionalCredentialOptions['generic'],
+): number[] {
+	const tokenExpiredStatusCodes = genericOptions?.tokenExpiredStatusCodes;
+	if (tokenExpiredStatusCodes?.length) {
+		return tokenExpiredStatusCodes;
+	}
+
+	return DEFAULT_TOKEN_EXPIRED_STATUS_CODES;
+}
+
 export async function httpRequestWithAuthentication(
 	this: IAllExecuteFunctions,
 	credentialsType: string,
@@ -106,9 +119,12 @@ export async function httpRequestWithAuthentication(
 	} catch (error) {
 		// if there is a pre authorization method defined and
 		// the method failed due to unauthorized request
+		const tokenExpiredStatusCodes = resolveTokenExpiredStatusCodes(
+			additionalCredentialOptions?.generic,
+		);
 		if (
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			error.response?.status === 401 &&
+			tokenExpiredStatusCodes.includes(error.response?.status) &&
 			additionalData.credentialsHelper.preAuthentication !== undefined
 		) {
 			try {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -46,7 +46,16 @@ import type { IRunExecutionData } from './run-execution-data/run-execution-data'
 export type { WorkflowExecuteModeValues as WorkflowExecuteMode } from './execution-context';
 
 export interface IAdditionalCredentialOptions {
+	/**
+	 * Additional options for OAuth2 credentials.
+	 */
 	oauth2?: IOAuth2Options;
+
+	/**
+	 * Additional options for non-OAuth2 & non-OAuth1 credentials.
+	 */
+	generic?: ISimplifiedAuthOptions;
+
 	credentialsDecrypted?: ICredentialsDecrypted;
 }
 
@@ -87,6 +96,15 @@ export interface IOAuth2Options {
 	keepBearer?: boolean;
 	tokenExpiredStatusCode?: number;
 	keyToIncludeInAccessTokenHeader?: string;
+}
+
+export interface ISimplifiedAuthOptions {
+	/**
+	 * HTTP status codes that trigger a token refresh (if preAuthentication is defined on the credentials).
+	 * Defaults to `[401]` when not set.
+	 * @default [401]
+	 */
+	tokenExpiredStatusCodes?: NonEmptyArray<number>;
 }
 
 export interface IConnection {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

As part of my work I develop n8n nodes, and I regularly run into APIs that return a
status other than `401` for an expired token (e.g. `403` or `429`). Non-OAuth
credentials refresh their token (via `preAuthentication`) only on `401`, so in those
cases the refresh never triggers and the request just fails.
 
This PR adds an optional `generic.tokenExpiredStatusCodes` to `IAdditionalCredentialOptions`,
passed per request. When set, those status codes trigger refresh-and-retry;
the default stays `[401]`. The type is `NonEmptyArray<number>`.
 
```ts
await this.helpers.httpRequestWithAuthentication.call(this, credentialsType, options, {
  generic: { tokenExpiredStatusCodes: [403, 419] },
});
```
 
For context, the deprecated `requestWithAuthentication` helper refreshes on *any*
error; `httpRequestWithAuthentication` narrowed that to `401`, and this PR makes the
set configurable.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

Unit tests added

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

Self-proposed feature request (no ticket). Mirrors #26641 (OAuth2 equivalent).


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->