### PR TITLE
chore: Add route-aware sampling for webhook traces

### DIFF
--- a/packages/@n8n/config/src/configs/sentry.config.ts
+++ b/packages/@n8n/config/src/configs/sentry.config.ts
@@ -47,6 +47,16 @@ export class SentryConfig {
 	tracesSlowSpanThresholdMs: number = 1000;
 
 	/**
+	 * Sample rate (0.0 to 1.0) for successful production webhook transaction
+	 * traces. These are by far the highest-volume route, so they are sampled
+	 * below the base rate. Errored webhook transactions are always kept.
+	 *
+	 * @default 0.05
+	 */
+	@Env('N8N_SENTRY_WEBHOOK_TRACES_SAMPLE_RATE', sampleRateSchema)
+	webhookTracesSampleRate: number = 0.05;
+
+	/**
 	 * Whether Sentry's native event-loop-block detection is enabled. When on, a
 	 * native watchdog (`@sentry/node-native`) captures the main thread's stack
 	 * whenever the event loop is blocked beyond the threshold below.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -398,6 +398,7 @@ describe('GlobalConfig', () => {
 			profilesSampleRate: 0,
 			tracesSampleRate: 0,
 			tracesSlowSpanThresholdMs: 1000,
+			webhookTracesSampleRate: 0.05,
 			eventLoopBlockDetectionEnabled: false,
 			eventLoopBlockThreshold: 500,
 			eventLoopBlockMaxEventsPerHour: 5,

--- a/packages/cli/src/commands/base-command.ts
+++ b/packages/cli/src/commands/base-command.ts
@@ -97,6 +97,7 @@ export abstract class BaseCommand<F = never> {
 			profilesSampleRate,
 			tracesSampleRate,
 			tracesSlowSpanThresholdMs,
+			webhookTracesSampleRate,
 			eventLoopBlockThreshold,
 			eventLoopBlockMaxEventsPerHour,
 			eventLoopBlockDetectionEnabled,
@@ -113,6 +114,8 @@ export abstract class BaseCommand<F = never> {
 			eventLoopBlockMaxEventsPerHour,
 			tracesSampleRate,
 			slowSpanThresholdMs: tracesSlowSpanThresholdMs,
+			webhookEndpoint: this.globalConfig.endpoints.webhook,
+			webhookTracesSampleRate,
 			profilesSampleRate,
 			healthEndpoint: resolveBackendHealthEndpointPath(this.globalConfig),
 			eligibleIntegrations: {

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -41,6 +41,12 @@ type ErrorReporterInitOptions = {
 	/** Threshold in ms below which non-errored `db`/`http.client` spans are dropped. */
 	slowSpanThresholdMs?: number;
 
+	/** Production webhook endpoint path segment (e.g. `webhook`), used to sample webhook traces. */
+	webhookEndpoint?: string;
+
+	/** Sample rate (0.0 to 1.0) for successful production webhook transaction traces. */
+	webhookTracesSampleRate?: number;
+
 	/** Sample rate for Sentry profiling (0.0 to 1.0). 0 means disabled */
 	profilesSampleRate: number;
 
@@ -149,6 +155,8 @@ export class ErrorReporter {
 		profilesSampleRate,
 		tracesSampleRate,
 		slowSpanThresholdMs = DEFAULT_SLOW_SPAN_THRESHOLD_MS,
+		webhookEndpoint,
+		webhookTracesSampleRate,
 		eligibleIntegrations = {},
 		healthEndpoint = '/healthz',
 	}: ErrorReporterInitOptions) {
@@ -242,7 +250,12 @@ export class ErrorReporter {
 			...(isTracingEnabled
 				? {
 						tracesSampler: buildTracesSampler(tracesSampleRate),
-						beforeSendTransaction: buildBeforeSendTransaction(slowSpanThresholdMs),
+						beforeSendTransaction: buildBeforeSendTransaction(
+							slowSpanThresholdMs,
+							webhookEndpoint && webhookTracesSampleRate !== undefined
+								? { endpoint: webhookEndpoint, sampleRate: webhookTracesSampleRate }
+								: undefined,
+						),
 					}
 				: {}),
 			...(isProfilingEnabled ? { profilesSampleRate, profileLifecycle: 'trace' } : {}),

--- a/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
@@ -1,4 +1,5 @@
 import type { SpanJSON, TracesSamplerSamplingContext, TransactionEvent } from '@sentry/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildBeforeSendTransaction, buildTracesSampler } from '../span-sampling';
 
@@ -134,6 +135,64 @@ describe('buildBeforeSendTransaction', () => {
 	it('returns the event unchanged when it has no spans', () => {
 		const event = { type: 'transaction' } as TransactionEvent;
 		expect(buildBeforeSendTransaction(THRESHOLD_MS)(event)).toBe(event);
+	});
+
+	describe('webhook trace sampling', () => {
+		const WEBHOOK = { endpoint: 'webhook', sampleRate: 0.05 };
+		const beforeSend = buildBeforeSendTransaction(THRESHOLD_MS, WEBHOOK);
+
+		/** Builds a webhook transaction with the given name and root status. */
+		function webhookTx(name: string, status?: SpanJSON['status']): TransactionEvent {
+			return {
+				type: 'transaction',
+				transaction: name,
+				contexts: { trace: { op: 'http.server', span_id: 'root', trace_id: 't', status } },
+			} as TransactionEvent;
+		}
+
+		afterEach(() => vi.restoreAllMocks());
+
+		it('drops a successful webhook transaction when the dice roll exceeds the rate', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.5);
+			expect(beforeSend(webhookTx('POST /webhook/*path', 'ok'))).toBeNull();
+		});
+
+		it('keeps a successful webhook transaction when the dice roll is below the rate', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.01);
+			expect(beforeSend(webhookTx('POST /webhook/*path', 'ok'))).not.toBeNull();
+		});
+
+		it('keeps errored webhook transactions regardless of the dice roll', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.99);
+			expect(beforeSend(webhookTx('POST /webhook/*path', 'internal_error'))).not.toBeNull();
+		});
+
+		it('does not sample /rest transactions', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.99);
+			expect(beforeSend(webhookTx('POST /rest/executions/:id/stop', 'ok'))).not.toBeNull();
+		});
+
+		it('does not sample test/waiting webhooks (production only)', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.99);
+			expect(beforeSend(webhookTx('POST /webhook-test/*path', 'ok'))).not.toBeNull();
+			expect(beforeSend(webhookTx('POST /webhook-waiting/:path', 'ok'))).not.toBeNull();
+		});
+
+		it('does not sample webhooks when no webhook config is provided', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.99);
+			expect(
+				buildBeforeSendTransaction(THRESHOLD_MS)(webhookTx('POST /webhook/*path', 'ok')),
+			).not.toBeNull();
+		});
+
+		it('does not sample webhooks when the rate is 1', () => {
+			vi.spyOn(Math, 'random').mockReturnValue(0.99);
+			const keepAll = buildBeforeSendTransaction(THRESHOLD_MS, {
+				endpoint: 'webhook',
+				sampleRate: 1,
+			});
+			expect(keepAll(webhookTx('POST /webhook/*path', 'ok'))).not.toBeNull();
+		});
 	});
 });
 

--- a/packages/core/src/observability/tracing/span-sampling.ts
+++ b/packages/core/src/observability/tracing/span-sampling.ts
@@ -38,6 +38,23 @@ function shouldKeepSpan(span: SpanJSON, slowSpanThresholdMs: number): boolean {
 	return true;
 }
 
+/**
+ * Whether a transaction is a successful (non-errored) production webhook request.
+ * Sentry names Express transactions by route pattern, e.g. `POST /webhook/*path`,
+ * so we match on the configured webhook endpoint. `webhook-test`/`webhook-waiting`
+ * are deliberately excluded (only production webhooks are high-volume).
+ */
+function isSuccessfulWebhook(event: TransactionEvent, webhookEndpoint: string): boolean {
+	if (isErrored(event.contexts?.trace?.status)) return false;
+
+	const name = event.transaction;
+	if (!name) return false;
+
+	const path = name.slice(name.indexOf(' ') + 1); // strip the HTTP method prefix
+	const prefix = `/${webhookEndpoint}`;
+	return path === prefix || path.startsWith(`${prefix}/`);
+}
+
 function reparentChildSpans(
 	spans: SpanJSON[],
 	droppedSpan: SpanJSON,
@@ -61,13 +78,23 @@ function reparentChildSpans(
  * - Fast, non-errored `db`/`http.client` child spans (below `slowSpanThresholdMs`).
  *
  * Kept descendants of dropped child spans are reparented.
+ *
+ * When `webhook` is set, successful production webhook transactions (the highest-volume
+ * route) are randomly dropped down to `webhook.sampleRate`; errored ones are always kept.
  */
-export function buildBeforeSendTransaction(slowSpanThresholdMs: number) {
+export function buildBeforeSendTransaction(
+	slowSpanThresholdMs: number,
+	webhook?: { endpoint: string; sampleRate: number },
+) {
 	return (event: TransactionEvent): TransactionEvent | null => {
 		// DB operations (queries, pool connects) get op `db`. A `db`-rooted transaction
 		// ran outside any request/job span — high volume, no signal. Child db spans under
 		// real transactions keep a non-`db` root op, so they are untouched.
 		if (event.contexts?.trace?.op === 'db') return null;
+
+		if (webhook && webhook.sampleRate < 1 && isSuccessfulWebhook(event, webhook.endpoint)) {
+			if (Math.random() >= webhook.sampleRate) return null;
+		}
 
 		if (event.spans) {
 			const spans = event.spans;


### PR DESCRIPTION
## Summary

Add separate sampling rate for production webhook endpoints (`POST`/`GET /webhook/*path`). These are by far the highest-volume route in Sentry tracing. Failed spans/transaction follow the global sampling rate.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3602

## Review / Merge checklist

- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->