### PR TITLE
fix(core): Validate data-table CSV uploads by file extension

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-uploads.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-uploads.controller.integration.test.ts
@@ -237,7 +237,21 @@ describe('POST /data-tables/uploads', () => {
 				.expect(400);
 		});
 
-		test('should reject non-CSV files based on MIME type', async () => {
+		test('should accept .csv files even when the browser reports a non-text/csv MIME type', async () => {
+			// Windows Firefox derives the MIME from the registry (Excel sets it to
+			// application/vnd.ms-excel), so the extension is the authoritative signal.
+			const csvContent = 'a,b\n1,2';
+
+			await authOwnerAgent
+				.post('/data-tables/uploads')
+				.attach('file', Buffer.from(csvContent), {
+					filename: 'test.csv',
+					contentType: 'application/vnd.ms-excel',
+				})
+				.expect(200);
+		});
+
+		test('should reject non-CSV files based on extension', async () => {
 			const textContent = 'This is a plain text file';
 
 			const response = await authOwnerAgent

--- a/packages/cli/src/modules/data-table/multer-upload-middleware.ts
+++ b/packages/cli/src/modules/data-table/multer-upload-middleware.ts
@@ -20,9 +20,6 @@ import {
 } from './types';
 import { formatBytes } from './utils/size-utils';
 
-// Validate by extension, not MIME: browsers derive the multipart Content-Type
-// differently (Windows Firefox reports a .csv as application/vnd.ms-excel from
-// the registry). The CSV parser validates content downstream.
 const ALLOWED_EXTENSIONS = ['.csv'];
 
 @Service()

--- a/packages/cli/src/modules/data-table/multer-upload-middleware.ts
+++ b/packages/cli/src/modules/data-table/multer-upload-middleware.ts
@@ -6,6 +6,7 @@ import type { Request, RequestHandler } from 'express';
 import { mkdir, readdir, stat, unlink } from 'fs/promises';
 import multer from 'multer';
 import { nanoid } from 'nanoid';
+import { extname } from 'path';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 
@@ -19,7 +20,10 @@ import {
 } from './types';
 import { formatBytes } from './utils/size-utils';
 
-const ALLOWED_MIME_TYPES = ['text/csv'];
+// Validate by extension, not MIME: browsers derive the multipart Content-Type
+// differently (Windows Firefox reports a .csv as application/vnd.ms-excel from
+// the registry). The CSV parser validates content downstream.
+const ALLOWED_EXTENSIONS = ['.csv'];
 
 @Service()
 export class MulterUploadMiddleware implements UploadMiddleware {
@@ -56,10 +60,10 @@ export class MulterUploadMiddleware implements UploadMiddleware {
 					this.globalConfig.dataTable.uploadMaxFileSize ?? this.globalConfig.dataTable.maxSize,
 			},
 			fileFilter: (_req, file, cb: multer.FileFilterCallback) => {
-				if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+				if (!ALLOWED_EXTENSIONS.includes(extname(file.originalname).toLowerCase())) {
 					cb(
 						new BadRequestError(
-							`Only the following file types are allowed: ${ALLOWED_MIME_TYPES.join(', ')}`,
+							`Only the following file types are allowed: ${ALLOWED_EXTENSIONS.join(', ')}`,
 						),
 					);
 					return;


### PR DESCRIPTION
## Summary

Data-table CSV uploads were validated by the multipart `Content-Type` (`text/csv` only). Browsers derive that MIME differently — Windows Firefox reads it from the registry, where Excel sets `.csv` to `application/vnd.ms-excel`, so valid CSVs were rejected before parsing while Chrome on the same machine worked. The multer `fileFilter` now validates by the `.csv` file extension instead; the CSV parser still validates content downstream.

## How to test

On Windows with Excel installed, open n8n in Firefox, import a valid `.csv` into a data table — it is now accepted. The added integration test uploads a `.csv` with `Content-Type: application/vnd.ms-excel` and asserts a `200`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5531

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

