### PR TITLE
fix(Chat Trigger Node): Pin @n8n/chat CDN version in hosted chat page

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/templates.test.ts
@@ -1,3 +1,4 @@
+import { CHAT_CDN_VERSION } from '../constants';
 import {
 	createPage,
 	escapeForScriptContext,
@@ -606,6 +607,30 @@ describe('ChatTrigger Templates Security', () => {
 			expect(result.count).toBe('123');
 			expect(result.enabled).toBe('');
 			expect(result.obj).toBe('');
+		});
+	});
+
+	describe('@n8n/chat CDN version pinning', () => {
+		it('should load the @n8n/chat stylesheet from a pinned version', () => {
+			const result = createPage(defaultParams);
+
+			expect(result).toContain(
+				`https://cdn.jsdelivr.net/npm/@n8n/chat@${CHAT_CDN_VERSION}/dist/style.css`,
+			);
+		});
+
+		it('should import the @n8n/chat bundle from a pinned version', () => {
+			const result = createPage(defaultParams);
+
+			expect(result).toContain(
+				`https://cdn.jsdelivr.net/npm/@n8n/chat@${CHAT_CDN_VERSION}/dist/chat.bundle.es.js`,
+			);
+		});
+
+		it('should not reference @n8n/chat without a version (would resolve to @latest)', () => {
+			const result = createPage(defaultParams);
+
+			expect(result).not.toContain('npm/@n8n/chat/dist/');
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/constants.ts
@@ -1,3 +1,10 @@
+// Version of `@n8n/chat` to load from the jsDelivr CDN in the hosted chat page.
+// Pinned so the served page always matches a tested bundle: without a version
+// the CDN serves `@latest`, and a new `@n8n/chat` release would change the
+// hosted page's markup/styles without any change on the user's side.
+// Keep in sync with the `@n8n/chat` package version on each release.
+export const CHAT_CDN_VERSION = '1.26.0';
+
 // CSS Variables are defined in `@n8n/chat/src/css/_tokens.scss`
 export const cssVariables = `
 :root {

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts
@@ -1,5 +1,6 @@
 import sanitizeHtml from 'sanitize-html';
 
+import { CHAT_CDN_VERSION } from './constants';
 import type { AuthenticationChatOption, LoadPreviousSessionChatOption } from './types';
 
 function sanitizeUserInput(input: unknown): string {
@@ -122,7 +123,7 @@ export function createPage({
 			<meta name="viewport" content="width=device-width, initial-scale=1">
 			<title>Chat</title>
 			<link href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css" rel="stylesheet" />
-			<link href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css" rel="stylesheet" />
+			<link href="https://cdn.jsdelivr.net/npm/@n8n/chat@${CHAT_CDN_VERSION}/dist/style.css" rel="stylesheet" />
 			<style>
 				html,
 				body,
@@ -135,7 +136,7 @@ export function createPage({
 		</head>
 		<body>
 			<script type="module">
-				import { createChat } from 'https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js';
+				import { createChat } from 'https://cdn.jsdelivr.net/npm/@n8n/chat@${CHAT_CDN_VERSION}/dist/chat.bundle.es.js';
 
 				(async function () {
 					const authentication = '${sanitizedAuthentication}';


### PR DESCRIPTION
## Summary

The Chat Trigger's hosted chat page loads `@n8n/chat` from jsDelivr **without a version pin**, so the CDN serves `@latest`. When a new `@n8n/chat` is published, the served page's markup/styles change with no change on the user's side — which is what broke the layout reported in #33121 (breakage observed at `@n8n/chat >= 1.24.0`).

The page is generated in [`templates.ts`](https://github.com/n8n-io/n8n/blob/master/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/templates.ts):

```html
<link href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css" rel="stylesheet" />
...
import { createChat } from 'https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js';
```

This change pins both URLs to a fixed version via a new `CHAT_CDN_VERSION` constant, so the served page always matches a tested bundle. This mirrors the already-pinned `normalize.css@8.0.1` in the same template.

## Open questions for maintainers (kept as draft)

1. **Pinning strategy** — `nodes-langchain` doesn't depend on `@n8n/chat`, so there's no version to read automatically. I went with a single hardcoded constant (smallest, safest change). If you'd prefer the version wired in from the `@n8n/chat` package so it stays in lockstep, happy to switch.
2. **Target version** — I defaulted the constant to `1.26.0` (the current `@n8n/chat` package version in the monorepo, i.e. "embed matches shipped package"). But the reporter sees breakage at `>= 1.24.0`, so if `1.26.0` itself carries a style regression, pinning alone won't fix the rendering and there's a second issue to fix in `@n8n/chat`. The constant is a one-line change to whatever version you confirm is good. I can also diff the `1.23.0` → `1.26.0` bundles to pinpoint the style change if helpful.

## How to test

1. Add a Chat Trigger node, open the hosted/public chat page.
2. View source — the `@n8n/chat` stylesheet and bundle URLs should include `@<version>`, not the bare `@n8n/chat/dist/...` form.

Automated coverage: `packages/@n8n/nodes-langchain` → `nodes/trigger/ChatTrigger/__test__/templates.test.ts` (new `@n8n/chat CDN version pinning` describe block asserting both URLs are versioned and the unpinned form is absent).

> Note: I couldn't run the langchain vitest suite in my local environment (Node version / workspace build constraints), so I'm relying on CI here — hence draft.

## Related issues

Fixes #33121

## Review / Merge checklist
- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (if urgent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33149">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

