### PR TITLE
fix(Calendly Trigger Node): Request required OAuth2 scopes for Calendly API

### DIFF
--- a/packages/nodes-base/credentials/CalendlyOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/CalendlyOAuth2Api.credentials.ts
@@ -46,7 +46,7 @@ export class CalendlyOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '',
+			default: 'users:read webhooks:read webhooks:write scheduled_events:read',
 		},
 	];
 }


### PR DESCRIPTION
## Summary

Calendly made a breaking API change: every API call now requires the OAuth2 access
token to carry explicit [authorization scopes](https://developer.calendly.com/scopes).
The **Calendly OAuth2 API** credential requested no scopes (`scope` defaulted to an
empty string), so newly authorized OAuth2 connections received tokens without the
permissions the Calendly Trigger needs — causing node execution and workflow
activation to fail with:

> This operation requires the scopes listed in the 'required_scopes' array.

This sets the credential's default `scope` to
`users:read webhooks:read webhooks:write scheduled_events:read`, the exact set the
Calendly Trigger (v2) needs:
- `users:read` — `GET /users/me` (preflight identity resolution)
- `webhooks:read` + `webhooks:write` — `/webhook_subscriptions` read / create / delete
- `scheduled_events:read` — required by Calendly to create a subscription for the
  `invitee.created` / `invitee.canceled` event family. Without it, `POST /webhook_subscriptions`
  fails with `400 — The supplied parameters are invalid` (verified locally).

**Migration:** this only changes the default for *new* authorizations. Existing
Calendly OAuth2 credentials keep their previously granted scopes and must be
**reconnected** to pick up the new ones.

**Follow-up:** docs update (instruct users to enable these four scopes on their
Calendly OAuth app and reconnect) tracked as a separate ticket in https://linear.app/n8n/issue/DOC-2059/docs-for-community-issue-calendly-oauth2-api-new-breaking-changes.

## How to test

*Prereqs:* a Calendly OAuth app with `users:read`, `webhooks:read`, `webhooks:write`,
`scheduled_events:read` enabled; a public HTTPS webhook URL (via https://pinggy.io/ or similar) (set
`WEBHOOK_URL=https://<tunnel>/` if testing locally behind a tunnel).

1. Create a **Calendly OAuth2** credential → Connect (if unauthorized error, replace tunnel domain with localhost domain)
2. Add a **Calendly Trigger**, pick events, **activate** the workflow → the webhook subscription is created **without** a `403 required_scopes` error.
3. Book/cancel a Calendly event → the workflow executes on the `invitee.created` payload.

*Before this fix:* step 2 fails with `This operation requires the scopes listed in the 'required_scopes' array.`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4676
- Fixes #27377

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with backport label (if urgent).

🤖 PR Summary generated by AI