### PR TITLE
fix(Structured Output Parser Node): Handle Responses API content blocks

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
 import type { BaseLanguageModel } from '@langchain/core/language_models/base';
+import { AIMessage } from '@langchain/core/messages';
 import { OutputParserException } from '@langchain/core/output_parsers';
 import { normalizeItems } from 'n8n-core';
 import type {
@@ -58,9 +59,7 @@ describe('OutputParserAutofixing', () => {
 
 	function getMockedRetryChain(output: string) {
 		return vi.fn().mockReturnValue({
-			invoke: vi.fn().mockResolvedValue({
-				content: output,
-			}),
+			invoke: vi.fn().mockResolvedValue(new AIMessage({ content: output })),
 		});
 	}
 

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import type { BaseLanguageModel } from '@langchain/core/language_models/base';
+import { AIMessage } from '@langchain/core/messages';
+import { OutputParserException } from '@langchain/core/output_parsers';
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+import type { MockProxy } from 'vitest-mock-extended';
+
+import { N8nOutputFixingParser } from './N8nOutputFixingParser';
+import type { N8nStructuredOutputParser } from './N8nStructuredOutputParser';
+import { NAIVE_FIX_PROMPT } from './prompt';
+
+describe('N8nOutputFixingParser', () => {
+	let context: MockProxy<ISupplyDataFunctions>;
+	let model: MockProxy<BaseLanguageModel>;
+	let structuredParser: MockProxy<N8nStructuredOutputParser>;
+	let parser: N8nOutputFixingParser;
+
+	beforeEach(() => {
+		context = mock<ISupplyDataFunctions>();
+		model = mock<BaseLanguageModel>();
+		structuredParser = mock<N8nStructuredOutputParser>();
+		context.addInputData.mockReturnValue({ index: 0 });
+		context.addOutputData.mockReturnValue();
+		parser = new N8nOutputFixingParser(context, model, structuredParser, NAIVE_FIX_PROMPT);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function mockRetryChainResult(message: AIMessage) {
+		parser.getRetryChain = vi.fn().mockReturnValue({
+			invoke: vi.fn().mockResolvedValue(message),
+		});
+	}
+
+	// The retry chain is `prompt.pipe(model)`, so it resolves to a raw AIMessage.
+	// Models that emit provider content blocks (e.g. the OpenAI Responses API, which
+	// the Tools Agent triggers by attaching tools) return `content` as an array of
+	// typed parts. Reading it via `result.content.toString()` coerced that array to
+	// the literal "[object Object]", discarding the fixed output; `.text` extracts the
+	// actual text instead.
+	it('extracts text from content-block array responses before re-parsing', async () => {
+		const validOutput = { name: 'Bob', age: 28 };
+		const fixedJson = JSON.stringify(validOutput);
+
+		structuredParser.parse
+			.mockRejectedValueOnce(new OutputParserException('Invalid JSON'))
+			.mockResolvedValueOnce(validOutput);
+		mockRetryChainResult(new AIMessage({ content: [{ type: 'text', text: fixedJson }] }));
+
+		const result = await parser.parse('Some narration then {"name":"Bob","age":28}');
+
+		expect(result).toEqual(validOutput);
+		expect(structuredParser.parse).toHaveBeenCalledTimes(2);
+		// The fix must be re-parsed verbatim, not as "[object Object]".
+		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
+	});
+
+	it('concatenates multiple text content blocks before re-parsing', async () => {
+		const validOutput = { name: 'Carol', age: 31 };
+		const fixedJson = JSON.stringify(validOutput);
+		const splitAt = Math.floor(fixedJson.length / 2);
+
+		structuredParser.parse
+			.mockRejectedValueOnce(new OutputParserException('Invalid JSON'))
+			.mockResolvedValueOnce(validOutput);
+		mockRetryChainResult(
+			new AIMessage({
+				content: [
+					{ type: 'text', text: fixedJson.slice(0, splitAt) },
+					{ type: 'text', text: fixedJson.slice(splitAt) },
+				],
+			}),
+		);
+
+		const result = await parser.parse('Invalid JSON string');
+
+		expect(result).toEqual(validOutput);
+		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
+	});
+
+	it('passes plain string content through unchanged', async () => {
+		const validOutput = { name: 'Dave', age: 42 };
+		const fixedJson = JSON.stringify(validOutput);
+
+		structuredParser.parse
+			.mockRejectedValueOnce(new OutputParserException('Invalid JSON'))
+			.mockResolvedValueOnce(validOutput);
+		mockRetryChainResult(new AIMessage({ content: fixedJson }));
+
+		const result = await parser.parse('Invalid JSON string');
+
+		expect(result).toEqual(validOutput);
+		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.test.ts
@@ -36,12 +36,7 @@ describe('N8nOutputFixingParser', () => {
 		});
 	}
 
-	// The retry chain is `prompt.pipe(model)`, so it resolves to a raw AIMessage.
-	// Models that emit provider content blocks (e.g. the OpenAI Responses API, which
-	// the Tools Agent triggers by attaching tools) return `content` as an array of
-	// typed parts. Reading it via `result.content.toString()` coerced that array to
-	// the literal "[object Object]", discarding the fixed output; `.text` extracts the
-	// actual text instead.
+	// Responses API content blocks were coerced to "[object Object]" before re-parsing.
 	it('extracts text from content-block array responses before re-parsing', async () => {
 		const validOutput = { name: 'Bob', age: 28 };
 		const fixedJson = JSON.stringify(validOutput);
@@ -56,44 +51,6 @@ describe('N8nOutputFixingParser', () => {
 		expect(result).toEqual(validOutput);
 		expect(structuredParser.parse).toHaveBeenCalledTimes(2);
 		// The fix must be re-parsed verbatim, not as "[object Object]".
-		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
-	});
-
-	it('concatenates multiple text content blocks before re-parsing', async () => {
-		const validOutput = { name: 'Carol', age: 31 };
-		const fixedJson = JSON.stringify(validOutput);
-		const splitAt = Math.floor(fixedJson.length / 2);
-
-		structuredParser.parse
-			.mockRejectedValueOnce(new OutputParserException('Invalid JSON'))
-			.mockResolvedValueOnce(validOutput);
-		mockRetryChainResult(
-			new AIMessage({
-				content: [
-					{ type: 'text', text: fixedJson.slice(0, splitAt) },
-					{ type: 'text', text: fixedJson.slice(splitAt) },
-				],
-			}),
-		);
-
-		const result = await parser.parse('Invalid JSON string');
-
-		expect(result).toEqual(validOutput);
-		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
-	});
-
-	it('passes plain string content through unchanged', async () => {
-		const validOutput = { name: 'Dave', age: 42 };
-		const fixedJson = JSON.stringify(validOutput);
-
-		structuredParser.parse
-			.mockRejectedValueOnce(new OutputParserException('Invalid JSON'))
-			.mockResolvedValueOnce(validOutput);
-		mockRetryChainResult(new AIMessage({ content: fixedJson }));
-
-		const result = await parser.parse('Invalid JSON string');
-
-		expect(result).toEqual(validOutput);
 		expect(structuredParser.parse.mock.calls[1][0]).toBe(fixedJson);
 	});
 });

--- a/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.ts
+++ b/packages/@n8n/nodes-langchain/utils/output_parsers/N8nOutputFixingParser.ts
@@ -64,7 +64,10 @@ export class N8nOutputFixingParser extends BaseOutputParser {
 					instructions: this.getFormatInstructions(),
 				})) as AIMessage;
 
-				const resultText = result.content.toString();
+				// Use `.text` rather than `result.content.toString()`: models that emit
+				// provider content blocks (e.g. the OpenAI Responses API) return `content`
+				// as an array, which `.toString()` would coerce to "[object Object]".
+				const resultText = result.text;
 				const parsed = await this.outputParser.parse(resultText, callbacks);
 
 				// Add the successfully parsed output to the context


### PR DESCRIPTION
## Summary

Fixes the Structured Output Parser node's auto-fix path when the fix model returns LangChain provider content blocks instead of plain string content.

The auto-fixing parser is used by both:

- Structured Output Parser node -> "Auto-Fix Format"
- Standalone Auto-fixing Output Parser node, which is deprecated in favor of Structured Output Parser

Previously, after the first parse failed, the retry chain resolved to a raw `AIMessage` and read the repaired output with:

```ts
result.content.toString()
```

For models routed through the OpenAI Responses API, `AIMessage.content` can be an array of typed content blocks. Calling `.toString()` on that array produces `"[object Object]"`, discarding the repaired JSON and causing the re-parse to fail even when the fix model returned valid output.

This now uses the message's `.text` accessor, which preserves plain string content and extracts/concatenates text blocks.

I also checked the rest of the repo for model-message `content.toString()` usage. Two related follow-ups remain outside this PR:

- `packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/assistant/message.operation.ts` replays LangChain memory into OpenAI Assistant threads with `message.content.toString()`. If memory contains content-block messages, this can send `"[object Object]"` into the recreated thread. Likely fix: use `message.text`.
- `packages/@n8n/nodes-langchain/nodes/memory/MemoryZep/MemoryZep.node.ts` filters Zep chat history with `m.content.toString().trim()`. This can treat empty content-block messages as non-empty. Likely fix: use `m.text.trim()`.

Other `content.toString()` hits were buffer/file conversions or local prompt assembly, not model response extraction.

## How to test

Run the focused regression tests from `packages/@n8n/nodes-langchain`:

```bash
pnpm test utils/output_parsers/N8nOutputFixingParser.test.ts nodes/output_parser/OutputParserAutofixing/test/OutputParserAutofixing.node.test.ts
```

Expected result:

```text
Test Files  2 passed (2)
Tests       9 passed (9)
```

The regression test covers:

- A retry-chain `AIMessage` with one `{ type: "text" }` content block.

## Related Linear tickets, Github issues, and Community forum posts

Related:

- n8n-io/n8n#23281
- n8n-io/n8n#29903
- n8n-io/n8n#26004


Closes #38016

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33184">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

