### PR TITLE
Fix workflow publication failure detection logic

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -513,7 +513,7 @@ describe('WorkflowPublicationApplier', () => {
 		);
 	});
 
-	test('returns partial when no trigger activated but the failures are not all deterministic', async () => {
+	test('returns failed when nothing activated even if a failure is transient', async () => {
 		setTriggerSets([], [triggerNode('b'), triggerNode('c')]);
 		const deterministic = new WebhookPathTakenError('b');
 		const transient = new Error('third-party unavailable');
@@ -525,13 +525,42 @@ describe('WorkflowPublicationApplier', () => {
 
 		const result = await applier.apply(makeRecord());
 
+		// Nothing is running, so the publication failed; the combined error names both nodes.
 		expect(result).toEqual({
-			type: 'partial',
+			type: 'failed',
+			error: expect.objectContaining({
+				message: `Triggers failed to activate: "b": ${deterministic.message}; "c": third-party unavailable`,
+			}),
 			triggerStatuses: [
 				{ nodeId: 'b', nodeName: 'b', status: 'failed', errorMessage: deterministic.message },
 				{ nodeId: 'c', nodeName: 'c', status: 'failed', errorMessage: 'third-party unavailable' },
 			],
 		});
+	});
+
+	test('returns partial when a newly-added trigger fails but an unchanged trigger keeps running', async () => {
+		// `a` is unchanged (old ∩ desired) and stays running; only `b` is added and fails.
+		setTriggerSets([triggerNode('a')], [triggerNode('a'), triggerNode('b')]);
+		const error = new WebhookPathTakenError('b');
+		workflowTriggerActivator.activate.mockResolvedValue({
+			// `a` is unchanged, so it never appears in the activation outcome.
+			activated: [],
+			failures: [{ nodeId: 'b', nodeName: 'b', error }],
+		});
+
+		const result = await applier.apply(makeRecord());
+
+		expect(result).toEqual({
+			type: 'partial',
+			triggerStatuses: [
+				{ nodeId: 'a', nodeName: 'a', status: 'activated' },
+				{ nodeId: 'b', nodeName: 'b', status: 'failed', errorMessage: error.message },
+			],
+		});
+		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
+			'wf-1',
+			'v-2',
+		);
 	});
 
 	test('treats a first publication (no published-version mapping yet) as all-added', async () => {

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -16,7 +16,6 @@ import type {
 	TriggerPublicationStatus,
 } from '@/workflows/publication/publication-result';
 import { computeTriggerDiff } from '@/workflows/publication/trigger-diff';
-import { isTransientActivationError } from '@/workflows/triggers/trigger-activation-retry';
 import {
 	WorkflowTriggerActivator,
 	type TriggerActivationFailure,
@@ -217,8 +216,11 @@ export class WorkflowPublicationApplier {
 		const triggerStatuses = this.buildTriggerStatuses(desiredTriggerNodes, outcome);
 		if (outcome.failures.length === 0) return { type: 'completed', triggerStatuses };
 
-		const allDeterministic = outcome.failures.every((f) => !isTransientActivationError(f.error));
-		if (outcome.activated.length === 0 && allDeterministic) {
+		// No desired trigger running — including unchanged triggers left in place, which
+		// `outcome.activated` (only the newly-added nodes) omits — means the publication
+		// failed outright. Otherwise some triggers run and some failed: partial.
+		const hasRunningTrigger = triggerStatuses.some((s) => s.status === 'activated');
+		if (!hasRunningTrigger) {
 			return { type: 'failed', error: this.toActivationError(outcome.failures), triggerStatuses };
 		}
 


### PR DESCRIPTION
## Summary

Fixes the logic for determining when a workflow publication should be marked as `failed` vs `partial`. Previously, the code incorrectly checked if all failures were deterministic errors to decide failure status. This has been replaced with a simpler, more correct approach: if no triggers are running (including unchanged triggers that remain in place), the publication failed; otherwise it's partial.

The key insight is that `outcome.activated` only contains newly-added triggers, so we must check all trigger statuses to determine if any trigger is actually running.

## Changes

- **workflow-publication-applier.ts**: Removed the `isTransientActivationError` check and replaced it with a direct check of whether any trigger has `status === 'activated'` in the final trigger statuses
- **workflow-publication-applier.test.ts**: Updated test expectations to match the corrected behavior and added a new test case for the partial publication scenario (newly-added trigger fails while unchanged trigger keeps running)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->