### PR TITLE
refactor(editor): Rename Instance AI route from /instance-ai to /assistant

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -333,7 +333,7 @@ async function handleSubmit(message: string, attachments?: InstanceAiAttachment[
 	isStartingThread.value = true;
 
 	// Persist the thread on the BE first. Otherwise we'd navigate to
-	// `/instance-ai/:threadId` for a thread the BE doesn't know about, and the
+	// `/assistant/:threadId` for a thread the BE doesn't know about, and the
 	// follow-up `postMessage` would 404.
 	try {
 		await store.syncThread(threadId, selectedProject.value);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -145,7 +145,7 @@ onUnmounted(() => {
 			</N8nResizeWrapper>
 		</Transition>
 
-		<!-- Inner route — Empty for `/instance-ai`, Thread for `/instance-ai/:threadId` -->
+		<!-- Inner route — Empty for `/assistant`, Thread for `/assistant/:threadId` -->
 		<RouterView v-slot="{ Component }">
 			<component :is="Component" :key="String(route.params.threadId ?? 'empty')" />
 		</RouterView>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/module.descriptor.test.ts
@@ -1,0 +1,62 @@
+import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router';
+import { InstanceAiModule } from '../module.descriptor';
+import { INSTANCE_AI_VIEW, INSTANCE_AI_THREAD_VIEW, INSTANCE_AI_SETTINGS_VIEW } from '../constants';
+
+const stub = { render: () => null };
+
+// Swap real lazy components for a stub so navigation doesn't pull the view tree.
+function withStubbedComponents(route: RouteRecordRaw): RouteRecordRaw {
+	const clone = { ...route } as Record<string, unknown>;
+	if (clone.component) clone.component = stub;
+	if (Array.isArray(clone.children)) {
+		clone.children = (clone.children as RouteRecordRaw[]).map(withStubbedComponents);
+	}
+	return clone as unknown as RouteRecordRaw;
+}
+
+const moduleRoutes = (InstanceAiModule.routes ?? []).map(withStubbedComponents);
+
+// Absolute-path routes register at the top level; relative ones nest under `/settings`.
+function createTestRouter() {
+	return createRouter({
+		history: createMemoryHistory(),
+		routes: [
+			...moduleRoutes.filter((route) => route.path.startsWith('/')),
+			{
+				path: '/settings',
+				component: stub,
+				children: moduleRoutes.filter((route) => !route.path.startsWith('/')),
+			},
+		],
+	});
+}
+
+describe('InstanceAiModule legacy route redirects', () => {
+	it('redirects /instance-ai to the /assistant view', async () => {
+		const router = createTestRouter();
+		await router.push('/instance-ai');
+
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_VIEW);
+		expect(router.currentRoute.value.path).toBe('/assistant');
+	});
+
+	it('redirects /instance-ai/:threadId preserving thread id, query and hash', async () => {
+		const router = createTestRouter();
+		await router.push('/instance-ai/thread-1?foo=bar#section');
+
+		const current = router.currentRoute.value;
+		expect(current.name).toBe(INSTANCE_AI_THREAD_VIEW);
+		expect(current.params).toEqual({ threadId: 'thread-1' });
+		expect(current.query).toEqual({ foo: 'bar' });
+		expect(current.hash).toBe('#section');
+		expect(current.path).toBe('/assistant/thread-1');
+	});
+
+	it('redirects /settings/instance-ai to /settings/assistant', async () => {
+		const router = createTestRouter();
+		await router.push('/settings/instance-ai');
+
+		expect(router.currentRoute.value.name).toBe(INSTANCE_AI_SETTINGS_VIEW);
+		expect(router.currentRoute.value.path).toBe('/settings/assistant');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoff.ts
@@ -102,7 +102,7 @@ export function useInstanceAiHandoff() {
 			const threadId = uuidv4();
 			// Open the tab now, inside the click gesture, so it isn't popup-blocked.
 			const tab = options?.newTab ? window.open('', '_blank') : null;
-			// Persist the thread on the BE before navigating — `/instance-ai/:threadId`
+			// Persist the thread on the BE before navigating — `/assistant/:threadId`
 			// expects an existing thread.
 			try {
 				await instanceAiStore.syncThread(threadId, projectId);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/module.descriptor.ts
@@ -23,7 +23,7 @@ export const InstanceAiModule: FrontendModuleDescription = {
 	icon: 'sparkles',
 	routes: [
 		{
-			path: '/instance-ai',
+			path: '/assistant',
 			component: InstanceAiView,
 			meta: {
 				layout: 'instanceAi',
@@ -43,8 +43,22 @@ export const InstanceAiModule: FrontendModuleDescription = {
 				},
 			],
 		},
+		// Permanent redirects from the legacy `/instance-ai` path to `/assistant`.
 		{
-			path: 'instance-ai',
+			path: '/instance-ai',
+			redirect: (to) => ({ name: INSTANCE_AI_VIEW, query: to.query, hash: to.hash }),
+		},
+		{
+			path: '/instance-ai/:threadId',
+			redirect: (to) => ({
+				name: INSTANCE_AI_THREAD_VIEW,
+				params: { threadId: to.params.threadId },
+				query: to.query,
+				hash: to.hash,
+			}),
+		},
+		{
+			path: 'assistant',
 			name: INSTANCE_AI_SETTINGS_VIEW,
 			component: SettingsInstanceAiView,
 			meta: {
@@ -55,6 +69,16 @@ export const InstanceAiModule: FrontendModuleDescription = {
 						scope: 'instanceAi:message',
 					},
 				},
+				telemetry: {
+					pageCategory: 'settings',
+				},
+			},
+		},
+		// Permanent redirect from the legacy `/settings/instance-ai` path.
+		{
+			path: 'instance-ai',
+			redirect: (to) => ({ name: INSTANCE_AI_SETTINGS_VIEW, query: to.query, hash: to.hash }),
+			meta: {
 				telemetry: {
 					pageCategory: 'settings',
 				},

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -322,7 +322,7 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 				setCurrentProject(null);
 			}
 
-			if (newRoute?.path?.includes('instance-ai')) {
+			if (newRoute?.path?.includes('assistant')) {
 				projectNavActiveId.value = 'instance-ai';
 				setCurrentProject(null);
 			}

--- a/packages/testing/playwright/helpers/NavigationHelper.ts
+++ b/packages/testing/playwright/helpers/NavigationHelper.ts
@@ -231,10 +231,10 @@ export class NavigationHelper {
 
 	/**
 	 * Navigate to Instance AI page
-	 * URL: /instance-ai
+	 * URL: /assistant
 	 */
 	async toInstanceAi() {
-		await this.page.goto('/instance-ai');
+		await this.page.goto('/assistant');
 		await this.instanceAi.enableInstanceAiIfPrompted();
 	}
 

--- a/packages/testing/playwright/pages/InstanceAiPage.ts
+++ b/packages/testing/playwright/pages/InstanceAiPage.ts
@@ -24,7 +24,7 @@ export class InstanceAiPage extends BasePage {
 	}
 
 	async goto(): Promise<void> {
-		await this.page.goto('/instance-ai');
+		await this.page.goto('/assistant');
 		await this.enableInstanceAiIfPrompted();
 	}
 
@@ -42,7 +42,7 @@ export class InstanceAiPage extends BasePage {
 	}
 
 	async gotoThread(threadId: string): Promise<void> {
-		await this.page.goto(`/instance-ai/${threadId}`);
+		await this.page.goto(`/assistant/${threadId}`);
 	}
 
 	getContainer(): Locator {

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-chat-basics.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-chat-basics.spec.ts
@@ -43,7 +43,7 @@ test.describe(
 
 			await n8n.instanceAi.sendMessage('Remember this persistence message');
 			await n8n.instanceAi.waitForResponseComplete(120_000);
-			await expect(n8n.page).toHaveURL(/\/instance-ai\/[^/]+$/);
+			await expect(n8n.page).toHaveURL(/\/assistant\/[^/]+$/);
 
 			await n8n.page.reload();
 			await expect(n8n.instanceAi.getChatInput()).toBeVisible({ timeout: 30_000 });

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-sidebar.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-sidebar.spec.ts
@@ -13,7 +13,7 @@ test.describe(
 			// Send a message to establish the current thread
 			await n8n.instanceAi.sendMessage('First thread message');
 			await n8n.instanceAi.waitForResponseComplete();
-			await expect(n8n.page).toHaveURL(/\/instance-ai\/[^/]+$/);
+			await expect(n8n.page).toHaveURL(/\/assistant\/[^/]+$/);
 			const firstThreadPath = new URL(n8n.page.url()).pathname;
 
 			// Sidebar starts collapsed; open it so the thread list is queryable.
@@ -28,7 +28,7 @@ test.describe(
 			// Send a message to materialize the new thread in the sidebar
 			await n8n.instanceAi.sendMessage('Second thread message');
 			await n8n.instanceAi.waitForResponseComplete();
-			await expect(n8n.page).toHaveURL(/\/instance-ai\/[^/]+$/);
+			await expect(n8n.page).toHaveURL(/\/assistant\/[^/]+$/);
 			const secondThreadPath = new URL(n8n.page.url()).pathname;
 			expect(secondThreadPath).not.toBe(firstThreadPath);
 
@@ -45,7 +45,7 @@ test.describe(
 				'For this thread switch test, reply with exactly: first thread ready',
 			);
 			await n8n.instanceAi.waitForResponseComplete();
-			await expect(n8n.page).toHaveURL(/\/instance-ai\/[^/]+$/);
+			await expect(n8n.page).toHaveURL(/\/assistant\/[^/]+$/);
 			const firstThreadPath = new URL(n8n.page.url()).pathname;
 
 			// Sidebar starts collapsed; open it so the new-thread button and

--- a/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/cancel-abort.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/cancel-abort.spec.ts
@@ -36,13 +36,13 @@ test.describe(
 						const tab = await n8n.start.newTab();
 						const { page, instanceAi: ai } = tab;
 
-						await page.goto('/instance-ai');
+						await page.goto('/assistant');
 						await ai.getContainer().waitFor({ state: 'visible', timeout: 15_000 });
 						await ai.getChatInput().waitFor({ state: 'visible', timeout: 10_000 });
 						await ai.sidebar.getNewThreadButton().click();
-						await page.waitForURL(/\/instance-ai\/[0-9a-f-]+/, { timeout: 10_000 });
+						await page.waitForURL(/\/assistant\/[0-9a-f-]+/, { timeout: 10_000 });
 
-						const threadId = page.url().match(/\/instance-ai\/([0-9a-f-]+)/)?.[1];
+						const threadId = page.url().match(/\/assistant\/([0-9a-f-]+)/)?.[1];
 
 						await ai.getChatInput().fill(BENCHMARK_PROMPTS[i % BENCHMARK_PROMPTS.length]);
 						await ai.getSendButton().click();

--- a/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/sse-reconnection.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/sse-reconnection.spec.ts
@@ -39,7 +39,7 @@ test.describe(
 					action: async () => {
 						await threadTab.page.goto('/home/workflows');
 						await threadTab.page.waitForLoadState('load');
-						await threadTab.page.goto(`/instance-ai/${threadId}`);
+						await threadTab.page.goto(`/assistant/${threadId}`);
 						await threadTab.instanceAi
 							.getChatInput()
 							.waitFor({ state: 'visible', timeout: 10_000 });

--- a/packages/testing/playwright/utils/benchmark/instance-ai-driver.ts
+++ b/packages/testing/playwright/utils/benchmark/instance-ai-driver.ts
@@ -98,13 +98,13 @@ export class InstanceAiDriver {
 				const ai = tab.instanceAi;
 
 				// Navigate and wait for UI ready
-				await page.goto('/instance-ai');
+				await page.goto('/assistant');
 				await ai.getContainer().waitFor({ state: 'visible', timeout: 15_000 });
 				await ai.getChatInput().waitFor({ state: 'visible', timeout: 10_000 });
 
 				// Create thread (click new chat, wait for URL)
 				await ai.sidebar.getNewThreadButton().click();
-				await page.waitForURL(/\/instance-ai\/[0-9a-f-]+/, { timeout: 10_000 });
+				await page.waitForURL(/\/assistant\/[0-9a-f-]+/, { timeout: 10_000 });
 				const threadId = this.extractThreadId(page);
 				this.createdThreadIds.push(threadId);
 
@@ -285,7 +285,7 @@ export class InstanceAiDriver {
 
 	private extractThreadId(page: Page): string {
 		const url = new URL(page.url());
-		const match = url.pathname.match(/\/instance-ai\/([0-9a-f-]+)/);
+		const match = url.pathname.match(/\/assistant\/([0-9a-f-]+)/);
 		if (!match) {
 			throw new Error(`No thread ID in URL: ${page.url()}`);
 		}


### PR DESCRIPTION
## Summary

Renames the AI Assistant frontend routes from `/instance-ai` to `/assistant`, with permanent client-side redirects from the old paths so existing bookmarks and shared links keep working.

- `/instance-ai` → `/assistant`
- `/instance-ai/:threadId` → `/assistant/:threadId` (preserves thread id, query, hash)
- `/settings/instance-ai` → `/settings/assistant` (with redirect)

Only the user-facing route **paths** change. Route name constants (`INSTANCE_AI_VIEW`, etc.), the `@n8n/instance-ai` backend package, and all `/rest/instance-ai/...` API endpoints are untouched, so there is no API/contract change. In-app navigation already routes by name, so menus and the root redirect are unaffected.

**Not a breaking change:** old URLs continue to resolve via the redirects.

## How to test

1. Navigate to `/instance-ai` → should redirect to `/assistant`.
2. Open a thread, copy its URL (`/assistant/<threadId>`), reload → thread persists.
3. Visit a legacy deep link `/instance-ai/<threadId>` → redirects to `/assistant/<threadId>` (thread id preserved).
4. Open Settings → AI Assistant; URL is `/settings/assistant`. Visiting `/settings/instance-ai` redirects there.

> The AI Assistant module requires the `instance-ai` module enabled (`N8N_ENABLED_MODULES`) and the `instanceAi:message` scope to access the chat routes.

## Related Linear tickets, Github issues, and Community forum posts

_No associated ticket._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI