### PR TITLE
feat(editor): Sets AIA v3 as default empty state & fixes display issues

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiSplitEmptyState/components/InstanceAiPreviewCanvas.vue
@@ -116,7 +116,8 @@ const displayNodes = computed(() =>
 		const icon = node.icon;
 		if (icon.type !== 'file' || !icon.src) return node;
 		const src = normalizeIconSrc(icon.src);
-		return src === icon.src ? node : { ...node, icon: { ...icon, src } };
+		if (src === icon.src) return node;
+		return { ...node, icon: { ...icon, src, lightInvert: false } };
 	}),
 );
 

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewCanvas.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import WorkflowPreviewCanvas from './WorkflowPreviewCanvas.vue';
+import type { PreviewWorkflow } from '../workflows/types';
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@vueuse/core')>();
+	return {
+		...actual,
+		useElementSize: vi.fn(),
+	};
+});
+
+import { useElementSize } from '@vueuse/core';
+import { ref } from 'vue';
+
+const minimalWorkflow: PreviewWorkflow = {
+	nodes: [
+		{
+			id: 'trigger',
+			label: 'Trigger',
+			icon: { type: 'icon', name: 'play' },
+			position: { x: 0, y: 0 },
+		},
+		{
+			id: 'action',
+			label: 'Action',
+			icon: { type: 'icon', name: 'bolt' },
+			position: { x: 200, y: 0 },
+		},
+	],
+	connections: [{ source: 'trigger', target: 'action' }],
+};
+
+describe('WorkflowPreviewCanvas renderScale', () => {
+	it('applies scale(width / 1600) when rendered width is narrower than canvas', () => {
+		const widthRef = ref(800);
+		vi.mocked(useElementSize).mockReturnValue({
+			width: widthRef,
+			height: ref(420),
+		} as unknown as ReturnType<typeof useElementSize>);
+
+		const wrapper = mount(WorkflowPreviewCanvas, {
+			props: { workflow: minimalWorkflow, animating: false },
+			global: { stubs: { WorkflowPreviewNode: true } },
+		});
+
+		const canvasContent = wrapper.find('[class*="canvasContent"]');
+		const style = canvasContent.attributes('style') ?? '';
+		expect(style).toContain('scale(0.5)');
+	});
+
+	it('applies scale(1) when rendered width equals or exceeds canvas width', () => {
+		const widthRef = ref(1600);
+		vi.mocked(useElementSize).mockReturnValue({
+			width: widthRef,
+			height: ref(420),
+		} as unknown as ReturnType<typeof useElementSize>);
+
+		const wrapper = mount(WorkflowPreviewCanvas, {
+			props: { workflow: minimalWorkflow, animating: false },
+			global: { stubs: { WorkflowPreviewNode: true } },
+		});
+
+		const canvasContent = wrapper.find('[class*="canvasContent"]');
+		const style = canvasContent.attributes('style') ?? '';
+		expect(style).toContain('scale(1)');
+	});
+
+	it('applies scale(1) when rendered width exceeds canvas width', () => {
+		const widthRef = ref(2400);
+		vi.mocked(useElementSize).mockReturnValue({
+			width: widthRef,
+			height: ref(420),
+		} as unknown as ReturnType<typeof useElementSize>);
+
+		const wrapper = mount(WorkflowPreviewCanvas, {
+			props: { workflow: minimalWorkflow, animating: false },
+			global: { stubs: { WorkflowPreviewNode: true } },
+		});
+
+		const canvasContent = wrapper.find('[class*="canvasContent"]');
+		const style = canvasContent.attributes('style') ?? '';
+		expect(style).toContain('scale(1)');
+	});
+});

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewCanvas.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewCanvas.vue
@@ -285,9 +285,20 @@ const scale = computed(() => {
 	return Math.min(scaleX, scaleY, 1);
 });
 
-const effectiveCanvasWidth = computed(() =>
-	canvasRenderedWidth.value > 0 ? canvasRenderedWidth.value : CANVAS_WIDTH,
+const renderScale = computed(() =>
+	canvasRenderedWidth.value > 0 ? Math.min(canvasRenderedWidth.value / CANVAS_WIDTH, 1) : 1,
 );
+
+const contentStyle = computed(() => {
+	const rs = renderScale.value;
+	const verticalOffset = (CANVAS_HEIGHT * (1 - rs)) / 2;
+	return {
+		width: `${CANVAS_WIDTH}px`,
+		height: `${CANVAS_HEIGHT}px`,
+		transform: `translateY(${verticalOffset}px) scale(${rs})`,
+		transformOrigin: 'top left',
+	};
+});
 
 const containerStyle = computed(() => {
 	const { width, height } = bounds.value;
@@ -300,7 +311,7 @@ const containerStyle = computed(() => {
 		height: `${height}px`,
 		transform: `scale(${s})`,
 		transformOrigin: 'top left',
-		left: `${(effectiveCanvasWidth.value - scaledWidth) / 2}px`,
+		left: `${(CANVAS_WIDTH - scaledWidth) / 2}px`,
 		top: `${(CANVAS_HEIGHT - scaledHeight) / 2}px`,
 	};
 });
@@ -312,7 +323,7 @@ const viewBox = computed(
 const canvasMarginLeft = computed(() => {
 	const s = scale.value;
 	const scaledWidth = bounds.value.width * s;
-	return (effectiveCanvasWidth.value - scaledWidth) / 2;
+	return (CANVAS_WIDTH - scaledWidth) / 2;
 });
 
 const canvasMarginTop = computed(() => {
@@ -399,57 +410,59 @@ function isEdgeSuccess(connection: PreviewWorkflowConnection): boolean {
 
 <template>
 	<div ref="canvasRef" :class="$style.canvas">
-		<div :class="$style.viewport" :style="containerStyle">
-			<svg :class="$style.edges" :viewBox="viewBox">
-				<path
-					v-for="(conn, idx) in props.workflow.connections"
-					:key="`edge-${idx}`"
-					:d="getEdgePath(conn)"
-					:class="[$style.edge, isEdgeSuccess(conn) && $style.edgeSuccess]"
-				/>
-			</svg>
-			<div :class="$style.nodesLayer">
-				<WorkflowPreviewNode
-					v-for="node in props.workflow.nodes"
-					:key="node.id"
-					:node="node"
-					:state="nodeStates[node.id] ?? 'idle'"
-					:trigger="triggerNodeIds.has(node.id)"
-					:offset-x="bounds.minX"
-					:offset-y="bounds.minY"
-					:icon-override="
-						crmCycleNodeIds.has(node.id) && crmCycleVisible ? crmCurrentVariant?.icon : undefined
-					"
+		<div :class="$style.canvasContent" :style="contentStyle">
+			<div :class="$style.viewport" :style="containerStyle">
+				<svg :class="$style.edges" :viewBox="viewBox">
+					<path
+						v-for="(conn, idx) in props.workflow.connections"
+						:key="`edge-${idx}`"
+						:d="getEdgePath(conn)"
+						:class="[$style.edge, isEdgeSuccess(conn) && $style.edgeSuccess]"
+					/>
+				</svg>
+				<div :class="$style.nodesLayer">
+					<WorkflowPreviewNode
+						v-for="node in props.workflow.nodes"
+						:key="node.id"
+						:node="node"
+						:state="nodeStates[node.id] ?? 'idle'"
+						:trigger="triggerNodeIds.has(node.id)"
+						:offset-x="bounds.minX"
+						:offset-y="bounds.minY"
+						:icon-override="
+							crmCycleNodeIds.has(node.id) && crmCycleVisible ? crmCurrentVariant?.icon : undefined
+						"
+					/>
+				</div>
+			</div>
+
+			<div v-if="inputVizComponent" :class="$style.vizSlot" :style="inputSlotStyle">
+				<component
+					:is="inputVizComponent"
+					:active="animationPhase !== 'idle'"
+					v-bind="props.workflow.inputVisualization?.props"
+					:icon-override="inputVizIcon"
+					slide-from="left"
+					@complete="handleInputComplete"
 				/>
 			</div>
-		</div>
 
-		<div v-if="inputVizComponent" :class="$style.vizSlot" :style="inputSlotStyle">
-			<component
-				:is="inputVizComponent"
-				:active="animationPhase !== 'idle'"
-				v-bind="props.workflow.inputVisualization?.props"
-				:icon-override="inputVizIcon"
-				slide-from="left"
-				@complete="handleInputComplete"
-			/>
-		</div>
-
-		<div
-			v-for="(outputViz, idx) in outputVizItems"
-			:key="`output-viz-${idx}`"
-			:class="[$style.vizSlot, outputVizItems.length > 1 && $style.vizSlotCompact]"
-			:style="outputSlotStyles[idx]"
-		>
-			<component
-				:is="visualizationComponents[outputViz.type]"
-				:active="animationPhase === 'output' || animationPhase === 'done'"
-				v-bind="outputViz.props"
-				:icon-override="
-					outputViz.type === 'salesforce-card' && crmCycleVisible ? inputVizIcon : undefined
-				"
-				@complete="handleOutputComplete"
-			/>
+			<div
+				v-for="(outputViz, idx) in outputVizItems"
+				:key="`output-viz-${idx}`"
+				:class="[$style.vizSlot, outputVizItems.length > 1 && $style.vizSlotCompact]"
+				:style="outputSlotStyles[idx]"
+			>
+				<component
+					:is="visualizationComponents[outputViz.type]"
+					:active="animationPhase === 'output' || animationPhase === 'done'"
+					v-bind="outputViz.props"
+					:icon-override="
+						outputViz.type === 'salesforce-card' && crmCycleVisible ? inputVizIcon : undefined
+					"
+					@complete="handleOutputComplete"
+				/>
+			</div>
 		</div>
 	</div>
 </template>
@@ -470,6 +483,12 @@ function isEdgeSuccess(connection: PreviewWorkflowConnection): boolean {
 	background-size: 16px 16px;
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius--xl);
+}
+
+.canvasContent {
+	position: absolute;
+	top: 0;
+	left: 0;
 }
 
 .viewport {

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewNode.vue
@@ -37,6 +37,7 @@ const iconName = computed(() =>
 const iconSrc = computed(() =>
 	activeIcon.value.type === 'file' ? activeIcon.value.src : undefined,
 );
+const iconLightInvert = computed(() => activeIcon.value.lightInvert === true);
 </script>
 
 <template>
@@ -52,7 +53,11 @@ const iconSrc = computed(() =>
 		<div :class="$style.iconWrapper" :style="iconWrapperStyle">
 			<N8nIcon v-if="iconName" :icon="iconName" :size="48" />
 			<Transition v-else-if="iconSrc" :name="$style.swipe" mode="out-in">
-				<img :key="iconSrc" :src="iconSrc" :class="$style.iconImage" />
+				<img
+					:key="iconSrc"
+					:src="iconSrc"
+					:class="[$style.iconImage, iconLightInvert && $style.lightInvert]"
+				/>
 			</Transition>
 			<span v-else :class="$style.iconFallback">{{ props.node.label.charAt(0) }}</span>
 		</div>
@@ -133,6 +138,20 @@ const iconSrc = computed(() =>
 	max-height: 48px;
 	width: auto;
 	height: auto;
+}
+
+.lightInvert {
+	filter: invert(1);
+}
+
+:global([data-theme='dark']) .lightInvert {
+	filter: none;
+}
+
+@media (prefers-color-scheme: dark) {
+	:global(body:not([data-theme])) .lightInvert {
+		filter: none;
+	}
 }
 
 .iconFallback {

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/visualizations/SalesforceCardVisualization.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/visualizations/SalesforceCardVisualization.vue
@@ -13,6 +13,7 @@ const props = withDefaults(
 		slideFrom?: 'left' | 'right';
 		icon?: string;
 		iconOverride?: string;
+		lightInvert?: boolean;
 	}>(),
 	{
 		title: 'New lead',
@@ -72,7 +73,12 @@ onUnmounted(clearTimers);
 		]"
 	>
 		<Transition :name="$style.swipe" mode="out-in">
-			<img :key="currentIcon" :class="$style.icon" :src="currentIcon" alt="" />
+			<img
+				:key="currentIcon"
+				:class="[$style.icon, props.lightInvert && $style.lightInvert]"
+				:src="currentIcon"
+				alt=""
+			/>
 		</Transition>
 		<div :class="$style.content">
 			<span :class="$style.title">{{ props.title }}</span>
@@ -115,6 +121,20 @@ onUnmounted(clearTimers);
 	width: 36px;
 	height: 36px;
 	flex-shrink: 0;
+}
+
+.lightInvert {
+	filter: invert(1);
+}
+
+:global([data-theme='dark']) .lightInvert {
+	filter: none;
+}
+
+@media (prefers-color-scheme: dark) {
+	:global(body:not([data-theme])) .lightInvert {
+		filter: none;
+	}
 }
 
 .swipe:global(-enter-active),

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/useInstanceAiWorkflowPreviewSuggestionsExperiment.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/useInstanceAiWorkflowPreviewSuggestionsExperiment.ts
@@ -1,16 +1,8 @@
 import { computed } from 'vue';
 
-import { INSTANCE_AI_WORKFLOW_PREVIEW_SUGGESTIONS_EXPERIMENT } from '@/app/constants/experiments';
-import { usePostHog } from '@/app/stores/posthog.store';
-
+// Experiment cleanup : remove with InstanceAiWorkflowPreviewSuggestionsExperiment
 export function useInstanceAiWorkflowPreviewSuggestionsExperiment() {
-	const posthogStore = usePostHog();
-
-	const isFeatureEnabled = computed(
-		() =>
-			posthogStore.getVariant(INSTANCE_AI_WORKFLOW_PREVIEW_SUGGESTIONS_EXPERIMENT.name) ===
-			INSTANCE_AI_WORKFLOW_PREVIEW_SUGGESTIONS_EXPERIMENT.variant,
-	);
+	const isFeatureEnabled = computed(() => true);
 
 	return { isFeatureEnabled };
 }

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/schedule-social-posts.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/schedule-social-posts.ts
@@ -48,7 +48,7 @@ export const scheduleSocialPostsWorkflow: PreviewWorkflow = {
 		{
 			id: 'post-x',
 			label: 'Post to X',
-			icon: { type: 'file', src: X_ICON_SVG },
+			icon: { type: 'file', src: X_ICON_SVG, lightInvert: true },
 			position: { x: 880, y: 10 },
 		},
 		{
@@ -80,6 +80,7 @@ export const scheduleSocialPostsWorkflow: PreviewWorkflow = {
 				icon: X_ICON_SVG,
 				title: 'Scheduled to X',
 				subtitle: 'Mon 9:00am',
+				lightInvert: true,
 			},
 		},
 		{

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/types.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/types.ts
@@ -2,6 +2,7 @@ export interface PreviewWorkflowNodeIcon {
 	type: 'icon' | 'file';
 	name?: string;
 	src?: string;
+	lightInvert?: boolean;
 }
 
 export interface PreviewWorkflowNode {

--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/whatsapp-support.ts
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/workflows/whatsapp-support.ts
@@ -48,7 +48,7 @@ export const whatsappSupportWorkflow: PreviewWorkflow = {
 		{
 			id: 'notion-ticket',
 			label: 'Create ticket',
-			icon: { type: 'file', src: NOTION_ICON_SVG },
+			icon: { type: 'file', src: NOTION_ICON_SVG, lightInvert: true },
 			position: { x: 880, y: 240 },
 		},
 	],
@@ -84,6 +84,7 @@ export const whatsappSupportWorkflow: PreviewWorkflow = {
 				icon: NOTION_ICON_SVG,
 				title: 'Ticket created',
 				subtitle: 'Password reset · Unresolved',
+				lightInvert: true,
 			},
 		},
 	],

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -297,7 +297,7 @@ useResizeObserver(emptyLayoutRef, () => {
 	const bottomPadding = parseFloat(layoutStyles.paddingBottom);
 	const gap = parseFloat(layoutStyles.gap) || 0;
 	const remainingSpace = containerRect.bottom - inputRect.bottom - bottomPadding - gap;
-	previewScale.value = Math.min(1, Math.max(0, remainingSpace / CANVAS_NATURAL_HEIGHT_PX));
+	previewScale.value = Math.max(0, Math.min(1, remainingSpace / CANVAS_NATURAL_HEIGHT_PX));
 });
 
 const hasSpaceForPreview = computed(() => previewScale.value >= PREVIEW_MIN_SCALE);
@@ -448,7 +448,7 @@ function handleShelfSuggestionInsert(payload: {
 				</template>
 			</InstanceAiSplitEmptyState>
 			<div v-else ref="emptyLayout" :class="$style.emptyLayout">
-				<InstanceAiEmptyState :title-key="emptyStateTitleKey" />
+				<InstanceAiEmptyState :title-key="emptyStateTitleKey" :show-title-icon="true" />
 				<div ref="centeredInput" :class="$style.centeredInput">
 					<CreditWarningBanner
 						v-if="creditBanner.visible.value"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -33,7 +33,7 @@ const {
 	experimentMocks: {
 		proactiveAgentEnabled: { value: false },
 		promptSuggestionsV2Enabled: { value: false },
-		workflowPreviewEnabled: { value: false },
+		workflowPreviewEnabled: { value: true }, // Experiment cleanup: remove with InstanceAiWorkflowPreviewSuggestionsExperiment
 		splitBelowInputVariant: { value: false },
 		personalizedPromptVariant: { value: undefined as string | undefined },
 		personalizedPromptFormat: { value: null as 'cards' | 'list' | null },
@@ -389,7 +389,7 @@ describe('InstanceAiEmptyView', () => {
 		store.getOrCreateRuntime.mockReturnValue(thread);
 		experimentMocks.proactiveAgentEnabled.value = false;
 		experimentMocks.promptSuggestionsV2Enabled.value = false;
-		experimentMocks.workflowPreviewEnabled.value = false;
+		experimentMocks.workflowPreviewEnabled.value = true; // Experiment cleanup: remove with InstanceAiWorkflowPreviewSuggestionsExperiment
 		experimentMocks.splitBelowInputVariant.value = false;
 		experimentMocks.personalizedPromptVariant.value = undefined;
 		experimentMocks.personalizedPromptFormat.value = null;

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -409,13 +409,15 @@ describe('InstanceAiEmptyView', () => {
 
 	it('passes the fixed suggestions to the empty-state composer', () => {
 		const { getByTestId, getByText } = renderView();
-		// 4 suggestions in INSTANCE_AI_EMPTY_STATE_SUGGESTIONS — suggestions array
-		// renders as its `.length`.
-		expect(getByText('AI Assistant')).toBeVisible();
+		expect(getByText('What do you want to automate?')).toBeVisible();
 		expect(getByTestId('instance-ai-input-suggestions')).toHaveTextContent('4');
-		expect(getByTestId('instance-ai-input-suggestions-component')).toHaveTextContent('unset');
-		expect(getByTestId('instance-ai-input-suggestion-catalog-version')).toHaveTextContent('unset');
-		expect(getByTestId('instance-ai-input-placeholder-key')).toHaveTextContent('unset');
+		expect(getByTestId('instance-ai-input-suggestions-component')).toHaveTextContent('set');
+		expect(getByTestId('instance-ai-input-suggestion-catalog-version')).toHaveTextContent(
+			'v3-workflow-preview',
+		);
+		expect(getByTestId('instance-ai-input-placeholder-key')).toHaveTextContent(
+			'experiments.instanceAiWorkflowPreviewSuggestions.input.placeholder',
+		);
 	});
 
 	it('passes v2 copy, suggestions, component, and catalog version when prompt suggestions v2 is enabled', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiEmptyState.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiEmptyState.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { N8nText } from '@n8n/design-system';
+import { N8nText, N8nIcon } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 
 const i18n = useI18n();
@@ -7,9 +7,11 @@ const i18n = useI18n();
 const props = withDefaults(
 	defineProps<{
 		titleKey?: BaseTextKey;
+		showTitleIcon?: boolean;
 	}>(),
 	{
 		titleKey: 'instanceAi.emptyState.title',
+		showTitleIcon: false,
 	},
 );
 </script>
@@ -17,6 +19,7 @@ const props = withDefaults(
 <template>
 	<div :class="$style.container" data-test-id="instance-ai-empty-state">
 		<N8nText tag="h1" size="xlarge" bold :class="$style.title">
+			<N8nIcon v-if="props.showTitleIcon" icon="sparkles" :class="$style.titleIcon" />
 			{{ i18n.baseText(props.titleKey) }}
 		</N8nText>
 	</div>
@@ -44,6 +47,12 @@ const props = withDefaults(
 }
 
 .title {
+	display: flex;
+	align-items: center;
 	text-align: center;
+}
+
+.titleIcon {
+	margin-right: var(--spacing--2xs);
 }
 </style>


### PR DESCRIPTION
## Summary

- Defaults the AIA v3 experiment on the empty state
- Implements downscaling of workflow preview on horizontal resize to prevent the workflow preview from being cut laterally on smaller screens
- Inverts Notion and X node (white) icons on light mode.

https://github.com/user-attachments/assets/efe814ac-5907-4020-bb59-8f4d895302e2

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

