### PR TITLE
fix(editor): Use menu icon for collapsed Instance AI sidebar toggle (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiViewHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiViewHeader.vue
@@ -40,7 +40,7 @@ const threadCreditsUsed = computed(() =>
 					:show-after="TOOLTIP_DELAY_MS"
 				>
 					<N8nIconButton
-						icon="bars"
+						icon="menu"
 						variant="ghost"
 						size="small"
 						icon-size="large"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiViewHeader.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiViewHeader.vue
@@ -40,7 +40,7 @@ const threadCreditsUsed = computed(() =>
 					:show-after="TOOLTIP_DELAY_MS"
 				>
 					<N8nIconButton
-						icon="history"
+						icon="bars"
 						variant="ghost"
 						size="small"
 						icon-size="large"


### PR DESCRIPTION
## Summary

The collapsed-sidebar toggle button in the Instance AI view header now uses the `menu` (hamburger) icon instead of the `history` (clock) icon. The button opens the chat-history sidebar, and the hamburger is the clearer affordance for that action.

## How to test

1. Open the Instance AI view.
2. Collapse the chat-history sidebar.
3. The toggle button in the header shows a hamburger (`menu`) icon. Clicking it re-opens the sidebar.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
