### PR TITLE
fix(Salesforce Node): Normalize empty 204 responses on JWT auth path

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -3120,7 +3120,10 @@ export class Salesforce implements INodeType {
 					}
 				}
 
-				if (!Array.isArray(responseData) && responseData === undefined) {
+				if (
+					!Array.isArray(responseData) &&
+					(responseData === undefined || responseData === '' || responseData === null)
+				) {
 					// Make sure that always valid JSON gets returned which also matches the
 					// Salesforce default response
 					responseData = {

--- a/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
@@ -2701,6 +2701,37 @@ describe('Salesforce', () => {
 					}),
 				);
 			});
+
+			// A 204 No Content reply has no body: the axios-based JWT auth path resolves
+			// it as '', the legacy OAuth2 path as undefined. All must normalize alike.
+			it.each([
+				['empty string', ''],
+				['undefined', undefined],
+				['null', null],
+			])(
+				'should normalize a %s 204 response into a valid success item',
+				async (_label, emptyResponse) => {
+					mockExecuteFunctions.getNodeParameter.mockImplementation((param: string): any => {
+						const params: Record<string, unknown> = {
+							resource: 'customObject',
+							operation: 'update',
+							recordId: 'custom123',
+							customObject: 'CustomObject__c',
+							customFieldsUi: {
+								customFieldsValues: [{ fieldId: 'Name', value: 'Updated' }],
+							},
+							updateFields: {},
+						};
+						return params[param];
+					});
+
+					salesforceApiRequestSpy.mockResolvedValue(emptyResponse);
+
+					const result = await node.execute.call(mockExecuteFunctions);
+
+					expect(result[0][0].json).toEqual({ errors: [], success: true });
+				},
+			);
 		});
 
 		describe('CustomObject Other Operations', () => {


### PR DESCRIPTION
## Summary

After PR #32325 ("Reuse JWT session token across requests") switched the Salesforce JWT auth path from the legacy `requestOAuth2` helper to axios-based `httpRequestWithAuthentication`, HTTP **204 No Content** replies now resolve as `''` instead of the legacy `undefined`.

The empty-response guard at `Salesforce.node.ts:3123` only matched `undefined`, so `''` slipped through and `returnJsonArray('')` wrapped it as `[{ json: '' }]` — rendering as an invalid `[""]` item instead of `[{ "errors": [], "success": true }]`.

This broadens the guard to also treat `''` and `null` as empty:

```ts
if (
    !Array.isArray(responseData) &&
    (responseData === undefined || responseData === '' || responseData === null)
) {
    responseData = { errors: [], success: true };
}
```

**Affected:** all 204-returning write ops on the **OAuth2 JWT Bearer** credential — Custom Object update/delete/upsert, and update/delete on Lead, Contact, Account, Opportunity, Case, Task. The OAuth2 web-server path is unaffected (it still uses the legacy helper returning `undefined`).

## How to test

### Automated (primary)
The regression is covered by a parameterized unit test in
`packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts`
("should normalize a <empty string|undefined|null> 204 response into a valid success item").

    cd packages/nodes-base
    pnpm test Salesforce.node.test.ts -t "204 response"

Expected: 3 passing cases. On `master` (before the fix) the `''` case fails with
`expected '' to deeply equal { errors: [], success: true }`.

### Manual (requires Salesforce OAuth2 JWT Bearer credential)

<details>
<summary>Test Workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        0
      ],
      "id": "477d27e1-2fa6-4433-9767-0822765eb5e4",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "authentication": "jwt",
        "resource": "task",
        "status": "In Progress",
        "additionalFields": {
          "description": "Test Task by Berni"
        }
      },
      "type": "n8n-nodes-base.salesforce",
      "typeVersion": 1.1,
      "position": [
        208,
        0
      ],
      "id": "5cae56ce-5862-4329-a48c-152e8908ef12",
      "name": "Create a task",
      "credentials": {
        "salesforceJwtApi": {
          "id": "NSDRu1Aw6cZ7UVpH",
          "name": "Salesforce JWT account"
        }
      }
    },
    {
      "parameters": {
        "authentication": "jwt",
        "resource": "task",
        "operation": "update",
        "taskId": "={{ $json.id }}",
        "updateFields": {
          "description": "Updated",
          "subject": "Other"
        }
      },
      "type": "n8n-nodes-base.salesforce",
      "typeVersion": 1.1,
      "position": [
        384,
        0
      ],
      "id": "18b9c0be-ff69-4e2f-a817-2c396d0fb651",
      "name": "Update a task",
      "credentials": {
        "salesforceJwtApi": {
          "id": "NSDRu1Aw6cZ7UVpH",
          "name": "Salesforce JWT account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Create a task",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Create a task": {
      "main": [
        [
          {
            "node": "Update a task",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "4e88fdf2ca2358b3af9fbecc28c6de3cd7b5ec37486b1d0dd8bae0f15bd2a988"
  }
}
```
</details>
<img width="1482" height="433" alt="salesforce_output_shape" src="https://github.com/user-attachments/assets/e921a7c8-8ec2-4e0e-a321-9ce115554f6d" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5344

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->