### PR TITLE
fix(editor): Reliably auto-open template credential setup modal

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -1,4 +1,4 @@
-import { shallowRef } from 'vue';
+import { ref, shallowRef } from 'vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { flushPromises } from '@vue/test-utils';
 import SetupWorkflowCredentialsButton from './SetupWorkflowCredentialsButton.vue';
@@ -477,6 +477,43 @@ describe('SetupWorkflowCredentialsButton', () => {
 			renderComponent();
 
 			expect(uiStore.openModal).not.toHaveBeenCalled();
+		});
+
+		it('opens modal once conditions become true after mount (nodes load late)', async () => {
+			// Nodes/node types load asynchronously, so the auto-open conditions can
+			// only hold after mount. The modal must still open reactively.
+			const nodesRef = ref<unknown[]>([]);
+			const workflowDocumentStore = useWorkflowDocumentStore(
+				createWorkflowDocumentId(workflowWithUnfilledCredentials.id),
+			);
+			Object.defineProperty(workflowDocumentStore, 'meta', {
+				value: workflowWithUnfilledCredentials.meta,
+				configurable: true,
+			});
+			Object.defineProperty(workflowDocumentStore, 'allNodes', {
+				get: () => nodesRef.value,
+				configurable: true,
+			});
+			workflowsStore.workflowId = workflowWithUnfilledCredentials.id;
+			workflowDocumentStoreRef.value = workflowDocumentStore;
+
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+			mockGetVariant.mockReturnValue(TEMPLATE_SETUP_EXPERIENCE.variant);
+			readyToRunStore.isReadyToRunTemplateId.mockReturnValue(false);
+			setupPanelStore.isFeatureEnabled = false;
+			mockRouteQuery.mockReturnValue({ templateId: '123' });
+
+			renderComponent();
+			await flushPromises();
+
+			// No nodes yet -> all credentials appear filled -> modal stays closed.
+			expect(uiStore.openModal).not.toHaveBeenCalled();
+
+			// Nodes finish loading with unfilled credentials.
+			nodesRef.value = workflowWithUnfilledCredentials.nodes;
+			await flushPromises();
+
+			expect(uiStore.openModal).toHaveBeenCalledWith(SETUP_CREDENTIALS_MODAL_KEY);
 		});
 
 		it('does not open modal for ready-to-run workflows', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, onBeforeUnmount, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { SETUP_CREDENTIALS_MODAL_KEY, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -114,23 +114,30 @@ onBeforeUnmount(() => {
 	uiStore.closeModal(SETUP_CREDENTIALS_MODAL_KEY);
 });
 
-onMounted(async () => {
-	// Wait for all reactive updates to settle before checking conditions
-	// This ensures meta.templateId is available after initialization
-	await nextTick();
-
+const shouldAutoOpenSetup = computed(() => {
 	const templateId = workflowDocumentStore?.value?.meta?.templateId;
-	const isReadyToRunWorkflow = readyToRunStore.isReadyToRunTemplateId(templateId);
-
-	if (
+	return (
 		isNewTemplatesSetupEnabled.value &&
+		!readyToRunStore.isReadyToRunTemplateId(templateId) &&
 		showButton.value &&
-		!isReadyToRunWorkflow &&
 		isTemplateImportRoute.value
-	) {
-		handleTemplateSetup();
-	}
+	);
 });
+
+// Auto-open the setup the first time all conditions hold. They may only become
+// true after nodes and node types finish loading (an unloaded node type reports
+// its credentials as filled), so react to the change rather than sampling once
+// on mount. The guard ensures we never re-open once the user closes it.
+let hasAutoOpened = false;
+watch(
+	shouldAutoOpenSetup,
+	(shouldOpen) => {
+		if (hasAutoOpened || !shouldOpen) return;
+		hasAutoOpened = true;
+		handleTemplateSetup();
+	},
+	{ immediate: true },
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

The template credential setup modal auto-opened from a one-shot `onMounted` check (after a single `nextTick`) in `SetupWorkflowCredentialsButton`. Its `showButton` condition is `false` until node types finish loading (an unloaded node type reports its credentials as already filled), so when the lazy-loaded component mounted before node types were ready, the check failed and the modal never opened — a race that caused the quarantined flaky e2e test. This replaces the one-shot check with a reactive `watch` that opens the setup the first time all conditions hold, guarded so it never re-opens after the user closes it.

## How to test

With the `055_template_setup_experience: variant` experiment on, navigate to a template import route (`/templates/:id/setup`) and confirm the credential setup modal auto-opens once the canvas nodes are loaded. Unit tests: `pnpm --filter n8n-editor-ui vitest run SetupWorkflowCredentialsButton` (20 pass, incl. a new case where conditions become true after mount).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5532

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33281">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->