### PR TITLE
fix(Basic LLM Chain Node): Prevent "Failed to parse agent steps" error

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts
@@ -147,7 +147,7 @@ export async function createPromptTemplate({
 }
 
 const isMessage = (message: unknown): message is BaseMessage => {
-	return message instanceof BaseMessage;
+	return BaseMessage.isInstance(message);
 };
 
 const isAgentFinish = (value: unknown): value is AgentFinish => {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
@@ -331,7 +331,7 @@ describe('promptUtils', () => {
 				type: 'human',
 				content: 'Cross-module text content',
 				get text() {
-					return this.content;
+					return (this as { content: string }).content;
 				},
 			} as unknown as BaseMessage;
 

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
@@ -1,5 +1,5 @@
 import type { AgentAction, AgentFinish } from '@langchain/core/agents';
-import { HumanMessage } from '@langchain/core/messages';
+import { BaseMessage, HumanMessage } from '@langchain/core/messages';
 import { ChatPromptTemplate, PromptTemplate } from '@langchain/core/prompts';
 import { FakeLLM, FakeChatModel } from '@langchain/core/utils/testing';
 import type { IExecuteFunctions } from 'n8n-workflow';
@@ -321,6 +321,28 @@ describe('promptUtils', () => {
 			const result = await parser(message);
 
 			expect(mockOutputParser.parse).toHaveBeenCalledWith('Simple text content');
+			expect(result).toEqual(parsedResult);
+		});
+
+		it('should parse BaseMessage from a different module instance', async () => {
+			const parser = getAgentStepsParser(mockOutputParser);
+			const message = {
+				[Symbol.for('langchain.message')]: true,
+				type: 'human',
+				content: 'Cross-module text content',
+				get text() {
+					return this.content;
+				},
+			} as unknown as BaseMessage;
+
+			const parsedResult = { content: 'Cross-module text content' };
+			mockOutputParser.parse.mockResolvedValue(parsedResult);
+
+			const result = await parser(message);
+
+			expect(message).not.toBeInstanceOf(BaseMessage);
+			expect(BaseMessage.isInstance(message)).toBe(true);
+			expect(mockOutputParser.parse).toHaveBeenCalledWith('Cross-module text content');
 			expect(result).toEqual(parsedResult);
 		});
 


### PR DESCRIPTION
## Summary

This PR fixes an issue when basic llm chain would fail with any chat model when using output parser. The issue is reproducible only in production docker images semi-randomly from build to build. The reason it happens is likely because `@langchain/core` is used both as ESM and CJS module which leads to Node.js loading two instances of the same package which breaks `instanceof BaseMessage`. This fix replaces it with `BaseMessage.isInstance` which relies on symbol checks.

## How to test

1. Run `pnpm build:docker`
2. Start dockerized n8n
3. Use this [workflow from linear to test](https://linear.app/n8n/issue/NODE-5347/basic-llm-chain-failed-to-parse-agent-steps). Doesn't need to be azure openai specifically

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5347/basic-llm-chain-failed-to-parse-agent-steps

closes #29903 


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33338">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->