### PR TITLE
fix(core): Acquire expression isolate when reconciling unregistered webhooks during publication (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -167,6 +167,54 @@ describe('WorkflowTriggerActivator', () => {
 			);
 		});
 
+		test('brackets the registrar call with an acquired isolate so path expressions resolve', async () => {
+			const callOrder: string[] = [];
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
+				callOrder.push('acquire');
+			});
+			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
+				callOrder.push('release');
+			});
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
+				mock<IWorkflowExecuteAdditionalData>(),
+			);
+			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
+			webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks.mockImplementation(async () => {
+				callOrder.push('resolve');
+				return new Set(['w']);
+			});
+			const activator = buildActivator({ webhookTriggerRegistrar });
+
+			await activator.getNodesWithUnregisteredWebhooks(
+				mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
+				{ nodes: [node('w', 'webhook')], connections: {} },
+			);
+
+			expect(callOrder).toEqual(['acquire', 'resolve', 'release']);
+		});
+
+		test('releases the isolate when the registrar throws', async () => {
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
+				mock<IWorkflowExecuteAdditionalData>(),
+			);
+			const releaseIsolate = vi
+				.spyOn(WorkflowExpression.prototype, 'releaseIsolate')
+				.mockResolvedValue(undefined);
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
+			webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks.mockRejectedValue(new Error('boom'));
+			const activator = buildActivator({ webhookTriggerRegistrar });
+
+			await expect(
+				activator.getNodesWithUnregisteredWebhooks(
+					mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
+					{ nodes: [node('w', 'webhook')], connections: {} },
+				),
+			).rejects.toThrow('boom');
+
+			expect(releaseIsolate).toHaveBeenCalledTimes(1);
+		});
+
 		test('returns empty without calling the registrar when there are no trigger nodes', async () => {
 			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
 			const activator = buildActivator({ webhookTriggerRegistrar });

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -155,11 +155,18 @@ export class WorkflowTriggerActivator {
 			workflowSettings: dbWorkflow.settings,
 		});
 
-		return await this.webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks(
-			workflow,
-			additionalData,
-			desiredNodes,
-		);
+		// Resolving webhook triggers evaluates each node's `path`/`httpMethod`
+		// expressions (e.g. the Form Trigger's dynamic path), which needs an isolate.
+		await workflow.expression.acquireIsolate();
+		try {
+			return await this.webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				desiredNodes,
+			);
+		} finally {
+			await workflow.expression.releaseIsolate();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Workflow publication was failing with `Unexpected: No bridge acquired for this context. Call acquire() first.` for workflows whose trigger resolves a webhook path via an expression (e.g. the Form Trigger, whose path is `={{ $parameter["path"] || $parameter["options"]?.path || $webhookId }}`).

On the publication path, `WorkflowTriggerActivator.getNodesWithUnregisteredWebhooks()` resolves each desired webhook trigger's `path`/`httpMethod`/`isFullPath` via `getWorkflowWebhooks` → `getNodeWebhooks` → `expression.getSimpleParameterValue`, which needs an expression isolate. Every other expression-resolving step in publication (`activate`, `deregisterWebhookTriggers`, `updateTriggerCount`) brackets its work in `acquireIsolate`/`releaseIsolate`, but this reconciliation step — run on *every* `publish()` before any trigger changes — did not, so it threw before the isolate was ever acquired.

The fix wraps the registrar call in `acquireIsolate`/`releaseIsolate` (with a `finally` release), matching the surrounding code.

## How to test

Publish (activate) a workflow whose trigger has an expression-based webhook path, e.g. a Form Trigger, via the workflow publication service. Before the fix this fails with the "No bridge acquired" error; after it, activation succeeds.

Added unit tests asserting the registrar call is bracketed by an acquired isolate and that the isolate is released even when the registrar throws.

## Related Linear tickets

https://linear.app/n8n/issue/CAT-3636


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

