### PR TITLE
test(MCP Server Trigger Node): De-flake header-auth E2E (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/nodes/mcp-trigger.spec.ts
+++ b/packages/testing/playwright/tests/e2e/nodes/mcp-trigger.spec.ts
@@ -193,6 +193,8 @@ test.describe(
 						capabilities: {},
 						clientInfo: { name: 'test', version: '1.0.0' },
 					}),
+					maxNotFoundRetries: 5,
+					notFoundRetryDelayMs: 500,
 				});
 
 				expect(noAuthResponse.status()).toBe(403);
@@ -261,6 +263,12 @@ test.describe(
 				const mcpNode = createdWorkflow.nodes?.find((n) => n.type.includes('mcpTrigger'));
 				const mcpPath = `mcp/${mcpNode?.parameters.path as string}`;
 
+				// Try with valid auth - should succeed
+				const session = await api.mcp.streamableHttpInitialize(mcpPath, {
+					headers: { [headerName]: headerValue },
+				});
+				expect(session.sessionId).toBeTruthy();
+
 				// Try without auth - should fail
 				const noAuthResponse = await api.webhooks.trigger(mcpPath, {
 					method: 'POST',
@@ -272,13 +280,6 @@ test.describe(
 					}),
 				});
 				expect(noAuthResponse.status()).toBe(403);
-
-				// Try with valid auth - should succeed
-				const session = await api.mcp.streamableHttpInitialize(mcpPath, {
-					headers: { [headerName]: headerValue },
-				});
-
-				expect(session.sessionId).toBeTruthy();
 			});
 		});
 


### PR DESCRIPTION
## Summary

De-flakes the quarantined E2E test `MCP Trigger Node > Authentication > should accept valid header auth` (`packages/testing/playwright/tests/e2e/nodes/mcp-trigger.spec.ts`), which was flaking at ~12% (Currents signature `3061e713fe272ff6cb7397449c2053a8`).

**Root cause:** after `api.workflows.activate(...)`, the webhook is registered asynchronously — an unregistered path returns `404`, a registered-but-unauthenticated one returns `403`. The test's no-auth `403` assertion goes through `WebhookApiHelper.trigger`, whose 404-retry budget is only ~0.75s (3×250ms), whereas the valid-auth init goes through `McpApiHelper.trigger` with 2.5s (5×500ms). Under CI load, registration occasionally outlasts the smaller budget, so the no-auth call returns a final `404` and `expect(...).toBe(403)` fails.

**Fix:**
- `should accept valid header auth`: run the valid-auth `streamableHttpInitialize` **first**. Its 2.5s retry budget absorbs the registration race and acts as a barrier; once it returns a session id the webhook is definitely registered, so the following no-auth request deterministically `403`s. (Pure reorder — no new timeouts.)
- `should reject unauthenticated request with bearerAuth`: shares the same race (a standalone no-auth→403 check with no init to gate on). Widened its 404-retry budget to match the init helper (`maxNotFoundRetries: 5`, `notFoundRetryDelayMs: 500`).

## How to test

Quarantine is enforced at runtime, so the header test is normally skipped locally. To exercise it, bypass the skip and stress it against a local n8n:

```bash
# boot services + a built n8n on :5678, then:
cd packages/testing/playwright
CURRENTS_RECORD_KEY=local-bypass N8N_BASE_URL=http://localhost:5678 RESET_E2E_DB=true \
  pnpm exec playwright test --project=e2e tests/e2e/nodes/mcp-trigger.spec.ts -g "auth" --repeat-each=20 --reporter=list
```

Locally verified: bearer tests 24/24 green; header test 20/20 green (quarantine bypassed, parallel workers)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5336
- https://linear.app/n8n/issue/AI-2581

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33221">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->