### PR TITLE
feat(ai-builder): Honor seedThread.liveTurnRunId in eval reconstruction (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
@@ -122,6 +122,24 @@ describe('WorkflowTestCaseSchema', () => {
 		).toThrow();
 	});
 
+	it('retains seedThread.liveTurnRunId through parse (LangTracer live-turn pin)', () => {
+		// Regression guard: the inner seedThread object is non-strict, so before the field
+		// was modelled it was silently stripped on parse and never reached the reconstructor.
+		const { conversation: _omit, ...rest } = validFixture();
+		const parsed = WorkflowTestCaseSchema.parse({
+			...rest,
+			seedThread: { threadId: 't1', liveTurnRunId: 'run-abc-123' },
+		});
+		expect(parsed.seedThread?.liveTurnRunId).toBe('run-abc-123');
+	});
+
+	it('rejects an empty-string seedThread.liveTurnRunId', () => {
+		const { conversation: _omit, ...rest } = validFixture();
+		expect(() =>
+			WorkflowTestCaseSchema.parse({ ...rest, seedThread: { threadId: 't1', liveTurnRunId: '' } }),
+		).toThrow();
+	});
+
 	it('rejects seedThread combined with another seeding mode', () => {
 		const { conversation: _omit, ...rest } = validFixture();
 		expect(() =>

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
@@ -636,6 +636,38 @@ describe('reconstructSeedFromThread — workflow deletes', () => {
 		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
 		expect(result.seed.workflows).toHaveLength(1);
 	});
+
+	it('keeps a workflow when the delete only suspended for confirmation (no success)', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			tool('b1', 3, 'build-workflow', { code: 'v1' }, { success: true, workflowId: 'WF1' }),
+			// HITL: the delete suspended awaiting confirmation; its output is the confirmation
+			// request (no success field), not a completed delete — the workflow still exists.
+			tool(
+				'd1',
+				5,
+				'workflows[delete]',
+				{ action: 'delete', workflowId: 'WF1' },
+				{ requestId: 'req-1', message: 'Archive WF1', severity: 'warning' },
+			),
+			turn('r2', 30, 'Change'),
+		];
+		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
+		expect(result.seed.workflows).toHaveLength(1);
+	});
+
+	it('ignores a delete-shaped input from a non-workflows tool', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			tool('b1', 3, 'build-workflow', { code: 'v1' }, { success: true, workflowId: 'WF1' }),
+			// Same delete-shaped input + success as a real workflow delete, but a different
+			// tool — the match is gated to `workflows`, so it must not evict the seed workflow.
+			tool('d1', 5, 'data-tables[delete-rows]', { action: 'delete', workflowId: 'WF1' }),
+			turn('r2', 30, 'Change'),
+		];
+		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
+		expect(result.seed.workflows).toHaveLength(1);
+	});
 });
 
 describe('reconstructSeedFromThread — workspace auto-discovery', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langsmith-seed.test.ts
@@ -82,6 +82,55 @@ describe('reconstructSeedFromThread', () => {
 		]);
 	});
 
+	it('pins the live turn to liveTurnRunId, seeding only the turns before the pin', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build Otter Digest, daily 9am'), outputs: { response: 'Built it.' } },
+			{
+				...turn('r2', 30, 'Change the schedule to every 30 minutes.'),
+				outputs: { response: 'Done.' },
+			},
+			turn('r3', 60, 'Now add error handling'),
+		];
+		// Pin the MIDDLE turn: it becomes the live turn and the later real turn (r3) is discarded.
+		const result = await reconstructSeedFromThread(
+			{ threadId: 'th1', liveTurnRunId: 'r2' },
+			fakeClient(runs),
+		);
+
+		expect(result.liveTurn).toBe('Change the schedule to every 30 minutes.');
+		// Only turn 1 is seeded — the pinned turn and everything after it are excluded.
+		const userTexts = result.seed.messages
+			.filter((m) => m.role === 'user')
+			.map((m) => (m.content as Array<{ text: string }>)[0].text);
+		expect(userTexts).toEqual(['Build Otter Digest, daily 9am']);
+	});
+
+	it('falls back to the last user turn (with a warning) when liveTurnRunId matches no turn', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			turn('r2', 30, 'Change the schedule'),
+		];
+		const result = await reconstructSeedFromThread(
+			{ threadId: 'th1', liveTurnRunId: 'no-such-run' },
+			fakeClient(runs),
+		);
+
+		expect(result.liveTurn).toBe('Change the schedule'); // unchanged: the last user turn
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('not found among'));
+		warn.mockRestore();
+	});
+
+	it('throws when liveTurnRunId pins the first user turn (no prior turn to seed)', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			turn('r2', 30, 'Change the schedule'),
+		];
+		await expect(
+			reconstructSeedFromThread({ threadId: 'th1', liveTurnRunId: 'r1' }, fakeClient(runs)),
+		).rejects.toThrow(/no prior turn to seed/);
+	});
+
 	it('rebuilds resolved tool-call blocks and compiles the seed workflow at the boundary', async () => {
 		const buildTool: FakeRun = {
 			id: 'tool1',
@@ -224,7 +273,7 @@ describe('reconstructSeedFromThread', () => {
 	it('throws when the trace has fewer than two user turns', async () => {
 		const runs: FakeRun[] = [turn('r1', 1, 'Only one user turn')];
 		await expect(reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs))).rejects.toThrow(
-			/need ≥2 to seed/,
+			/no prior turn to seed/,
 		);
 	});
 
@@ -544,6 +593,51 @@ describe('reconstructSeedFromThread — filesystem-based builds (post-#32545)', 
 	});
 });
 
+describe('reconstructSeedFromThread — workflow deletes', () => {
+	it('excludes a workflow deleted before the boundary and not rebuilt', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			tool('b1', 4, 'build-workflow', { code: 'v1' }, { success: true, workflowId: 'WF1' }),
+			// The user said "delete everything" → the entity is removed and never rebuilt,
+			// so it must not be restored into the seed.
+			tool('d1', 6, 'workflows[delete]', { action: 'delete', workflowId: 'WF1' }),
+			turn('r2', 30, 'Change'),
+		];
+		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
+		expect(result.seed.workflows).toHaveLength(0);
+	});
+
+	it('keeps a workflow rebuilt after an earlier delete (latest build wins)', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			tool('b1', 3, 'build-workflow', { code: 'v1' }, { success: true, workflowId: 'WF1' }),
+			tool('d1', 5, 'workflows[delete]', { action: 'delete', workflowId: 'WF1' }),
+			tool('b2', 7, 'build-workflow', { code: 'v2' }, { success: true, workflowId: 'WF1' }),
+			turn('r2', 30, 'Change'),
+		];
+		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
+		expect(result.seed.workflows).toHaveLength(1);
+		expect(result.seed.workflows[0].nodes[0]).toMatchObject({ __code: 'v2' });
+	});
+
+	it('ignores a failed delete — the workflow stays in the seed', async () => {
+		const runs: FakeRun[] = [
+			{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
+			tool('b1', 3, 'build-workflow', { code: 'v1' }, { success: true, workflowId: 'WF1' }),
+			tool(
+				'd1',
+				5,
+				'workflows[delete]',
+				{ action: 'delete', workflowId: 'WF1' },
+				{ success: false },
+			),
+			turn('r2', 30, 'Change'),
+		];
+		const result = await reconstructSeedFromThread({ threadId: 'th1' }, fakeClient(runs));
+		expect(result.seed.workflows).toHaveLength(1);
+	});
+});
+
 describe('reconstructSeedFromThread — workspace auto-discovery', () => {
 	const seedableRuns: FakeRun[] = [
 		{ ...turn('r1', 1, 'Build it'), outputs: { response: 'Built.' } },
@@ -597,7 +691,7 @@ describe('reconstructSeedFromThread — workspace auto-discovery', () => {
 					fakeClient(id === 'staging-id' ? oneTurn : seedableRuns),
 				ambientClient: () => fakeClient([]),
 			}),
-		).rejects.toThrow(/need ≥2 to seed/);
+		).rejects.toThrow(/no prior turn to seed/);
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -96,6 +96,9 @@ const workflowTestCaseObjectSchema = z
 				 *  are unchanged. A US-sourced case carries the US host; the harness maps
 				 *  host→key via env (LANGSMITH_API_KEY_US). */
 				endpoint: z.string().url().optional(),
+				/** Pin which user turn is sent live (its LangSmith run id); everything before it
+				 *  is seeded. Omit ⇒ the thread's last user turn (default). */
+				liveTurnRunId: z.string().min(1).optional(),
 			})
 			.optional(),
 		/**

--- a/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
@@ -559,13 +559,18 @@ function buildSeedWorkflows(
 			continue;
 		}
 
-		// A workflow-entity delete (shape-detected to survive renames): drop any prior
-		// reconstruction of that id — else a built-then-deleted workflow is wrongly
-		// restored. Chronological loop ⇒ a later rebuild re-adds it (delete→rebuild = kept).
-		if (isRecord(tool.inputs) && tool.inputs.action === 'delete') {
+		// A `workflows`-tool delete (traced as `workflows[delete]`) drops that id's prior
+		// reconstruction. Gated to the `workflows` tool so an unrelated delete-shaped input
+		// can't evict a seed workflow, and to success === true so a suspended (HITL) or denied
+		// delete keeps it. Chronological loop ⇒ a later rebuild re-adds it.
+		if (
+			tool.name.split('[')[0] === DOMAIN_TOOL_IDS.WORKFLOWS &&
+			isRecord(tool.inputs) &&
+			tool.inputs.action === 'delete'
+		) {
 			const deletedId = asString(tool.inputs.workflowId);
-			const deleteFailed = isRecord(tool.outputs) && tool.outputs.success === false;
-			if (deletedId !== undefined && !deleteFailed) {
+			const deleteSucceeded = isRecord(tool.outputs) && tool.outputs.success === true;
+			if (deletedId !== undefined && deleteSucceeded) {
 				builtByWorkflowId.delete(deletedId);
 				buildSignalIds.delete(deletedId);
 				getAsCodeByWorkflowId.delete(deletedId);

--- a/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
@@ -1,7 +1,8 @@
 // Reconstruct a conversation seed from a LangSmith trace at run time: pull the
-// thread's runs, rebuild the message log, split at the last user turn (before =
-// seed, last = live), and reconstruct each seed workflow from its source at the
-// build boundary. Transient: traces retain ~14 days.
+// thread's runs, rebuild the message log, split at the live turn (the last user
+// turn, or one pinned by liveTurnRunId — before = seed, that turn = live), and
+// reconstruct each seed workflow from its source at the build boundary. Transient:
+// traces retain ~14 days.
 
 import { isRecord } from '@n8n/utils';
 import { Client } from 'langsmith';
@@ -164,6 +165,10 @@ export interface SeedThreadRef {
 	 *  Maps host→key via env (home key for the home host, LANGSMITH_API_KEY_US for
 	 *  the US host); an unknown/unkeyed host throws rather than read the wrong tenant. */
 	endpoint?: string;
+	/** Pin which user turn is sent live (its LangSmith run id); everything before it
+	 *  is seeded. Omit ⇒ the thread's last user turn (default). LangTracer's live-turn
+	 *  picker exports this. */
+	liveTurnRunId?: string;
 }
 
 export interface ReconstructedSeed {
@@ -252,7 +257,8 @@ interface ToolCallBlock {
  * `client` to bypass discovery (tests).
  *
  * Throws when the thread isn't found in any accessible workspace (trace aged out
- * or wrong project), or when it has fewer than two user turns.
+ * or wrong project), or when the live turn has no prior turn to seed (a lone user
+ * turn, or a `liveTurnRunId` pin on the first turn).
  */
 export async function reconstructSeedFromThread(
 	ref: SeedThreadRef,
@@ -329,15 +335,30 @@ async function reconstructWithClient(
 	const rootRuns = runs.filter((r) => r.run_type === 'chain' && !r.parent_run_id).sort(byStartTime);
 	const toolRuns = runs.filter((r) => r.run_type === 'tool').sort(byStartTime);
 
-	// Split point: the last genuine user turn is sent live; everything strictly
-	// before it is the seed.
+	// Split point: the live turn is sent live; everything strictly before it is the
+	// seed. Default = the last user turn; a `liveTurnRunId` pin (LangTracer's live-turn
+	// picker) moves it earlier, discarding the real turns at/after it.
 	const userTurns = rootRuns.filter((r) => userMessageOf(r) !== undefined);
-	if (userTurns.length < 2) {
+	let liveIndex = userTurns.length - 1; // default: last user turn (unchanged behavior)
+	if (ref.liveTurnRunId) {
+		const idx = userTurns.findIndex((r) => r.id === ref.liveTurnRunId);
+		if (idx === -1) {
+			console.warn(
+				`[seed] Thread ${ref.threadId}: pinned liveTurnRunId ${ref.liveTurnRunId} not found among ` +
+					`${userTurns.length} user turn(s) — falling back to the last user turn. (LangTracer pins the ` +
+					"agent_role=message_turn root id; verify it matches the name==='turn' root id.)",
+			);
+		} else {
+			liveIndex = idx;
+		}
+	}
+	if (liveIndex < 1) {
 		throw new Error(
-			`Thread ${ref.threadId} has ${userTurns.length} user turn(s) — need ≥2 to seed (one prior + one live). Use a plain conversation case instead.`,
+			`Thread ${ref.threadId}: the live turn is the first/only user turn — no prior turn to seed. ` +
+				'Pin a later turn, or use a plain conversation case.',
 		);
 	}
-	const liveTurnRun = userTurns[userTurns.length - 1];
+	const liveTurnRun = userTurns[liveIndex];
 	const boundaryMs = new Date(liveTurnRun.start_time).getTime();
 	const liveTurn = userMessageOf(liveTurnRun)!;
 
@@ -504,10 +525,11 @@ function applyFileMutation(files: Map<string, string>, tool: Run): boolean {
 }
 
 /** Reconstruct the seed's workflows: the latest successful build per workflow id
- *  before the boundary. Post-#32545 the builder builds from a workspace file
- *  (`build-workflow {filePath}`, no inline code), so the source is that file
- *  replayed from the workspace ops; inline `code` and `get-as-code` are fallbacks.
- *  Only files an actual build references become workflows. */
+ *  before the boundary, excluding any workflow deleted (and not rebuilt) before it.
+ *  Post-#32545 the builder builds from a workspace file (`build-workflow {filePath}`,
+ *  no inline code), so the source is that file replayed from the workspace ops; inline
+ *  `code` and `get-as-code` are fallbacks. Only files an actual build references become
+ *  workflows. */
 function buildSeedWorkflows(
 	toolRuns: Run[],
 	boundaryMs: number,
@@ -533,6 +555,20 @@ function buildSeedWorkflows(
 				if (path !== undefined) divergedPaths.delete(path);
 			} else if (!applied && path !== undefined) {
 				divergedPaths.add(path);
+			}
+			continue;
+		}
+
+		// A workflow-entity delete (shape-detected to survive renames): drop any prior
+		// reconstruction of that id — else a built-then-deleted workflow is wrongly
+		// restored. Chronological loop ⇒ a later rebuild re-adds it (delete→rebuild = kept).
+		if (isRecord(tool.inputs) && tool.inputs.action === 'delete') {
+			const deletedId = asString(tool.inputs.workflowId);
+			const deleteFailed = isRecord(tool.outputs) && tool.outputs.success === false;
+			if (deletedId !== undefined && !deleteFailed) {
+				builtByWorkflowId.delete(deletedId);
+				buildSignalIds.delete(deletedId);
+				getAsCodeByWorkflowId.delete(deletedId);
 			}
 			continue;
 		}

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -217,10 +217,11 @@ export interface WorkflowTestCase {
 	 *  Mutually exclusive with `seedFile`. */
 	priorConversation?: ConversationTurn[];
 	/** Reproduce a real conversation from its LangSmith trace at run time: restore
-	 *  up to the last user message, send that live. Commits only the thread id
-	 *  (workspace auto-discovered; `project` overrides the source project).
-	 *  Supplies the live turn, so `conversation` is optional. Transient (~14d). */
-	seedThread?: { threadId: string; project?: string };
+	 *  up to the live turn (the last user message, or one pinned by `liveTurnRunId`)
+	 *  and send that live. Commits only the thread id (workspace auto-discovered;
+	 *  `project`/`endpoint` override the source project/tenant). Supplies the live
+	 *  turn, so `conversation` is optional. Transient (~14d). */
+	seedThread?: { threadId: string; project?: string; endpoint?: string; liveTurnRunId?: string };
 	/** Logical groupings this case belongs to (e.g. `['pr', 'full']`). Defaults to `['full']`. */
 	datasets: string[];
 }


### PR DESCRIPTION
## Summary

Two improvements to the Instance AI eval harness's `seedThread` reconstruction — the path that rebuilds a real LangSmith thread, seeds everything before the live user turn, and sends that turn live.

**1. Honor `seedThread.liveTurnRunId` (LangTracer's live-turn picker).** A reviewer can pin *which* user turn is sent live; everything before it is seeded and the rest of the thread is discarded. The harness now matches the pinned run id within the thread's user turns and splits there. On a miss it warns and falls back to the last user turn (unchanged behavior); it throws if the pin is the first/only turn (no prior turn to seed). The field was previously dropped on parse (the inner `seedThread` object is non-strict), so the split was always the last user turn. Mirrors the sibling `seedThread.endpoint` field.

**2. Exclude user-deleted workflows from the seed.** `buildSeedWorkflows` tracked only build events, so a workflow built and then deleted before the boundary was wrongly restored — inflating the seeded workspace and polluting the live build. It now shape-detects a workflow-entity delete (`inputs.action === 'delete'` + `workflowId`, skipping failed deletes) and drops that id; a later rebuild re-adds it (`delete → rebuild` ⇒ kept).

Both are eval-harness-internal (not user-facing) → `no-changelog`.

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm test langsmith-seed data-workflows-schema   # the new unit tests
pnpm exec vitest run evaluations                 # full eval suite (721 tests, green)
```

Unit coverage: pin-to-middle / pin-miss-warns-and-falls-back / pin-on-first-throws; delete-not-rebuilt ⇒ excluded, delete-then-rebuilt ⇒ kept, failed-delete ⇒ kept; schema `liveTurnRunId` survives parse / rejects empty string.

End-to-end (local CLI, transient replay case): with `liveTurnRunId` set, reconstruction seeds up to the pinned turn and sends it live. Verified on a real replay thread — the pin selected a mid-thread turn rather than the last, and a workflow the user had deleted mid-conversation was correctly absent from the seed.

## Related Linear tickets, Github issues, and Community forum posts

Extends the dual-tenant `seedThread.endpoint` reconstruction work (sibling field, same LangTracer ⇄ n8n contract).
<!-- add the specific Linear ticket for the live-turn picker if one exists -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created. <!-- N/A — eval-harness-internal -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` <!-- N/A — not an urgent fix -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33251">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->