### PR TITLE
fix(core): Await in-flight insights compaction when stopping the timer

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
@@ -460,14 +460,12 @@ describe('compaction', () => {
 			}
 		});
 
-		test('stop succeeds after a scheduled compaction fails', async () => {
+		test('stop succeeds after compaction fails', async () => {
 			// ARRANGE
-			vi.useFakeTimers();
 			const insightsCompactionService = new InsightsCompactionService(
 				mock<InsightsByPeriodRepository>(),
 				mock<InsightsRawRepository>(),
 				mock<InsightsConfig>({
-					compactionIntervalMinutes: 1,
 					compactionBatchSize: 2,
 					compactionBatchDelayMilliseconds: 0,
 					compactionMaxBatchesPerRun: 0,
@@ -479,20 +477,13 @@ describe('compaction', () => {
 				new Error('compaction failed'),
 			);
 
-			try {
-				insightsCompactionService.startCompactionTimer();
+			// ACT
+			const compactionPromise = insightsCompactionService.compactInsights();
+			const stopPromise = insightsCompactionService.stopCompactionTimer();
 
-				// ACT
-				vi.advanceTimersByTime(1000 * 60);
-				await Promise.resolve();
-				await Promise.resolve();
-
-				// ASSERT
-				await expect(insightsCompactionService.stopCompactionTimer()).resolves.toBeUndefined();
-			} finally {
-				await insightsCompactionService.stopCompactionTimer();
-				vi.useRealTimers();
-			}
+			// ASSERT
+			await expect(compactionPromise).rejects.toThrow('compaction failed');
+			await expect(stopPromise).resolves.toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
@@ -380,7 +380,9 @@ describe('compaction', () => {
 				mockLogger(),
 			);
 			// spy on the compactInsights method to check if it's called
-			const compactInsightsSpy = vi.spyOn(insightsCompactionService, 'compactInsights');
+			const compactInsightsSpy = vi
+				.spyOn(insightsCompactionService, 'compactInsights')
+				.mockResolvedValue();
 
 			try {
 				insightsCompactionService.startCompactionTimer();
@@ -392,7 +394,103 @@ describe('compaction', () => {
 				// ASSERT
 				expect(compactInsightsSpy).toHaveBeenCalledTimes(1);
 			} finally {
-				insightsCompactionService.stopCompactionTimer();
+				await insightsCompactionService.stopCompactionTimer();
+				vi.useRealTimers();
+			}
+		});
+
+		test('stop waits for the active compaction after a skipped overlapping interval', async () => {
+			// ARRANGE
+			vi.useFakeTimers();
+			const loggerDebug = vi.fn();
+			const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis(), debug: loggerDebug });
+			const insightsCompactionService = new InsightsCompactionService(
+				mock<InsightsByPeriodRepository>(),
+				mock<InsightsRawRepository>(),
+				mock<InsightsConfig>({
+					compactionIntervalMinutes: 1,
+					compactionBatchSize: 2,
+					compactionBatchDelayMilliseconds: 0,
+					compactionMaxBatchesPerRun: 0,
+					compactionMaxRuntimeSeconds: 0,
+				}),
+				logger,
+			);
+
+			let resolveRawToHour!: (numberOfCompactedRawData: number) => void;
+			const firstRawToHourPromise = new Promise<number>((resolve) => {
+				resolveRawToHour = resolve;
+			});
+			const rawToHourSpy = vi
+				.spyOn(insightsCompactionService, 'compactRawToHour')
+				.mockReturnValueOnce(firstRawToHourPromise)
+				.mockResolvedValue(0);
+			vi.spyOn(insightsCompactionService, 'compactHourToDay').mockResolvedValue(0);
+			vi.spyOn(insightsCompactionService, 'compactDayToWeek').mockResolvedValue(0);
+
+			try {
+				insightsCompactionService.startCompactionTimer();
+
+				// ACT
+				vi.advanceTimersByTime(1000 * 60);
+				await Promise.resolve();
+				vi.advanceTimersByTime(1000 * 60);
+				await Promise.resolve();
+
+				const stopPromise = insightsCompactionService.stopCompactionTimer();
+				let stopped = false;
+				void stopPromise.then(() => {
+					stopped = true;
+				});
+				await Promise.resolve();
+
+				// ASSERT
+				expect(stopped).toBe(false);
+				expect(loggerDebug).toHaveBeenCalledWith(
+					'Skipping insights compaction because another compaction run is active',
+				);
+
+				resolveRawToHour(0);
+				await stopPromise;
+				expect(stopped).toBe(true);
+				expect(rawToHourSpy).toHaveBeenCalledTimes(1);
+			} finally {
+				await insightsCompactionService.stopCompactionTimer();
+				vi.useRealTimers();
+			}
+		});
+
+		test('stop succeeds after a scheduled compaction fails', async () => {
+			// ARRANGE
+			vi.useFakeTimers();
+			const insightsCompactionService = new InsightsCompactionService(
+				mock<InsightsByPeriodRepository>(),
+				mock<InsightsRawRepository>(),
+				mock<InsightsConfig>({
+					compactionIntervalMinutes: 1,
+					compactionBatchSize: 2,
+					compactionBatchDelayMilliseconds: 0,
+					compactionMaxBatchesPerRun: 0,
+					compactionMaxRuntimeSeconds: 0,
+				}),
+				mockLogger(),
+			);
+			vi.spyOn(insightsCompactionService, 'compactRawToHour').mockRejectedValueOnce(
+				new Error('compaction failed'),
+			);
+
+			try {
+				insightsCompactionService.startCompactionTimer();
+
+				// ACT
+				vi.advanceTimersByTime(1000 * 60);
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// ASSERT
+				await expect(insightsCompactionService.stopCompactionTimer()).resolves.toBeUndefined();
+			} finally {
+				await insightsCompactionService.stopCompactionTimer();
 				vi.useRealTimers();
 			}
 		});

--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -1099,6 +1099,13 @@ describe('InsightsService (Integration)', () => {
 			);
 		});
 
+		beforeEach(() => {
+			mockCompactionService.stopCompactionTimer.mockReset();
+			mockCompactionService.stopCompactionTimer.mockResolvedValue(undefined);
+			mockPruningService.stopPruningTimer.mockReset();
+			mockPruningService.stopPruningTimer.mockReturnValue(undefined);
+		});
+
 		test('shutdown stops timers and shuts down services', async () => {
 			// ARRANGE
 			// Get the real service from the container and spy on it
@@ -1112,6 +1119,31 @@ describe('InsightsService (Integration)', () => {
 			expect(shutdownSpy).toHaveBeenCalled();
 			expect(mockCompactionService.stopCompactionTimer).toHaveBeenCalled();
 			expect(mockPruningService.stopPruningTimer).toHaveBeenCalled();
+		});
+
+		test('stops pruning before waiting for compaction to finish', async () => {
+			// ARRANGE
+			const callOrder: string[] = [];
+			let resolveCompaction!: () => void;
+			mockCompactionService.stopCompactionTimer.mockImplementation(async () => {
+				callOrder.push('compaction');
+				await new Promise<void>((resolve) => {
+					resolveCompaction = resolve;
+				});
+			});
+			mockPruningService.stopPruningTimer.mockImplementation(() => {
+				callOrder.push('pruning');
+			});
+
+			// ACT
+			const stopPromise = insightsService.stopCompactionAndPruningTimers();
+			await Promise.resolve();
+
+			// ASSERT
+			expect(callOrder).toEqual(['pruning', 'compaction']);
+
+			resolveCompaction();
+			await stopPromise;
 		});
 	});
 });

--- a/packages/cli/src/modules/insights/insights-compaction.service.ts
+++ b/packages/cli/src/modules/insights/insights-compaction.service.ts
@@ -23,7 +23,12 @@ type CompactionStopReason = 'max-batches' | 'max-runtime';
 export class InsightsCompactionService {
 	private compactInsightsTimer: NodeJS.Timeout | undefined;
 
-	private isCompactionRunning = false;
+	/** Tracks the in-flight compaction run so stopping the timer can await it. */
+	private compactionPromise: Promise<void> | undefined;
+
+	private get isCompactionRunning() {
+		return this.compactionPromise !== undefined;
+	}
 
 	constructor(
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
@@ -35,7 +40,7 @@ export class InsightsCompactionService {
 	}
 
 	startCompactionTimer() {
-		this.stopCompactionTimer();
+		void this.stopCompactionTimer();
 		this.compactInsightsTimer = setInterval(
 			async () => await this.compactInsights(),
 			this.insightsConfig.compactionIntervalMinutes * Time.minutes.toMilliseconds,
@@ -43,12 +48,15 @@ export class InsightsCompactionService {
 		this.logger.debug('Started compaction timer');
 	}
 
-	stopCompactionTimer() {
+	async stopCompactionTimer() {
 		if (this.compactInsightsTimer !== undefined) {
 			clearInterval(this.compactInsightsTimer);
 			this.compactInsightsTimer = undefined;
 			this.logger.debug('Stopped compaction timer');
 		}
+		// Wait for an in-flight run to finish so its transaction isn't left running
+		// against a connection that may be closed right after stopping.
+		await this.compactionPromise?.catch(() => {});
 	}
 
 	async compactInsights() {
@@ -57,46 +65,52 @@ export class InsightsCompactionService {
 			return;
 		}
 
-		this.isCompactionRunning = true;
+		const compactionPromise = this.runCompaction();
+		const trackedCompactionPromise = compactionPromise.finally(() => {
+			if (this.compactionPromise === trackedCompactionPromise) {
+				this.compactionPromise = undefined;
+			}
+		});
+		this.compactionPromise = trackedCompactionPromise;
 
-		try {
-			const runState: CompactionRunState = {
-				startedAt: Date.now(),
-				batchesProcessed: 0,
-				rowsCompacted: 0,
-			};
+		await this.compactionPromise;
+	}
 
-			const stoppedAfterRawToHour = await this.compactStage({
-				stageName: 'raw-to-hour',
-				beforeBatchMessage: 'Compacting raw data to hourly aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} raw data to hourly aggregates`,
-				compactBatch: this.compactRawToHour.bind(this),
-				runState,
-			});
-			if (stoppedAfterRawToHour) return;
+	private async runCompaction() {
+		const runState: CompactionRunState = {
+			startedAt: Date.now(),
+			batchesProcessed: 0,
+			rowsCompacted: 0,
+		};
 
-			const stoppedAfterHourToDay = await this.compactStage({
-				stageName: 'hour-to-day',
-				beforeBatchMessage: 'Compacting hourly data to daily aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} hourly data to daily aggregates`,
-				compactBatch: this.compactHourToDay.bind(this),
-				runState,
-			});
-			if (stoppedAfterHourToDay) return;
+		const stoppedAfterRawToHour = await this.compactStage({
+			stageName: 'raw-to-hour',
+			beforeBatchMessage: 'Compacting raw data to hourly aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} raw data to hourly aggregates`,
+			compactBatch: this.compactRawToHour.bind(this),
+			runState,
+		});
+		if (stoppedAfterRawToHour) return;
 
-			await this.compactStage({
-				stageName: 'day-to-week',
-				beforeBatchMessage: 'Compacting daily data to weekly aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} daily data to weekly aggregates`,
-				compactBatch: this.compactDayToWeek.bind(this),
-				runState,
-			});
-		} finally {
-			this.isCompactionRunning = false;
-		}
+		const stoppedAfterHourToDay = await this.compactStage({
+			stageName: 'hour-to-day',
+			beforeBatchMessage: 'Compacting hourly data to daily aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} hourly data to daily aggregates`,
+			compactBatch: this.compactHourToDay.bind(this),
+			runState,
+		});
+		if (stoppedAfterHourToDay) return;
+
+		await this.compactStage({
+			stageName: 'day-to-week',
+			beforeBatchMessage: 'Compacting daily data to weekly aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} daily data to weekly aggregates`,
+			compactBatch: this.compactDayToWeek.bind(this),
+			runState,
+		});
 	}
 
 	private async compactStage({

--- a/packages/cli/src/modules/insights/insights.service.ts
+++ b/packages/cli/src/modules/insights/insights.service.ts
@@ -56,14 +56,14 @@ export class InsightsService {
 	}
 
 	@OnLeaderStepdown()
-	stopCompactionAndPruningTimers() {
-		this.compactionService.stopCompactionTimer();
+	async stopCompactionAndPruningTimers() {
 		this.pruningService.stopPruningTimer();
+		await this.compactionService.stopCompactionTimer();
 	}
 
 	async shutdown() {
 		await this.toggleCollectionService(false);
-		this.stopCompactionAndPruningTimers();
+		await this.stopCompactionAndPruningTimers();
 	}
 
 	async getInsightsSummary({

--- a/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
+++ b/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
@@ -98,9 +98,10 @@ describe('Insights vs Workflow Statistics Integration', () => {
 		insightsCompactionService.startCompactionTimer();
 	});
 
-	afterAll(() => {
-		// Stop compaction timer
-		insightsCompactionService.stopCompactionTimer();
+	afterAll(async () => {
+		// Stop compaction timer and wait for any in-flight run to finish before the
+		// sibling afterAll terminates the DB connection.
+		await insightsCompactionService.stopCompactionTimer();
 	});
 
 	beforeEach(async () => {


### PR DESCRIPTION
## Summary

Track inflight compactions in `InsightsCompactionService` so we can await them when stopping them. This makes shutdown / leader stepdown graceful and fixes integration test that fails with:

```
The integration test
packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
intermittently emits an unhandled rejection that fails the run:

DriverAlreadyReleasedError: Driver has already been released.
  ❯ ...insights-by-period.repository.ts:247  await trx.query(deleteBatch);
  ❯ InsightsCompactionService.compactHourToDay
  ❯ InsightsCompactionService.compactStage
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3605
