### PR TITLE
feat(Kafka Node): Add mTLS (client certificate) authentication

### DIFF
--- a/packages/nodes-base/credentials/Kafka.credentials.ts
+++ b/packages/nodes-base/credentials/Kafka.credentials.ts
@@ -30,19 +30,6 @@ export class Kafka implements ICredentialType {
 			default: true,
 		},
 		{
-			displayName: 'Ignore SSL Issues (Insecure)',
-			name: 'allowUnauthorizedCerts',
-			type: 'boolean',
-			default: false,
-			displayOptions: {
-				show: {
-					ssl: [true],
-				},
-			},
-			description:
-				'Whether to connect even when SSL certificate validation fails (e.g. a self-signed or hostname-mismatched broker certificate)',
-		},
-		{
 			displayName: 'CA Certificate',
 			name: 'ca',
 			type: 'string',
@@ -89,6 +76,21 @@ export class Kafka implements ICredentialType {
 			},
 			description:
 				'PEM-encoded client private key for mutual TLS (mTLS). Provide together with the client certificate.',
+		},
+		{
+			// Kept last so the common-case TLS fields come first and the insecure
+			// escape hatch is not the first thing presented after enabling SSL.
+			displayName: 'Ignore SSL Issues (Insecure)',
+			name: 'allowUnauthorizedCerts',
+			type: 'boolean',
+			default: false,
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			description:
+				'Whether to connect even when SSL certificate validation fails (e.g. a self-signed or hostname-mismatched broker certificate)',
 		},
 		{
 			displayName: 'Authentication',

--- a/packages/nodes-base/credentials/Kafka.credentials.ts
+++ b/packages/nodes-base/credentials/Kafka.credentials.ts
@@ -30,6 +30,67 @@ export class Kafka implements ICredentialType {
 			default: true,
 		},
 		{
+			displayName: 'Ignore SSL Issues (Insecure)',
+			name: 'allowUnauthorizedCerts',
+			type: 'boolean',
+			default: false,
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			description:
+				'Whether to connect even when SSL certificate validation fails (e.g. a self-signed or hostname-mismatched broker certificate)',
+		},
+		{
+			displayName: 'CA Certificate',
+			name: 'ca',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			description:
+				'PEM-encoded CA certificate(s) used to verify the broker. Leave empty to use the system CAs.',
+		},
+		{
+			displayName: 'Client Certificate',
+			name: 'cert',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			description:
+				'PEM-encoded client certificate for mutual TLS (mTLS). Provide together with the client private key.',
+		},
+		{
+			displayName: 'Client Private Key',
+			name: 'key',
+			type: 'string',
+			typeOptions: {
+				password: true,
+			},
+			default: '',
+			displayOptions: {
+				show: {
+					ssl: [true],
+				},
+			},
+			description:
+				'PEM-encoded client private key for mutual TLS (mTLS). Provide together with the client certificate.',
+		},
+		{
 			displayName: 'Authentication',
 			name: 'authentication',
 			type: 'boolean',

--- a/packages/nodes-base/nodes/Kafka/Kafka.node.ts
+++ b/packages/nodes-base/nodes/Kafka/Kafka.node.ts
@@ -15,7 +15,7 @@ import type {
 import { NodeConnectionTypes, NodeOperationError, UserError } from 'n8n-workflow';
 
 import { generatePairedItemData } from '../../utils/utilities';
-import { createSchemaRegistry } from './utils';
+import { createSchemaRegistry, resolveKafkaSsl, type KafkaCredentials } from './utils';
 
 export class Kafka implements INodeType {
 	description: INodeTypeDescription = {
@@ -231,12 +231,10 @@ export class Kafka implements INodeType {
 
 					const clientId = credentials.clientId as string;
 
-					const ssl = credentials.ssl as boolean;
-
 					const config: KafkaConfig = {
 						clientId,
 						brokers,
-						ssl,
+						ssl: resolveKafkaSsl(credentials as unknown as KafkaCredentials),
 					};
 					if (credentials.authentication === true) {
 						if (!(credentials.username && credentials.password)) {
@@ -295,21 +293,19 @@ export class Kafka implements INodeType {
 				compression = CompressionTypes.GZIP;
 			}
 
-			const credentials = await this.getCredentials('kafka');
+			const credentials = await this.getCredentials<KafkaCredentials>('kafka');
 
-			const brokers = ((credentials.brokers as string) || '').split(',').map((item) => item.trim());
+			const brokers = (credentials.brokers || '').split(',').map((item) => item.trim());
 
-			const clientId = credentials.clientId as string;
-
-			const ssl = credentials.ssl as boolean;
+			const clientId = credentials.clientId;
 
 			const config: KafkaConfig = {
 				clientId,
 				brokers,
-				ssl,
+				ssl: resolveKafkaSsl(credentials),
 			};
 
-			if (credentials.authentication === true) {
+			if (credentials.authentication) {
 				if (!(credentials.username && credentials.password)) {
 					throw new NodeOperationError(
 						this.getNode(),
@@ -317,8 +313,8 @@ export class Kafka implements INodeType {
 					);
 				}
 				config.sasl = {
-					username: credentials.username as string,
-					password: credentials.password as string,
+					username: credentials.username,
+					password: credentials.password,
 					mechanism: credentials.saslMechanism as string,
 				} as SASLOptions;
 			}

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -21,7 +21,9 @@ import {
 	getAutoCommitSettings,
 	configureDataEmitter,
 	type KafkaTriggerOptions,
+	type KafkaCredentials,
 	getSchemaRegistryOptions,
+	resolveKafkaSsl,
 	setSchemaRegistry,
 } from '../utils';
 
@@ -37,6 +39,87 @@ vi.mock('n8n-workflow', async () => {
 const mockedSleep = vi.mocked(sleep);
 
 describe('Kafka Utils', () => {
+	describe('resolveKafkaSsl', () => {
+		const CERT_PEM = '-----BEGIN CERTIFICATE-----\nMIIBclientcertbody==\n-----END CERTIFICATE-----';
+		const KEY_PEM = '-----BEGIN PRIVATE KEY-----\nMIIBclientkeybody==\n-----END PRIVATE KEY-----';
+		const CA_PEM = '-----BEGIN CERTIFICATE-----\nMIIBcacertbody==\n-----END CERTIFICATE-----';
+
+		const creds = (overrides: Partial<KafkaCredentials> = {}): KafkaCredentials => ({
+			clientId: 'test',
+			brokers: 'localhost:9092',
+			ssl: true,
+			authentication: false,
+			...overrides,
+		});
+
+		type SslObject = Exclude<ReturnType<typeof resolveKafkaSsl>, boolean>;
+
+		it('returns false when SSL is disabled, even if cert material is present', () => {
+			expect(resolveKafkaSsl(creds({ ssl: false, cert: CERT_PEM, key: KEY_PEM }))).toBe(false);
+		});
+
+		it('returns plain boolean true for SSL-only credentials (legacy, no mTLS material)', () => {
+			expect(resolveKafkaSsl(creds())).toBe(true);
+		});
+
+		it('treats whitespace-only cert/key/CA as empty and stays on boolean SSL', () => {
+			expect(resolveKafkaSsl(creds({ cert: '   ', key: '\n', ca: ' ' }))).toBe(true);
+		});
+
+		it('builds cert + key buffers when a client certificate and key are provided', () => {
+			const ssl = resolveKafkaSsl(creds({ cert: CERT_PEM, key: KEY_PEM })) as SslObject;
+			expect(Buffer.isBuffer(ssl.cert)).toBe(true);
+			expect(Buffer.isBuffer(ssl.key)).toBe(true);
+			expect((ssl.cert as Buffer).toString()).toContain('BEGIN CERTIFICATE');
+			expect((ssl.key as Buffer).toString()).toContain('BEGIN PRIVATE KEY');
+			expect(ssl.ca).toBeUndefined();
+			expect(ssl.rejectUnauthorized).toBeUndefined();
+		});
+
+		it('wraps a CA certificate in an array', () => {
+			const ssl = resolveKafkaSsl(creds({ ca: CA_PEM })) as SslObject;
+			expect(Array.isArray(ssl.ca)).toBe(true);
+			expect(Buffer.isBuffer((ssl.ca as Buffer[])[0])).toBe(true);
+			expect(ssl.cert).toBeUndefined();
+			expect(ssl.key).toBeUndefined();
+		});
+
+		it('maps cert, key, CA and the insecure toggle together', () => {
+			const ssl = resolveKafkaSsl(
+				creds({ cert: CERT_PEM, key: KEY_PEM, ca: CA_PEM, allowUnauthorizedCerts: true }),
+			) as SslObject;
+			expect(Buffer.isBuffer(ssl.cert)).toBe(true);
+			expect(Buffer.isBuffer(ssl.key)).toBe(true);
+			expect(Array.isArray(ssl.ca)).toBe(true);
+			expect(ssl.rejectUnauthorized).toBe(false);
+		});
+
+		it('sets rejectUnauthorized:false for the insecure toggle on its own', () => {
+			expect(resolveKafkaSsl(creds({ allowUnauthorizedCerts: true }))).toEqual({
+				rejectUnauthorized: false,
+			});
+		});
+
+		it('throws when a client certificate is provided without its key', () => {
+			expect(() => resolveKafkaSsl(creds({ cert: CERT_PEM }))).toThrow('Kafka mTLS needs both');
+		});
+
+		it('throws when a client key is provided without its certificate', () => {
+			expect(() => resolveKafkaSsl(creds({ key: KEY_PEM }))).toThrow('Kafka mTLS needs both');
+		});
+
+		it('throws on a value that is not PEM at all', () => {
+			expect(() => resolveKafkaSsl(creds({ ca: 'not-a-pem' }))).toThrow('not a valid PEM block');
+		});
+
+		it('throws on a truncated PEM that has BEGIN but no matching END', () => {
+			const truncated = '-----BEGIN CERTIFICATE-----\nMIIBtruncatedbody==';
+			expect(() => resolveKafkaSsl(creds({ cert: truncated, key: KEY_PEM }))).toThrow(
+				'not a valid PEM block',
+			);
+		});
+	});
+
 	describe('getAutoCommitSettings', () => {
 		it('should return autoCommit true and eachBatchAutoResolve false for version 1.1', () => {
 			const options: KafkaTriggerOptions = {};

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -88,7 +88,10 @@ type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatu
  */
 function toPemBuffer(value: string, fieldName: string): Buffer {
 	const formatted = formatPemBlock(value);
-	if (!/-----BEGIN [A-Z0-9 ]+-----/.test(formatted)) {
+	// Require a matching BEGIN/END pair with the same label — a lone BEGIN header
+	// (e.g. a truncated paste) would otherwise pass and only fail later as an
+	// opaque TLS handshake error.
+	if (!/-----BEGIN ([A-Z0-9 ]+)-----[\s\S]+-----END \1-----/.test(formatted)) {
 		throw new UserError(`The Kafka ${fieldName} is not a valid PEM block`, {
 			level: 'warning',
 			description:

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -83,6 +83,11 @@ type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatu
  * Normalizes a PEM credential field and returns it as a Buffer, throwing a clear
  * error when the value is not a PEM block (the most common paste mistake) so the
  * failure surfaces at config time instead of as an opaque TLS handshake error.
+ *
+ * The strict BEGIN/END check stays here rather than in the shared `formatPemBlock`
+ * normalizer: that helper is a non-throwing, best-effort formatter used by many
+ * credentials (it returns multi-block chains and unrecognized input unchanged), so
+ * only this Kafka mTLS path wants to reject an incomplete PEM loudly at config time.
  * @param value - The raw PEM string from the credential
  * @param fieldName - Human-readable field name used in the error message
  */

--- a/packages/nodes-base/nodes/Kafka/utils.ts
+++ b/packages/nodes-base/nodes/Kafka/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from 'kafkajs';
 import { logLevel } from 'kafkajs';
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import { formatPemBlock } from '@n8n/utils';
 import type {
 	Logger,
 	ITriggerFunctions,
@@ -19,9 +20,10 @@ import type {
 	FunctionsBase,
 	RequestHelperFunctions,
 } from 'n8n-workflow';
-import { ensureError, jsonParse, NodeOperationError, sleep } from 'n8n-workflow';
+import { ensureError, jsonParse, NodeOperationError, sleep, UserError } from 'n8n-workflow';
 import http from 'node:http';
 import https from 'node:https';
+import type { ConnectionOptions } from 'node:tls';
 
 // Default delay in milliseconds before retrying after a failed offset resolution.
 // This prevents rapid retry loops that could overwhelm the Kafka broker
@@ -49,7 +51,7 @@ export interface KafkaTriggerOptions {
 	sessionTimeout?: number;
 }
 
-interface KafkaCredentials {
+export interface KafkaCredentials {
 	clientId: string;
 	brokers: string;
 	ssl: boolean;
@@ -57,6 +59,10 @@ interface KafkaCredentials {
 	username?: string;
 	password?: string;
 	saslMechanism?: 'plain' | 'scram-sha-256' | 'scram-sha-512';
+	allowUnauthorizedCerts?: boolean;
+	ca?: string;
+	cert?: string;
+	key?: string;
 }
 
 interface SchemaRegistryCredentials {
@@ -74,6 +80,64 @@ interface SchemaRegistryOptions {
 type ResolveOffsetMode = 'immediately' | 'onCompletion' | 'onSuccess' | 'onStatus';
 
 /**
+ * Normalizes a PEM credential field and returns it as a Buffer, throwing a clear
+ * error when the value is not a PEM block (the most common paste mistake) so the
+ * failure surfaces at config time instead of as an opaque TLS handshake error.
+ * @param value - The raw PEM string from the credential
+ * @param fieldName - Human-readable field name used in the error message
+ */
+function toPemBuffer(value: string, fieldName: string): Buffer {
+	const formatted = formatPemBlock(value);
+	if (!/-----BEGIN [A-Z0-9 ]+-----/.test(formatted)) {
+		throw new UserError(`The Kafka ${fieldName} is not a valid PEM block`, {
+			level: 'warning',
+			description:
+				'Paste the full PEM, including the "-----BEGIN ...-----" and "-----END ...-----" lines.',
+		});
+	}
+	return Buffer.from(formatted);
+}
+
+/**
+ * Resolves the kafkajs `ssl` option from the Kafka credential. Returns the plain
+ * boolean (system CAs, full verification — unchanged legacy behavior) unless the
+ * credential supplies mTLS material (client cert + key), a custom CA, or the
+ * "Ignore SSL Issues" toggle, in which case a `tls.ConnectionOptions` object is
+ * built. Throws a clear error when the cert/key pair is incomplete or a value is
+ * not PEM, so misconfiguration fails loudly rather than at the TLS handshake.
+ * @param credentials - The decrypted Kafka credential
+ */
+export function resolveKafkaSsl(credentials: KafkaCredentials): ConnectionOptions | boolean {
+	if (!credentials.ssl) return false;
+
+	const cert = credentials.cert?.trim() ? credentials.cert : undefined;
+	const key = credentials.key?.trim() ? credentials.key : undefined;
+	const ca = credentials.ca?.trim() ? credentials.ca : undefined;
+	const allowUnauthorized = credentials.allowUnauthorizedCerts === true;
+
+	// A client certificate and its private key are only meaningful together.
+	if (Boolean(cert) !== Boolean(key)) {
+		throw new UserError('Kafka mTLS needs both a client certificate and a client private key', {
+			level: 'warning',
+			description:
+				'Set both the "Client Certificate" and "Client Private Key" credential fields, or clear both.',
+		});
+	}
+
+	// Nothing beyond plain server-side TLS configured: keep the boolean form so
+	// existing SSL-only and SASL credentials are completely unaffected.
+	if (!cert && !ca && !allowUnauthorized) return true;
+
+	const sslOptions: ConnectionOptions = {};
+	if (ca) sslOptions.ca = [toPemBuffer(ca, 'CA certificate')];
+	if (cert) sslOptions.cert = toPemBuffer(cert, 'client certificate');
+	if (key) sslOptions.key = toPemBuffer(key, 'client private key');
+	if (allowUnauthorized) sslOptions.rejectUnauthorized = false;
+
+	return sslOptions;
+}
+
+/**
  * Creates Kafka client configuration from n8n credentials
  * @param ctx - The trigger function context
  * @returns Kafka configuration object with authentication settings
@@ -82,12 +146,11 @@ export async function createConfig(ctx: ITriggerFunctions) {
 	const credentials = (await ctx.getCredentials('kafka')) as KafkaCredentials;
 	const clientId = credentials.clientId;
 	const brokers = (credentials.brokers ?? '').split(',').map((item) => item.trim());
-	const ssl = credentials.ssl;
 
 	const config: KafkaConfig = {
 		clientId,
 		brokers,
-		ssl,
+		ssl: resolveKafkaSsl(credentials),
 		logLevel: logLevel.ERROR,
 	};
 


### PR DESCRIPTION
## Summary

Adds **mutual TLS (mTLS) / client-certificate authentication** to the **Kafka** credential, so n8n can connect to brokers that require the client to present a certificate. This unblocks enterprise customers whose Kafka brokers mandate mTLS and who currently cannot connect at all.

Today the Kafka credential exposes only server-side TLS (`SSL` on/off) and SASL (PLAIN/SCRAM). `kafkajs` already accepts a full `ssl: { ca, cert, key, rejectUnauthorized }` object — the gap was purely at the credential/UI + wiring layer. This PR closes that gap.

**What changed**

- **Credential** (`Kafka.credentials.ts`) — four new fields, shown only when **SSL** is enabled:
  - **CA Certificate** (PEM, optional — defaults to the system CAs)
  - **Client Certificate** (PEM)
  - **Client Private Key** (PEM, masked)
  - **Ignore SSL Issues (Insecure)** — optional, **off by default** (mirrors the Postgres credential); sets `rejectUnauthorized: false`
- **Shared `resolveKafkaSsl()` helper** (`nodes/Kafka/utils.ts`) — maps the credential to the `kafkajs` `ssl` option. Returns the existing **boolean** for SSL-only / SASL credentials (no behaviour change), or a `tls.ConnectionOptions` object when any mTLS material / the insecure toggle is set. PEM input is normalised via `formatPemBlock`, so single-line / escaped-newline pastes work.
- **Wired into all three Kafka client-config sites** — the **producer** node (`execute`), the **Kafka Trigger** (`createConfig`), and the credential **Test** button — so they all connect identically. This also removes the previously triplicated inline SSL handling.
- **Validation** — a client certificate and private key must be supplied together; an incomplete pair or a non-PEM value fails with a clear, actionable error instead of an opaque TLS handshake failure.

**Backwards compatible:** the new fields are optional and gated behind `SSL`. Existing SSL-only and SASL credentials are unaffected — `resolveKafkaSsl` returns the same boolean they get today, and all 118 existing Kafka tests pass unchanged.

**Library note:** implemented against `kafkajs` (the current client). Per ENT-81's sequencing note, if the `@confluentinc/kafka-javascript` migration (ENT-8) lands first, mTLS is a native librdkafka capability there; this implementation is isolated in `resolveKafkaSsl` to keep that transition easy.

## How to test

> mTLS requires a broker configured to require client certificates, so it can't be exercised against a plaintext broker.

1. Stand up (or point at) a Kafka broker that requires client-cert auth (`ssl.client.auth=required`).
2. In n8n, create/edit a **Kafka** credential: enable **SSL**, then paste the **Client Certificate** and **Client Private Key** (PEM), plus the **CA Certificate** if the broker uses a private CA.
3. Click **Test** — it should connect (admin connect/disconnect) and report success.
4. **Kafka** node → produce a message to a topic; **Kafka Trigger** → consume from a topic. Both should succeed against the mTLS broker.
5. **Regression:** a credential with **SSL** on and no cert fields (server-side TLS only), and a SASL credential, should behave exactly as before.
6. **Negative:** providing only the certificate **or** only the key, or a non-PEM value, should fail with a clear error.

`resolveKafkaSsl` unit tests are in (`nodes/Kafka/test/utils.test.ts`); producer/trigger integration assertions are still being added (see Status below).

## Test harness setup (local mTLS broker)

mTLS can't be exercised against a plaintext broker, so here's a self-contained single-node Kafka (KRaft) whose external listener enforces `ssl.client.auth=required`, PEM throughout (matching what the credential sends). It is **not committed** — recreate it in a scratch dir. You can also paste this section into an AI coding agent (e.g. Claude Code) to automate steps 1–2.

> **Why a custom `server.properties` instead of `KAFKA_*` env vars?** The `apache/kafka` image's `configure` script assumes JKS keystores + credentials files and crashes on PEM-via-env (`!1: unbound variable`), so we bypass it and start Kafka directly. Keys must be **PKCS#8** (its PEM keystore rejects PKCS#1) and the broker cert's **SAN is `localhost`** so n8n can verify it.

<details>
<summary><b>1. Create three files in a scratch dir</b></summary>

`generate-certs.sh`:
```bash
#!/usr/bin/env bash
set -euo pipefail
cd "$(dirname "$0")"; mkdir -p certs; cd certs
openssl req -x509 -nodes -newkey rsa:2048 -days 3650 -keyout ca.key -out ca.crt -subj "/CN=n8n-kafka-test-CA"
openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out broker.key
openssl req -new -key broker.key -out broker.csr -subj "/CN=localhost"
openssl x509 -req -in broker.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 825 -out broker.crt \
  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
cat broker.key broker.crt > broker.keystore.pem
openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out client.key
openssl req -new -key client.key -out client.csr -subj "/CN=n8n-client"
openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -days 825 -out client.crt
```

`server.properties`:
```properties
process.roles=broker,controller
node.id=1
controller.quorum.voters=1@localhost:9093
listeners=CONTROLLER://:9093,PLAINTEXT://:9094,SSL://:9092
advertised.listeners=PLAINTEXT://localhost:9094,SSL://localhost:9092
listener.security.protocol.map=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL
controller.listener.names=CONTROLLER
inter.broker.listener.name=PLAINTEXT
log.dirs=/tmp/kraft-combined-logs
offsets.topic.replication.factor=1
transaction.state.log.replication.factor=1
transaction.state.log.min.isr=1
group.initial.rebalance.delay.ms=0
ssl.keystore.type=PEM
ssl.keystore.location=/etc/kafka/secrets/broker.keystore.pem
ssl.truststore.type=PEM
ssl.truststore.location=/etc/kafka/secrets/ca.crt
ssl.client.auth=required
ssl.endpoint.identification.algorithm=
```

`docker-compose.yml`:
```yaml
services:
  kafka:
    image: apache/kafka:3.8.0
    container_name: n8n-kafka-mtls
    ports: ['9092:9092', '9094:9094']
    volumes:
      - ./certs:/etc/kafka/secrets:ro
      - ./server.properties:/etc/kafka/server.properties:ro
    entrypoint: ['/bin/bash', '-c']
    command:
      - |
        set -e
        /opt/kafka/bin/kafka-storage.sh format -t 5L6g3nShT-eMCtK--X86sw \
          -c /etc/kafka/server.properties --ignore-formatted
        exec /opt/kafka/bin/kafka-server-start.sh /etc/kafka/server.properties
```
</details>

**2. Generate certs, start the broker, and prove mTLS is enforced:**
```bash
chmod +x generate-certs.sh && ./generate-certs.sh
openssl verify -CAfile certs/ca.crt certs/client.crt                       # -> client.crt: OK
docker compose up -d
docker compose logs kafka | grep "Kafka Server started"                    # wait for this line
docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh \
  --bootstrap-server localhost:9094 --create --topic ent81-test --if-not-exists

# WITH a client cert -> accepted
openssl s_client -connect localhost:9092 -CAfile certs/ca.crt \
  -cert certs/client.crt -key certs/client.key </dev/null 2>&1 | grep "Verify return code"   # -> 0 (ok)
# WITHOUT a client cert (force TLS 1.2 — under TLS 1.3 the alert isn't printed) -> rejected
openssl s_client -connect localhost:9092 -CAfile certs/ca.crt -tls1_2 </dev/null 2>&1 \
  | grep -iE "alert|handshake failure"                                     # -> sslv3 alert bad certificate
```

**3. In n8n (run on the host with `pnpm dev`), create a Kafka credential:**

| Field | Value |
|---|---|
| Client ID | `n8n-ent81` (cosmetic — broker logs only) |
| Brokers | `localhost:9092` (the SSL listener, **not** 9094) |
| SSL | on · Authentication off |
| CA / Client Certificate / Client Private Key | contents of `certs/ca.crt`, `certs/client.crt`, `certs/client.key` |

Click **Test** → success. Then produce via the **Kafka** node and consume via the **Kafka Trigger** on topic `ent81-test`.

**4. Error cases (AC #5 — clear, not silent):**

| Credential change | Expected |
|---|---|
| clear cert **and** key, keep CA | broker rejects the handshake (surfaced, not silent) |
| set cert, clear key (or vice-versa) | `Kafka mTLS needs both a client certificate and a client private key` |
| put `not-a-pem` in Client Certificate | `…is not a valid PEM block` |
| clear CA Certificate | `unable to verify the first certificate`; enable **Ignore SSL Issues** → connects |

**5. Teardown:** `docker compose down -v`

## Screenshots

### Successful connection with new mtls settings

<img width="1063" height="613" alt="image" src="https://github.com/user-attachments/assets/3baa4fd3-730c-4610-bae0-6602bf7c76ea" />

### mTls settings

<img width="1063" height="613" alt="image" src="https://github.com/user-attachments/assets/e829b9d9-be1f-4dbc-8034-adbfc37a2a9f" />

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-81
- Prior community attempts (canceled, no native replacement shipped): NODE-3366 (PR #17549), GHC-653, PR #6398
- Sequencing context: ENT-8 (`kafkajs` → `@confluentinc/kafka-javascript` migration)

## Status (draft)

- [x] Credential fields + shared `resolveKafkaSsl` resolver
- [x] Wired into the producer node, the Kafka Trigger, and the credential test
- [x] Typecheck clean, lint clean (0 errors), 118 existing Kafka tests green (no regression)
- [x] Unit tests for `resolveKafkaSsl` (config resolution, cert/key pairing errors, PEM validation)
- [ ] Producer/trigger integration assertions (object-form `ssl` passed through to the kafkajs client)
- [ ] Docs (n8n-docs: Kafka credentials page — new fields + mTLS vs SASL guidance)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

