### PR TITLE
fix(core): Restore node-cli eslint peer to a range

### DIFF
--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -75,7 +75,7 @@
     "vitest-mock-extended": "catalog:"
   },
   "peerDependencies": {
-    "eslint": "catalog:"
+    "eslint": ">= 9"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/packages/testing/code-health/src/rules/catalog-violations.rule.test.ts
+++ b/packages/testing/code-health/src/rules/catalog-violations.rule.test.ts
@@ -126,6 +126,35 @@ catalog:
 		expect(violations).toHaveLength(0);
 	});
 
+	it('ignores peer dependencies (they express compatibility ranges)', async () => {
+		writeFile(
+			tmpDir,
+			'pnpm-workspace.yaml',
+			`
+packages:
+  - packages/*
+catalog:
+  eslint: 9.29.0
+`,
+		);
+		writeFile(
+			tmpDir,
+			'packages/node-cli/package.json',
+			JSON.stringify(
+				{
+					name: 'node-cli',
+					peerDependencies: { eslint: '>= 9' },
+				},
+				null,
+				2,
+			),
+		);
+
+		const violations = await rule.analyze(context());
+
+		expect(violations).toHaveLength(0);
+	});
+
 	it('ignores workspace references', async () => {
 		writeFile(
 			tmpDir,

--- a/packages/testing/code-health/src/rules/catalog-violations.rule.ts
+++ b/packages/testing/code-health/src/rules/catalog-violations.rule.ts
@@ -47,6 +47,11 @@ export class CatalogViolationsRule extends BaseRule<CodeHealthContext> {
 		for (const pkgInfo of packages) {
 			for (const dep of pkgInfo.deps) {
 				if (dep.usesCatalog || dep.version.startsWith('workspace:')) continue;
+				// Peer dependencies MAY contain a compatibility range for consumers.
+				// Forcing them to `catalog:` freezes them to an exact version on
+				// publish, which breaks downstream installs (e.g. scaffolded
+				// community nodes resolving @n8n/node-cli's eslint peer).
+				if (dep.section === 'peerDependencies') continue;
 
 				const catalogMatch = findInCatalog(catalogData, dep.name);
 				if (!catalogMatch.found) continue;


### PR DESCRIPTION
## Summary

Scaffolding a community node with `npm create @n8n/node@latest` (or running `npm i` in a freshly scaffolded node) failed with an `ERESOLVE` error:

```
npm error Could not resolve dependency:
npm error peer eslint@"9.29.0" from @n8n/node-cli@0.36.2
```

Root cause: `@n8n/node-cli`'s `eslint` peer dependency was `">= 9"` until #30297, which swapped it to `catalog:` as part of a catalog-conformance sweep. pnpm freezes `catalog:` to the **exact** catalog version (`9.29.0`) at publish time, so the published peer became an exact `9.29.0`. The scaffolded templates pin a different eslint version, which no longer satisfied that exact peer, so npm aborted.

A peer dependency should express a compatibility **range**, not an exact pin. This restores the eslint peer to `">= 9"`.

To keep that durable, the `catalog-violations` code-health rule (which forced the `catalog:` swap in the first place) now skips `peerDependencies` — peer deps legitimately need ranges, so they shouldn't be coerced to an exact `catalog:` reference.

## How to test

After this ships in a new `@n8n/node-cli` release:

1. `npm create @n8n/node@latest`
2. Enter a package name (e.g. `n8n-nodes-testing-123`), pick `Programmatic` → `Basic`
3. Dependency installation should complete without an `ERESOLVE` error
4. `npm i` inside the scaffolded directory should also succeed

Repeat for declarative and AI template variants.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5338

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI