### PR TITLE
feat: Include response timestamp in Send and Wait responses

### DIFF
--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -232,7 +232,7 @@ describe('Send and Wait utils tests', () => {
 
 			expect(result).toEqual({
 				webhookResponse: expect.any(String),
-				workflowData: [[{ json: { data: { approved: true } } }]],
+				workflowData: [[{ json: { data: { approved: true, respondedAt: expect.any(String) } } }]],
 			});
 		});
 
@@ -245,7 +245,7 @@ describe('Send and Wait utils tests', () => {
 
 			expect(result).toEqual({
 				webhookResponse: expect.any(String),
-				workflowData: [[{ json: { data: { approved: false } } }]],
+				workflowData: [[{ json: { data: { approved: false, respondedAt: expect.any(String) } } }]],
 			});
 		});
 
@@ -325,7 +325,9 @@ describe('Send and Wait utils tests', () => {
 
 			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
 
-			expect(result.workflowData).toEqual([[{ json: { data: { text: 'test value' } } }]]);
+			expect(result.workflowData).toEqual([
+				[{ json: { data: { text: 'test value', respondedAt: expect.any(String) } } }],
+			]);
 		});
 
 		it('should handle customForm GET webhook', async () => {
@@ -474,7 +476,44 @@ describe('Send and Wait utils tests', () => {
 
 			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
 
-			expect(result.workflowData).toEqual([[{ json: { data: { 'test 1': 'test value' } } }]]);
+			expect(result.workflowData).toEqual([
+				[{ json: { data: { 'test 1': 'test value', respondedAt: expect.any(String) } } }],
+			]);
+		});
+
+		it('overrides a form field named respondedAt with the server timestamp', async () => {
+			mockWebhookFunctions.getRequestObject.mockReturnValue({
+				method: 'POST',
+				contentType: 'multipart/form-data',
+			} as any);
+			mockWebhookFunctions.getNode.mockReturnValue({} as any);
+
+			mockWebhookFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const params: { [key: string]: any } = {
+					responseType: 'customForm',
+					defineForm: 'fields',
+					'formFields.values': [
+						{
+							fieldLabel: 'respondedAt',
+							fieldType: 'text',
+						},
+					],
+				};
+				return params[parameterName];
+			});
+
+			mockWebhookFunctions.getBodyData.mockReturnValue({
+				data: {
+					'field-0': 'user-supplied-value',
+				},
+			} as any);
+
+			const result = await sendAndWaitWebhook.call(mockWebhookFunctions);
+
+			const json = (result.workflowData as any)[0][0].json;
+			// The server-set timestamp must win over a same-named form field.
+			expect(json.data.respondedAt).not.toBe('user-supplied-value');
+			expect(new Date(json.data.respondedAt as string).toISOString()).toBe(json.data.respondedAt);
 		});
 
 		it('should return noWebhookResponse if method GET and user-agent is bot', async () => {

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -405,7 +405,18 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 
 			return {
 				webhookResponse: ACTION_RECORDED_PAGE,
-				workflowData: [[{ json: { data: { text: data[INPUT_FIELD_IDENTIFIER] } } }]],
+				workflowData: [
+					[
+						{
+							json: {
+								data: {
+									text: data[INPUT_FIELD_IDENTIFIER],
+									respondedAt: new Date().toISOString(),
+								},
+							},
+						},
+					],
+				],
 			};
 		}
 	}
@@ -461,7 +472,9 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 			delete json.submittedAt;
 			delete json.formMode;
 
-			returnItem.json = { data: json };
+			// respondedAt is applied last so a form field of the same name can't override
+			// the server-set response timestamp.
+			returnItem.json = { data: { ...json, respondedAt: new Date().toISOString() } };
 
 			return {
 				webhookResponse: ACTION_RECORDED_PAGE,
@@ -474,7 +487,7 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 	const approved = query.approved === 'true';
 	return {
 		webhookResponse: ACTION_RECORDED_PAGE,
-		workflowData: [[{ json: { data: { approved } } }]],
+		workflowData: [[{ json: { data: { approved, respondedAt: new Date().toISOString() } } }]],
 	};
 }
 


### PR DESCRIPTION
## Summary

Send-and-Wait / Human-in-the-Loop (HITL) responses now include an optional **`respondedAt`** field — an ISO-8601 timestamp of the moment n8n received the response — on **approval**, **free-text**, and **custom-form** replies.

It's added centrally in the shared `sendAndWaitWebhook` resume handler (`packages/nodes-base/utils/sendAndWait/utils.ts`), so every node that uses Send and Wait gets it automatically (Slack, Telegram, Discord, WhatsApp, Google Chat, Gmail, Outlook, Email/SMTP, Microsoft Teams — and the Chat Trigger node in `@n8n/nodes-langchain`, which shares the same handler).

The field is **additive and optional** — the existing output shape is unchanged. On the custom-form path the metadata is spread *before* the user's submitted fields, so a form field can never be overwritten by it.

**Scope note:** capturing the *original message* (text / channel / message ID) was intentionally split out of this PR. That part has to capture provider data at send time and persist it with the waiting execution — the same persistence primitive being built for the HITL "who responded" work — so it will land alongside [ENT-113](https://linear.app/n8n/issue/ENT-113) rather than here.

3 files changed, +48 / −8. Typecheck, lint, and the `sendAndWait` unit tests (38) all pass.

## How to test

Add a node that supports **Send and Wait for response** (e.g. Slack → *Send and Wait for response*, or the Send Email node) with any response type (Approval / Free Text / Custom Form). Run the workflow so it pauses, then respond (click Approve/Decline, or submit the form). When the workflow resumes, the node's output `json.data` now contains a `respondedAt` ISO-8601 timestamp alongside the existing `approved` / `text` / form fields.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-112

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33283">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

