### PR TITLE
fix(editor): Restore Instance AI credential card without a loaded workflow

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -231,6 +231,25 @@ describe('NodeCredentials', () => {
 		expect(screen.queryByText('OpenAi account')).toBeInTheDocument();
 	});
 
+	it('renders standalone when no active workflow document store is provided', () => {
+		// Instance AI credential card: rendered standalone, outside a loaded
+		// workflow document. The strict injectNDVStore() used to throw here on the
+		// immediate parameters watch, tearing down the card (mount/unmount flicker).
+		workflowDocumentStoreRef.value = null;
+		credentialsStore.state.credentials = {
+			c8vqdPpPClh4TgIO: createCredential(),
+		};
+
+		expect(() =>
+			renderComponent(
+				{ props: { node: httpNode, overrideCredType: 'openAiApi', standalone: true } },
+				{ merge: true },
+			),
+		).not.toThrow();
+
+		expect(screen.getByTestId('node-credentials-select')).toBeInTheDocument();
+	});
+
 	it('should refresh credentials from the server when mounted on an existing node', () => {
 		ndvStore.activeNode = httpNode;
 		credentialsStore.state.credentials = {};

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -33,7 +33,7 @@ import { useCredentialsStore } from '../credentials.store';
 import { useQuickConnect } from '../quickConnect/composables/useQuickConnect';
 import { useCredentialOAuth } from '../composables/useCredentialOAuth';
 import QuickConnectButton from '../quickConnect/components/QuickConnectButton.vue';
-import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStoreIfProvided } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
@@ -113,7 +113,7 @@ function instanceAiCredentialHelp(): InstanceAiCredentialHelpHandler | undefined
 
 const credentialsStore = useCredentialsStore();
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = injectNDVStore();
+const ndvStore = injectNDVStoreIfProvided();
 const uiStore = useUIStore();
 const projectsStore = useProjectsStore();
 const workflowsStore = useWorkflowsStore();
@@ -221,7 +221,7 @@ watch(
 	(newValue, oldValue) => {
 		// When active node parameters change, check if authentication type has been changed
 		// and set `subscribedToCredentialType` to corresponding credential type
-		const isActive = props.node.name === ndvStore.value.activeNode?.name;
+		const isActive = props.node.name === ndvStore.value?.activeNode?.name;
 		// Only do this for active node and if it's listening for auth change
 		if (isActive && nodeType.value && listeningForAuthChange.value) {
 			if (mainNodeAuthField.value && oldValue && newValue) {


### PR DESCRIPTION
## Summary

The Instance AI credential card (`InstanceAiCredentialSetup.vue`) renders `NodeCredentials` in **standalone** mode, outside a loaded workflow document. Since #32460 made `injectNDVStore()` resolve strictly from the workflow document store (it now **throws** when none is provided), `NodeCredentials` crashed during its `{ immediate: true }` parameters watch:

```
Error: injectNDVStore() was accessed without an active workflow document store.
    at ndv.store.ts:504
    at NodeCredentials.vue:224
    at setup (NodeCredentials.vue:219)
```

The thrown error tears the component down, so the card flickers (mount/unmount) and never appears.

This is **per-credential** because the card only renders `NodeCredentials` when the user already has a credential of that type (otherwise it shows a plain "set up" button). So a type with an existing credential (e.g. OpenAI) crashes, while one without (e.g. Anthropic) renders fine. The `onMounted` credential fetch flipping that condition after load is what produces the visible flicker.

### Fix

Switch `NodeCredentials` to the purpose-built non-throwing `injectNDVStoreIfProvided()` (its doc comment already names the credential modals as the intended caller) and guard the single access: `ndvStore.value?.activeNode?.name`. In standalone mode there is no active NDV node, so this correctly resolves to `false`. This also hardens the other standalone renderers (template setup, setup panel).

## How to test

1. On an instance with Instance AI enabled, ensure you have an existing credential of some type (e.g. an OpenAI API credential).
2. Open the AI Assistant and ask it to help create that credential type.
3. The credential card now renders the credential selector instead of flickering and disappearing; no console error is thrown.

A regression unit test reproduces the exact scenario (standalone render with no active workflow document store).

## Related Linear tickets, Github issues, and Community forum posts

<!-- add ticket/issue link here -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->