### PR TITLE
feat(ai-builder): Make eval executionScenarios optional for build-only cases (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -225,7 +225,7 @@ A test case can declare optional natural-language assertions, split by what they
 - **`processExpectations: string[]`** — about *how the build went* (clarifications asked, push-back, ordering). Judged from the **conversation transcript** (plus the workflow and conversation metrics). They require a transcript, so they are **skipped in prebuilt/MCP runs**. e.g. `"Before building, the agent asked which Slack channel to use."`
 - **`outcomeExpectations: string[]`** — about the **resulting workflow**. Judged from the **workflow JSON**, so they **also run in prebuilt/MCP runs** (which have no transcript). e.g. `"The final workflow splits the records envelope before posting."`
 
-Both are graded by the same Sonnet judge (`build-expectations/verifier.ts`) and **count as units in the pass rate**: evaluated expectations fold into the per-case and headline pass@k/pass^k alongside execution scenarios. They don't flip an individual scenario's pass/fail (each is its own unit), and a judge `incomplete` verdict is excluded from the count. A full build judges the union of both fields against the transcript; a prebuilt build judges only `outcomeExpectations` against the workflow.
+Both are graded by the same Sonnet judge (`build-expectations/verifier.ts`) and **count as units in the pass rate**: evaluated expectations fold into the per-case and headline pass@k/pass^k alongside execution scenarios. They don't flip an individual scenario's pass/fail (each is its own unit), and a judge `incomplete` verdict is excluded from the count. A full build judges the union of both fields against the transcript; a prebuilt build judges only `outcomeExpectations` against the workflow. A case may omit `executionScenarios` entirely — a **build-only** case — and is then graded by these expectations plus the always-on workflow checks.
 
 Use them for things the binary checks and `successCriteria` don't cover:
 
@@ -576,7 +576,7 @@ Test cases live in `evaluations/data/workflows/*.json`. Drop a file in — the C
 }
 ```
 
-`conversation` (≥1 turn, first must be `user`) and `executionScenarios` (≥1), plus `complexity` and `tags`, are required. `description`, `triggerType`, `messageBudget`, `processExpectations`, `outcomeExpectations`, `credentials`, and `datasets` (default `["full"]`) are optional. A turn’s `text` may be a string or an array of strings joined with newlines — handy for long stage directions.
+`conversation` (≥1 turn, first must be `user`), plus `complexity` and `tags`, are required. `executionScenarios`, `description`, `triggerType`, `messageBudget`, `processExpectations`, `outcomeExpectations`, `credentials`, and `datasets` (default `["full"]`) are optional — but **a case must declare at least one `executionScenario`, or one process/outcome expectation** (a case that asserts nothing is rejected at load). A _build-only_ case omits `executionScenarios` and is graded by its `processExpectations`/`outcomeExpectations` plus the always-on workflow checks: the workflow is still built, only the mock-execution `successCriteria` pass is skipped. A turn’s `text` may be a string or an array of strings joined with newlines — handy for long stage directions.
 
 **One JSON file = one LangSmith split**, named from the filename slug. Pick a slug you're happy to also use as a `--filter` target.
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
@@ -117,6 +117,35 @@ describe('evaluateGate', () => {
 		expect(gate.excluded).toHaveLength(0);
 	});
 
+	it('grades a build-only case (0 scenarios) by its expectation alone', () => {
+		const { evaluation, slugByTestCase } = makeEval(3, [
+			{
+				slug: 'build-only',
+				expectations: [{ text: 'splits the records envelope', verdicts: [true, true, true] }],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+
+		expect(gate.units).toHaveLength(1);
+		expect(gate.units[0].kind).toBe('buildExpectation');
+		expect(gate.green).toBe(true);
+		expect(gate.excluded).toHaveLength(0);
+	});
+
+	it('fails a build-only case when its sole expectation never passes', () => {
+		const { evaluation, slugByTestCase } = makeEval(3, [
+			{
+				slug: 'build-only',
+				expectations: [{ text: 'splits the records envelope', verdicts: [false, false, false] }],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+
+		expect(gate.units).toHaveLength(1);
+		expect(gate.failing).toHaveLength(1);
+		expect(gate.green).toBe(false);
+	});
+
 	it('is not green when a unit never passes, and records its failure categories', () => {
 		const { evaluation, slugByTestCase } = makeEval(3, [
 			{

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-schema.test.ts
@@ -52,10 +52,30 @@ describe('WorkflowTestCaseSchema', () => {
 		expect(parsed.conversation[0].text).toBe('line 1\nline 2');
 	});
 
-	it('rejects an empty executionScenarios array', () => {
+	it('rejects 0 execution scenarios AND 0 expectations (a case must assert something)', () => {
 		expect(() =>
 			WorkflowTestCaseSchema.parse({ ...validFixture(), executionScenarios: [] }),
-		).toThrow();
+		).toThrow(/at least one executionScenario, or a process\/outcome expectation/);
+	});
+
+	it('accepts an empty executionScenarios array when an outcome expectation is present', () => {
+		const parsed = WorkflowTestCaseSchema.parse({
+			...validFixture(),
+			executionScenarios: [],
+			outcomeExpectations: ['The workflow posts a summary to Slack #growth.'],
+		});
+		expect(parsed.executionScenarios).toEqual([]);
+		expect(parsed.outcomeExpectations).toHaveLength(1);
+	});
+
+	it('accepts an omitted executionScenarios key when a process expectation is present', () => {
+		const { executionScenarios: _omit, ...rest } = validFixture();
+		const parsed = WorkflowTestCaseSchema.parse({
+			...rest,
+			processExpectations: ['Before building, the agent asked which Slack channel to use.'],
+		});
+		expect(parsed.executionScenarios).toBeUndefined();
+		expect(parsed.processExpectations).toHaveLength(1);
 	});
 
 	it('rejects an unknown complexity value', () => {
@@ -237,7 +257,7 @@ describe('loadWorkflowTestCasesWithFiles · file-aware errors', () => {
 	it('throws with the file path on a schema validation failure', () => {
 		mockedReadFile.mockReturnValue(JSON.stringify({ conversation: [] }));
 		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/demo\.json/);
-		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/executionScenarios/);
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/complexity/);
 	});
 });
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
@@ -5,7 +5,7 @@ import type { Mock } from 'vitest';
 
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
 import type { EvalLogger } from '../harness/logger';
-import { syncDataset } from '../langsmith/dataset-sync';
+import { BUILD_ONLY_SCENARIO_NAME, syncDataset } from '../langsmith/dataset-sync';
 
 function scenarioFixture(testCaseFile: string, scenarioName: string): WorkflowTestCaseWithFile {
 	return {
@@ -22,6 +22,21 @@ function scenarioFixture(testCaseFile: string, scenarioName: string): WorkflowTe
 					successCriteria: `criteria for ${scenarioName}`,
 				},
 			],
+			datasets: ['full'],
+		},
+		fileSlug: testCaseFile,
+	};
+}
+
+function buildOnlyFixture(testCaseFile: string): WorkflowTestCaseWithFile {
+	return {
+		testCase: {
+			conversation: [{ role: 'user' as const, text: `prompt for ${testCaseFile}` }],
+			complexity: 'medium' as const,
+			tags: ['test'],
+			triggerType: 'manual' as const,
+			executionScenarios: [],
+			outcomeExpectations: ['The workflow posts to Slack.'],
 			datasets: ['full'],
 		},
 		fileSlug: testCaseFile,
@@ -116,6 +131,20 @@ describe('syncDataset', () => {
 		expect(created).toHaveLength(1);
 		expect(created[0].id).toMatch(UUID_RE);
 		expect(created[0].inputs).toMatchObject({ testCaseFile: 'foo', scenarioName: 'happy-path' });
+	});
+
+	it('emits one build-only sentinel example for a 0-scenario case', async () => {
+		const { client, createExamples } = buildClient([]);
+
+		await syncDataset(client, 'ds', logger, [buildOnlyFixture('build-only')]);
+
+		expect(createExamples).toHaveBeenCalledTimes(1);
+		const created = createExamples.mock.calls[0][0];
+		expect(created).toHaveLength(1);
+		expect(created[0].inputs).toMatchObject({
+			testCaseFile: 'build-only',
+			scenarioName: BUILD_ONLY_SCENARIO_NAME,
+		});
 	});
 
 	it('updates existing examples in place when inputs change, preserving the existing UUID', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -107,6 +107,30 @@ describe('reshapeLangSmithRuns', () => {
 		expect(tc.buildExpectationResults).toEqual([verdict]);
 	});
 
+	it('reports a build-only case whose build failed as not built, surfacing the build error', () => {
+		const cases = [withFile('build-only', [])];
+		// The sentinel row carries the build-failure output the target returns before the
+		// build-only branch — reshape must report it as not built, not mask it as success.
+		const rows = [
+			row(
+				{ testCaseFile: 'build-only', scenarioName: BUILD_ONLY_SCENARIO_NAME, _iteration: 0 },
+				{
+					buildSuccess: false,
+					passed: false,
+					score: 0,
+					reasoning: 'Build failed: agent produced no workflow',
+				},
+			),
+		];
+
+		const result = reshapeLangSmithRuns(rows, cases, 1, new Map(), new Map(), undefined);
+
+		const tc = result[0][0];
+		expect(tc.executionScenarioResults).toEqual([]); // no phantom scenario unit
+		expect(tc.workflowBuildSuccess).toBe(false);
+		expect(tc.buildError).toBe('Build failed: agent produced no workflow');
+	});
+
 	it('attaches build-expectation verdicts by iteration:fileSlug even with no threadId (prebuilt/MCP path)', () => {
 		// Prebuilt/MCP builds have no threadId. Transcript stays threadId-gated (so it
 		// remains undefined here), but outcome-expectation verdicts must still attach via

--- a/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/reshape.test.ts
@@ -2,6 +2,7 @@ import type { Run } from 'langsmith/schemas';
 
 import { reshapeLangSmithRuns } from '../cli/reshape';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type {
 	BuildExpectationResult,
 	ExecutionScenario,
@@ -70,6 +71,40 @@ describe('reshapeLangSmithRuns', () => {
 		expect(tc.workflowBuildSuccess).toBe(true);
 		expect(tc.n8nBaseUrl).toBe('http://localhost:5678');
 		expect(tc.executionScenarioResults.map((r) => r.success)).toEqual([true, true]);
+	});
+
+	it('grades a build-only case (0 scenarios) from the sentinel row without a scenario unit', () => {
+		const cases = [withFile('build-only', [])];
+		const rows = [
+			row(
+				{ testCaseFile: 'build-only', scenarioName: BUILD_ONLY_SCENARIO_NAME, _iteration: 0 },
+				{
+					buildSuccess: true,
+					passed: false,
+					score: 0,
+					reasoning: 'Build-only case — graded by process/outcome expectations',
+					workflowId: 'wf-1',
+					threadId: 'tid-1',
+				},
+			),
+		];
+
+		const result = reshapeLangSmithRuns(
+			rows,
+			cases,
+			1,
+			new Map([['tid-1', [turn]]]),
+			new Map([['0:build-only', [verdict]]]),
+			undefined,
+		);
+
+		const tc = result[0][0];
+		expect(tc.executionScenarioResults).toEqual([]); // no phantom scenario unit
+		expect(tc.workflowBuildSuccess).toBe(true);
+		expect(tc.workflowId).toBe('wf-1');
+		expect(tc.threadId).toBe('tid-1');
+		expect(tc.transcript).toEqual([turn]);
+		expect(tc.buildExpectationResults).toEqual([verdict]);
 	});
 
 	it('attaches build-expectation verdicts by iteration:fileSlug even with no threadId (prebuilt/MCP path)', () => {

--- a/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
@@ -68,11 +68,11 @@ export function aggregateResults(
 		const testCase = runs[0].testCase;
 		const buildSuccessCount = runs.filter((r) => r.workflowBuildSuccess).length;
 
-		const scenarioCount = testCase.executionScenarios.length;
+		const scenarioCount = (testCase.executionScenarios ?? []).length;
 		const executionScenarios: ExecutionScenarioAggregation[] = [];
 
 		for (let sIdx = 0; sIdx < scenarioCount; sIdx++) {
-			const scenario = testCase.executionScenarios[sIdx];
+			const scenario = (testCase.executionScenarios ?? [])[sIdx];
 			const scenarioRuns = runs.map(
 				(r) =>
 					r.executionScenarioResults[sIdx] ?? {

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -68,7 +68,11 @@ import {
 	runWithConcurrency,
 	type BuildResult,
 } from '../harness/runner';
-import { syncDataset, type DatasetExampleInputs } from '../langsmith/dataset-sync';
+import {
+	BUILD_ONLY_SCENARIO_NAME,
+	syncDataset,
+	type DatasetExampleInputs,
+} from '../langsmith/dataset-sync';
 import { seedMcpRegistry } from '../mcp-registry/seeder';
 import { snapshotWorkflowIds } from '../outcome/workflow-discovery';
 import { writeRunDebugReport } from '../report/run-debug-report';
@@ -556,6 +560,25 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			};
 		}
 
+		// Build-only case: the build (and its expectation judging in getOrBuild) is the whole test; skip execution.
+		if (inputs.scenarioName === BUILD_ONLY_SCENARIO_NAME) {
+			return {
+				buildSuccess: true,
+				workflowId: build.workflowId,
+				passed: false,
+				score: 0,
+				reasoning: 'Build-only case — graded by process/outcome expectations',
+				execErrors: [],
+				buildDurationMs,
+				execDurationMs: 0,
+				nodeCount: build.workflowJsons[0]?.nodes.length ?? 0,
+				threadId: build.threadId,
+				workflowChecks: build.workflowChecks,
+				workflowJson: build.workflowJsons[0],
+				buildTrace: build.buildTrace,
+			};
+		}
+
 		const execStart = Date.now();
 		const nodeCount = build.workflowJsons[0]?.nodes.length ?? 0;
 		const maxExecAttempts = 5;
@@ -950,7 +973,7 @@ async function runDirectLoop(config: RunConfig): Promise<{
 	}
 
 	const totalScenarios = testCasesWithFiles.reduce(
-		(sum, { testCase }) => sum + testCase.executionScenarios.length,
+		(sum, { testCase }) => sum + (testCase.executionScenarios ?? []).length,
 		0,
 	);
 	logger.info(

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -560,10 +560,12 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			};
 		}
 
-		// Build-only case: the build (and its expectation judging in getOrBuild) is the whole test; skip execution.
+		// Build-only case — the build plus its expectation judging (in getOrBuild) is the whole
+		// test; skip execution. A failed build returns above with its error reasoning; reflect
+		// the real build status here rather than assuming success.
 		if (inputs.scenarioName === BUILD_ONLY_SCENARIO_NAME) {
 			return {
-				buildSuccess: true,
+				buildSuccess: build.success,
 				workflowId: build.workflowId,
 				passed: false,
 				score: 0,

--- a/packages/@n8n/instance-ai/evaluations/cli/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/reshape.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import { CHECK_DIMENSIONS, type CheckOutcome } from '../binaryChecks/types';
 import type { WorkflowResponse } from '../clients/n8n-client';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
+import { BUILD_ONLY_SCENARIO_NAME } from '../langsmith/dataset-sync';
 import type {
 	BuildTrace,
 	BuildExpectationResult,
@@ -166,7 +167,7 @@ export function reshapeLangSmithRuns(
 			let workflowJson: WorkflowResponse | undefined;
 			let buildTrace: BuildTrace | undefined;
 
-			for (const scenario of testCase.executionScenarios) {
+			for (const scenario of testCase.executionScenarios ?? []) {
 				const run = byKey.get(`${String(iter)}/${fileSlug}/${scenario.name}`);
 				const output = run ? parseTargetOutput(run.outputs) : undefined;
 				if (!run || !output) {
@@ -194,6 +195,21 @@ export function reshapeLangSmithRuns(
 					failureCategory: output.failureCategory,
 					rootCause: output.rootCause,
 				});
+			}
+
+			// Build-only case (0 scenarios): pull build fields from the sentinel row; no scenario unit is recorded.
+			if ((testCase.executionScenarios?.length ?? 0) === 0) {
+				const run = byKey.get(`${String(iter)}/${fileSlug}/${BUILD_ONLY_SCENARIO_NAME}`);
+				const output = run ? parseTargetOutput(run.outputs) : undefined;
+				if (output) {
+					workflowBuildSuccess = output.buildSuccess;
+					workflowId = output.workflowId;
+					threadId = output.threadId;
+					if (!output.buildSuccess && output.reasoning) buildError = output.reasoning;
+					workflowChecks = output.workflowChecks;
+					workflowJson = output.workflowJson;
+					buildTrace = output.buildTrace;
+				}
 			}
 
 			const transcript = threadId ? transcriptByThreadId.get(threadId) : undefined;

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/dont-ask-technical-implementation-choice.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/dont-ask-technical-implementation-choice.json
@@ -31,12 +31,7 @@
 		"The agent did not ask the user to approve or choose a technical implementation detail — for example which node type or API to use, whether to use the built-in Linear node or an HTTP Request to Linear's API (e.g. its GraphQL API), or which endpoint. It made any such decision itself.",
 		"Any questions the agent did ask were about the user's goal or desired outcome, never about how to build the workflow technically. The agent never described an implementation approach and asked whether it was acceptable."
 	],
-	"executionScenarios": [
-		{
-			"name": "happy-path",
-			"description": "Linear returns a couple of issues labeled 'bug' with descriptions; a summary is posted to Slack",
-			"dataSetup": "The Linear source returns 2 issues labeled 'bug': 'Login button unresponsive' and 'Export times out', each with a one-sentence description. The Slack postMessage call returns { \"ok\": true, \"ts\": \"1700000000.000100\" }.",
-			"successCriteria": "Judge only the built workflow's structure, not the conversation. A pass is a weekday 9am schedule trigger that retrieves Linear issues filtered to the 'bug' label (including their descriptions) and posts a summary to Slack #bugs. Because no credentials are provided, empty/placeholder values (e.g. an unset Linear team or Slack channel) that cause a validation failure before any request is made are acceptable and count as a pass — they are values to fill in at setup, not build mistakes. If values are set and the run succeeds, that is also a pass."
-		}
+	"outcomeExpectations": [
+		"The built workflow triggers on a weekday 9am schedule, retrieves Linear issues filtered to the 'bug' label and including each issue's description (via whichever node or HTTP Request achieves this), and posts a summary of them to Slack #bugs. Unset or placeholder credential values (e.g. an unset Linear team or Slack channel) are acceptable — they are values to fill in at setup, not build mistakes."
 	]
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -38,7 +38,7 @@ const workflowTestCaseObjectSchema = z
 		complexity: z.enum(['simple', 'medium', 'complex']),
 		tags: z.array(z.string()),
 		triggerType: z.enum(['manual', 'webhook', 'schedule', 'form']).optional(),
-		executionScenarios: z.array(ExecutionScenarioSchema).min(1),
+		executionScenarios: z.array(ExecutionScenarioSchema).optional(),
 		messageBudget: z.number().int().positive().optional(),
 		/** Optional NL assertions about the build CONVERSATION (process: clarifications, push-back,
 		 *  ordering). LLM-judged from the transcript, so skipped in prebuilt/MCP runs. Counted as units. */
@@ -126,6 +126,16 @@ export const WorkflowTestCaseSchema = workflowTestCaseObjectSchema
 	.refine((c) => c.seedThread !== undefined || c.conversation !== undefined, {
 		message:
 			'a case needs a conversation, or a seedThread (which supplies the live turn from the trace)',
-	});
+	})
+	.refine(
+		(c) =>
+			(c.executionScenarios?.length ?? 0) > 0 ||
+			(c.processExpectations?.length ?? 0) > 0 ||
+			(c.outcomeExpectations?.length ?? 0) > 0,
+		{
+			message:
+				'a case needs at least one executionScenario, or a process/outcome expectation to grade',
+		},
+	);
 
 export type WorkflowTestCaseInput = z.infer<typeof WorkflowTestCaseSchema>;

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -284,7 +284,7 @@ export async function runWorkflowTestCase(
 
 	const scenarioStart = Date.now();
 	const scenariosPromise = runWithConcurrency(
-		testCase.executionScenarios,
+		testCase.executionScenarios ?? [],
 		async (scenario) => {
 			try {
 				return await executeScenario(

--- a/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
+++ b/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
@@ -178,6 +178,11 @@ export async function syncDataset(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Scenario name for the single "build-only" row a 0-scenario case emits, so the
+ *  workflow still builds and its process/outcome expectations get judged. Shared
+ *  with target() and reshape so all three agree on the sentinel. */
+export const BUILD_ONLY_SCENARIO_NAME = '__build_only__';
+
 interface FlatScenario {
 	testCaseFile: string;
 	scenarioName: string;
@@ -200,13 +205,13 @@ interface FlatScenario {
 function buildRoundRobinScenarios(testCasesWithFiles: WorkflowTestCaseWithFile[]): FlatScenario[] {
 	const result: FlatScenario[] = [];
 	const maxScenarios = Math.max(
-		...testCasesWithFiles.map((tc) => tc.testCase.executionScenarios.length),
+		...testCasesWithFiles.map((tc) => (tc.testCase.executionScenarios ?? []).length),
 		0,
 	);
 
 	for (let i = 0; i < maxScenarios; i++) {
 		for (const { testCase, fileSlug } of testCasesWithFiles) {
-			const scenario = testCase.executionScenarios[i];
+			const scenario = testCase.executionScenarios?.[i];
 			if (scenario) {
 				result.push({
 					testCaseFile: fileSlug,
@@ -220,6 +225,23 @@ function buildRoundRobinScenarios(testCasesWithFiles: WorkflowTestCaseWithFile[]
 					datasets: testCase.datasets,
 				});
 			}
+		}
+	}
+
+	// Build-only cases (0 scenarios) emit one sentinel row so the workflow still builds and its expectations get judged.
+	for (const { testCase, fileSlug } of testCasesWithFiles) {
+		if ((testCase.executionScenarios?.length ?? 0) === 0) {
+			result.push({
+				testCaseFile: fileSlug,
+				scenarioName: BUILD_ONLY_SCENARIO_NAME,
+				scenarioDescription: '',
+				dataSetup: '',
+				successCriteria: '',
+				complexity: testCase.complexity,
+				tags: testCase.tags,
+				triggerType: testCase.triggerType,
+				datasets: testCase.datasets,
+			});
 		}
 	}
 

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -194,7 +194,8 @@ export interface WorkflowTestCase {
 	complexity: 'simple' | 'medium' | 'complex';
 	tags: string[];
 	triggerType?: 'manual' | 'webhook' | 'schedule' | 'form';
-	executionScenarios: ExecutionScenario[];
+	/** Optional — a build-only case is graded by process/outcome expectations instead. */
+	executionScenarios?: ExecutionScenario[];
 	/** Max follow-up messages the proxy will send. Ignored in auto-approve mode. */
 	messageBudget?: number;
 	/** Optional NL assertions about the build CONVERSATION (process: clarifications, push-back,


### PR DESCRIPTION
## Summary

Eval test cases can now omit `executionScenarios` entirely. A scenario-less **build-only** case is graded by its `processExpectations` / `outcomeExpectations` plus the always-on workflow checks — the workflow is still built, only the mock-execution `successCriteria` pass is skipped. A case with **zero scenarios AND zero expectations is rejected at load** (it asserts nothing).

- **Schema** (`schema.ts`, `types.ts`): `executionScenarios: z.array(...).min(1)` → `.optional()`, plus a `.refine()` requiring ≥1 scenario **or** ≥1 process/outcome expectation.
- **Direct runner / aggregator / CLI**: build + expectation judging already ran independently of scenarios; normalized the raw `WorkflowTestCase.executionScenarios` reads to tolerate `undefined`.
- **LangSmith `evaluate()` (the one real gap)**: that path flattens cases into per-scenario dataset rows, so a 0-scenario case produced no rows and never built. Fixed by emitting one `__build_only__` sentinel row per scenario-less case — `target()` runs the build (its expectations are judged in `getOrBuild`) and skips execution; `reshape` reconstructs the build fields from the sentinel **without** creating a phantom scenario unit.
- **Example case** (separate commit): `dont-ask-technical-implementation-choice.json` drops its placeholder `happy-path` scenario (whose `successCriteria` only judged workflow structure) in favour of an `outcomeExpectation`.

## How to test

```
pnpm --filter @n8n/instance-ai typecheck                              # ✓
pnpm --filter @n8n/instance-ai exec vitest run evaluations/__tests__  # 564 pass
```

New unit coverage: schema refine (rejects 0+0 / accepts `[]`+expectation / accepts omitted+expectation), gate counting the expectation as the sole unit, `dataset-sync` sentinel emission, and `reshape` sentinel round-trip (no phantom scenario unit).

## Validation

Both commits are validated:
- **Harness**: typecheck / biome / eslint ✓, 564 eval unit tests ✓, plus a live `evaluate()` run — the `__build_only__` sentinel row built and `eval-results.json` reported `scenarioUnits: 0` with all 3 expectations as graded units.
- **Conversion**: re-ran the case on a healthy backend — it **builds** ("Daily Linear Bug Digest to Slack", 4 nodes, 119s) and **all 3 expectations pass** (`passRatePerIter: 100%`), including the `outcomeExpectation`.

Known follow-up (not in this PR): the terminal `Aggregate` headline counts scenario trials only, so a build-only case shows `0.0% (0/0)` even though the green-gate and JSON summary correctly report 100%. The scenario-only-vs-units split across report surfaces (TRUST-158) warrants a deliberate, standalone change.

## Related Linear tickets, Github issues, and Community forum posts

Internal eval-harness change — no ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
