### PR TITLE
fix(core): Skip vite analysis of security-audit reporter dynamic import (no-changelog)

### DIFF
--- a/packages/cli/src/security-audit/security-audit.service.ts
+++ b/packages/cli/src/security-audit/security-audit.service.ts
@@ -62,8 +62,13 @@ export class SecurityAuditService {
 				NodesRiskReporter: 'nodes-risk-reporter',
 			};
 
+			// `@vite-ignore` keeps vite's dynamic-import-vars plugin from analyzing this
+			// runtime-only import: without a static file extension it otherwise errors,
+			// which surfaces fatally during v8 coverage's uncovered-file walk.
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			const RiskReporterModule = await import(`./risk-reporters/${toFilename[className]}`);
+			const RiskReporterModule = await import(
+				/* @vite-ignore */ `./risk-reporters/${toFilename[className]}`
+			);
 
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			const RiskReporterClass = RiskReporterModule[className] as { new (): RiskReporter };


### PR DESCRIPTION
## Summary

The `master` CI `Unit tests / Backend Unit Tests` job (cli-scoped) was failing even though **all 192 test files passed**. The process exited `1` because the **v8 coverage provider crashed** while transforming an *uncovered* source file.

With coverage enabled, `@vitest/coverage-v8` walks every file matching `coverage.include` (`src/**/*.ts`) — including files no test imports — to report 0% coverage. One such file, `packages/cli/src/security-audit/security-audit.service.ts`, contains a runtime-only dynamic import:

```ts
await import(`./risk-reporters/${toFilename[className]}`);
```

vite's `vite:dynamic-import-vars` plugin tries to analyze it, derives the glob `./risk-reporters/*`, and throws because the static part has **no file extension**:

> `invalid import "./risk-reporters/${toFilename[className]}". A file extension must be included in the static part of the import.`

In vite's normal SSR transform this is only a `this.warn` (non-fatal), but coverage's uncovered-file walk surfaces the same condition fatally. Whether `security-audit.service.ts` lands in the uncovered set depends on the changed-files scope of `test:unit:changed` (janitor `test-scoped`), so it only crashed on some commits — hence the intermittent / flaky appearance. (Same class as the earlier #31206 "Fix coverage include/exclude to prevent RolldownErrors".)

**Fix:** add `/* @vite-ignore */` to the import. The plugin explicitly honors this (`hasViteIgnoreRE` → skips the import) in **every** transform path. It's a no-op for the cli's `tsc` build and Node's runtime resolution.

## How to test

This is a tooling/coverage fix with no runtime behavior change. To verify the crash is gone:

```bash
cd packages/cli
COVERAGE_ENABLED=true CI=true N8N_LOG_LEVEL=silent DB_SQLITE_POOL_SIZE=4 DB_TYPE=sqlite \
  npx vitest run src/utils/__tests__/get-item-count-by-connection-type.test.ts 2>&1 | grep -i "dynamic-import-vars"
```

Before the fix this prints the `vite:dynamic-import-vars` warning/error for `security-audit.service.ts`; after the fix there is no output.

Runtime resolution is unchanged — the security-audit integration tests still exercise the dynamic import:

```bash
cd packages/cli
npx vitest run --config vitest.config.integration.ts test/integration/security-audit/instance-risk-reporter.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- Existing security-audit integration tests already cover the runtime import path; the failure was a coverage-tooling crash, not a logic bug. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

