### PR TITLE
fix(MCP Server Trigger Node): Evict idle sessions to prevent memory leak

### DIFF
--- a/packages/@n8n/config/src/configs/mcp-server.config.ts
+++ b/packages/@n8n/config/src/configs/mcp-server.config.ts
@@ -1,0 +1,23 @@
+import { Time } from '@n8n/constants';
+
+import { Config, Env } from '../decorators';
+
+/** Configuration for the MCP Server Trigger node. */
+@Config
+export class McpServerConfig {
+	/**
+	 * Time in milliseconds a session may stay idle before it is evicted and its
+	 * resources (MCP server, transport, tools) released. Streamable HTTP clients
+	 * that disconnect without sending an explicit DELETE rely on this to avoid
+	 * leaking sessions. Default: 1 hour.
+	 */
+	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS')
+	sessionIdleTtl: number = Time.hours.toMilliseconds;
+
+	/**
+	 * Interval in milliseconds between sweeps that evict idle sessions.
+	 * Default: 5 minutes.
+	 */
+	@Env('N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS')
+	sessionSweepInterval: number = 5 * Time.minutes.toMilliseconds;
+}

--- a/packages/@n8n/config/src/configs/mcp-server.config.ts
+++ b/packages/@n8n/config/src/configs/mcp-server.config.ts
@@ -1,10 +1,7 @@
 import { Time } from '@n8n/constants';
-import z from 'zod';
 
 import { Config, Env } from '../decorators';
-
-// Reject non-numeric/zero/negative values, which would disable eviction or spin the sweep.
-const positiveInt = z.number({ coerce: true }).int().positive();
+import { positiveIntSchema } from '../schemas';
 
 /** Configuration for the MCP Server Trigger node. */
 @Config
@@ -15,13 +12,13 @@ export class McpServerConfig {
 	 * that disconnect without sending an explicit DELETE rely on this to avoid
 	 * leaking sessions. Default: 1 hour.
 	 */
-	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS', positiveInt)
+	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS', positiveIntSchema)
 	sessionIdleTtl: number = Time.hours.toMilliseconds;
 
 	/**
 	 * Interval in milliseconds between sweeps that evict idle sessions.
 	 * Default: 5 minutes.
 	 */
-	@Env('N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS', positiveInt)
+	@Env('N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS', positiveIntSchema)
 	sessionSweepInterval: number = 5 * Time.minutes.toMilliseconds;
 }

--- a/packages/@n8n/config/src/configs/mcp-server.config.ts
+++ b/packages/@n8n/config/src/configs/mcp-server.config.ts
@@ -1,6 +1,10 @@
 import { Time } from '@n8n/constants';
+import z from 'zod';
 
 import { Config, Env } from '../decorators';
+
+// Reject non-numeric/zero/negative values, which would disable eviction or spin the sweep.
+const positiveInt = z.number({ coerce: true }).int().positive();
 
 /** Configuration for the MCP Server Trigger node. */
 @Config
@@ -11,13 +15,13 @@ export class McpServerConfig {
 	 * that disconnect without sending an explicit DELETE rely on this to avoid
 	 * leaking sessions. Default: 1 hour.
 	 */
-	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS')
+	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS', positiveInt)
 	sessionIdleTtl: number = Time.hours.toMilliseconds;
 
 	/**
 	 * Interval in milliseconds between sweeps that evict idle sessions.
 	 * Default: 5 minutes.
 	 */
-	@Env('N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS')
+	@Env('N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS', positiveInt)
 	sessionSweepInterval: number = 5 * Time.minutes.toMilliseconds;
 }

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -30,6 +30,7 @@ import { InstanceSettingsLoaderConfig } from './configs/instance-settings-loader
 import { LicenseConfig } from './configs/license.config';
 import { LoggingConfig } from './configs/logging.config';
 import { McpClientConfig } from './configs/mcp-client.config';
+import { McpServerConfig } from './configs/mcp-server.config';
 import { MfaConfig } from './configs/mfa.config';
 import { MultiMainSetupConfig } from './configs/multi-main-setup.config';
 import { NodesConfig } from './configs/nodes.config';
@@ -72,6 +73,7 @@ export { WorkflowsConfig } from './configs/workflows.config';
 export * from './custom-types';
 export { DeploymentConfig } from './configs/deployment.config';
 export { McpClientConfig } from './configs/mcp-client.config';
+export { McpServerConfig } from './configs/mcp-server.config';
 export { MfaConfig } from './configs/mfa.config';
 export { HiringBannerConfig } from './configs/hiring-banner.config';
 export { HttpRequestConfig } from './configs/http-request.config';
@@ -278,6 +280,9 @@ export class GlobalConfig {
 
 	@Nested
 	mcpClient: McpClientConfig;
+
+	@Nested
+	mcpServer: McpServerConfig;
 
 	@Nested
 	instanceAi: InstanceAiConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -296,6 +296,10 @@ describe('GlobalConfig', () => {
 			cacheTtl: 300000,
 			cacheMaxSize: 500,
 		},
+		mcpServer: {
+			sessionIdleTtl: 3600000,
+			sessionSweepInterval: 300000,
+		},
 		chatHub: {
 			executionContextTtl: 3600,
 			maxBufferedChunks: 1000,

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -32,9 +32,6 @@ import { StreamableHttpTransport } from './transport/StreamableHttpTransport';
 import type { CompressionResponse, McpTransport } from './transport/Transport';
 import { TransportFactory } from './transport/TransportFactory';
 
-export const DEFAULT_SESSION_IDLE_TTL_MS = 60 * 60 * 1000;
-export const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
-
 export interface HandlePostResult {
 	wasToolCall: boolean;
 	toolCallInfo?: McpToolCallInfo;
@@ -78,10 +75,9 @@ export class McpServer {
 		this.transportFactory = new TransportFactory();
 		this.pendingCallsManager = new PendingCallsManager();
 		this.executionCoordinator = new ExecutionCoordinator();
-		// DI can't resolve @n8n/config in the node test env, so fall back to defaults there.
 		const config = Container.get(McpServerConfig);
-		this.idleTtlMs = config.sessionIdleTtl ?? DEFAULT_SESSION_IDLE_TTL_MS;
-		this.sweepIntervalMs = config.sessionSweepInterval ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
+		this.idleTtlMs = config.sessionIdleTtl;
+		this.sweepIntervalMs = config.sessionSweepInterval;
 		this.logger.debug('McpServer created');
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -1,4 +1,6 @@
 import type { Tool } from '@langchain/core/tools';
+import { McpServerConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type {
@@ -29,6 +31,9 @@ import type { SSETransport } from './transport/SSETransport';
 import { StreamableHttpTransport } from './transport/StreamableHttpTransport';
 import type { CompressionResponse, McpTransport } from './transport/Transport';
 import { TransportFactory } from './transport/TransportFactory';
+
+export const DEFAULT_SESSION_IDLE_TTL_MS = 60 * 60 * 1000;
+export const DEFAULT_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 export interface HandlePostResult {
 	wasToolCall: boolean;
@@ -63,18 +68,27 @@ export class McpServer {
 	private pendingGateResults: Record<string, CredentialCheckResult> = {};
 	private logger: Logger;
 
+	private idleTtlMs: number;
+	private sweepIntervalMs: number;
+	private sweepTimer?: ReturnType<typeof setInterval>;
+
 	private constructor(logger: Logger) {
 		this.logger = logger;
 		this.sessionManager = new SessionManager(new InMemorySessionStore());
 		this.transportFactory = new TransportFactory();
 		this.pendingCallsManager = new PendingCallsManager();
 		this.executionCoordinator = new ExecutionCoordinator();
+		// DI can't resolve @n8n/config in the node test env, so fall back to defaults there.
+		const config = Container.get(McpServerConfig);
+		this.idleTtlMs = config.sessionIdleTtl ?? DEFAULT_SESSION_IDLE_TTL_MS;
+		this.sweepIntervalMs = config.sessionSweepInterval ?? DEFAULT_SESSION_SWEEP_INTERVAL_MS;
 		this.logger.debug('McpServer created');
 	}
 
 	static instance(logger: Logger): McpServer {
 		if (!McpServer.instance_) {
 			McpServer.instance_ = new McpServer(logger);
+			McpServer.instance_.startSweep();
 			logger.debug('Created singleton McpServer');
 		}
 		return McpServer.instance_;
@@ -129,6 +143,8 @@ export class McpServer {
 		gateResult?: CredentialCheckResult,
 	): Promise<HandlePostResult> {
 		const sessionId = this.getSessionId(req);
+		// A request on a known session counts as activity (no-op for unknown ids).
+		if (sessionId) this.sessionManager.touch(sessionId);
 		let transport = sessionId ? this.sessionManager.getTransport(sessionId) : undefined;
 		const rawBody = req.rawBody.toString();
 		let toolCallInfo = MessageParser.extractToolCallInfo(rawBody);
@@ -366,6 +382,44 @@ export class McpServer {
 
 	setExecutionStrategy(strategy: ExecutionStrategy): void {
 		this.executionCoordinator.setStrategy(strategy);
+	}
+
+	private startSweep(): void {
+		if (this.sweepTimer) return;
+		this.sweepTimer = setInterval(() => {
+			void this.runSweep();
+		}, this.sweepIntervalMs);
+		this.sweepTimer.unref?.();
+	}
+
+	stopSweep(): void {
+		if (this.sweepTimer) {
+			clearInterval(this.sweepTimer);
+			this.sweepTimer = undefined;
+		}
+	}
+
+	private async runSweep(): Promise<void> {
+		for (const sessionId of this.sessionManager.getIdleSessions(this.idleTtlMs)) {
+			// SSE sessions are released reliably via the connection's close handler.
+			// Only Streamable HTTP sessions (stateless clients that never DELETE) leak.
+			if (this.sessionManager.getTransport(sessionId)?.transportType !== 'streamableHttp') continue;
+			// Don't evict a session whose tool call is still awaiting a result.
+			if (this.hasInFlightWork(sessionId)) continue;
+			try {
+				this.logger.debug(`Evicting idle MCP session ${sessionId}`);
+				await this.cleanupSession(sessionId);
+			} catch (error) {
+				this.logger.error(
+					`Failed to evict idle MCP session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
+	}
+
+	private hasInFlightWork(sessionId: string): boolean {
+		if (this.pendingCallsManager.hasForSession(sessionId)) return true;
+		return Object.values(this.pendingResponses).some((pending) => pending.sessionId === sessionId);
 	}
 
 	isQueueMode(): boolean {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -419,6 +419,11 @@ export class McpServer {
 
 	private hasInFlightWork(sessionId: string): boolean {
 		if (this.pendingCallsManager.hasForSession(sessionId)) return true;
+		// Direct-mode tool calls are tracked only by resolveFunctions for their whole
+		// duration; queue-mode also uses pendingResponses below.
+		const ownsSession = (callId: string) =>
+			callId === sessionId || callId.startsWith(`${sessionId}_`);
+		if (Object.keys(this.resolveFunctions).some(ownsSession)) return true;
 		return Object.values(this.pendingResponses).some((pending) => pending.sessionId === sessionId);
 	}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -11,14 +11,18 @@ import {
 	createMockServer,
 	MCP_SESSION_ID_HEADER,
 } from './helpers';
+import type { McpServerConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+
 import { QueuedExecutionStrategy } from '../execution/QueuedExecutionStrategy';
-import {
-	McpServer,
-	DEFAULT_SESSION_IDLE_TTL_MS,
-	DEFAULT_SESSION_SWEEP_INTERVAL_MS,
-} from '../McpServer';
+import { McpServer } from '../McpServer';
 import { InMemorySessionStore } from '../session/InMemorySessionStore';
 import type { SessionManager } from '../session/SessionManager';
+
+const setEvictionConfig = (sessionIdleTtl: number, sessionSweepInterval: number) =>
+	vi
+		.mocked(Container.get)
+		.mockReturnValue({ sessionIdleTtl, sessionSweepInterval } as McpServerConfig);
 
 describe('McpServer', () => {
 	let mcpServer: McpServer;
@@ -27,6 +31,7 @@ describe('McpServer', () => {
 	beforeEach(() => {
 		// Reset singleton for testing
 		(McpServer as unknown as { instance_: McpServer | undefined }).instance_ = undefined;
+		setEvictionConfig(60 * 60 * 1000, 5 * 60 * 1000);
 		mockLogger = createMockLogger();
 		mcpServer = McpServer.instance(mockLogger);
 	});
@@ -213,8 +218,8 @@ describe('McpServer', () => {
 	});
 
 	describe('idle session eviction', () => {
-		const TTL = DEFAULT_SESSION_IDLE_TTL_MS;
-		const INTERVAL = DEFAULT_SESSION_SWEEP_INTERVAL_MS;
+		const TTL = 1_000;
+		const INTERVAL = 500;
 
 		const sessionManagerOf = (server: McpServer) =>
 			(server as unknown as { sessionManager: SessionManager }).sessionManager;
@@ -234,7 +239,8 @@ describe('McpServer', () => {
 		beforeEach(() => {
 			vi.useFakeTimers();
 			vi.setSystemTime(0);
-			// Recreate the singleton so its sweep interval is registered under fake timers.
+			// Recreate the singleton with short timings registered under fake timers.
+			setEvictionConfig(TTL, INTERVAL);
 			(McpServer as unknown as { instance_: McpServer | undefined }).instance_ = undefined;
 			mcpServer = McpServer.instance(mockLogger);
 		});
@@ -250,6 +256,15 @@ describe('McpServer', () => {
 			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
 
 			expect(mcpServer.getTransport('idle-1')).toBeUndefined();
+		});
+
+		it('should close the server when evicting a session', async () => {
+			await registerSession('idle-3');
+			const server = sessionManagerOf(mcpServer).getServer('idle-3');
+
+			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
+
+			expect(server?.close).toHaveBeenCalled();
 		});
 
 		it('should not evict an idle SSE session (cleaned up via connection close instead)', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -12,8 +12,13 @@ import {
 	MCP_SESSION_ID_HEADER,
 } from './helpers';
 import { QueuedExecutionStrategy } from '../execution/QueuedExecutionStrategy';
-import { McpServer } from '../McpServer';
+import {
+	McpServer,
+	DEFAULT_SESSION_IDLE_TTL_MS,
+	DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+} from '../McpServer';
 import { InMemorySessionStore } from '../session/InMemorySessionStore';
+import type { SessionManager } from '../session/SessionManager';
 
 describe('McpServer', () => {
 	let mcpServer: McpServer;
@@ -27,6 +32,7 @@ describe('McpServer', () => {
 	});
 
 	afterEach(() => {
+		mcpServer.stopSweep();
 		// Clean up singleton
 		(McpServer as unknown as { instance_: McpServer | undefined }).instance_ = undefined;
 	});
@@ -203,6 +209,87 @@ describe('McpServer', () => {
 
 		it('should not be in queue mode by default', () => {
 			expect(mcpServer.isQueueMode()).toBe(false);
+		});
+	});
+
+	describe('idle session eviction', () => {
+		const TTL = DEFAULT_SESSION_IDLE_TTL_MS;
+		const INTERVAL = DEFAULT_SESSION_SWEEP_INTERVAL_MS;
+
+		const sessionManagerOf = (server: McpServer) =>
+			(server as unknown as { sessionManager: SessionManager }).sessionManager;
+
+		const registerSession = async (
+			sessionId: string,
+			transportType: 'sse' | 'streamableHttp' = 'streamableHttp',
+		) =>
+			await sessionManagerOf(mcpServer).registerSession(
+				sessionId,
+				createMockServer(),
+				createMockTransport(sessionId, transportType),
+			);
+
+		const touch = (sessionId: string) => sessionManagerOf(mcpServer).touch(sessionId);
+
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(0);
+			// Recreate the singleton so its sweep interval is registered under fake timers.
+			(McpServer as unknown as { instance_: McpServer | undefined }).instance_ = undefined;
+			mcpServer = McpServer.instance(mockLogger);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should evict a session idle past the ttl', async () => {
+			await registerSession('idle-1');
+			expect(mcpServer.getTransport('idle-1')).toBeDefined();
+
+			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
+
+			expect(mcpServer.getTransport('idle-1')).toBeUndefined();
+		});
+
+		it('should not evict an idle SSE session (cleaned up via connection close instead)', async () => {
+			await registerSession('sse-1', 'sse');
+
+			await vi.advanceTimersByTimeAsync(TTL * 2);
+
+			expect(mcpServer.getTransport('sse-1')).toBeDefined();
+		});
+
+		it('should not evict a session that keeps being touched', async () => {
+			await registerSession('active-1');
+
+			// Stay active across more than a full idle window via periodic touches.
+			await vi.advanceTimersByTimeAsync(TTL - INTERVAL);
+			touch('active-1');
+			await vi.advanceTimersByTimeAsync(TTL - INTERVAL);
+
+			expect(mcpServer.getTransport('active-1')).toBeDefined();
+		});
+
+		it('should not evict a session with an in-flight pending response', async () => {
+			await registerSession('busy-1');
+			mcpServer.storePendingResponse('busy-1', 'msg-1');
+
+			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
+			expect(mcpServer.getTransport('busy-1')).toBeDefined();
+
+			mcpServer.removePendingResponse('busy-1', 'msg-1');
+			await vi.advanceTimersByTimeAsync(INTERVAL);
+			expect(mcpServer.getTransport('busy-1')).toBeUndefined();
+		});
+
+		it('should stop evicting once the sweep is stopped', async () => {
+			await registerSession('idle-2');
+			mcpServer.stopSweep();
+
+			await vi.advanceTimersByTimeAsync(TTL * 2);
+
+			expect(mcpServer.getTransport('idle-2')).toBeDefined();
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -283,6 +283,22 @@ describe('McpServer', () => {
 			expect(mcpServer.getTransport('busy-1')).toBeUndefined();
 		});
 
+		it('should not evict a session with an in-flight direct-mode tool call', async () => {
+			await registerSession('busy-2');
+			// Direct mode tracks the running call only via resolveFunctions.
+			const resolveFunctions = (
+				mcpServer as unknown as { resolveFunctions: Record<string, () => void> }
+			).resolveFunctions;
+			resolveFunctions['busy-2_msg-1'] = () => {};
+
+			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
+			expect(mcpServer.getTransport('busy-2')).toBeDefined();
+
+			delete resolveFunctions['busy-2_msg-1'];
+			await vi.advanceTimersByTimeAsync(INTERVAL);
+			expect(mcpServer.getTransport('busy-2')).toBeUndefined();
+		});
+
 		it('should stop evicting once the sweep is stopped', async () => {
 			await registerSession('idle-2');
 			mcpServer.stopSweep();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/PendingCallsManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/execution/PendingCallsManager.ts
@@ -6,6 +6,9 @@ export interface PendingCall {
 	timer: ReturnType<typeof setTimeout>;
 }
 
+/** Pending calls are keyed `${sessionId}_${messageId}`. */
+const belongsToSession = (callId: string, sessionId: string) => callId.startsWith(`${sessionId}_`);
+
 export class PendingCallsManager {
 	private pendingCalls: Record<string, PendingCall> = {};
 
@@ -62,13 +65,17 @@ export class PendingCallsManager {
 		return callId in this.pendingCalls;
 	}
 
+	hasForSession(sessionId: string): boolean {
+		return Object.keys(this.pendingCalls).some((callId) => belongsToSession(callId, sessionId));
+	}
+
 	remove(callId: string): void {
 		delete this.pendingCalls[callId];
 	}
 
 	cleanupBySessionId(sessionId: string): void {
 		for (const callId of Object.keys(this.pendingCalls)) {
-			if (callId.startsWith(`${sessionId}_`)) {
+			if (belongsToSession(callId, sessionId)) {
 				const pending = this.pendingCalls[callId];
 				if (pending) {
 					clearTimeout(pending.timer);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/SessionManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/SessionManager.ts
@@ -47,8 +47,10 @@ export class SessionManager {
 	}
 
 	async destroySession(sessionId: string): Promise<void> {
+		const session = this.sessions[sessionId];
 		await this.store.unregister(sessionId);
 		delete this.sessions[sessionId];
+		await session?.server.close().catch(() => {});
 	}
 
 	getSession(sessionId: string): SessionInfo | undefined {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/SessionManager.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/SessionManager.ts
@@ -8,6 +8,8 @@ export interface SessionInfo {
 	sessionId: string;
 	server: Server;
 	transport: McpTransport;
+	/** Epoch ms of the last client request on this session; drives idle eviction. */
+	lastActivityAt: number;
 }
 
 export class SessionManager {
@@ -23,10 +25,25 @@ export class SessionManager {
 	): Promise<void> {
 		if (!sessionId) return;
 		await this.store.register(sessionId);
-		this.sessions[sessionId] = { sessionId, server, transport };
+		this.sessions[sessionId] = { sessionId, server, transport, lastActivityAt: Date.now() };
 		if (tools) {
 			this.store.setTools(sessionId, tools);
 		}
+	}
+
+	/** Mark a session as active. No-op for unknown sessions (never resurrects one). */
+	touch(sessionId: string): void {
+		const session = this.sessions[sessionId];
+		if (session) {
+			session.lastActivityAt = Date.now();
+		}
+	}
+
+	/** Session ids that have been idle for at least `idleTtlMs`. */
+	getIdleSessions(idleTtlMs: number, now: number = Date.now()): string[] {
+		return Object.values(this.sessions)
+			.filter((session) => now - session.lastActivityAt >= idleTtlMs)
+			.map((session) => session.sessionId);
 	}
 
 	async destroySession(sessionId: string): Promise<void> {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/__tests__/SessionManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/__tests__/SessionManager.test.ts
@@ -96,6 +96,35 @@ describe('SessionManager', () => {
 			await expect(manager.destroySession('non-existent')).resolves.not.toThrow();
 			expect(mockStore.unregister).toHaveBeenCalledWith('non-existent');
 		});
+
+		it('should close the server it held to release the transport', async () => {
+			const server = createMockServer();
+			await manager.registerSession('session-1', server, createMockTransport('session-1'));
+
+			await manager.destroySession('session-1');
+
+			expect(server.close).toHaveBeenCalled();
+		});
+
+		it('should not recurse when closing the server re-enters destroySession', async () => {
+			const server = createMockServer();
+			// Production wires transport.onclose -> cleanupSession -> destroySession, so
+			// server.close() re-enters this method for the same session.
+			let reentered = false;
+			server.close.mockImplementation(async () => {
+				if (!reentered) {
+					reentered = true;
+					await manager.destroySession('session-1');
+				}
+			});
+			await manager.registerSession('session-1', server, createMockTransport('session-1'));
+
+			await expect(manager.destroySession('session-1')).resolves.not.toThrow();
+
+			// Deleted before close, so the re-entrant call finds nothing and skips close.
+			expect(server.close).toHaveBeenCalledTimes(1);
+			expect(manager.getSession('session-1')).toBeUndefined();
+		});
 	});
 
 	describe('getSession', () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/__tests__/SessionManager.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/session/__tests__/SessionManager.test.ts
@@ -28,7 +28,7 @@ describe('SessionManager', () => {
 			await manager.registerSession('session-1', server, transport);
 
 			expect(mockStore.register).toHaveBeenCalledWith('session-1');
-			expect(manager.getSession('session-1')).toEqual({
+			expect(manager.getSession('session-1')).toMatchObject({
 				sessionId: 'session-1',
 				server,
 				transport,
@@ -106,7 +106,7 @@ describe('SessionManager', () => {
 
 			const session = manager.getSession('session-1');
 
-			expect(session).toEqual({
+			expect(session).toMatchObject({
 				sessionId: 'session-1',
 				server,
 				transport,
@@ -115,6 +115,89 @@ describe('SessionManager', () => {
 
 		it('should return undefined for unregistered session', () => {
 			expect(manager.getSession('non-existent')).toBeUndefined();
+		});
+	});
+
+	describe('activity tracking', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should stamp lastActivityAt on register', async () => {
+			vi.setSystemTime(1_000);
+			await manager.registerSession(
+				'session-1',
+				createMockServer(),
+				createMockTransport('session-1'),
+			);
+
+			expect(manager.getSession('session-1')?.lastActivityAt).toBe(1_000);
+		});
+
+		it('should refresh lastActivityAt on touch', async () => {
+			vi.setSystemTime(1_000);
+			await manager.registerSession(
+				'session-1',
+				createMockServer(),
+				createMockTransport('session-1'),
+			);
+
+			vi.setSystemTime(5_000);
+			manager.touch('session-1');
+
+			expect(manager.getSession('session-1')?.lastActivityAt).toBe(5_000);
+		});
+
+		it('should ignore touch for unknown session without creating it', () => {
+			manager.touch('non-existent');
+			expect(manager.getSession('non-existent')).toBeUndefined();
+		});
+
+		describe('getIdleSessions', () => {
+			it('should return sessions idle for at least the ttl', async () => {
+				vi.setSystemTime(0);
+				await manager.registerSession('stale', createMockServer(), createMockTransport('stale'));
+
+				expect(manager.getIdleSessions(1_000, 2_500)).toEqual(['stale']);
+			});
+
+			it('should treat exactly-ttl as idle', async () => {
+				vi.setSystemTime(1_000);
+				await manager.registerSession(
+					'session-1',
+					createMockServer(),
+					createMockTransport('session-1'),
+				);
+
+				expect(manager.getIdleSessions(1_000, 2_000)).toEqual(['session-1']);
+			});
+
+			it('should exclude recently touched sessions', async () => {
+				vi.setSystemTime(0);
+				await manager.registerSession('active', createMockServer(), createMockTransport('active'));
+				await manager.registerSession('stale', createMockServer(), createMockTransport('stale'));
+
+				vi.setSystemTime(5_000);
+				manager.touch('active');
+
+				expect(manager.getIdleSessions(1_000, 5_500)).toEqual(['stale']);
+			});
+
+			it('should not return destroyed sessions', async () => {
+				vi.setSystemTime(0);
+				await manager.registerSession(
+					'session-1',
+					createMockServer(),
+					createMockTransport('session-1'),
+				);
+				await manager.destroySession('session-1');
+
+				expect(manager.getIdleSessions(1_000, 10_000)).toEqual([]);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

In queue mode with the MCP webhook enabled, the `McpServer` singleton accumulated `SessionInfo` objects (each holding an MCP SDK `Server`, an open transport, and the tool list, ~5MB) without ever releasing them, eventually exhausting the heap and OOM-crashing the webhook process.

The root cause is a cleanup asymmetry: SSE sessions are released reliably via `resp.on('close')` on their long-lived connection, but Streamable HTTP sessions were only cleaned up on `transport.onclose`, which the MCP SDK fires **only** on an explicit HTTP `DELETE`. Stateless clients (e.g. AWS Bedrock Agents) never send `DELETE`, so their sessions were retained forever.

This adds **idle-TTL eviction**:
- `SessionManager` now stamps `lastActivityAt` and exposes `touch` / `getIdleSessions`.
- `McpServer` runs an `unref`'d periodic sweep that evicts idle sessions through the existing `cleanupSession`, skipping sessions with in-flight work and only targeting **Streamable HTTP** transports (SSE already cleans up via its connection close handler).
- Timings are configurable via a new `McpServerConfig`:
  - `N8N_MCP_SERVER_SESSION_IDLE_TTL_MS` (default `3600000` = 1h)
  - `N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS` (default `300000` = 5m)

The fix is self-contained in `nodes-langchain` + `@n8n/config`.

## How to test

1. Start n8n with a short idle window so you don't have to wait an hour:
   ```bash
   N8N_MCP_SERVER_SESSION_IDLE_TTL_MS=10000 \
   N8N_MCP_SERVER_SESSION_SWEEP_INTERVAL_MS=5000 \
   N8N_LOG_LEVEL=debug \
   pnpm dev
   ```
2. Import the workflow below, set the **MCP Server Trigger** path to `mcp-test`, and **activate** it (so the production URL serves it).
3. Run the loop below to open many Streamable HTTP sessions that never send `DELETE` (simulating a stateless client like AWS Bedrock).
4. Observe the logs: each request logs `New session initialized`, and after the idle window the sweep logs `Evicting idle MCP session <id>`. On `master` the eviction never happens and the sessions accumulate.
5. Confirm an **active** session is not evicted by issuing a `tools/call` within the idle window.

<details>
<summary>Example workflow (import into n8n)</summary>

```json
{
  "name": "MCP Server idle-eviction test",
  "nodes": [
    {
      "parameters": {
        "authentication": "none",
        "path": "mcp-test"
      },
      "id": "0c0a0a0a-0000-4000-8000-000000000001",
      "name": "MCP Server Trigger",
      "type": "@n8n/n8n-nodes-langchain.mcpTrigger",
      "typeVersion": 2,
      "position": [420, 300]
    },
    {
      "parameters": {},
      "id": "0c0a0a0a-0000-4000-8000-000000000002",
      "name": "Calculator",
      "type": "@n8n/n8n-nodes-langchain.toolCalculator",
      "typeVersion": 1,
      "position": [220, 460]
    }
  ],
  "connections": {
    "Calculator": {
      "ai_tool": [
        [{ "node": "MCP Server Trigger", "type": "ai_tool", "index": 0 }]
      ]
    }
  },
  "settings": {},
  "active": false
}
```

</details>

<details>
<summary>Test command (open 50 sessions that never DELETE)</summary>

```bash
URL=http://localhost:5678/mcp/mcp-test
for i in $(seq 1 50); do
  curl -s -D - -o /dev/null -X POST "$URL" \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"leak-test","version":"1.0"}}}' \
  | grep -i 'mcp-session-id'   # each line = a new retained session
done
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5329

fixes #32889

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33201">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->