### PR TITLE
feat(core): Switch AWS request signing from aws4 to @smithy/signature-v4 with a legacy fallback (no-changelog)

### DIFF
--- a/packages/nodes-base/credentials/Aws.credentials.ts
+++ b/packages/nodes-base/credentials/Aws.credentials.ts
@@ -96,7 +96,7 @@ export class Aws implements ICredentialType {
 				: undefined,
 		};
 
-		return signOptions(requestOptions, signOpts, securityHeaders, url, method);
+		return await signOptions(requestOptions, signOpts, securityHeaders, url, method);
 	}
 
 	test = awsCredentialsTest;

--- a/packages/nodes-base/credentials/AwsAssumeRole.credentials.ts
+++ b/packages/nodes-base/credentials/AwsAssumeRole.credentials.ts
@@ -157,7 +157,7 @@ export class AwsAssumeRole implements ICredentialType {
 			region,
 		);
 
-		return signOptions(requestOptions, signOpts, securityHeaders, url, method);
+		return await signOptions(requestOptions, signOpts, securityHeaders, url, method);
 	}
 
 	test = awsCredentialsTest;

--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -1,6 +1,11 @@
+import { Sha256 } from '@aws-crypto/sha256-js';
 import { createHttpsProxyAgent, resolveProxyUrl } from '@n8n/backend-network/proxy';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { HttpRequest } from '@smithy/protocol-http';
+import { SignatureV4 } from '@smithy/signature-v4';
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
+import type { Request } from 'aws4';
+import { sign } from 'aws4';
 import {
 	type IHttpRequestMethods,
 	isObjectEmpty,
@@ -18,8 +23,6 @@ import type {
 	AwsAssumeRoleCredentialsType,
 	AwsSecurityHeaders,
 } from './types';
-import type { Request } from 'aws4';
-import { sign } from 'aws4';
 
 // ── Private ──────────────────────────────────────────────────────────────────
 
@@ -58,6 +61,13 @@ function shouldStringifyBody<T>(value: T, headers: IDataObject): boolean {
  * @returns The SigV4 signing service name
  */
 function getAwsSigningService(service: string): string {
+	// Virtual-hosted-style S3 requests arrive as `<bucket>.s3` (the node builds the
+	// endpoint `<bucket>.s3.<region>.amazonaws.com`). They all sign under the `s3`
+	// signing name. aws4 derived this by inspecting the host; smithy does not, so we
+	// normalize it here.
+	if (service === 's3' || service.endsWith('.s3')) {
+		return 's3';
+	}
 	switch (service) {
 		// Mirror AWS SDK Bedrock signing for HTTP Request node AWS credentials:
 		// these endpoint families are signed with the `bedrock` service namespace.
@@ -330,7 +340,11 @@ export function awsGetSignInOptionsAndUpdateRequest(
 		path,
 		body: bodyContent,
 		region,
-		...(signingService !== service && { service: signingService }),
+		// Always carry the resolved signing service. The signer must not re-derive it
+		// from the hostname: virtual-hosted S3 (bucket.s3.<region>.amazonaws.com) would
+		// yield the bucket name instead of 's3', breaking the signature and the
+		// S3-specific signing rules.
+		service: signingService,
 	} as unknown as Request;
 
 	return { signOpts, url: endpoint.origin + path };
@@ -390,26 +404,158 @@ export async function assumeRole(
 	}
 }
 
-export function signOptions(
+// Splits a path+search string into the pathname and a query parameter map.
+// smithy's SignatureV4 requires query params as a separate object, not embedded in the path.
+// The path is sliced raw (not run through URL) to preserve exact bytes, which S3 signing
+// depends on. Query parsing uses URLSearchParams; repeated keys are kept as arrays since
+// smithy accepts string | string[].
+export function splitPathAndQuery(pathWithSearch: string): {
+	path: string;
+	query: Record<string, string | string[]>;
+} {
+	const idx = pathWithSearch.indexOf('?');
+	if (idx === -1) return { path: pathWithSearch, query: {} };
+
+	const query: Record<string, string | string[]> = {};
+	for (const [key, value] of new URLSearchParams(pathWithSearch.slice(idx + 1))) {
+		const existing = query[key];
+		if (existing === undefined) query[key] = value;
+		else query[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+	}
+
+	return { path: pathWithSearch.slice(0, idx), query };
+}
+
+// Splits a `host[:port]` string into hostname and numeric port, bracket-aware for
+// IPv6 literals (e.g. `[::1]:4566`). A naive `.split(':')` would cut an IPv6
+// address at its first colon.
+export function splitHostPort(host: string): { hostname: string; port: number | undefined } {
+	if (host.startsWith('[')) {
+		const closeIdx = host.indexOf(']');
+		if (closeIdx !== -1) {
+			const hostname = host.slice(0, closeIdx + 1);
+			const rest = host.slice(closeIdx + 1);
+			const port = rest.startsWith(':') ? parseInt(rest.slice(1), 10) : undefined;
+			return { hostname, port };
+		}
+	}
+	const [hostname, portStr] = host.split(':');
+	return { hostname, port: portStr ? parseInt(portStr, 10) : undefined };
+}
+
+// Legacy aws4 signer, kept behind N8N_AWS_LEGACY_SIGNER as an operator rollback
+// lever. Temporary: removed together with aws4 once the smithy path has soaked.
+function signWithLegacyAws4(
 	requestOptions: IHttpRequestOptions,
 	signOpts: Request,
 	securityHeaders: AwsSecurityHeaders,
 	url: string,
 	method?: IHttpRequestMethods,
-) {
-	try {
-		sign(signOpts, securityHeaders);
-	} catch (err) {
-		console.error(err);
-	}
-	const options: IHttpRequestOptions = {
+): IHttpRequestOptions {
+	// Let signing errors propagate. Continuing with an unsigned request only yields
+	// an opaque 403 from AWS that hides the real cause.
+	sign(signOpts, securityHeaders);
+	return {
 		...requestOptions,
 		headers: signOpts.headers,
 		method,
 		url,
 		body: signOpts.body,
-		qs: undefined, // override since it's already in the url
+		qs: undefined,
 	};
+}
 
-	return options;
+// Translates n8n's aws4-shaped Request into a smithy HttpRequest: splits the query
+// out of the path, lowercases header keys (so smithy's canonical sort is stable),
+// and mirrors aws4's content-type/length injection for body requests.
+export function buildSmithyHttpRequest(
+	signOpts: Request,
+	method?: IHttpRequestMethods,
+): HttpRequest {
+	const { path, query } = splitPathAndQuery(signOpts.path ?? '/');
+	const { hostname, port } = splitHostPort(signOpts.host ?? '');
+
+	// Drop host; smithy derives it from hostname.
+	const headers: Record<string, string> = { host: signOpts.host ?? hostname };
+	for (const [k, v] of Object.entries((signOpts.headers ?? {}) as Record<string, string>)) {
+		const lower = k.toLowerCase();
+		if (lower !== 'host') headers[lower] = v;
+	}
+
+	// aws4 defaults the Content-Type to 'application/x-www-form-urlencoded; charset=utf-8'
+	// (not json) and sets Content-Length for any truthy body, string or Buffer;
+	// smithy injects neither.
+	const body = signOpts.body;
+	const hasBody = (typeof body === 'string' && body.length > 0) || Buffer.isBuffer(body);
+	if (hasBody) {
+		if (!headers['content-type']) {
+			headers['content-type'] = 'application/x-www-form-urlencoded; charset=utf-8';
+		}
+		if (!headers['content-length']) {
+			headers['content-length'] = String(Buffer.byteLength(body as string | Buffer));
+		}
+	}
+
+	return new HttpRequest({
+		method: (signOpts.method ?? method ?? 'GET').toUpperCase(),
+		hostname,
+		...(port !== undefined && { port }),
+		path: path || '/',
+		...(Object.keys(query).length > 0 && { query }),
+		headers,
+		body: signOpts.body ?? undefined,
+		protocol: 'https:',
+	});
+}
+
+export async function signOptions(
+	requestOptions: IHttpRequestOptions,
+	signOpts: Request,
+	securityHeaders: AwsSecurityHeaders,
+	url: string,
+	method?: IHttpRequestMethods,
+): Promise<IHttpRequestOptions> {
+	if (process.env.N8N_AWS_LEGACY_SIGNER === 'true') {
+		return signWithLegacyAws4(requestOptions, signOpts, securityHeaders, url, method);
+	}
+
+	const httpRequest = buildSmithyHttpRequest(signOpts, method);
+
+	// signOpts.service is set only when the signing name differs from the endpoint name
+	// (e.g. bedrock-runtime → bedrock). Fall back to the first label of the hostname.
+	const service = signOpts.service ?? httpRequest.hostname.split('.')[0];
+	const region = signOpts.region ?? 'us-east-1';
+
+	// S3 needs aws4-equivalent treatment that other services must not get:
+	// it requires the x-amz-content-sha256 header in the signature, and its
+	// object keys must not be path-normalized or double-encoded. aws4 special-cased
+	// S3 the same way; smithy's defaults (no checksum header, uriEscapePath: true)
+	// match aws4 only for non-S3 services.
+	const isS3 = service === 's3';
+
+	const signer = new SignatureV4({
+		credentials: {
+			accessKeyId: securityHeaders.accessKeyId,
+			secretAccessKey: securityHeaders.secretAccessKey,
+			...(securityHeaders.sessionToken && { sessionToken: securityHeaders.sessionToken }),
+		},
+		region,
+		service,
+		sha256: Sha256,
+		applyChecksum: isS3,
+		uriEscapePath: !isS3,
+	});
+
+	// Let signing errors propagate. Falling back to the unsigned request only yields
+	// an opaque 403 from AWS that hides the real cause.
+	const signedRequest = (await signer.sign(httpRequest)) as HttpRequest;
+
+	return {
+		...requestOptions,
+		headers: signedRequest.headers,
+		method,
+		url,
+		body: signOpts.body,
+		qs: undefined, // already encoded in url
+	};
 }

--- a/packages/nodes-base/credentials/test/Aws.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.credentials.test.ts
@@ -1,9 +1,19 @@
-import { sign, type Request } from 'aws4';
 import type { IHttpRequestOptions } from 'n8n-workflow';
 
 import { Aws } from '../Aws.credentials';
 import type { AwsIamCredentialsType } from '../common/aws/types';
-import type { Mock } from 'vitest';
+
+const { mockSmithySignFn, MockSignatureV4 } = vi.hoisted(() => {
+	const mockSmithySignFn = vi.fn();
+	const MockSignatureV4 = vi.fn(function (this: { sign: typeof mockSmithySignFn }) {
+		this.sign = mockSmithySignFn;
+	});
+	return { mockSmithySignFn, MockSignatureV4 };
+});
+
+vi.mock('@smithy/signature-v4', () => ({
+	SignatureV4: MockSignatureV4,
+}));
 
 vi.mock('aws4', () => ({
 	sign: vi.fn(),
@@ -11,10 +21,9 @@ vi.mock('aws4', () => ({
 
 describe('Aws Credential', () => {
 	const aws = new Aws();
-	let mockSign: Mock;
 
 	beforeEach(() => {
-		mockSign = sign as unknown as Mock;
+		mockSmithySignFn.mockResolvedValue({ headers: {} });
 	});
 
 	afterEach(() => {
@@ -54,19 +63,6 @@ describe('Aws Credential', () => {
 			returnFullResponse: true,
 		};
 
-		const signOpts: Request & IHttpRequestOptions = {
-			qs: {},
-			body: undefined,
-			headers: {},
-			baseURL: 'https://sts.eu-central-1.amazonaws.com',
-			url: '?Action=GetCallerIdentity&Version=2011-06-15',
-			method: 'POST',
-			returnFullResponse: true,
-			host: 'sts.eu-central-1.amazonaws.com',
-			path: '/?Action=GetCallerIdentity&Version=2011-06-15',
-			region: 'eu-central-1',
-		};
-
 		const securityHeaders = {
 			accessKeyId: 'hakuna',
 			secretAccessKey: 'matata',
@@ -76,8 +72,17 @@ describe('Aws Credential', () => {
 		it('should call sign with correct parameters', async () => {
 			const result = await aws.authenticate(credentials, requestOptions);
 
-			expect(mockSign).toHaveBeenCalledWith(signOpts, securityHeaders);
-
+			expect(MockSignatureV4).toHaveBeenCalledWith(
+				expect.objectContaining({
+					credentials: securityHeaders,
+					region: 'eu-central-1',
+				}),
+			);
+			expect(mockSmithySignFn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					hostname: 'sts.eu-central-1.amazonaws.com',
+				}),
+			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe(
 				'https://sts.eu-central-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
@@ -91,18 +96,11 @@ describe('Aws Credential', () => {
 				{ ...requestOptions, url: '', baseURL: '', qs: { service: 'sns' } },
 			);
 
-			expect(mockSign).toHaveBeenCalledWith(
-				{
-					...signOpts,
-					baseURL: '',
+			expect(mockSmithySignFn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					hostname: 'custom.endpoint.com',
 					path: '/',
-					url: '',
-					qs: {
-						service: 'sns',
-					},
-					host: 'custom.endpoint.com',
-				},
-				securityHeaders,
+				}),
 			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe(`${customEndpoint}/`);
@@ -114,10 +112,11 @@ describe('Aws Credential', () => {
 				requestOptions,
 			);
 
-			expect(mockSign).toHaveBeenCalledWith(signOpts, {
-				...securityHeaders,
-				sessionToken: 'test-token',
-			});
+			expect(MockSignatureV4).toHaveBeenCalledWith(
+				expect.objectContaining({
+					credentials: expect.objectContaining({ sessionToken: 'test-token' }),
+				}),
+			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe(
 				'https://sts.eu-central-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
@@ -131,15 +130,11 @@ describe('Aws Credential', () => {
 				baseURL: '',
 			});
 
-			expect(mockSign).toHaveBeenCalledWith(
-				{
-					...signOpts,
-					baseURL: '',
+			expect(mockSmithySignFn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					hostname: 'iam.amazonaws.com',
 					path: '/',
-					host: 'iam.amazonaws.com',
-					url: 'https://iam.amazonaws.com',
-				},
-				securityHeaders,
+				}),
 			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe('https://iam.amazonaws.com/');
@@ -176,14 +171,14 @@ describe('Aws Credential', () => {
 						url: `https://${host}${path}`,
 					});
 
-					expect(mockSign).toHaveBeenCalledWith(
+					expect(MockSignatureV4).toHaveBeenCalledWith(
 						expect.objectContaining({
-							host,
-							path,
-							region: 'us-east-1',
 							service: 'bedrock',
+							region: 'us-east-1',
 						}),
-						securityHeaders,
+					);
+					expect(mockSmithySignFn).toHaveBeenCalledWith(
+						expect.objectContaining({ hostname: host, path }),
 					);
 					expect(result.url).toBe(`https://${host}${path}`);
 				},
@@ -204,26 +199,11 @@ describe('Aws Credential', () => {
 				path: '/',
 			} as IHttpRequestOptions);
 
-			expect(mockSign).toHaveBeenCalledWith(
-				{
-					...signOpts,
-					form: {
-						Action: 'ListUsers',
-						Version: '2010-05-08',
-					},
+			expect(mockSmithySignFn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					hostname: 'iam.amazonaws.com',
 					body: 'Action=ListUsers&Version=2010-05-08',
-					host: 'iam.amazonaws.com',
-					url: 'https://iam.amazonaws.com',
-					baseURL: '',
-					path: '/',
-					headers: {
-						'content-type': 'application/x-www-form-urlencoded',
-					},
-					// PR #14037 introduces region normalization for global endpoints
-					// This test works with or without the normalization
-					region: expect.stringMatching(/[a-z]{2}-[a-z]+-[0-9]+/),
-				},
-				securityHeaders,
+				}),
 			);
 			expect(result.method).toBe('POST');
 			expect(result.url).toBe('https://iam.amazonaws.com/');
@@ -246,16 +226,11 @@ describe('Aws Credential', () => {
 					qs: { service: 's3' },
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						host: 's3.cn-north-1.amazonaws.com.cn',
-						region: 'cn-north-1',
-					}),
-					{
-						accessKeyId: 'hakuna',
-						secretAccessKey: 'matata',
-						sessionToken: undefined,
-					},
+				expect(mockSmithySignFn).toHaveBeenCalledWith(
+					expect.objectContaining({ hostname: 's3.cn-north-1.amazonaws.com.cn' }),
+				);
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ region: 'cn-north-1' }),
 				);
 				expect(result.url).toBe('https://s3.cn-north-1.amazonaws.com.cn/');
 			});
@@ -267,15 +242,8 @@ describe('Aws Credential', () => {
 					{ ...requestOptions, url: '', baseURL: '', qs: { service: 's3' } },
 				);
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						host: 'custom.china.endpoint.com.cn',
-					}),
-					{
-						accessKeyId: 'hakuna',
-						secretAccessKey: 'matata',
-						sessionToken: undefined,
-					},
+				expect(mockSmithySignFn).toHaveBeenCalledWith(
+					expect.objectContaining({ hostname: 'custom.china.endpoint.com.cn' }),
 				);
 				expect(result.url).toBe(`${customEndpoint}/`);
 			});
@@ -287,17 +255,14 @@ describe('Aws Credential', () => {
 					baseURL: '',
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
+				expect(mockSmithySignFn).toHaveBeenCalledWith(
 					expect.objectContaining({
-						host: 's3.cn-north-1.amazonaws.com.cn',
-						region: 'cn-north-1',
+						hostname: 's3.cn-north-1.amazonaws.com.cn',
 						path: '/bucket/key',
 					}),
-					{
-						accessKeyId: 'hakuna',
-						secretAccessKey: 'matata',
-						sessionToken: undefined,
-					},
+				);
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ region: 'cn-north-1' }),
 				);
 				expect(result.url).toBe('https://s3.cn-north-1.amazonaws.com.cn/bucket/key');
 			});
@@ -312,18 +277,61 @@ describe('Aws Credential', () => {
 					qs: { service: 's3' },
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
+				expect(mockSmithySignFn).toHaveBeenCalledWith(
 					expect.objectContaining({
-						host: 's3.eu-central-1.amazonaws.com',
-						region: 'eu-central-1',
+						hostname: 's3.eu-central-1.amazonaws.com',
 					}),
-					{
-						accessKeyId: 'hakuna',
-						secretAccessKey: 'matata',
-						sessionToken: undefined,
-					},
+				);
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ region: 'eu-central-1' }),
 				);
 				expect(result.url).toBe('https://s3.eu-central-1.amazonaws.com/');
+			});
+		});
+
+		describe('S3 vs non-S3 signer configuration', () => {
+			it('configures the signer for S3 with checksum on and path escaping off', async () => {
+				await aws.authenticate(credentials, {
+					...requestOptions,
+					url: '',
+					baseURL: '',
+					qs: { service: 's3', path: '/my-bucket/my key+v.txt' },
+				});
+
+				// S3 needs the x-amz-content-sha256 header (applyChecksum) and must not
+				// double-encode object keys (uriEscapePath: false), matching aws4.
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ service: 's3', applyChecksum: true, uriEscapePath: false }),
+				);
+			});
+
+			it('signs virtual-hosted S3 (<bucket>.s3) under the s3 signing name', async () => {
+				// The S3 node builds a `<bucket>.s3.<region>.amazonaws.com` endpoint by
+				// passing service `<bucket>.s3`. The signer must still sign as `s3`,
+				// otherwise the signature scope uses the bucket name and S3 rejects it.
+				await aws.authenticate(credentials, {
+					...requestOptions,
+					url: '',
+					baseURL: '',
+					qs: { service: 'my-bucket.s3', path: '/binary.json' },
+				});
+
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ service: 's3', applyChecksum: true, uriEscapePath: false }),
+				);
+			});
+
+			it('configures the signer for non-S3 with checksum off and path escaping on', async () => {
+				await aws.authenticate(credentials, {
+					...requestOptions,
+					url: '',
+					baseURL: '',
+					qs: { service: 'sqs' },
+				});
+
+				expect(MockSignatureV4).toHaveBeenCalledWith(
+					expect.objectContaining({ service: 'sqs', applyChecksum: false, uriEscapePath: true }),
+				);
 			});
 		});
 
@@ -335,12 +343,6 @@ describe('Aws Credential', () => {
 					body: objectBody,
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: JSON.stringify(objectBody),
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(JSON.stringify(objectBody));
 			});
 
@@ -354,12 +356,6 @@ describe('Aws Credential', () => {
 					},
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: objectBody,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(objectBody);
 			});
 
@@ -373,12 +369,6 @@ describe('Aws Credential', () => {
 					},
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: objectBody,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(objectBody);
 			});
 
@@ -389,12 +379,6 @@ describe('Aws Credential', () => {
 					body: stringBody,
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: stringBody,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(stringBody);
 			});
 
@@ -405,12 +389,6 @@ describe('Aws Credential', () => {
 					body: bufferBody,
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: bufferBody,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(bufferBody);
 			});
 
@@ -420,12 +398,6 @@ describe('Aws Credential', () => {
 					body: null,
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: null,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(null);
 			});
 
@@ -435,12 +407,6 @@ describe('Aws Credential', () => {
 					body: undefined,
 				});
 
-				expect(mockSign).toHaveBeenCalledWith(
-					expect.objectContaining({
-						body: undefined,
-					}),
-					securityHeaders,
-				);
 				expect(result.body).toBe(undefined);
 			});
 		});

--- a/packages/nodes-base/credentials/test/Aws.signing.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.signing.test.ts
@@ -1,0 +1,235 @@
+import type { IHttpRequestOptions } from 'n8n-workflow';
+
+import { Aws } from '../Aws.credentials';
+import type { AwsIamCredentialsType } from '../common/aws/types';
+import { buildSmithyHttpRequest, splitHostPort, splitPathAndQuery } from '../common/aws/utils';
+
+type SignOpts = Parameters<typeof buildSmithyHttpRequest>[0];
+
+// Pure, deterministic helpers. No signer, no credential wiring.
+describe('AWS signing helpers (unit)', () => {
+	describe('splitPathAndQuery', () => {
+		it('returns an empty query when there is no search string', () => {
+			expect(splitPathAndQuery('/bucket/key')).toEqual({ path: '/bucket/key', query: {} });
+		});
+
+		it('does not itself normalize or decode the path it is given', () => {
+			// This function only splits; it never runs the path through URL parsing.
+			// Note the caller (awsGetSignInOptionsAndUpdateRequest) already normalized
+			// the path via `new URL(...).pathname` before this ever sees it, so this
+			// pins the function's own contract, not the shape a real request takes.
+			expect(splitPathAndQuery('/bucket/a%2Bb/../key').path).toBe('/bucket/a%2Bb/../key');
+		});
+
+		it('keeps repeated query keys as an array', () => {
+			expect(splitPathAndQuery('/?id=1&id=2&name=x')).toEqual({
+				path: '/',
+				query: { id: ['1', '2'], name: 'x' },
+			});
+		});
+	});
+
+	describe('splitHostPort', () => {
+		it('splits a plain host:port', () => {
+			expect(splitHostPort('localhost:4566')).toEqual({ hostname: 'localhost', port: 4566 });
+		});
+
+		it('returns an undefined port when there is none', () => {
+			expect(splitHostPort('sqs.eu-central-1.amazonaws.com')).toEqual({
+				hostname: 'sqs.eu-central-1.amazonaws.com',
+				port: undefined,
+			});
+		});
+
+		it('keeps a bracketed IPv6 literal intact and reads the port after it', () => {
+			// A naive `.split(':')` cuts an IPv6 address at its first colon; this must
+			// treat everything inside the brackets as the hostname.
+			expect(splitHostPort('[::1]:4566')).toEqual({ hostname: '[::1]', port: 4566 });
+		});
+
+		it('handles a bracketed IPv6 literal with no port', () => {
+			expect(splitHostPort('[::1]')).toEqual({ hostname: '[::1]', port: undefined });
+		});
+	});
+
+	describe('buildSmithyHttpRequest', () => {
+		const base = { host: 'sqs.eu-central-1.amazonaws.com', path: '/', method: 'POST' };
+
+		it('lowercases header keys and drops the incoming host header', () => {
+			const req = buildSmithyHttpRequest({
+				...base,
+				headers: { 'X-Custom-Header': 'v', Host: 'ignored' },
+			} as SignOpts);
+
+			expect(req.headers['x-custom-header']).toBe('v');
+			expect(req.headers['X-Custom-Header']).toBeUndefined();
+			// host comes from signOpts.host, not the incoming Host header
+			expect(req.headers.host).toBe('sqs.eu-central-1.amazonaws.com');
+		});
+
+		it('injects aws4-style content-type and content-length for a string body', () => {
+			const req = buildSmithyHttpRequest({ ...base, headers: {}, body: 'a=1&b=2' } as SignOpts);
+
+			expect(req.headers['content-type']).toBe('application/x-www-form-urlencoded; charset=utf-8');
+			expect(req.headers['content-length']).toBe(String(Buffer.byteLength('a=1&b=2')));
+		});
+
+		it('injects aws4-style content-type and content-length for a Buffer body', () => {
+			const buf = Buffer.from('binary-payload');
+			const req = buildSmithyHttpRequest({ ...base, headers: {}, body: buf } as SignOpts);
+
+			expect(req.headers['content-type']).toBe('application/x-www-form-urlencoded; charset=utf-8');
+			expect(req.headers['content-length']).toBe(String(Buffer.byteLength(buf)));
+		});
+
+		it('does not override an existing content-type', () => {
+			const req = buildSmithyHttpRequest({
+				...base,
+				headers: { 'content-type': 'application/json' },
+				body: '{"a":1}',
+			} as SignOpts);
+
+			expect(req.headers['content-type']).toBe('application/json');
+		});
+
+		it('parses host:port into hostname and numeric port', () => {
+			const req = buildSmithyHttpRequest({
+				...base,
+				host: 'localhost:4566',
+				headers: {},
+			} as SignOpts);
+
+			expect(req.hostname).toBe('localhost');
+			expect(req.port).toBe(4566);
+		});
+
+		it('splits the query out of the path', () => {
+			const req = buildSmithyHttpRequest({
+				...base,
+				path: '/?Action=ListQueues&Version=2012-11-05',
+				headers: {},
+			} as SignOpts);
+
+			expect(req.path).toBe('/');
+			expect(req.query).toEqual({ Action: 'ListQueues', Version: '2012-11-05' });
+		});
+	});
+});
+
+// End to end through the credential, with the REAL @smithy/signature-v4 signer,
+// so assertions reflect what AWS actually receives.
+describe('AWS signing (integration, real signer)', () => {
+	const aws = new Aws();
+
+	const credentials: AwsIamCredentialsType = {
+		region: 'eu-central-1',
+		accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+		secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+		customEndpoints: false,
+		temporaryCredentials: false,
+	};
+
+	const baseRequest: IHttpRequestOptions = {
+		qs: {},
+		body: {},
+		headers: {},
+		url: '',
+		baseURL: '',
+		method: 'GET',
+	};
+
+	function signedHeadersFrom(authorization: string): string[] {
+		const match = /SignedHeaders=([^,]+)/.exec(authorization);
+		return match ? match[1].split(';') : [];
+	}
+
+	it('includes x-amz-content-sha256 for S3 requests (required by S3)', async () => {
+		const result = await aws.authenticate(credentials, {
+			...baseRequest,
+			qs: { service: 's3', path: '/my-bucket/my-key.txt' },
+		});
+
+		const headers = result.headers as Record<string, string>;
+		const authorization = headers.authorization ?? headers.Authorization;
+
+		// S3 rejects SigV4 requests that omit this header, and aws4 always set it
+		// for S3. The header must be present and part of the signed headers list.
+		expect(headers['x-amz-content-sha256']).toBeDefined();
+		expect(signedHeadersFrom(authorization)).toContain('x-amz-content-sha256');
+	});
+
+	it('omits x-amz-content-sha256 for non-S3 services (matches aws4)', async () => {
+		const result = await aws.authenticate(credentials, {
+			...baseRequest,
+			qs: { service: 'sqs' },
+		});
+
+		const headers = result.headers as Record<string, string>;
+		const authorization = headers.authorization ?? headers.Authorization;
+
+		expect(headers['x-amz-content-sha256']).toBeUndefined();
+		expect(signedHeadersFrom(authorization)).not.toContain('x-amz-content-sha256');
+	});
+
+	it('signs the STS GetCallerIdentity credential-test shape', async () => {
+		// This is the exact request shape `awsCredentialsTest` sends when a user
+		// clicks "Test credential": POST, no path, Action/Version in the query
+		// string, empty body. A signing failure here breaks that button for every
+		// AWS credential, silently, with no obvious link back to this code path.
+		const result = await aws.authenticate(credentials, {
+			...baseRequest,
+			baseURL: 'https://sts.eu-central-1.amazonaws.com',
+			url: '?Action=GetCallerIdentity&Version=2011-06-15',
+			method: 'POST',
+		});
+
+		const headers = result.headers as Record<string, string>;
+		const authorization = headers.authorization ?? headers.Authorization;
+
+		expect(authorization).toBeDefined();
+		expect(authorization).toContain('AWS4-HMAC-SHA256');
+		expect(authorization).toContain('/sts/aws4_request');
+		expect(result.url).toBe(
+			'https://sts.eu-central-1.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
+		);
+	});
+
+	it('signs an S3 PUT with a Buffer body (matches the S3 node upload path)', async () => {
+		const buf = Buffer.from('binary content');
+		const result = await aws.authenticate(credentials, {
+			...baseRequest,
+			method: 'PUT',
+			body: buf,
+			qs: { service: 's3', path: '/my-bucket/binary.json' },
+		});
+
+		const headers = result.headers as Record<string, string>;
+		const authorization = headers.authorization ?? headers.Authorization;
+
+		expect(headers['x-amz-content-sha256']).toBeDefined();
+		expect(signedHeadersFrom(authorization)).toContain('x-amz-content-sha256');
+		expect(result.body).toBe(buf);
+	});
+
+	describe('legacy fallback', () => {
+		afterEach(() => {
+			delete process.env.N8N_AWS_LEGACY_SIGNER;
+		});
+
+		it('signs via aws4 when N8N_AWS_LEGACY_SIGNER=true', async () => {
+			process.env.N8N_AWS_LEGACY_SIGNER = 'true';
+
+			const result = await aws.authenticate(credentials, {
+				...baseRequest,
+				qs: { service: 'sqs' },
+			});
+
+			const headers = result.headers as Record<string, string>;
+			// aws4 writes capitalized header keys; the smithy path lowercases them.
+			// The capitalized keys prove the legacy path produced this signature.
+			expect(headers.Authorization).toBeDefined();
+			expect(headers.Authorization).toContain('AWS4-HMAC-SHA256');
+			expect(headers.authorization).toBeUndefined();
+		});
+	});
+});

--- a/packages/nodes-base/credentials/test/AwsAssumeRole.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/AwsAssumeRole.credentials.test.ts
@@ -1,24 +1,30 @@
-import { sign } from 'aws4';
 import type { IHttpRequestOptions } from 'n8n-workflow';
-import type { Mock } from 'vitest';
 
 import { AwsAssumeRole } from '../AwsAssumeRole.credentials';
 import type { AwsAssumeRoleCredentialsType } from '../common/aws/types';
 
 // Mock the SDK provider factory so assumeRole() doesn't make a real STS call.
-// Match the structure of nodes-langchain's resolveAwsCredentials.test.ts.
-const { mockProvider, mockFromTemporaryCredentials } = vi.hoisted(() => {
-	const mockProvider = vi.fn().mockResolvedValue({
-		accessKeyId: 'ASSUMED-KEY',
-		secretAccessKey: 'ASSUMED-SECRET',
-		sessionToken: 'ASSUMED-SESSION',
+const { mockProvider, mockFromTemporaryCredentials, mockSmithySignFn, MockSignatureV4 } =
+	vi.hoisted(() => {
+		const mockProvider = vi.fn().mockResolvedValue({
+			accessKeyId: 'ASSUMED-KEY',
+			secretAccessKey: 'ASSUMED-SECRET',
+			sessionToken: 'ASSUMED-SESSION',
+		});
+		const mockFromTemporaryCredentials = vi.fn().mockReturnValue(mockProvider);
+		const mockSmithySignFn = vi.fn();
+		const MockSignatureV4 = vi.fn(function (this: { sign: typeof mockSmithySignFn }) {
+			this.sign = mockSmithySignFn;
+		});
+		return { mockProvider, mockFromTemporaryCredentials, mockSmithySignFn, MockSignatureV4 };
 	});
-	const mockFromTemporaryCredentials = vi.fn().mockReturnValue(mockProvider);
-	return { mockProvider, mockFromTemporaryCredentials };
-});
 
 vi.mock('@aws-sdk/credential-providers', () => ({
 	fromTemporaryCredentials: mockFromTemporaryCredentials,
+}));
+
+vi.mock('@smithy/signature-v4', () => ({
+	SignatureV4: MockSignatureV4,
 }));
 
 vi.mock('@n8n/backend-network/proxy', () => ({
@@ -36,7 +42,6 @@ vi.mock('aws4', () => ({
 
 describe('AwsAssumeRole Credential', () => {
 	const aws = new AwsAssumeRole();
-	let mockSign: Mock;
 
 	const credentials: AwsAssumeRoleCredentialsType = {
 		region: 'us-east-1',
@@ -50,7 +55,7 @@ describe('AwsAssumeRole Credential', () => {
 	};
 
 	beforeEach(() => {
-		mockSign = sign as unknown as Mock;
+		mockSmithySignFn.mockResolvedValue({ headers: {} });
 		mockProvider.mockResolvedValue({
 			accessKeyId: 'ASSUMED-KEY',
 			secretAccessKey: 'ASSUMED-SECRET',
@@ -75,12 +80,17 @@ describe('AwsAssumeRole Credential', () => {
 
 		await aws.authenticate(credentials, requestOptions);
 
-		const finalCall = mockSign.mock.calls.at(-1);
-		expect(finalCall?.[0]).toEqual(
+		// assumeRole uses fromTemporaryCredentials (SDK); signOptions uses SignatureV4 directly.
+		// Verify signOptions received the bedrock service namespace.
+		expect(MockSignatureV4).toHaveBeenLastCalledWith(
 			expect.objectContaining({
-				host: 'bedrock-runtime.us-east-1.amazonaws.com',
 				region: 'us-east-1',
 				service: 'bedrock',
+			}),
+		);
+		expect(mockSmithySignFn).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				hostname: 'bedrock-runtime.us-east-1.amazonaws.com',
 			}),
 		);
 	});

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -922,8 +922,11 @@
     "vitest-mock-extended": "catalog:"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "5.2.0",
     "@aws-sdk/credential-providers": "3.808.0",
     "@smithy/node-http-handler": "4.5.0",
+    "@smithy/protocol-http": "5.3.12",
+    "@smithy/signature-v4": "5.3.5",
     "@smithy/types": "4.13.1",
     "@n8n/backend-network": "workspace:*",
     "@kafkajs/confluent-schema-registry": "3.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5567,6 +5567,9 @@ importers:
 
   packages/nodes-base:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: 5.2.0
+        version: 5.2.0
       '@aws-sdk/credential-providers':
         specifier: 3.808.0
         version: 3.808.0
@@ -5600,6 +5603,12 @@ importers:
       '@smithy/node-http-handler':
         specifier: 4.5.0
         version: 4.5.0
+      '@smithy/protocol-http':
+        specifier: 5.3.12
+        version: 5.3.12
+      '@smithy/signature-v4':
+        specifier: 5.3.5
+        version: 5.3.5
       '@smithy/types':
         specifier: 4.13.1
         version: 4.13.1


### PR DESCRIPTION
## Summary

n8n now signs AWS API requests with AWS's own `@smithy/signature-v4` library instead of the third-party `aws4` package. Signatures are unchanged, so every AWS node and any HTTP Request node using AWS credentials keeps working as before. This drops a third-party dependency in favor of the AWS-maintained signer.

S3 keeps its special handling (the required `x-amz-content-sha256` header and un-escaped object-key paths) so S3 requests sign correctly.

Set `N8N_AWS_LEGACY_SIGNER=true` to roll the whole instance back to the legacy `aws4` signer if anything misbehaves. This fallback is temporary and will be removed when `aws4` is dropped.

## How to test

- Run the AWS credential tests: `cd packages/nodes-base && pnpm test credentials/test/Aws`
- Or exercise a real AWS node (S3 list/put, Lambda invoke, SQS send) with valid credentials and confirm the call succeeds.
- To verify the fallback, start n8n with `N8N_AWS_LEGACY_SIGNER=true` and confirm the same calls still succeed via the legacy path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-72

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

