### PR TITLE
feat(core): Add durable scheduler configuration and feature flag (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
@@ -1,0 +1,72 @@
+import { Container } from '@n8n/di';
+
+import { GlobalConfig } from '../../index';
+
+describe('SchedulerConfig', () => {
+	beforeEach(() => {
+		Container.reset();
+		vi.unstubAllEnvs();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('flag off (defaults)', () => {
+		it('should be disabled by default', () => {
+			const { scheduler } = Container.get(GlobalConfig);
+
+			expect(scheduler.enabled).toBe(false);
+		});
+
+		it('should use default tunables', () => {
+			const { scheduler } = Container.get(GlobalConfig);
+
+			expect(scheduler.materializationWindow).toBe(60);
+			expect(scheduler.sweepInterval).toBe(10);
+			expect(scheduler.executorInterval).toBe(5);
+			expect(scheduler.reaperInterval).toBe(30);
+			expect(scheduler.leaseDuration).toBe(60);
+			expect(scheduler.retention).toBe(7 * 24 * 60 * 60);
+			expect(scheduler.minInterval).toBe(0);
+		});
+	});
+
+	describe('flag on (env overrides)', () => {
+		it('should enable via env', () => {
+			vi.stubEnv('N8N_SCHEDULER_ENABLED', 'true');
+
+			const { scheduler } = Container.get(GlobalConfig);
+
+			expect(scheduler.enabled).toBe(true);
+		});
+
+		it('should override each tunable from env', () => {
+			vi.stubEnv('N8N_SCHEDULER_MATERIALIZATION_WINDOW', '120');
+			vi.stubEnv('N8N_SCHEDULER_SWEEP_INTERVAL', '20');
+			vi.stubEnv('N8N_SCHEDULER_EXECUTOR_INTERVAL', '2');
+			vi.stubEnv('N8N_SCHEDULER_REAPER_INTERVAL', '45');
+			vi.stubEnv('N8N_SCHEDULER_LEASE_DURATION', '90');
+			vi.stubEnv('N8N_SCHEDULER_RETENTION', '86400');
+			vi.stubEnv('N8N_SCHEDULER_MIN_INTERVAL', '15');
+
+			const { scheduler } = Container.get(GlobalConfig);
+
+			expect(scheduler.materializationWindow).toBe(120);
+			expect(scheduler.sweepInterval).toBe(20);
+			expect(scheduler.executorInterval).toBe(2);
+			expect(scheduler.reaperInterval).toBe(45);
+			expect(scheduler.leaseDuration).toBe(90);
+			expect(scheduler.retention).toBe(86400);
+			expect(scheduler.minInterval).toBe(15);
+		});
+
+		it('should allow disabling the min-interval clamp with 0', () => {
+			vi.stubEnv('N8N_SCHEDULER_MIN_INTERVAL', '0');
+
+			const { scheduler } = Container.get(GlobalConfig);
+
+			expect(scheduler.minInterval).toBe(0);
+		});
+	});
+});

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -1,0 +1,52 @@
+import { Time } from '@n8n/constants';
+import { z } from 'zod';
+
+import { Config, Env } from '../decorators';
+import { positiveIntSchema } from '../schemas';
+
+/** Allows 0 (clamp disabled) in addition to any positive interval, in seconds. */
+const nonNegativeIntSchema = z.number({ coerce: true }).int().nonnegative();
+
+/**
+ * Configuration for the durable scheduler: a master on/off flag plus the engine
+ * tunables (loop cadences, lease and retention windows). All durations are in
+ * seconds, matching the `@n8n/scheduler` schedule math (`intervalSeconds`).
+ *
+ * Default off: with `enabled` false nothing reads these values, so the existing
+ * in-memory schedule trigger engine is unaffected. The engine loops that consume
+ * this config are wired up separately (lifecycle wiring, materialiser).
+ */
+@Config
+export class SchedulerConfig {
+	/** Master flag for the durable scheduler. Off by default; opt in to enable. */
+	@Env('N8N_SCHEDULER_ENABLED')
+	enabled: boolean = false;
+
+	/** How far ahead (seconds) the materialiser turns schedules into concrete tasks. */
+	@Env('N8N_SCHEDULER_MATERIALIZATION_WINDOW', positiveIntSchema)
+	materializationWindow: number = Time.minutes.toSeconds;
+
+	/** Interval (seconds) between sweeps that materialise due schedules into tasks. */
+	@Env('N8N_SCHEDULER_SWEEP_INTERVAL', positiveIntSchema)
+	sweepInterval: number = 10;
+
+	/** Interval (seconds) between executor passes that claim and run due tasks. */
+	@Env('N8N_SCHEDULER_EXECUTOR_INTERVAL', positiveIntSchema)
+	executorInterval: number = 5;
+
+	/** Interval (seconds) between reaper passes that reclaim expired task leases. */
+	@Env('N8N_SCHEDULER_REAPER_INTERVAL', positiveIntSchema)
+	reaperInterval: number = 30;
+
+	/** How long (seconds) a claimed task is leased before the reaper may reclaim it. */
+	@Env('N8N_SCHEDULER_LEASE_DURATION', positiveIntSchema)
+	leaseDuration: number = Time.minutes.toSeconds;
+
+	/** How long (seconds) terminal tasks are retained before being purged. */
+	@Env('N8N_SCHEDULER_RETENTION', positiveIntSchema)
+	retention: number = 7 * Time.days.toSeconds;
+
+	/** Minimum allowed interval (seconds) between schedule fires. 0 disables the clamp. */
+	@Env('N8N_SCHEDULER_MIN_INTERVAL', nonNegativeIntSchema)
+	minInterval: number = 0;
+}

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -8,41 +8,42 @@ import { positiveIntSchema } from '../schemas';
 const nonNegativeIntSchema = z.number({ coerce: true }).int().nonnegative();
 
 /**
- * Configuration for the durable scheduler: the master on/off flag and the engine
- * tunables. Off by default; while `enabled` is false nothing reads these values,
- * so the existing in-memory schedule trigger engine is unaffected.
+ * Configuration for the durable scheduler, which runs scheduled workflow
+ * executions from a persisted store so they survive restarts. Off by default;
+ * while `enabled` is false nothing reads these values, so the existing schedule
+ * trigger behaviour is unchanged.
  */
 @Config
 export class SchedulerConfig {
-	/** Master flag for the durable scheduler. Off by default; opt in to enable. */
+	/** Whether the durable scheduler is enabled. Off by default; set to opt in. */
 	@Env('N8N_SCHEDULER_ENABLED')
 	enabled: boolean = false;
 
-	/** How far ahead (seconds) the materialiser turns schedules into concrete tasks. */
+	/** How far ahead, in seconds, upcoming scheduled executions are prepared. */
 	@Env('N8N_SCHEDULER_MATERIALIZATION_WINDOW', positiveIntSchema)
 	materializationWindow: number = Time.minutes.toSeconds;
 
-	/** Interval (seconds) between sweeps that materialise due schedules into tasks. */
+	/** How often, in seconds, n8n checks for upcoming scheduled executions to prepare. */
 	@Env('N8N_SCHEDULER_SWEEP_INTERVAL', positiveIntSchema)
 	sweepInterval: number = 10;
 
-	/** Interval (seconds) between executor passes that claim and run due tasks. */
+	/** How often, in seconds, n8n checks for due scheduled executions to start. */
 	@Env('N8N_SCHEDULER_EXECUTOR_INTERVAL', positiveIntSchema)
 	executorInterval: number = 5;
 
-	/** Interval (seconds) between reaper passes that reclaim expired task leases. */
+	/** How often, in seconds, n8n recovers scheduled executions left running by a stopped instance. */
 	@Env('N8N_SCHEDULER_REAPER_INTERVAL', positiveIntSchema)
 	reaperInterval: number = 30;
 
-	/** How long (seconds) a claimed task is leased before the reaper may reclaim it. */
+	/** How long, in seconds, one instance holds a scheduled execution before another may retry it. */
 	@Env('N8N_SCHEDULER_LEASE_DURATION', positiveIntSchema)
 	leaseDuration: number = Time.minutes.toSeconds;
 
-	/** How long (seconds) terminal tasks are retained before being purged. */
+	/** How long, in seconds, finished scheduled executions are kept before being deleted. */
 	@Env('N8N_SCHEDULER_RETENTION', positiveIntSchema)
 	retention: number = 7 * Time.days.toSeconds;
 
-	/** Minimum allowed interval (seconds) between schedule fires. 0 disables the clamp. */
+	/** Smallest interval, in seconds, allowed between scheduled executions. 0 means no limit. */
 	@Env('N8N_SCHEDULER_MIN_INTERVAL', nonNegativeIntSchema)
 	minInterval: number = 0;
 }

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -4,46 +4,108 @@ import { z } from 'zod';
 import { Config, Env } from '../decorators';
 import { positiveIntSchema } from '../schemas';
 
-/** Allows 0 (clamp disabled) in addition to positive values. */
+/**
+ * Allows 0 (the clamp disabled) in addition to any positive value. Used for a
+ * setting where 0 is a meaningful "off", not just a smaller number.
+ */
 const nonNegativeIntSchema = z.number({ coerce: true }).int().nonnegative();
 
 /**
- * Configuration for the durable scheduler, which runs scheduled workflow
- * executions from a persisted store so they survive restarts. Off by default;
- * while `enabled` is false nothing reads these values, so the existing schedule
- * trigger behaviour is unchanged.
+ * Configuration for the durable scheduler: the engine that runs time-based
+ * workflows (such as Schedule Trigger nodes) from a database-backed queue.
+ *
+ * Unlike the in-memory scheduler, due runs are recorded in the database before
+ * they start, so they survive restarts and, in a multi-instance setup, each run
+ * is picked up by exactly one instance instead of every instance firing it.
+ *
+ * Off by default. While {@link enabled} is false none of these settings have any
+ * effect and the existing in-memory Schedule Trigger behaviour is unchanged. The
+ * tunables below only matter once the scheduler is turned on; the defaults suit
+ * most instances, so change them only to tune timing precision or storage.
  */
 @Config
 export class SchedulerConfig {
-	/** Whether the durable scheduler is enabled. Off by default; set to opt in. */
+	/**
+	 * Turn on the durable scheduler. Off by default so existing self-hosted setups
+	 * keep using the in-memory scheduler and behave exactly as before.
+	 *
+	 * When on, scheduled runs are stored in the database before they execute, so a
+	 * restart doesn't drop them and, across multiple instances, each run executes
+	 * once rather than once per instance.
+	 */
 	@Env('N8N_SCHEDULER_ENABLED')
 	enabled: boolean = false;
 
-	/** How far ahead, in seconds, upcoming scheduled executions are prepared. */
+	/**
+	 * How far into the future, in seconds, the scheduler works out and records the
+	 * runs that are coming up. Defaults to 60 seconds.
+	 *
+	 * A larger window commits more runs to the database in advance (more resilient
+	 * to downtime, slightly more storage churn); a smaller one keeps less ahead.
+	 * Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_MATERIALIZATION_WINDOW', positiveIntSchema)
 	materializationWindow: number = Time.minutes.toSeconds;
 
-	/** How often, in seconds, n8n checks for upcoming scheduled executions to prepare. */
+	/**
+	 * How often, in seconds, the scheduler scans active schedules to record their
+	 * upcoming runs (those falling within the window above). Defaults to 10 seconds.
+	 * Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_SWEEP_INTERVAL', positiveIntSchema)
 	sweepInterval: number = 10;
 
-	/** How often, in seconds, n8n checks for due scheduled executions to start. */
+	/**
+	 * How often, in seconds, the scheduler checks for recorded runs whose time has
+	 * arrived and starts them. Defaults to 5 seconds.
+	 *
+	 * This sets the worst-case delay between a run's scheduled time and when it
+	 * actually starts. Lower it for tighter timing at the cost of more frequent
+	 * polling. Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_EXECUTOR_INTERVAL', positiveIntSchema)
 	executorInterval: number = 5;
 
-	/** How often, in seconds, n8n recovers scheduled executions left running by a stopped instance. */
+	/**
+	 * How often, in seconds, the scheduler looks for runs that an instance claimed
+	 * but never finished (for example because it crashed or was shut down) and
+	 * makes them available again so another instance can pick them up. Defaults to
+	 * 30 seconds. Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_REAPER_INTERVAL', positiveIntSchema)
 	reaperInterval: number = 30;
 
-	/** How long, in seconds, one instance holds a scheduled execution before another may retry it. */
+	/**
+	 * How long, in seconds, a single instance holds an exclusive claim on a run it
+	 * has picked up, so no other instance starts the same one. Defaults to 60 seconds.
+	 *
+	 * If that instance stops without finishing, the claim expires after this long
+	 * and another instance may take the run over. Keep it comfortably above the
+	 * time a run needs to get going: too short risks two instances starting the
+	 * same run; too long delays recovery after a crash. Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_LEASE_DURATION', positiveIntSchema)
 	leaseDuration: number = Time.minutes.toSeconds;
 
-	/** How long, in seconds, finished scheduled executions are kept before being deleted. */
+	/**
+	 * How long, in seconds, finished runs are kept in the scheduler's tables before
+	 * being deleted. Defaults to 7 days.
+	 *
+	 * Raise it to keep scheduling history longer for auditing; lower it to reclaim
+	 * database space sooner. Must be greater than 0.
+	 */
 	@Env('N8N_SCHEDULER_RETENTION', positiveIntSchema)
 	retention: number = 7 * Time.days.toSeconds;
 
-	/** Smallest interval, in seconds, allowed between scheduled executions. 0 means no limit. */
+	/**
+	 * The smallest gap, in seconds, allowed between consecutive runs of the same
+	 * schedule. A schedule set to run more often than this is slowed down to this
+	 * gap. Defaults to 0, which disables the limit and honours whatever interval
+	 * each schedule specifies.
+	 *
+	 * Set it to put a floor on how frequently any schedule can run, for example to
+	 * stop a misconfigured every-second schedule from overloading the instance.
+	 */
 	@Env('N8N_SCHEDULER_MIN_INTERVAL', nonNegativeIntSchema)
 	minInterval: number = 0;
 }

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -4,17 +4,13 @@ import { z } from 'zod';
 import { Config, Env } from '../decorators';
 import { positiveIntSchema } from '../schemas';
 
-/** Allows 0 (clamp disabled) in addition to any positive interval, in seconds. */
+/** Allows 0 (clamp disabled) in addition to positive values. */
 const nonNegativeIntSchema = z.number({ coerce: true }).int().nonnegative();
 
 /**
- * Configuration for the durable scheduler: a master on/off flag plus the engine
- * tunables (loop cadences, lease and retention windows). All durations are in
- * seconds, matching the `@n8n/scheduler` schedule math (`intervalSeconds`).
- *
- * Default off: with `enabled` false nothing reads these values, so the existing
- * in-memory schedule trigger engine is unaffected. The engine loops that consume
- * this config are wired up separately (lifecycle wiring, materialiser).
+ * Configuration for the durable scheduler: the master on/off flag and the engine
+ * tunables. Off by default; while `enabled` is false nothing reads these values,
+ * so the existing in-memory schedule trigger engine is unaffected.
  */
 @Config
 export class SchedulerConfig {

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -38,6 +38,7 @@ import { PublicApiConfig } from './configs/public-api.config';
 import { RedisConfig } from './configs/redis.config';
 import { TaskRunnersConfig } from './configs/runners.config';
 import { ScalingModeConfig } from './configs/scaling-mode.config';
+import { SchedulerConfig } from './configs/scheduler.config';
 import { SecurityConfig } from './configs/security.config';
 import { SentryConfig } from './configs/sentry.config';
 import { SsoConfig } from './configs/sso.config';
@@ -87,6 +88,7 @@ export { PasswordConfig } from './configs/password.config';
 export { AgentsConfig } from './configs/agents.config';
 export { CompressionNodeConfig } from './configs/compression.config';
 export { RedisConfig } from './configs/redis.config';
+export { SchedulerConfig } from './configs/scheduler.config';
 export { EndpointsConfig, PrometheusMetricsConfig };
 
 const protocolSchema = z.enum(['http', 'https']);
@@ -171,6 +173,9 @@ export class GlobalConfig {
 
 	@Nested
 	multiMainSetup: MultiMainSetupConfig;
+
+	@Nested
+	scheduler: SchedulerConfig;
 
 	@Nested
 	generic: GenericConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -425,6 +425,16 @@ describe('GlobalConfig', () => {
 			ttl: 10,
 			interval: 3,
 		},
+		scheduler: {
+			enabled: false,
+			materializationWindow: 60,
+			sweepInterval: 10,
+			executorInterval: 5,
+			reaperInterval: 30,
+			leaseDuration: 60,
+			retention: 604800,
+			minInterval: 0,
+		},
 		evaluation: {
 			collectionsEnabled: false,
 		},


### PR DESCRIPTION
## Summary

Adds the configuration surface for the durable scheduler (project: Durable Scheduler, milestone M0 - Foundation). This is a pure config addition: a master on/off flag plus the engine tunables, with no consumer wired up yet.

New `SchedulerConfig` in `@n8n/config`:

| Env var | Type | Default | Meaning |
|---------|------|---------|---------|
| `N8N_SCHEDULER_ENABLED` | boolean | `false` | Master flag (opt-in, default off) |
| `N8N_SCHEDULER_MATERIALIZATION_WINDOW` | number (s) | `60` | How far ahead schedules are materialised into tasks |
| `N8N_SCHEDULER_SWEEP_INTERVAL` | number (s) | `10` | Sweep cadence (materialise due schedules) |
| `N8N_SCHEDULER_EXECUTOR_INTERVAL` | number (s) | `5` | Executor cadence (claim and run due tasks) |
| `N8N_SCHEDULER_REAPER_INTERVAL` | number (s) | `30` | Reaper cadence (reclaim expired leases) |
| `N8N_SCHEDULER_LEASE_DURATION` | number (s) | `60` | How long a claimed task is leased |
| `N8N_SCHEDULER_RETENTION` | number (s) | `604800` | Retention for finished tasks (7 days) |
| `N8N_SCHEDULER_MIN_INTERVAL` | number (s) | `0` | Minimum interval clamp; `0` disables it |

Design decisions:
- **Durations in seconds**, matching the `@n8n/scheduler` schedule math (`intervalSeconds`) and the existing config classes (runners, multi-main).
- **Flat props on a nested config class**, following the `TaskRunnersConfig` / `MultiMainSetupConfig` precedent.
- **Min-interval clamp lives here**, default `0` (disabled); the materialiser reads it later.
- Strictly-positive tunables validate via `positiveIntSchema`; `minInterval` allows `0`.

Flag defaults off and nothing consumes it yet, so **existing behaviour is unchanged**. The engine loops and lifecycle wiring that read this config land in separate tickets (B6 lifecycle wiring, B2 materialiser). Marked `(no-changelog)` since the surface is inert until those consumers ship.

## How to test

Unit tests cover both flag states:

```bash
cd packages/@n8n/config && pnpm test scheduler.config
```

- Flag off: `GlobalConfig.scheduler` exposes the defaults above.
- Flag on: each tunable overrides from its env var; `minInterval=0` disables the clamp.

`pnpm typecheck` and `pnpm lint` are clean in the package.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3609

Follows the opt-in/default-off flag convention from #33130. Docs PR (new env vars) opened against n8n-io/n8n-docs.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated (n8n-docs PR for the new env vars).
- [x] Tests included (both flag states).
- [ ] PR Labeled with backport label (n/a).

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33308">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

