### PR TITLE
fix(editor): Replace radio buttons with checkmark in instance role dropdown

### DIFF
--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleAssignmentsTab.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleAssignmentsTab.vue
@@ -17,7 +17,6 @@ import {
 } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useAsyncState } from '@vueuse/core';
-import { ElRadio } from 'element-plus';
 import { computed, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
@@ -54,9 +53,14 @@ const updatingUserIds = ref(new Set<string>());
 
 // Assignable instance roles (owner already filtered out by the store) drive the dropdown,
 // so custom roles appear alongside the built-in ones.
-const roleOptions = computed<Array<ActionDropdownItem<string>>>(() =>
-	rolesStore.processedInstanceRoles.map((role) => ({ id: role.slug, label: role.displayName })),
-);
+// The currently-assigned role gets `checked: true` so the built-in trailing checkmark renders.
+function roleOptionsFor(currentRoleSlug: string): Array<ActionDropdownItem<string>> {
+	return rolesStore.processedInstanceRoles.map((role) => ({
+		id: role.slug,
+		label: role.displayName,
+		checked: role.slug === currentRoleSlug,
+	}));
+}
 
 const memberUserIds = computed(() => members.value.members.map((member) => member.userId));
 
@@ -174,7 +178,7 @@ onMounted(async () => {
 						<N8nActionDropdown
 							v-if="canEditMember(member)"
 							placement="bottom-start"
-							:items="roleOptions"
+							:items="roleOptionsFor(member.role)"
 							:disabled="updatingUserIds.has(member.userId)"
 							data-test-id="instance-role-member-dropdown"
 							@select="(slug: string) => changeRole(member.userId, slug)"
@@ -197,9 +201,7 @@ onMounted(async () => {
 								</button>
 							</template>
 							<template #menuItem="item">
-								<ElRadio :model-value="member.role" :label="item.id">
-									<N8nText color="text-dark">{{ item.label }}</N8nText>
-								</ElRadio>
+								<N8nText color="text-dark">{{ item.label }}</N8nText>
 							</template>
 						</N8nActionDropdown>
 						<N8nText v-else color="text-dark">{{ roleLabel(member.role) }}</N8nText>


### PR DESCRIPTION
## Summary

Replaces the `ElRadio` component in the instance role assignment dropdown with a native checkmark (`checked` flag) from `N8nActionDropdown`'s built-in trailing slot. The selected role now shows a `✓` icon at the right end of its row instead of a radio button, matching the design pattern used elsewhere in the app.

<img width="710" height="223" alt="image" src="https://github.com/user-attachments/assets/6a38e57d-7db7-4b00-be3f-99fa620b0b88" />

## How to test

1. Go to **Settings → Roles** and open any role's **Assignments** tab.
2. Click the role dropdown next to a member.
3. Confirm the currently assigned role has a checkmark at the right end of its row.
4. Select a different role and reopen the dropdown — the checkmark should move to the newly selected role.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33242">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->