### PR TITLE
feat(core): Expose per-trigger workflow publication status (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -221,6 +221,11 @@ export {
 	type WorkflowExecutionStatus,
 } from './schemas/workflow-execution-status.schema';
 
+export {
+	WorkflowPublicationStatusSchema,
+	type WorkflowPublicationStatus,
+} from './schemas/workflow-publication-status.schema';
+
 export type { UsageState } from './schemas/usage.schema';
 
 export type {

--- a/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
@@ -9,7 +9,6 @@ export const WorkflowPublicationStatusSchema = z.object({
 	triggers: z.array(
 		z.object({
 			nodeId: z.string(),
-			nodeName: z.string(),
 			status: z.enum(['activated', 'failed']),
 			errorMessage: z.string().nullable(),
 		}),

--- a/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const WorkflowPublicationStatusSchema = z.object({
+	status: z.enum(['in_progress', 'published', 'partial', 'failed', 'not_published']),
+	// version whose triggers are currently registered; null if nothing is live
+	liveVersionId: z.string().nullable(),
+	// version being published right now; null unless status === 'in_progress'
+	pendingVersionId: z.string().nullable(),
+	triggers: z.array(
+		z.object({
+			nodeId: z.string(),
+			nodeName: z.string(),
+			status: z.enum(['activated', 'failed']),
+			errorMessage: z.string().nullable(),
+		}),
+	),
+});
+
+export type WorkflowPublicationStatus = z.infer<typeof WorkflowPublicationStatusSchema>;

--- a/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/workflow-publication-status.schema.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 
 export const WorkflowPublicationStatusSchema = z.object({
+	// overall status of the workflow publication process
+	// in_progress: currently being published
+	// published: all triggers activated
+	// partial: some triggers failed to activate
+	// failed: all triggers failed to activate
+	// not_published: no version is live
+	// NOTE: the trigger statuses are finalized at the end of the publication process,
+	// so if there is a publication in progress, there may be some mismatch.
 	status: z.enum(['in_progress', 'published', 'partial', 'failed', 'not_published']),
 	// version whose triggers are currently registered; null if nothing is live
 	liveVersionId: z.string().nullable(),

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { Brackets, DataSource, Repository } from '@n8n/typeorm';
+import { Brackets, DataSource, In, Repository } from '@n8n/typeorm';
 import type { EntityManager } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -20,13 +20,14 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	}
 
 	/**
-	 * Latest outbox record for a workflow (highest id), or null.
-	 *
-	 * NOTE: this is only guaranteed to return a result for in-progress publications.
-	 * Any terminal (completed, partial, or failed) publication may have been cleaned up.
-	 * */
-	async findLatestByWorkflowId(workflowId: string): Promise<WorkflowPublicationOutbox | null> {
-		return await this.findOne({ where: { workflowId }, order: { id: 'DESC' } });
+	 * The in-flight (pending or in_progress) publication for a workflow, or null.
+	 * In-progress is preferred when both exist.
+	 */
+	async findInFlightByWorkflowId(workflowId: string): Promise<WorkflowPublicationOutbox | null> {
+		const inFlight = await this.find({
+			where: { workflowId, status: In([Status.InProgress, Status.Pending]) },
+		});
+		return inFlight.find((record) => record.status === Status.InProgress) ?? inFlight[0] ?? null;
 	}
 
 	/**

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -19,7 +19,12 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		super(WorkflowPublicationOutbox, dataSource.manager);
 	}
 
-	/** Latest outbox record for a workflow (highest id), or null. */
+	/**
+	 * Latest outbox record for a workflow (highest id), or null.
+	 *
+	 * NOTE: this is only guaranteed to return a result for in-progress publications.
+	 * Any terminal (completed, partial, or failed) publication may have been cleaned up.
+	 * */
 	async findLatestByWorkflowId(workflowId: string): Promise<WorkflowPublicationOutbox | null> {
 		return await this.findOne({ where: { workflowId }, order: { id: 'DESC' } });
 	}

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -19,6 +19,11 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		super(WorkflowPublicationOutbox, dataSource.manager);
 	}
 
+	/** Latest outbox record for a workflow (highest id), or null. */
+	async findLatestByWorkflowId(workflowId: string): Promise<WorkflowPublicationOutbox | null> {
+		return await this.findOne({ where: { workflowId }, order: { id: 'DESC' } });
+	}
+
 	/**
 	 * Enqueue a publication for `workflowId`. If a pending record is already in
 	 * place for the same workflow, its `publishedVersionId` is updated in place,

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -24,8 +24,9 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	 * In-progress is preferred when both exist.
 	 */
 	async findInFlightByWorkflowId(workflowId: string): Promise<WorkflowPublicationOutbox | null> {
-		const inFlight = await this.find({
-			where: { workflowId, status: In([Status.InProgress, Status.Pending]) },
+		const inFlight = await this.findBy({
+			workflowId,
+			status: In([Status.InProgress, Status.Pending]),
 		});
 		return inFlight.find((record) => record.status === Status.InProgress) ?? inFlight[0] ?? null;
 	}

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -1,0 +1,214 @@
+import type {
+	WorkflowPublicationOutbox,
+	WorkflowPublicationOutboxRepository,
+	WorkflowPublicationTriggerStatus,
+	WorkflowPublicationTriggerStatusRepository,
+} from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { WorkflowPublicationStatusService } from '@/workflows/publication/workflow-publication-status.service';
+
+describe('WorkflowPublicationStatusService', () => {
+	const outboxRepository = mock<WorkflowPublicationOutboxRepository>();
+	const triggerStatusRepository = mock<WorkflowPublicationTriggerStatusRepository>();
+
+	const service = new WorkflowPublicationStatusService(outboxRepository, triggerStatusRepository);
+
+	const WORKFLOW_ID = 'wf-1';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	function makeOutbox(
+		overrides: Partial<WorkflowPublicationOutbox> = {},
+	): WorkflowPublicationOutbox {
+		return {
+			id: 1,
+			workflowId: WORKFLOW_ID,
+			publishedVersionId: 'v-2',
+			status: 'completed',
+			errorMessage: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			...overrides,
+		} as WorkflowPublicationOutbox;
+	}
+
+	function makeRow(
+		overrides: Partial<WorkflowPublicationTriggerStatus> = {},
+	): WorkflowPublicationTriggerStatus {
+		return {
+			workflowId: WORKFLOW_ID,
+			nodeId: 'node-1',
+			nodeName: 'Trigger',
+			versionId: 'v-2',
+			status: 'activated',
+			errorMessage: null,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+			...overrides,
+		} as WorkflowPublicationTriggerStatus;
+	}
+
+	describe('never published (no rows, no outbox)', () => {
+		it('returns not_published with null versions', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(null);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('not_published');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBeNull();
+			expect(result.triggers).toEqual([]);
+		});
+	});
+
+	describe('first publish in flight (no rows; outbox in_progress)', () => {
+		it('returns in_progress with pending version and null live version', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('in_progress');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBe('v-2');
+			expect(result.triggers).toEqual([]);
+		});
+	});
+
+	describe('first publish pending (no rows; outbox pending)', () => {
+		it('returns in_progress with pending version and null live version', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'pending', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('in_progress');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBe('v-2');
+			expect(result.triggers).toEqual([]);
+		});
+	});
+
+	describe('republish over live v1 (rows v1 all activated; outbox in_progress pubVer v2)', () => {
+		it('returns in_progress with live v1 and pending v2', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
+				makeRow({ versionId: 'v-1', status: 'activated' }),
+			]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('in_progress');
+			expect(result.liveVersionId).toBe('v-1');
+			expect(result.pendingVersionId).toBe('v-2');
+		});
+	});
+
+	describe('all triggers up (rows v2 all activated; latest outbox completed)', () => {
+		it('returns published with live v2 and null pending', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'completed', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
+				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'activated' }),
+				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'activated' }),
+			]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('published');
+			expect(result.liveVersionId).toBe('v-2');
+			expect(result.pendingVersionId).toBeNull();
+		});
+	});
+
+	describe('mixed (rows v2: ≥1 activated, ≥1 failed)', () => {
+		it('returns partial with live v2 and null pending', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'partial_success', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
+				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'activated' }),
+				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'failed', errorMessage: 'oops' }),
+			]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('partial');
+			expect(result.liveVersionId).toBe('v-2');
+			expect(result.pendingVersionId).toBeNull();
+		});
+	});
+
+	describe('all failed (rows v2 all failed)', () => {
+		it('returns failed with null live version and null pending', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'failed', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
+				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'failed', errorMessage: 'err1' }),
+				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'failed', errorMessage: 'err2' }),
+			]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('failed');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBeNull();
+		});
+	});
+
+	describe('no rows + latest outbox failed', () => {
+		it('returns failed with null versions', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'failed', publishedVersionId: 'v-1' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('failed');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBeNull();
+		});
+	});
+
+	describe('triggers field mirrors the rows', () => {
+		it('maps nodeId, nodeName, status, errorMessage from rows', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'partial_success' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
+				makeRow({
+					nodeId: 'n1',
+					nodeName: 'Webhook',
+					status: 'activated',
+					errorMessage: null,
+				}),
+				makeRow({
+					nodeId: 'n2',
+					nodeName: 'Cron',
+					status: 'failed',
+					errorMessage: 'schedule parse error',
+				}),
+			]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.triggers).toEqual([
+				{ nodeId: 'n1', nodeName: 'Webhook', status: 'activated', errorMessage: null },
+				{ nodeId: 'n2', nodeName: 'Cron', status: 'failed', errorMessage: 'schedule parse error' },
+			]);
+		});
+	});
+});

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -41,7 +41,6 @@ describe('WorkflowPublicationStatusService', () => {
 		return {
 			workflowId: WORKFLOW_ID,
 			nodeId: 'node-1',
-			nodeName: 'Trigger',
 			versionId: 'v-2',
 			status: 'activated',
 			errorMessage: null,
@@ -184,20 +183,18 @@ describe('WorkflowPublicationStatusService', () => {
 	});
 
 	describe('triggers field mirrors the rows', () => {
-		it('maps nodeId, nodeName, status, errorMessage from rows', async () => {
+		it('maps nodeId, status, errorMessage from rows', async () => {
 			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'partial_success' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({
 					nodeId: 'n1',
-					nodeName: 'Webhook',
 					status: 'activated',
 					errorMessage: null,
 				}),
 				makeRow({
 					nodeId: 'n2',
-					nodeName: 'Cron',
 					status: 'failed',
 					errorMessage: 'schedule parse error',
 				}),
@@ -206,8 +203,8 @@ describe('WorkflowPublicationStatusService', () => {
 			const result = await service.getStatus(WORKFLOW_ID);
 
 			expect(result.triggers).toEqual([
-				{ nodeId: 'n1', nodeName: 'Webhook', status: 'activated', errorMessage: null },
-				{ nodeId: 'n2', nodeName: 'Cron', status: 'failed', errorMessage: 'schedule parse error' },
+				{ nodeId: 'n1', status: 'activated', errorMessage: null },
+				{ nodeId: 'n2', status: 'failed', errorMessage: 'schedule parse error' },
 			]);
 		});
 	});

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -4,7 +4,7 @@ import type {
 	WorkflowPublicationTriggerStatus,
 	WorkflowPublicationTriggerStatusRepository,
 } from '@n8n/db';
-import { mock } from 'jest-mock-extended';
+import { mock } from 'vitest-mock-extended';
 
 import { WorkflowPublicationStatusService } from '@/workflows/publication/workflow-publication-status.service';
 
@@ -17,7 +17,7 @@ describe('WorkflowPublicationStatusService', () => {
 	const WORKFLOW_ID = 'wf-1';
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	function makeOutbox(
@@ -177,6 +177,21 @@ describe('WorkflowPublicationStatusService', () => {
 			const result = await service.getStatus(WORKFLOW_ID);
 
 			expect(result.status).toBe('failed');
+			expect(result.liveVersionId).toBeNull();
+			expect(result.pendingVersionId).toBeNull();
+		});
+	});
+
+	describe('unpublished (rows cleared; latest outbox completed)', () => {
+		it('returns not_published with null versions', async () => {
+			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+				makeOutbox({ status: 'completed', publishedVersionId: 'v-2' }),
+			);
+			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
+
+			const result = await service.getStatus(WORKFLOW_ID);
+
+			expect(result.status).toBe('not_published');
 			expect(result.liveVersionId).toBeNull();
 			expect(result.pendingVersionId).toBeNull();
 		});

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-status.service.test.ts
@@ -50,9 +50,9 @@ describe('WorkflowPublicationStatusService', () => {
 		} as WorkflowPublicationTriggerStatus;
 	}
 
-	describe('never published (no rows, no outbox)', () => {
+	describe('never published (no rows, no in-flight publication)', () => {
 		it('returns not_published with null versions', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(null);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
 
 			const result = await service.getStatus(WORKFLOW_ID);
@@ -64,9 +64,9 @@ describe('WorkflowPublicationStatusService', () => {
 		});
 	});
 
-	describe('first publish in flight (no rows; outbox in_progress)', () => {
+	describe('first publish in flight (no rows; in-flight in_progress)', () => {
 		it('returns in_progress with pending version and null live version', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
@@ -80,9 +80,9 @@ describe('WorkflowPublicationStatusService', () => {
 		});
 	});
 
-	describe('first publish pending (no rows; outbox pending)', () => {
+	describe('first publish pending (no rows; in-flight pending)', () => {
 		it('returns in_progress with pending version and null live version', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'pending', publishedVersionId: 'v-2' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
@@ -96,9 +96,9 @@ describe('WorkflowPublicationStatusService', () => {
 		});
 	});
 
-	describe('republish over live v1 (rows v1 all activated; outbox in_progress pubVer v2)', () => {
+	describe('republish over live v1 (rows v1 all activated; in-flight in_progress pubVer v2)', () => {
 		it('returns in_progress with live v1 and pending v2', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
 				makeOutbox({ status: 'in_progress', publishedVersionId: 'v-2' }),
 			);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
@@ -113,11 +113,9 @@ describe('WorkflowPublicationStatusService', () => {
 		});
 	});
 
-	describe('all triggers up (rows v2 all activated; latest outbox completed)', () => {
+	describe('all triggers up (rows v2 all activated; no in-flight publication)', () => {
 		it('returns published with live v2 and null pending', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'completed', publishedVersionId: 'v-2' }),
-			);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'activated' }),
 				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'activated' }),
@@ -133,9 +131,7 @@ describe('WorkflowPublicationStatusService', () => {
 
 	describe('mixed (rows v2: ≥1 activated, ≥1 failed)', () => {
 		it('returns partial with live v2 and null pending', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'partial_success', publishedVersionId: 'v-2' }),
-			);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'activated' }),
 				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'failed', errorMessage: 'oops' }),
@@ -151,9 +147,7 @@ describe('WorkflowPublicationStatusService', () => {
 
 	describe('all failed (rows v2 all failed)', () => {
 		it('returns failed with null live version and null pending', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'failed', publishedVersionId: 'v-2' }),
-			);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({ nodeId: 'node-1', versionId: 'v-2', status: 'failed', errorMessage: 'err1' }),
 				makeRow({ nodeId: 'node-2', versionId: 'v-2', status: 'failed', errorMessage: 'err2' }),
@@ -167,26 +161,22 @@ describe('WorkflowPublicationStatusService', () => {
 		});
 	});
 
-	describe('no rows + latest outbox failed', () => {
-		it('returns failed with null versions', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'failed', publishedVersionId: 'v-1' }),
-			);
+	describe('no rows, no in-flight publication (e.g. a prior publish failed terminally)', () => {
+		it('returns not_published: settled state comes from rows, terminal outbox is not consulted', async () => {
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
 
 			const result = await service.getStatus(WORKFLOW_ID);
 
-			expect(result.status).toBe('failed');
+			expect(result.status).toBe('not_published');
 			expect(result.liveVersionId).toBeNull();
 			expect(result.pendingVersionId).toBeNull();
 		});
 	});
 
-	describe('unpublished (rows cleared; latest outbox completed)', () => {
+	describe('unpublished (rows cleared; no in-flight publication)', () => {
 		it('returns not_published with null versions', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'completed', publishedVersionId: 'v-2' }),
-			);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([]);
 
 			const result = await service.getStatus(WORKFLOW_ID);
@@ -199,9 +189,7 @@ describe('WorkflowPublicationStatusService', () => {
 
 	describe('triggers field mirrors the rows', () => {
 		it('maps nodeId, status, errorMessage from rows', async () => {
-			outboxRepository.findLatestByWorkflowId.mockResolvedValue(
-				makeOutbox({ status: 'partial_success' }),
-			);
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 			triggerStatusRepository.findByWorkflowId.mockResolvedValue([
 				makeRow({
 					nodeId: 'n1',

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -1,10 +1,11 @@
-import { Service } from '@n8n/di';
 import type { WorkflowPublicationStatus } from '@n8n/api-types';
 import {
+	type WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxRepository,
-	WorkflowPublicationOutboxStatus,
+	type WorkflowPublicationTriggerStatus,
 	WorkflowPublicationTriggerStatusRepository,
 } from '@n8n/db';
+import { Service } from '@n8n/di';
 
 @Service()
 export class WorkflowPublicationStatusService {
@@ -14,8 +15,10 @@ export class WorkflowPublicationStatusService {
 	) {}
 
 	async getStatus(workflowId: string): Promise<WorkflowPublicationStatus> {
-		const latest = await this.outboxRepository.findLatestByWorkflowId(workflowId);
-		const rows = await this.triggerStatusRepository.findByWorkflowId(workflowId);
+		const [latest, rows] = await Promise.all([
+			this.outboxRepository.findLatestByWorkflowId(workflowId),
+			this.triggerStatusRepository.findByWorkflowId(workflowId),
+		]);
 
 		const triggers = rows.map((r) => ({
 			nodeId: r.nodeId,
@@ -36,8 +39,8 @@ export class WorkflowPublicationStatusService {
 
 	private deriveStatus(
 		isPublishing: boolean,
-		rows: Array<{ status: 'activated' | 'failed' }>,
-		latest: { status: WorkflowPublicationOutboxStatus } | null,
+		rows: WorkflowPublicationTriggerStatus[],
+		latest: WorkflowPublicationOutbox | null,
 	): WorkflowPublicationStatus['status'] {
 		if (isPublishing) return 'in_progress';
 		if (rows.length > 0) {

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -1,6 +1,5 @@
 import type { WorkflowPublicationStatus } from '@n8n/api-types';
 import {
-	type WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxRepository,
 	type WorkflowPublicationTriggerStatus,
 	WorkflowPublicationTriggerStatusRepository,
@@ -17,14 +16,16 @@ export class WorkflowPublicationStatusService {
 	/**
 	 * Get the publication status of a workflow.
 	 *
-	 * The status is derived from the latest outbox record and the current trigger statuses.
+	 * The status is derived from the in-flight publication (if any) and the current
+	 * trigger statuses. The outbox is consulted only to detect an in-flight
+	 * publication; settled state comes entirely from the trigger statuses.
 	 *
 	 * NOTE: we only update the trigger statuses when a publication is completed,
 	 * so if there is a publication in progress, the trigger statuses may not reflect the latest state.
 	 */
 	async getStatus(workflowId: string): Promise<WorkflowPublicationStatus> {
-		const [latestPublicationRequest, currentTriggerStatuses] = await Promise.all([
-			this.outboxRepository.findLatestByWorkflowId(workflowId),
+		const [inFlightPublication, currentTriggerStatuses] = await Promise.all([
+			this.outboxRepository.findInFlightByWorkflowId(workflowId),
 			this.triggerStatusRepository.findByWorkflowId(workflowId),
 		]);
 
@@ -34,27 +35,20 @@ export class WorkflowPublicationStatusService {
 			errorMessage: r.errorMessage,
 		}));
 
-		const isPublishing =
-			latestPublicationRequest?.status === 'pending' ||
-			latestPublicationRequest?.status === 'in_progress';
-		const pendingVersionId = isPublishing ? latestPublicationRequest.publishedVersionId : null;
+		const isPublishing = inFlightPublication !== null;
+		const pendingVersionId = inFlightPublication?.publishedVersionId ?? null;
 
 		// The settled rows ARE the running triggers; if none are activated, nothing is live.
 		const activatedRow = currentTriggerStatuses.find((r) => r.status === 'activated');
 		const liveVersionId = activatedRow?.versionId ?? null;
 
-		const status = this.deriveStatus(
-			isPublishing,
-			currentTriggerStatuses,
-			latestPublicationRequest,
-		);
+		const status = this.deriveStatus(isPublishing, currentTriggerStatuses);
 		return { status, liveVersionId, pendingVersionId, triggers };
 	}
 
 	private deriveStatus(
 		isPublishing: boolean,
 		currentTriggerStatuses: WorkflowPublicationTriggerStatus[],
-		latestPublicationRequest: WorkflowPublicationOutbox | null,
 	): WorkflowPublicationStatus['status'] {
 		if (isPublishing) return 'in_progress';
 		if (currentTriggerStatuses.length > 0) {
@@ -65,6 +59,6 @@ export class WorkflowPublicationStatusService {
 					? 'partial'
 					: 'failed';
 		}
-		return latestPublicationRequest?.status === 'failed' ? 'failed' : 'not_published';
+		return 'not_published';
 	}
 }

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -19,7 +19,6 @@ export class WorkflowPublicationStatusService {
 
 		const triggers = rows.map((r) => ({
 			nodeId: r.nodeId,
-			nodeName: r.nodeName,
 			status: r.status,
 			errorMessage: r.errorMessage,
 		}));

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -27,8 +27,8 @@ export class WorkflowPublicationStatusService {
 		const pendingVersionId = isPublishing ? latest.publishedVersionId : null;
 
 		// The settled rows ARE the running triggers; if none are activated, nothing is live.
-		const hasActivated = rows.some((r) => r.status === 'activated');
-		const liveVersionId = hasActivated ? rows[0].versionId : null;
+		const activatedRow = rows.find((r) => r.status === 'activated');
+		const liveVersionId = activatedRow?.versionId ?? null;
 
 		const status = this.deriveStatus(isPublishing, rows, latest);
 		return { status, liveVersionId, pendingVersionId, triggers };

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -51,14 +51,9 @@ export class WorkflowPublicationStatusService {
 		currentTriggerStatuses: WorkflowPublicationTriggerStatus[],
 	): WorkflowPublicationStatus['status'] {
 		if (isPublishing) return 'in_progress';
-		if (currentTriggerStatuses.length > 0) {
-			const failed = currentTriggerStatuses.filter((r) => r.status === 'failed').length;
-			return failed === 0
-				? 'published'
-				: failed < currentTriggerStatuses.length
-					? 'partial'
-					: 'failed';
-		}
-		return 'not_published';
+		if (currentTriggerStatuses.length === 0) return 'not_published';
+		const failed = currentTriggerStatuses.filter((r) => r.status === 'failed').length;
+		if (failed === 0) return 'published';
+		return failed < currentTriggerStatuses.length ? 'partial' : 'failed';
 	}
 }

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -1,0 +1,49 @@
+import { Service } from '@n8n/di';
+import {
+	WorkflowPublicationOutboxRepository,
+	WorkflowPublicationTriggerStatusRepository,
+} from '@n8n/db';
+import type { WorkflowPublicationStatus } from '@n8n/api-types';
+
+@Service()
+export class WorkflowPublicationStatusService {
+	constructor(
+		private readonly outboxRepository: WorkflowPublicationOutboxRepository,
+		private readonly triggerStatusRepository: WorkflowPublicationTriggerStatusRepository,
+	) {}
+
+	async getStatus(workflowId: string): Promise<WorkflowPublicationStatus> {
+		const latest = await this.outboxRepository.findLatestByWorkflowId(workflowId);
+		const rows = await this.triggerStatusRepository.findByWorkflowId(workflowId);
+
+		const triggers = rows.map((r) => ({
+			nodeId: r.nodeId,
+			nodeName: r.nodeName,
+			status: r.status,
+			errorMessage: r.errorMessage,
+		}));
+
+		const isPublishing = latest?.status === 'pending' || latest?.status === 'in_progress';
+		const pendingVersionId = isPublishing ? latest.publishedVersionId : null;
+
+		// The settled rows ARE the running triggers; if none are activated, nothing is live.
+		const hasActivated = rows.some((r) => r.status === 'activated');
+		const liveVersionId = hasActivated ? rows[0].versionId : null;
+
+		const status = this.deriveStatus(isPublishing, rows, latest);
+		return { status, liveVersionId, pendingVersionId, triggers };
+	}
+
+	private deriveStatus(
+		isPublishing: boolean,
+		rows: Array<{ status: 'activated' | 'failed' }>,
+		latest: { status: string } | null,
+	): WorkflowPublicationStatus['status'] {
+		if (isPublishing) return 'in_progress';
+		if (rows.length > 0) {
+			const failed = rows.filter((r) => r.status === 'failed').length;
+			return failed === 0 ? 'published' : failed < rows.length ? 'partial' : 'failed';
+		}
+		return latest?.status === 'failed' ? 'failed' : 'not_published';
+	}
+}

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -1,9 +1,10 @@
 import { Service } from '@n8n/di';
+import type { WorkflowPublicationStatus } from '@n8n/api-types';
 import {
 	WorkflowPublicationOutboxRepository,
+	WorkflowPublicationOutboxStatus,
 	WorkflowPublicationTriggerStatusRepository,
 } from '@n8n/db';
-import type { WorkflowPublicationStatus } from '@n8n/api-types';
 
 @Service()
 export class WorkflowPublicationStatusService {
@@ -37,7 +38,7 @@ export class WorkflowPublicationStatusService {
 	private deriveStatus(
 		isPublishing: boolean,
 		rows: Array<{ status: 'activated' | 'failed' }>,
-		latest: { status: string } | null,
+		latest: { status: WorkflowPublicationOutboxStatus } | null,
 	): WorkflowPublicationStatus['status'] {
 		if (isPublishing) return 'in_progress';
 		if (rows.length > 0) {

--- a/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-status.service.ts
@@ -14,39 +14,57 @@ export class WorkflowPublicationStatusService {
 		private readonly triggerStatusRepository: WorkflowPublicationTriggerStatusRepository,
 	) {}
 
+	/**
+	 * Get the publication status of a workflow.
+	 *
+	 * The status is derived from the latest outbox record and the current trigger statuses.
+	 *
+	 * NOTE: we only update the trigger statuses when a publication is completed,
+	 * so if there is a publication in progress, the trigger statuses may not reflect the latest state.
+	 */
 	async getStatus(workflowId: string): Promise<WorkflowPublicationStatus> {
-		const [latest, rows] = await Promise.all([
+		const [latestPublicationRequest, currentTriggerStatuses] = await Promise.all([
 			this.outboxRepository.findLatestByWorkflowId(workflowId),
 			this.triggerStatusRepository.findByWorkflowId(workflowId),
 		]);
 
-		const triggers = rows.map((r) => ({
+		const triggers = currentTriggerStatuses.map((r) => ({
 			nodeId: r.nodeId,
 			status: r.status,
 			errorMessage: r.errorMessage,
 		}));
 
-		const isPublishing = latest?.status === 'pending' || latest?.status === 'in_progress';
-		const pendingVersionId = isPublishing ? latest.publishedVersionId : null;
+		const isPublishing =
+			latestPublicationRequest?.status === 'pending' ||
+			latestPublicationRequest?.status === 'in_progress';
+		const pendingVersionId = isPublishing ? latestPublicationRequest.publishedVersionId : null;
 
 		// The settled rows ARE the running triggers; if none are activated, nothing is live.
-		const activatedRow = rows.find((r) => r.status === 'activated');
+		const activatedRow = currentTriggerStatuses.find((r) => r.status === 'activated');
 		const liveVersionId = activatedRow?.versionId ?? null;
 
-		const status = this.deriveStatus(isPublishing, rows, latest);
+		const status = this.deriveStatus(
+			isPublishing,
+			currentTriggerStatuses,
+			latestPublicationRequest,
+		);
 		return { status, liveVersionId, pendingVersionId, triggers };
 	}
 
 	private deriveStatus(
 		isPublishing: boolean,
-		rows: WorkflowPublicationTriggerStatus[],
-		latest: WorkflowPublicationOutbox | null,
+		currentTriggerStatuses: WorkflowPublicationTriggerStatus[],
+		latestPublicationRequest: WorkflowPublicationOutbox | null,
 	): WorkflowPublicationStatus['status'] {
 		if (isPublishing) return 'in_progress';
-		if (rows.length > 0) {
-			const failed = rows.filter((r) => r.status === 'failed').length;
-			return failed === 0 ? 'published' : failed < rows.length ? 'partial' : 'failed';
+		if (currentTriggerStatuses.length > 0) {
+			const failed = currentTriggerStatuses.filter((r) => r.status === 'failed').length;
+			return failed === 0
+				? 'published'
+				: failed < currentTriggerStatuses.length
+					? 'partial'
+					: 'failed';
 		}
-		return latest?.status === 'failed' ? 'failed' : 'not_published';
+		return latestPublicationRequest?.status === 'failed' ? 'failed' : 'not_published';
 	}
 }

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -668,6 +668,13 @@ export class WorkflowsController {
 		_res: unknown,
 		@Param('workflowId') workflowId: string,
 	): Promise<WorkflowPublicationStatus> {
+		// The publication tables this reads are only populated when the publication
+		// service is enabled; otherwise the legacy path runs and the status would be
+		// misleading. Treat the route as absent when the feature is off.
+		if (!this.globalConfig.workflows.useWorkflowPublicationService) {
+			throw new NotFoundError('Workflow publication status is not available');
+		}
+
 		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, req.user, [
 			'workflow:read',
 		]);

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -7,6 +7,7 @@ import {
 	ImportWorkflowFromUrlDto,
 	TransferWorkflowBodyDto,
 	UpdateWorkflowDto,
+	type WorkflowPublicationStatus,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { OutboundHttp, SsrfBlockedIpError, SsrfProtectionService } from '@n8n/backend-network';
@@ -43,6 +44,7 @@ import { WorkflowCreationService } from './workflow-creation.service';
 import { createWorkflowEntityFromPayload } from './workflow-entity-mapper';
 import { WorkflowExecutionService } from './workflow-execution.service';
 import { WorkflowFinderService } from './workflow-finder.service';
+import { WorkflowPublicationStatusService } from './publication/workflow-publication-status.service';
 import { WorkflowRequest } from './workflow.request';
 import { WorkflowService } from './workflow.service';
 import { EnterpriseWorkflowService } from './workflow.service.ee';
@@ -87,6 +89,7 @@ export class WorkflowsController {
 		private readonly ssrfConfig: SsrfProtectionConfig,
 		private readonly ssrfProtectionService: SsrfProtectionService,
 		private readonly outboundHttp: OutboundHttp,
+		private readonly workflowPublicationStatusService: WorkflowPublicationStatusService,
 	) {}
 
 	@Post('/')
@@ -656,6 +659,22 @@ export class WorkflowsController {
 		);
 
 		return lastExecution ?? null;
+	}
+
+	@Get('/:workflowId/publication-status')
+	@ProjectScope('workflow:read')
+	async getPublicationStatus(
+		req: AuthenticatedRequest,
+		_res: unknown,
+		@Param('workflowId') workflowId: string,
+	): Promise<WorkflowPublicationStatus> {
+		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, req.user, [
+			'workflow:read',
+		]);
+		if (!workflow) {
+			throw new NotFoundError(`Workflow with ID "${workflowId}" does not exist`);
+		}
+		return await this.workflowPublicationStatusService.getStatus(workflowId);
 	}
 
 	@Post('/with-node-types')

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -40,11 +40,11 @@ import express from 'express';
 import { calculateWorkflowChecksum, ensureError } from 'n8n-workflow';
 
 import { CollaborationService } from '../collaboration/collaboration.service';
+import { WorkflowPublicationStatusService } from './publication/workflow-publication-status.service';
 import { WorkflowCreationService } from './workflow-creation.service';
 import { createWorkflowEntityFromPayload } from './workflow-entity-mapper';
 import { WorkflowExecutionService } from './workflow-execution.service';
 import { WorkflowFinderService } from './workflow-finder.service';
-import { WorkflowPublicationStatusService } from './publication/workflow-publication-status.service';
 import { WorkflowRequest } from './workflow.request';
 import { WorkflowService } from './workflow.service';
 import { EnterpriseWorkflowService } from './workflow.service.ee';

--- a/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
+++ b/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
@@ -90,34 +90,49 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		expect(await repo.findByWorkflowId(ownWorkflow.id)).toEqual([]);
 	});
 
-	it('findLatestByWorkflowId returns the highest-id outbox record', async () => {
+	it('findInFlightByWorkflowId prefers the in_progress record when a pending one coexists', async () => {
 		const wf = await createWorkflow();
-		// Insert two completed rows — completed has no partial-unique-index constraint,
-		// so both rows can coexist for the same workflowId.
-		const first = outboxRepo.create({
-			workflowId: wf.id,
-			publishedVersionId: 'v1',
-			status: 'completed',
-			errorMessage: null,
-		});
-		const second = outboxRepo.create({
-			workflowId: wf.id,
-			publishedVersionId: 'v2',
-			status: 'completed',
-			errorMessage: null,
-		});
-		await outboxRepo.save(first);
-		await outboxRepo.save(second);
+		// A pending and an in_progress record can coexist for the same workflow:
+		// their (workflowId, status) tuples differ, so the partial unique index allows both.
+		await outboxRepo.save(
+			outboxRepo.create({
+				workflowId: wf.id,
+				publishedVersionId: 'v-pending',
+				status: 'pending',
+				errorMessage: null,
+			}),
+		);
+		await outboxRepo.save(
+			outboxRepo.create({
+				workflowId: wf.id,
+				publishedVersionId: 'v-in-progress',
+				status: 'in_progress',
+				errorMessage: null,
+			}),
+		);
 
-		const latest = await outboxRepo.findLatestByWorkflowId(wf.id);
-		expect(latest).not.toBeNull();
-		expect(latest!.id).toBe(second.id);
-		expect(latest!.publishedVersionId).toBe('v2');
+		const inFlight = await outboxRepo.findInFlightByWorkflowId(wf.id);
+		expect(inFlight).not.toBeNull();
+		expect(inFlight!.status).toBe('in_progress');
+		expect(inFlight!.publishedVersionId).toBe('v-in-progress');
 	});
 
-	it('findLatestByWorkflowId returns null when no outbox records exist', async () => {
+	it('findInFlightByWorkflowId ignores terminal records', async () => {
 		const wf = await createWorkflow();
-		const result = await outboxRepo.findLatestByWorkflowId(wf.id);
-		expect(result).toBeNull();
+		await outboxRepo.save(
+			outboxRepo.create({
+				workflowId: wf.id,
+				publishedVersionId: 'v1',
+				status: 'completed',
+				errorMessage: null,
+			}),
+		);
+
+		expect(await outboxRepo.findInFlightByWorkflowId(wf.id)).toBeNull();
+	});
+
+	it('findInFlightByWorkflowId returns null when no outbox records exist', async () => {
+		const wf = await createWorkflow();
+		expect(await outboxRepo.findInFlightByWorkflowId(wf.id)).toBeNull();
 	});
 });

--- a/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
+++ b/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
@@ -2,6 +2,7 @@ import { createWorkflow, createWorkflowHistory, testDb } from '@n8n/backend-test
 import type { IWorkflowDb } from '@n8n/db';
 import {
 	WorkflowHistoryRepository,
+	WorkflowPublicationOutboxRepository,
 	WorkflowPublicationTriggerStatusRepository,
 	WorkflowRepository,
 } from '@n8n/db';
@@ -16,6 +17,7 @@ async function seedVersions(workflow: IWorkflowDb, versionIds: string[]): Promis
 
 describe('WorkflowPublicationTriggerStatusRepository', () => {
 	let repo: WorkflowPublicationTriggerStatusRepository;
+	let outboxRepo: WorkflowPublicationOutboxRepository;
 	let workflowRepository: WorkflowRepository;
 	let workflowHistoryRepository: WorkflowHistoryRepository;
 
@@ -26,6 +28,7 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 	beforeAll(async () => {
 		await testDb.init();
 		repo = Container.get(WorkflowPublicationTriggerStatusRepository);
+		outboxRepo = Container.get(WorkflowPublicationOutboxRepository);
 		workflowRepository = Container.get(WorkflowRepository);
 		workflowHistoryRepository = Container.get(WorkflowHistoryRepository);
 
@@ -33,7 +36,7 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		await seedVersions(workflow, ['v1', 'v2']);
 	});
 	afterEach(async () => {
-		await testDb.truncate(['WorkflowPublicationTriggerStatus']);
+		await testDb.truncate(['WorkflowPublicationTriggerStatus', 'WorkflowPublicationOutbox']);
 	});
 	afterAll(async () => await testDb.terminate());
 
@@ -85,5 +88,36 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 		await workflowHistoryRepository.delete({ versionId: 'v-version-cascade' });
 
 		expect(await repo.findByWorkflowId(ownWorkflow.id)).toEqual([]);
+	});
+
+	it('findLatestByWorkflowId returns the highest-id outbox record', async () => {
+		const wf = await createWorkflow();
+		// Insert two completed rows — completed has no partial-unique-index constraint,
+		// so both rows can coexist for the same workflowId.
+		const first = outboxRepo.create({
+			workflowId: wf.id,
+			publishedVersionId: 'v1',
+			status: 'completed',
+			errorMessage: null,
+		});
+		const second = outboxRepo.create({
+			workflowId: wf.id,
+			publishedVersionId: 'v2',
+			status: 'completed',
+			errorMessage: null,
+		});
+		await outboxRepo.save(first);
+		await outboxRepo.save(second);
+
+		const latest = await outboxRepo.findLatestByWorkflowId(wf.id);
+		expect(latest).not.toBeNull();
+		expect(latest!.id).toBe(second.id);
+		expect(latest!.publishedVersionId).toBe('v2');
+	});
+
+	it('findLatestByWorkflowId returns null when no outbox records exist', async () => {
+		const wf = await createWorkflow();
+		const result = await outboxRepo.findLatestByWorkflowId(wf.id);
+		expect(result).toBeNull();
 	});
 });

--- a/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
@@ -1,0 +1,98 @@
+import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { WorkflowPublicationTriggerStatusRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { v4 as uuid } from 'uuid';
+
+import { createOwner, createMember } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils/';
+
+const testServer = utils.setupTestServer({ endpointGroups: ['workflows'] });
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'WorkflowPublicationTriggerStatus',
+		'SharedWorkflow',
+		'WorkflowEntity',
+		'User',
+	]);
+});
+
+describe('GET /workflows/:workflowId/publication-status', () => {
+	let triggerStatusRepo: WorkflowPublicationTriggerStatusRepository;
+	let ownerAgent: SuperAgentTest;
+	let memberAgent: SuperAgentTest;
+
+	beforeEach(async () => {
+		triggerStatusRepo = Container.get(WorkflowPublicationTriggerStatusRepository);
+		const owner = await createOwner();
+		const member = await createMember();
+		ownerAgent = testServer.authAgentFor(owner);
+		memberAgent = testServer.authAgentFor(member);
+	});
+
+	test('returns partial status when workflow has mixed activated/failed trigger rows', async () => {
+		const owner = await createOwner();
+		ownerAgent = testServer.authAgentFor(owner);
+		const workflow = await createWorkflow(undefined, owner);
+		const versionId = uuid();
+
+		await triggerStatusRepo.replaceForWorkflow(workflow.id, [
+			{
+				nodeId: 'node-1',
+				nodeName: 'Webhook',
+				versionId,
+				status: 'activated',
+				errorMessage: null,
+			},
+			{
+				nodeId: 'node-2',
+				nodeName: 'Cron',
+				versionId,
+				status: 'failed',
+				errorMessage: 'Could not register trigger',
+			},
+		]);
+
+		const res = await ownerAgent.get(`/workflows/${workflow.id}/publication-status`).expect(200);
+
+		expect(res.body.data).toMatchObject({
+			status: 'partial',
+			liveVersionId: versionId,
+			pendingVersionId: null,
+			triggers: expect.arrayContaining([
+				expect.objectContaining({ nodeId: 'node-1', status: 'activated', errorMessage: null }),
+				expect.objectContaining({
+					nodeId: 'node-2',
+					status: 'failed',
+					errorMessage: 'Could not register trigger',
+				}),
+			]),
+		});
+		expect(res.body.data.triggers).toHaveLength(2);
+	});
+
+	test('returns not_published status when workflow has no trigger rows', async () => {
+		const owner = await createOwner();
+		ownerAgent = testServer.authAgentFor(owner);
+		const workflow = await createWorkflow(undefined, owner);
+
+		const res = await ownerAgent.get(`/workflows/${workflow.id}/publication-status`).expect(200);
+
+		expect(res.body.data).toMatchObject({
+			status: 'not_published',
+			liveVersionId: null,
+			pendingVersionId: null,
+			triggers: [],
+		});
+	});
+
+	test('returns 403 when member cannot access the workflow', async () => {
+		const owner = await createOwner();
+		const member = await createMember();
+		memberAgent = testServer.authAgentFor(member);
+		const workflow = await createWorkflow(undefined, owner);
+
+		await memberAgent.get(`/workflows/${workflow.id}/publication-status`).expect(403);
+	});
+});

--- a/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
@@ -1,4 +1,5 @@
 import { createWorkflow, createWorkflowHistory, testDb } from '@n8n/backend-test-utils';
+import { WorkflowsConfig } from '@n8n/config';
 import { WorkflowPublicationTriggerStatusRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { nanoid } from 'nanoid';
@@ -9,6 +10,18 @@ import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
 
 const testServer = utils.setupTestServer({ endpointGroups: ['workflows'] });
+
+// The endpoint is gated behind the publication service flag; enable it for the suite.
+let originalUseWorkflowPublicationService: boolean;
+beforeAll(() => {
+	const workflowsConfig = Container.get(WorkflowsConfig);
+	originalUseWorkflowPublicationService = workflowsConfig.useWorkflowPublicationService;
+	workflowsConfig.useWorkflowPublicationService = true;
+});
+afterAll(() => {
+	Container.get(WorkflowsConfig).useWorkflowPublicationService =
+		originalUseWorkflowPublicationService;
+});
 
 beforeEach(async () => {
 	await testDb.truncate([
@@ -97,5 +110,16 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 		const nonExistentId = nanoid();
 
 		await ownerAgent.get(`/workflows/${nonExistentId}/publication-status`).expect(404);
+	});
+
+	test('returns 404 when the publication service is disabled', async () => {
+		const workflow = await createWorkflow(undefined, owner);
+		const workflowsConfig = Container.get(WorkflowsConfig);
+		workflowsConfig.useWorkflowPublicationService = false;
+		try {
+			await ownerAgent.get(`/workflows/${workflow.id}/publication-status`).expect(404);
+		} finally {
+			workflowsConfig.useWorkflowPublicationService = true;
+		}
 	});
 });

--- a/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
@@ -1,4 +1,4 @@
-import { createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { createWorkflow, createWorkflowHistory, testDb } from '@n8n/backend-test-utils';
 import { WorkflowPublicationTriggerStatusRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { nanoid } from 'nanoid';
@@ -13,6 +13,7 @@ const testServer = utils.setupTestServer({ endpointGroups: ['workflows'] });
 beforeEach(async () => {
 	await testDb.truncate([
 		'WorkflowPublicationTriggerStatus',
+		'WorkflowHistory',
 		'SharedWorkflow',
 		'WorkflowEntity',
 		'User',
@@ -37,18 +38,18 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 	test('returns partial status when workflow has mixed activated/failed trigger rows', async () => {
 		const workflow = await createWorkflow(undefined, owner);
 		const versionId = uuid();
+		// Seed the workflow_history version the trigger-status rows reference (FK).
+		await createWorkflowHistory(workflow, owner, undefined, { versionId });
 
 		await triggerStatusRepo.replaceForWorkflow(workflow.id, [
 			{
 				nodeId: 'node-1',
-				nodeName: 'Webhook',
 				versionId,
 				status: 'activated',
 				errorMessage: null,
 			},
 			{
 				nodeId: 'node-2',
-				nodeName: 'Cron',
 				versionId,
 				status: 'failed',
 				errorMessage: 'Could not register trigger',

--- a/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.publication-status.test.ts
@@ -1,6 +1,7 @@
 import { createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { WorkflowPublicationTriggerStatusRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { nanoid } from 'nanoid';
 import { v4 as uuid } from 'uuid';
 
 import { createOwner, createMember } from '../shared/db/users';
@@ -22,18 +23,18 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 	let triggerStatusRepo: WorkflowPublicationTriggerStatusRepository;
 	let ownerAgent: SuperAgentTest;
 	let memberAgent: SuperAgentTest;
+	let owner: Awaited<ReturnType<typeof createOwner>>;
+	let member: Awaited<ReturnType<typeof createMember>>;
 
 	beforeEach(async () => {
 		triggerStatusRepo = Container.get(WorkflowPublicationTriggerStatusRepository);
-		const owner = await createOwner();
-		const member = await createMember();
+		owner = await createOwner();
+		member = await createMember();
 		ownerAgent = testServer.authAgentFor(owner);
 		memberAgent = testServer.authAgentFor(member);
 	});
 
 	test('returns partial status when workflow has mixed activated/failed trigger rows', async () => {
-		const owner = await createOwner();
-		ownerAgent = testServer.authAgentFor(owner);
 		const workflow = await createWorkflow(undefined, owner);
 		const versionId = uuid();
 
@@ -73,8 +74,6 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 	});
 
 	test('returns not_published status when workflow has no trigger rows', async () => {
-		const owner = await createOwner();
-		ownerAgent = testServer.authAgentFor(owner);
 		const workflow = await createWorkflow(undefined, owner);
 
 		const res = await ownerAgent.get(`/workflows/${workflow.id}/publication-status`).expect(200);
@@ -88,11 +87,14 @@ describe('GET /workflows/:workflowId/publication-status', () => {
 	});
 
 	test('returns 403 when member cannot access the workflow', async () => {
-		const owner = await createOwner();
-		const member = await createMember();
-		memberAgent = testServer.authAgentFor(member);
 		const workflow = await createWorkflow(undefined, owner);
 
 		await memberAgent.get(`/workflows/${workflow.id}/publication-status`).expect(403);
+	});
+
+	test('returns 404 for a non-existent workflow id', async () => {
+		const nonExistentId = nanoid();
+
+		await ownerAgent.get(`/workflows/${nonExistentId}/publication-status`).expect(404);
 	});
 });


### PR DESCRIPTION
## Summary

Expose the per-trigger publication status through an API. The semantics are as follows:
- Returns one of `'in_progress', 'published', 'partial', 'failed', 'not_published'`. If there is a publication currently being processed, it returns in_progress. Otherwise it derives the terminal state from the per-trigger data. All active -> published, some active -> partial, all failed -> failed, no rows -> not_published.
- It bases the per-trigger data on what's persisted. As a result, there may be some mismatch during a publication processing because we don't update the per-trigger status until we finalize publication. In the future we might move towards per-trigger reconciliation, at which point this might change, but it's somewhat more complicated. The limitation is documented on the API.

It's all behind the publication service feature flag, we throw if it isn't enabled.

This is PR 2 of 3 - the last PR will consume it on the frontend.

## How to test

Backend-only, behind the `useWorkflowPublicationService` flag. Covered by tests:
- Repository integration (replace/delete/find, FK CASCADE, latest-outbox lookup).
- Applier unit tests (full success / partial / all-fail → correct per-trigger statuses).
- Reporter unit tests (rows written per outcome; `register` no longer called on partial).
- Status-service unit matrix (all status × version-field combinations).
- Endpoint integration (`partial`/`not_published` payloads, 403 no-access, 404 non-existent).

No user-facing behaviour yet.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3579
- Parent: https://linear.app/n8n/issue/CAT-2245
- Fixes: https://linear.app/n8n/issue/CAT-3432

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33211">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

