### PR TITLE
ci: Improve Windows build resilience with retry and concurrency cap

### DIFF
--- a/.github/scripts/retry.mjs
+++ b/.github/scripts/retry.mjs
@@ -60,7 +60,12 @@ if (!command) {
 for (let i = 1; i <= attempts; i++) {
 	try {
 		if (isSafeRetry) {
-			const result = spawnSync(command, commandArgs, { stdio: 'inherit' });
+			// On Windows a shell is required to launch `.cmd`/`.bat` shims (e.g. `pnpm`);
+			// keep the no-shell path on POSIX so the safe form stays injection-safe there.
+			const result = spawnSync(command, commandArgs, {
+				stdio: 'inherit',
+				shell: process.platform === 'win32',
+			});
 			if (result.status !== 0) throw new Error(`Exit code ${result.status}`);
 		} else {
 			execSync(command, { shell: true, stdio: 'inherit' });

--- a/.github/scripts/retry.mjs
+++ b/.github/scripts/retry.mjs
@@ -74,7 +74,8 @@ for (let i = 1; i <= attempts; i++) {
 	} catch {
 		if (i < attempts) {
 			console.error(`Attempt ${i}/${attempts} failed, retrying in ${delay}s...`);
-			execSync(`sleep ${delay}`);
+			// `sleep` isn't available on Windows cmd.exe; use a timer that works everywhere.
+			await new Promise((resolve) => setTimeout(resolve, delay * 1000));
 		} else {
 			console.error(`Attempt ${i}/${attempts} failed, no more retries.`);
 		}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,7 +37,11 @@ jobs:
       - name: Setup Node.js and Build
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: pnpm build
+          # Windows runners intermittently hit OS-level process-init crashes
+          # (STATUS_DLL_INIT_FAILED) when turbo fans out many tsc processes at once.
+          # Cap concurrency to ease the pressure and retry once — turbo's cache makes
+          # the retry rebuild only the crashed package.
+          build-command: node .github/scripts/retry.mjs --attempts 2 --delay 5 -- pnpm build --concurrency=5
 
       - name: Smoke test pnpm start -- -- --version
         shell: pwsh


### PR DESCRIPTION
## Summary

The **Build: Windows** CI job intermittently fails with a Windows OS-level
process-initialization crash (`STATUS_DLL_INIT_FAILED`, surfaced as exit
`-1073741502` / `3221225794`). It is not a build error: `turbo run build` fans
out many `tsc` processes in parallel (each through the safe-chain `pnpm.cmd`
shim), and under that load one child process occasionally fails to initialize.
The crash lands on a **different package each run** (most recently
`@n8n/ai-workflow-builder`), confirming it is environmental rather than a code
defect — the SCSS deprecation warnings in the logs are unrelated interleaved
output.

This PR makes the Windows build resilient to the flake:

- **Cap turbo concurrency** (`--concurrency=5`) to reduce simultaneous process
  spawns and the resulting init pressure (precedent: `scripts/agent-setup.mjs`).
- **Retry the build once** via the existing `.github/scripts/retry.mjs`. Turbo
  caches successful tasks, so the retry rebuilds only the crashed package — cheap,
  and a 1/N race crash almost never recurs.
- **Fix `retry.mjs` for Windows**: its safe (`--`) form spawned without a shell,
  which Node refuses for `.cmd`/`.bat` shims (e.g. `pnpm`). The spawn is now
  `shell: true` only on `win32`; POSIX keeps the no-shell, injection-safe path.

## How to test

This only affects the Windows build pipeline. Editing `build-windows.yml`
satisfies the job's path filter, so the **Build: Windows** check runs on this PR
— confirm it is green. Worth a glance on the run:

- The SafeChain download steps still pass on a cache-miss Windows run (they also
  use `retry.mjs`).
- If a crash occurs on attempt 1, attempt 2 (turbo cache hit on all but the
  crashed package) should succeed.

Local sanity (POSIX path unchanged):
```bash
node .github/scripts/retry.mjs --attempts 1 -- node --version   # exits 0
node .github/scripts/retry.mjs --attempts 1 -- node -e "process.exit(3)"  # exits 1
```

## Related Linear tickets, Github issues, and Community forum posts

Observed on run https://github.com/n8n-io/n8n/actions/runs/28355445706 (PR #32898).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

