### PR TITLE
chore: Drop DB-rooted Sentry transactions (no-changelog)

### DIFF
--- a/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
@@ -18,13 +18,50 @@ function span(overrides: Partial<SpanJSON> & { op?: string; durationMs?: number 
 	};
 }
 
+/** Builds a transaction event with an optional root op and child spans. */
+function transaction(overrides: {
+	op?: string;
+	name?: string;
+	spans?: SpanJSON[];
+}): TransactionEvent {
+	const { op, name, spans } = overrides;
+	return {
+		type: 'transaction',
+		transaction: name,
+		spans,
+		contexts: op ? { trace: { op, span_id: 'root-span', trace_id: 'trace-id' } } : undefined,
+	} as TransactionEvent;
+}
+
 /** Runs the filter and returns the surviving child spans. */
 function filterSpans(spans: SpanJSON[]): SpanJSON[] {
 	const event = { type: 'transaction', spans } as TransactionEvent;
-	return buildBeforeSendTransaction(THRESHOLD_MS)(event).spans ?? [];
+	return buildBeforeSendTransaction(THRESHOLD_MS)(event)?.spans ?? [];
 }
 
 describe('buildBeforeSendTransaction', () => {
+	it.each([
+		'SELECT "WorkflowStatistics" WHERE ...',
+		'pg-pool.connect',
+		'UPDATE execution_entity SET "deletedAt" ...',
+		'INSERT INTO execution_metadata ...',
+	])('drops db-rooted transactions (%s)', (name) => {
+		const event = transaction({ op: 'db', name, spans: [span({ op: 'db', durationMs: 5 })] });
+		expect(buildBeforeSendTransaction(THRESHOLD_MS)(event)).toBeNull();
+	});
+
+	it('keeps a real request transaction that contains fast db child spans', () => {
+		const slowDb = span({ op: 'db', durationMs: THRESHOLD_MS, status: 'ok' });
+		const event = transaction({
+			op: 'http.server',
+			name: 'GET /rest/workflows',
+			spans: [span({ op: 'db', durationMs: 2, status: 'ok' }), slowDb],
+		});
+		const result = buildBeforeSendTransaction(THRESHOLD_MS)(event);
+		expect(result).not.toBeNull();
+		expect(result?.spans).toEqual([slowDb]);
+	});
+
 	it.each(['middleware.express', 'router.express', 'request_handler.express'])(
 		'drops %s spans wholesale',
 		(op) => {

--- a/packages/core/src/observability/tracing/span-sampling.ts
+++ b/packages/core/src/observability/tracing/span-sampling.ts
@@ -54,14 +54,21 @@ function reparentChildSpans(
 }
 
 /**
- * Filters noisy auto-instrumentation child spans before Sentry sends a transaction:
- * - Express middleware/router/handler spans wholesale.
- * - Fast, non-errored `db`/`http.client` spans (below `slowSpanThresholdMs`).
+ * Filters noise before Sentry sends a transaction:
+ * - Drops transactions rooted on a `db` operation wholesale (DB queries/pool connects
+ *   that became roots outside any request/job span — high volume, no signal).
+ * - Express middleware/router/handler child spans wholesale.
+ * - Fast, non-errored `db`/`http.client` child spans (below `slowSpanThresholdMs`).
  *
- * Kept descendants of dropped spans are reparented.
+ * Kept descendants of dropped child spans are reparented.
  */
 export function buildBeforeSendTransaction(slowSpanThresholdMs: number) {
-	return (event: TransactionEvent): TransactionEvent => {
+	return (event: TransactionEvent): TransactionEvent | null => {
+		// DB operations (queries, pool connects) get op `db`. A `db`-rooted transaction
+		// ran outside any request/job span — high volume, no signal. Child db spans under
+		// real transactions keep a non-`db` root op, so they are untouched.
+		if (event.contexts?.trace?.op === 'db') return null;
+
 		if (event.spans) {
 			const spans = event.spans;
 			event.spans = spans.filter((span) => {


### PR DESCRIPTION
## Summary

Reduce tracing noise:

Drop **root** DB transactions (e.g. `SELECT "WorkflowStatistics"`, `pg-pool.connect`, `UPDATE …execution_entity SET "deletedAt"`, `INSERT INTO execution_metadata`) to reduce noise (~500k/7d, ~30% of all volume). `db` spans that are children of transaction are still kept.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3598

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33190">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

