### PR TITLE
fix(editor): Sort move workflow project dropdown alphabetically

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
@@ -250,6 +250,45 @@ describe('ProjectSharing', () => {
 		expect(disabledItems).toHaveLength(0);
 	});
 
+	describe('ordering', () => {
+		const unorderedProjects: ProjectListItem[] = [
+			{ ...createProjectListItem('team'), name: 'Charlie' },
+			{ ...createProjectListItem('team'), name: 'Alpha' },
+			{ ...createProjectListItem('team'), name: 'Bravo' },
+		];
+
+		it('should list projects alphabetically by name regardless of input order', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					searchFn: createTestSearchFn(unorderedProjects),
+					modelValue: [],
+				},
+			});
+
+			const projectSelect = getByTestId('project-sharing-select');
+			const dropdownItems = await getDropdownItems(projectSelect);
+			const names = Array.from(dropdownItems).map((item) => item.textContent?.trim());
+
+			expect(names).toEqual(['Alpha', 'Bravo', 'Charlie']);
+		});
+
+		it('should keep "All Users" first and sort the remaining projects alphabetically', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					searchFn: createTestSearchFn(unorderedProjects),
+					modelValue: [],
+					canShareGlobally: true,
+				},
+			});
+
+			const projectSelect = getByTestId('project-sharing-select');
+			const dropdownItems = await getDropdownItems(projectSelect);
+			const names = Array.from(dropdownItems).map((item) => item.textContent?.trim());
+
+			expect(names).toEqual(['All users and projects', 'Alpha', 'Bravo', 'Charlie']);
+		});
+	});
+
 	describe('global sharing', () => {
 		it('should show "All Users" option when canShareGlobally is true', async () => {
 			const { getByTestId } = renderComponent({

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -108,9 +108,12 @@ const filteredProjects = computed(() => {
 });
 
 const sortedProjects = computed((): ProjectListItem[] => {
+	const projects = [...filteredProjects.value].sort((projectA, projectB) =>
+		(projectA.name ?? '').localeCompare(projectB.name ?? ''),
+	);
 	return [
 		...(props.canShareGlobally && !props.isSharedGlobally ? [GLOBAL_GROUP] : []),
-		...filteredProjects.value,
+		...projects,
 	];
 });
 


### PR DESCRIPTION
## Summary

The project dropdown in the "Move workflow" modal (and the shared `ProjectSharing` component) listed projects in a non-deterministic order because its `sortedProjects` computed never actually sorted. It now orders entries alphabetically by name, so projects and users appear predictably, with the global "All users and projects" option kept first where applicable.

### Before

<img width="546" height="483" alt="CleanShot 2026-06-27 at 09 31 26" src="https://github.com/user-attachments/assets/1d13f11e-3bd0-4312-9457-4a168e94fead" />

### After

<img width="561" height="486" alt="CleanShot 2026-06-27 at 09 24 23" src="https://github.com/user-attachments/assets/d48c7ea1-34f8-4a54-aa73-bdb5dbb58f2f" />

<img width="555" height="484" alt="CleanShot 2026-06-27 at 09 24 38" src="https://github.com/user-attachments/assets/5f4d41d2-c439-4485-b04c-53895243578f" />


## How to test

1. Have several projects/users with names that are out of alphabetical order.
2. Open a workflow → `…` menu → **Move**.
3. Open the project dropdown and confirm the entries are listed alphabetically.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-427

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33150">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

