### PR TITLE
fix(ai-builder): Prevent snapshot staging races during concurrent sandbox creation

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
@@ -38,7 +38,9 @@ describe('snapshot-image-context', () => {
 		).resolves.toBe('# Schedule');
 	});
 
-	it('reuses a hash-keyed staging directory for the same cache key', async () => {
+	it('stages once per cache key and reuses the directory read-only', async () => {
+		// Same cache key ⇒ same content in production (key is the n8n version or a
+		// content hash), so a repeat call reuses the first staging without re-writing.
 		const filesA = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"a"}']]);
 		const filesB = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"b"}']]);
 		const cacheKey = 'aaaaaaaaaaaa-bbbbbbbbbbbb';
@@ -49,24 +51,37 @@ describe('snapshot-image-context', () => {
 
 		expect(second.stagingDir).toBe(first.stagingDir);
 		await expect(readFile(join(first.stagingDir, 'package.json'), 'utf-8')).resolves.toBe(
-			'{"name":"b"}',
+			'{"name":"a"}',
 		);
 	});
 
-	it('removes stale files when reusing a cache-keyed staging directory', async () => {
+	it('serves concurrent stagings for the same cache key from a single directory', async () => {
 		const cacheKey = 'cccccccccccc-dddddddddddd';
-		const filesWithExtra = new Map([
-			[`${WORKSPACE_ROOT}/package.json`, '{"name":"a"}'],
-			[`${WORKSPACE_ROOT}/skills/removed/SKILL.md`, '# Removed'],
+		const files = new Map([
+			[`${WORKSPACE_ROOT}/package.json`, '{"name":"concurrent"}'],
+			[`${WORKSPACE_ROOT}/skills/post-build-flow/SKILL.md`, '# Post build'],
+			[`${WORKSPACE_ROOT}/knowledge-base/templates/example.ts`, 'export const x = 1;'],
 		]);
-		const filesWithoutExtra = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"b"}']]);
 
-		const first = await stageWorkspaceFilesForImage(filesWithExtra, WORKSPACE_ROOT, cacheKey);
-		const second = await stageWorkspaceFilesForImage(filesWithoutExtra, WORKSPACE_ROOT, cacheKey);
-		tempDirs.push(first.stagingDir);
+		const results = await Promise.all(
+			Array.from(
+				{ length: 8 },
+				async () => await stageWorkspaceFilesForImage(files, WORKSPACE_ROOT, cacheKey),
+			),
+		);
+		tempDirs.push(results[0].stagingDir);
 
-		expect(second.stagingDir).toBe(first.stagingDir);
-		await expect(access(join(first.stagingDir, 'skills/removed/SKILL.md'))).rejects.toThrow();
+		// All callers resolve to the same directory, and every staged file is intact —
+		// no caller's rm clobbered another's write.
+		for (const result of results) {
+			expect(result.stagingDir).toBe(results[0].stagingDir);
+		}
+		await expect(
+			readFile(join(results[0].stagingDir, 'skills/post-build-flow/SKILL.md'), 'utf-8'),
+		).resolves.toBe('# Post build');
+		await expect(
+			readFile(join(results[0].stagingDir, 'knowledge-base/templates/example.ts'), 'utf-8'),
+		).resolves.toBe('export const x = 1;');
 	});
 
 	it('disposeSnapshotImageContext removes the staging directory', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
@@ -39,8 +39,7 @@ describe('snapshot-image-context', () => {
 	});
 
 	it('stages once per cache key and reuses the directory read-only', async () => {
-		// Same cache key ⇒ same content in production (key is the n8n version or a
-		// content hash), so a repeat call reuses the first staging without re-writing.
+		// Same key ⇒ same content in prod, so the repeat reuses the first staging (filesB ignored).
 		const filesA = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"a"}']]);
 		const filesB = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"b"}']]);
 		const cacheKey = 'aaaaaaaaaaaa-bbbbbbbbbbbb';
@@ -71,8 +70,7 @@ describe('snapshot-image-context', () => {
 		);
 		tempDirs.push(results[0].stagingDir);
 
-		// All callers resolve to the same directory, and every staged file is intact —
-		// no caller's rm clobbered another's write.
+		// All callers share one directory and every file is intact — no rm clobbered a write.
 		for (const result of results) {
 			expect(result.stagingDir).toBe(results[0].stagingDir);
 		}

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
@@ -8,6 +8,17 @@ export interface SnapshotImageContext {
 	stagingDir: string;
 }
 
+/**
+ * Concurrent sandbox creations for the same n8n version stage identical files
+ * (`cacheKey` is the n8n version or a content hash, so same key ⇒ same content).
+ * Dedupe by key so the destructive `rm`+`mkdir`+`writeFile` runs exactly once per
+ * key per process; concurrent and subsequent callers await it and reuse the same
+ * directory read-only. Without this, overlapping stagings raced on the shared path
+ * — one caller's recursive `rm` deleting files another was writing (ENOTEMPTY) or
+ * that Daytona was still reading for `addLocalDir` (ENOENT).
+ */
+const stagingByCacheKey = new Map<string, Promise<SnapshotImageContext>>();
+
 function workspaceRelativePath(filePath: string, workspaceRoot: string): string {
 	const root = workspaceRoot.endsWith('/') ? workspaceRoot : `${workspaceRoot}/`;
 
@@ -20,35 +31,53 @@ function workspaceRelativePath(filePath: string, workspaceRoot: string): string 
 	return filePath.slice(root.length);
 }
 
-/**
- * Writes sandbox workspace files to a host directory for Daytona `addLocalDir` / COPY.
- * When `cacheKey` is set, reuses `os.tmpdir()/n8n-snapshot-context-<cacheKey>` so repeated
- * image builds do not accumulate temp directories.
- */
-export async function stageWorkspaceFilesForImage(
+async function writeStagedFiles(
+	stagingDir: string,
 	files: Map<string, string>,
 	workspaceRoot: string,
-	cacheKey?: string,
-): Promise<SnapshotImageContext> {
-	let stagingDir: string;
-
-	if (cacheKey) {
-		stagingDir = join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}${cacheKey}`);
-
-		await rm(stagingDir, { recursive: true, force: true });
-		await mkdir(stagingDir, { recursive: true });
-	} else {
-		stagingDir = await mkdtemp(join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}temp-`));
-	}
-
+): Promise<void> {
 	for (const [filePath, content] of files) {
 		const targetPath = join(stagingDir, workspaceRelativePath(filePath, workspaceRoot));
 
 		await mkdir(dirname(targetPath), { recursive: true });
 		await writeFile(targetPath, content, 'utf-8');
 	}
+}
 
-	return { stagingDir };
+/**
+ * Writes sandbox workspace files to a host directory for Daytona `addLocalDir` / COPY.
+ * When `cacheKey` is set, reuses `os.tmpdir()/n8n-snapshot-context-<cacheKey>` and stages
+ * the files exactly once per key per process (see `stagingByCacheKey`), so repeated and
+ * concurrent image builds share one read-only directory instead of racing rm/write on it.
+ */
+export async function stageWorkspaceFilesForImage(
+	files: Map<string, string>,
+	workspaceRoot: string,
+	cacheKey?: string,
+): Promise<SnapshotImageContext> {
+	if (!cacheKey) {
+		const stagingDir = await mkdtemp(join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}temp-`));
+		await writeStagedFiles(stagingDir, files, workspaceRoot);
+		return { stagingDir };
+	}
+
+	const inFlightOrDone = stagingByCacheKey.get(cacheKey);
+	if (inFlightOrDone) return await inFlightOrDone;
+
+	const staging = (async () => {
+		const stagingDir = join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}${cacheKey}`);
+		await rm(stagingDir, { recursive: true, force: true });
+		await mkdir(stagingDir, { recursive: true });
+		await writeStagedFiles(stagingDir, files, workspaceRoot);
+		return { stagingDir };
+	})().catch((error) => {
+		// Don't leave a rejected promise cached — let the next caller retry from scratch.
+		stagingByCacheKey.delete(cacheKey);
+		throw error;
+	});
+
+	stagingByCacheKey.set(cacheKey, staging);
+	return await staging;
 }
 
 export async function disposeSnapshotImageContext(stagingDir: string): Promise<void> {

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
@@ -9,13 +9,9 @@ export interface SnapshotImageContext {
 }
 
 /**
- * Concurrent sandbox creations for the same n8n version stage identical files
- * (`cacheKey` is the n8n version or a content hash, so same key ⇒ same content).
- * Dedupe by key so the destructive `rm`+`mkdir`+`writeFile` runs exactly once per
- * key per process; concurrent and subsequent callers await it and reuse the same
- * directory read-only. Without this, overlapping stagings raced on the shared path
- * — one caller's recursive `rm` deleting files another was writing (ENOTEMPTY) or
- * that Daytona was still reading for `addLocalDir` (ENOENT).
+ * Dedupe staging by key: the destructive `rm`+`mkdir`+`writeFile` runs once per
+ * key, and concurrent callers await it and reuse the directory read-only. Same key
+ * ⇒ same content, so reuse both avoids re-writing and prevents rm/write races.
  */
 const stagingByCacheKey = new Map<string, Promise<SnapshotImageContext>>();
 
@@ -46,9 +42,8 @@ async function writeStagedFiles(
 
 /**
  * Writes sandbox workspace files to a host directory for Daytona `addLocalDir` / COPY.
- * When `cacheKey` is set, reuses `os.tmpdir()/n8n-snapshot-context-<cacheKey>` and stages
- * the files exactly once per key per process (see `stagingByCacheKey`), so repeated and
- * concurrent image builds share one read-only directory instead of racing rm/write on it.
+ * With a `cacheKey`, stages into `os.tmpdir()/n8n-snapshot-context-<cacheKey>` once per key
+ * (see `stagingByCacheKey`) so repeated and concurrent builds share one directory.
  */
 export async function stageWorkspaceFilesForImage(
 	files: Map<string, string>,
@@ -71,7 +66,7 @@ export async function stageWorkspaceFilesForImage(
 		await writeStagedFiles(stagingDir, files, workspaceRoot);
 		return { stagingDir };
 	})().catch((error) => {
-		// Don't leave a rejected promise cached — let the next caller retry from scratch.
+		// Evict a rejected staging so the next caller retries.
 		stagingByCacheKey.delete(cacheKey);
 		throw error;
 	});

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -177,10 +177,9 @@ export class SnapshotManager {
 	}
 
 	/**
-	 * Invalidate the in-memory image/bundle caches (e.g., when the base image
-	 * changes). The shared staging directory is owned by the per-key cache in
-	 * `stageWorkspaceFilesForImage` and is intentionally not removed here — doing
-	 * so would delete a directory other in-flight sandbox creations may still read.
+	 * Invalidate the in-memory image/bundle caches. The shared staging dir is owned
+	 * by the per-key cache in `stageWorkspaceFilesForImage` and intentionally not
+	 * removed here (in-flight creations may still be reading it).
 	 */
 	invalidate(): void {
 		this.cachedImage = null;

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -26,7 +26,7 @@ import {
 	builderTemplatesOptionsFromEnv,
 } from './builder-templates-service';
 import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS } from './sandbox-setup';
-import { disposeSnapshotImageContext, stageWorkspaceFilesForImage } from './snapshot-image-context';
+import { stageWorkspaceFilesForImage } from './snapshot-image-context';
 import { buildRuntimeSkillWorkspaceBundle } from '../skills/materialize-runtime-skills';
 import { loadInstanceAiRuntimeSkillSource } from '../skills/runtime-skills';
 
@@ -51,8 +51,6 @@ export class SnapshotManager {
 		null;
 
 	private knowledgeBaseBundlePromise: Promise<KnowledgeBaseWorkspaceBundle> | null = null;
-
-	private stagingDir: string | null = null;
 
 	constructor(
 		private readonly baseImage: string | undefined,
@@ -88,7 +86,6 @@ export class SnapshotManager {
 			DAYTONA_WORKSPACE_ROOT,
 			cacheKey,
 		);
-		this.stagingDir = stagingDir;
 
 		const { Image } = loadDaytona();
 		const layoutDirs = SNAPSHOT_WORKSPACE_LAYOUT_DIRS.map(
@@ -179,15 +176,15 @@ export class SnapshotManager {
 		});
 	}
 
-	/** Invalidate cached image (e.g., when base image changes). */
+	/**
+	 * Invalidate the in-memory image/bundle caches (e.g., when the base image
+	 * changes). The shared staging directory is owned by the per-key cache in
+	 * `stageWorkspaceFilesForImage` and is intentionally not removed here — doing
+	 * so would delete a directory other in-flight sandbox creations may still read.
+	 */
 	invalidate(): void {
-		const stagingDir = this.stagingDir;
 		this.cachedImage = null;
 		this.runtimeSkillBundlePromise = null;
 		this.knowledgeBaseBundlePromise = null;
-		this.stagingDir = null;
-		if (stagingDir) {
-			void disposeSnapshotImageContext(stagingDir);
-		}
 	}
 }


### PR DESCRIPTION
## Summary

Concurrent Instance AI sandbox creations for the same n8n version staged their workspace files (runtime skill bundle, knowledge-base bundle, `package.json`/`tsconfig.json`/`build.mjs`) into a **single shared** `os.tmpdir()/n8n-snapshot-context-<version>` directory, and each call **destructively `rm -rf` + recreated + rewrote** it. When two or more sandbox creations overlapped they raced on that shared path:

- one caller's recursive `rm` deleted files another was mid-`writeFile` on → `ENOTEMPTY: rmdir …/skills/post-build-flow`
- or deleted files Daytona was still reading for `addLocalDir` → `ENOENT: open …/knowledge-base/templates/…ts`

Either error aborted the run (`Instance AI error in instance-ai-run`) and the agent returned **no output** — the user saw an empty response.

### Fix

- Dedupe staging by `cacheKey` in `stageWorkspaceFilesForImage`: the destructive `rm`+`mkdir`+`writeFile` runs **once per key per process**; concurrent and subsequent callers `await` the same promise and reuse the directory **read-only**. A rejected staging is evicted from the cache so the next caller retries. Since `cacheKey` is the n8n version (or a content hash), same key ⇒ same content, so reuse is safe.
- Stop `SnapshotManager.invalidate()` from removing the shared staging dir — it is now owned by the per-key cache, and (per git history) the method has never had a caller, so this is a safe cleanup.

### Scope

Affects **only Daytona sandboxes**, specifically the local image-build (`useSnapshotFallback`) path that stages files for `Image.addLocalDir(...)` — i.e. whenever a Daytona image is built on the host rather than resumed from a prebuilt versioned snapshot (dev, evals, on-the-fly builds). The **n8n-sandbox** provider goes through a different code path and never stages via this function, so it is unaffected. CI's `build-snapshot.cjs` runs single-threaded and never raced.

### Context

Surfaced while running the Instance AI intent-eval suite (#33224) at concurrency 4: roughly one run per full pass returned an empty transcript. The staging code is pre-existing infra, not part of that PR — hence this separate fix.

## How to test

- `cd packages/@n8n/instance-ai && pnpm test src/workspace/` — 160/160 pass, including a new concurrency regression test (`serves concurrent stagings for the same cache key from a single directory`).
- `pnpm typecheck` and `pnpm lint` are clean.
- End-to-end: running the `agents` eval tier at `--concurrency 4 --iterations 3` against a local backend, the `ENOTEMPTY`/`ENOENT` staging errors and empty-transcript failures disappeared (aggregate pass rate 94.3% → 98.5%; 0 staging errors post-fix vs 1–2 per run before).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->