### PR TITLE
fix(core): Keep the user message when a run is stopped before it starts

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/terminal-response-guard.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/terminal-response-guard.test.ts
@@ -162,6 +162,14 @@ describe('InstanceAiTerminalResponseGuard', () => {
 		expect(decision.visibilitySource).toBe('root-text');
 	});
 
+	it('emits no placeholder when a run is cancelled with no output', () => {
+		const decision = guard().evaluateTerminal([runStart()], 'cancelled');
+
+		expect(decision.action).toBe('none');
+		expect(decision.reason).toBe('cancelled-silent');
+		expect(decision.event).toBeUndefined();
+	});
+
 	it('logs root error then completed as already visible', () => {
 		const decision = guard().evaluateTerminal([runStart(), rootError()], 'completed');
 

--- a/packages/@n8n/instance-ai/src/runtime/terminal-response-guard.ts
+++ b/packages/@n8n/instance-ai/src/runtime/terminal-response-guard.ts
@@ -128,6 +128,7 @@ export class InstanceAiTerminalResponseGuard {
 		}
 
 		if (status === 'cancelled') {
+			// A cancelled run needs no assistant placeholder: the stopped state is self-evident in the UI.
 			if (visibility.hasRootText || visibility.hasRootError) {
 				return {
 					status,
@@ -136,11 +137,12 @@ export class InstanceAiTerminalResponseGuard {
 					reason: 'already-visible',
 				};
 			}
-			return this.emitText(
+			return {
 				status,
-				'cancelled-silent',
-				'The run was cancelled before I could send a response.',
-			);
+				visibilitySource: 'none',
+				action: 'none',
+				reason: 'cancelled-silent',
+			};
 		}
 
 		if (visibility.hasRootError) {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -146,6 +146,7 @@ vi.mock('@n8n/instance-ai', async () => {
 			}
 		},
 		resumeAgentRun: vi.fn(),
+		createInstanceAiTraceContext: vi.fn(async () => ({ rootRun: { otelTraceId: undefined } })),
 		TerminalOutcomeStorage: class {
 			constructor(_memory: unknown) {}
 		},
@@ -2337,6 +2338,73 @@ describe('InstanceAiService — run error reporter lifecycle', () => {
 			'maybeStartWorkflowSetupFollowUp',
 			'endRun',
 		]);
+	});
+});
+
+describe('InstanceAiService — user message persistence on cancel', () => {
+	type ExecuteRunInternals = {
+		executeRun: (
+			user: User,
+			threadId: string,
+			runId: string,
+			message: string,
+			abortController: AbortController,
+		) => Promise<void>;
+		agentMemory: { saveMessages: Mock };
+		eventBus: { publish: Mock };
+		terminalOutcome: { evaluateTerminalResponse: Mock };
+		logger: { warn: Mock; error: Mock };
+		createProxyRunConfig: Mock;
+		isRunDebugEnabled: Mock;
+		runState: { clearActiveRun: Mock; hasSuspendedRun: Mock };
+		domainAccessTrackersByThread: Map<string, unknown>;
+		instanceAiErrorReporter: { beginRun: Mock; endRun: Mock };
+	};
+
+	function createCancelPersistenceService(): ExecuteRunInternals {
+		const service = Object.create(InstanceAiService.prototype) as unknown as ExecuteRunInternals;
+		service.agentMemory = { saveMessages: vi.fn(async () => {}) };
+		service.eventBus = { publish: vi.fn() };
+		service.terminalOutcome = { evaluateTerminalResponse: vi.fn() };
+		service.logger = { warn: vi.fn(), error: vi.fn() };
+		service.createProxyRunConfig = vi.fn(async () => ({ tracingProxyConfig: undefined }));
+		service.isRunDebugEnabled = vi.fn(() => false);
+		// hasSuspendedRun → true short-circuits the finally's post-run scheduling
+		service.runState = { clearActiveRun: vi.fn(), hasSuspendedRun: vi.fn(() => true) };
+		service.domainAccessTrackersByThread = new Map();
+		service.instanceAiErrorReporter = { beginRun: vi.fn(), endRun: vi.fn() };
+		return service;
+	}
+
+	it('persists the user message when Stop is hit before the stream starts', async () => {
+		const service = createCancelPersistenceService();
+		const abortController = new AbortController();
+		abortController.abort();
+
+		await service.executeRun(fakeUser, 'thread-1', 'run-1', 'banana', abortController);
+
+		expect(service.agentMemory.saveMessages).toHaveBeenCalledWith(
+			expect.objectContaining({
+				threadId: 'thread-1',
+				resourceId: 'user-1',
+				messages: [
+					expect.objectContaining({
+						role: 'user',
+						content: [{ type: 'text', text: 'banana' }],
+					}),
+				],
+			}),
+		);
+	});
+
+	it('does not persist an empty user message', async () => {
+		const service = createCancelPersistenceService();
+		const abortController = new AbortController();
+		abortController.abort();
+
+		await service.executeRun(fakeUser, 'thread-1', 'run-1', '', abortController);
+
+		expect(service.agentMemory.saveMessages).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -2749,6 +2749,36 @@ export class InstanceAiService {
 		}
 	}
 
+	/** Save the user's prompt when Stop is hit before the stream starts; the SDK only persists it once the stream is invoked. */
+	private async persistInterruptedUserMessage(
+		threadId: string,
+		userId: string,
+		message: string,
+		createdAt: Date,
+	): Promise<void> {
+		if (!message) return;
+		try {
+			await this.agentMemory.saveMessages({
+				threadId,
+				resourceId: userId,
+				messages: [
+					{
+						id: nanoid(),
+						createdAt,
+						type: 'llm',
+						role: 'user',
+						content: [{ type: 'text', text: message }],
+					},
+				],
+			});
+		} catch (error) {
+			this.logger.warn('Failed to persist user message on cancel', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
 	/**
 	 * Run body for a fresh orchestrator turn. Never call directly — go through
 	 * `startExecuteRun` so the promise is registered with `inFlightExecutions`
@@ -2786,6 +2816,8 @@ export class InstanceAiService {
 		let aiCreatedWorkflowIds: Set<string> | undefined;
 		let activeSnapshotStorage: DbSnapshotStorage | undefined;
 		let messageId = '';
+		let streamReached = false;
+		const turnStartedAt = new Date();
 
 		try {
 			this.instanceAiErrorReporter.beginRun(runId);
@@ -2856,6 +2888,7 @@ export class InstanceAiService {
 
 			// Check if already cancelled before starting agent work
 			if (signal.aborted) {
+				await this.persistInterruptedUserMessage(threadId, user.id, message, turnStartedAt);
 				this.terminalOutcome.evaluateTerminalResponse(threadId, runId, 'cancelled', {
 					messageGroupId,
 					correlationId: messageId,
@@ -3149,6 +3182,7 @@ export class InstanceAiService {
 
 			const streamOptions = this.buildOrchestratorAgentStreamOptions(user, threadId, runId, signal);
 
+			streamReached = true;
 			const result = tracing
 				? await tracing.withActiveSpan(tracing.actorRun, async () => {
 						return await streamAgentRun(agent as StreamableAgent, streamInput, streamOptions, {
@@ -3381,6 +3415,9 @@ export class InstanceAiService {
 				// to see on reload, so just bail out.
 				if (this.shouldPreserveHitlOnShutdown(runId)) {
 					return;
+				}
+				if (!streamReached) {
+					await this.persistInterruptedUserMessage(threadId, user.id, message, turnStartedAt);
 				}
 				const runTimeout = this.liveness.consumeRunTimeout(runId);
 				const cancellationReason = runTimeout.timedOut


### PR DESCRIPTION
## Summary

When a chat run is cancelled before the agent stream is invoked (Stop clicked during the pre-stream setup window: proxy token, tracing, MCP registry, sandbox/env creation), the SDK's eager input persistence never runs, so the user's prompt was silently dropped from thread history. The next turn the assistant had no record of it (e.g. "what did I just say?" → "That's the first message in our conversation").

PR #32917 fixed the mid-stream case by persisting the input inside `agent.stream()`. This closes the remaining gap: the two cancel paths in `executeRun` that short-circuit before the stream is reached now persist the user's prompt to thread memory. A `streamReached` flag ensures we never double-write once the stream has been invoked (from that point the SDK's persist always completes, since DB writes aren't abort-interruptible).

Also stops emitting the "The run was cancelled before I could send a response." placeholder reply. It only appeared on zero-output cancellations, is redundant (the user just hit Stop), and the editor already filters out empty cancelled turns via `messageHasVisibleContent`, so the result is clean: just the user's message.

## How to test

1. Open the AI Assistant, type a message, send it, and immediately click Stop (before any response streams).
2. Send a follow-up such as "what did I just say?".
3. The assistant references your first message instead of treating the follow-up as the first turn.
4. The cancelled turn no longer shows a "run was cancelled..." bubble.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-732

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->