### PR TITLE
fix(HubSpot Node): Load full property list in selection dropdowns

### DIFF
--- a/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/HubspotTrigger.node.ts
@@ -11,21 +11,15 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
-import { hubspotApiRequest, propertyEvents } from './V1/GenericFunctions';
+import type { HubspotObjectType } from './V1/GenericFunctions';
+import { getAllProperties, hubspotApiRequest, propertyEvents } from './V1/GenericFunctions';
 
 export async function getEntityProperties(
 	this: ILoadOptionsFunctions,
-	endpoint: string,
+	objectType: HubspotObjectType,
 ): Promise<INodePropertyOptions[]> {
 	const returnData: INodePropertyOptions[] = [];
-	const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-
-	if (!Array.isArray(properties)) {
-		throw new NodeOperationError(
-			this.getNode(),
-			`HubSpot returned an unexpected response while loading properties from "${endpoint}". Expected an array of properties.`,
-		);
-	}
+	const properties = await getAllProperties.call(this, objectType);
 
 	for (const property of properties) {
 		if (typeof property?.label === 'string' && typeof property?.name === 'string') {
@@ -324,16 +318,16 @@ export class HubspotTrigger implements INodeType {
 	methods = {
 		loadOptions: {
 			async getContactProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return await getEntityProperties.call(this, '/properties/v2/contacts/properties');
+				return await getEntityProperties.call(this, 'contacts');
 			},
 			async getCompanyProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return await getEntityProperties.call(this, '/properties/v2/companies/properties');
+				return await getEntityProperties.call(this, 'companies');
 			},
 			async getDealProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return await getEntityProperties.call(this, '/properties/v2/deals/properties');
+				return await getEntityProperties.call(this, 'deals');
 			},
 			async getTicketProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				return await getEntityProperties.call(this, '/properties/v2/tickets/properties');
+				return await getEntityProperties.call(this, 'tickets');
 			},
 		},
 	};

--- a/packages/nodes-base/nodes/Hubspot/V1/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/CompanyDescription.ts
@@ -169,7 +169,7 @@ export const companyFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getCompanyCustomProperties',
+									loadOptionsMethod: 'getCompanyProperties',
 								},
 								default: '',
 								description:
@@ -523,7 +523,7 @@ export const companyFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getCompanyCustomProperties',
+									loadOptionsMethod: 'getCompanyProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V1/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/ContactDescription.ts
@@ -186,7 +186,7 @@ export const contactFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getContactCustomProperties',
+									loadOptionsMethod: 'getContactProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V1/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/DealDescription.ts
@@ -154,7 +154,7 @@ export const dealFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getDealCustomProperties',
+									loadOptionsMethod: 'getDealProperties',
 								},
 								default: '',
 								description:
@@ -264,7 +264,7 @@ export const dealFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getDealCustomProperties',
+									loadOptionsMethod: 'getDealProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/GenericFunctions.ts
@@ -110,6 +110,36 @@ export async function hubspotApiRequestAllItems(
 	return returnData;
 }
 
+export type HubspotObjectType = 'contacts' | 'companies' | 'deals' | 'tickets';
+
+export interface HubspotProperty {
+	name: string;
+	label: string;
+	type?: string;
+	hubspotDefined?: boolean;
+	options?: Array<{ label: string; value: string }>;
+}
+
+export async function getAllProperties(
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
+	objectType: HubspotObjectType,
+): Promise<HubspotProperty[]> {
+	const returnData: HubspotProperty[] = [];
+	const endpoint = `/crm/v3/properties/${objectType}`;
+	const query: IDataObject = { limit: 100 };
+
+	let responseData;
+	do {
+		responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, query);
+		if (Array.isArray(responseData?.results)) {
+			returnData.push(...(responseData.results as HubspotProperty[]));
+		}
+		query.after = responseData?.paging?.next?.after;
+	} while (query.after);
+
+	return returnData;
+}
+
 // tslint:disable-next-line:no-any
 export function validateJSON(json: string | undefined): any {
 	let result;

--- a/packages/nodes-base/nodes/Hubspot/V1/HubspotV1.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V1/HubspotV1.node.ts
@@ -31,6 +31,7 @@ import {
 	getEmailMetadata,
 	getMeetingMetadata,
 	getTaskMetadata,
+	getAllProperties,
 	hubspotApiRequest,
 	hubspotApiRequestAllItems,
 	validateCredentials,
@@ -198,11 +199,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getContactLeadStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_lead_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -219,11 +219,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getContactLealBasics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_legal_basis') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -242,11 +241,10 @@ export class HubspotV1 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'lifecyclestage') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const stageName = option.label;
 							const stageId = option.value;
 							returnData.push({
@@ -265,11 +263,10 @@ export class HubspotV1 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_analytics_source') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const sourceName = option.label;
 							const sourceId = option.value;
 							returnData.push({
@@ -288,11 +285,10 @@ export class HubspotV1 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_language') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const languageName = option.label;
 							const languageId = option.value;
 							returnData.push({
@@ -309,11 +305,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getContactStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_content_membership_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const languageName = option.label;
 							const languageId = option.value;
 							returnData.push({
@@ -330,8 +325,7 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getContactProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -343,38 +337,16 @@ export class HubspotV1 implements INodeType {
 				return returnData;
 			},
 
-			// Get all the contact properties to display them to user so that they can
-			// select them easily
-			async getContactCustomProperties(
-				this: ILoadOptionsFunctions,
-			): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
-				}
-				return returnData;
-			},
-
 			// Get all the contact number of employees options to display them to user so that they can
 			// select them easily
 			async getContactNumberOfEmployees(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'numemployees') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const optionName = option.label;
 							const optionId = option.value;
 							returnData.push({
@@ -395,11 +367,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanyIndustries(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'industry') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const industryName = option.label;
 							const industryId = option.value;
 							returnData.push({
@@ -416,11 +387,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanyleadStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_lead_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -439,11 +409,10 @@ export class HubspotV1 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'lifecyclestage') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const stageName = option.label;
 							const stageId = option.value;
 							returnData.push({
@@ -460,11 +429,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanyTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'type') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const typeName = option.label;
 							const typeId = option.value;
 							returnData.push({
@@ -481,11 +449,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanyTargetAccounts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_target_account') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const targetName = option.label;
 							const targetId = option.value;
 							returnData.push({
@@ -502,11 +469,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanySourceTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_analytics_source') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const typeName = option.label;
 							const typeId = option.value;
 							returnData.push({
@@ -525,11 +491,10 @@ export class HubspotV1 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'web_technologies') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const technologyName = option.label;
 							const technologyId = option.value;
 							returnData.push({
@@ -546,8 +511,7 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getCompanyProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -555,27 +519,6 @@ export class HubspotV1 implements INodeType {
 						name: propertyName,
 						value: propertyId,
 					});
-				}
-				return returnData;
-			},
-
-			// Get all the company custom properties to display them to user so that they can
-			// select them easily
-			async getCompanyCustomProperties(
-				this: ILoadOptionsFunctions,
-			): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
 				}
 				return returnData;
 			},
@@ -621,28 +564,9 @@ export class HubspotV1 implements INodeType {
 
 			// Get all the deal properties to display them to user so that they can
 			// select them easily
-			async getDealCustomProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/deals/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
-				}
-				return returnData;
-			},
-			// Get all the deal properties to display them to user so that they can
-			// select them easily
 			async getDealProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/deals/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'deals');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -706,11 +630,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getTicketCategories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_ticket_category') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const categoryName = option.label;
 							const categoryId = option.value;
 							returnData.push({
@@ -744,11 +667,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getTicketPriorities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_ticket_priority') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const priorityName = option.label;
 							const priorityId = option.value;
 							returnData.push({
@@ -765,8 +687,7 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getTicketProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -782,11 +703,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getTicketResolutions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_resolution') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const resolutionName = option.label;
 							const resolutionId = option.value;
 							returnData.push({
@@ -803,11 +723,10 @@ export class HubspotV1 implements INodeType {
 			// select them easily
 			async getTicketSources(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'source_type') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const sourceName = option.label;
 							const sourceId = option.value;
 							returnData.push({

--- a/packages/nodes-base/nodes/Hubspot/V2/CompanyDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/CompanyDescription.ts
@@ -167,7 +167,7 @@ export const companyFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getCompanyCustomProperties',
+									loadOptionsMethod: 'getCompanyProperties',
 								},
 								default: {},
 								description:
@@ -554,7 +554,7 @@ export const companyFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getCompanyCustomProperties',
+									loadOptionsMethod: 'getCompanyProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V2/ContactDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/ContactDescription.ts
@@ -242,7 +242,7 @@ export const contactFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getContactCustomProperties',
+									loadOptionsMethod: 'getContactProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/DealDescription.ts
@@ -150,7 +150,7 @@ export const dealFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getDealCustomProperties',
+									loadOptionsMethod: 'getDealProperties',
 								},
 								default: '',
 								description:
@@ -327,7 +327,7 @@ export const dealFields: INodeProperties[] = [
 								name: 'property',
 								type: 'options',
 								typeOptions: {
-									loadOptionsMethod: 'getDealCustomProperties',
+									loadOptionsMethod: 'getDealProperties',
 								},
 								default: '',
 								description:

--- a/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
@@ -102,6 +102,36 @@ export async function hubspotApiRequestAllItems(
 	return returnData;
 }
 
+export type HubspotObjectType = 'contacts' | 'companies' | 'deals' | 'tickets';
+
+export interface HubspotProperty {
+	name: string;
+	label: string;
+	type?: string;
+	hubspotDefined?: boolean;
+	options?: Array<{ label: string; value: string }>;
+}
+
+export async function getAllProperties(
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
+	objectType: HubspotObjectType,
+): Promise<HubspotProperty[]> {
+	const returnData: HubspotProperty[] = [];
+	const endpoint = `/crm/v3/properties/${objectType}`;
+	const query: IDataObject = { limit: 100 };
+
+	let responseData;
+	do {
+		responseData = await hubspotApiRequest.call(this, 'GET', endpoint, {}, query);
+		if (Array.isArray(responseData?.results)) {
+			returnData.push(...(responseData.results as HubspotProperty[]));
+		}
+		query.after = responseData?.paging?.next?.after;
+	} while (query.after);
+
+	return returnData;
+}
+
 export function validateJSON(json: string | undefined): any {
 	let result;
 	try {

--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -30,6 +30,7 @@ import {
 	clean,
 	getAssociations,
 	getCallMetadata,
+	getAllProperties,
 	getEmailMetadata,
 	getMeetingMetadata,
 	getTaskMetadata,
@@ -202,11 +203,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getContactLeadStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_lead_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -223,11 +223,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getContactLealBasics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_legal_basis') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -246,11 +245,10 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'lifecyclestage') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const stageName = option.label;
 							const stageId = option.value;
 							returnData.push({
@@ -269,11 +267,10 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_analytics_source') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const sourceName = option.label;
 							const sourceId = option.value;
 							returnData.push({
@@ -292,11 +289,10 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_language') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const languageName = option.label;
 							const languageId = option.value;
 							returnData.push({
@@ -313,11 +309,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getContactStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'hs_content_membership_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const languageName = option.label;
 							const languageId = option.value;
 							returnData.push({
@@ -333,14 +328,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getContactProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
 
-				let properties = (await hubspotApiRequest.call(this, 'GET', endpoint, {})) as Array<{
-					label: string;
-					name: string;
-				}>;
+				const properties = await getAllProperties.call(this, 'contacts');
 
-				properties = properties.sort((a, b) => {
+				properties.sort((a, b) => {
 					if (a.label < b.label) return -1;
 					if (a.label > b.label) return 1;
 					return 0;
@@ -363,8 +354,7 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -378,38 +368,16 @@ export class HubspotV2 implements INodeType {
 				return returnData;
 			},
 
-			// Get all the contact properties to display them to user so that they can
-			// select them easily
-			async getContactCustomProperties(
-				this: ILoadOptionsFunctions,
-			): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
-				}
-				return returnData;
-			},
-
 			// Get all the contact number of employees options to display them to user so that they can
 			// select them easily
 			async getContactNumberOfEmployees(
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/contacts/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'contacts');
 				for (const property of properties) {
 					if (property.name === 'numemployees') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const optionName = option.label;
 							const optionId = option.value;
 							returnData.push({
@@ -430,11 +398,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanyIndustries(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'industry') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const industryName = option.label;
 							const industryId = option.value;
 							returnData.push({
@@ -451,11 +418,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanyleadStatuses(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_lead_status') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const statusName = option.label;
 							const statusId = option.value;
 							returnData.push({
@@ -474,11 +440,10 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'lifecyclestage') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const stageName = option.label;
 							const stageId = option.value;
 							returnData.push({
@@ -495,11 +460,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanyTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'type') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const typeName = option.label;
 							const typeId = option.value;
 							returnData.push({
@@ -516,11 +480,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanyTargetAccounts(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_target_account') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const targetName = option.label;
 							const targetId = option.value;
 							returnData.push({
@@ -537,11 +500,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanySourceTypes(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'hs_analytics_source') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const typeName = option.label;
 							const typeId = option.value;
 							returnData.push({
@@ -560,11 +522,10 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					if (property.name === 'web_technologies') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const technologyName = option.label;
 							const technologyId = option.value;
 							returnData.push({
@@ -581,8 +542,7 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getCompanyProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'companies');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -590,27 +550,6 @@ export class HubspotV2 implements INodeType {
 						name: propertyName,
 						value: propertyId,
 					});
-				}
-				return returnData;
-			},
-
-			// Get all the company custom properties to display them to user so that they can
-			// select them easily
-			async getCompanyCustomProperties(
-				this: ILoadOptionsFunctions,
-			): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/companies/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
 				}
 				return returnData;
 			},
@@ -656,33 +595,12 @@ export class HubspotV2 implements INodeType {
 
 			// Get all the deal properties to display them to user so that they can
 			// select them easily
-			async getDealCustomProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/deals/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
-				for (const property of properties) {
-					if (property.hubspotDefined === null) {
-						const propertyName = property.label;
-						const propertyId = property.name;
-						returnData.push({
-							name: propertyName,
-							value: propertyId,
-						});
-					}
-				}
-				return returnData;
-			},
-			// Get all the deal properties to display them to user so that they can
-			// select them easily
 			async getDealProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/deals/properties';
-				let properties = (await hubspotApiRequest.call(this, 'GET', endpoint, {})) as Array<{
-					label: string;
-					name: string;
-				}>;
 
-				properties = properties.sort((a, b) => {
+				const properties = await getAllProperties.call(this, 'deals');
+
+				properties.sort((a, b) => {
 					if (a.label < b.label) return -1;
 					if (a.label > b.label) return 1;
 					return 0;
@@ -703,8 +621,7 @@ export class HubspotV2 implements INodeType {
 				this: ILoadOptionsFunctions,
 			): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/deals/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'deals');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -712,7 +629,6 @@ export class HubspotV2 implements INodeType {
 					returnData.push({
 						name: propertyName,
 						// Hacky way to get the property type need to be parsed to be use in the api
-						// this is no longer working, properties does not returned in the response
 						value: `${propertyId}|${propertyType}`,
 					});
 				}
@@ -786,11 +702,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getTicketCategories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_ticket_category') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const categoryName = option.label;
 							const categoryId = option.value;
 							returnData.push({
@@ -824,11 +739,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getTicketPriorities(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_ticket_priority') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const priorityName = option.label;
 							const priorityId = option.value;
 							returnData.push({
@@ -845,8 +759,7 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getTicketProperties(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					const propertyName = property.label;
 					const propertyId = property.name;
@@ -862,11 +775,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getTicketResolutions(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'hs_resolution') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const resolutionName = option.label;
 							const resolutionId = option.value;
 							returnData.push({
@@ -883,11 +795,10 @@ export class HubspotV2 implements INodeType {
 			// select them easily
 			async getTicketSources(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const endpoint = '/properties/v2/tickets/properties';
-				const properties = await hubspotApiRequest.call(this, 'GET', endpoint, {});
+				const properties = await getAllProperties.call(this, 'tickets');
 				for (const property of properties) {
 					if (property.name === 'source_type') {
-						for (const option of property.options) {
+						for (const option of property.options ?? []) {
 							const sourceName = option.label;
 							const sourceId = option.value;
 							returnData.push({

--- a/packages/nodes-base/nodes/Hubspot/__test__/HubspotTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Hubspot/__test__/HubspotTrigger.node.test.ts
@@ -1,14 +1,15 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
 import { getEntityProperties } from '../HubspotTrigger.node';
-import { hubspotApiRequest } from '../V1/GenericFunctions';
+import { getAllProperties } from '../V1/GenericFunctions';
 
 vi.mock('../V1/GenericFunctions', () => ({
+	getAllProperties: vi.fn(),
 	hubspotApiRequest: vi.fn(),
 	propertyEvents: [],
 }));
 
-const mockedHubspotApiRequest = vi.mocked(hubspotApiRequest);
+const mockedGetAllProperties = vi.mocked(getAllProperties);
 
 describe('HubspotTrigger getEntityProperties', () => {
 	afterEach(() => {
@@ -16,50 +17,31 @@ describe('HubspotTrigger getEntityProperties', () => {
 	});
 
 	it('maps HubSpot properties into options', async () => {
-		mockedHubspotApiRequest.mockResolvedValueOnce([
+		mockedGetAllProperties.mockResolvedValueOnce([
 			{ label: 'Email', name: 'email' },
 			{ label: 'First Name', name: 'firstname' },
 		]);
 
 		const context = {} as ILoadOptionsFunctions;
-		const result = await getEntityProperties.call(context, '/properties/v2/contacts/properties');
+		const result = await getEntityProperties.call(context, 'contacts');
 
 		expect(result).toEqual([
 			{ name: 'Email', value: 'email' },
 			{ name: 'First Name', value: 'firstname' },
 		]);
-		expect(mockedHubspotApiRequest).toHaveBeenCalledWith(
-			'GET',
-			'/properties/v2/contacts/properties',
-			{},
-		);
-		expect(mockedHubspotApiRequest.mock.contexts[0]).toBe(context);
-	});
-
-	it('throws for non-array responses', async () => {
-		mockedHubspotApiRequest.mockResolvedValueOnce({ results: [] });
-		const endpoint = '/properties/v2/contacts/properties';
-		const context = {
-			getNode: vi.fn().mockReturnValue({}),
-		} as unknown as ILoadOptionsFunctions;
-
-		await expect(getEntityProperties.call(context, endpoint)).rejects.toThrow(
-			`HubSpot returned an unexpected response while loading properties from "${endpoint}". Expected an array of properties.`,
-		);
+		expect(mockedGetAllProperties).toHaveBeenCalledWith('contacts');
+		expect(mockedGetAllProperties.mock.contexts[0]).toBe(context);
 	});
 
 	it('filters invalid property entries', async () => {
-		mockedHubspotApiRequest.mockResolvedValueOnce([
+		mockedGetAllProperties.mockResolvedValueOnce([
 			{ label: 'Valid', name: 'valid_name' },
 			{ label: 'Missing Name' },
 			{ name: 'missing_label' },
 			{ label: 123, name: 'bad_label_type' },
-		]);
+		] as never);
 
-		const result = await getEntityProperties.call(
-			{} as ILoadOptionsFunctions,
-			'/properties/v2/contacts/properties',
-		);
+		const result = await getEntityProperties.call({} as ILoadOptionsFunctions, 'contacts');
 
 		expect(result).toEqual([{ name: 'Valid', value: 'valid_name' }]);
 	});

--- a/packages/nodes-base/nodes/Hubspot/__test__/loadOptions.test.ts
+++ b/packages/nodes-base/nodes/Hubspot/__test__/loadOptions.test.ts
@@ -1,0 +1,117 @@
+import type { ILoadOptionsFunctions, INodeTypeBaseDescription } from 'n8n-workflow';
+
+import { getAllProperties } from '../V2/GenericFunctions';
+import { HubspotV2 } from '../V2/HubspotV2.node';
+
+const baseDescription: INodeTypeBaseDescription = {
+	displayName: 'HubSpot',
+	name: 'hubspot',
+	group: ['output'],
+	description: 'Consume HubSpot API',
+};
+
+type DealProperty = {
+	name: string;
+	label: string;
+	type?: string;
+	hubspotDefined?: boolean;
+};
+
+/**
+ * Build a fake ILoadOptionsFunctions whose HTTP helper serves the given
+ * deal properties as one or two pages of the CRM v3 properties response.
+ * `pageBreakAfter` splits the list to simulate cursor pagination.
+ */
+function createContext(properties: DealProperty[], pageBreakAfter?: number) {
+	// `qs` is mutated in place between requests, so snapshot the cursor per call.
+	const cursorsSent: Array<string | undefined> = [];
+	const urisRequested: string[] = [];
+	const requestWithAuthentication = vi.fn(async (_credentialType: string, options: any) => {
+		const after = options.qs?.after as string | undefined;
+		cursorsSent.push(after);
+		urisRequested.push(options.uri as string);
+		if (pageBreakAfter === undefined) {
+			return { results: properties };
+		}
+		if (!after) {
+			return {
+				results: properties.slice(0, pageBreakAfter),
+				paging: { next: { after: 'cursor-1' } },
+			};
+		}
+		return { results: properties.slice(pageBreakAfter) };
+	});
+
+	const context = {
+		getNodeParameter: vi.fn((name: string) => (name === 'authentication' ? 'appToken' : undefined)),
+		getNode: vi.fn().mockReturnValue({ type: 'n8n-nodes-base.hubspot' }),
+		helpers: { requestWithAuthentication },
+	} as unknown as ILoadOptionsFunctions;
+
+	return { context, requestWithAuthentication, cursorsSent, urisRequested };
+}
+
+const node = new HubspotV2(baseDescription);
+const loadOptions = node.methods!.loadOptions!;
+
+describe('HubSpot V2 deal property loadOptions', () => {
+	afterEach(() => vi.clearAllMocks());
+
+	describe('getAllProperties pagination', () => {
+		it('follows the paging cursor to collect properties across pages', async () => {
+			const properties: DealProperty[] = [
+				{ name: 'amount', label: 'Amount' },
+				{ name: 'pipeline', label: 'Pipeline' },
+				{ name: 'hs_priority', label: 'Priority' },
+			];
+			const { context, requestWithAuthentication, cursorsSent, urisRequested } = createContext(
+				properties,
+				2,
+			);
+
+			const result = await getAllProperties.call(context, 'deals');
+
+			expect(result).toHaveLength(3);
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(2);
+			// first page has no cursor, second page passes the cursor from the first page
+			expect(cursorsSent).toEqual([undefined, 'cursor-1']);
+			expect(urisRequested[1]).toContain('/crm/v3/properties/deals');
+		});
+	});
+
+	describe('getDealProperties', () => {
+		it('returns every property (including ones on later pages) sorted by label', async () => {
+			const properties: DealProperty[] = [
+				{ name: 'pipeline', label: 'Pipeline' },
+				{ name: 'amount', label: 'Amount' },
+				{ name: 'hs_priority', label: 'Priority' },
+			];
+			const { context } = createContext(properties, 2);
+
+			const result = await loadOptions.getDealProperties.call(context);
+
+			expect(result).toEqual([
+				{ name: 'Amount', value: 'amount' },
+				{ name: 'Pipeline', value: 'pipeline' },
+				{ name: 'Priority', value: 'hs_priority' },
+			]);
+		});
+	});
+
+	describe('getDealPropertiesWithType', () => {
+		it('encodes the property type into the option value', async () => {
+			const properties: DealProperty[] = [
+				{ name: 'amount', label: 'Amount', type: 'number' },
+				{ name: 'closedate', label: 'Close Date', type: 'datetime' },
+			];
+			const { context } = createContext(properties);
+
+			const result = await loadOptions.getDealPropertiesWithType.call(context);
+
+			expect(result).toEqual([
+				{ name: 'Amount', value: 'amount|number' },
+				{ name: 'Close Date', value: 'closedate|datetime' },
+			]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Property dropdowns in the HubSpot node only showed a partial list, two causes:

- The property loaders used the legacy `/properties/v2/{object}/properties` endpoint, which truncates the result. Switched all of them to the CRM v3 `/crm/v3/properties/{object}` endpoint with `after`-cursor pagination, so the full list comes back.

- The "Custom Properties" picker for contacts/companies/deals was wired to a custom-only loader, so HubSpot-defined properties like Deal Priority couldn't be selected.

Selected values are unchanged, so existing workflows keep working.

<img width="1062" height="1422" alt="image" src="https://github.com/user-attachments/assets/2a7ad442-6866-4dd1-adb5-827f643a109a" />

## How to test

Deal → Create → Add Field → Custom Properties → Property Name: search "Priority" → Deal Priority now shows and can be set. Same for contact/company pickers and enum dropdowns.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4577
fixes #24395

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->