### PR TITLE
ci: Restore full dependency closure in release SBOM

### DIFF
--- a/scripts/build-n8n.mjs
+++ b/scripts/build-n8n.mjs
@@ -190,6 +190,16 @@ if (excludeTestController) {
 	echo(chalk.gray('  - Excluded test controller from packages/cli/package.json'));
 }
 
+// The release SBOM is built by cdxgen inventorying the top-level node_modules of this
+// deployed closure. Since #32569 dropped shamefully-hoist, only direct deps surface at
+// top level, so cdxgen would miss the transitive tree (the manifest would be incomplete).
+// Re-enable hoisting for the licenses build only — shipped images keep the non-hoisted
+// layout, since regular builds leave N8N_GENERATE_LICENSES unset.
+const generateLicenses = process.env.N8N_GENERATE_LICENSES === 'true';
+if (generateLicenses) {
+	process.env.npm_config_shamefully_hoist = 'true';
+}
+
 await $`cd ${config.rootDir} && NODE_ENV=production DOCKER_BUILD=true pnpm --filter=n8n --prod --legacy deploy --no-optional ./compiled`;
 
 // Strip test/example/benchmark dirs shipped inside production deps that lack a
@@ -229,7 +239,7 @@ const packageDeployTime = getElapsedTime('package_deploy');
 // Default: skip. cdxgen + license rendering adds ~minutes to every build:deploy and
 // is only needed for the release SBOM job. The release-publish workflow opts in by
 // setting N8N_GENERATE_LICENSES=true; regular CI Docker prepare runs skip it.
-if (process.env.N8N_GENERATE_LICENSES === 'true') {
+if (generateLicenses) {
 	echo(chalk.yellow('INFO: Generating SBOM and rendering THIRD_PARTY_LICENSES.md...'));
 	try {
 		const toolingDir = path.join(config.rootDir, '.github', 'scripts');


### PR DESCRIPTION
## Summary

The **Generate and Attach SBOM to Release** job started failing on `n8n@2.29.0`, exiting at the SBOM enrichment gate with every license override/election reported as "stale".

The release SBOM is generated by cdxgen scanning the deployed artifact (`cdxgen -t pnpm --no-install-deps … compiled/`). Since there is no `pnpm-lock.yaml` in `compiled/`, cdxgen enumerates the **top-level `node_modules`** to build the component list — so SBOM completeness silently depends on pnpm's hoisting.

When #32569 removed `shamefully-hoist=true` from `.npmrc`, the top-level `node_modules` of the deployed closure dropped from ~998 to ~109 entries, so cdxgen only saw the direct dependencies. The SBOM collapsed from **1332 → 147 components** (~6 MB → 0.66 MB), the transitive tree disappeared, and the pinned license overrides no longer matched anything — hence the "stale" gate error.

**Fix:** re-enable `shamefully-hoist` for the deploy step **only when the SBOM/licenses build is requested** (`N8N_GENERATE_LICENSES=true`), in `scripts/build-n8n.mjs`. Regular Docker builds leave that flag unset, so the shipped images keep the non-hoisted layout introduced in #32569 — no behavioral change to what we ship. `scripts/licenses/license-overrides.json` is intentionally left untouched (deleting the "stale" overrides would have papered over the regression and shipped an incomplete `THIRD_PARTY_LICENSES.md`).

Verified locally against the 2.29.0 closure:

| | Before | After |
|---|---|---|
| SBOM components | 147 | **1332** |
| Overrides / elections matched | 0 / 0 | **11 / 2** |
| License gate (`check-licenses`) | ❌ exit 3 | **✅ exit 0** |
| `THIRD_PARTY_LICENSES.md` packages | ~117 | **1294** |

## How to test

Run the release SBOM pipeline against the deployed artifact:

```bash
N8N_GENERATE_LICENSES=true pnpm build:deploy
jq '.components | length' sbom-source.cdx.json   # expect ~1300+, not 147
```

The `enrich-sbom` step should exit 0 with no "Stale overrides/elections", and `check-licenses` should pass. Re-running the **Generate and Attach SBOM to Release** workflow on the release tag should now be green. Regular Docker builds (no `N8N_GENERATE_LICENSES`) are unaffected and stay non-hoisted.

## Related Linear tickets, Github issues, and Community forum posts

Regression from #32569 (removal of `shamefully-hoist`).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

