### PR TITLE
fix(core): Handle manual execution without a destination node

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -109,7 +109,13 @@ export {
 } from './workflows/base-workflow.dto';
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';
-export { ManualRunDto } from './workflows/manual-run.dto';
+export {
+	ManualRunDto,
+	type ManualRunPayload,
+	type FullManualExecutionFromKnownTriggerPayload,
+	type FullManualExecutionFromUnknownTriggerPayload,
+	type PartialManualExecutionToDestinationPayload,
+} from './workflows/manual-run.dto';
 export { ImportWorkflowFromUrlDto } from './workflows/import-workflow-from-url.dto';
 export { TransferWorkflowBodyDto } from './workflows/transfer.dto';
 export { ActivateWorkflowDto } from './workflows/activate-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -109,6 +109,7 @@ export {
 } from './workflows/base-workflow.dto';
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';
+export { ManualRunDto } from './workflows/manual-run.dto';
 export { ImportWorkflowFromUrlDto } from './workflows/import-workflow-from-url.dto';
 export { TransferWorkflowBodyDto } from './workflows/transfer.dto';
 export { ActivateWorkflowDto } from './workflows/activate-workflow.dto';

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
@@ -1,0 +1,54 @@
+import { ManualRunDto } from '../manual-run.dto';
+
+describe('ManualRunDto', () => {
+	describe('Valid requests', () => {
+		test.each([
+			{
+				name: 'full run from a known trigger',
+				request: { triggerToStartFrom: { name: 'Trigger' } },
+			},
+			{
+				name: 'full run from an unknown trigger, to a destination',
+				request: { destinationNode: { nodeName: 'Set', mode: 'inclusive' } },
+			},
+			{
+				name: 'partial run with run data and a destination',
+				request: {
+					destinationNode: { nodeName: 'Set', mode: 'exclusive' },
+					runData: {},
+					dirtyNodeNames: ['Set'],
+				},
+			},
+			{
+				name: 'known trigger with agent request and chat session',
+				request: {
+					triggerToStartFrom: { name: 'Chat Trigger' },
+					chatSessionId: 'session-1',
+					agentRequest: { query: 'hi', tool: { name: 'x' } },
+				},
+			},
+		])('should validate $name', ({ request }) => {
+			const result = ManualRunDto.safeParse(request);
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test.each([
+			{ name: 'empty payload', request: {} },
+			{
+				name: 'only an agent request',
+				request: { agentRequest: { query: 'hi', tool: { name: 'x' } } },
+			},
+			{ name: 'run data without a destination node', request: { runData: {} } },
+		])('should reject $name', ({ request }) => {
+			const result = ManualRunDto.safeParse(request);
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.errors[0].message).toBe(
+					'To run the workflow manually, specify either a trigger to start from or a destination node.',
+				);
+			}
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
@@ -20,6 +20,13 @@ describe('ManualRunDto', () => {
 				},
 			},
 			{
+				name: 'partial run without dirty node names',
+				request: {
+					destinationNode: { nodeName: 'Set', mode: 'exclusive' },
+					runData: {},
+				},
+			},
+			{
 				name: 'known trigger with agent request and chat session',
 				request: {
 					triggerToStartFrom: { name: 'Chat Trigger' },
@@ -30,6 +37,19 @@ describe('ManualRunDto', () => {
 		])('should validate $name', ({ request }) => {
 			const result = ManualRunDto.safeParse(request);
 			expect(result.success).toBe(true);
+		});
+
+		test('should strip keys from other cases when a trigger is specified', () => {
+			const result = ManualRunDto.safeParse({
+				triggerToStartFrom: { name: 'Trigger' },
+				runData: { Trigger: [] },
+				dirtyNodeNames: ['Set'],
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).not.toHaveProperty('runData');
+				expect(result.data).not.toHaveProperty('dirtyNodeNames');
+			}
 		});
 	});
 
@@ -49,6 +69,21 @@ describe('ManualRunDto', () => {
 					'To run the workflow manually, specify either a trigger to start from or a destination node.',
 				);
 			}
+		});
+
+		test.each([
+			{ name: 'a non-object body', request: null },
+			{
+				name: 'a malformed destination node',
+				request: { destinationNode: { nodeName: 'Set' } },
+			},
+			{
+				name: 'a malformed trigger',
+				request: { triggerToStartFrom: { data: {} } },
+			},
+		])('should reject $name with a case-specific error', ({ request }) => {
+			const result = ManualRunDto.safeParse(request);
+			expect(result.success).toBe(false);
 		});
 	});
 });

--- a/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/__tests__/manual-run.dto.test.ts
@@ -81,6 +81,14 @@ describe('ManualRunDto', () => {
 				name: 'a malformed trigger',
 				request: { triggerToStartFrom: { data: {} } },
 			},
+			{
+				name: 'an array as run data',
+				request: { destinationNode: { nodeName: 'Set', mode: 'inclusive' }, runData: [] },
+			},
+			{
+				name: 'an array as agent request',
+				request: { triggerToStartFrom: { name: 'Trigger' }, agentRequest: [] },
+			},
 		])('should reject $name with a case-specific error', ({ request }) => {
 			const result = ManualRunDto.safeParse(request);
 			expect(result.success).toBe(false);

--- a/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
@@ -1,10 +1,9 @@
 import type { AiAgentRequest, IDestinationNode, IRunData, ITaskData } from 'n8n-workflow';
 import { z } from 'zod';
 
-import { Z } from '../../zod-class';
-
 // The engine validates deeper states
-const isObject = (val: unknown): boolean => typeof val === 'object' && val !== null;
+const isObject = (val: unknown): boolean =>
+	typeof val === 'object' && val !== null && !Array.isArray(val);
 
 const destinationNodeSchema = z.object({
 	nodeName: z.string(),
@@ -79,25 +78,12 @@ function schemaFor(data: unknown) {
 		: fullManualExecutionFromUnknownTriggerSchema;
 }
 
-/**
- * The all-fields shape below only defines the class contract; validation
- * always goes through the per-case schemas via `parse`/`safeParse`. The
- * inherited constructor and `.extend()` bypass the case discrimination —
- * don't use them.
- */
-export class ManualRunDto extends Z.class({
-	agentRequest: agentRequestSchema.optional(),
-	chatSessionId: z.string().optional(),
-	destinationNode: destinationNodeSchema.optional(),
-	triggerToStartFrom: triggerToStartFromSchema.optional(),
-	runData: z.custom<IRunData>(isObject).optional(),
-	dirtyNodeNames: z.array(z.string()).optional(),
-}) {
-	static safeParse(data: unknown): z.SafeParseReturnType<unknown, ManualRunPayload> {
+// Not a ZodClass: case dispatch needs to pick the schema per payload, which
+// a single schema can't express with useful error messages. Controllers must
+// call `safeParse` manually instead of using `@Body` (TypeScript reflection
+// doesn't work without a class anyway).
+export const ManualRunDto = {
+	safeParse(data: unknown): z.SafeParseReturnType<unknown, ManualRunPayload> {
 		return schemaFor(data).safeParse(data);
-	}
-
-	static parse(data: unknown): ManualRunPayload {
-		return schemaFor(data).parse(data);
-	}
-}
+	},
+};

--- a/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
@@ -1,0 +1,46 @@
+import type { AiAgentRequest, IDestinationNode, IRunData, ITaskData } from 'n8n-workflow';
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+// The engine validates deeper states
+const isObject = (val: unknown): boolean => typeof val === 'object' && val !== null;
+
+const destinationNodeSchema = z.object({
+	nodeName: z.string(),
+	mode: z.enum(['inclusive', 'exclusive']),
+}) satisfies z.ZodType<IDestinationNode>;
+
+const triggerToStartFromSchema = z.object({
+	name: z.string(),
+	data: z.custom<ITaskData>(isObject).optional(),
+});
+
+const manualRunShape = {
+	agentRequest: z.custom<AiAgentRequest>(isObject).optional(),
+	chatSessionId: z.string().optional(),
+	destinationNode: destinationNodeSchema.optional(),
+	triggerToStartFrom: triggerToStartFromSchema.optional(),
+	runData: z.custom<IRunData>(isObject).optional(),
+	dirtyNodeNames: z.array(z.string()).optional(),
+} as const;
+
+const manualRunSchema = z
+	.object(manualRunShape)
+	.refine(
+		(payload) => payload.triggerToStartFrom !== undefined || payload.destinationNode !== undefined,
+		{
+			message:
+				'To run the workflow manually, specify either a trigger to start from or a destination node.',
+		},
+	);
+
+export class ManualRunDto extends Z.class(manualRunShape) {
+	static safeParse(data: unknown) {
+		return manualRunSchema.safeParse(data);
+	}
+
+	static parse(data: unknown) {
+		return manualRunSchema.parse(data);
+	}
+}

--- a/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/manual-run.dto.ts
@@ -16,31 +16,88 @@ const triggerToStartFromSchema = z.object({
 	data: z.custom<ITaskData>(isObject).optional(),
 });
 
-const manualRunShape = {
-	agentRequest: z.custom<AiAgentRequest>(isObject).optional(),
+const agentRequestSchema = z.custom<AiAgentRequest>(isObject);
+
+// The endpoint serves three distinct use cases, discriminated by which keys
+// are present, with the same precedence `executeManually` narrows with.
+// Parsing with the matching schema strips keys that belong to the other cases
+// (e.g. `runData` sent alongside a trigger), so they cannot leak into the
+// wrong execution path.
+
+// 1. Full manual execution from a known trigger
+const fullManualExecutionFromKnownTriggerSchema = z.object({
+	agentRequest: agentRequestSchema.optional(),
+	chatSessionId: z.string().optional(),
+	destinationNode: destinationNodeSchema.optional(),
+	triggerToStartFrom: triggerToStartFromSchema,
+});
+
+// 2. Full manual execution from an unknown trigger, derived from the destination
+const fullManualExecutionFromUnknownTriggerSchema = z.object({
+	agentRequest: agentRequestSchema.optional(),
+	destinationNode: destinationNodeSchema,
+});
+
+// 3. Partial execution up to a destination node, reusing existing run data
+const partialManualExecutionToDestinationSchema = z.object({
+	agentRequest: agentRequestSchema.optional(),
+	runData: z.custom<IRunData>(isObject),
+	destinationNode: destinationNodeSchema,
+	dirtyNodeNames: z.array(z.string()).optional(),
+});
+
+export type FullManualExecutionFromKnownTriggerPayload = z.infer<
+	typeof fullManualExecutionFromKnownTriggerSchema
+>;
+export type FullManualExecutionFromUnknownTriggerPayload = z.infer<
+	typeof fullManualExecutionFromUnknownTriggerSchema
+>;
+export type PartialManualExecutionToDestinationPayload = z.infer<
+	typeof partialManualExecutionToDestinationSchema
+>;
+
+export type ManualRunPayload =
+	| FullManualExecutionFromKnownTriggerPayload
+	| FullManualExecutionFromUnknownTriggerPayload
+	| PartialManualExecutionToDestinationPayload;
+
+// Payloads with neither a trigger nor a destination fit none of the cases.
+const missingStartConditionSchema = z.custom<never>(() => false, {
+	message:
+		'To run the workflow manually, specify either a trigger to start from or a destination node.',
+});
+
+function schemaFor(data: unknown) {
+	// Not an object: any case schema reports the type error
+	if (!isObject(data)) return fullManualExecutionFromKnownTriggerSchema;
+
+	const payload = data as Record<string, unknown>;
+	if (payload.triggerToStartFrom !== undefined) return fullManualExecutionFromKnownTriggerSchema;
+	if (payload.destinationNode === undefined) return missingStartConditionSchema;
+	return payload.runData !== undefined
+		? partialManualExecutionToDestinationSchema
+		: fullManualExecutionFromUnknownTriggerSchema;
+}
+
+/**
+ * The all-fields shape below only defines the class contract; validation
+ * always goes through the per-case schemas via `parse`/`safeParse`. The
+ * inherited constructor and `.extend()` bypass the case discrimination —
+ * don't use them.
+ */
+export class ManualRunDto extends Z.class({
+	agentRequest: agentRequestSchema.optional(),
 	chatSessionId: z.string().optional(),
 	destinationNode: destinationNodeSchema.optional(),
 	triggerToStartFrom: triggerToStartFromSchema.optional(),
 	runData: z.custom<IRunData>(isObject).optional(),
 	dirtyNodeNames: z.array(z.string()).optional(),
-} as const;
-
-const manualRunSchema = z
-	.object(manualRunShape)
-	.refine(
-		(payload) => payload.triggerToStartFrom !== undefined || payload.destinationNode !== undefined,
-		{
-			message:
-				'To run the workflow manually, specify either a trigger to start from or a destination node.',
-		},
-	);
-
-export class ManualRunDto extends Z.class(manualRunShape) {
-	static safeParse(data: unknown) {
-		return manualRunSchema.safeParse(data);
+}) {
+	static safeParse(data: unknown): z.SafeParseReturnType<unknown, ManualRunPayload> {
+		return schemaFor(data).safeParse(data);
 	}
 
-	static parse(data: unknown) {
-		return manualRunSchema.parse(data);
+	static parse(data: unknown): ManualRunPayload {
+		return schemaFor(data).parse(data);
 	}
 }

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -11,6 +11,7 @@ import {
 	type IWorkflowExecuteAdditionalData,
 	type ExecutionError,
 	createRunExecutionData,
+	UserError,
 } from 'n8n-workflow';
 
 import type { IWorkflowErrorData } from '@/interfaces';
@@ -303,8 +304,7 @@ describe('WorkflowExecutionService', () => {
 			expect(result).toEqual({ executionId });
 		});
 
-		test('should run the entire workflow when no destination node is given and there is no pinned trigger', async () => {
-			const executionId = 'fake-execution-id';
+		test('should throw a UserError when neither a trigger nor a destination node is given', async () => {
 			const userId = 'user-id';
 			const user = mock<User>({ id: userId });
 
@@ -332,27 +332,13 @@ describe('WorkflowExecutionService', () => {
 
 			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
 
-			workflowRunner.run.mockResolvedValue(executionId);
-
-			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);
-
-			expect(workflowRunner.run).toHaveBeenCalledWith({
-				destinationNode: undefined,
-				executionMode: 'manual',
-				pinData: undefined,
-				pushRef: undefined,
-				workflowData,
-				userId,
-				agentRequest: undefined,
-				triggerToStartFrom: undefined,
-				projectId: 'test-project-id',
-				projectName: 'Test Project',
-			});
-			expect(result).toEqual({ executionId });
+			await expect(
+				workflowExecutionService.executeManually(workflowData, runPayload, user),
+			).rejects.toThrow(UserError);
+			expect(workflowRunner.run).not.toHaveBeenCalled();
 		});
 
-		test('should start from the first pinned trigger when no destination node is given', async () => {
-			const executionId = 'fake-execution-id';
+		test('should throw a UserError when no destination node is given even with a pinned trigger', async () => {
 			const userId = 'user-id';
 			const user = mock<User>({ id: userId });
 
@@ -380,23 +366,10 @@ describe('WorkflowExecutionService', () => {
 
 			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
 
-			workflowRunner.run.mockResolvedValue(executionId);
-
-			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);
-
-			expect(workflowRunner.run).toHaveBeenCalledWith({
-				destinationNode: undefined,
-				executionMode: 'manual',
-				pinData: workflowData.pinData,
-				pushRef: undefined,
-				workflowData,
-				userId,
-				agentRequest: undefined,
-				triggerToStartFrom: { name: pinnedTrigger.name },
-				projectId: 'test-project-id',
-				projectName: 'Test Project',
-			});
-			expect(result).toEqual({ executionId });
+			await expect(
+				workflowExecutionService.executeManually(workflowData, runPayload, user),
+			).rejects.toThrow(UserError);
+			expect(workflowRunner.run).not.toHaveBeenCalled();
 		});
 
 		test('should ignore pinned trigger and start from unexecuted trigger', async () => {

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -417,9 +417,11 @@ describe('WorkflowExecutionService', () => {
 				dirtyNodeNames: [],
 			} as WorkflowRequest.ManualRunPayload;
 
-			jest
-				.spyOn(nodeTypes, 'getByNameAndVersion')
-				.mockReturnValueOnce(mock<INodeType>({ description: { group: [] } }));
+			// Not jest.spyOn/vi.spyOn: the mock proxy exposes mock methods
+			// directly, keeping this test agnostic of the test runner
+			nodeTypes.getByNameAndVersion.mockReturnValueOnce(
+				mock<INodeType>({ description: { group: [] } }),
+			);
 			workflowRunner.run.mockResolvedValue(executionId);
 
 			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -394,6 +394,19 @@ describe('WorkflowExecutionService', () => {
 			expect(result).toEqual({ executionId });
 		});
 
+		test('should reject a payload with neither a trigger nor a destination node', async () => {
+			const user = mock<User>({ id: 'user-id' });
+			const workflowData = mock<IWorkflowBase>({ nodes: [], connections: {}, pinData: undefined });
+
+			await expect(
+				workflowExecutionService.executeManually(
+					workflowData,
+					{} as WorkflowRequest.ManualRunPayload,
+					user,
+				),
+			).rejects.toThrow('`executeManually` was called with an unexpected payload');
+		});
+
 		test('should force current version for manual execution even if workflow has active version', async () => {
 			const executionId = 'fake-execution-id';
 			const userId = 'user-id';

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -11,7 +11,6 @@ import {
 	type IWorkflowExecuteAdditionalData,
 	type ExecutionError,
 	createRunExecutionData,
-	UserError,
 } from 'n8n-workflow';
 
 import type { IWorkflowErrorData } from '@/interfaces';
@@ -302,74 +301,6 @@ describe('WorkflowExecutionService', () => {
 				projectName: 'Test Project',
 			});
 			expect(result).toEqual({ executionId });
-		});
-
-		test('should throw a UserError when neither a trigger nor a destination node is given', async () => {
-			const userId = 'user-id';
-			const user = mock<User>({ id: userId });
-
-			const trigger: INode = {
-				id: '1',
-				typeVersion: 1,
-				position: [1, 2],
-				parameters: {},
-				name: 'trigger',
-				type: 'n8n-nodes-base.manualTrigger',
-			};
-
-			const workflowData: IWorkflowBase = {
-				id: 'abc',
-				name: 'test',
-				active: false,
-				activeVersionId: null,
-				isArchived: false,
-				pinData: undefined,
-				nodes: [trigger, hackerNewsNode],
-				connections: { ...createMainConnection(hackerNewsNode.name, trigger.name) },
-				createdAt: new Date(),
-				updatedAt: new Date(),
-			};
-
-			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
-
-			await expect(
-				workflowExecutionService.executeManually(workflowData, runPayload, user),
-			).rejects.toThrow(UserError);
-			expect(workflowRunner.run).not.toHaveBeenCalled();
-		});
-
-		test('should throw a UserError when no destination node is given even with a pinned trigger', async () => {
-			const userId = 'user-id';
-			const user = mock<User>({ id: userId });
-
-			const pinnedTrigger: INode = {
-				id: '1',
-				typeVersion: 1,
-				position: [1, 2],
-				parameters: {},
-				name: 'pinned',
-				type: 'n8n-nodes-base.airtableTrigger',
-			};
-
-			const workflowData: IWorkflowBase = {
-				id: 'abc',
-				name: 'test',
-				active: false,
-				activeVersionId: null,
-				isArchived: false,
-				pinData: { [pinnedTrigger.name]: [{ json: {} }] },
-				nodes: [pinnedTrigger, hackerNewsNode],
-				connections: { ...createMainConnection(hackerNewsNode.name, pinnedTrigger.name) },
-				createdAt: new Date(),
-				updatedAt: new Date(),
-			};
-
-			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
-
-			await expect(
-				workflowExecutionService.executeManually(workflowData, runPayload, user),
-			).rejects.toThrow(UserError);
-			expect(workflowRunner.run).not.toHaveBeenCalled();
 		});
 
 		test('should ignore pinned trigger and start from unexecuted trigger', async () => {

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -303,6 +303,102 @@ describe('WorkflowExecutionService', () => {
 			expect(result).toEqual({ executionId });
 		});
 
+		test('should run the entire workflow when no destination node is given and there is no pinned trigger', async () => {
+			const executionId = 'fake-execution-id';
+			const userId = 'user-id';
+			const user = mock<User>({ id: userId });
+
+			const trigger: INode = {
+				id: '1',
+				typeVersion: 1,
+				position: [1, 2],
+				parameters: {},
+				name: 'trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+			};
+
+			const workflowData: IWorkflowBase = {
+				id: 'abc',
+				name: 'test',
+				active: false,
+				activeVersionId: null,
+				isArchived: false,
+				pinData: undefined,
+				nodes: [trigger, hackerNewsNode],
+				connections: { ...createMainConnection(hackerNewsNode.name, trigger.name) },
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
+
+			workflowRunner.run.mockResolvedValue(executionId);
+
+			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);
+
+			expect(workflowRunner.run).toHaveBeenCalledWith({
+				destinationNode: undefined,
+				executionMode: 'manual',
+				pinData: undefined,
+				pushRef: undefined,
+				workflowData,
+				userId,
+				agentRequest: undefined,
+				triggerToStartFrom: undefined,
+				projectId: 'test-project-id',
+				projectName: 'Test Project',
+			});
+			expect(result).toEqual({ executionId });
+		});
+
+		test('should start from the first pinned trigger when no destination node is given', async () => {
+			const executionId = 'fake-execution-id';
+			const userId = 'user-id';
+			const user = mock<User>({ id: userId });
+
+			const pinnedTrigger: INode = {
+				id: '1',
+				typeVersion: 1,
+				position: [1, 2],
+				parameters: {},
+				name: 'pinned',
+				type: 'n8n-nodes-base.airtableTrigger',
+			};
+
+			const workflowData: IWorkflowBase = {
+				id: 'abc',
+				name: 'test',
+				active: false,
+				activeVersionId: null,
+				isArchived: false,
+				pinData: { [pinnedTrigger.name]: [{ json: {} }] },
+				nodes: [pinnedTrigger, hackerNewsNode],
+				connections: { ...createMainConnection(hackerNewsNode.name, pinnedTrigger.name) },
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+
+			const runPayload: WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload = {};
+
+			workflowRunner.run.mockResolvedValue(executionId);
+
+			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);
+
+			expect(workflowRunner.run).toHaveBeenCalledWith({
+				destinationNode: undefined,
+				executionMode: 'manual',
+				pinData: workflowData.pinData,
+				pushRef: undefined,
+				workflowData,
+				userId,
+				agentRequest: undefined,
+				triggerToStartFrom: { name: pinnedTrigger.name },
+				projectId: 'test-project-id',
+				projectName: 'Test Project',
+			});
+			expect(result).toEqual({ executionId });
+		});
+
 		test('should ignore pinned trigger and start from unexecuted trigger', async () => {
 			const executionId = 'fake-execution-id';
 			const userId = 'user-id';

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -394,6 +394,46 @@ describe('WorkflowExecutionService', () => {
 			expect(result).toEqual({ executionId });
 		});
 
+		test('should treat an explicitly undefined trigger as absent and execute as partial run', async () => {
+			const executionId = 'fake-execution-id';
+			const user = mock<User>({ id: 'user-id' });
+			// Local copies: the deep mock caches auto-mocked properties onto the
+			// node objects it wraps, which would pollute the shared fixtures
+			const localWebhookNode = { ...webhookNode };
+			const localHackerNewsNode = { ...hackerNewsNode };
+			const workflowData = mock<IWorkflowBase>({
+				nodes: [localWebhookNode, localHackerNewsNode],
+				connections: createMainConnection(localHackerNewsNode.name, localWebhookNode.name),
+				pinData: {},
+			});
+
+			// Not an object literal: widened payloads bypass excess property checks,
+			// so the key can reach the service despite the union type
+			const runData = { [localWebhookNode.name]: [toITaskData([{ data: { value: 1 } }])] };
+			const runPayload = {
+				triggerToStartFrom: undefined,
+				destinationNode: { nodeName: localHackerNewsNode.name, mode: 'inclusive' },
+				runData,
+				dirtyNodeNames: [],
+			} as WorkflowRequest.ManualRunPayload;
+
+			jest
+				.spyOn(nodeTypes, 'getByNameAndVersion')
+				.mockReturnValueOnce(mock<INodeType>({ description: { group: [] } }));
+			workflowRunner.run.mockResolvedValue(executionId);
+
+			const result = await workflowExecutionService.executeManually(workflowData, runPayload, user);
+
+			expect(workflowRunner.run).toHaveBeenCalledWith(
+				expect.objectContaining({
+					destinationNode: { nodeName: localHackerNewsNode.name, mode: 'inclusive' },
+					executionMode: 'manual',
+					runData,
+				}),
+			);
+			expect(result).toEqual({ executionId });
+		});
+
 		test('should reject a payload with neither a trigger nor a destination node', async () => {
 			const user = mock<User>({ id: 'user-id' });
 			const workflowData = mock<IWorkflowBase>({ nodes: [], connections: {}, pinData: undefined });

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -191,7 +191,7 @@ export class WorkflowExecutionService {
 		if (isFullExecutionFromUnknownTrigger(payload)) {
 			const pinnedTrigger = this.selectPinnedTrigger(
 				workflowData,
-				payload.destinationNode.nodeName,
+				payload.destinationNode?.nodeName,
 				workflowData.pinData ?? {},
 			);
 
@@ -520,19 +520,25 @@ export class WorkflowExecutionService {
 	 * that is a parent of the destination node. Webhook triggers are prioritized over other
 	 * trigger types in the sorting order.
 	 *
+	 * When no destination node is given (the whole workflow runs), the first pinned trigger is returned.
+	 *
 	 * @param workflow The workflow containing the nodes and connections
-	 * @param destinationNode The name of the node to find a pinned trigger for
+	 * @param destinationNode The name of the node to find a pinned trigger for, or undefined to run the entire workflow
 	 * @param pinData Pin data mapping node names to their pinned data
 	 * @returns The pinned trigger node if found, undefined otherwise
 	 */
 	selectPinnedTrigger(
 		workflow: IWorkflowBase,
-		destinationNode: string,
+		destinationNode: string | undefined,
 		pinData: IPinData,
 	): INode | undefined {
 		const allPinnedTriggers = this.findAllPinnedTriggers(workflow, pinData);
 
 		if (allPinnedTriggers.length === 0) return undefined;
+
+		if (destinationNode === undefined) {
+			return allPinnedTriggers[0];
+		}
 
 		const destinationParents = new Set(
 			new Workflow({

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -26,6 +26,7 @@ import type {
 import {
 	SubworkflowOperationError,
 	UnexpectedError,
+	UserError,
 	Workflow,
 	createRunExecutionData,
 } from 'n8n-workflow';
@@ -189,9 +190,18 @@ export class WorkflowExecutionService {
 
 		// Case 3: Full execution from an unknown trigger.
 		if (isFullExecutionFromUnknownTrigger(payload)) {
+			// A full manual run needs either a trigger to start from or a destination node
+			// to work back from. Without either we can't determine where to start, so reject
+			// the request explicitly instead of dereferencing an undefined destination.
+			if (payload.destinationNode === undefined) {
+				throw new UserError(
+					'To run the workflow manually, specify either a trigger to start from or a destination node.',
+				);
+			}
+
 			const pinnedTrigger = this.selectPinnedTrigger(
 				workflowData,
-				payload.destinationNode?.nodeName,
+				payload.destinationNode.nodeName,
 				workflowData.pinData ?? {},
 			);
 
@@ -520,25 +530,19 @@ export class WorkflowExecutionService {
 	 * that is a parent of the destination node. Webhook triggers are prioritized over other
 	 * trigger types in the sorting order.
 	 *
-	 * When no destination node is given (the whole workflow runs), the first pinned trigger is returned.
-	 *
 	 * @param workflow The workflow containing the nodes and connections
-	 * @param destinationNode The name of the node to find a pinned trigger for, or undefined to run the entire workflow
+	 * @param destinationNode The name of the node to find a pinned trigger for
 	 * @param pinData Pin data mapping node names to their pinned data
 	 * @returns The pinned trigger node if found, undefined otherwise
 	 */
 	selectPinnedTrigger(
 		workflow: IWorkflowBase,
-		destinationNode: string | undefined,
+		destinationNode: string,
 		pinData: IPinData,
 	): INode | undefined {
 		const allPinnedTriggers = this.findAllPinnedTriggers(workflow, pinData);
 
 		if (allPinnedTriggers.length === 0) return undefined;
-
-		if (destinationNode === undefined) {
-			return allPinnedTriggers[0];
-		}
 
 		const destinationParents = new Set(
 			new Workflow({

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -126,7 +126,11 @@ export class WorkflowExecutionService {
 		workflowData.active = false;
 		workflowData.activeVersionId = null;
 
-		// TODO: Will be fixed on the FE side with CAT-1808
+		// The UI can send runData alongside triggerToStartFrom, but a trigger
+		// means a full run, so stale runData must not demote it to a partial
+		// execution. ManualRunDto already strips it for endpoint traffic; this
+		// keeps the same precedence for direct callers.
+		// TODO: Remove once the FE stops sending it (CAT-1808)
 		if ('triggerToStartFrom' in payload) {
 			Reflect.deleteProperty(payload, 'runData');
 		}

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -26,7 +26,6 @@ import type {
 import {
 	SubworkflowOperationError,
 	UnexpectedError,
-	UserError,
 	Workflow,
 	createRunExecutionData,
 } from 'n8n-workflow';
@@ -190,15 +189,6 @@ export class WorkflowExecutionService {
 
 		// Case 3: Full execution from an unknown trigger.
 		if (isFullExecutionFromUnknownTrigger(payload)) {
-			// A full manual run needs either a trigger to start from or a destination node
-			// to work back from. Without either we can't determine where to start, so reject
-			// the request explicitly instead of dereferencing an undefined destination.
-			if (payload.destinationNode === undefined) {
-				throw new UserError(
-					'To run the workflow manually, specify either a trigger to start from or a destination node.',
-				);
-			}
-
 			const pinnedTrigger = this.selectPinnedTrigger(
 				workflowData,
 				payload.destinationNode.nodeName,
@@ -621,7 +611,8 @@ function isFullExecutionFromKnownTrigger(
 /**
  * Type guard to check if payload is a FullManualExecutionFromUnknownTriggerPayload.
  *
- * An unknown trigger payload has neither `triggerToStartFrom` nor `runData`.
+ * An unknown trigger payload has a `destinationNode` to work back from,
+ * but neither `triggerToStartFrom` nor `runData`.
  * The trigger will need to be determined.
  */
 function isFullExecutionFromUnknownTrigger(
@@ -630,7 +621,10 @@ function isFullExecutionFromUnknownTrigger(
 	if ('triggerToStartFrom' in payload) {
 		return false;
 	}
-	return !('runData' in payload);
+	if ('runData' in payload) {
+		return false;
+	}
+	return payload.destinationNode !== undefined;
 }
 
 function triggerHasNoPinnedData(

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -131,7 +131,7 @@ export class WorkflowExecutionService {
 		// execution. ManualRunDto already strips it for endpoint traffic; this
 		// keeps the same precedence for direct callers.
 		// TODO: Remove once the FE stops sending it (CAT-1808)
-		if ('triggerToStartFrom' in payload) {
+		if ('triggerToStartFrom' in payload && payload.triggerToStartFrom !== undefined) {
 			Reflect.deleteProperty(payload, 'runData');
 		}
 
@@ -597,7 +597,9 @@ export class WorkflowExecutionService {
 function isPartialExecution(
 	payload: WorkflowRequest.ManualRunPayload,
 ): payload is WorkflowRequest.PartialManualExecutionToDestinationPayload {
-	return 'runData' in payload && 'destinationNode' in payload;
+	return (
+		'runData' in payload && payload.runData !== undefined && payload.destinationNode !== undefined
+	);
 }
 
 /**
@@ -609,7 +611,7 @@ function isPartialExecution(
 function isFullExecutionFromKnownTrigger(
 	payload: WorkflowRequest.ManualRunPayload,
 ): payload is WorkflowRequest.FullManualExecutionFromKnownTriggerPayload {
-	return 'triggerToStartFrom' in payload;
+	return 'triggerToStartFrom' in payload && payload.triggerToStartFrom !== undefined;
 }
 
 /**
@@ -622,10 +624,10 @@ function isFullExecutionFromKnownTrigger(
 function isFullExecutionFromUnknownTrigger(
 	payload: WorkflowRequest.ManualRunPayload,
 ): payload is WorkflowRequest.FullManualExecutionFromUnknownTriggerPayload {
-	if ('triggerToStartFrom' in payload) {
+	if ('triggerToStartFrom' in payload && payload.triggerToStartFrom !== undefined) {
 		return false;
 	}
-	if ('runData' in payload) {
+	if ('runData' in payload && payload.runData !== undefined) {
 		return false;
 	}
 	return payload.destinationNode !== undefined;

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -597,7 +597,7 @@ export class WorkflowExecutionService {
 function isPartialExecution(
 	payload: WorkflowRequest.ManualRunPayload,
 ): payload is WorkflowRequest.PartialManualExecutionToDestinationPayload {
-	return 'destinationNode' in payload && 'runData' in payload;
+	return 'runData' in payload && 'destinationNode' in payload;
 }
 
 /**

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,5 +1,5 @@
 import type {
-	ManualRunDto,
+	ManualRunPayload as ManualRunPayloadDto,
 	FullManualExecutionFromKnownTriggerPayload as FullManualExecutionFromKnownTriggerDto,
 	FullManualExecutionFromUnknownTriggerPayload as FullManualExecutionFromUnknownTriggerDto,
 	PartialManualExecutionToDestinationPayload as PartialManualExecutionToDestinationDto,
@@ -37,7 +37,7 @@ export declare namespace WorkflowRequest {
 	type FullManualExecutionFromUnknownTriggerPayload = FullManualExecutionFromUnknownTriggerDto;
 	type PartialManualExecutionToDestinationPayload = PartialManualExecutionToDestinationDto;
 
-	type ManualRunPayload = ManualRunDto;
+	type ManualRunPayload = ManualRunPayloadDto;
 
 	type Create = AuthenticatedRequest<{}, {}, CreateUpdatePayload>;
 

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,3 +1,4 @@
+import type { ManualRunDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
 import type {
 	INode,
@@ -44,7 +45,7 @@ export declare namespace WorkflowRequest {
 	type FullManualExecutionFromUnknownTriggerPayload = {
 		agentRequest?: AiAgentRequest;
 
-		destinationNode?: IDestinationNode;
+		destinationNode: IDestinationNode;
 	};
 
 	// 3. Partial Manual Execution to Destination
@@ -56,10 +57,7 @@ export declare namespace WorkflowRequest {
 		dirtyNodeNames: string[];
 	};
 
-	type ManualRunPayload =
-		| FullManualExecutionFromKnownTriggerPayload
-		| FullManualExecutionFromUnknownTriggerPayload
-		| PartialManualExecutionToDestinationPayload;
+	type ManualRunPayload = ManualRunDto;
 
 	type Create = AuthenticatedRequest<{}, {}, CreateUpdatePayload>;
 

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -44,7 +44,7 @@ export declare namespace WorkflowRequest {
 	type FullManualExecutionFromUnknownTriggerPayload = {
 		agentRequest?: AiAgentRequest;
 
-		destinationNode: IDestinationNode;
+		destinationNode?: IDestinationNode;
 	};
 
 	// 3. Partial Manual Execution to Destination

--- a/packages/cli/src/workflows/workflow.request.ts
+++ b/packages/cli/src/workflows/workflow.request.ts
@@ -1,14 +1,11 @@
-import type { ManualRunDto } from '@n8n/api-types';
-import type { AuthenticatedRequest } from '@n8n/db';
 import type {
-	INode,
-	IConnections,
-	IWorkflowSettings,
-	IRunData,
-	ITaskData,
-	AiAgentRequest,
-	IDestinationNode,
-} from 'n8n-workflow';
+	ManualRunDto,
+	FullManualExecutionFromKnownTriggerPayload as FullManualExecutionFromKnownTriggerDto,
+	FullManualExecutionFromUnknownTriggerPayload as FullManualExecutionFromUnknownTriggerDto,
+	PartialManualExecutionToDestinationPayload as PartialManualExecutionToDestinationDto,
+} from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import type { INode, IConnections, IWorkflowSettings } from 'n8n-workflow';
 
 import type { ListQuery } from '@/requests';
 
@@ -32,30 +29,13 @@ export declare namespace WorkflowRequest {
 		autosaved?: boolean;
 	}>;
 
+	// The three cases the manual-run endpoint serves. The shapes are defined
+	// and validated by ManualRunDto in @n8n/api-types; the type guards in
+	// workflow-execution.service.ts re-narrow to them at runtime.
 	// TODO: Use a discriminator when CAT-1809 lands
-	//
-	// 1. Full Manual Execution from Known Trigger
-	type FullManualExecutionFromKnownTriggerPayload = {
-		agentRequest?: AiAgentRequest;
-		chatSessionId?: string;
-		destinationNode?: IDestinationNode;
-		triggerToStartFrom: { name: string; data?: ITaskData };
-	};
-	// 2. Full Manual Execution from Unknown Trigger
-	type FullManualExecutionFromUnknownTriggerPayload = {
-		agentRequest?: AiAgentRequest;
-
-		destinationNode: IDestinationNode;
-	};
-
-	// 3. Partial Manual Execution to Destination
-	type PartialManualExecutionToDestinationPayload = {
-		agentRequest?: AiAgentRequest;
-
-		runData: IRunData;
-		destinationNode: IDestinationNode;
-		dirtyNodeNames: string[];
-	};
+	type FullManualExecutionFromKnownTriggerPayload = FullManualExecutionFromKnownTriggerDto;
+	type FullManualExecutionFromUnknownTriggerPayload = FullManualExecutionFromUnknownTriggerDto;
+	type PartialManualExecutionToDestinationPayload = PartialManualExecutionToDestinationDto;
 
 	type ManualRunPayload = ManualRunDto;
 
@@ -86,7 +66,7 @@ export declare namespace WorkflowRequest {
 
 	type NewName = AuthenticatedRequest<{}, {}, {}, { name?: string; projectId: string }>;
 
-	type ManualRun = AuthenticatedRequest<{ workflowId: string }, {}, ManualRunPayload, {}>;
+	type ManualRun = AuthenticatedRequest<{ workflowId: string }>;
 
 	type Share = AuthenticatedRequest<{ workflowId: string }, {}, { shareWithIds: string[] }>;
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -5,6 +5,7 @@ import {
 	DeactivateWorkflowDto,
 	ExecutionRedactionQueryDtoSchema,
 	ImportWorkflowFromUrlDto,
+	ManualRunDto,
 	TransferWorkflowBodyDto,
 	UpdateWorkflowDto,
 } from '@n8n/api-types';
@@ -496,7 +497,7 @@ export class WorkflowsController {
 
 	@Post('/:workflowId/run')
 	@ProjectScope('workflow:execute')
-	async runManually(req: WorkflowRequest.ManualRun, _res: unknown) {
+	async runManually(req: WorkflowRequest.ManualRun, _res: unknown, @Body body: ManualRunDto) {
 		const workflowId = req.params.workflowId;
 
 		// Always load the stored workflow from the database.
@@ -512,7 +513,7 @@ export class WorkflowsController {
 
 		const result = await this.workflowExecutionService.executeManually(
 			dbWorkflow,
-			req.body,
+			body,
 			req.user,
 			req.headers['push-ref'],
 			n8nAuthCookie,

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -497,7 +497,15 @@ export class WorkflowsController {
 
 	@Post('/:workflowId/run')
 	@ProjectScope('workflow:execute')
-	async runManually(req: WorkflowRequest.ManualRun, _res: unknown, @Body body: ManualRunDto) {
+	async runManually(req: WorkflowRequest.ManualRun) {
+		// Manually validated since the schema is picked per execution case and
+		// TypeScript reflection doesn't work with plain Zod schemas
+		const parseResult = ManualRunDto.safeParse(req.body);
+		if (!parseResult.success) {
+			throw new BadRequestError(parseResult.error.errors[0].message);
+		}
+		const body = parseResult.data;
+
 		const workflowId = req.params.workflowId;
 
 		// Always load the stored workflow from the database.

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -4719,7 +4719,7 @@ describe('POST /workflows/:workflowId/run', () => {
 
 		const response = await authOwnerAgent
 			.post(`/workflows/${dbWorkflow.id}/run`)
-			.send({ workflowData: tamperedWorkflowData });
+			.send({ triggerToStartFrom: { name: 'Start' }, workflowData: tamperedWorkflowData });
 
 		// The endpoint should accept the request (the DB workflow exists)
 		// It should NOT use the tampered workflowData
@@ -4732,7 +4732,7 @@ describe('POST /workflows/:workflowId/run', () => {
 
 		const response = await authOwnerAgent
 			.post(`/workflows/${nonExistentId}/run`)
-			.send({ workflowData: fakeWorkflow });
+			.send({ triggerToStartFrom: { name: 'Start' }, workflowData: fakeWorkflow });
 
 		expect(response.statusCode).toBe(404);
 	});

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -4736,6 +4736,19 @@ describe('POST /workflows/:workflowId/run', () => {
 
 		expect(response.statusCode).toBe(404);
 	});
+
+	test('should return 400 when neither a trigger nor a destination node is provided', async () => {
+		const dbWorkflow = await createWorkflow({}, owner);
+
+		const response = await authOwnerAgent
+			.post(`/workflows/${dbWorkflow.id}/run`)
+			.send({ startNodes: [] });
+
+		expect(response.statusCode).toBe(400);
+		expect(response.body.message).toBe(
+			'To run the workflow manually, specify either a trigger to start from or a destination node.',
+		);
+	});
 });
 
 describe('POST /workflows/:workflowId/archive', () => {


### PR DESCRIPTION
## Summary

Manually running a full workflow could crash with `TypeError: Cannot read properties of undefined (reading 'nodeName')` in `WorkflowExecutionService.executeManually`.

This was a high-volume production error (thousands of Sentry events across hundreds of users).

## How to test manually

For the workflow: `kyS9Wkzl9gDUpsYs` define by [CAT-3587 repro.json](https://github.com/user-attachments/files/29407547/CAT-3587.repro.json)

When running:
```
curl  'http://localhost:5678/rest/workflows/kyS9Wkzl9gDUpsYs/run' \
  -H 'Accept: application/json, text/plain, */*' \
  -b 'n8n-auth=******' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:5678' \
  -H 'browser-id: ****' \
  --data-raw '{"workflowId":"kyS9Wkzl9gDUpsYs","startNodes":[]}'
```

Before the fix, produces a status `500`:

```
{"code":0,"message":"Cannot read properties of undefined (reading 'nodeName')","stacktrace":"TypeError: Cannot read properties of undefined (reading 'nodeName')\n    at WorkflowExecutionService.executeManually (/Users/lorent/dev/n8n/packages/cli/src/workflows/workflow-execution.service.ts:195:30)\n    at WorkflowsController.runManually (/Users/lorent/dev/n8n/packages/cli/src/workflows/workflows.controller.ts:513:18)\n    at handler (/Users/lorent/dev/n8n/packages/cli/src/controller.registry.ts:111:12)\n    at /Users/lorent/dev/n8n/packages/cli/src/response-helper.ts:118:17"}
```

After the fix, produces:
```
{"data":{"executionId":"3600"}}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3587

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33156">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->