### PR TITLE
fix(core): Cap builder verification re-runs with a hard attempt budget (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
@@ -8,7 +8,7 @@ import type {
 	OrchestrationContext,
 	WorkflowTaskService,
 } from '../../../types';
-import { createRemediation } from '../../../workflow-loop/remediation';
+import { createRemediation, MAX_VERIFY_ATTEMPTS } from '../../../workflow-loop/remediation';
 import type { WorkflowBuildOutcome } from '../../../workflow-loop/workflow-loop-state';
 import { createVerifyBuiltWorkflowTool } from '../verify-built-workflow.tool';
 
@@ -612,6 +612,37 @@ describe('verify-built-workflow tool', () => {
 		});
 		expect(update.verification?.evidence?.nodesExecuted).toEqual(['Form Trigger', 'Insert Row']);
 		expect(typeof update.verification?.verifiedAt).toBe('string');
+	});
+
+	it('increments the verify attempt count on the build outcome each run', async () => {
+		const { ctx, updateBuildOutcome } = makeContext(makeBuildOutcome({ verifyAttempts: 2 }), {
+			executionId: 'exec-count',
+			status: 'success',
+			data: { 'Manual Trigger': [{ ok: true }] },
+		});
+
+		await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(updateBuildOutcome.mock.calls[0][1].verifyAttempts).toBe(3);
+	});
+
+	it('blocks verification once the verify attempt budget is exhausted', async () => {
+		const { ctx, updateBuildOutcome } = makeContext(
+			makeBuildOutcome({ verifyAttempts: MAX_VERIFY_ATTEMPTS }),
+			{ executionId: 'exec-exhausted', status: 'success', data: {} },
+		);
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.success).toBe(false);
+		expect(result.remediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'verify_budget_exhausted',
+		});
+		expect(result.error).toContain('executions(action="run")');
+		expect(ctx.domainContext.executionService.run).not.toHaveBeenCalled();
+		expect(updateBuildOutcome).not.toHaveBeenCalled();
 	});
 
 	it('returns compact verification evidence by default without full execution data', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/finalize-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/finalize-result.ts
@@ -88,11 +88,15 @@ export async function persistVerificationOutcome(args: {
 	workflowId: string;
 	result: ExecutionRunResult;
 	analysis: VerificationAnalysis;
+	/** Running count of verify runs for this build, used to enforce MAX_VERIFY_ATTEMPTS. */
+	verifyAttempts: number;
 }): Promise<void> {
-	const { input, context, workflowTaskService, workflowId, result, analysis } = args;
+	const { input, context, workflowTaskService, workflowId, result, analysis, verifyAttempts } =
+		args;
 	try {
 		const executedForEvidence = namesOrDataKeys(analysis.reachedNames, result.data);
 		await workflowTaskService.updateBuildOutcome(input.workItemId, {
+			verifyAttempts,
 			verification: {
 				attempted: true,
 				success: analysis.success,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/resolve-target.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/resolve-target.ts
@@ -7,6 +7,7 @@ import type {
 import type { OrchestrationContext } from '../../../types';
 import {
 	createRemediation,
+	MAX_VERIFY_ATTEMPTS,
 	terminalRemediationFromState,
 } from '../../../workflow-loop/remediation';
 import type { WorkflowBuildOutcome } from '../../../workflow-loop/workflow-loop-state';
@@ -112,6 +113,29 @@ export async function resolveVerificationTarget(
 				error:
 					`Build outcome ${resolvedInput.workItemId} belongs to workflow ${buildOutcome.workflowId}, ` +
 					`but verification was requested for workflow ${input.workflowId}.`,
+			},
+		};
+	}
+
+	if ((buildOutcome.verifyAttempts ?? 0) >= MAX_VERIFY_ATTEMPTS) {
+		const remediation = createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'verify_budget_exhausted',
+			attemptCount: buildOutcome.verifyAttempts ?? 0,
+			guidance:
+				'Verification has already run the maximum number of times for this workflow. ' +
+				'Report which nodes were and were not reached, and let the user decide whether to run it manually. ' +
+				'Do not call executions(action="run") to expand coverage.',
+		});
+		return {
+			kind: 'blocked',
+			result: {
+				success: false,
+				resolvedWorkItemId: resolvedInput.workItemId,
+				error: remediation.guidance,
+				remediation,
+				guidance: remediation.guidance,
 			},
 		};
 	}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -169,6 +169,7 @@ export function createVerifyBuiltWorkflowTool(context: OrchestrationContext) {
 				workflowId,
 				result,
 				analysis,
+				verifyAttempts: (buildOutcome.verifyAttempts ?? 0) + 1,
 			});
 
 			const maxDataChars = resolvedInput.maxDataChars ?? DEFAULT_NODE_PREVIEW_CHARS;

--- a/packages/@n8n/instance-ai/src/workflow-loop/remediation.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/remediation.ts
@@ -6,6 +6,7 @@ import type {
 
 export const MAX_PRE_SAVE_SUBMIT_FAILURES = 3;
 export const MAX_POST_SUBMIT_REMEDIATION_SUBMITS = 2;
+export const MAX_VERIFY_ATTEMPTS = 5;
 
 export function createRemediation(input: {
 	category: RemediationCategory;

--- a/packages/@n8n/instance-ai/src/workflow-loop/remediation.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/remediation.ts
@@ -6,7 +6,7 @@ import type {
 
 export const MAX_PRE_SAVE_SUBMIT_FAILURES = 3;
 export const MAX_POST_SUBMIT_REMEDIATION_SUBMITS = 2;
-export const MAX_VERIFY_ATTEMPTS = 5;
+export const MAX_VERIFY_ATTEMPTS = 20;
 
 export function createRemediation(input: {
 	category: RemediationCategory;

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -291,6 +291,8 @@ export const workflowBuildOutcomeSchema = z.object({
 	/** Deterministic setup handoff verdict for post-verification workflow setup. */
 	setupRequirement: workflowSetupRequirementSchema.optional(),
 	remediation: remediationMetadataSchema.optional(),
+	/** Count of verify-built-workflow runs for this build; capped by MAX_VERIFY_ATTEMPTS. */
+	verifyAttempts: z.number().int().min(0).optional(),
 	/**
 	 * Structured verification record from the most recent `verify-built-workflow`
 	 * tool call. This is tool evidence, not builder prose, so downstream checks may


### PR DESCRIPTION
## Summary

Follow-up to #33141 (INS-676), addressing review feedback from @riqwan: that PR was guidance-only (tool description + skill), so add a **code-level backstop** as well.

The `post-build-flow` skill tells the builder to re-verify with `fixtureOverrides` and to fall back to a manual-test note only "when the repair budget is exhausted" — but nothing in code enforced that budget. `verify-built-workflow` could be re-run without limit, which is the loop pressure that nudges the agent toward improvising a live `executions(action="run")` (the confusing post-verification run-approval prompt reported in INS-676).

### Fix

Add a `MAX_VERIFY_ATTEMPTS` cap (5), mirroring the existing `MAX_POST_SUBMIT_REMEDIATION_SUBMITS` repair-budget pattern:

- Each `verify-built-workflow` run increments `verifyAttempts` on the build outcome (folded into the existing post-run persist — no extra write).
- Once the budget is spent, the tool short-circuits with terminal guidance: report which nodes were/weren't reached, let the user decide whether to run it manually, and **explicitly do not** call `executions(action="run")` to expand coverage.

The cap is generous enough not to impede legitimate multi-fixture branch-coverage verification (most workflows verify 1–3 times); it only stops a runaway loop. The HITL run-approval gate is unchanged.

## How to test

Unit tests added to `verify-built-workflow.tool.test.ts`:

1. `verifyAttempts` increments on each verify run (persisted on the build outcome).
2. Once `verifyAttempts >= MAX_VERIFY_ATTEMPTS`, verification is blocked with `reason: verify_budget_exhausted`, the workflow is **not** executed, and the guidance steers away from `executions(action="run")`.

Local: `pnpm vitest run src/tools/orchestration src/workflow-loop` → 197 passed; `pnpm typecheck` / `pnpm lint` clean.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-676

Follow-up to #33141.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with backport labels (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->