### PR TITLE
feat: Add telemetry events for browser use connect modal (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-browser-session.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-browser-session.service.test.ts
@@ -7,6 +7,7 @@ import { mock } from 'vitest-mock-extended';
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { Push } from '@/push';
 import type { UrlService } from '@/services/url.service';
+import type { Telemetry } from '@/telemetry';
 
 import {
 	CDP_TOKEN_HEADER,
@@ -106,6 +107,7 @@ describe('InstanceAiBrowserSessionService', () => {
 	const userRepository = mock<UserRepository>();
 	const credentialsService = mock<CredentialsService>();
 	const globalConfig = mock<GlobalConfig>({ port: 5678 });
+	const telemetry = mock<Telemetry>();
 	let service: InstanceAiBrowserSessionService;
 
 	beforeEach(() => {
@@ -120,6 +122,7 @@ describe('InstanceAiBrowserSessionService', () => {
 			userRepository,
 			credentialsService,
 			globalConfig,
+			telemetry,
 		);
 	});
 
@@ -269,6 +272,16 @@ describe('InstanceAiBrowserSessionService', () => {
 			const status = service.getStatus(USER_ID);
 			expect(status.connected).toBe(true);
 			expect(status.toolCategories).toEqual([{ name: 'browser', enabled: true }]);
+		});
+
+		it('tracks a connect event when the extension connects', async () => {
+			const { relay } = await createSession(service);
+
+			relay.onExtensionConnect?.();
+
+			expect(telemetry.track).toHaveBeenCalledWith('Instance AI Browser connected', {
+				user_id: USER_ID,
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/browser/instance-ai-browser-session.service.ts
+++ b/packages/cli/src/modules/instance-ai/browser/instance-ai-browser-session.service.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { Push } from '@/push';
 import { UrlService } from '@/services/url.service';
+import { Telemetry } from '@/telemetry';
 
 import { BrowserLocalMcpServer } from './browser-local-mcp-server';
 import {
@@ -65,6 +66,7 @@ export class InstanceAiBrowserSessionService {
 		private readonly userRepository: UserRepository,
 		private readonly credentialsService: CredentialsService,
 		private readonly globalConfig: GlobalConfig,
+		private readonly telemetry: Telemetry,
 	) {
 		this.logger = logger.scoped('instance-ai');
 	}
@@ -219,6 +221,7 @@ export class InstanceAiBrowserSessionService {
 			name: 'browser_connect',
 			arguments: {},
 		});
+		this.telemetry.track('Instance AI Browser connected', { user_id: userId });
 		this.logger.info('Browser Use extension connected', { userId });
 		this.pushState(userId);
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
@@ -24,7 +24,9 @@ describe('instance ai browser use telemetry', () => {
 		useInstanceAiBrowserUseTelemetry().trackInstallExtensionClicked();
 
 		expect(track).toHaveBeenCalledTimes(1);
-		expect(track).toHaveBeenCalledWith('Instance AI Install Chrome Extension button clicked');
+		expect(track).toHaveBeenCalledWith(
+			'Instance AI Install Chrome Browser Extension button clicked',
+		);
 	});
 
 	test('tracks the open extension button click', () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAiBrowserUse.telemetry.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useInstanceAiBrowserUseTelemetry } from '../instanceAiBrowserUse.telemetry';
+
+const track = vi.fn();
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track }),
+}));
+
+describe('instance ai browser use telemetry', () => {
+	beforeEach(() => {
+		track.mockClear();
+	});
+
+	test('tracks the connect modal opening', () => {
+		useInstanceAiBrowserUseTelemetry().trackModalOpened();
+
+		expect(track).toHaveBeenCalledTimes(1);
+		expect(track).toHaveBeenCalledWith('Instance AI Connect Browser Use modal opened');
+	});
+
+	test('tracks the install extension button click', () => {
+		useInstanceAiBrowserUseTelemetry().trackInstallExtensionClicked();
+
+		expect(track).toHaveBeenCalledTimes(1);
+		expect(track).toHaveBeenCalledWith('Instance AI Install Chrome Extension button clicked');
+	});
+
+	test('tracks the open extension button click', () => {
+		useInstanceAiBrowserUseTelemetry().trackOpenExtensionClicked();
+
+		expect(track).toHaveBeenCalledTimes(1);
+		expect(track).toHaveBeenCalledWith('Instance AI Open Browser Use Extension button clicked');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/BrowserUseSetupModal.vue
@@ -4,6 +4,7 @@ import { N8nButton, N8nHeading, N8nIcon, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import Modal from '@/app/components/Modal.vue';
 import { useInstanceAiSettingsStore } from '../../instanceAiSettings.store';
+import { useInstanceAiBrowserUseTelemetry } from '../../instanceAiBrowserUse.telemetry';
 
 import { CHROME_EXTENSION_URL } from './constants';
 
@@ -13,6 +14,7 @@ const props = defineProps<{ modalName: string }>();
 
 const i18n = useI18n();
 const store = useInstanceAiSettingsStore();
+const telemetry = useInstanceAiBrowserUseTelemetry();
 
 const isConnected = computed(() => store.browserConnected);
 const connectUrl = ref<string | null>(null);
@@ -39,6 +41,7 @@ async function refreshConnectUrl(): Promise<void> {
 }
 
 onMounted(() => {
+	telemetry.trackModalOpened();
 	void store.fetchBrowserStatus();
 	if (!store.browserConnected) {
 		void refreshConnectUrl();
@@ -98,6 +101,7 @@ onBeforeUnmount(() => {
 							size="medium"
 							icon="external-link"
 							data-test-id="browser-use-install-extension"
+							@click="telemetry.trackInstallExtensionClicked"
 						/>
 					</div>
 
@@ -117,6 +121,7 @@ onBeforeUnmount(() => {
 							icon="external-link"
 							:disabled="!connectUrl"
 							data-test-id="browser-use-open-connect-page"
+							@click="telemetry.trackOpenExtensionClicked"
 						/>
 					</div>
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/modals/__tests__/BrowserUseSetupModal.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
+import { createComponentRenderer } from '@/__tests__/render';
+import BrowserUseSetupModal from '../BrowserUseSetupModal.vue';
+
+vi.mock('@n8n/i18n', async (importOriginal) => ({
+	...(await importOriginal()),
+	useI18n: () => ({
+		baseText: (key: string) => key,
+	}),
+}));
+
+const { telemetryMock } = vi.hoisted(() => ({
+	telemetryMock: {
+		trackModalOpened: vi.fn(),
+		trackInstallExtensionClicked: vi.fn(),
+		trackOpenExtensionClicked: vi.fn(),
+	},
+}));
+
+vi.mock('../../../instanceAiBrowserUse.telemetry', () => ({
+	useInstanceAiBrowserUseTelemetry: () => telemetryMock,
+}));
+
+const settingsStoreMock = vi.fn();
+vi.mock('../../../instanceAiSettings.store', () => ({
+	useInstanceAiSettingsStore: () => settingsStoreMock(),
+}));
+
+function makeSettingsStore(overrides: Record<string, unknown> = {}) {
+	return {
+		browserConnected: false,
+		browserConnectUrlExpiresAt: null,
+		fetchBrowserStatus: vi.fn(),
+		fetchBrowserConnectUrl: vi.fn().mockResolvedValue('https://connect.example/extension'),
+		clearBrowserConnectUrl: vi.fn(),
+		...overrides,
+	};
+}
+
+const renderComponent = createComponentRenderer(BrowserUseSetupModal, {
+	props: { modalName: 'browserUseSetup' },
+	global: {
+		stubs: {
+			Modal: {
+				template: '<div><slot name="content" /></div>',
+			},
+		},
+	},
+});
+
+describe('BrowserUseSetupModal', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		settingsStoreMock.mockReturnValue(makeSettingsStore());
+	});
+
+	it('tracks the modal opening on mount', () => {
+		renderComponent();
+		expect(telemetryMock.trackModalOpened).toHaveBeenCalledTimes(1);
+	});
+
+	it('tracks the install extension button click', async () => {
+		const { getByTestId } = renderComponent();
+		await flushPromises();
+
+		await fireEvent.click(getByTestId('browser-use-install-extension'));
+
+		expect(telemetryMock.trackInstallExtensionClicked).toHaveBeenCalledTimes(1);
+	});
+
+	it('tracks the open extension button click', async () => {
+		const { getByTestId } = renderComponent();
+		await flushPromises();
+
+		await fireEvent.click(getByTestId('browser-use-open-connect-page'));
+
+		expect(telemetryMock.trackOpenExtensionClicked).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not render the connect steps when already connected', () => {
+		settingsStoreMock.mockReturnValue(makeSettingsStore({ browserConnected: true }));
+		const { queryByTestId } = renderComponent();
+
+		expect(queryByTestId('browser-use-install-extension')).toBeNull();
+		expect(queryByTestId('browser-use-open-connect-page')).toBeNull();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
@@ -1,0 +1,16 @@
+import { useTelemetry } from '@/app/composables/useTelemetry';
+
+export function useInstanceAiBrowserUseTelemetry() {
+	const telemetry = useTelemetry();
+	return {
+		trackModalOpened() {
+			telemetry.track('Instance AI Connect Browser Use modal opened');
+		},
+		trackInstallExtensionClicked() {
+			telemetry.track('Instance AI Install Chrome Extension button clicked');
+		},
+		trackOpenExtensionClicked() {
+			telemetry.track('Instance AI Open Browser Use Extension button clicked');
+		},
+	};
+}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiBrowserUse.telemetry.ts
@@ -7,7 +7,7 @@ export function useInstanceAiBrowserUseTelemetry() {
 			telemetry.track('Instance AI Connect Browser Use modal opened');
 		},
 		trackInstallExtensionClicked() {
-			telemetry.track('Instance AI Install Chrome Extension button clicked');
+			telemetry.track('Instance AI Install Chrome Browser Extension button clicked');
 		},
 		trackOpenExtensionClicked() {
 			telemetry.track('Instance AI Open Browser Use Extension button clicked');


### PR DESCRIPTION
## Summary

Adds telemetry events for browser use connection modal/state
- Instance AI Connect Browser Use modal opened (frontend)
- Instance AI Install Chrome Browser Extension button clicked (frontend)
- Instance AI Open Browser Use Extension button clicked (frontend)
- Instance AI Browser connected (backend)

The frontend events send user id per default and do not need this information as explicit event data

## How to test

1. Run n8n instance with AI Assistant activated
2. Enable browser use feature flag via devtools console `window.featureFlags.override('090_instance_ai_browser_use', 'variant')`
3. Open devtools network tab
4. In AI Assistant chat click on `...` next to Browser Use card and click on connect (only visible after writing the first message in a thread)
5. Observe that the `Instance AI Connect Browser Use modal opened` was sent
6. click on the button to install extension and observe that the `Instance AI Install Chrome Browser Extension button clicked` event was sent
7. click on the button to connect extension and observe that the `Instance AI Open Browser Use Extension button clicked` event was sent
8. connect the browser in the extension tab and observe that the `Instance AI Browser connected` was sent (see https://linear.app/n8n/issue/NODE-5352/add-telemetry-events-for-browser-use-connect-modal#comment-2719899a)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5352/add-telemetry-events-for-browser-use-connect-modal


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->