### PR TITLE
test(MCP Client Tool Node): Stabilize runtime mocks and use vi APIs (no-changelog)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOracleDB/listModels.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsOracleDB/listModels.test.ts
@@ -1,6 +1,7 @@
-import type { ILoadOptionsFunctions } from 'n8n-workflow';
 import { configureOracleDB } from 'n8n-nodes-base/dist/nodes/Oracle/Sql/transport';
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
 import type oracledb from 'oracledb';
+import type { Mocked } from 'vitest';
 
 vi.mock('n8n-nodes-base/dist/nodes/Oracle/Sql/transport', () => ({
 	configureOracleDB: vi.fn(),
@@ -14,32 +15,32 @@ const normalizeSql = (sql: string) => sql.replace(/\s+/g, ' ').trim();
 
 describe('EmbeddingsOracleDB listModels', () => {
 	const connection = {
-		execute: jest.fn(),
-		close: jest.fn(),
+		execute: vi.fn(),
+		close: vi.fn(),
 	};
 
 	const pool = {
-		getConnection: jest.fn(),
+		getConnection: vi.fn(),
 	};
 
 	const context = {
-		getCredentials: jest.fn(),
+		getCredentials: vi.fn(),
 		logger: {
-			debug: jest.fn(),
-			error: jest.fn(),
-			info: jest.fn(),
-			warn: jest.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
 		},
-	} as unknown as jest.Mocked<ILoadOptionsFunctions>;
+	} as unknown as Mocked<ILoadOptionsFunctions>;
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		mockConfigureOracleDB.mockResolvedValue(pool as unknown as oracledb.Pool);
-		pool.getConnection = jest.fn().mockResolvedValue(connection);
-		connection.execute = jest.fn().mockResolvedValue({
+		pool.getConnection = vi.fn().mockResolvedValue(connection);
+		connection.execute = vi.fn().mockResolvedValue({
 			rows: [['MODEL_A'], ['MODEL_B']],
 		});
-		connection.close = jest.fn().mockResolvedValue(undefined);
+		connection.close = vi.fn().mockResolvedValue(undefined);
 		context.getCredentials.mockResolvedValue({ user: 'user', password: 'pw' });
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/test/EmbeddingsOracleDb.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/test/EmbeddingsOracleDb.test.ts
@@ -1,9 +1,10 @@
 // cspell:ignore langchain oracledb ONNX
-import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import type * as AiUtilitiesModule from '@n8n/ai-utilities';
+import { configureOracleDB } from 'n8n-nodes-base/dist/nodes/Oracle/Sql/transport';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
 import type oracledb from 'oracledb';
-import { configureOracleDB } from 'n8n-nodes-base/dist/nodes/Oracle/Sql/transport';
+import type { Mock, Mocked } from 'vitest';
 
 import { EmbeddingsOracleDb } from '../EmbeddingsOracleDB/EmbeddingsOracleDb.node';
 
@@ -13,7 +14,7 @@ const { mockGetConnection, mockEmbedQuery, mockEmbedDocuments } = vi.hoisted(() 
 	mockEmbedDocuments: vi.fn(),
 }));
 
-type MockConnection = oracledb.Connection & { close: jest.Mock };
+type MockConnection = oracledb.Connection & { close: Mock };
 
 vi.mock('@n8n/ai-utilities', async (importOriginal) => {
 	const actual = await importOriginal<typeof AiUtilitiesModule>();
@@ -41,7 +42,7 @@ const mockConfigureOracleDB = vi.mocked(configureOracleDB);
 
 describe('EmbeddingsOracleDb', () => {
 	let node: EmbeddingsOracleDb;
-	let context: jest.Mocked<ISupplyDataFunctions>;
+	let context: Mocked<ISupplyDataFunctions>;
 	let borrowedConnections: MockConnection[];
 
 	const baseNode: INode = {
@@ -61,7 +62,7 @@ describe('EmbeddingsOracleDb', () => {
 		} as unknown as oracledb.Pool);
 		mockGetConnection.mockImplementation(async () => {
 			const connection = {
-				close: jest.fn().mockResolvedValue(undefined),
+				close: vi.fn().mockResolvedValue(undefined),
 			} as unknown as MockConnection;
 			borrowedConnections.push(connection);
 			return connection;
@@ -72,19 +73,19 @@ describe('EmbeddingsOracleDb', () => {
 		context = createMockExecuteFunction<ISupplyDataFunctions>(
 			{},
 			baseNode,
-		) as jest.Mocked<ISupplyDataFunctions>;
+		) as Mocked<ISupplyDataFunctions>;
 
-		context.getNodeParameter = jest.fn().mockImplementation((parameterName: string) => {
+		context.getNodeParameter = vi.fn().mockImplementation((parameterName: string) => {
 			if (parameterName === 'model') return 'ONNX_MODEL';
 			return undefined;
 		});
 
-		context.getCredentials = jest.fn().mockResolvedValue({ user: 'user', password: 'pw' });
+		context.getCredentials = vi.fn().mockResolvedValue({ user: 'user', password: 'pw' });
 		context.logger = {
-			debug: jest.fn(),
-			error: jest.fn(),
-			info: jest.fn(),
-			warn: jest.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
 		};
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -13,13 +13,13 @@ import {
 	type ISupplyDataFunctions,
 	jsonParse,
 } from 'n8n-workflow';
+import type { MockedFunction } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
+import { McpClientsManager } from '../../shared/McpClientsManager';
 import { getTools } from '../loadOptions';
 import { McpClientTool } from '../McpClientTool.node';
 import { buildMcpToolName } from '../utils';
-import { McpClientsManager } from '../../shared/McpClientsManager';
-import type { MockedFunction } from 'vitest';
 
 vi.mock('@modelcontextprotocol/sdk/client/sse.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -1030,12 +1030,12 @@ describe('McpClientTool', () => {
 		});
 
 		it('should treat isError: true as success on version 1.2 (legacy behavior)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				isError: true,
 				content: [{ type: 'text', text: 'simulated tool-level error' }],
 			});
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [
 					{
 						name: 'get_weather',
@@ -1047,8 +1047,8 @@ describe('McpClientTool', () => {
 
 			const mockNode = mock<INode>({ typeVersion: 1.2, type: 'mcpClientTool', name: 'MCP Client' });
 			const mockExecuteFunctions = mock<any>({
-				getNode: jest.fn(() => mockNode),
-				getInputData: jest.fn(() => [
+				getNode: vi.fn(() => mockNode),
+				getInputData: vi.fn(() => [
 					{
 						json: {
 							tool: buildMcpToolName('MCP Client', 'get_weather'),
@@ -1056,7 +1056,7 @@ describe('McpClientTool', () => {
 						},
 					},
 				]),
-				getNodeParameter: jest.fn((key) => {
+				getNodeParameter: vi.fn((key) => {
 					const params: Record<string, any> = {
 						include: 'all',
 						includeTools: [],
@@ -1083,12 +1083,12 @@ describe('McpClientTool', () => {
 		});
 
 		it('should throw NodeOperationError when tool result has isError: true (version 1.3+)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				isError: true,
 				content: [{ type: 'text', text: 'simulated tool-level error' }],
 			});
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [
 					{
 						name: 'get_weather',
@@ -1100,8 +1100,8 @@ describe('McpClientTool', () => {
 
 			const mockNode = mock<INode>({ typeVersion: 1.3, type: 'mcpClientTool', name: 'MCP Client' });
 			const mockExecuteFunctions = mock<any>({
-				getNode: jest.fn(() => mockNode),
-				getInputData: jest.fn(() => [
+				getNode: vi.fn(() => mockNode),
+				getInputData: vi.fn(() => [
 					{
 						json: {
 							tool: buildMcpToolName('MCP Client', 'get_weather'),
@@ -1109,7 +1109,7 @@ describe('McpClientTool', () => {
 						},
 					},
 				]),
-				getNodeParameter: jest.fn((key) => {
+				getNodeParameter: vi.fn((key) => {
 					const params: Record<string, any> = {
 						include: 'all',
 						includeTools: [],
@@ -1129,12 +1129,12 @@ describe('McpClientTool', () => {
 		});
 
 		it('should throw generic error when isError: true with no text content (version 1.3+)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				isError: true,
 				content: [{ type: 'image', data: 'abc', mimeType: 'image/png' }],
 			});
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [
 					{
 						name: 'get_weather',
@@ -1146,8 +1146,8 @@ describe('McpClientTool', () => {
 
 			const mockNode = mock<INode>({ typeVersion: 1.3, type: 'mcpClientTool', name: 'MCP Client' });
 			const mockExecuteFunctions = mock<any>({
-				getNode: jest.fn(() => mockNode),
-				getInputData: jest.fn(() => [
+				getNode: vi.fn(() => mockNode),
+				getInputData: vi.fn(() => [
 					{
 						json: {
 							tool: buildMcpToolName('MCP Client', 'get_weather'),
@@ -1155,7 +1155,7 @@ describe('McpClientTool', () => {
 						},
 					},
 				]),
-				getNodeParameter: jest.fn((key) => {
+				getNodeParameter: vi.fn((key) => {
 					const params: Record<string, any> = {
 						include: 'all',
 						includeTools: [],

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -14,11 +14,13 @@ import {
 import { McpClientsManager } from './McpClientsManager';
 import { buildMcpToolkit, executeMcpTool, loadMcpToolOptions } from './runtime';
 import type { ResolvedMcpConfig, McpConnectionConfig } from './runtime';
+import type { McpTool } from './types';
+import * as utils from './utils';
 import { buildMcpToolName } from '../McpClientTool/utils';
 
-jest.mock('@modelcontextprotocol/sdk/client/sse.js');
-jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js');
-jest.mock('@modelcontextprotocol/sdk/client/index.js');
+vi.mock('@modelcontextprotocol/sdk/client/sse.js');
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js');
+vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@n8n/ai-utilities', async () => {
 	const actual = await vi.importActual('@n8n/ai-utilities');
 	return {
@@ -53,10 +55,10 @@ const sampleTool = {
 
 function createSupplyDataCtx(overrides: Record<string, unknown> = {}) {
 	return mock<ISupplyDataFunctions>({
-		getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP', type: 'mcp' })),
-		logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() },
-		addInputData: jest.fn(() => ({ index: 0 })),
-		addOutputData: jest.fn(),
+		getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP', type: 'mcp' })),
+		logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+		addInputData: vi.fn(() => ({ index: 0 })),
+		addOutputData: vi.fn(),
 		...overrides,
 	} as Partial<ISupplyDataFunctions>);
 }
@@ -66,94 +68,64 @@ function createExecuteCtx(
 	overrides: Record<string, unknown> = {},
 ) {
 	return mock<IExecuteFunctions>({
-		getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP', type: 'mcp' })),
-		logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() },
-		getInputData: jest.fn(() => inputItems),
+		getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP', type: 'mcp' })),
+		logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+		getInputData: vi.fn(() => inputItems),
 		...overrides,
 	} as Partial<IExecuteFunctions>);
 }
 
 describe('runtime', () => {
 	beforeEach(() => {
-		jest.resetAllMocks();
+		vi.resetAllMocks();
 	});
 
 	describe('buildMcpToolkit', () => {
 		it('passes the execution cancel signal to connectMcpClient while connecting', async () => {
 			const abort = new AbortController();
-			const connectMcpClientForCredential = vi.fn().mockResolvedValue({
-				ok: true,
-				result: {
-					close: vi.fn(),
-				},
-			});
-			const getAllTools = vi.fn().mockResolvedValue([sampleTool]);
+			const connectMcpClientForCredential = vi
+				.spyOn(utils, 'connectMcpClientForCredential')
+				.mockResolvedValue({ ok: true, result: mock<Client>() });
+			vi.spyOn(utils, 'getAllTools').mockResolvedValue([sampleTool] as McpTool[]);
 
-			vi.resetModules();
-			vi.doMock('./utils', async () => {
-				const actual = await vi.importActual('./utils');
-				return {
-					...(actual as Record<string, unknown>),
-					connectMcpClientForCredential,
-					getAllTools,
-					getAuthHeaders: vi.fn().mockResolvedValue({ headers: undefined }),
-				};
-			});
-			const { buildMcpToolkit: buildMcpToolkitWithMockedUtils } = await import('./runtime');
 			const ctx = createSupplyDataCtx({
-				getExecutionCancelSignal: jest.fn(() => abort.signal),
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
 			});
 
-			await buildMcpToolkitWithMockedUtils(ctx, 0, baseConfig);
+			await buildMcpToolkit(ctx, 0, baseConfig);
 
 			expect(connectMcpClientForCredential).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({ signal: abort.signal }),
 			);
-			vi.doUnmock('./utils');
 		});
 
 		it('passes undefined as signal when getExecutionCancelSignal returns no signal', async () => {
-			const connectMcpClientForCredential = vi.fn().mockResolvedValue({
-				ok: true,
-				result: {
-					close: vi.fn(),
-				},
-			});
-			const getAllTools = vi.fn().mockResolvedValue([sampleTool]);
+			const connectMcpClientForCredential = vi
+				.spyOn(utils, 'connectMcpClientForCredential')
+				.mockResolvedValue({ ok: true, result: mock<Client>() });
+			vi.spyOn(utils, 'getAllTools').mockResolvedValue([sampleTool] as McpTool[]);
 
-			vi.resetModules();
-			vi.doMock('./utils', async () => {
-				const actual = await vi.importActual('./utils');
-				return {
-					...(actual as Record<string, unknown>),
-					connectMcpClientForCredential,
-					getAllTools,
-					getAuthHeaders: vi.fn().mockResolvedValue({ headers: undefined }),
-				};
-			});
-			const { buildMcpToolkit: buildMcpToolkitWithMockedUtils } = await import('./runtime');
 			const ctx = createSupplyDataCtx({
-				getExecutionCancelSignal: jest.fn(() => undefined),
+				getExecutionCancelSignal: vi.fn(() => undefined),
 			});
 
-			await buildMcpToolkitWithMockedUtils(ctx, 0, baseConfig);
+			await buildMcpToolkit(ctx, 0, baseConfig);
 
 			expect(connectMcpClientForCredential).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({ signal: undefined }),
 			);
-			vi.doUnmock('./utils');
 		});
 
 		it('surfaces a cancelled connection result without listing tools', async () => {
 			const abortError = new Error('aborted');
 			abortError.name = 'AbortError';
-			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(abortError);
-			const listTools = jest.spyOn(Client.prototype, 'listTools');
+			vi.spyOn(Client.prototype, 'connect').mockRejectedValue(abortError);
+			const listTools = vi.spyOn(Client.prototype, 'listTools');
 			const abort = new AbortController();
 			const ctx = createSupplyDataCtx({
-				getExecutionCancelSignal: jest.fn(() => abort.signal),
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
 			});
 
 			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow('Execution was cancelled');
@@ -170,14 +142,14 @@ describe('runtime', () => {
 			const abort = new AbortController();
 			abort.abort();
 			const ctx = createSupplyDataCtx({
-				getExecutionCancelSignal: jest.fn(() => abort.signal),
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
 			});
 
 			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow('Execution was cancelled');
 		});
 
 		it('routes connection failures through addOutputData and surfaces a NodeOperationError', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('boom'));
+			vi.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('boom'));
 			const ctx = createSupplyDataCtx();
 
 			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow(NodeOperationError);
@@ -189,9 +161,9 @@ describe('runtime', () => {
 		});
 
 		it('throws "MCP Server returned no tools" when the server returns an empty list', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [] });
-			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [] });
+			const closeSpy = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = createSupplyDataCtx();
 
 			await expect(buildMcpToolkit(ctx, 0, baseConfig)).rejects.toThrow(
@@ -201,9 +173,9 @@ describe('runtime', () => {
 		});
 
 		it('returns a StructuredToolkit with prefixed tool names and a working closeFunction', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			const closeSpy = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = createSupplyDataCtx();
 
 			const result = await buildMcpToolkit(ctx, 0, baseConfig);
@@ -218,11 +190,11 @@ describe('runtime', () => {
 		});
 
 		it('applies the tool filter (selected mode)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [sampleTool, { ...sampleTool, name: 'fetch' }],
 			});
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = createSupplyDataCtx();
 
 			const result = await buildMcpToolkit(ctx, 0, {
@@ -241,7 +213,7 @@ describe('runtime', () => {
 			const abort = new AbortController();
 			abort.abort();
 			const ctx = createExecuteCtx([{ json: { tool: 'whatever' } }], {
-				getExecutionCancelSignal: jest.fn(() => abort.signal),
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
 			});
 
 			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow(
@@ -250,17 +222,17 @@ describe('runtime', () => {
 		});
 
 		it('throws when item.json.tool is missing', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = createExecuteCtx([{ json: { query: 'foo' } }]);
 
 			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow('Tool name not found');
 		});
 
 		it('sanitizes arguments against the tool inputSchema when additionalProperties is false', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [
 					{
 						name: 'search',
@@ -276,7 +248,7 @@ describe('runtime', () => {
 			const callTool = jest
 				.spyOn(Client.prototype, 'callTool')
 				.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([
 				{
@@ -298,8 +270,8 @@ describe('runtime', () => {
 		});
 
 		it('passes additional arguments through when additionalProperties is true', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
 				tools: [
 					{
 						name: 'search',
@@ -311,7 +283,7 @@ describe('runtime', () => {
 			const callTool = jest
 				.spyOn(Client.prototype, 'callTool')
 				.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([
 				{
@@ -333,14 +305,14 @@ describe('runtime', () => {
 		});
 
 		it('forwards the abort signal and timeout to client.callTool', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			const callTool = jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			const callTool = vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const abort = new AbortController();
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }], {
-				getExecutionCancelSignal: jest.fn(() => abort.signal),
+				getExecutionCancelSignal: vi.fn(() => abort.signal),
 			});
 
 			await executeMcpTool(ctx, () => ({ ...baseConfig, timeout: 7777 }));
@@ -353,13 +325,13 @@ describe('runtime', () => {
 		});
 
 		it('includes structuredContent in the response only when it is a non-empty object', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				content: [{ type: 'text', text: 'ok' }],
 				structuredContent: { id: 'abc' },
 			});
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }]);
 
@@ -372,14 +344,14 @@ describe('runtime', () => {
 		});
 
 		it('omits structuredContent when it is null', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				content: [{ type: 'text', text: 'ok' }],
 				toolResult: undefined,
 				structuredContent: null,
 			});
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }]);
 
@@ -391,10 +363,10 @@ describe('runtime', () => {
 		});
 
 		it('closes the client even when the call throws', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockRejectedValue(new Error('network'));
-			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockRejectedValue(new Error('network'));
+			const closeSpy = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }]);
 
@@ -406,15 +378,15 @@ describe('runtime', () => {
 		// output. Only a thrown error reaches the execution engine's node-failure
 		// handling, which is what routes the error back to the calling agent.
 		it('throws with the tool error text when the tool result is flagged isError (v1.3+)', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				isError: true,
 				content: [{ type: 'text', text: 'MCP error -32602: bad arguments' }],
 			});
 
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }], {
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.3, name: 'MCP', type: 'mcp' })),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.3, name: 'MCP', type: 'mcp' })),
 			});
 
 			await expect(executeMcpTool(ctx, () => baseConfig)).rejects.toThrow(
@@ -425,16 +397,16 @@ describe('runtime', () => {
 		// Throwing on isError only applies to typeVersion >= 1.3; older nodes
 		// pass the flagged result through as normal output.
 		it('returns the flagged result without throwing for nodes before v1.3', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({
 				isError: true,
 				content: [{ type: 'text', text: 'some error' }],
 			});
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createExecuteCtx([{ json: { tool: buildMcpToolName('MCP', 'search') } }], {
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.2, name: 'MCP', type: 'mcp' })),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.2, name: 'MCP', type: 'mcp' })),
 			});
 
 			const result = await executeMcpTool(ctx, () => baseConfig);
@@ -450,12 +422,12 @@ describe('runtime', () => {
 
 		function createCachedCtx(executionId: string, overrides: Record<string, unknown> = {}) {
 			return mock<IExecuteFunctions>({
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP', type: 'mcp' })),
-				logger: { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() },
-				getInputData: jest.fn(() => [{ json: { tool: buildMcpToolName('MCP', 'search') } }]),
-				getExecutionId: jest.fn(() => executionId),
-				getExecutionCancelSignal: jest.fn(() => undefined),
-				onExecutionCancellation: jest.fn(),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.4, name: 'MCP', type: 'mcp' })),
+				logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+				getInputData: vi.fn(() => [{ json: { tool: buildMcpToolName('MCP', 'search') } }]),
+				getExecutionId: vi.fn(() => executionId),
+				getExecutionCancelSignal: vi.fn(() => undefined),
+				onExecutionCancellation: vi.fn(),
 				...overrides,
 			} as Partial<IExecuteFunctions>);
 		}
@@ -473,10 +445,10 @@ describe('runtime', () => {
 		});
 
 		it('reuses one client across execute calls within the same execution', async () => {
-			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createCachedCtx('exec-1');
 			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
@@ -489,10 +461,10 @@ describe('runtime', () => {
 		});
 
 		it('opens a fresh client per call when the cache is disabled', async () => {
-			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createCachedCtx('exec-1');
 			await executeMcpTool(ctx, () => baseConfig);
@@ -503,10 +475,10 @@ describe('runtime', () => {
 		});
 
 		it('bypasses the cache when there is no execution id', async () => {
-			const connect = jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			const connect = vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			const ctx = createCachedCtx('');
 			await executeMcpTool(ctx, () => baseConfig, { enableSessionCache: true });
@@ -518,10 +490,10 @@ describe('runtime', () => {
 		});
 
 		it('does not share the cache across different executions', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			await executeMcpTool(createCachedCtx('exec-1'), () => baseConfig, {
 				enableSessionCache: true,
@@ -535,14 +507,14 @@ describe('runtime', () => {
 		});
 
 		it('closes and evicts the cached client on execution cancellation', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
-			const close = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'callTool').mockResolvedValue({ content: [] });
+			const close = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 
 			let cancel: () => void = () => {};
 			const ctx = createCachedCtx('exec-1', {
-				onExecutionCancellation: jest.fn((handler: () => void) => {
+				onExecutionCancellation: vi.fn((handler: () => void) => {
 					cancel = handler;
 				}),
 			});
@@ -558,11 +530,11 @@ describe('runtime', () => {
 
 	describe('loadMcpToolOptions', () => {
 		it('returns INodePropertyOptions mapped from listTools', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
-			jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({ tools: [sampleTool] });
+			vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = mock<ILoadOptionsFunctions>({
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
 			});
 
 			const result = await loadMcpToolOptions(ctx, baseConnectionConfig);
@@ -578,9 +550,9 @@ describe('runtime', () => {
 		});
 
 		it('throws NodeOperationError when connect fails', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('boom'));
+			vi.spyOn(Client.prototype, 'connect').mockRejectedValue(new Error('boom'));
 			const ctx = mock<ILoadOptionsFunctions>({
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
 			});
 
 			await expect(loadMcpToolOptions(ctx, baseConnectionConfig)).rejects.toThrow(
@@ -589,11 +561,11 @@ describe('runtime', () => {
 		});
 
 		it('closes the client even when listing fails', async () => {
-			jest.spyOn(Client.prototype, 'connect').mockResolvedValue();
-			jest.spyOn(Client.prototype, 'listTools').mockRejectedValue(new Error('list-failed'));
-			const closeSpy = jest.spyOn(Client.prototype, 'close').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockRejectedValue(new Error('list-failed'));
+			const closeSpy = vi.spyOn(Client.prototype, 'close').mockResolvedValue();
 			const ctx = mock<ILoadOptionsFunctions>({
-				getNode: jest.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP' })),
 			});
 
 			await expect(loadMcpToolOptions(ctx, baseConnectionConfig)).rejects.toThrow('list-failed');

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreOracleDB/VectorStoreOracleDB.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreOracleDB/VectorStoreOracleDB.node.test.ts
@@ -6,6 +6,7 @@ import type { VectorStoreNodeConstructorArgs } from '@n8n/ai-utilities';
 import { ConnectionPoolManager } from 'n8n-nodes-base/dist/utils/connection-pool-manager';
 import type { IExecuteFunctions } from 'n8n-workflow';
 import type { Pool } from 'oracledb';
+import type { Mocked } from 'vitest';
 
 type OracleFilter = Record<string, unknown>;
 
@@ -323,15 +324,15 @@ import { VectorStoreOracleDB } from './VectorStoreOracleDB.node';
 
 describe('VectorStoreOracleDB.node', () => {
 	const context = {
-		getNodeParameter: jest.fn(),
-		getCredentials: jest.fn(),
+		getNodeParameter: vi.fn(),
+		getCredentials: vi.fn(),
 		logger: {
-			debug: jest.fn(),
-			error: jest.fn(),
-			info: jest.fn(),
-			warn: jest.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
 		},
-	} as unknown as jest.Mocked<IExecuteFunctions>;
+	} as unknown as Mocked<IExecuteFunctions>;
 
 	const embeddings = {} as Embeddings;
 	const documents: Array<Document<Record<string, unknown>>> = [
@@ -361,7 +362,7 @@ describe('VectorStoreOracleDB.node', () => {
 	const createNode = () => new VectorStoreOracleDB() as unknown as TestNodeInstance;
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 		createdPools.length = 0;
 		poolCloseMocks.length = 0;
 		connectionCloseMocks.length = 0;
@@ -410,7 +411,7 @@ describe('VectorStoreOracleDB.node', () => {
 
 		expect(mockCreatePool).toHaveBeenCalledTimes(1);
 		expect(createdPools).toHaveLength(1);
-		const poolConfig = mockCreatePool.mock.calls[0]![0];
+		const poolConfig = mockCreatePool.mock.calls[0][0];
 		expect(poolConfig).toMatchObject({
 			user: 'user',
 			password: 'pw',

--- a/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tests/helpers.test.ts
@@ -356,8 +356,8 @@ describe('getConnectedTools', () => {
 			{ name: 'charlie', description: 'desc-charlie' },
 		];
 
-		mockExecuteFunctions.getInputConnectionData = jest.fn().mockResolvedValue(mockTools);
-		mockExecuteFunctions.getParentNodes = jest.fn().mockReturnValue(mockParentNodes);
+		mockExecuteFunctions.getInputConnectionData = vi.fn().mockResolvedValue(mockTools);
+		mockExecuteFunctions.getParentNodes = vi.fn().mockReturnValue(mockParentNodes);
 
 		const tools = await getConnectedTools(mockExecuteFunctions, false);
 


### PR DESCRIPTION
## Summary

`nodes/mcp/shared/runtime.test.ts > buildMcpToolkit > passes undefined as signal when getExecutionCancelSignal returns no signal` has been failing intermittently in CI (e.g. [run 28369746814](https://github.com/n8n-io/n8n/actions/runs/28369746814/job/84044300682)) with:

```
TypeError: Cannot destructure property 'tools' of '(intermediate value)' as it is undefined.
 ❯ getAllTools nodes/mcp/shared/utils.ts:31:10
```

### Root cause

The two "signal" tests stubbed `connectMcpClientForCredential` and `getAllTools` via `vi.resetModules()` + `vi.doMock('./utils')` + a dynamic `import('./runtime')`. Under the parallel `forks` pool, the `doMock` intermittently failed to apply to the re-imported `runtime` module. When that happened the **real** `getAllTools` ran against the stub client (whose `result` has no `listTools`), and the destructure threw. The CI stack trace confirms the real `getAllTools`/`connectAndGetTools`/`buildMcpToolkit` were executing. It does not reproduce locally because the race needs a loaded CI worker.

### Fix

- Replace the `resetModules`/`doMock`/dynamic-import pattern with direct `vi.spyOn(utils, …)` on the shared module namespace, which is order-independent and intercepts `runtime`'s calls via Vite's live ESM bindings.
- Convert mixed `jest.*`/`vi.*` usage (which relied on the `globalThis.jest = vi` shim) to `vi.*` across the affected nodes-langchain test files, importing the `Mocked`/`Mock` types from `vitest` where the type-level `jest.Mocked`/`jest.Mock` were used.

## Verification

- The 6 modified test files pass (156 tests).
- `pnpm lint` — 0 errors (remaining warnings are pre-existing, on untouched lines).
- `pnpm typecheck` — no errors in the modified files.

## Review / Merge checklist

- [x] Tests included.
- [x] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33222">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

