### PR TITLE
feat(editor): Add preview-node hover and click telemetry to split empty state experiment (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/CyclingPreviewCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/CyclingPreviewCanvas.test.ts
@@ -17,8 +17,9 @@ vi.mock('../useBuildManually', () => ({
 vi.mock('./InstanceAiPreviewCanvas.vue', () => ({
 	default: {
 		name: 'InstanceAiPreviewCanvas',
-		template: '<div data-test-id="instance-ai-preview-canvas" />',
-		props: ['workflow', 'animating'],
+		template:
+			'<div data-test-id="instance-ai-preview-canvas" :data-suggestion-id="suggestionId" />',
+		props: ['workflow', 'animating', 'suggestionId'],
 	},
 }));
 
@@ -57,5 +58,13 @@ describe('CyclingPreviewCanvas', () => {
 		const { getByTestId } = renderComponent();
 		await fireEvent.click(getByTestId('instance-ai-canvas-build-manually'));
 		expect(buildManually).toHaveBeenCalledWith('p1');
+	});
+
+	it('passes the active example id to the preview canvas as suggestionId', () => {
+		// renderComponent default props use activeIndex: 1
+		const { getByTestId } = renderComponent();
+		expect(getByTestId('instance-ai-preview-canvas').getAttribute('data-suggestion-id')).toBe(
+			INSTANCE_AI_SPLIT_EMPTY_STATE_EXAMPLES[1].id,
+		);
 	});
 });

--- a/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/CyclingPreviewCanvas.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/CyclingPreviewCanvas.vue
@@ -45,6 +45,7 @@ const activeWorkflow = computed(() =>
 				v-else-if="activeWorkflow"
 				:key="props.activeIndex"
 				:workflow="activeWorkflow"
+				:suggestion-id="props.examples[props.activeIndex].id"
 			/>
 		</div>
 	</div>

--- a/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.test.ts
@@ -1,24 +1,132 @@
-import { describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import { scoreMyLeadsWorkflow } from '@/experiments/instanceAiWorkflowPreviewSuggestions/workflows/score-my-leads';
 import InstanceAiPreviewCanvas from './InstanceAiPreviewCanvas.vue';
 
-const renderComponent = createComponentRenderer(InstanceAiPreviewCanvas);
+const telemetryTrack = vi.fn();
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: telemetryTrack }),
+}));
+
+// First node of scoreMyLeadsWorkflow: { id: 'salesforce-trigger', label: 'New lead' }.
+const NODE_TEST_ID = 'instance-ai-preview-node-salesforce-trigger';
+const HOVERED_EVENT = 'AI Assistant preview node hovered';
+const CLICKED_EVENT = 'AI Assistant preview node clicked';
+
+const renderComponent = createComponentRenderer(InstanceAiPreviewCanvas, {
+	props: { workflow: scoreMyLeadsWorkflow, suggestionId: 'score-my-leads', animating: false },
+});
 
 describe('InstanceAiPreviewCanvas', () => {
+	beforeEach(() => {
+		telemetryTrack.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('renders the canvas root element', () => {
-		const { getByTestId } = renderComponent({
-			props: { workflow: scoreMyLeadsWorkflow, animating: false },
-		});
+		const { getByTestId } = renderComponent();
 		expect(getByTestId('instance-ai-preview-canvas')).toBeInTheDocument();
 	});
 
 	it('renders node labels from the workflow', () => {
-		const { getAllByText } = renderComponent({
-			props: { workflow: scoreMyLeadsWorkflow, animating: false },
+		const { getAllByText } = renderComponent();
+		expect(getAllByText('New lead').length).toBeGreaterThan(0);
+	});
+
+	it('tracks a node hover with fractional dwell seconds once it settles', async () => {
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		const { getByTestId } = renderComponent();
+		const node = getByTestId(NODE_TEST_ID);
+
+		await fireEvent.mouseEnter(node);
+		nowSpy.mockReturnValue(1_500); // 500ms later
+		await fireEvent.mouseLeave(node);
+
+		expect(telemetryTrack).toHaveBeenCalledWith(HOVERED_EVENT, {
+			node_id: 'salesforce-trigger',
+			node_label: 'New lead',
+			suggestion_id: 'score-my-leads',
+			seconds: 0.5,
 		});
-		// scoreMyLeadsWorkflow has a node labelled "New lead".
-		const matches = getAllByText('New lead');
-		expect(matches.length).toBeGreaterThan(0);
+	});
+
+	it('does not track hovers shorter than the settle threshold', async () => {
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		const { getByTestId } = renderComponent();
+		const node = getByTestId(NODE_TEST_ID);
+
+		await fireEvent.mouseEnter(node);
+		nowSpy.mockReturnValue(1_200); // 200ms < 300ms
+		await fireEvent.mouseLeave(node);
+
+		expect(telemetryTrack).not.toHaveBeenCalled();
+	});
+
+	it('tracks a node click and flushes the open hover before it', async () => {
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		const { getByTestId } = renderComponent();
+		const node = getByTestId(NODE_TEST_ID);
+
+		await fireEvent.mouseEnter(node);
+		nowSpy.mockReturnValue(1_400); // 400ms
+		await fireEvent.click(node);
+
+		expect(telemetryTrack).toHaveBeenCalledWith(HOVERED_EVENT, {
+			node_id: 'salesforce-trigger',
+			node_label: 'New lead',
+			suggestion_id: 'score-my-leads',
+			seconds: 0.4,
+		});
+		expect(telemetryTrack).toHaveBeenCalledWith(CLICKED_EVENT, {
+			node_id: 'salesforce-trigger',
+			node_label: 'New lead',
+			suggestion_id: 'score-my-leads',
+		});
+
+		// A later mouseleave must not emit a second hover (the hover was already flushed).
+		telemetryTrack.mockClear();
+		await fireEvent.mouseLeave(node);
+		expect(telemetryTrack).not.toHaveBeenCalled();
+	});
+
+	it('tracks a click with no prior settled hover as click-only', async () => {
+		const { getByTestId } = renderComponent();
+		const node = getByTestId(NODE_TEST_ID);
+
+		await fireEvent.click(node);
+
+		expect(telemetryTrack).toHaveBeenCalledTimes(1);
+		expect(telemetryTrack).toHaveBeenCalledWith(CLICKED_EVENT, {
+			node_id: 'salesforce-trigger',
+			node_label: 'New lead',
+			suggestion_id: 'score-my-leads',
+		});
+	});
+
+	it('flushes an open hover when the canvas unmounts', async () => {
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+		const { getByTestId, unmount } = renderComponent();
+		const node = getByTestId(NODE_TEST_ID);
+
+		await fireEvent.mouseEnter(node);
+		nowSpy.mockReturnValue(1_900); // 900ms
+		unmount();
+
+		expect(telemetryTrack).toHaveBeenCalledWith(HOVERED_EVENT, {
+			node_id: 'salesforce-trigger',
+			node_label: 'New lead',
+			suggestion_id: 'score-my-leads',
+			seconds: 0.9,
+		});
+	});
+
+	it('marks interactive nodes with pointer-events auto', () => {
+		const { getByTestId } = renderComponent();
+		expect(getByTestId(NODE_TEST_ID).style.pointerEvents).toBe('auto');
 	});
 });

--- a/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.vue
@@ -4,7 +4,9 @@ import { useElementSize } from '@vueuse/core';
 import type {
 	PreviewWorkflow,
 	PreviewWorkflowConnection,
+	PreviewWorkflowNode,
 } from '@/experiments/instanceAiWorkflowPreviewSuggestions/workflows/types';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import WorkflowPreviewNode from '@/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.vue';
 
 const NODE_HALF_WIDTH = 48;
@@ -66,10 +68,54 @@ function normalizeIconSrc(src: string): string {
 const props = withDefaults(
 	defineProps<{
 		workflow: PreviewWorkflow;
+		suggestionId: string;
 		animating?: boolean;
 	}>(),
 	{ animating: true },
 );
+
+const SETTLE_MS = 300;
+const telemetry = useTelemetry();
+const hoverStartTimes = new Map<string, number>();
+
+function emitHover(nodeId: string, label: string) {
+	const start = hoverStartTimes.get(nodeId);
+	if (start === undefined) return;
+	hoverStartTimes.delete(nodeId);
+	const elapsedMs = Date.now() - start;
+	if (elapsedMs < SETTLE_MS) return;
+	telemetry.track('AI Assistant preview node hovered', {
+		node_id: nodeId,
+		node_label: label,
+		suggestion_id: props.suggestionId,
+		seconds: Math.round(elapsedMs / 10) / 100,
+	});
+}
+
+function onNodeEnter(node: PreviewWorkflowNode) {
+	hoverStartTimes.set(node.id, Date.now());
+}
+
+function onNodeLeave(node: PreviewWorkflowNode) {
+	emitHover(node.id, node.label);
+}
+
+function onNodeClick(node: PreviewWorkflowNode) {
+	// Flush the open hover first, mirroring the suggestion-button reference.
+	emitHover(node.id, node.label);
+	telemetry.track('AI Assistant preview node clicked', {
+		node_id: node.id,
+		node_label: node.label,
+		suggestion_id: props.suggestionId,
+	});
+}
+
+function flushOpenHovers() {
+	for (const id of [...hoverStartTimes.keys()]) {
+		const node = props.workflow.nodes.find((n) => n.id === id);
+		emitHover(id, node?.label ?? '');
+	}
+}
 
 const canvasRef = ref<HTMLElement | null>(null);
 const { width: canvasRenderedWidth, height: canvasRenderedHeight } = useElementSize(canvasRef);
@@ -175,6 +221,7 @@ onMounted(() => {
 });
 
 onUnmounted(stopAnimation);
+onUnmounted(flushOpenHovers);
 
 const bounds = computed(() => {
 	const nodes = props.workflow.nodes;
@@ -273,6 +320,11 @@ function isEdgeSuccess(connection: PreviewWorkflowConnection): boolean {
 					:trigger="triggerNodeIds.has(node.id)"
 					:offset-x="bounds.minX"
 					:offset-y="bounds.minY"
+					interactive
+					:data-test-id="`instance-ai-preview-node-${node.id}`"
+					@mouseenter="onNodeEnter(node)"
+					@mouseleave="onNodeLeave(node)"
+					@click="onNodeClick(node)"
 				/>
 			</div>
 		</div>

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createComponentRenderer } from '@/__tests__/render';
+import type { PreviewWorkflowNode } from '../workflows/types';
+import WorkflowPreviewNode from './WorkflowPreviewNode.vue';
+
+const baseNode: PreviewWorkflowNode = {
+	id: 'n1',
+	label: 'Node One',
+	icon: { type: 'icon', name: 'node:code' },
+	position: { x: 0, y: 0 },
+};
+
+const renderComponent = createComponentRenderer(WorkflowPreviewNode, {
+	props: { node: baseNode, offsetX: 0, offsetY: 0 },
+});
+
+describe('WorkflowPreviewNode', () => {
+	it('is non-interactive by default (sibling experiment safety)', () => {
+		const { container } = renderComponent();
+		expect((container.firstElementChild as HTMLElement).style.pointerEvents).toBe('');
+	});
+
+	it('sets pointer-events auto when interactive', () => {
+		const { container } = renderComponent({ props: { interactive: true } });
+		expect((container.firstElementChild as HTMLElement).style.pointerEvents).toBe('auto');
+	});
+});

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.vue
@@ -13,8 +13,9 @@ const props = withDefaults(
 		state?: NodeAnimationState;
 		trigger?: boolean;
 		iconOverride?: PreviewWorkflowNodeIcon;
+		interactive?: boolean;
 	}>(),
-	{ state: 'idle', trigger: false },
+	{ state: 'idle', trigger: false, interactive: false },
 );
 
 const style = computed(() => ({
@@ -47,7 +48,7 @@ const iconSrc = computed(() =>
 			props.state === 'running' && $style.running,
 			props.state === 'success' && $style.success,
 		]"
-		:style="style"
+		:style="[style, props.interactive ? { pointerEvents: 'auto' } : {}]"
 	>
 		<div :class="$style.iconWrapper" :style="iconWrapperStyle">
 			<N8nIcon v-if="iconName" :icon="iconName" :size="48" />


### PR DESCRIPTION
## Summary

Adds engagement telemetry to the auto-cycling **workflow preview** in the `089_instance_ai_split_empty_state` experiment. The preview nodes (rendered by `InstanceAiPreviewCanvas`) now emit two events so we can see whether users *try* to interact with the preview:

- `AI Assistant preview node hovered` → `{ node_id, node_label, suggestion_id, seconds }` — fired after a 300ms settle; `seconds` is fractional dwell time
- `AI Assistant preview node clicked` → `{ node_id, node_label, suggestion_id }`

**Instrumentation only — no functional or visual change.** Nodes get `pointer-events: auto` (no cursor change, highlight, or scale), so we measure *organic* intent rather than inviting clicks. The auto-cycle is not paused on hover; an in-progress hover is flushed on click and on unmount.

Mechanism:
- The shared `WorkflowPreviewNode.vue` gains an opt-in `interactive` prop (default `false`), so the sibling `instanceAiWorkflowPreviewSuggestions` experiment is unaffected.
- Hover/click bookkeeping lives in `InstanceAiPreviewCanvas.vue`; `CyclingPreviewCanvas.vue` passes the active example id as `suggestionId`.

## How to test

Automated (from `packages/frontend/editor-ui`):
- `CI=true pnpm test src/experiments/instanceAiSplitEmptyState src/experiments/instanceAiWorkflowPreviewSuggestions` → 53/53 pass (incl. the sibling experiment, proving the shared change is a no-op).
- `pnpm typecheck` passes.

Manual smoke (recommended): enable the `089_instance_ai_split_empty_state` experiment, open the Instance AI empty state on a wide viewport, hover and click the preview nodes, and confirm in devtools/PostHog that the two events fire with the expected payload — and that the preview looks visually unchanged.

## Related Linear tickets, Github issues, and Community forum posts

No Linear ticket linked (iteration on the 089 split-screen experiment). Happy to attach one if there's a corresponding ticket.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- N/A: experiment-only telemetry, no user-facing docs -->
- [x] Tests included.
- [ ] PR Labeled with Backport (if urgent fix). <!-- N/A -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->