### PR TITLE
fix(cli): include description field in workflows API

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -256,6 +256,7 @@ const workflowHandlers: WorkflowHandlers = {
 				'versionId',
 				'triggerCount',
 				'shared',
+				'description',
 			];
 
 			if (!excludePinnedData) {

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -168,8 +168,8 @@ describe('GET /workflows', () => {
 
 	test('should return all owned workflows', async () => {
 		await Promise.all([
-			createWorkflowWithHistory({}, member),
-			createWorkflowWithHistory({}, member),
+			createWorkflowWithHistory({ description: 'First workflow description' }, member),
+			createWorkflowWithHistory({ description: 'Second workflow description' }, member),
 			createWorkflowWithHistory({}, member),
 		]);
 
@@ -178,6 +178,9 @@ describe('GET /workflows', () => {
 		expect(response.statusCode).toBe(200);
 		expect(response.body.data.length).toBe(3);
 		expect(response.body.nextCursor).toBeNull();
+
+		let firstWorkflowFound = false;
+		let secondWorkflowFound = false;
 
 		for (const workflow of response.body.data) {
 			const {
@@ -190,6 +193,7 @@ describe('GET /workflows', () => {
 				nodeGroups,
 				settings,
 				name,
+				description,
 				createdAt,
 				updatedAt,
 				isArchived,
@@ -198,6 +202,13 @@ describe('GET /workflows', () => {
 				meta,
 				tags,
 			} = workflow;
+
+			if (description === 'First workflow description') {
+				firstWorkflowFound = true;
+			}
+			if (description === 'Second workflow description') {
+				secondWorkflowFound = true;
+			}
 
 			expect(id).toBeDefined();
 			expect(name).toBeDefined();
@@ -215,7 +226,11 @@ describe('GET /workflows', () => {
 			expect(versionId).toBeDefined();
 			expect(triggerCount).toBeDefined();
 			expect(meta).toBeDefined();
+			expect(description).toBeDefined();
 		}
+
+		expect(firstWorkflowFound).toBe(true);
+		expect(secondWorkflowFound).toBe(true);
 	});
 
 	test('should include node groups when returning owned workflows', async () => {
@@ -280,6 +295,7 @@ describe('GET /workflows', () => {
 				nodes,
 				settings,
 				name,
+				description,
 				createdAt,
 				updatedAt,
 				isArchived,
@@ -304,6 +320,7 @@ describe('GET /workflows', () => {
 			expect(versionId).toBeDefined();
 			expect(triggerCount).toBeDefined();
 			expect(meta).toBeDefined();
+			expect(description).toBeDefined();
 		}
 
 		// check that we really received a different result
@@ -651,7 +668,10 @@ describe('GET /workflows/:id', () => {
 
 	test('should retrieve workflow', async () => {
 		// create and assign workflow to owner
-		const workflow = await createWorkflowWithHistory({}, member);
+		const workflow = await createWorkflowWithHistory(
+			{ description: 'Workflow description here' },
+			member,
+		);
 
 		const response = await authMemberAgent.get(`/workflows/${workflow.id}`);
 
@@ -666,6 +686,7 @@ describe('GET /workflows/:id', () => {
 			nodes,
 			settings,
 			name,
+			description,
 			createdAt,
 			updatedAt,
 			isArchived,
@@ -677,6 +698,7 @@ describe('GET /workflows/:id', () => {
 
 		expect(id).toEqual(workflow.id);
 		expect(name).toEqual(workflow.name);
+		expect(description).toEqual('Workflow description here');
 		expect(connections).toEqual(workflow.connections);
 		expect(active).toBe(false);
 		expect(activeVersionId).toBeNull();


### PR DESCRIPTION
Fixes #33261
Linear Ticket: https://linear.app/n8n/issue/GHC-8834

## What this PR does
Added the missing `description` field to the `selectFields` array in `workflows.handler.ts` so that it is properly returned by the `/api/v1/workflows` endpoint as specified in the documentation. 

Thanks to @hagebau-benjamin for reporting this!

## How to test
1. Create a workflow with a description.
2. Make a GET request to `/api/v1/workflows` using the Public API.
3. Verify the `description` field is now present in the JSON response.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33321">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
