### PR TITLE
fix(GitHub Node): Fix owner resource locator empty search

### DIFF
--- a/packages/nodes-base/nodes/Github/SearchFunctions.ts
+++ b/packages/nodes-base/nodes/Github/SearchFunctions.ts
@@ -6,7 +6,7 @@ import type {
 
 import { githubApiRequest } from './GenericFunctions';
 
-type UserSearchItem = {
+type OwnerSearchItem = {
 	login: string;
 	html_url: string;
 };
@@ -17,7 +17,7 @@ type RepositorySearchItem = {
 };
 
 type UserSearchResponse = {
-	items: UserSearchItem[];
+	items: OwnerSearchItem[];
 	total_count: number;
 };
 
@@ -26,9 +26,24 @@ type RepositorySearchResponse = {
 	total_count: number;
 };
 
+type WorkflowSearchResponse = {
+	workflows: Array<{ id: string; name: string }>;
+	total_count: number;
+};
+
 type RefItem = {
 	ref: string;
 };
+
+const toResourceLocatorItems = (items: OwnerSearchItem[]): INodeListSearchItems[] =>
+	items.map((item) => ({
+		name: item.login,
+		value: item.login,
+		url: item.html_url,
+	}));
+
+const getCurrentStringParameter = (thisContext: ILoadOptionsFunctions, parameter: string) =>
+	String(thisContext.getCurrentNodeParameter(parameter, { extractValue: true }) ?? '').trim();
 
 export async function getUsers(
 	this: ILoadOptionsFunctions,
@@ -37,33 +52,42 @@ export async function getUsers(
 ): Promise<INodeListSearchResult> {
 	const page = paginationToken ? +paginationToken : 1;
 	const per_page = 100;
+	const query = filter?.trim();
 
-	let responseData: UserSearchResponse = {
-		items: [],
-		total_count: 0,
-	};
-
-	try {
-		responseData = await githubApiRequest.call(
+	if (!query) {
+		const authenticatedUser: OwnerSearchItem = await githubApiRequest.call(
 			this,
 			'GET',
-			'/search/users',
+			'/user',
 			{},
-			{ q: filter, page, per_page },
 		);
-	} catch {
-		// will fail if the owner does not have any users
+		const organizations: OwnerSearchItem[] = await githubApiRequest.call(
+			this,
+			'GET',
+			'/user/orgs',
+			{},
+			{ page, per_page },
+		);
+		const owners = page === 1 ? [authenticatedUser, ...organizations] : organizations;
+		const nextPaginationToken = organizations.length === per_page ? String(page + 1) : undefined;
+
+		return { results: toResourceLocatorItems(owners), paginationToken: nextPaginationToken };
 	}
 
-	const results: INodeListSearchItems[] = responseData.items.map((item: UserSearchItem) => ({
-		name: item.login,
-		value: item.login,
-		url: item.html_url,
-	}));
+	const responseData: UserSearchResponse = await githubApiRequest.call(
+		this,
+		'GET',
+		'/search/users',
+		{},
+		{ q: query, page, per_page },
+	);
 
 	const nextPaginationToken =
 		page * per_page < responseData.total_count ? String(page + 1) : undefined;
-	return { results, paginationToken: nextPaginationToken };
+	return {
+		results: toResourceLocatorItems(responseData.items),
+		paginationToken: nextPaginationToken,
+	};
 }
 
 export async function getRepositories(
@@ -71,26 +95,19 @@ export async function getRepositories(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	const owner = this.getCurrentNodeParameter('owner', { extractValue: true });
+	const owner = getCurrentStringParameter(this, 'owner');
+	if (!owner) return { results: [] };
+
 	const page = paginationToken ? +paginationToken : 1;
 	const per_page = 100;
-	const q = `${filter ?? ''} user:${owner} fork:true`;
-	let responseData: RepositorySearchResponse = {
-		items: [],
-		total_count: 0,
-	};
-
-	try {
-		responseData = await githubApiRequest.call(
-			this,
-			'GET',
-			'/search/repositories',
-			{},
-			{ q, page, per_page },
-		);
-	} catch {
-		// will fail if the owner does not have any repositories
-	}
+	const q = [filter?.trim(), `user:${owner}`, 'fork:true'].filter(Boolean).join(' ');
+	const responseData: RepositorySearchResponse = await githubApiRequest.call(
+		this,
+		'GET',
+		'/search/repositories',
+		{},
+		{ q, page, per_page },
+	);
 
 	const results: INodeListSearchItems[] = responseData.items.map((item: RepositorySearchItem) => ({
 		name: item.name,
@@ -107,21 +124,20 @@ export async function getWorkflows(
 	this: ILoadOptionsFunctions,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	const owner = this.getCurrentNodeParameter('owner', { extractValue: true });
-	const repository = this.getCurrentNodeParameter('repository', { extractValue: true });
+	const owner = getCurrentStringParameter(this, 'owner');
+	const repository = getCurrentStringParameter(this, 'repository');
+	if (!owner || !repository) return { results: [] };
+
 	const page = paginationToken ? +paginationToken : 1;
 	const per_page = 100;
 	const endpoint = `/repos/${owner}/${repository}/actions/workflows`;
-	let responseData: { workflows: Array<{ id: string; name: string }>; total_count: number } = {
-		workflows: [],
-		total_count: 0,
-	};
-
-	try {
-		responseData = await githubApiRequest.call(this, 'GET', endpoint, {}, { page, per_page });
-	} catch {
-		// will fail if the repository does not have any workflows
-	}
+	const responseData: WorkflowSearchResponse = await githubApiRequest.call(
+		this,
+		'GET',
+		endpoint,
+		{},
+		{ page, per_page },
+	);
 
 	const results: INodeListSearchItems[] = responseData.workflows.map((workflow) => ({
 		name: workflow.name,
@@ -138,8 +154,10 @@ export async function getRefs(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	const owner = this.getCurrentNodeParameter('owner', { extractValue: true });
-	const repository = this.getCurrentNodeParameter('repository', { extractValue: true });
+	const owner = getCurrentStringParameter(this, 'owner');
+	const repository = getCurrentStringParameter(this, 'repository');
+	if (!owner || !repository) return { results: [] };
+
 	const page = paginationToken ? +paginationToken : 1;
 	const per_page = 100;
 

--- a/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
+++ b/packages/nodes-base/nodes/Github/__tests__/SearchFunctions.test.ts
@@ -17,8 +17,13 @@ const mockLoadOptionsFunctions = {
 describe('Search Functions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		(mockLoadOptionsFunctions.getNodeParameter as Mock).mockReset();
+		(mockLoadOptionsFunctions.getCredentials as Mock).mockReset().mockResolvedValue({
+			server: 'https://api.github.com',
+		});
+		(mockLoadOptionsFunctions.helpers.requestWithAuthentication as Mock).mockReset();
+		(mockLoadOptionsFunctions.getCurrentNodeParameter as Mock).mockReset();
 	});
-
 	describe('getUsers', () => {
 		it('should fetch users', async () => {
 			const filter = 'test-user';
@@ -48,11 +53,10 @@ describe('Search Functions', () => {
 				'githubOAuth2Api',
 				expect.objectContaining({
 					method: 'GET',
-					qs: expect.objectContaining({ page: 1 }),
+					qs: expect.objectContaining({ q: filter, page: 1 }),
 				}),
 			);
 		});
-
 		it('should handle pagination', async () => {
 			const filter = 'test-user';
 			const responseData = {
@@ -77,7 +81,6 @@ describe('Search Functions', () => {
 				paginationToken: '2',
 			});
 		});
-
 		it('should use paginationToken when provided', async () => {
 			const filter = 'test-user';
 			const paginationToken = '3';
@@ -111,8 +114,45 @@ describe('Search Functions', () => {
 				}),
 			);
 		});
-	});
 
+		it('should fetch authenticated user and organizations without a filter', async () => {
+			(mockLoadOptionsFunctions.helpers.requestWithAuthentication as Mock)
+				.mockResolvedValueOnce({ login: 'test-user', html_url: 'https://github.com/test-user' })
+				.mockResolvedValueOnce([
+					{ login: 'test-org-1', html_url: 'https://github.com/test-org-1' },
+					{ login: 'test-org-2', html_url: 'https://github.com/test-org-2' },
+				]);
+
+			const result = await getUsers.call(mockLoadOptionsFunctions);
+
+			expect(result).toEqual({
+				results: [
+					{ name: 'test-user', value: 'test-user', url: 'https://github.com/test-user' },
+					{ name: 'test-org-1', value: 'test-org-1', url: 'https://github.com/test-org-1' },
+					{ name: 'test-org-2', value: 'test-org-2', url: 'https://github.com/test-org-2' },
+				],
+				paginationToken: undefined,
+			});
+
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).toHaveBeenNthCalledWith(
+				1,
+				'githubOAuth2Api',
+				expect.objectContaining({
+					method: 'GET',
+					uri: 'https://api.github.com/user',
+				}),
+			);
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).toHaveBeenNthCalledWith(
+				2,
+				'githubOAuth2Api',
+				expect.objectContaining({
+					method: 'GET',
+					uri: 'https://api.github.com/user/orgs',
+					qs: expect.objectContaining({ page: 1, per_page: 100 }),
+				}),
+			);
+		});
+	});
 	describe('getRepositories', () => {
 		it('should fetch repositories', async () => {
 			const filter = 'test-repo';
@@ -148,7 +188,6 @@ describe('Search Functions', () => {
 				paginationToken: undefined,
 			});
 		});
-
 		it('should fetch repositories without filter', async () => {
 			const owner = 'test-owner';
 			const responseData = {
@@ -182,7 +221,6 @@ describe('Search Functions', () => {
 				paginationToken: undefined,
 			});
 		});
-
 		it('should use paginationToken when provided', async () => {
 			const filter = 'test-repo';
 			const paginationToken = '3';
@@ -227,6 +265,14 @@ describe('Search Functions', () => {
 			);
 		});
 
+		it('should not fetch repositories before an owner is selected', async () => {
+			(mockLoadOptionsFunctions.getCurrentNodeParameter as Mock).mockReturnValue('');
+
+			const result = await getRepositories.call(mockLoadOptionsFunctions);
+
+			expect(result).toEqual({ results: [] });
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).not.toHaveBeenCalled();
+		});
 		it('should handle empty repositories', async () => {
 			const filter = 'test-repo';
 			const owner = 'test-owner';
@@ -248,7 +294,6 @@ describe('Search Functions', () => {
 			});
 		});
 	});
-
 	describe('getWorkflows', () => {
 		it('should fetch workflows', async () => {
 			const owner = 'test-owner';
@@ -278,7 +323,6 @@ describe('Search Functions', () => {
 				paginationToken: undefined,
 			});
 		});
-
 		it('should handle pagination', async () => {
 			const owner = 'test-owner';
 			const repository = 'test-repo';
@@ -307,7 +351,6 @@ describe('Search Functions', () => {
 				paginationToken: '2',
 			});
 		});
-
 		it('should use paginationToken when provided and return next page token', async () => {
 			const paginationToken = '1';
 			const owner = 'test-owner';
@@ -346,6 +389,16 @@ describe('Search Functions', () => {
 			);
 		});
 
+		it('should not fetch workflows before owner and repository are selected', async () => {
+			(mockLoadOptionsFunctions.getCurrentNodeParameter as Mock)
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('test-repo');
+
+			const result = await getWorkflows.call(mockLoadOptionsFunctions);
+
+			expect(result).toEqual({ results: [] });
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).not.toHaveBeenCalled();
+		});
 		it('should handle empty workflows', async () => {
 			const owner = 'test-owner';
 			const repository = 'test-repo';
@@ -369,8 +422,17 @@ describe('Search Functions', () => {
 			});
 		});
 	});
-
 	describe('getRefs', () => {
+		it('should not fetch refs before owner and repository are selected', async () => {
+			(mockLoadOptionsFunctions.getCurrentNodeParameter as Mock)
+				.mockReturnValueOnce('test-owner')
+				.mockReturnValueOnce('');
+
+			const result = await getRefs.call(mockLoadOptionsFunctions);
+
+			expect(result).toEqual({ results: [] });
+			expect(mockLoadOptionsFunctions.helpers.requestWithAuthentication).not.toHaveBeenCalled();
+		});
 		it('should fetch branches and tags using git/refs endpoint', async () => {
 			const owner = 'test-owner';
 			const repository = 'test-repo';
@@ -406,7 +468,6 @@ describe('Search Functions', () => {
 				paginationToken: undefined,
 			});
 		});
-
 		it('should use paginationToken when provided', async () => {
 			const paginationToken = '3';
 			const owner = 'test-owner';
@@ -442,7 +503,6 @@ describe('Search Functions', () => {
 				}),
 			);
 		});
-
 		it('should filter refs based on the provided filter', async () => {
 			const owner = 'test-owner';
 			const repository = 'test-repo';
@@ -470,7 +530,6 @@ describe('Search Functions', () => {
 				results: [{ name: 'v1.0.0', value: 'v1.0.0', description: 'Tag: v1.0.0' }],
 			});
 		});
-
 		it('should handle pagination correctly', async () => {
 			const owner = 'test-owner';
 			const repository = 'test-repo';


### PR DESCRIPTION
## Summary

Fixes the GitHub node resource locator lookup path so the owner selector does not call GitHub Search with an empty query and then silently render an empty list.

Changes:
- Load the authenticated user and their organizations when the owner selector has no search filter
- Keep typed owner searches on `/search/users`, but only after a non-empty query exists
- Stop swallowing GitHub API errors in owner/repository/workflow list searches so real auth/API failures surface instead of empty dropdowns
- Avoid repository/workflow/ref API calls until their required owner/repository values are selected

## Why

GitHub Search requires `q`. The current owner locator allows empty searches and calls `/search/users` with no meaningful `q`, which GitHub rejects with `422 Validation Failed`. The node catches that error and returns an empty list, making valid credentials look broken.

## Testing

- `pnpm --filter @n8n/vitest-config build`
- `pnpm --filter n8n-workflow... build`
- `cd packages/nodes-base && pnpm exec vitest run nodes/Github/__tests__/SearchFunctions.test.ts`
- `cd packages/nodes-base && pnpm exec biome check nodes/Github/SearchFunctions.ts nodes/Github/__tests__/SearchFunctions.test.ts`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33174">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

