### PR TITLE
feat(ai-builder): Dual-tenant LangSmith reads for Instance AI evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
@@ -102,6 +102,26 @@ describe('WorkflowTestCaseSchema', () => {
 		expect(parsed.conversation).toHaveLength(1);
 	});
 
+	it('accepts a seedThread carrying a dual-tenant endpoint (US-sourced case)', () => {
+		// Cross-repo contract (TRUST-212): LangTracer's buildExportedTestCase emits
+		// seedThread.endpoint for a US-sourced replay; the harness must retain it
+		// (the inner seedThread object isn't .strict(), so an un-modelled field
+		// would be silently stripped and the read would wrongly target home/EU).
+		const { conversation: _omit, ...rest } = validFixture();
+		const parsed = WorkflowTestCaseSchema.parse({
+			...rest,
+			seedThread: { threadId: 't1', endpoint: 'https://api.smith.langchain.com' },
+		});
+		expect(parsed.seedThread?.endpoint).toBe('https://api.smith.langchain.com');
+	});
+
+	it('rejects a seedThread endpoint that is not a URL', () => {
+		const { conversation: _omit, ...rest } = validFixture();
+		expect(() =>
+			WorkflowTestCaseSchema.parse({ ...rest, seedThread: { threadId: 't1', endpoint: 'us' } }),
+		).toThrow();
+	});
+
 	it('rejects seedThread combined with another seeding mode', () => {
 		const { conversation: _omit, ...rest } = validFixture();
 		expect(() =>

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
@@ -13,7 +13,7 @@ vi.mock('../harness/parse-seed-workflow', () => ({
 	}),
 }));
 
-import { reconstructSeedFromThread } from '../harness/langsmith-seed';
+import { configFor, reconstructSeedFromThread } from '../harness/langsmith-seed';
 
 // Discovery test doubles return fixed, already-resolved workspace lists.
 /* eslint-disable @typescript-eslint/promise-function-async */
@@ -598,5 +598,59 @@ describe('reconstructSeedFromThread — workspace auto-discovery', () => {
 				ambientClient: () => fakeClient([]),
 			}),
 		).rejects.toThrow(/need ≥2 to seed/);
+	});
+});
+
+// Dual-tenant READS (US→EU migration): a seed ref's `endpoint` selects which
+// LangSmith tenant to read from. Writes are unaffected (they stay on the home
+// tenant elsewhere). The endpoint→key mapping is the cross-repo contract that
+// LangTracer's exported `seedThread.endpoint` rides on (TRUST-212).
+describe('configFor — dual-tenant read resolution', () => {
+	const EU = 'https://eu.api.smith.langchain.com';
+	const US = 'https://api.smith.langchain.com';
+
+	beforeEach(() => {
+		vi.stubEnv('LANGSMITH_ENDPOINT', EU);
+		vi.stubEnv('LANGSMITH_API_KEY', 'eu-key');
+		vi.stubEnv('LANGSMITH_ENDPOINT_US', US);
+		vi.stubEnv('LANGSMITH_API_KEY_US', 'us-key');
+	});
+	afterEach(() => vi.unstubAllEnvs());
+
+	it('resolves an omitted endpoint to the home (EU) host + key', () => {
+		expect(configFor()).toEqual({ apiUrl: EU, apiKey: 'eu-key' });
+	});
+
+	it('resolves the home endpoint to the home key', () => {
+		expect(configFor(EU)).toEqual({ apiUrl: EU, apiKey: 'eu-key' });
+	});
+
+	it('resolves the US endpoint to the US key — never the home key', () => {
+		expect(configFor(US)).toEqual({ apiUrl: US, apiKey: 'us-key' });
+	});
+
+	it('tolerates a trailing slash and an /api/v1 suffix on the endpoint', () => {
+		expect(configFor(`${US}/`)).toEqual({ apiUrl: US, apiKey: 'us-key' });
+		expect(configFor(`${EU}/api/v1`)).toEqual({ apiUrl: EU, apiKey: 'eu-key' });
+	});
+
+	it('throws (does NOT fall back to the home key) when the US key is missing', () => {
+		vi.stubEnv('LANGSMITH_API_KEY_US', '');
+		expect(() => configFor(US)).toThrow(/LANGSMITH_API_KEY_US is not set/);
+	});
+
+	it('throws on an endpoint that matches no configured tenant', () => {
+		expect(() => configFor('https://made-up.smith.langchain.com')).toThrow(
+			/no configured LangSmith tenant/,
+		);
+	});
+
+	it('routes a US-endpoint ref through the US resolver (no silent home fallback)', async () => {
+		// End-to-end: the endpoint flows ref → discoveryDepsFor(ref.endpoint) →
+		// configFor, so a missing US key fails loudly instead of querying EU.
+		vi.stubEnv('LANGSMITH_API_KEY_US', '');
+		await expect(reconstructSeedFromThread({ threadId: 't1', endpoint: US })).rejects.toThrow(
+			/LANGSMITH_API_KEY_US is not set/,
+		);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-normalize.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-normalize.test.ts
@@ -46,6 +46,42 @@ describe('normalizeExportedCase', () => {
 		expect('scenarios' in out).toBe(false);
 	});
 
+	it('strips arbitrary export-only keys the strict schema would reject', () => {
+		// LangTracer attaches keys like id/name/suiteId/timestamps to an exported
+		// case; n8n's schema is `.strict()` and the loader aggregates errors, so a
+		// single stray key fails the whole suite. Whitelisting to the schema's keys
+		// (not blacklisting the two we happen to know) keeps the export loadable.
+		const out = normalizeExportedCase({
+			conversation: [{ role: 'user', text: 'hi' }],
+			complexity: 'simple',
+			id: 42,
+			name: 'My case',
+			suiteId: 7,
+			createdAt: '2026-01-01',
+			randomFutureKey: { nested: true },
+		}) as Record<string, unknown>;
+		// Real schema fields survive...
+		expect(out.conversation).toEqual([{ role: 'user', text: 'hi' }]);
+		expect(out.complexity).toBe('simple');
+		// ...export-only keys are gone.
+		for (const k of ['id', 'name', 'suiteId', 'createdAt', 'randomFutureKey']) {
+			expect(k in out).toBe(false);
+		}
+	});
+
+	it('keeps a real schema field (seedThread, incl. its endpoint) through the whitelist', () => {
+		const out = normalizeExportedCase({
+			seedThread: { threadId: 't1', endpoint: 'https://api.smith.langchain.com' },
+			complexity: 'medium',
+			id: 1,
+		}) as Record<string, unknown>;
+		expect(out.seedThread).toEqual({
+			threadId: 't1',
+			endpoint: 'https://api.smith.langchain.com',
+		});
+		expect('id' in out).toBe(false);
+	});
+
 	it('returns non-object input unchanged', () => {
 		expect(normalizeExportedCase(null)).toBeNull();
 		expect(normalizeExportedCase('x')).toBe('x');

--- a/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
@@ -10,7 +10,7 @@ import { homedir, tmpdir } from 'os';
 import { basename, join, resolve } from 'path';
 import { z } from 'zod';
 
-import { DEFAULT_DATASETS, conversationTurnTextSchema } from '../data/workflows/schema';
+import { ConversationTurnSchema, DEFAULT_DATASETS } from '../data/workflows/schema';
 import { createLogger } from '../harness/logger';
 import { prebuiltManifestSchema, type PrebuiltManifest } from '../harness/prebuilt-workflows';
 import { runWithConcurrency } from '../harness/runner';
@@ -402,11 +402,15 @@ interface BuildOutcome {
 	durationMs: number;
 }
 
+/** Canonical conversation-turn type (role enum + normalized text), reused from
+ *  the harness schema instead of a looser inline `{ role: string; text }`. */
+type ConversationTurn = z.infer<typeof ConversationTurnSchema>;
+
 const testCaseSchema = z
 	.object({
-		// Reuse the canonical text normalizer so the array (multi-line) form of a
-		// turn's `text` is accepted and joined here exactly as in the eval harness.
-		conversation: z.array(z.object({ role: z.string(), text: conversationTurnTextSchema })).min(1),
+		// Reuse the canonical turn schema so `role` is the exact 'user' | 'assistant'
+		// enum and the array (multi-line) `text` form is normalized as in the harness.
+		conversation: z.array(ConversationTurnSchema).min(1),
 	})
 	.passthrough();
 
@@ -440,7 +444,7 @@ async function buildOne(
 	iteration: number,
 	args: CliArgs,
 	mcpConfigPath: string,
-	conversation: Array<{ role: string; text: string }>,
+	conversation: ConversationTurn[],
 	allowedTools: readonly string[],
 ): Promise<BuildOutcome> {
 	const projectInstruction = args.projectId
@@ -624,7 +628,7 @@ async function main(): Promise<void> {
 	// Resolve slug -> conversation from the chosen source. Disk reads --workflow-dir
 	// (positional slugs or discovered), langtracer pulls a suite over MCP; both feed
 	// the same buildOne prompt.
-	const casesBySlug = new Map<string, Array<{ role: string; text: string }>>();
+	const casesBySlug = new Map<string, ConversationTurn[]>();
 	if (args.source === 'langtracer') {
 		const suite = args.suite;
 		if (!suite) throw new Error('--source langtracer requires --suite <slug>');

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -15,7 +15,7 @@ export const conversationTurnTextSchema = z
 	.union([z.string(), z.array(z.string())])
 	.transform((t) => (Array.isArray(t) ? t.join('\n') : t));
 
-const ConversationTurnSchema = z.object({
+export const ConversationTurnSchema = z.object({
 	role: z.enum(['user', 'assistant']),
 	text: conversationTurnTextSchema,
 });
@@ -88,7 +88,15 @@ const workflowTestCaseObjectSchema = z
 		 *  id; workspace auto-discovered. Supplies the live turn, so `conversation` is
 		 *  optional (continues after it). */
 		seedThread: z
-			.object({ threadId: z.string().min(1), project: z.string().min(1).optional() })
+			.object({
+				threadId: z.string().min(1),
+				project: z.string().min(1).optional(),
+				/** LangSmith host the source trace lives on (dual-tenant reads during the
+				 *  US→EU migration). Omit ⇒ the eval's home (EU) tenant, so existing cases
+				 *  are unchanged. A US-sourced case carries the US host; the harness maps
+				 *  host→key via env (LANGSMITH_API_KEY_US). */
+				endpoint: z.string().url().optional(),
+			})
 			.optional(),
 		/**
 		 * Logical groupings this case belongs to (e.g. `['pr', 'full']`). Used by
@@ -101,6 +109,13 @@ const workflowTestCaseObjectSchema = z
 	// `.strict()` so any key outside the schema (a legacy `buildExpectations`, a typo'd
 	// `outcomeExpectaiton`, etc.) fails at case-load instead of being silently stripped.
 	.strict();
+
+/** The keys n8n's case schema accepts. Exported so non-harness emitters (the
+ *  lang-tracer normalizer) can WHITELIST an exported case down to exactly these —
+ *  the schema is `.strict()`, so any extra key LangTracer attaches (id, name,
+ *  suiteId, timestamps, …) fails the whole suite load. Whitelisting the allowed
+ *  set is robust where blacklisting the few keys we happen to know today is not. */
+export const WORKFLOW_TEST_CASE_KEYS = Object.keys(workflowTestCaseObjectSchema.shape);
 
 // At most one seeding mode, and a source for the live turn.
 export const WorkflowTestCaseSchema = workflowTestCaseObjectSchema

--- a/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
@@ -61,26 +61,63 @@ export const IGNORED_WORKSPACE_TOOLS: readonly string[] = [
 // The source thread may live in a different workspace than the eval writes to
 // (e.g. seed from prod, trace to staging). A PAT spans workspaces, so we
 // enumerate them and find the one holding the thread; reads are read-only.
+//
+// Reads are also dual-tenant: during the US→EU migration a US-sourced case
+// carries `seedThread.endpoint` = the US host, while results always write to the
+// home (EU) tenant elsewhere. `configFor` maps an endpoint → host + key via env.
 
-/** Ambient LangSmith host + key (the eval's own), used to enumerate workspaces. */
-function ambientLangSmithConfig(): { apiUrl: string; apiKey: string } {
-	const raw =
-		process.env.LANGSMITH_ENDPOINT ??
-		process.env.LANGCHAIN_ENDPOINT ??
-		'https://api.smith.langchain.com';
-	const host = raw.replace(/\/$/, '');
-	const apiUrl = host.endsWith('/api/v1') ? host : `${host}/api/v1`;
-	const apiKey = process.env.LANGSMITH_API_KEY ?? process.env.LANGCHAIN_API_KEY ?? '';
-	return { apiUrl, apiKey };
+/** The langsmith SDK's default endpoint is the US tenant, so an unset
+ *  LANGSMITH_ENDPOINT silently means US. The eval env sets it to the home host. */
+const US_DEFAULT_ENDPOINT = 'https://api.smith.langchain.com';
+
+/** Bare host the langsmith Client wants as `apiUrl` (it appends paths itself):
+ *  a trailing slash and an optional `/api/v1` suffix stripped. */
+function bareHost(raw: string): string {
+	return raw.replace(/\/+$/, '').replace(/\/api\/v1$/, '');
 }
 
-/** Workspaces the ambient key can access. Returns [] on any failure so the
+/**
+ * Resolve the LangSmith host + key to READ a seed trace from, by endpoint.
+ * Omitted ⇒ the eval's home tenant (its own env), so existing cases are
+ * unchanged. The home host uses the home key; the secondary (US) host uses
+ * LANGSMITH_API_KEY_US. A non-home host with no configured key THROWS rather
+ * than silently read with the home key — which would query the wrong tenant and
+ * report the thread as missing. Writes never go through here; they stay home.
+ */
+export function configFor(endpoint?: string): { apiUrl: string; apiKey: string } {
+	const homeHost = bareHost(
+		process.env.LANGSMITH_ENDPOINT ?? process.env.LANGCHAIN_ENDPOINT ?? US_DEFAULT_ENDPOINT,
+	);
+	const homeKey = process.env.LANGSMITH_API_KEY ?? process.env.LANGCHAIN_API_KEY ?? '';
+	if (!endpoint) return { apiUrl: homeHost, apiKey: homeKey };
+
+	const host = bareHost(endpoint);
+	if (host === homeHost) return { apiUrl: host, apiKey: homeKey };
+
+	const usHost = bareHost(process.env.LANGSMITH_ENDPOINT_US ?? US_DEFAULT_ENDPOINT);
+	if (host === usHost) {
+		const usKey = process.env.LANGSMITH_API_KEY_US ?? '';
+		if (!usKey) {
+			throw new Error(
+				`seedThread.endpoint "${endpoint}" is the secondary (US) tenant but LANGSMITH_API_KEY_US is not set — refusing to read it with the home key. Set LANGSMITH_API_KEY_US.`,
+			);
+		}
+		return { apiUrl: usHost, apiKey: usKey };
+	}
+	throw new Error(
+		`seedThread.endpoint "${endpoint}" matches no configured LangSmith tenant (home: ${homeHost}; secondary: ${usHost}). Set LANGSMITH_ENDPOINT_US + LANGSMITH_API_KEY_US, or omit endpoint to use the home tenant.`,
+	);
+}
+
+/** Workspaces a key can access on a host. Returns [] on any failure so the
  *  caller falls back to the key's default workspace. */
-async function listAccessibleWorkspaces(): Promise<Array<{ id: string; name: string }>> {
-	const { apiUrl, apiKey } = ambientLangSmithConfig();
+async function listAccessibleWorkspaces(
+	apiUrl: string,
+	apiKey: string,
+): Promise<Array<{ id: string; name: string }>> {
 	if (!apiKey) return [];
 	try {
-		const res = await fetch(`${apiUrl}/workspaces`, { headers: { 'x-api-key': apiKey } });
+		const res = await fetch(`${apiUrl}/api/v1/workspaces`, { headers: { 'x-api-key': apiKey } });
 		if (!res.ok) return [];
 		const data: unknown = await res.json();
 		if (!Array.isArray(data)) return [];
@@ -103,11 +140,17 @@ export interface SeedDiscoveryDeps {
 	ambientClient: () => Client;
 }
 
-const realDiscoveryDeps: SeedDiscoveryDeps = {
-	listWorkspaces: listAccessibleWorkspaces,
-	clientForWorkspace: (workspaceId) => new Client({ workspaceId }),
-	ambientClient: () => new Client(),
-};
+/** Build discovery deps bound to one tenant (host + key resolved from the seed
+ *  ref's endpoint). All three seams target that host, so cross-workspace
+ *  discovery stays within the chosen tenant. */
+function discoveryDepsFor(endpoint?: string): SeedDiscoveryDeps {
+	const { apiUrl, apiKey } = configFor(endpoint);
+	return {
+		listWorkspaces: async () => await listAccessibleWorkspaces(apiUrl, apiKey),
+		clientForWorkspace: (workspaceId) => new Client({ apiUrl, apiKey, workspaceId }),
+		ambientClient: () => new Client({ apiUrl, apiKey }),
+	};
+}
 
 /** Thrown when a thread has no runs in the queried (workspace, project) — used
  *  as control flow during discovery to advance to the next workspace. */
@@ -117,6 +160,10 @@ export interface SeedThreadRef {
 	threadId: string;
 	/** Override the LangSmith project to read the source trace from. */
 	project?: string;
+	/** LangSmith host the source trace lives on. Omit ⇒ the eval's home tenant.
+	 *  Maps host→key via env (home key for the home host, LANGSMITH_API_KEY_US for
+	 *  the US host); an unknown/unkeyed host throws rather than read the wrong tenant. */
+	endpoint?: string;
 }
 
 export interface ReconstructedSeed {
@@ -210,12 +257,13 @@ interface ToolCallBlock {
 export async function reconstructSeedFromThread(
 	ref: SeedThreadRef,
 	client?: Client,
-	deps: SeedDiscoveryDeps = realDiscoveryDeps,
+	deps?: SeedDiscoveryDeps,
 ): Promise<ReconstructedSeed> {
 	const project = ref.project ?? DEFAULT_SOURCE_PROJECT;
-	// An explicit client (tests) reads that one source; otherwise auto-discover.
+	// An explicit client (tests) reads that one source; otherwise auto-discover
+	// within the ref's tenant. Explicit deps (tests) override tenant resolution.
 	if (client) return await reconstructWithClient(ref, client, project);
-	return await discoverAndReconstruct(ref, project, deps);
+	return await discoverAndReconstruct(ref, project, deps ?? discoveryDepsFor(ref.endpoint));
 }
 
 /** Find the workspace holding the thread and reconstruct from it. Falls back to

--- a/packages/@n8n/instance-ai/evaluations/langtracer/normalize.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/normalize.ts
@@ -1,3 +1,8 @@
+import { WORKFLOW_TEST_CASE_KEYS } from '../data/workflows/schema';
+
+/** Keys n8n's `.strict()` case schema accepts — anything else must be stripped. */
+const ALLOWED_KEYS = new Set(WORKFLOW_TEST_CASE_KEYS);
+
 /** Fold lang-tracer's legacy `buildExpectations` into `outcomeExpectations` (the key
  *  n8n's schema forbids). Outcome runs in every build mode. No-ops post-split. */
 export function normalizeExportedCase(raw: unknown): unknown {
@@ -15,9 +20,14 @@ export function normalizeExportedCase(raw: unknown): unknown {
 		delete obj.buildExpectations;
 	}
 
-	// drop dispatch-only keys (not part of n8n's schema)
-	delete obj.prompt;
-	delete obj.scenarios;
-
-	return obj;
+	// Whitelist to the schema's accepted keys. LangTracer attaches export-only keys
+	// (id, name, suiteId, timestamps, the dispatch-only prompt/scenarios, …); n8n's
+	// schema is `.strict()` and the loader aggregates errors, so a single stray key
+	// fails the whole suite. Stripping to the allowed set is robust where deleting
+	// the two keys we happen to know today is not.
+	const cleaned: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(obj)) {
+		if (ALLOWED_KEYS.has(key)) cleaned[key] = value;
+	}
+	return cleaned;
 }


### PR DESCRIPTION
## Summary

Dual-tenant LangSmith **reads** for Instance AI evals, for the US→EU migration. While EU builds volume we keep sourcing seed traces from the US tenant — review them, create eval cases, and replay/run them — without disrupting EU. This is dual-tenant **reads**, single-tenant (EU) **writes**: run telemetry is untouched and stays on EU.

A case selects its read tenant via a new optional `seedThread.endpoint`:

- `data/workflows/schema.ts` + `harness/langsmith-seed.ts`: add `seedThread.endpoint` (+ `SeedThreadRef.endpoint`); `ambientLangSmithConfig()` → `configFor(endpoint?)` resolves `{apiUrl, apiKey}` by host — home key for the home host, `LANGSMITH_API_KEY_US` for the US host; an unknown/unkeyed host **throws** rather than silently reading EU. Discovery deps are built per ref-tenant, preserving cross-workspace auto-discovery within the chosen tenant.
- **Omitted `endpoint` ⇒ the home (EU) tenant**, so existing cases are byte-identical and EU is zero-change. Sunset: when US drains, stop emitting the endpoint and drop the secondary key — no leftover.
- The **write path** (`cli/index.ts` `new Client()` + builder-telemetry) is untouched → results always land on EU.
- **No CI change**: seeded / US-sourced cases are `datasets: ["seeded"]`, off the PR/full suites, so CI never pulls a US trace and needs no new secret. The US key (`LANGSMITH_API_KEY_US`) is local-only (`.env.local`) for now. Home `LANGSMITH_ENDPOINT` stays explicitly EU (the SDK default endpoint is US).

The second commit folds in two unrelated cleanups from the `--source langtracer` review: the exported-case normalizer now whitelists to the schema's key set (robust vs `.strict()`), and the mcp-manifest builder reuses the canonical `ConversationTurnSchema` enum.

**Cross-repo contract:** `seedThread.endpoint` is emitted by LangTracer — companion PR n8n-io/lang-tracer#25.

## How to test

- `pnpm --filter @n8n/instance-ai typecheck` clean; **710 eval vitest green** (`configFor` resolution, schema `endpoint` acceptance, normalizer whitelist); eslint + biome clean.
- Live: run a seedThread case with `seedThread.endpoint: "https://api.smith.langchain.com"` against a real US thread, with `LANGSMITH_API_KEY_US` set in `.env.local`; the harness reconstructs from US while results write to EU. _This live US reconstruct is the remaining check before un-drafting._

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-217

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
