### PR TITLE
fix(Github Node): Set `searchFilterRequired:true` for owner property, fix behavior on frontend

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.test.ts
@@ -39,6 +39,20 @@ describe('ResourceLocatorDropdown', () => {
 		vi.useRealTimers();
 	});
 
+	it('should show search required message even when loading', () => {
+		renderComponent({
+			props: {
+				show: true,
+				filterRequired: true,
+				filter: '',
+				loading: true,
+				resources: [],
+			},
+		});
+
+		expect(screen.getByText('Enter a search term to show results')).toBeInTheDocument();
+	});
+
 	describe('slow loading hint', () => {
 		it('should show slow loading hint when loading and showSlowLoadNotice is true', () => {
 			const slowLoadNotice = 'This is taking longer than expected. Please wait...';

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -490,10 +490,9 @@ watch(
 
 .searchRequired {
 	height: 50px;
-	margin-top: 40px;
 	padding-left: var(--spacing--xs);
 	font-size: var(--font-size--xs);
-	color: var(--color--text);
+	color: var(--color--text--tint-1);
 	display: flex;
 	align-items: center;
 }

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -304,7 +304,7 @@ watch(
 				</N8nInput>
 			</div>
 			<div
-				v-if="props.filterRequired && !props.filter && !props.errorView && !props.loading"
+				v-if="props.filterRequired && !props.filter && !props.errorView"
 				:class="$style.searchRequired"
 			>
 				{{ i18n.baseText('resourceLocator.mode.list.searchRequired') }}

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -552,7 +552,7 @@ export class Github implements INodeType {
 						typeOptions: {
 							searchListMethod: 'getUsers',
 							searchable: true,
-							searchFilterRequired: false,
+							searchFilterRequired: true,
 						},
 					},
 					{

--- a/packages/nodes-base/nodes/Github/Github.node.ts
+++ b/packages/nodes-base/nodes/Github/Github.node.ts
@@ -552,6 +552,8 @@ export class Github implements INodeType {
 						typeOptions: {
 							searchListMethod: 'getUsers',
 							searchable: true,
+							// Endpoint requires a search filter
+							// https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-users
 							searchFilterRequired: true,
 						},
 					},


### PR DESCRIPTION
## Summary

This PR fixes a bug that caused resource locators with `searchFilterRequired: true` to show loading state rather than a special message. 
Changes `searchFilterRequired` to `true` in `owner` property of Github Node, as the previous [change](https://github.com/n8n-io/n8n/pull/17122) assumed that query parameter is optional, but it's not. The listing is not possible without search parameter

Before:

<img width="413" height="335" alt="image" src="https://github.com/user-attachments/assets/9b2418d4-3955-406f-b86e-565c8046bd30" />


After:

<img width="390" height="155" alt="image" src="https://github.com/user-attachments/assets/7a617ebb-e405-4918-9ba0-19fe42ec6ee0" />


https://github.com/user-attachments/assets/91430b0b-5965-4bf6-84c4-61d1a3fa29e4




## How to test

1. Add Github node
2. Choose "Create an issue" operation
3. Open "Owner" dropdown, verify it shows a special message
4. Verify that it lists items after search starts

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4819/community-issue-difficulties-with-github-and-sentry-authentication
Related to, but doesn't fully address https://github.com/n8n-io/n8n/issues/27866

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

