### PR TITLE
fix(ai-builder): Send eval build traces to a separate LangSmith project (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -248,6 +248,8 @@ jobs:
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
           LANGSMITH_REVISION_ID: ${{ inputs.revision-sha || github.sha }}
           LANGSMITH_BRANCH: ${{ inputs.head-ref || github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
+          # Dedicated project so eval build traces don't pollute the default 'instance-ai' corpus.
+          LANGSMITH_PROJECT: instance-ai-evals
           FILTER: ${{ inputs.filter }}
           TIER: ${{ inputs.tier }}
           ITERATIONS: ${{ inputs.iterations }}


### PR DESCRIPTION
## Summary

The eval CI step (`Run Instance AI Evals`) sets LangSmith creds (`LANGSMITH_TRACING` / `LANGSMITH_ENDPOINT` / `LANGSMITH_API_KEY`) but no `LANGSMITH_PROJECT`. Instance-ai build telemetry resolves the project as `LANGSMITH_PROJECT ?? LANGCHAIN_PROJECT ?? 'instance-ai'` (`packages/cli/src/modules/agents/tracing/builder-telemetry.ts`), so eval **build conversations** fall back to the default **`instance-ai`** project and pollute the real-user trace corpus that the trace-review tooling reads from.

This pins eval build traces to a dedicated **`instance-ai-evals`** project. Experiment/scoring runs are unaffected — they set their project explicitly via `experimentName`.

⚠️ Prevents *future* pollution only; eval threads already in `instance-ai` are unchanged.

## How to test

Trigger the eval workflow and confirm the build-conversation threads land in the `instance-ai-evals` LangSmith project (EU tenant) instead of `instance-ai`.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if urgent).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->