### PR TITLE
test(core): Re-land webhook reconciliation e2e with sqlite-safe skip guard (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
+++ b/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
@@ -66,5 +66,53 @@ test.describe(
 			expect(details.data).toContain('Webhook received');
 			expect(details.data).not.toContain('draft-only');
 		});
+
+		// Direct DB access (services.postgres) is only available on the postgres
+		// infra modes, so this test is skipped under sqlite.
+		test('reconciles a webhook that went missing from storage on re-publish', async ({
+			api,
+			services,
+		}) => {
+			test.skip(!services.postgres, 'requires direct postgres access');
+
+			const { workflowId, webhookPath } = await api.workflows.importWorkflowFromFile(
+				'simple-webhook-test.json',
+			);
+
+			const countWebhooks = async () =>
+				Number.parseInt(
+					(
+						await services.postgres.exec(
+							`SELECT COUNT(*) FROM webhook_entity WHERE "workflowId" = '${workflowId}';`,
+						)
+					).trim() || '0',
+					10,
+				);
+
+			// Activation is applied asynchronously by the outbox consumer, so wait for
+			// the webhook to be registered in storage.
+			await expect.poll(countWebhooks, { timeout: 10_000 }).toBe(1);
+
+			// Simulate a missed/partial registration: drop the row while the published
+			// version stays the same, so the next publish has an empty trigger diff.
+			await services.postgres.exec(
+				`DELETE FROM webhook_entity WHERE "workflowId" = '${workflowId}';`,
+			);
+			expect(await countWebhooks()).toBe(0);
+
+			// Re-publishing the same version reconciles the desired webhooks against
+			// stored state and re-registers the missing one.
+			const published = await api.workflows.getWorkflow(workflowId);
+			await api.workflows.activate(workflowId, published.versionId!);
+
+			await expect.poll(countWebhooks, { timeout: 10_000 }).toBe(1);
+
+			// The reconciled webhook is functional end to end.
+			const response = await api.webhooks.trigger(`/webhook/${webhookPath}`, {
+				method: 'POST',
+				data: { message: 'after-reconciliation' },
+			});
+			expect(response.ok()).toBe(true);
+		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
+++ b/packages/testing/playwright/tests/e2e/api/workflow-publication-service.spec.ts
@@ -68,12 +68,16 @@ test.describe(
 		});
 
 		// Direct DB access (services.postgres) is only available on the postgres
-		// infra modes, so this test is skipped under sqlite.
+		// infra modes, so this test is skipped under sqlite. We probe
+		// `n8nContainer.serviceResults.postgres` rather than `services.postgres`
+		// because the latter is a lazy helper that throws when postgres is absent,
+		// which would error the test on sqlite instead of skipping it.
 		test('reconciles a webhook that went missing from storage on re-publish', async ({
 			api,
 			services,
+			n8nContainer,
 		}) => {
-			test.skip(!services.postgres, 'requires direct postgres access');
+			test.skip(!n8nContainer.serviceResults.postgres, 'requires direct postgres access');
 
 			const { workflowId, webhookPath } = await api.workflows.importWorkflowFromFile(
 				'simple-webhook-test.json',


### PR DESCRIPTION
## Summary

Re-lands the webhook-reconciliation e2e test from #32966 (reverted in #33128) with a fix to its skip guard.

The test is Postgres-only and tried to skip on sqlite with `test.skip(!services.postgres, ...)`. But `services` is a lazy Proxy whose `.postgres` getter eagerly instantiates the helper and **throws** `"Postgres service not found in context"` when postgres isn't in the stack. So on sqlite shards the guard threw while evaluating its own condition — before `test.skip` could fire — erroring the test (~75ms, no retry recovery) and turning E2E sqlite shards red across PRs.

The fix probes the plain-data fixture `n8nContainer.serviceResults.postgres` (returns `ServiceResult | undefined`, never throws) instead of the throwing proxy. Since `usePostgres = usePostgresConfig || isQueueMode || ...`, this is truthy on postgres/queue/multi-main and `undefined` only under sqlite — exactly when the test should skip.

Split into two commits for review clarity: (1) a pure un-revert (byte-identical to the original), then (2) the guard fix.

## How to test

Container-only (needs direct Postgres access for the SQL delete):

```bash
pnpm build:docker
pnpm --filter=n8n-playwright test:container:postgres --grep "reconciles a webhook"
```

On sqlite infra modes the test should now **skip** with "requires direct postgres access" rather than error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3586

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33200">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

