### PR TITLE
fix(core): Preserve Date values passed to the expression isolate

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -284,6 +284,34 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		});
 	});
 
+	describe('Date marshaling from workflow data', () => {
+		it('should read a top-level Date in $json as a Date, not {}', () => {
+			const data = { $json: { d: new Date('2026-06-30T20:34:04.498Z') } };
+
+			const result = evaluator.evaluate('{{ $json.d }}', data, caller);
+
+			expect(result).not.toEqual({});
+			expect(result).toBeInstanceOf(Date);
+			expect((result as Date).toISOString()).toBe('2026-06-30T20:34:04.498Z');
+		});
+
+		it('should read a nested Date in $json (e.g. Data Table createdAt)', () => {
+			const data = { $json: { row: { createdAt: new Date('2026-06-30T20:34:04.498Z') } } };
+
+			const result = evaluator.evaluate('{{ $json.row.createdAt }}', data, caller);
+
+			expect(result).toBeInstanceOf(Date);
+		});
+
+		it('should read a Date array element in $json', () => {
+			const data = { $json: { dates: [new Date('2026-06-30T20:34:04.498Z')] } };
+
+			const result = evaluator.evaluate('{{ $json.dates[0] }}', data, caller);
+
+			expect(result).toBeInstanceOf(Date);
+		});
+	});
+
 	it('should throw on invalid timezone', async () => {
 		const data = { $json: { x: 1 } };
 

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -338,6 +338,12 @@ export class IsolatedVmBridge implements RuntimeBridge {
 					};
 				}
 
+				// Dates have no enumerable own keys; pass through instead of
+				// marshaling as an empty object.
+				if (value instanceof Date) {
+					return value;
+				}
+
 				// Handle objects - return metadata with keys
 				if (value !== null && typeof value === 'object') {
 					return {
@@ -395,6 +401,12 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				}
 
 				const element = arr[index];
+
+				// Dates have no enumerable own keys; pass through instead of
+				// marshaling as an empty object.
+				if (element instanceof Date) {
+					return element;
+				}
 
 				// If element is object/array, return metadata
 				if (element !== null && typeof element === 'object') {


### PR DESCRIPTION
## Summary

Most nodes apart from Code Nodes return native `Date` objects in their output (Data Tables, SQL/DB, FTP, MongoDB, ...). The `isolated-vm` bridge marshals every object across the boundary as `{ __isObject, __keys: Object.keys(value) }` - and a `Date` has no enumerable keys, so it crosses as an empty object and resolves to `{}` downstream. The Code node is unaffected only because it runs in the task runner, which JSON-stringifies output before it reaches the next node.

Fix: pass `Date` through in `getValueAtPath` and `getArrayElement`, so `isolated-vm` structured-clones it into a real `Date` in the isolate (matching how Dates created inside the isolate already round-trip).

## How to test

On the VM engine (`N8N_EXPRESSION_ENGINE=vm`, default on cloud):

```bash
pnpm --filter=@n8n/expression-runtime test src/__tests__/integration.test.ts -t "CAT-3589"
```

Or end-to-end: Manual Trigger → Data Table (Insert row) → Set node with `{{ $json.createdAt }}` (string), run the **full workflow** — output should be an ISO timestamp, not `{}`, consistently with the legacy engine.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3589

fixes #33062

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
