### PR TITLE
test(core): Align MCP OAuth e2e with decoupled access setting

### DIFF
--- a/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
@@ -391,30 +391,16 @@ test.describe(
 				await api.setMcpAccess(true);
 			});
 
-			test('should block OAuth endpoints when MCP access is disabled', async ({ api }) => {
-				const responses = await Promise.all([
-					api.mcpOauth.registerClient({
-						client_name: `e2e OAuth client ${nanoid(8)}`,
-						redirect_uris: ['https://example.com/callback'],
-						grant_types: ['authorization_code'],
-						token_endpoint_auth_method: 'none',
-					}),
-					api.mcpOauth.authorize({
-						clientId: 'any-client',
-						redirectUri: 'https://example.com/callback',
-						challenge: api.mcpOauth.createPkcePair().challenge,
-					}),
-					api.mcpOauth.exchangeAuthorizationCode({
-						code: 'any-code',
-						clientId: 'any-client',
-						codeVerifier: 'any-verifier',
-						redirectUri: 'https://example.com/callback',
-					}),
-				]);
+			// #32157 decoupled the OAuth server from MCP access; endpoints stay reachable when off.
+			test('should keep OAuth endpoints available when MCP access is disabled', async ({ api }) => {
+				const response = await api.mcpOauth.registerClient({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: ['https://example.com/callback'],
+					grant_types: ['authorization_code'],
+					token_endpoint_auth_method: 'none',
+				});
 
-				for (const response of responses) {
-					expect(response.status()).toBe(403);
-				}
+				expect(response.status()).toBe(201);
 			});
 		});
 


### PR DESCRIPTION
## Summary

`#32157` **decoupled the shared OAuth server from the instance MCP access setting**: the OAuth endpoints (`/mcp-oauth/register`, `/authorize`, `/token`) now stay available regardless of the `mcpAccessEnabled` toggle, and the unit tests in `oauth.controller.api.test.ts` were updated to match (e.g. `should register a client even when MCP access is disabled` → `201`).

The e2e test `mcp-oauth.spec.ts` was missed in that refactor — it still asserted the **pre**-decoupling behavior (OAuth endpoints returning `403` when MCP access is disabled). Because the endpoints now correctly return `201`, this test has been failing on `master` and on every PR's `E2E` shard since #32157 landed (2026-06-11).

This inverts the stale assertion to match the shipped design: with MCP access disabled, dynamic client registration still succeeds (`201`).

```diff
-test('should block OAuth endpoints when MCP access is disabled', ...
-  expect(response.status()).toBe(403);
+test('should keep OAuth endpoints available when MCP access is disabled', ...
+  expect(response.status()).toBe(201);
```

## How to test

Multi-main E2E: `mcp-oauth.spec.ts › MCP access disabled › should keep OAuth endpoints available when MCP access is disabled` should pass. The OAuth server ships in a default instance — no extra modules, license, or flags needed.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #32157 (decouple n8n OAuth server availability from MCP access setting). The decoupled behavior is already covered by unit tests in `packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts`.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33155">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->