### PR TITLE
fix: Preserve AI Assistant Anthropic reasoning through proxy

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
@@ -123,6 +123,29 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 		});
 	});
 
+	it.each([
+		{ name: 'no provider metadata', content: {} },
+		{
+			name: 'unsupported Anthropic metadata',
+			content: { providerMetadata: { anthropic: { unsupported: true } } },
+		},
+	])('drops reasoning parts with $name', ({ content }) => {
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'reasoning',
+						text: 'Reasoning text without replay metadata',
+						...content,
+					},
+				],
+			},
+		];
+
+		expect(toAiMessages(input)).toEqual([]);
+	});
+
 	it('sanitizes replayed non-object tool-call inputs for provider requests', () => {
 		const input: Message[] = [
 			{

--- a/packages/@n8n/agents/src/runtime/model/messages.ts
+++ b/packages/@n8n/agents/src/runtime/model/messages.ts
@@ -106,6 +106,29 @@ function getRecord(value: unknown): Record<string, unknown> | undefined {
 	return isRecord(value) ? value : undefined;
 }
 
+function hasEntries(value: Record<string, unknown>): boolean {
+	return Object.keys(value).length > 0;
+}
+
+function hasReplayableReasoningProviderOptions(
+	providerOptions: ProviderOptions | undefined,
+): boolean {
+	if (!providerOptions) return false;
+
+	const anthropicOptions = getRecord(providerOptions.anthropic);
+	if (
+		typeof anthropicOptions?.signature === 'string' ||
+		typeof anthropicOptions?.redactedData === 'string'
+	) {
+		return true;
+	}
+
+	return Object.entries(providerOptions).some(
+		([provider, options]) =>
+			provider !== 'anthropic' && provider !== 'openai' && hasEntries(options),
+	);
+}
+
 type ContentToolResultOutput = Extract<ToolResultPart['output'], { type: 'content' }>;
 
 function isContentToolResultOutput(value: JSONValue): value is ContentToolResultOutput {
@@ -166,6 +189,9 @@ function toAiContent(block: MessageContent): AiContentPart | undefined {
 		const providerOptions = isReasoning(block)
 			? toReasoningProviderOptions(block)
 			: block.providerOptions;
+		if (isReasoning(block) && !hasReplayableReasoningProviderOptions(providerOptions)) {
+			return undefined;
+		}
 
 		return {
 			...base,

--- a/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/apply-agent-thinking.test.ts
@@ -28,6 +28,21 @@ describe('applyAgentThinking', () => {
 		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
 	});
 
+	it('enables adaptive thinking for dotted Anthropic provider IDs', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, 'anthropic.messages/claude-opus-4-8');
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
+	});
+
+	it('enables adaptive thinking for AI SDK Anthropic model objects', () => {
+		const agent = new Agent('test');
+		applyAgentThinking(agent, {
+			modelId: 'claude-opus-4-8',
+			config: { provider: 'anthropic.messages' },
+		} as unknown as Parameters<typeof applyAgentThinking>[1]);
+		expect(mockAgentInstances[0]?.thinking).toHaveBeenCalledWith('anthropic', { mode: 'adaptive' });
+	});
+
 	it('enables OpenAI reasoning for supported models', () => {
 		const agent = new Agent('test');
 		applyAgentThinking(agent, 'openai/gpt-5.5');

--- a/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
+++ b/packages/@n8n/instance-ai/src/agent/apply-agent-thinking.ts
@@ -1,29 +1,36 @@
 import type { Agent, ModelConfig } from '@n8n/agents';
 import { PROVIDER_CAPABILITIES } from '@n8n/api-types';
+import { isRecord } from '@n8n/utils';
 
-function resolveModelId(modelId: ModelConfig): string | undefined {
-	if (typeof modelId === 'string') return modelId;
-	if (typeof modelId === 'object' && modelId !== null && 'id' in modelId) {
-		return typeof modelId.id === 'string' ? modelId.id : undefined;
-	}
-	if (
-		typeof modelId === 'object' &&
-		modelId !== null &&
-		'provider' in modelId &&
-		'modelId' in modelId
-	) {
-		const provider = typeof modelId.provider === 'string' ? modelId.provider : undefined;
-		const model = typeof modelId.modelId === 'string' ? modelId.modelId : undefined;
-		return provider && model ? `${provider}/${model}` : undefined;
-	}
-	return undefined;
+function normalizeProvider(provider: string): string {
+	return provider.split('.')[0] ?? provider;
+}
+
+function getStringProperty(value: Record<string, unknown>, key: string): string | undefined {
+	const property = value[key];
+	return typeof property === 'string' ? property : undefined;
+}
+
+function getProviderFromConfig(value: Record<string, unknown>): string | undefined {
+	const config = value.config;
+	return isRecord(config) ? getStringProperty(config, 'provider') : undefined;
+}
+
+function getProviderFromId(id: string): string | undefined {
+	const slashIndex = id.indexOf('/');
+	return slashIndex > 0 ? normalizeProvider(id.slice(0, slashIndex)) : undefined;
 }
 
 function resolveModelProvider(modelId: ModelConfig): string | undefined {
-	const id = resolveModelId(modelId);
-	if (!id) return undefined;
-	const slashIndex = id.indexOf('/');
-	return slashIndex > 0 ? id.slice(0, slashIndex) : undefined;
+	if (typeof modelId === 'string') return getProviderFromId(modelId);
+	if (!isRecord(modelId)) return undefined;
+
+	const id = getStringProperty(modelId, 'id');
+	if (id) return getProviderFromId(id);
+
+	const provider = getStringProperty(modelId, 'provider') ?? getProviderFromConfig(modelId);
+	const model = getStringProperty(modelId, 'modelId');
+	return provider && model ? normalizeProvider(provider) : undefined;
 }
 
 export function applyAgentThinking(agent: Agent, modelId: ModelConfig): void {


### PR DESCRIPTION
## Summary

Preserve Anthropic reasoning when AI Assistant uses API-proxied model IDs/configs.

This does two small things:
- Detects proxied Anthropic provider IDs like `anthropic.messages/...` so thinking still gets enabled.
- Only replays reasoning parts when they have Anthropic replay metadata the provider can accept, so valid reasoning survives and unsupported blocks do not create noisy warnings.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-721

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33193">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

