### PR TITLE
feat(editor): Make data table artifacts editable when AI is not running

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
@@ -1,10 +1,15 @@
 <script lang="ts" setup>
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
+import { getResourcePermissions } from '@n8n/permissions';
 import DataTableTable from '@/features/core/dataTable/components/dataGrid/DataTableTable.vue';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { collectActiveBuilderAgents } from '../builderAgents';
+import { useThread } from '../instanceAi.store';
 
 const props = withDefaults(
 	defineProps<{
@@ -18,10 +23,54 @@ const props = withDefaults(
 
 const i18n = useI18n();
 const dataTableStore = useDataTableStore();
+const projectsStore = useProjectsStore();
+const sourceControlStore = useSourceControlStore();
+const thread = useThread();
 
 const dataTable = ref<DataTable | null>(null);
 const isLoading = ref(false);
 const fetchError = ref<string | null>(null);
+
+// === Editing lock ===
+// The grid is editable only while the AI is not running, so user edits can't
+// race agent mutations (each successful data-tables tool call re-fetches and
+// remounts the grid, which would discard an in-progress cell edit). Hydration
+// counts as busy: right after a reload an in-flight run isn't known until the
+// thread status resolves.
+const isAgentWorking = computed(
+	() =>
+		thread.isHydratingThread ||
+		thread.isStreaming ||
+		thread.isSendingMessage ||
+		thread.isAwaitingConfirmation ||
+		collectActiveBuilderAgents(thread.messages).length > 0,
+);
+
+// Whether the user may edit rows of this table. Resolved from the table's own
+// project — dataTableStore.projectPermissions derives from the route-driven
+// currentProject, which is null on the instance-ai route.
+const canWriteRows = ref(false);
+
+watch(
+	() => props.projectId,
+	async (projectId) => {
+		canWriteRows.value = false;
+		if (!projectId) return;
+		try {
+			const project = await projectsStore.fetchProject(projectId);
+			if (projectId !== props.projectId) return; // stale response
+			canWriteRows.value = getResourcePermissions(project.scopes).dataTable.writeRow === true;
+		} catch {
+			canWriteRows.value = false;
+		}
+	},
+	{ immediate: true },
+);
+
+const isReadOnly = computed(
+	() =>
+		isAgentWorking.value || !canWriteRows.value || sourceControlStore.preferences.branchReadOnly,
+);
 
 async function fetchDataTable(id: string, projectId: string) {
 	const isRefresh = dataTable.value?.id === id;
@@ -33,9 +82,10 @@ async function fetchDataTable(id: string, projectId: string) {
 	}
 
 	try {
-		const result = isRefresh
-			? await dataTableStore.fetchDataTableDetails(id, projectId)
-			: await dataTableStore.fetchOrFindDataTable(id, projectId);
+		// Always fetch fresh details (never the store cache): the grid is
+		// editable, so stale columns would let the user edit against a schema
+		// the agent has since changed.
+		const result = await dataTableStore.fetchDataTableDetails(id, projectId);
 		dataTable.value = result ?? null;
 		if (!result) {
 			fetchError.value = i18n.baseText('instanceAi.dataTablePreview.fetchError');
@@ -70,12 +120,13 @@ watch(
 			<N8nText color="text-light">{{ fetchError }}</N8nText>
 		</div>
 
-		<!-- Data table grid -->
+		<!-- Data table grid. readOnly is part of the key because the grid bakes it
+		     into its column defs at grid-ready, so flipping it requires a remount. -->
 		<DataTableTable
 			v-if="dataTable"
-			:key="props.refreshKey"
+			:key="`${props.refreshKey}-${isReadOnly}`"
 			:data-table="dataTable"
-			:read-only="true"
+			:read-only="isReadOnly"
 		/>
 
 		<!-- Loading overlay (shown during initial load or when no data table yet) -->

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
@@ -2,11 +2,9 @@
 import { computed, ref, watch } from 'vue';
 import { N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
-import { getResourcePermissions } from '@n8n/permissions';
 import DataTableTable from '@/features/core/dataTable/components/dataGrid/DataTableTable.vue';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
-import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { collectActiveBuilderAgents } from '../builderAgents';
 import { useThread } from '../instanceAi.store';
@@ -23,7 +21,6 @@ const props = withDefaults(
 
 const i18n = useI18n();
 const dataTableStore = useDataTableStore();
-const projectsStore = useProjectsStore();
 const sourceControlStore = useSourceControlStore();
 const thread = useThread();
 
@@ -46,30 +43,10 @@ const isAgentWorking = computed(
 		collectActiveBuilderAgents(thread.messages).length > 0,
 );
 
-// Whether the user may edit rows of this table. Resolved from the table's own
-// project — dataTableStore.projectPermissions derives from the route-driven
-// currentProject, which is null on the instance-ai route.
-const canWriteRows = ref(false);
-
-watch(
-	() => props.projectId,
-	async (projectId) => {
-		canWriteRows.value = false;
-		if (!projectId) return;
-		try {
-			const project = await projectsStore.fetchProject(projectId);
-			if (projectId !== props.projectId) return; // stale response
-			canWriteRows.value = getResourcePermissions(project.scopes).dataTable.writeRow === true;
-		} catch {
-			canWriteRows.value = false;
-		}
-	},
-	{ immediate: true },
-);
-
+// No client-side RBAC gate, mirroring DataTableDetailsView: the server
+// enforces write permissions and rejections surface as error toasts.
 const isReadOnly = computed(
-	() =>
-		isAgentWorking.value || !canWriteRows.value || sourceControlStore.preferences.branchReadOnly,
+	() => isAgentWorking.value || sourceControlStore.preferences.branchReadOnly,
 );
 
 async function fetchDataTable(id: string, projectId: string) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiDataTablePreview.vue
@@ -34,12 +34,16 @@ const fetchError = ref<string | null>(null);
 // remounts the grid, which would discard an in-progress cell edit). Hydration
 // counts as busy: right after a reload an in-flight run isn't known until the
 // thread status resolves.
+// Note: a live confirmation keeps the run active (activeRunId stays set →
+// isStreaming), so isStreaming already covers "awaiting confirmation mid-run".
+// isAwaitingConfirmation is deliberately NOT used here — it can linger on
+// confirmations left unresolved by an already-finished run, which would keep
+// the grid locked while no run is active.
 const isAgentWorking = computed(
 	() =>
 		thread.isHydratingThread ||
 		thread.isStreaming ||
 		thread.isSendingMessage ||
-		thread.isAwaitingConfirmation ||
 		collectActiveBuilderAgents(thread.messages).length > 0,
 );
 

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.test.ts
@@ -723,6 +723,34 @@ describe('useAgGrid', () => {
 
 			// No assertion needed, just ensuring no error is thrown
 		});
+
+		it('should not paste when cell is not editable (e.g. read-only grid)', () => {
+			const { onGridReady } = createComposable();
+			onGridReady({ api: mockGridApi as GridApi } as GridReadyEvent);
+
+			const mockColumn = {
+				getColId: () => 'name',
+				getColDef: () => ({ cellDataType: 'text' }),
+				isCellEditable: () => false,
+			} as unknown as Column;
+
+			const mockRow = { setDataValue: vi.fn() };
+
+			mockGridApi.getFocusedCell = vi.fn(() => ({
+				rowIndex: 0,
+				column: mockColumn,
+				rowPinned: null,
+			}));
+			mockGridApi.getEditingCells = vi.fn(() => []);
+			mockGridApi.getDisplayedRowAtIndex = vi.fn(() => mockRow as unknown as IRowNode);
+
+			const mockUseClipboard = vi.mocked(useClipboard);
+			const onPasteCallback =
+				mockUseClipboard.mock.calls[mockUseClipboard.mock.calls.length - 1]?.[0]?.onPaste;
+			onPasteCallback?.('some data');
+
+			expect(mockRow.setDataValue).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('onCellClicked', () => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.test.ts
@@ -415,6 +415,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'name',
 				getColDef: () => ({ cellDataType: 'text' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -444,6 +445,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'age',
 				getColDef: () => ({ cellDataType: 'number' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -473,6 +475,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'age',
 				getColDef: () => ({ cellDataType: 'number' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -502,6 +505,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'createdAt',
 				getColDef: () => ({ cellDataType: 'date' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -531,6 +535,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'createdAt',
 				getColDef: () => ({ cellDataType: 'date' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -560,6 +565,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'active',
 				getColDef: () => ({ cellDataType: 'boolean' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -589,6 +595,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'active',
 				getColDef: () => ({ cellDataType: 'boolean' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -618,6 +625,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'active',
 				getColDef: () => ({ cellDataType: 'boolean' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -667,6 +675,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'name',
 				getColDef: () => ({ cellDataType: 'text' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			const mockRow = {
@@ -696,6 +705,7 @@ describe('useAgGrid', () => {
 			const mockColumn = {
 				getColId: () => 'name',
 				getColDef: () => ({ cellDataType: 'text' }),
+				isCellEditable: () => true,
 			} as unknown as Column;
 
 			mockGridApi.getFocusedCell = vi.fn(() => ({

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useAgGrid.ts
@@ -46,6 +46,11 @@ export const useAgGrid = <TRowData extends Record<string, unknown> = Record<stri
 		const row = initializedGridApi.value.getDisplayedRowAtIndex(focusedCell.rowIndex);
 		if (!row) return;
 
+		// setDataValue bypasses colDef.editable, so check it explicitly — pasting
+		// must respect the same rules as regular editing (read-only grid, add-row
+		// row, oversized values).
+		if (!focusedCell.column.isCellEditable(row)) return;
+
 		const colDef = focusedCell.column.getColDef();
 		if (colDef.cellDataType === 'text') {
 			row.setDataValue(focusedCell.column.getColId(), data);

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.test.ts
@@ -166,6 +166,30 @@ describe('useDataTableColumns', () => {
 			expect(colDef.editable).toBe(false);
 			expect(colDef.width).toBe(100);
 		});
+
+		it('should suppress column move only in read-only mode', () => {
+			const column: DataTableColumn = { id: 'col1', name: 'Column 1', type: 'string', index: 0 };
+
+			const editable = useDataTableColumns({
+				onDeleteColumn: mockOnDeleteColumn,
+				onRenameColumn: mockOnRenameColumn,
+				onAddRowClick: mockOnAddRowClick,
+				onAddColumn: mockOnAddColumn,
+				isTextEditorOpen,
+				readOnly: ref(false),
+			});
+			expect(editable.createColumnDef(column).suppressMovable).toBe(false);
+
+			const readOnly = useDataTableColumns({
+				onDeleteColumn: mockOnDeleteColumn,
+				onRenameColumn: mockOnRenameColumn,
+				onAddRowClick: mockOnAddRowClick,
+				onAddColumn: mockOnAddColumn,
+				isTextEditorOpen,
+				readOnly: ref(true),
+			});
+			expect(readOnly.createColumnDef(column).suppressMovable).toBe(true);
+		});
 	});
 
 	describe('loadColumns', () => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/composables/useDataTableColumns.ts
@@ -69,6 +69,9 @@ export const useDataTableColumns = ({
 				!isOversizedValue(params.data?.[col.name]),
 			resizable: true,
 			lockPinned: true,
+			// Dragging a column triggers a server-side move, so block it in
+			// read-only mode.
+			suppressMovable: readOnly.value,
 			headerComponent: ColumnHeader,
 			headerComponentParams: {
 				onDelete: onDeleteColumn,


### PR DESCRIPTION
## Summary

Data table artifacts in the AI Assistant are editable when the agent is idle and read-only while it works. The artifact preview reuses `DataTableTable` (the same grid as the main data-table view), giving inline cell editing, add/delete rows, and column operations directly in the panel.

The grid locks whenever the agent is active — streaming, sending, awaiting confirmation, hydrating after reload, or running a background builder — so user edits never race agent mutations. After each agent data-table tool call the grid re-fetches and remounts, keeping the view current.

Permissions match the main view (`DataTableDetailsView`): no client-side RBAC gate — the server enforces write access and rejections surface as error toasts. The only added read-only condition is source-control `branchReadOnly`.

Two read-only bypasses in the shared grid are fixed (both also affected the main data-table view):
- **Paste**: `setDataValue` ignored `colDef.editable`, so pasting into a focused cell could mutate a read-only grid. Now guarded with `column.isCellEditable(row)`.
- **Column drag**: dragging a column header issued a server-side move with no read-only check. Now `suppressMovable` is set in read-only mode.

## How to test

1. Open the AI Assistant, ask it to create or modify a data table.
2. While the agent is running, confirm the data table artifact grid is read-only (no cell editing, no add row/column).
3. Once the agent finishes, edit a cell, add a row, add/rename/delete a column — changes persist.
4. Send another message; confirm the grid locks again while the agent works and refreshes when it edits the table.
5. On a source-control read-only branch, confirm the grid stays read-only even when idle.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-517


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
