### PR TITLE
feat(core): add Gzip compression support for execution data payloads

### DIFF
--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -83,6 +83,10 @@ const executionModeSchema = z.enum(['regular', 'queue']);
 
 export type ExecutionMode = z.infer<typeof executionModeSchema>;
 
+const compressionSchema = z.enum(['none', 'gzip']);
+
+export type CompressionMode = z.infer<typeof compressionSchema>;
+
 @Config
 export class ExecutionsConfig {
 	/** Whether to run executions in regular mode (in-process) or scaling mode (in workers). */
@@ -163,4 +167,8 @@ export class ExecutionsConfig {
 	 */
 	@Env('EXECUTIONS_DATA_MAX_DISPLAY_SIZE')
 	maxDisplaySize: number = 100 * 1024 * 1024; // 100 MB
+
+	/** Whether to compress execution data payloads stored in the DB/FS. */
+	@Env('EXECUTIONS_DATA_COMPRESSION', compressionSchema)
+	compression: CompressionMode = 'none';
 }

--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -202,6 +202,23 @@ describe('ExecutionPersistence', () => {
 					expect.objectContaining({ workflowVersionId: null }),
 				);
 			});
+
+			it('should compress the execution data when executionsConfig.compression is gzip', async () => {
+				executionsConfig.compression = 'gzip';
+				const mockTx = createMockTransaction();
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.create(createPayload);
+
+				expect(dbStore.write).toHaveBeenCalledWith(
+					{ workflowId: 'workflow-123', executionId: 'exec-1' },
+					expect.objectContaining({
+						data: expect.stringMatching(/^gzip:base64:/),
+					}),
+					mockTx,
+				);
+				executionsConfig.compression = 'none';
+			});
 		});
 
 		describe('filesystem mode', () => {

--- a/packages/cli/src/executions/execution-data/__tests__/compression.test.ts
+++ b/packages/cli/src/executions/execution-data/__tests__/compression.test.ts
@@ -1,0 +1,25 @@
+import { compressPayload, decompressPayload } from '../compression';
+
+describe('Execution Data Compression Helpers', () => {
+	it('should compress and decompress data correctly', () => {
+		const original = '{"foo":"bar","baz":[1,2,3]}';
+		const compressed = compressPayload(original);
+		expect(compressed).toMatch(/^gzip:base64:/);
+
+		const decompressed = decompressPayload(compressed);
+		expect(decompressed).toBe(original);
+	});
+
+	it('should fall back to raw input if decompression prefix is not found', () => {
+		const raw = '{"hello":"world"}';
+		const result = decompressPayload(raw);
+		expect(result).toBe(raw);
+	});
+
+	it('should handle null or undefined payloads', () => {
+		expect(compressPayload(null)).toBeNull();
+		expect(compressPayload(undefined)).toBeUndefined();
+		expect(decompressPayload(null)).toBeNull();
+		expect(decompressPayload(undefined)).toBeUndefined();
+	});
+});

--- a/packages/cli/src/executions/execution-data/compression.ts
+++ b/packages/cli/src/executions/execution-data/compression.ts
@@ -1,0 +1,43 @@
+import { gzipSync, gunzipSync } from 'node:zlib';
+
+const GZIP_PREFIX = 'gzip:base64:';
+
+/**
+ * Compresses a string payload using Gzip and returns it in a prefixed base64 format.
+ * If the payload is empty, null, or undefined, it is returned as is.
+ */
+export function compressPayload(data: string): string;
+export function compressPayload(data: string | null): string | null;
+export function compressPayload(data: string | undefined): string | undefined;
+export function compressPayload(data: string | null | undefined): string | null | undefined {
+	if (!data) return data;
+	try {
+		const compressed = gzipSync(Buffer.from(data, 'utf8'));
+		return GZIP_PREFIX + compressed.toString('base64');
+	} catch (error) {
+		// Fallback to uncompressed if compression fails
+		return data;
+	}
+}
+
+/**
+ * Decompresses a payload if it is prefixed with the gzip indicator.
+ * If it is not prefixed, returns the input payload as is (for backward compatibility).
+ */
+export function decompressPayload(data: string): string;
+export function decompressPayload(data: string | null): string | null;
+export function decompressPayload(data: string | undefined): string | undefined;
+export function decompressPayload(data: string | null | undefined): string | null | undefined {
+	if (!data) return data;
+	if (data.startsWith(GZIP_PREFIX)) {
+		try {
+			const base64Data = data.substring(GZIP_PREFIX.length);
+			const decompressed = gunzipSync(Buffer.from(base64Data, 'base64'));
+			return decompressed.toString('utf8');
+		} catch (error) {
+			// If decompression fails, we log it or fallback (it should not happen unless corrupted)
+			return data;
+		}
+	}
+	return data;
+}

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -27,6 +27,7 @@ import { CorruptedExecutionDataError } from './execution-data/corrupted-executio
 import { DbStore } from './execution-data/db-store';
 import { FsStore } from './execution-data/fs-store';
 import { MissingExecutionDataError } from './execution-data/missing-execution-data.error';
+import { compressPayload, decompressPayload } from './execution-data/compression';
 import type {
 	BundleWorkflowSnapshot,
 	ExecutionDataBundle,
@@ -114,8 +115,12 @@ export class ExecutionPersistence {
 				const store = this.getStoreFor(storedAt);
 
 				const jsonSizeBytes = await this.trackWrite(storedAt, async () => {
+					const rawSerialized = stringify(rawData);
 					const bundle: ExecutionDataPayload = {
-						data: stringify(rawData),
+						data:
+							this.executionsConfig.compression === 'gzip'
+								? compressPayload(rawSerialized)
+								: rawSerialized,
 						workflowData: workflowSnapshot,
 						workflowVersionId,
 					};
@@ -631,8 +636,12 @@ export class ExecutionPersistence {
 			) {
 				const binaryDataSizeBytes = sumBinaryDataBytes(data);
 				const jsonSizeBytes = await this.trackWrite(mode, async () => {
+					const rawSerialized = stringify(data);
 					const bundle: ExecutionDataPayload = {
-						data: stringify(data),
+						data:
+							this.executionsConfig.compression === 'gzip'
+								? compressPayload(rawSerialized)
+								: rawSerialized,
 						workflowData: this.toWorkflowSnapshot(workflowData),
 						workflowVersionId,
 					};
@@ -656,8 +665,12 @@ export class ExecutionPersistence {
 			if (!existing) throw new MissingExecutionDataError(ref);
 
 			const jsonSizeBytes = await this.trackWrite(mode, async () => {
+				const rawSerialized = data !== undefined ? stringify(data) : existing.data;
 				const bundle: ExecutionDataPayload = {
-					data: data !== undefined ? stringify(data) : existing.data,
+					data:
+						data !== undefined && this.executionsConfig.compression === 'gzip'
+							? compressPayload(rawSerialized)
+							: rawSerialized,
 					workflowData: workflowData
 						? this.toWorkflowSnapshot(workflowData)
 						: existing.workflowData,
@@ -935,6 +948,7 @@ export class ExecutionPersistence {
 		options: { unflattenData?: boolean; includeAnnotation?: boolean },
 		max: number,
 	) {
+		bundle.data = decompressPayload(bundle.data);
 		if (max > 0 && entity.jsonSizeBytes === 0 && Buffer.byteLength(bundle.data, 'utf8') > max) {
 			return this.assembleOversizedExecution(
 				entity,
@@ -950,10 +964,11 @@ export class ExecutionPersistence {
 		data: string,
 		options: { unflattenData?: boolean },
 	): Promise<IRunExecutionData | string | undefined> {
-		if (!options.unflattenData) return data;
+		const decompressedData = decompressPayload(data);
+		if (!options.unflattenData) return decompressedData;
 
 		try {
-			const deserialized: unknown = await parseFlatted(data);
+			const deserialized: unknown = await parseFlatted(decompressedData);
 			if (!deserialized) return undefined;
 			return migrateRunExecutionData(deserialized as IRunExecutionDataAll);
 		} catch (error) {


### PR DESCRIPTION
## Summary

Adds optional Gzip compression support for execution data payloads before persistence.

## Why is this needed?

Execution payloads can become large, especially for workflows containing extensive execution data. Compressing them can reduce storage usage while keeping the feature configurable.

## What problem does this solve?

- Reduces database storage requirements.
- Lowers disk usage for large execution records.
- Keeps existing behavior unchanged when compression is disabled.

## How was this implemented?

- Added a configurable gzip compression option.
- Compressed execution payloads before persistence.
- Added tests covering compressed payload storage.
- Preserved the existing none behavior for backwards compatibility.

## Testing

- Added unit tests for gzip compression.
- Verified existing tests continue to pass.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this  code.
- [x] PR title and summary are descriptive.
- [ ]  Docs updated or follow-up ticket created.
- [ ]  Spec and designs reviewed (if applicable).
- [x] Co-authored by signed-off commits.


 