### PR TITLE
fix(editor): Show implied scope options as disabled with tooltip

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2820,6 +2820,7 @@
 	"instanceRoles.option.manage": "Manage",
 	"instanceRoles.option.manageOwn": "Manage own",
 	"instanceRoles.option.manageAll": "Manage others",
+	"instanceRoles.option.includedIn": "Included in {option}",
 	"roles.instance.newRole": "New instance role",
 	"roles.instance.editRole": "Custom instance role",
 	"roles.instance.backToRoles": "Back to roles",

--- a/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.test.ts
@@ -2,7 +2,7 @@ import { renderComponent } from '@/__tests__/render';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/vue';
 import ScopeGroupSelector from './ScopeGroupSelector.vue';
-import { INSTANCE_SCOPE_GROUP_LIST } from '../instanceRoleScopes';
+import { INSTANCE_SCOPE_GROUP_LIST, INSTANCE_SCOPE_GROUPS } from '../instanceRoleScopes';
 
 const totalOptions = INSTANCE_SCOPE_GROUP_LIST.reduce((sum, g) => sum + g.options.length, 0);
 
@@ -86,5 +86,37 @@ describe('ScopeGroupSelector', () => {
 		const { getByTestId } = renderComponent(ScopeGroupSelector, { props: { modelValue: [] } });
 		expect(getByTestId('scope-option-apiKey-manage-own')).toBeTruthy();
 		expect(getByTestId('scope-option-apiKey-manage-all')).toBeTruthy();
+	});
+
+	describe('apiKey implied-state behaviour', () => {
+		const allScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage all']];
+		const ownScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage own']];
+
+		it('shows "Manage own" as checked and disabled when "Manage all" is selected', () => {
+			const { getByTestId } = renderComponent(ScopeGroupSelector, {
+				props: { modelValue: allScopes },
+			});
+			const manageOwn = getByTestId('scope-option-apiKey-manage-own');
+			expect(manageOwn.getAttribute('aria-checked')).toBe('true');
+			expect(manageOwn.hasAttribute('disabled')).toBe(true);
+		});
+
+		it('shows "Manage all" as checked and not disabled when "Manage all" is selected', () => {
+			const { getByTestId } = renderComponent(ScopeGroupSelector, {
+				props: { modelValue: allScopes },
+			});
+			const manageAll = getByTestId('scope-option-apiKey-manage-all');
+			expect(manageAll.getAttribute('aria-checked')).toBe('true');
+			expect(manageAll.hasAttribute('disabled')).toBe(false);
+		});
+
+		it('shows "Manage all" as unchecked (not indeterminate) when only "Manage own" is selected', () => {
+			const { getByTestId } = renderComponent(ScopeGroupSelector, {
+				props: { modelValue: ownScopes },
+			});
+			expect(getByTestId('scope-option-apiKey-manage-all').getAttribute('aria-checked')).toBe(
+				'false',
+			);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/components/ScopeGroupSelector.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { N8nCheckbox, N8nLoading } from '@n8n/design-system';
+import { N8nCheckbox, N8nLoading, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import {
+	INSTANCE_OPTION_LABEL_KEYS,
 	INSTANCE_SCOPE_GROUP_LIST,
-	getOptionState,
+	SUPERSEDED_BY,
+	isOptionImplied,
+	resolveOptionState,
 	toggleOption,
 	type InstanceScopeOption,
 } from '../instanceRoleScopes';
@@ -30,8 +33,18 @@ function optionTestId(resource: string, option: InstanceScopeOption): string {
 	return `scope-option-${resource}-${slug}`;
 }
 
-function onToggle(option: InstanceScopeOption) {
+function impliedTooltip(option: InstanceScopeOption): string {
+	const supersededByKey = SUPERSEDED_BY[option.key];
+	if (!supersededByKey) return '';
+	const labelKey = INSTANCE_OPTION_LABEL_KEYS[supersededByKey];
+	return i18n.baseText('instanceRoles.option.includedIn', {
+		interpolate: { option: i18n.baseText(labelKey) },
+	});
+}
+
+function onToggle(option: InstanceScopeOption, groupOptions: InstanceScopeOption[]) {
 	if (props.readonly) return;
+	if (isOptionImplied(option, groupOptions, props.modelValue)) return;
 	emit('update:modelValue', toggleOption(props.modelValue, option.scopes));
 }
 </script>
@@ -45,17 +58,25 @@ function onToggle(option: InstanceScopeOption) {
 			<div :class="$style.optionList">
 				<N8nLoading v-if="loading" :rows="group.options.length" :shrink-last="false" />
 				<template v-else>
-					<N8nCheckbox
+					<N8nTooltip
 						v-for="option in group.options"
 						:key="option.key"
-						:data-test-id="optionTestId(group.resource, option)"
-						:label="i18n.baseText(option.labelKey)"
-						:model-value="getOptionState(modelValue, option.scopes) === 'checked'"
-						:indeterminate="getOptionState(modelValue, option.scopes) === 'indeterminate'"
-						:disabled="readonly"
-						:class="$style.checkbox"
-						@update:model-value="onToggle(option)"
-					/>
+						:content="impliedTooltip(option)"
+						:disabled="!isOptionImplied(option, group.options, modelValue)"
+						placement="top"
+					>
+						<N8nCheckbox
+							:data-test-id="optionTestId(group.resource, option)"
+							:label="i18n.baseText(option.labelKey)"
+							:model-value="resolveOptionState(option, group.options, modelValue) === 'checked'"
+							:indeterminate="
+								resolveOptionState(option, group.options, modelValue) === 'indeterminate'
+							"
+							:disabled="readonly || isOptionImplied(option, group.options, modelValue)"
+							:class="$style.checkbox"
+							@update:model-value="onToggle(option, group.options)"
+						/>
+					</N8nTooltip>
 				</template>
 			</div>
 		</div>

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
@@ -5,6 +5,8 @@ import {
 	INSTANCE_RESOURCE_ORDER,
 	ALL_INSTANCE_SCOPES,
 	getOptionState,
+	isOptionImplied,
+	resolveOptionState,
 	toggleOption,
 } from './instanceRoleScopes';
 
@@ -90,6 +92,85 @@ describe('getOptionState', () => {
 	it('returns indeterminate for a partial subset (round-trip of presets / API roles)', () => {
 		expect(getOptionState(['tag:read'], option)).toBe('indeterminate');
 		expect(getOptionState(['tag:list', 'user:read'], option)).toBe('indeterminate');
+	});
+});
+
+describe('isOptionImplied', () => {
+	const apiKeyGroup = INSTANCE_SCOPE_GROUP_LIST.find((g) => g.resource === 'apiKey')!;
+	const manageOwn = apiKeyGroup.options.find((o) => o.key === 'Manage own')!;
+	const manageAll = apiKeyGroup.options.find((o) => o.key === 'Manage all')!;
+	const allScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage all']];
+	const ownScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage own']];
+
+	it('returns false for an option that has no SUPERSEDED_BY entry', () => {
+		expect(isOptionImplied(manageAll, apiKeyGroup.options, allScopes)).toBe(false);
+	});
+
+	it('returns false when the superseding option is unchecked', () => {
+		expect(isOptionImplied(manageOwn, apiKeyGroup.options, [])).toBe(false);
+	});
+
+	it('returns false when the superseding option is only indeterminate', () => {
+		// only apiKey:manage present — "Manage all" is indeterminate (1/5)
+		expect(isOptionImplied(manageOwn, apiKeyGroup.options, ['apiKey:manage'])).toBe(false);
+	});
+
+	it('returns true when the superseding option is fully checked', () => {
+		expect(isOptionImplied(manageOwn, apiKeyGroup.options, allScopes)).toBe(true);
+	});
+
+	it('returns false for options in groups with no superseding relationships', () => {
+		const tagGroup = INSTANCE_SCOPE_GROUP_LIST.find((g) => g.resource === 'tag')!;
+		const tagView = tagGroup.options.find((o) => o.key === 'View')!;
+		expect(isOptionImplied(tagView, tagGroup.options, ['tag:read', 'tag:list'])).toBe(false);
+	});
+
+	it('returns false when the superseding option is present but "Manage own" is checked via own scopes only', () => {
+		expect(isOptionImplied(manageOwn, apiKeyGroup.options, ownScopes)).toBe(false);
+	});
+});
+
+describe('resolveOptionState', () => {
+	const apiKeyGroup = INSTANCE_SCOPE_GROUP_LIST.find((g) => g.resource === 'apiKey')!;
+	const manageOwn = apiKeyGroup.options.find((o) => o.key === 'Manage own')!;
+	const manageAll = apiKeyGroup.options.find((o) => o.key === 'Manage all')!;
+	const allScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage all']];
+	const ownScopes = [...INSTANCE_SCOPE_GROUPS.apiKey['Manage own']];
+
+	it('returns checked when all scopes are present (passthrough)', () => {
+		expect(resolveOptionState(manageAll, apiKeyGroup.options, allScopes)).toBe('checked');
+		expect(resolveOptionState(manageOwn, apiKeyGroup.options, ownScopes)).toBe('checked');
+	});
+
+	it('returns unchecked when no scopes are present (passthrough)', () => {
+		expect(resolveOptionState(manageAll, apiKeyGroup.options, [])).toBe('unchecked');
+		expect(resolveOptionState(manageOwn, apiKeyGroup.options, [])).toBe('unchecked');
+	});
+
+	it('returns indeterminate for a genuine partial subset with no fully-checked sub-option', () => {
+		// Only 1 of 4 "Manage own" scopes present — "Manage own" sub-option is not fully checked
+		expect(resolveOptionState(manageAll, apiKeyGroup.options, ['apiKey:create'])).toBe(
+			'indeterminate',
+		);
+	});
+
+	it('suppresses false indeterminate on "Manage all" when "Manage own" is fully checked', () => {
+		// "Manage own" (4 scopes) fully checked → "Manage all" would be 4/5 (indeterminate)
+		// but all 4 matching scopes come from the fully-checked sub-option → unchecked
+		expect(resolveOptionState(manageAll, apiKeyGroup.options, ownScopes)).toBe('unchecked');
+	});
+
+	it('keeps indeterminate on "Manage all" when the sub-option is only partially checked', () => {
+		// 3 of 4 "Manage own" scopes present — "Manage own" is indeterminate, not fully checked
+		const partialOwn = ownScopes.slice(0, 3);
+		expect(resolveOptionState(manageAll, apiKeyGroup.options, partialOwn)).toBe('indeterminate');
+	});
+
+	it('does not affect unrelated groups', () => {
+		const tagGroup = INSTANCE_SCOPE_GROUP_LIST.find((g) => g.resource === 'tag')!;
+		const tagView = tagGroup.options.find((o) => o.key === 'View')!;
+		expect(resolveOptionState(tagView, tagGroup.options, ['tag:read'])).toBe('indeterminate');
+		expect(resolveOptionState(tagView, tagGroup.options, ['tag:read', 'tag:list'])).toBe('checked');
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
@@ -166,6 +166,32 @@ export const ALL_INSTANCE_SCOPES: Scope[] = [
 export type OptionState = 'checked' | 'indeterminate' | 'unchecked';
 
 /**
+ * Declares when one option is visually superseded by another within the same
+ * resource group. If the superseding option is fully checked, the superseded
+ * option is implied — it should render as disabled ✔︎ with an explanatory
+ * tooltip rather than as an independently active selection.
+ */
+export const SUPERSEDED_BY: Partial<Record<string, string>> = {
+	'Manage own': 'Manage all',
+};
+
+/**
+ * Returns true when another option in the same group is fully checked and
+ * supersedes this option. The caller should render implied options as disabled
+ * with a tooltip explaining they are included in the superseding option.
+ */
+export function isOptionImplied(
+	option: InstanceScopeOption,
+	groupOptions: InstanceScopeOption[],
+	roleScopes: readonly string[],
+): boolean {
+	const supersededByKey = SUPERSEDED_BY[option.key];
+	if (!supersededByKey) return false;
+	const superseding = groupOptions.find((o) => o.key === supersededByKey);
+	return !!superseding && getOptionState(roleScopes, superseding.scopes) === 'checked';
+}
+
+/**
  * Resolve how an option should render against a saved flat scope list.
  * - all of the option's scopes present -> checked
  * - some but not all present          -> indeterminate (e.g. system-role presets
@@ -180,6 +206,43 @@ export function getOptionState(
 	if (present === 0) return 'unchecked';
 	if (present === optionScopes.length) return 'checked';
 	return 'indeterminate';
+}
+
+/**
+ * When option A is a strict superset of option B (B is superseded by A), and B
+ * is fully checked, A will appear indeterminate via raw scope arithmetic because
+ * B's scopes are already present. That indeterminate is misleading — the user
+ * selected B only, not A. This function returns 'unchecked' in that case.
+ *
+ * The guard only fires when a sub-option is *fully* checked, so genuine partial
+ * selections (e.g. API-created roles with an arbitrary subset) still show
+ * indeterminate correctly.
+ */
+export function resolveOptionState(
+	option: InstanceScopeOption,
+	groupOptions: InstanceScopeOption[],
+	roleScopes: readonly string[],
+): OptionState {
+	const base = getOptionState(roleScopes, option.scopes);
+	if (base !== 'indeterminate') return base;
+
+	// Collect scopes that belong to fully-checked sub-options of this option.
+	const fullyCheckedSubScopes = new Set(
+		groupOptions
+			.filter(
+				(other) =>
+					SUPERSEDED_BY[other.key] === option.key &&
+					getOptionState(roleScopes, other.scopes) === 'checked',
+			)
+			.flatMap((o) => o.scopes),
+	);
+
+	if (fullyCheckedSubScopes.size === 0) return base;
+
+	// If every present scope in this option is already accounted for by a
+	// fully-checked sub-option, the indeterminate is an artifact — show unchecked.
+	const presentScopes = option.scopes.filter((s) => roleScopes.includes(s));
+	return presentScopes.every((s) => fullyCheckedSubScopes.has(s)) ? 'unchecked' : base;
 }
 
 /**


### PR DESCRIPTION
## Summary

In the instance role editor, API Keys has two overlapping options: Manage own (4 scopes) and Manage others (those same 4 + apiKey:manage). Because the scope sets overlap, raw scope arithmetic produced two misleading states:

Manage others selected → Manage own incorrectly showed ✔︎ as if independently selected
Manage own selected → Manage others incorrectly showed − (indeterminate)
This PR introduces SUPERSEDED_BY config and two helpers (isOptionImplied, resolveOptionState) to handle both cases at the display layer without touching scope storage or backend logic. Implied options render as disabled ✔︎ with a tooltip "Included in Manage others"; superset options render as unchecked when their indeterminate state is purely an artifact of a selected sub-option.

<img width="688" height="93" alt="image" src="https://github.com/user-attachments/assets/9e1030de-69d8-4a68-a1a9-aea22d692776" />

<img width="589" height="124" alt="image" src="https://github.com/user-attachments/assets/33f7eb34-630a-43bb-96c9-540064824776" />

## How to test

1. Open Settings → Roles and create or edit an instance role
2. Under API keys, select Manage others → Manage own should appear dimmed with tooltip "Included in Manage others", not as an active selection
3. Deselect Manage others, select Manage own → Manage others should appear unchecked (not −)
4. Check a system role (e.g. Member) — indeterminate states on unrelated resources should be unaffected


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

