### PR TITLE
fix(core): Prevent Code node failure when a workflow contains an AI tool

### DIFF
--- a/packages/cli/src/__tests__/node-types.test.ts
+++ b/packages/cli/src/__tests__/node-types.test.ts
@@ -84,6 +84,62 @@ describe('NodeTypes', () => {
 			supplyData: undefined,
 		},
 	};
+	// Plain object, not a mock proxy: a proxy hides the prototype/serialization
+	// behavior that the synthetic-tool test needs to exercise.
+	const plainToolSupportingNode: LoadedClass<INodeType> = {
+		sourcePath: '',
+		type: {
+			description: {
+				name: 'n8n-nodes-base.plainToolNode',
+				displayName: 'Plain Tool Node',
+				description: 'A plain tool node',
+				group: ['transform'],
+				version: 1,
+				defaults: { name: 'Plain Tool Node' },
+				usableAsTool: true,
+				properties: [{ displayName: 'Field', name: 'field', type: 'string', default: '' }],
+			} as unknown as INodeTypeDescription,
+			supplyData: undefined,
+		},
+	};
+	const hitlSupportingNode: LoadedClass<INodeType> = {
+		sourcePath: '',
+		type: {
+			description: {
+				name: 'n8n-nodes-base.hitlNode',
+				displayName: 'Hitl Node',
+				version: 1,
+				properties: [{ displayName: 'Operation', name: 'operation', type: 'string', default: '' }],
+			} as unknown as INodeTypeDescription,
+			supplyData: undefined,
+		},
+	};
+	const realToolNode: LoadedClass<INodeType> = {
+		sourcePath: '',
+		type: {
+			description: {
+				name: 'n8n-nodes-base.realTool',
+				displayName: 'Real Tool',
+				version: 1,
+				properties: [],
+			} as unknown as INodeTypeDescription,
+			supplyData: undefined,
+		},
+	};
+	const replacementToolNode: LoadedClass<INodeType> = {
+		sourcePath: '',
+		type: {
+			description: {
+				name: 'n8n-nodes-base.replacementToolNode',
+				displayName: 'Replacement Tool Node',
+				description: 'Original description',
+				version: 1,
+				usableAsTool: { replacements: { description: 'Replaced via replacements' } },
+				properties: [],
+			} as unknown as INodeTypeDescription,
+			supplyData: undefined,
+		},
+	};
 	const communityNode: LoadedClass<INodeType> = {
 		sourcePath: '',
 		type: {
@@ -105,9 +161,17 @@ describe('NodeTypes', () => {
 			if (nodeType === 'testNode') return toolSupportingNode;
 			if (nodeType === 'declarativeNode') return declarativeNode;
 			if (nodeType === 'toolNode') return toolNode;
+			if (nodeType === 'plainToolNode') return plainToolSupportingNode;
+			if (nodeType === 'hitlNode') return hitlSupportingNode;
+			if (nodeType === 'realTool') return realToolNode;
+			if (nodeType === 'replacementToolNode') return replacementToolNode;
 		} else if (fullNodeType === 'n8n-nodes-community.testNode') return communityNode;
 		throw new UnrecognizedNodeTypeError(packageName, nodeType);
 	});
+
+	loadNodesAndCredentials.recognizesNode.mockImplementation(
+		(name) => name === 'n8n-nodes-base.realTool',
+	);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -240,6 +304,48 @@ describe('NodeTypes', () => {
 			expect(() =>
 				nodeTypes.getNodeTypeDescriptions([{ name: 'n8n-nodes-base.nonExistent', version: 1 }]),
 			).toThrow('Unrecognized node type: n8n-nodes-base.nonExistent');
+		});
+
+		it('should resolve a synthetic tool node type into a complete, serializable description', () => {
+			const [result] = nodeTypes.getNodeTypeDescriptions([
+				{ name: 'n8n-nodes-base.plainToolNodeTool', version: 1 },
+			]);
+
+			expect(result.name).toBe('n8n-nodes-base.plainToolNodeTool');
+			expect(result.outputs).toEqual(['ai_tool']);
+			// Base fields must survive: the runner can't build the node without them.
+			expect(result.version).toBe(1);
+			expect(result.group).toEqual(['transform']);
+			expect(Array.isArray(result.properties)).toBe(true);
+			expect(result.properties.some((p) => p.name === 'field')).toBe(true);
+		});
+
+		it('should resolve a synthetic HITL tool node type', () => {
+			const [result] = nodeTypes.getNodeTypeDescriptions([
+				{ name: 'n8n-nodes-base.hitlNodeHitlTool', version: 1 },
+			]);
+
+			expect(result.name).toBe('n8n-nodes-base.hitlNodeHitlTool');
+			expect(result.version).toBe(1);
+			expect(Array.isArray(result.properties)).toBe(true);
+		});
+
+		it('should apply object-form usableAsTool replacements when building a synthetic tool', () => {
+			const [result] = nodeTypes.getNodeTypeDescriptions([
+				{ name: 'n8n-nodes-base.replacementToolNodeTool', version: 1 },
+			]);
+
+			expect(result.name).toBe('n8n-nodes-base.replacementToolNodeTool');
+			expect(result.description).toBe('Replaced via replacements');
+		});
+
+		it('should not convert a real on-disk node whose type ends in Tool', () => {
+			const [result] = nodeTypes.getNodeTypeDescriptions([
+				{ name: 'n8n-nodes-base.realTool', version: 1 },
+			]);
+
+			expect(result.name).toBe('n8n-nodes-base.realTool');
+			expect(result.outputs).toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/node-types.ts
+++ b/packages/cli/src/node-types.ts
@@ -5,12 +5,15 @@ import { readdir, readFile } from 'fs/promises';
 import { RoutingNode } from 'n8n-core';
 import type { ExecuteContext } from 'n8n-core';
 import type { INodeType, INodeTypeDescription, INodeTypes, IVersionedNodeType } from 'n8n-workflow';
-import { NodeHelpers, UnexpectedError, UserError } from 'n8n-workflow';
+import { deepCopy, NodeHelpers, UnexpectedError, UserError } from 'n8n-workflow';
 import { join, dirname } from 'path';
 
 import { LoadNodesAndCredentials } from './load-nodes-and-credentials';
 import { convertNodeToAiTool, convertNodeToHitlTool } from './tool-generation';
 import { shouldAssignExecuteMethod } from './utils';
+
+const stripToolSuffix = (nodeType: string) =>
+	nodeType.replace(/HitlTool$/, '').replace(/Tool$/, '');
 
 @Service()
 export class NodeTypes implements INodeTypes {
@@ -74,9 +77,8 @@ export class NodeTypes implements INodeTypes {
 		}
 
 		// Make sure the nodeType to actually get from disk is the un-wrapped type
-		// Handle both regular Tool suffix and HitlTool suffix
 		if (toolRequested) {
-			nodeType = nodeType.replace(/HitlTool$/, '').replace(/Tool$/, '');
+			nodeType = stripToolSuffix(nodeType);
 		}
 
 		const node = this.loadNodesAndCredentials.getNode(nodeType);
@@ -173,10 +175,16 @@ export class NodeTypes implements INodeTypes {
 
 	getNodeTypeDescriptions(nodeTypes: NeededNodeType[]): INodeTypeDescription[] {
 		return nodeTypes.map(({ name: nodeTypeName, version: nodeTypeVersion }) => {
-			const nodeType = this.loadNodesAndCredentials.getNode(nodeTypeName);
+			const isSyntheticTool =
+				nodeTypeName.endsWith('Tool') && !this.loadNodesAndCredentials.recognizesNode(nodeTypeName);
+			const baseName = isSyntheticTool ? stripToolSuffix(nodeTypeName) : nodeTypeName;
+
+			const nodeType = this.loadNodesAndCredentials.getNode(baseName);
 			const { description } = NodeHelpers.getVersionedNodeType(nodeType.type, nodeTypeVersion);
 
-			const descriptionCopy = { ...description };
+			const descriptionCopy = isSyntheticTool
+				? this.buildSyntheticToolDescription(nodeTypeName, description)
+				: { ...description };
 
 			// TODO: do we still need this?
 			descriptionCopy.name = descriptionCopy.name.startsWith('n8n-nodes')
@@ -185,5 +193,26 @@ export class NodeTypes implements INodeTypes {
 
 			return descriptionCopy;
 		});
+	}
+
+	/**
+	 * Rebuilds a synthetic tool's description from a plain copy of its base node.
+	 * `getByNameAndVersion` returns a prototype-backed tool type whose fields are
+	 * lost when the description is serialized to the task runner, so we can't reuse it.
+	 */
+	private buildSyntheticToolDescription(
+		nodeTypeName: string,
+		description: INodeTypeDescription,
+	): INodeTypeDescription {
+		if (nodeTypeName.endsWith('HitlTool')) {
+			return convertNodeToHitlTool({ description: deepCopy(description) }).description;
+		}
+
+		// Object-form `usableAsTool` carries replacements to apply before conversion
+		const base =
+			typeof description.usableAsTool === 'object'
+				? { ...deepCopy(description), ...description.usableAsTool?.replacements }
+				: deepCopy(description);
+		return convertNodeToAiTool({ description: base }).description;
 	}
 }


### PR DESCRIPTION
## Summary

A Code node failed to execute with `UnrecognizedNodeTypeError` whenever **both** of these were true:

1. The Code node's JS forced **all-nodes resolution** — e.g. `$('Node').item` / `.pairedItem` / `.itemMatching`, `$node`, `$item`, bare `$('Node')`, or `$(variable)`.
2. The workflow contained a node with a **synthetic AI-tool type** — any `nodes-base` node flagged `usableAsTool` placed as a tool (e.g. `n8n-nodes-base.dataTableTool`). Connection to an agent is irrelevant; the task runner enumerates all `workflow.nodes`.

**Root cause:** when the JS task runner needs all nodes, it requests node-type descriptions for every node via `NodeTypes.getNodeTypeDescriptions()`. That method called `loadNodesAndCredentials.getNode()` with the raw `…Tool` name. Synthetic tool types are generated by `createAiTools()`/`createHitlTools()` and registered only in the aggregate `known.nodes`, not in any per-package loader — so the lookup threw, failing the whole execution.

**Fix:** `getNodeTypeDescriptions()` now detects synthetic `…Tool`/`…HitlTool` types, resolves the base node, and rebuilds the tool description from a plain `deepCopy` via `convertNodeToAiTool`/`convertNodeToHitlTool` (mirroring `createAiTools`/`createHitlTools`, including object-form `usableAsTool.replacements`). This yields a complete, serializable description for the runner. Real on-disk nodes whose type ends in `Tool` continue to take the regular path, and the non-tool path is unchanged. The suffix-strip logic shared with `getByNameAndVersion` was extracted into a small helper.

## How to test

Import the following workflow:

[NODE-5354 repro + sanity checks.json](https://github.com/user-attachments/files/29538824/NODE-5354.repro.%2B.sanity.checks.json)

Before the fix: 
* A will fail/timeout
* B & C will pass
* If you remove the Data table node: A will pass again

After the fix: All pass

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5354

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->