### PR TITLE
fix: Unify Microsoft Service Principal target validation across nodes (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/GenericFunctions.ts
@@ -1,0 +1,73 @@
+import type { INode } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Overridable throw-site copy for {@link validateUserTargetId}. Messages are static
+ * (they never interpolate the id) so a caller only swaps wording — e.g. Outlook uses
+ * "mailbox" phrasing. Defaults to the To Do "target ID" copy.
+ */
+export interface UserTargetMessages {
+	required: { message: string; description: string };
+	dotsOnly: { message: string; description: string };
+	invalid: { message: string; description: string };
+}
+
+// App-only Microsoft Graph has no `/me`, so a user-scoped request is addressed under an
+// explicit `/users/{id}` root. A user is only a user object ID (GUID) or a UPN (has `@`);
+// there is no bare host/domain form. The UPN local part is Entra's documented
+// userPrincipalName set (A-Z a-z 0-9 ' . - _ ! # ^ ~) plus `+`, and covers B2B guest UPNs
+// (`user_contoso.com#EXT#@tenant.onmicrosoft.com`). It excludes `%`, so an encoded-traversal
+// payload like `..%2f..%2fx@y.com` is rejected; for the rest, `encodeURIComponent` makes
+// `#`/`^` path-safe (`%23`/`%5E`) before they reach the URL. Kept module-local (not exported)
+// so this throwing validator stays the single interpolation gate — a caller cannot compose
+// its own check, mis-order it, and interpolate an unvalidated value.
+const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+const USER_TARGET_UPN = /^[A-Za-z0-9._+'!#^~-]+@[A-Za-z0-9.-]+$/;
+
+const DEFAULT_MESSAGES: UserTargetMessages = {
+	required: {
+		message: 'A target ID is required for the Service Principal',
+		description:
+			'Set the User ID under "Access As" — app-only Microsoft Graph has no personal context to default to.',
+	},
+	dotsOnly: {
+		message: 'The target ID is not valid',
+		description: 'A target ID cannot consist only of dots.',
+	},
+	invalid: {
+		message: 'The target ID is not valid',
+		description: 'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
+	},
+};
+
+/**
+ * Validates an app-only user target id before it is encoded and used to compose a Graph
+ * URL. Throws a `NodeOperationError` with a fully static message (never interpolating the
+ * id). The id shape is validated BEFORE encoding — `encodeURIComponent` leaves `..` intact,
+ * so shape validation (not encoding) is what keeps the value safe to interpolate into a
+ * Graph URL path. Order: empty → dots-only → accepted user shapes (GUID / UPN). Callers
+ * trim the id before calling. Pass `messages` to override the throw-site copy (e.g. Outlook
+ * "mailbox" wording); it defaults to the To Do "target ID" copy.
+ */
+export function validateUserTargetId(
+	id: string,
+	node: INode,
+	messages: UserTargetMessages = DEFAULT_MESSAGES,
+): void {
+	if (id === '') {
+		throw new NodeOperationError(node, messages.required.message, {
+			description: messages.required.description,
+		});
+	}
+	if (/^\.+$/.test(id)) {
+		throw new NodeOperationError(node, messages.dotsOnly.message, {
+			description: messages.dotsOnly.description,
+		});
+	}
+	const valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id);
+	if (!valid) {
+		throw new NodeOperationError(node, messages.invalid.message, {
+			description: messages.invalid.description,
+		});
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -94,10 +94,17 @@ const DRIVE_TARGET_ID = /^[A-Za-z0-9!._-]+$/;
  * dots-only → drive-id checks with drive-specific wording.
  */
 export function validateResourceTargetId(target: string, id: string, node: INode): void {
-	// `user` (and any unknown target) validates via the shared user-target validator.
-	if (target !== 'drive') {
+	// The `resourceTarget` param only offers `user` and `drive`. Handle each explicitly and
+	// fail loudly on anything else, so a target added later without updating this validator
+	// can't silently fall through to a user-shape check.
+	if (target === 'user') {
 		validateUserTargetId(id, node);
 		return;
+	}
+	if (target !== 'drive') {
+		throw new NodeOperationError(node, 'The target ID is not valid', {
+			description: 'Unknown target type.',
+		});
 	}
 
 	// Drive target: empty → dots-only → drive-id shape, with drive-specific wording.

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -13,6 +13,8 @@ import {
 	type IPollFunctions,
 } from 'n8n-workflow';
 
+import { validateUserTargetId } from '../GenericFunctions';
+
 /**
  * Characters that OneDrive/SharePoint forbid in file names. Sending any of
  * these breaks Graph's `:/path:/` addressing (a colon collapses the URL to the
@@ -77,24 +79,28 @@ export function getOneDriveCredentialType(
 }
 
 // App-only Microsoft Graph has no `/me`, so the drive is addressed under an
-// explicit user or drive root. The accepted shapes are deliberately narrow and the
-// id shape is validated BEFORE encoding — `encodeURIComponent` leaves `..` intact,
-// so shape validation (not encoding) is what keeps a value safe to interpolate into
-// a Graph URL path. Validation messages are static, so the id is never echoed back.
-const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-const USER_TARGET_UPN = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$/;
-const USER_TARGET_HOST = /^[A-Za-z0-9.-]+$/;
+// explicit user or drive root. The drive-id shape is deliberately narrow and validated
+// BEFORE encoding — `encodeURIComponent` leaves `..` intact, so shape validation (not
+// encoding) is what keeps a value safe to interpolate into a Graph URL path. The user
+// target reuses the shared `validateUserTargetId` (see below).
 const DRIVE_TARGET_ID = /^[A-Za-z0-9!._-]+$/;
 
 /**
  * Validates an app-only `resourceTargetId` for a given target before it is encoded
- * and used to compose a Graph URL. Throws a `NodeOperationError` with a fully
- * static message (never interpolating the id) on a bad shape. The common rejects
- * (empty / whitespace-only / dots-only) are checked FIRST for all targets, then the
- * per-target regex.
+ * and used to compose a Graph URL. Throws a `NodeOperationError` with a fully static
+ * message (never interpolating the id) on a bad shape. The `user` target delegates
+ * entirely to the shared `validateUserTargetId` (default "target ID" wording, widened
+ * Entra UPN set — no bare-host form). The `drive` target keeps its own empty →
+ * dots-only → drive-id checks with drive-specific wording.
  */
 export function validateResourceTargetId(target: string, id: string, node: INode): void {
-	// Common rejects for every target, ordered first.
+	// `user` (and any unknown target) validates via the shared user-target validator.
+	if (target !== 'drive') {
+		validateUserTargetId(id, node);
+		return;
+	}
+
+	// Drive target: empty → dots-only → drive-id shape, with drive-specific wording.
 	if (id === '') {
 		throw new NodeOperationError(node, 'A target ID is required for the Service Principal', {
 			description:
@@ -106,16 +112,7 @@ export function validateResourceTargetId(target: string, id: string, node: INode
 			description: 'A target ID cannot consist only of dots.',
 		});
 	}
-
-	let valid = false;
-	if (target === 'drive') {
-		valid = DRIVE_TARGET_ID.test(id);
-	} else {
-		// user (and any unknown target falls back to the user shape)
-		valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id) || USER_TARGET_HOST.test(id);
-	}
-
-	if (!valid) {
+	if (!DRIVE_TARGET_ID.test(id)) {
 		throw new NodeOperationError(node, 'The target ID is not valid', {
 			description: 'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
 		});
@@ -124,9 +121,11 @@ export function validateResourceTargetId(target: string, id: string, node: INode
 
 /**
  * Builds the `/drive`-free Graph resource root for an app-only request from the
- * chosen target and its id. Reusable kernel (ENT-92+ lifts this) — it deliberately
- * contains NO `/drive` and `encodeURIComponent`s the id. The id shape is validated
- * BEFORE encoding so a malformed id throws (and is not echoed back).
+ * chosen target and its id. It deliberately contains NO `/drive` and
+ * `encodeURIComponent`s the id. The id shape is validated BEFORE encoding so a
+ * malformed id throws (and is not echoed back). ENT-123 lifted only the shared
+ * user-target validator (`Microsoft/GenericFunctions.ts`); this per-node
+ * `getServicePrincipalResourceRoot` stays local because it also handles the drive root.
  */
 export function getServicePrincipalResourceRoot(
 	target: string,

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
@@ -44,6 +44,8 @@ export const userTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
+	// injected into the RLC's value via import/API — the resolved value is validated regardless.
 	noDataExpression: true,
 	modes: [
 		{
@@ -69,6 +71,8 @@ export const driveTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
+	// injected into the RLC's value via import/API — the resolved value is validated regardless.
 	noDataExpression: true,
 	modes: [
 		{

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
@@ -44,9 +44,8 @@ export const userTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
-	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
-	// injected into the RLC's value via import/API — the resolved value is validated regardless.
-	noDataExpression: true,
+	// Resolved once per run (from the first item) and reused for every item, so it accepts a fixed
+	// value or an expression; for per-item targeting, feed a single item or use Loop Over Items.
 	modes: [
 		{
 			displayName: 'By ID',
@@ -56,7 +55,8 @@ export const userTargetRLC: INodeProperties = {
 			hint: 'The user principal name (UPN) or object ID of the user whose OneDrive to use',
 		},
 	],
-	description: 'The user whose OneDrive the Service Principal should act on',
+	description:
+		'The user whose OneDrive the Service Principal should act on. Applies to the whole node (every item in the execution).',
 	displayOptions: {
 		show: {
 			authentication: ['microsoftEntraServicePrincipalApi'],
@@ -71,9 +71,8 @@ export const driveTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
-	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
-	// injected into the RLC's value via import/API — the resolved value is validated regardless.
-	noDataExpression: true,
+	// Resolved once per run (from the first item) and reused for every item, so it accepts a fixed
+	// value or an expression; for per-item targeting, feed a single item or use Loop Over Items.
 	modes: [
 		{
 			displayName: 'By ID',
@@ -83,7 +82,8 @@ export const driveTargetRLC: INodeProperties = {
 			hint: "The drive's own ID (looks like `b!…`), not a file or folder ID. Get it from `GET /users/{upn}/drive` (the `id` field).",
 		},
 	],
-	description: 'The drive the Service Principal should act on',
+	description:
+		'The drive the Service Principal should act on. Applies to the whole node (every item in the execution).',
 	displayOptions: {
 		show: {
 			authentication: ['microsoftEntraServicePrincipalApi'],

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/descriptions/TargetDescription.ts
@@ -44,6 +44,7 @@ export const userTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	noDataExpression: true,
 	modes: [
 		{
 			displayName: 'By ID',
@@ -68,6 +69,7 @@ export const driveTargetRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	noDataExpression: true,
 	modes: [
 		{
 			displayName: 'By ID',

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -4,6 +4,7 @@ import type {
 	INode,
 	IPollFunctions,
 	IWorkflowMetadata,
+	NodeOperationError,
 	NodeParameterValueType,
 } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
@@ -505,9 +506,11 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 		});
 
 		it('coerces a non-string id robustly via String(rawId ?? "") and stringifies it into the root', () => {
-			// a number id (e.g. a poll fallback) must be coerced, validated, and used
-			expect(getServicePrincipalResourceRoot('user', 12345 as unknown as string, mockNode)).toBe(
-				'/users/12345',
+			// A number id (e.g. a poll fallback) must be coerced, validated, and used. Asserted
+			// on the drive target: a bare numeric label is a legal drive id but not a valid user
+			// id (the user branch requires a GUID or UPN), so this isolates the coercion behavior.
+			expect(getServicePrincipalResourceRoot('drive', 12345 as unknown as string, mockNode)).toBe(
+				'/drives/12345',
 			);
 		});
 	});
@@ -553,12 +556,72 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 			).not.toThrow();
 		});
 
+		it('accepts the widened Entra UPN set (! ^ ~ #) and a B2B guest (#EXT#) UPN for the user target', () => {
+			expect(() => validateResourceTargetId('user', 'o!brien@contoso.com', mockNode)).not.toThrow();
+			expect(() =>
+				validateResourceTargetId('user', 'joe^smith@contoso.com', mockNode),
+			).not.toThrow();
+			expect(() =>
+				validateResourceTargetId('user', 'jane~doe@contoso.com', mockNode),
+			).not.toThrow();
+			expect(() => validateResourceTargetId('user', 'a#b@contoso.com', mockNode)).not.toThrow();
+			expect(() =>
+				validateResourceTargetId('user', 'user_contoso.com#EXT#@tenant.onmicrosoft.com', mockNode),
+			).not.toThrow();
+		});
+
+		it('rejects a bare host / bare label / legal-but-user-invalid host for the user target (bare-host branch is gone)', () => {
+			// The dropped USER_TARGET_HOST regex once accepted these for the user target;
+			// none forms a valid /users/{id}, so all three must now reject.
+			expect(() => validateResourceTargetId('user', 'contoso.com', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+			expect(() => validateResourceTargetId('user', 'jane', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+			expect(() => validateResourceTargetId('user', 'sub.contoso.co.uk', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+		});
+
+		it('rejects an encoded-traversal UPN for the user target (% is not a legal UPN char)', () => {
+			expect(() => validateResourceTargetId('user', '..%2f..%2fx@y.com', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+		});
+
 		it('rejects a drive-shaped id ("b!abc") as a user (the "!" is not a valid user id)', () => {
 			expect(() => validateResourceTargetId('user', 'b!abc', mockNode)).toThrow();
 		});
 
 		it('accepts a drive id containing "!"', () => {
 			expect(() => validateResourceTargetId('drive', 'b!abc-123_XYZ', mockNode)).not.toThrow();
+		});
+
+		it('reports the shared "user"-branch empty message (delegates to the shared validator)', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateResourceTargetId('user', '', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('A target ID is required for the Service Principal');
+			expect(caught?.description).toBe(
+				'Set the User ID under "Access As" — app-only Microsoft Graph has no personal context to default to.',
+			);
+		});
+
+		it('keeps the drive-branch empty message unchanged (mentions the personal drive)', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateResourceTargetId('drive', '', mockNode);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('A target ID is required for the Service Principal');
+			expect(caught?.description).toBe(
+				'Set the User or Drive ID under "Access As" — app-only Microsoft Graph has no personal drive to default to.',
+			);
 		});
 
 		it('throws a static message that never echoes the rejected id', () => {
@@ -609,6 +672,56 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 				}),
 			);
 			expect(mockRequestOAuth2).not.toHaveBeenCalled();
+		});
+
+		it('carries a B2B guest (#EXT#) UPN end-to-end into an encoded /users/{id}/drive uri', async () => {
+			const scopeRoot = getServicePrincipalResourceRoot(
+				'user',
+				'user_contoso.com#EXT#@tenant.onmicrosoft.com',
+				mockNode,
+			);
+
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/drive/items/x',
+				{},
+				{},
+				undefined,
+				{},
+				{ json: true },
+				scopeRoot,
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com/drive/items/x',
+				}),
+			);
+		});
+
+		it('carries a "^"/"!" UPN end-to-end into an encoded /users/{id}/drive uri', async () => {
+			const scopeRoot = getServicePrincipalResourceRoot('user', 'joe^smith@contoso.com', mockNode);
+
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/drive/items/x',
+				{},
+				{},
+				undefined,
+				{},
+				{ json: true },
+				scopeRoot,
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/users/joe%5Esmith%40contoso.com/drive/items/x',
+				}),
+			);
 		});
 
 		it('roots a drive request as /drives/{id}/items/x with no double /drive', async () => {

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -590,6 +590,14 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 			);
 		});
 
+		it('throws for an unexpected target type instead of treating it as a user', () => {
+			// A valid UPN would pass the user validator; an unknown target must still throw,
+			// proving the value is not silently routed through the user shape.
+			expect(() => validateResourceTargetId('site', 'jane@contoso.com', mockNode)).toThrow(
+				'The target ID is not valid',
+			);
+		});
+
 		it('rejects a drive-shaped id ("b!abc") as a user (the "!" is not a valid user id)', () => {
 			expect(() => validateResourceTargetId('user', 'b!abc', mockNode)).toThrow();
 		});

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/MicrosoftOneDriveTrigger.transport.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/MicrosoftOneDriveTrigger.transport.test.ts
@@ -69,4 +69,40 @@ describe('MicrosoftOneDriveTrigger transport (real GenericFunctions)', () => {
 		);
 		expect(requestOAuth2).not.toHaveBeenCalled();
 	});
+
+	it('carries a B2B guest (#EXT#) UPN through the poll path into an encoded delta-root uri', async () => {
+		const params: Record<string, unknown> = {
+			authentication: 'microsoftEntraServicePrincipalApi',
+			resourceTarget: 'user',
+			event: 'fileCreated',
+			watch: 'anyFile',
+			watchFolder: false,
+			'options.folderChild': false,
+			simple: false,
+		};
+		const rlcValues: Record<string, string> = {
+			userTarget: 'user_contoso.com#EXT#@tenant.onmicrosoft.com',
+		};
+		pollFunctions.getNodeParameter.mockImplementation(
+			(name: string, fallback?: unknown, options?: { extractValue?: boolean }) => {
+				if (options?.extractValue && name in rlcValues) {
+					return rlcValues[name];
+				}
+				if (name in params) {
+					return params[name] as NodeParameterValueType;
+				}
+				return fallback as NodeParameterValueType;
+			},
+		);
+
+		await trigger.poll.call(pollFunctions);
+
+		expect(requestWithAuthentication).toHaveBeenCalledWith(
+			'microsoftEntraServicePrincipalApi',
+			expect.objectContaining({
+				uri: 'https://graph.microsoft.com/v1.0/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com/drive/root/delta',
+			}),
+		);
+		expect(requestOAuth2).not.toHaveBeenCalled();
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/trigger/MicrosoftOutlookTrigger.transport.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/trigger/MicrosoftOutlookTrigger.transport.test.ts
@@ -83,6 +83,27 @@ describe('MicrosoftOutlookTrigger transport - Service Principal mailbox rewrite'
 		);
 	});
 
+	it('carries a B2B guest (#EXT#) mailbox through the poll path into an encoded /users/{mailbox}/messages uri', async () => {
+		mockPollFunctions.getMode.mockReturnValue('manual');
+		mockPollFunctions.getNodeParameter.mockImplementation(((name: string, fallback?: unknown) => {
+			if (name === 'authentication') return 'microsoftEntraServicePrincipalApi';
+			if (name === 'mailbox') return 'user_contoso.com#EXT#@tenant.onmicrosoft.com';
+			if (name === 'filters') return {};
+			if (name === 'options') return {};
+			if (name === 'output') return 'simple';
+			return fallback;
+		}) as unknown as IPollFunctions['getNodeParameter']);
+
+		await getPollResponse.call(mockPollFunctions, pollStartDate, pollEndDate);
+
+		expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+			'microsoftEntraServicePrincipalApi',
+			expect.objectContaining({
+				uri: 'https://graph.microsoft.com/v1.0/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com/messages',
+			}),
+		);
+	});
+
 	it('targets /users/{encoded-mailbox}/mailFolders/{id}/messages when folders are included', async () => {
 		mockPollFunctions.getMode.mockReturnValue('manual');
 		const folderId = 'AAMkADYyN2Q4ZTZl';

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
@@ -295,6 +295,32 @@ describe('MicrosoftOutlookV2 - microsoftApiRequest', () => {
 			);
 		});
 
+		it('should carry a B2B guest (#EXT#) mailbox end-to-end into an encoded /users/{id} uri', async () => {
+			setupSP({ mailbox: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' });
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/messages');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com/messages',
+				}),
+			);
+		});
+
+		it('should carry a "^"/"!" mailbox end-to-end into an encoded /users/{id} uri', async () => {
+			setupSP({ mailbox: 'joe^smith@contoso.com' });
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/messages');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/users/joe%5Esmith%40contoso.com/messages',
+				}),
+			);
+		});
+
 		it('should target the sovereign cloud base for the SP mailbox', async () => {
 			setupSP({ mailbox: 'user@example.com', graphApiBaseUrl: 'https://graph.microsoft.us' });
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/transport/index.test.ts
@@ -368,6 +368,17 @@ describe('MicrosoftOutlookV2 - microsoftApiRequest', () => {
 			).rejects.toThrow('A mailbox is required for the Service Principal');
 			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 		});
+
+		it('should reject a malformed (non-empty) mailbox and make no request', async () => {
+			// A bare host is a plausible-looking string but not a GUID/UPN, so it must be
+			// rejected before any request is issued — symmetric with the empty-mailbox case.
+			setupSP({ mailbox: 'contoso.com' });
+
+			await expect(
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/messages'),
+			).rejects.toThrow('The mailbox is not valid');
+			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
+		});
 	});
 });
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/utils/utils.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/utils/utils.test.ts
@@ -274,6 +274,19 @@ describe('Test MicrosoftOutlookV2, validateMailbox', () => {
 		expect(() => validateMailbox("o'connor@contoso.com", node)).not.toThrow();
 	});
 
+	it('should accept the widened Entra UPN special characters (! ^ ~ # with @)', () => {
+		expect(() => validateMailbox('o!brien@contoso.com', node)).not.toThrow();
+		expect(() => validateMailbox('joe^smith@contoso.com', node)).not.toThrow();
+		expect(() => validateMailbox('jane~doe@contoso.com', node)).not.toThrow();
+		expect(() => validateMailbox('a#b@contoso.com', node)).not.toThrow();
+	});
+
+	it('should accept a B2B guest (#EXT#) UPN', () => {
+		expect(() =>
+			validateMailbox('user_contoso.com#EXT#@tenant.onmicrosoft.com', node),
+		).not.toThrow();
+	});
+
 	it('should reject a bare host/domain (not a valid mailbox identifier)', () => {
 		expect(() => validateMailbox('contoso.onmicrosoft.com', node)).toThrow(
 			'The mailbox is not valid',
@@ -303,10 +316,13 @@ describe('Test MicrosoftOutlookV2, validateMailbox', () => {
 		expect(() => validateMailbox('https://evil.com', node)).toThrow('The mailbox is not valid');
 	});
 
-	it('should reject other URL-unsafe characters (?, #, space)', () => {
+	it('should reject URL-unsafe characters (?, space, colon, slash)', () => {
+		// `#` is now a legal UPN local-part char, so it is no longer part of this proof;
+		// these characters are genuinely rejected (not a GUID, not in the UPN set).
 		expect(() => validateMailbox('a?b', node)).toThrow('The mailbox is not valid');
-		expect(() => validateMailbox('a#b', node)).toThrow('The mailbox is not valid');
 		expect(() => validateMailbox('a b@contoso.com', node)).toThrow('The mailbox is not valid');
+		expect(() => validateMailbox('a:b', node)).toThrow('The mailbox is not valid');
+		expect(() => validateMailbox('a/b', node)).toThrow('The mailbox is not valid');
 	});
 
 	it('should reject a drive-style "!"-bearing id (proves the drive shape was not lifted)', () => {

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
@@ -17,10 +17,10 @@ export const mailboxRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
-	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
-	// injected into the RLC's value via import/API — the resolved value is validated regardless.
-	noDataExpression: true,
-	description: 'The mailbox the Service Principal should act on',
+	// Resolved once per run (from the first item) and reused for every item, so it accepts a fixed
+	// value or an expression; for per-item targeting, feed a single item or use Loop Over Items.
+	description:
+		'The mailbox the Service Principal should act on. Applies to the whole node (every item in the execution).',
 	modes: [
 		{
 			displayName: 'By ID',

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
@@ -17,6 +17,8 @@ export const mailboxRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	// UI guard only: unlike a plain string param, this does NOT neutralize an expression
+	// injected into the RLC's value via import/API — the resolved value is validated regardless.
 	noDataExpression: true,
 	description: 'The mailbox the Service Principal should act on',
 	modes: [

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/descriptions/mailbox.description.ts
@@ -17,6 +17,7 @@ export const mailboxRLC: INodeProperties = {
 	type: 'resourceLocator',
 	default: { mode: 'id', value: '' },
 	required: true,
+	noDataExpression: true,
 	description: 'The mailbox the Service Principal should act on',
 	modes: [
 		{

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
@@ -343,10 +343,11 @@ export function prepareApiError(
 }
 
 /**
- * Throws a `NodeOperationError` (fully static message, never echoing the id) unless the
- * mailbox is a valid GUID or UPN. Delegates to the shared `validateUserTargetId` with
- * "mailbox" wording (see `MAILBOX_MESSAGES` above) — that is the single interpolation gate
- * for user-scoped Graph targets and carries the accepted-shape / validate-before-encode logic.
+ * Validates a mailbox (a user object ID or UPN) before it is used to compose a Graph URL.
+ * Delegates to the shared `validateUserTargetId` with "mailbox" wording (see `MAILBOX_MESSAGES`
+ * above), which throws a `NodeOperationError` with a fully static message (never echoing the id)
+ * on a bad shape — that shared validator is the single interpolation gate for user-scoped Graph
+ * targets and carries the accepted-shape / validate-before-encode logic.
  */
 export function validateMailbox(id: string, node: INode): void {
 	validateUserTargetId(id, node, MAILBOX_MESSAGES);

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/helpers/utils.ts
@@ -7,20 +7,31 @@ import type {
 	IPollFunctions,
 	JsonObject,
 } from 'n8n-workflow';
-import { jsonParse, NodeApiError, NodeOperationError, UserError } from 'n8n-workflow';
+import { jsonParse, NodeApiError, UserError } from 'n8n-workflow';
 
-// A mailbox is always a user, addressed as `/users/{id}`. The only valid Graph
-// identifiers are a user object ID (GUID) or a UPN (has `@`) — there is no bare
-// host/domain mailbox form, so those two shapes are exactly what we accept.
-// Validation runs BEFORE encoding — `encodeURIComponent` leaves `..` intact, so
-// shape validation (not encoding) is what keeps the value safe to interpolate into
-// a Graph URL path. A drive-style `!`-bearing id is intentionally not accepted. The
-// UPN local part is a deliberately safe subset that excludes URL-unsafe characters
-// (`/ \ : ? # %`, whitespace, control) — so `%`-encoded traversal like
-// `..%2f..%2fx@y.com` stays rejected — while allowing the common apostrophe
-// (e.g. `o'connor@contoso.com`), which is URL-path-safe.
-const MAILBOX_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-const MAILBOX_UPN = /^[A-Za-z0-9._+'-]+@[A-Za-z0-9.-]+$/;
+import { validateUserTargetId, type UserTargetMessages } from '../../../GenericFunctions';
+
+// A mailbox is always a user, addressed as `/users/{id}`, so it validates via the shared
+// `validateUserTargetId` (the widened Entra UPN set — a GUID or a UPN, no bare host/domain
+// form). Only the throw-site copy is overridden to "mailbox" wording; the dots-only variant
+// gets an explicit mailbox message (previously a dots-only mailbox fell through to the
+// generic invalid copy).
+const MAILBOX_MESSAGES: UserTargetMessages = {
+	required: {
+		message: 'A mailbox is required for the Service Principal',
+		description:
+			'Set the Mailbox (a UPN or user object ID) — app-only Microsoft Graph has no personal mailbox to default to.',
+	},
+	dotsOnly: {
+		message: 'The mailbox is not valid',
+		description: 'A mailbox cannot consist only of dots.',
+	},
+	invalid: {
+		message: 'The mailbox is not valid',
+		description:
+			'Enter a user principal name (UPN) or object ID. Remove any slashes, backslashes, colons, commas, spaces, or encoded characters and try again.',
+	},
+};
 
 export const messageFields = [
 	'bccRecipients',
@@ -332,28 +343,13 @@ export function prepareApiError(
 }
 
 /**
- * Throws a `NodeOperationError` (fully static message, never echoing the id) unless
- * the mailbox is a valid GUID or UPN. See the `MAILBOX_*` const block above for the
- * accepted-shape and validate-before-encode rationale.
+ * Throws a `NodeOperationError` (fully static message, never echoing the id) unless the
+ * mailbox is a valid GUID or UPN. Delegates to the shared `validateUserTargetId` with
+ * "mailbox" wording (see `MAILBOX_MESSAGES` above) — that is the single interpolation gate
+ * for user-scoped Graph targets and carries the accepted-shape / validate-before-encode logic.
  */
 export function validateMailbox(id: string, node: INode): void {
-	if (id === '') {
-		throw new NodeOperationError(node, 'A mailbox is required for the Service Principal', {
-			description:
-				'Set the Mailbox (a UPN or user object ID) — app-only Microsoft Graph has no personal mailbox to default to.',
-		});
-	}
-
-	// Only a user object ID (GUID) or a UPN (has `@`) is a valid mailbox; there is no
-	// bare host/domain form. Path-traversal tokens like `..` match neither, so they
-	// are rejected here too.
-	const valid = MAILBOX_GUID.test(id) || MAILBOX_UPN.test(id);
-	if (!valid) {
-		throw new NodeOperationError(node, 'The mailbox is not valid', {
-			description:
-				'Enter a user principal name (UPN) or object ID. Remove any slashes, backslashes, colons, commas, spaces, or encoded characters and try again.',
-		});
-	}
+	validateUserTargetId(id, node, MAILBOX_MESSAGES);
 }
 
 export const encodeOutlookId = (id: string) => {

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -40,10 +40,9 @@ export function getToDoCredentialType(
 // App-only Microsoft Graph has no `/me`, and To Do lists/tasks belong to a user, so under
 // the Service Principal credential the request is addressed under an explicit `/users/{id}`
 // root. To Do is user-only, so it validates via the shared `validateUserTargetId` (default
-// "target ID" wording) and re-exports it here — the id shape is checked BEFORE encoding.
-// ENT-123 lifted that validator to `Microsoft/GenericFunctions.ts`; SharePoint (ENT-92)
-// adopts the same validator when Service Principal support lands there.
-export { validateUserTargetId };
+// "target ID" wording) — the id shape is checked BEFORE encoding. ENT-123 lifted that
+// validator to `Microsoft/GenericFunctions.ts`; SharePoint (ENT-92) adopts the same
+// validator when Service Principal support lands there.
 
 /**
  * Builds the `/users/{id}` Graph root for an app-only request. The id is validated before

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -8,7 +8,9 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 } from 'n8n-workflow';
-import { NodeApiError, NodeOperationError } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+
+import { validateUserTargetId } from '../GenericFunctions';
 
 export type ToDoCredentialType =
 	| 'microsoftToDoOAuth2Api'
@@ -37,45 +39,11 @@ export function getToDoCredentialType(
 
 // App-only Microsoft Graph has no `/me`, and To Do lists/tasks belong to a user, so under
 // the Service Principal credential the request is addressed under an explicit `/users/{id}`
-// root. The user id shape is validated BEFORE encoding — `encodeURIComponent` leaves `..`
-// intact, so shape validation (not encoding) is what keeps the value safe to interpolate
-// into a Graph URL path. Validation messages are static, so the id is never echoed back.
-//
-// NOTE: To Do is user-only — a Graph `/users/{id}` is only a user object ID (GUID) or a UPN
-// (has `@`); there is no bare host/domain form. The UPN character set follows Entra's
-// documented userPrincipalName policy; ENT-92 should lift a shared helper and bring the
-// Outlook node's `validateMailbox` to the same set.
-const USER_TARGET_GUID = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
-// Local part = Entra's documented userPrincipalName set (A-Z a-z 0-9 ' . - _ ! # ^ ~) plus
-// `+`, and covers B2B guest UPNs (`user_contoso.com#EXT#@tenant.onmicrosoft.com`). It excludes
-// `%`, so an encoded-traversal payload like `..%2f..%2fx@y.com` is rejected; for the rest,
-// `encodeURIComponent` makes `#`/`^` path-safe (`%23`/`%5E`) before they reach the URL.
-const USER_TARGET_UPN = /^[A-Za-z0-9._+'!#^~-]+@[A-Za-z0-9.-]+$/;
-
-/**
- * Validates an app-only user target id before it is encoded and used to compose a Graph
- * URL. Throws a `NodeOperationError` with a fully static message (never interpolating the
- * id). Empty / dots-only are rejected first, then the accepted user shapes (GUID / UPN).
- */
-export function validateUserTargetId(id: string, node: INode): void {
-	if (id === '') {
-		throw new NodeOperationError(node, 'A target ID is required for the Service Principal', {
-			description:
-				'Set the User ID under "Access As" — app-only Microsoft Graph has no personal context to default to.',
-		});
-	}
-	if (/^\.+$/.test(id)) {
-		throw new NodeOperationError(node, 'The target ID is not valid', {
-			description: 'A target ID cannot consist only of dots.',
-		});
-	}
-	const valid = USER_TARGET_GUID.test(id) || USER_TARGET_UPN.test(id);
-	if (!valid) {
-		throw new NodeOperationError(node, 'The target ID is not valid', {
-			description: 'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
-		});
-	}
-}
+// root. To Do is user-only, so it validates via the shared `validateUserTargetId` (default
+// "target ID" wording) and re-exports it here — the id shape is checked BEFORE encoding.
+// ENT-123 lifted that validator to `Microsoft/GenericFunctions.ts`; SharePoint (ENT-92)
+// adopts the same validator when Service Principal support lands there.
+export { validateUserTargetId };
 
 /**
  * Builds the `/users/{id}` Graph root for an app-only request. The id is validated before

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -16,9 +16,11 @@ export const userTargetRLC: INodeProperties = {
 	displayName: 'User',
 	name: 'userTarget',
 	type: 'resourceLocator',
-	// Node-level target, not per-item: `noDataExpression` keeps it a fixed value for the whole
-	// run, so the transport resolving it once (item 0) can never silently target the wrong user
-	// from a per-item expression like `={{ $json.user }}`.
+	// Node-level target, not per-item: resolved once (item 0) for the whole run.
+	// `noDataExpression` stops the editor offering a per-item expression toggle (which would
+	// silently apply item 0's user to every item). It's a UI guard only, though: unlike a plain
+	// string param it does NOT neutralize an expression injected into the RLC's value via
+	// import/API — the resolved value is validated regardless.
 	noDataExpression: true,
 	default: { mode: 'id', value: '' },
 	required: true,

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -16,12 +16,8 @@ export const userTargetRLC: INodeProperties = {
 	displayName: 'User',
 	name: 'userTarget',
 	type: 'resourceLocator',
-	// Node-level target, not per-item: resolved once (item 0) for the whole run.
-	// `noDataExpression` stops the editor offering a per-item expression toggle (which would
-	// silently apply item 0's user to every item). It's a UI guard only, though: unlike a plain
-	// string param it does NOT neutralize an expression injected into the RLC's value via
-	// import/API — the resolved value is validated regardless.
-	noDataExpression: true,
+	// Resolved once per run (from the first item) and reused for every item, so it accepts a fixed
+	// value or an expression; for per-item targeting, feed a single item or use Loop Over Items.
 	default: { mode: 'id', value: '' },
 	required: true,
 	modes: [

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -368,6 +368,32 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			);
 		});
 
+		it('carries a B2B guest (#EXT#) UPN end-to-end into an encoded /users/{id} uri', async () => {
+			setSpParams({ userTarget: { value: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' } });
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: `${baseUrl}/v1.0/users/user_contoso.com%23EXT%23%40tenant.onmicrosoft.com/todo/lists`,
+				}),
+			);
+		});
+
+		it('carries a "^"/"!" UPN end-to-end into an encoded /users/{id} uri', async () => {
+			setSpParams({ userTarget: { value: 'joe^smith@contoso.com' } });
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({
+					uri: `${baseUrl}/v1.0/users/joe%5Esmith%40contoso.com/todo/lists`,
+				}),
+			);
+		});
+
 		it('uses an absolute @odata.nextLink uri verbatim (pagination bypasses scoping)', async () => {
 			const nextLink =
 				'https://graph.microsoft.com/v1.0/users/jane%40contoso.com/todo/lists?$skiptoken=abc';

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -8,12 +8,12 @@ import {
 import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
+import { validateUserTargetId } from '../../GenericFunctions';
 import {
 	getServicePrincipalResourceRoot,
 	getToDoCredentialType,
 	microsoftApiRequest,
 	resolveScopeRoot,
-	validateUserTargetId,
 } from '../GenericFunctions';
 import { MicrosoftToDo } from '../MicrosoftToDo.node';
 

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/authentication.test.ts
@@ -53,8 +53,9 @@ describe('MicrosoftToDo authentication descriptor', () => {
 		expect(userTarget?.displayOptions?.show?.authentication).toEqual([
 			'microsoftEntraServicePrincipalApi',
 		]);
-		// Node-level target: no per-item expression, so item-0 resolution can't misroute.
-		expect(userTarget?.noDataExpression).toBe(true);
+		// Team decision (ENT-123): the SP target stays expression-capable (no `noDataExpression`),
+		// so it can be driven from upstream data; it is resolved once per run (from the first item).
+		expect(userTarget?.noDataExpression).toBeUndefined();
 		// To Do is user-only: no "Access As" selector and no drive/site targets.
 		expect(properties.find((property) => property.name === 'resourceTarget')).toBeUndefined();
 	});

--- a/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
@@ -137,14 +137,14 @@ describe('Microsoft shared validateUserTargetId', () => {
 	});
 
 	describe('the rejected id is never echoed in the message or description', () => {
-		it.each([
+		it.each<[string, UserTargetMessages | undefined]>([
 			['default messages', undefined],
 			['overridden messages', MAILBOX_MESSAGES],
 		])('%s', (_label, messages) => {
 			const evil = 'evil/../%2fsecret@attacker.com';
 			let caught: NodeOperationError | undefined;
 			try {
-				validateUserTargetId(evil, node, messages as UserTargetMessages | undefined);
+				validateUserTargetId(evil, node, messages);
 			} catch (error) {
 				caught = error as NodeOperationError;
 			}

--- a/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
@@ -1,0 +1,161 @@
+import { NodeOperationError, type INode } from 'n8n-workflow';
+
+import { validateUserTargetId, type UserTargetMessages } from '../GenericFunctions';
+
+const node: INode = {
+	id: 'test-node',
+	name: 'Microsoft Node',
+	type: 'n8n-nodes-base.microsoft',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters: {},
+};
+
+// The Outlook-style override; used to prove `messages` swaps the copy at every throw site
+// without touching the accepted-shape logic.
+const MAILBOX_MESSAGES: UserTargetMessages = {
+	required: {
+		message: 'A mailbox is required for the Service Principal',
+		description:
+			'Set the Mailbox — app-only Microsoft Graph has no personal mailbox to default to.',
+	},
+	dotsOnly: {
+		message: 'The mailbox is not valid',
+		description: 'A mailbox cannot consist only of dots.',
+	},
+	invalid: {
+		message: 'The mailbox is not valid',
+		description: 'Enter a user principal name (UPN) or object ID and try again.',
+	},
+};
+
+describe('Microsoft shared validateUserTargetId', () => {
+	describe('accepted shapes (widened Entra UPN set + B2B guest)', () => {
+		it.each([
+			['a GUID', '11111111-1111-1111-1111-111111111111'],
+			['a plain UPN', 'jane@contoso.com'],
+			['an apostrophe UPN', "o'connor@contoso.com"],
+			['a "+" sub-address UPN', 'jane+test@contoso.com'],
+			['a "!" UPN', 'o!brien@contoso.com'],
+			['a "^" UPN', 'joe^smith@contoso.com'],
+			['a "~" UPN', 'jane~doe@contoso.com'],
+			['a "#" UPN (has @)', 'a#b@contoso.com'],
+			['a B2B guest #EXT# UPN', 'user_contoso.com#EXT#@tenant.onmicrosoft.com'],
+		])('accepts %s', (_label, id) => {
+			expect(() => validateUserTargetId(id, node)).not.toThrow();
+		});
+	});
+
+	describe('rejected shapes', () => {
+		it.each([
+			['empty', ''],
+			['a single dot', '.'],
+			['two dots', '..'],
+			['three dots', '...'],
+			['a forward slash', 'a/b'],
+			['a backslash', 'a\\b'],
+			['a colon', 'a:b'],
+			['a space', 'a b@contoso.com'],
+			['a question mark', 'a?b'],
+			['a bare host', 'contoso.com'],
+			['a bare label', 'jane'],
+			['a legal-but-user-invalid host', 'sub.contoso.co.uk'],
+			['an encoded traversal UPN', '..%2f..%2fx@y.com'],
+			['an encoded dots-only', '%2e%2e'],
+			['a "#" without @', 'a#b'],
+			['a drive-shaped "!" id (no @)', 'b!abc'],
+		])('rejects %s', (_label, id) => {
+			expect(() => validateUserTargetId(id, node)).toThrow(NodeOperationError);
+		});
+	});
+
+	describe('default messages (To Do "target ID" copy) at each throw site', () => {
+		it('required: empty id', () => {
+			expect(() => validateUserTargetId('', node)).toThrow(
+				'A target ID is required for the Service Principal',
+			);
+		});
+
+		it('dotsOnly: dots-only id', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId('..', node);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The target ID is not valid');
+			expect(caught?.description).toBe('A target ID cannot consist only of dots.');
+		});
+
+		it('invalid: bad-shape id', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId('a/b', node);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The target ID is not valid');
+			expect(caught?.description).toBe(
+				'Remove any slashes, backslashes, colons, commas, or spaces and try again.',
+			);
+		});
+	});
+
+	describe('overridden messages (Outlook "mailbox" copy) at each throw site', () => {
+		it('required: empty id', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId('', node, MAILBOX_MESSAGES);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('A mailbox is required for the Service Principal');
+			expect(caught?.description).toBe(MAILBOX_MESSAGES.required.description);
+		});
+
+		it('dotsOnly: dots-only id uses the mailbox variant (no "target ID" leakage)', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId('..', node, MAILBOX_MESSAGES);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The mailbox is not valid');
+			expect(caught?.description).toBe('A mailbox cannot consist only of dots.');
+		});
+
+		it('invalid: bad-shape id', () => {
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId('a/b', node, MAILBOX_MESSAGES);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught?.message).toBe('The mailbox is not valid');
+			expect(caught?.description).toBe(MAILBOX_MESSAGES.invalid.description);
+		});
+	});
+
+	describe('the rejected id is never echoed in the message or description', () => {
+		it.each([
+			['default messages', undefined],
+			['overridden messages', MAILBOX_MESSAGES],
+		])('%s', (_label, messages) => {
+			const evil = 'evil/../%2fsecret@attacker.com';
+			let caught: NodeOperationError | undefined;
+			try {
+				validateUserTargetId(evil, node, messages as UserTargetMessages | undefined);
+			} catch (error) {
+				caught = error as NodeOperationError;
+			}
+			expect(caught).toBeDefined();
+			expect(caught?.message).not.toContain('evil');
+			expect(caught?.message).not.toContain('secret');
+			expect(caught?.message).not.toContain('..');
+			expect(caught?.message).not.toContain('%2');
+			expect(caught?.description).not.toContain('evil');
+			expect(caught?.description).not.toContain('secret');
+			expect(caught?.description).not.toContain('%2');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Unifies the app-only (Service Principal) user-target validation across the Microsoft **To Do**, **OneDrive**, and **Outlook** nodes by extracting a single shared validator (`validateUserTargetId` in `nodes/Microsoft/GenericFunctions.ts`), porting the hardening that landed with To Do (ENT-84). Part of the MS Service Principal epic (ENT-82).

- **Fixes a correctness bug (Outlook & OneDrive).** Under the Service Principal credential, both nodes previously rejected valid user principal names — their narrow character set excluded `! # ^ ~` and **B2B guest UPNs** like `user_contoso.com#EXT#@tenant.onmicrosoft.com`. Both now accept the full documented Entra `userPrincipalName` set (`A-Z a-z 0-9 ' . - _ ! # ^ ~` plus `+`). The widening is **strictly additive** — every previously-valid id still validates.
- **Security invariant preserved.** Validation runs **before** `encodeURIComponent` (shape-checking, not encoding, is what keeps the id safe to interpolate into a Graph `/users/{id}` path). `%` stays excluded, so encoded-traversal payloads (`..%2f..%2fx@y.com`) are still rejected. The shared validator is the single interpolation gate (the regexes are module-local, not exported).
- **Drops OneDrive's bare-host branch on the user target.** `contoso.com` / `jane` were never a valid `/users/{id}` — they now fail with a clear, static client-side error instead of deferring to a confusing Graph 404. The `drive` target's validation is unchanged.
- **The Service Principal target stays expression-capable** (team decision). The user/drive/mailbox target keeps supporting expressions (no `noDataExpression`), so it can be driven from upstream data. It resolves once per run (from the first item) and is reused for every item; for per-item targeting, feed a single item or use Loop Over Items. This PR also drops `noDataExpression` from the To Do target so all three nodes behave the same.
- **Teams and SharePoint intentionally untouched.** Teams validates opaque per-item Graph IDs (`19:…@thread.tacv2`) via its own guard — a different model. SharePoint has no Service Principal support yet; the shared helper is import-ready for it (ENT-92) when it lands.

**Behavior/UX notes**
- OneDrive's *user*-target empty-input message now uses the shared "target ID" wording (previously "User or Drive ID"); the *drive*-target message is unchanged.
- **To Do's target is now expression-capable too.** Its SP user target previously set `noDataExpression: true` (from ENT-84); this PR removes it so all three nodes match. Existing To Do workflows are unaffected — a fixed value still works.
- No credential, DB, or `@n8n/api-types` changes. **No migration needed** (these Service Principal fields are part of the in-flight, unreleased epic).

## How to test

**Automated** — from `packages/nodes-base`:
```
pnpm test Microsoft/
```
Coverage: a new shared validator matrix (`Microsoft/test/GenericFunctions.test.ts`), per-node delegation, and **end-to-end Graph URL-shape assertions** that carry the widened UPNs through the real URL builder (e.g. `user_contoso.com#EXT#@…` → `/users/user_contoso.com%23EXT%23%40…`, with `^`→`%5E` and `!`/`~` passing through literally), plus both trigger transports. Bare-host inputs are asserted to reject for the user target; the OneDrive `/drives/{id}` vs `/users/{id}/drive` no-double-`/drive` assertions are retained.

**Manual** (requires a licensed M365 tenant + a `microsoftEntraServicePrincipalApi` credential): in a Microsoft Outlook or OneDrive node using the Service Principal credential, set the mailbox / user target to a B2B guest UPN such as `user_contoso.com#EXT#@tenant.onmicrosoft.com` and run an operation — it now validates and resolves the correct `/users/{encoded}` root instead of failing validation. You can also set the target from an expression (e.g. `={{ $json.email }}`); it resolves once per run, so use Loop Over Items for per-item targeting.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-123

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33343">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->