### PR TITLE
fix(core): Surface a clear retryable error when the Instance AI sandbox is unreachable (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
@@ -1,0 +1,15 @@
+import { getUserFacingErrorMessage } from '../instance-ai.service';
+
+describe('getUserFacingErrorMessage', () => {
+	it('maps a sandbox "Endpoint not allowed" failure to a clear, retryable message', () => {
+		const message = getUserFacingErrorMessage(new Error('Endpoint not allowed'));
+		expect(message).toContain("couldn't reach the workspace sandbox");
+		expect(message).toContain('try again');
+	});
+
+	it('falls back to a generic retryable message for unknown errors', () => {
+		expect(getUserFacingErrorMessage(new Error('kaboom'))).toBe(
+			'Something went wrong before I could finish that response. Please try again.',
+		);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts
@@ -3,7 +3,7 @@ import { getUserFacingErrorMessage } from '../instance-ai.service';
 describe('getUserFacingErrorMessage', () => {
 	it('maps a sandbox "Endpoint not allowed" failure to a clear, retryable message', () => {
 		const message = getUserFacingErrorMessage(new Error('Endpoint not allowed'));
-		expect(message).toContain("couldn't reach the workspace sandbox");
+		expect(message).toContain("couldn't finish preparing the workspace sandbox");
 		expect(message).toContain('try again');
 	});
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -254,8 +254,7 @@ function isTextMessagePart(part: unknown): part is { type: 'text'; text: string 
 	);
 }
 
-// "Endpoint not allowed" is the sandbox proxy's 403 for a blocked/unreachable endpoint.
-function isSandboxUnreachableError(error: unknown): boolean {
+function isSandboxEndpointNotAllowedError(error: unknown): boolean {
 	return getErrorMessage(error).toLowerCase().includes('endpoint not allowed');
 }
 
@@ -264,8 +263,8 @@ export function getUserFacingErrorMessage(error: unknown): string {
 		return error.message;
 	}
 
-	if (isSandboxUnreachableError(error)) {
-		return "I couldn't reach the workspace sandbox — it may have been paused or is temporarily unavailable. Please try again in a moment.";
+	if (isSandboxEndpointNotAllowedError(error)) {
+		return "I couldn't finish preparing the workspace sandbox. Please try again in a moment.";
 	}
 
 	if (error instanceof OperationalError) {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -254,9 +254,18 @@ function isTextMessagePart(part: unknown): part is { type: 'text'; text: string 
 	);
 }
 
-function getUserFacingErrorMessage(error: unknown): string {
+// "Endpoint not allowed" is the sandbox proxy's 403 for a blocked/unreachable endpoint.
+function isSandboxUnreachableError(error: unknown): boolean {
+	return getErrorMessage(error).toLowerCase().includes('endpoint not allowed');
+}
+
+export function getUserFacingErrorMessage(error: unknown): string {
 	if (error instanceof UserError) {
 		return error.message;
+	}
+
+	if (isSandboxUnreachableError(error)) {
+		return "I couldn't reach the workspace sandbox — it may have been paused or is temporarily unavailable. Please try again in a moment.";
 	}
 
 	if (error instanceof OperationalError) {
@@ -3344,11 +3353,14 @@ export class InstanceAiService {
 					messageId,
 				});
 			}
+			const userFacingErrorMessage =
+				result.status === 'errored' ? getUserFacingErrorMessage(result.error) : undefined;
 			if (runControl.shouldEmitTerminalOutcome(result.stopReason)) {
 				this.terminalOutcome.evaluateTerminalResponse(threadId, runId, result.status, {
 					messageGroupId,
 					correlationId: messageId,
 					workSummary: result.workSummary,
+					errorMessage: userFacingErrorMessage,
 					suppressCompletedFallback:
 						checkpoint?.isCheckpointFollowUp === true ||
 						plannedBuild?.isPlannedBuildFollowUp === true,
@@ -3378,6 +3390,7 @@ export class InstanceAiService {
 				archivedWorkflowIds,
 				workSummary: result.workSummary,
 				usage: result.usage,
+				errorReason: userFacingErrorMessage,
 			});
 
 			// Bill token usage for every terminal outcome (completed / cancelled / errored),
@@ -4270,10 +4283,13 @@ export class InstanceAiService {
 					},
 				);
 			}
+			const userFacingErrorMessage =
+				result.status === 'errored' ? getUserFacingErrorMessage(result.error) : undefined;
 			if (runControl.shouldEmitTerminalOutcome(result.stopReason)) {
 				this.terminalOutcome.evaluateTerminalResponse(opts.threadId, opts.runId, result.status, {
 					messageGroupId,
 					workSummary: result.workSummary,
+					errorMessage: userFacingErrorMessage,
 					suppressCompletedFallback:
 						opts.checkpoint?.isCheckpointFollowUp === true ||
 						opts.plannedBuild?.isPlannedBuildFollowUp === true,
@@ -4302,6 +4318,7 @@ export class InstanceAiService {
 				archivedWorkflowIds,
 				workSummary: result.workSummary,
 				usage: result.usage,
+				errorReason: userFacingErrorMessage,
 			});
 
 			// Bill token usage for every terminal outcome, deduped per run segment.
@@ -4829,7 +4846,11 @@ export class InstanceAiService {
 			agentId: orchestratorAgentId(runId),
 			payload: {
 				status: effectiveStatus,
-				...(status === 'cancelled' ? { reason: reason ?? 'user_cancelled' } : {}),
+				...(status === 'cancelled'
+					? { reason: reason ?? 'user_cancelled' }
+					: status === 'errored' && reason
+						? { reason }
+						: {}),
 				...(hasArchived ? { archivedWorkflowIds } : {}),
 			},
 		});
@@ -4853,13 +4874,14 @@ export class InstanceAiService {
 			archivedWorkflowIds?: string[];
 			workSummary?: WorkSummary;
 			usage?: RunTokenUsage;
+			errorReason?: string;
 		},
 	): Promise<void> {
 		this.publishRunFinish(
 			threadId,
 			runId,
 			status,
-			undefined,
+			options?.errorReason,
 			options?.archivedWorkflowIds,
 			options?.userId,
 		);


### PR DESCRIPTION
## Summary

A failed Instance AI turn caused by an unreachable workspace sandbox (Daytona `Endpoint not allowed` / 403) reached the user as a bare `{status:"error"}` with no message or retry guidance (INS-620).

This makes that failure graceful: errored streams now attach a user-facing `reason` to `run-finish` (both the live and resumed paths), and `publishRunFinish` carries `reason` for `errored` (previously only for `cancelled`). The sandbox-unreachable case (`Endpoint not allowed`) maps to a clear, retryable message instead of a bare/raw error.

> Root cause of the 403 itself is the sandbox proxy allow-list in `ai-assistant-service` (it blocks a route the Daytona SDK needs) — addressed separately in the companion PR below. This PR is purely the user-facing error surface.

## How to test

1. Trigger an Instance AI turn where the workspace sandbox is unreachable (or stub the Daytona client to reject with `DaytonaError('Endpoint not allowed', 403)`).
2. The `run-finish` event now carries a friendly `reason` ("I couldn't reach the workspace sandbox …") rather than a bare `{status:"error"}`.
3. Unit test: `pnpm --filter n8n test src/modules/instance-ai/__tests__/instance-ai.service.errorMessage.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-620

Companion gateway PR (ai-assistant-service — surfaces the blocked Daytona route so it can be allow-listed): https://github.com/n8n-io/ai-assistant-service/pull/455

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. `(no-changelog)` used — internal Instance AI fix.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if urgent).
