### PR TITLE
chore: Filter static-asset and telemetry traces from Sentry

### DIFF
--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -13,6 +13,8 @@ import {
 	SentryTracing,
 	buildBeforeSendTransaction,
 	buildTracesSampler,
+	shouldIgnoreIncomingRequest,
+	shouldIgnoreOutgoingRequest,
 	DEFAULT_SLOW_SPAN_THRESHOLD_MS,
 } from '@/observability';
 
@@ -191,6 +193,7 @@ export class ErrorReporter {
 			setUser,
 			requestDataIntegration,
 			rewriteFramesIntegration,
+			httpIntegration,
 		} = sentry;
 
 		// Most of the integrations are listed here:
@@ -250,7 +253,17 @@ export class ErrorReporter {
 			ignoreTransactions: [`GET ${healthEndpoint}`, 'GET /metrics', 'SET search_path TO'],
 			ignoreSpans: [`GET ${healthEndpoint}`, 'GET /metrics', 'SET search_path TO'],
 			integrations: (integrations) => [
-				...integrations.filter(({ name }) => enabledIntegrations.has(name)),
+				...integrations.filter(({ name }) => enabledIntegrations.has(name) && name !== 'Http'),
+				// Replace the default Http integration with one that skips noise paths
+				// (static source maps, telemetry/posthog proxies, outbound telemetry).
+				...(enabledIntegrations.has('Http')
+					? [
+							httpIntegration({
+								ignoreIncomingRequests: shouldIgnoreIncomingRequest,
+								ignoreOutgoingRequests: shouldIgnoreOutgoingRequest,
+							}),
+						]
+					: []),
 				rewriteFramesIntegration({
 					root: '/',
 					iteratee: (frame) => {

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -9,5 +9,7 @@ export { SentryTracing } from './tracing/sentry-tracing';
 export {
 	buildBeforeSendTransaction,
 	buildTracesSampler,
+	shouldIgnoreIncomingRequest,
+	shouldIgnoreOutgoingRequest,
 	DEFAULT_SLOW_SPAN_THRESHOLD_MS,
 } from './tracing/span-sampling';

--- a/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
@@ -1,6 +1,11 @@
 import type { SpanJSON, TracesSamplerSamplingContext, TransactionEvent } from '@sentry/core';
 
-import { buildBeforeSendTransaction, buildTracesSampler } from '../span-sampling';
+import {
+	buildBeforeSendTransaction,
+	buildTracesSampler,
+	shouldIgnoreIncomingRequest,
+	shouldIgnoreOutgoingRequest,
+} from '../span-sampling';
 
 const THRESHOLD_MS = 1000;
 
@@ -175,5 +180,49 @@ describe('buildTracesSampler', () => {
 
 	it('returns the base rate when attributes are missing', () => {
 		expect(tracesSampler(ctx())).toBe(BASE_RATE);
+	});
+});
+
+describe('shouldIgnoreIncomingRequest', () => {
+	it.each([
+		'/assets/index-abc.js',
+		'/assets/index-abc.js.map',
+		'/styles.css.map',
+		'/rest/ph',
+		'/rest/ph/decide',
+		'/rest/telemetry/proxy/v1/track',
+		'/rest/telemetry/proxy/v1/page',
+		'/assets/index-abc.js?v=1',
+		'/rest/telemetry/proxy/v1/track?foo=bar',
+		'/healthz',
+		'/healthz/readiness',
+	])('ignores noise path %s', (path) => {
+		expect(shouldIgnoreIncomingRequest(path)).toBe(true);
+	});
+
+	it.each(['/rest/workflows', '/rest/phony', '/', '/healthcheck'])(
+		'keeps signal-bearing path %s',
+		(path) => {
+			expect(shouldIgnoreIncomingRequest(path)).toBe(false);
+		},
+	);
+});
+
+describe('shouldIgnoreOutgoingRequest', () => {
+	it.each(['https://telemetry.n8n.io/v1/batch', 'https://telemetry.n8n.io:443/v1/track?foo=bar'])(
+		'ignores outbound telemetry call %s',
+		(url) => {
+			expect(shouldIgnoreOutgoingRequest(url)).toBe(true);
+		},
+	);
+
+	it.each([
+		'https://ph.n8n.io/decide',
+		'https://api.n8n.io/x',
+		'https://api.example.com/redirect?to=https://telemetry.n8n.io/v1/batch',
+		'https://telemetry.n8n.io.example.com/v1/batch',
+		'telemetry.n8n.io/v1/batch',
+	])('keeps non-telemetry outbound call %s', (url) => {
+		expect(shouldIgnoreOutgoingRequest(url)).toBe(false);
 	});
 });

--- a/packages/core/src/observability/tracing/span-sampling.ts
+++ b/packages/core/src/observability/tracing/span-sampling.ts
@@ -19,6 +19,35 @@ const POLL_TRIGGER_SAMPLE_RATE = 0.001;
 /** Fallback slow-span threshold (ms) when a caller doesn't configure one. */
 export const DEFAULT_SLOW_SPAN_THRESHOLD_MS = 1000;
 
+/**
+ * Skipper request paths with no tracing signal. Sentry's `ignoreStaticAssets`
+ * already drops `.js/.css/…` but misses source maps.
+ */
+const NOISE_INCOMING_PATHS = [
+	/^\/assets\//,
+	/\.map$/,
+	/^\/healthz(\/|$)/, // liveness/readiness probes (default endpoint)
+	/^\/rest\/ph(\/|$)/,
+	/^\/rest\/telemetry\/proxy\//,
+];
+
+const TELEMETRY_HOSTNAME = 'telemetry.n8n.io';
+
+/** Whether an incoming request path should be skipped before a server span is created. */
+export function shouldIgnoreIncomingRequest(urlPath: string): boolean {
+	const path = urlPath.split('?')[0];
+	return NOISE_INCOMING_PATHS.some((re) => re.test(path));
+}
+
+/** Outbound telemetry batch calls carry no tracing signal. */
+export function shouldIgnoreOutgoingRequest(url: string): boolean {
+	try {
+		return new URL(url).hostname === TELEMETRY_HOSTNAME;
+	} catch {
+		return false;
+	}
+}
+
 /** A span errored unless Sentry explicitly marked it ok. */
 function isErrored(status: SpanJSON['status']): boolean {
 	return status !== undefined && status !== 'ok';


### PR DESCRIPTION
## Summary

Drop HTTP traces from Sentry that produce no signal:
- Source maps (`/assets/*.js.map`)
- PostHog (`/rest/ph`)
- Inbound & outbound telemetry (`/rest/telemetry/proxy` & Rudderstack)
- Healthcheck (`/healthz`)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3600

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

