### PR TITLE
feat(core): Emit wake-up signal on workflow publication changes (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -92,6 +92,7 @@ describe('WorkflowService', () => {
 				mock(), // licenseState
 				mock(), // projectRepository
 				mock(), // redactionEnforcementService
+				mock(), // workflowPublicationNotifier
 			);
 		});
 
@@ -352,6 +353,7 @@ describe('WorkflowService', () => {
 				licenseStateMock, // licenseState
 				mock(), // projectRepository
 				redactionEnforcementServiceMock, // redactionEnforcementService
+				mock(), // workflowPublicationNotifier
 			);
 
 			vi.clearAllMocks();
@@ -1047,6 +1049,7 @@ describe('WorkflowService', () => {
 				mock(), // licenseState
 				mock(), // projectRepository
 				mock(), // redactionEnforcementService
+				mock(), // workflowPublicationNotifier
 			);
 
 			// Bypass validation internals
@@ -1275,6 +1278,7 @@ describe('WorkflowService', () => {
 				mock(), // licenseState
 				mock(), // projectRepository
 				mock(), // redactionEnforcementService
+				mock(), // workflowPublicationNotifier
 			);
 		});
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
@@ -1,22 +1,25 @@
+import type { WorkflowsConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import type { ErrorReporter, InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import { WorkflowPublicationNotifier } from '@/workflows/publication/workflow-publication-notifier';
-import type { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
+import { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
 
 describe('WorkflowPublicationNotifier', () => {
 	const errorReporter = mock<ErrorReporter>();
 	const publisher = mock<Publisher>();
 	const outboxConsumer = mock<WorkflowPublicationOutboxConsumer>();
 
-	function makeNotifier(isMultiMain: boolean) {
+	function makeNotifier(isMultiMain: boolean, useWorkflowPublicationService = true) {
 		const instanceSettings = mock<InstanceSettings>({ isMultiMain });
+		const workflowsConfig = mock<WorkflowsConfig>({ useWorkflowPublicationService });
 		return new WorkflowPublicationNotifier(
 			errorReporter,
 			instanceSettings,
 			publisher,
-			outboxConsumer,
+			workflowsConfig,
 		);
 	}
 
@@ -24,6 +27,9 @@ describe('WorkflowPublicationNotifier', () => {
 		vi.clearAllMocks();
 		publisher.publishCommand.mockResolvedValue(undefined);
 		outboxConsumer.wakeUp.mockResolvedValue(undefined);
+		// The consumer is resolved lazily to avoid eagerly constructing its
+		// flag-guarded dependency chain.
+		vi.spyOn(Container, 'get').mockReturnValue(outboxConsumer);
 	});
 
 	describe('multi-main', () => {
@@ -41,7 +47,18 @@ describe('WorkflowPublicationNotifier', () => {
 		it('wakes the local consumer directly and does not publish a command', () => {
 			makeNotifier(false).requestDrain();
 
+			expect(Container.get).toHaveBeenCalledWith(WorkflowPublicationOutboxConsumer);
 			expect(outboxConsumer.wakeUp).toHaveBeenCalledTimes(1);
+			expect(publisher.publishCommand).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('publication service disabled', () => {
+		it('does nothing (never constructs the consumer nor publishes)', () => {
+			makeNotifier(false, false).requestDrain();
+
+			expect(Container.get).not.toHaveBeenCalled();
+			expect(outboxConsumer.wakeUp).not.toHaveBeenCalled();
 			expect(publisher.publishCommand).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
@@ -7,6 +7,13 @@ import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import { WorkflowPublicationNotifier } from '@/workflows/publication/workflow-publication-notifier';
 import { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
 
+// Stub the consumer module: the notifier imports it dynamically, and loading the
+// real module pulls in its flag-guarded dependency chain. We only need the class
+// token so `Container.get` can be intercepted.
+vi.mock('@/workflows/publication/workflow-publication-outbox-consumer', () => ({
+	WorkflowPublicationOutboxConsumer: class WorkflowPublicationOutboxConsumer {},
+}));
+
 describe('WorkflowPublicationNotifier', () => {
 	const errorReporter = mock<ErrorReporter>();
 	const publisher = mock<Publisher>();
@@ -27,8 +34,8 @@ describe('WorkflowPublicationNotifier', () => {
 		vi.clearAllMocks();
 		publisher.publishCommand.mockResolvedValue(undefined);
 		outboxConsumer.wakeUp.mockResolvedValue(undefined);
-		// The consumer is resolved lazily to avoid eagerly constructing its
-		// flag-guarded dependency chain.
+		// The consumer is resolved lazily (dynamic import + Container.get) to keep its
+		// flag-guarded dependency chain off the default graph.
 		vi.spyOn(Container, 'get').mockReturnValue(outboxConsumer);
 	});
 
@@ -39,22 +46,23 @@ describe('WorkflowPublicationNotifier', () => {
 			expect(publisher.publishCommand).toHaveBeenCalledWith({
 				command: 'workflow-publish-wake-up',
 			});
+			expect(Container.get).not.toHaveBeenCalled();
 			expect(outboxConsumer.wakeUp).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('single-main', () => {
-		it('wakes the local consumer directly and does not publish a command', () => {
+		it('wakes the local consumer directly and does not publish a command', async () => {
 			makeNotifier(false).requestDrain();
 
+			await vi.waitFor(() => expect(outboxConsumer.wakeUp).toHaveBeenCalledTimes(1));
 			expect(Container.get).toHaveBeenCalledWith(WorkflowPublicationOutboxConsumer);
-			expect(outboxConsumer.wakeUp).toHaveBeenCalledTimes(1);
 			expect(publisher.publishCommand).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('publication service disabled', () => {
-		it('does nothing (never constructs the consumer nor publishes)', () => {
+		it('does nothing (never resolves the consumer nor publishes)', () => {
 			makeNotifier(false, false).requestDrain();
 
 			expect(Container.get).not.toHaveBeenCalled();

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-notifier.test.ts
@@ -1,0 +1,59 @@
+import type { ErrorReporter, InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
+
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import { WorkflowPublicationNotifier } from '@/workflows/publication/workflow-publication-notifier';
+import type { WorkflowPublicationOutboxConsumer } from '@/workflows/publication/workflow-publication-outbox-consumer';
+
+describe('WorkflowPublicationNotifier', () => {
+	const errorReporter = mock<ErrorReporter>();
+	const publisher = mock<Publisher>();
+	const outboxConsumer = mock<WorkflowPublicationOutboxConsumer>();
+
+	function makeNotifier(isMultiMain: boolean) {
+		const instanceSettings = mock<InstanceSettings>({ isMultiMain });
+		return new WorkflowPublicationNotifier(
+			errorReporter,
+			instanceSettings,
+			publisher,
+			outboxConsumer,
+		);
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		publisher.publishCommand.mockResolvedValue(undefined);
+		outboxConsumer.wakeUp.mockResolvedValue(undefined);
+	});
+
+	describe('multi-main', () => {
+		it('routes the wake-up through pubsub and does not touch the local consumer', () => {
+			makeNotifier(true).requestDrain();
+
+			expect(publisher.publishCommand).toHaveBeenCalledWith({
+				command: 'workflow-publish-wake-up',
+			});
+			expect(outboxConsumer.wakeUp).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('single-main', () => {
+		it('wakes the local consumer directly and does not publish a command', () => {
+			makeNotifier(false).requestDrain();
+
+			expect(outboxConsumer.wakeUp).toHaveBeenCalledTimes(1);
+			expect(publisher.publishCommand).not.toHaveBeenCalled();
+		});
+	});
+
+	it('reports errors from the wake path instead of throwing (fire-and-forget)', async () => {
+		const error = new Error('drain failed');
+		outboxConsumer.wakeUp.mockRejectedValue(error);
+
+		expect(() => makeNotifier(false).requestDrain()).not.toThrow();
+
+		await vi.waitFor(() =>
+			expect(errorReporter.error).toHaveBeenCalledWith(error, { shouldBeLogged: true }),
+		);
+	});
+});

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -7,15 +7,6 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 /**
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
- *
- * Callers use a single method; the single-main vs multi-main split is hidden here
- * so it can be collapsed once single-main also loops pubsub back to itself:
- * - multi-main: the leader may be a different process, so route through pubsub
- *   (the `workflow-publish-wake-up` command self-delivers to the leader).
- * - single-main: pubsub is inert (no Redis), so wake the local consumer directly.
- *
- * Fire-and-forget by design: publication is asynchronous, so the enqueue path
- * must not block on the drain.
  */
 @Service()
 export class WorkflowPublicationNotifier {

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -9,13 +9,6 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
  *
- * Callers use a single method; the single-main vs multi-main split is hidden here
- * so it can be collapsed once single-main also loops pubsub back to itself:
- * - multi-main: the leader may be a different process, so route through pubsub
- *   (the `workflow-publish-wake-up` command self-delivers to the leader).
- * - single-main: this process is the leader and pubsub is inert (no Redis), so
- *   wake the local consumer directly.
- *
  * Fire-and-forget by design: publication is asynchronous, so the enqueue path
  * must not block on the drain.
  */

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -40,7 +40,8 @@ export class WorkflowPublicationNotifier {
 	 * chain (WorkflowTriggerActivator) asserts the publication service is enabled in
 	 * its constructor, and it registers @OnShutdown/@OnPubSubEvent handlers that the
 	 * shutdown/pubsub registries eagerly `Container.get`. Loading it only on this
-	 * flag-gated path keeps it off the default graph, matching start.ts.
+	 * flag-gated path keeps it off the default graph, matching start.ts. Node caches
+	 * the module after the first import, so later calls resolve it from cache.
 	 */
 	private async wakeLocalConsumer(): Promise<void> {
 		const { WorkflowPublicationOutboxConsumer } = await import(

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -1,4 +1,5 @@
-import { Service } from '@n8n/di';
+import { WorkflowsConfig } from '@n8n/config';
+import { Container, Service } from '@n8n/di';
 import { ErrorReporter, InstanceSettings } from 'n8n-core';
 
 import { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -8,6 +9,15 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
 /**
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
+ *
+ * Callers use a single method; the single-main vs multi-main split is hidden here
+ * so it can be collapsed once single-main also loops pubsub back to itself:
+ * - multi-main: the leader may be a different process, so route through pubsub
+ *   (the `workflow-publish-wake-up` command self-delivers to the leader).
+ * - single-main: pubsub is inert (no Redis), so wake the local consumer directly.
+ *
+ * Fire-and-forget by design: publication is asynchronous, so the enqueue path
+ * must not block on the drain.
  */
 @Service()
 export class WorkflowPublicationNotifier {
@@ -15,7 +25,7 @@ export class WorkflowPublicationNotifier {
 		private readonly errorReporter: ErrorReporter,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
-		private readonly outboxConsumer: WorkflowPublicationOutboxConsumer,
+		private readonly workflowsConfig: WorkflowsConfig,
 	) {}
 
 	/**
@@ -25,9 +35,14 @@ export class WorkflowPublicationNotifier {
 	 * otherwise we might try to drain the record before it's actually created.
 	 */
 	requestDrain(): void {
+		if (!this.workflowsConfig.useWorkflowPublicationService) return;
+
 		const wake = this.instanceSettings.isMultiMain
 			? this.publisher.publishCommand({ command: 'workflow-publish-wake-up' })
-			: this.outboxConsumer.wakeUp();
+			: // Resolve the consumer lazily: its dependency chain (WorkflowTriggerActivator)
+				// asserts the publication service is enabled in its constructor, so it must
+				// only ever be constructed on this flag-gated path, never eagerly via DI.
+				Container.get(WorkflowPublicationOutboxConsumer).wakeUp();
 
 		void wake.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
 	}

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -4,11 +4,18 @@ import { ErrorReporter, InstanceSettings } from 'n8n-core';
 
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 
-import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox-consumer';
-
 /**
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
+ *
+ * Callers use a single method; the single-main vs multi-main split is hidden here
+ * so it can be collapsed once single-main also loops pubsub back to itself:
+ * - multi-main: the leader may be a different process, so route through pubsub
+ *   (the `workflow-publish-wake-up` command self-delivers to the leader).
+ * - single-main: pubsub is inert (no Redis), so wake the local consumer directly.
+ *
+ * Fire-and-forget by design: publication is asynchronous, so the enqueue path
+ * must not block on the drain.
  */
 @Service()
 export class WorkflowPublicationNotifier {
@@ -30,11 +37,24 @@ export class WorkflowPublicationNotifier {
 
 		const wake = this.instanceSettings.isMultiMain
 			? this.publisher.publishCommand({ command: 'workflow-publish-wake-up' })
-			: // Resolve the consumer lazily: its dependency chain (WorkflowTriggerActivator)
-				// asserts the publication service is enabled in its constructor, so it must
-				// only ever be constructed on this flag-gated path, never eagerly via DI.
-				Container.get(WorkflowPublicationOutboxConsumer).wakeUp();
+			: this.wakeLocalConsumer();
 
 		void wake.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
+	}
+
+	/**
+	 * Wake the local leader's consumer in-process.
+	 *
+	 * The consumer module is imported dynamically, never statically: its dependency
+	 * chain (WorkflowTriggerActivator) asserts the publication service is enabled in
+	 * its constructor, and it registers @OnShutdown/@OnPubSubEvent handlers that the
+	 * shutdown/pubsub registries eagerly `Container.get`. Loading it only on this
+	 * flag-gated path keeps it off the default graph, matching start.ts.
+	 */
+	private async wakeLocalConsumer(): Promise<void> {
+		const { WorkflowPublicationOutboxConsumer } = await import(
+			'./workflow-publication-outbox-consumer'
+		);
+		await Container.get(WorkflowPublicationOutboxConsumer).wakeUp();
 	}
 }

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -1,0 +1,39 @@
+import { Service } from '@n8n/di';
+import { ErrorReporter, InstanceSettings } from 'n8n-core';
+
+import { Publisher } from '@/scaling/pubsub/publisher.service';
+
+import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox-consumer';
+
+/**
+ * Signals the leader to drain the publication outbox immediately after a record
+ * is enqueued, instead of waiting for the next poll cycle.
+ *
+ * Callers use a single method; the single-main vs multi-main split is hidden here
+ * so it can be collapsed once single-main also loops pubsub back to itself:
+ * - multi-main: the leader may be a different process, so route through pubsub
+ *   (the `workflow-publish-wake-up` command self-delivers to the leader).
+ * - single-main: this process is the leader and pubsub is inert (no Redis), so
+ *   wake the local consumer directly.
+ *
+ * Fire-and-forget by design: publication is asynchronous, so the enqueue path
+ * must not block on the drain.
+ */
+@Service()
+export class WorkflowPublicationNotifier {
+	constructor(
+		private readonly errorReporter: ErrorReporter,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly publisher: Publisher,
+		private readonly outboxConsumer: WorkflowPublicationOutboxConsumer,
+	) {}
+
+	/** Wake the leader's outbox consumer so a freshly enqueued record is drained promptly. */
+	requestDrain(): void {
+		const wake = this.instanceSettings.isMultiMain
+			? this.publisher.publishCommand({ command: 'workflow-publish-wake-up' })
+			: this.outboxConsumer.wakeUp();
+
+		void wake.catch((error) => this.errorReporter.error(error, { shouldBeLogged: true }));
+	}
+}

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -9,15 +9,6 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
 /**
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
- *
- * Callers use a single method; the single-main vs multi-main split is hidden here
- * so it can be collapsed once single-main also loops pubsub back to itself:
- * - multi-main: the leader may be a different process, so route through pubsub
- *   (the `workflow-publish-wake-up` command self-delivers to the leader).
- * - single-main: pubsub is inert (no Redis), so wake the local consumer directly.
- *
- * Fire-and-forget by design: publication is asynchronous, so the enqueue path
- * must not block on the drain.
  */
 @Service()
 export class WorkflowPublicationNotifier {

--- a/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-notifier.ts
@@ -8,9 +8,6 @@ import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox
 /**
  * Signals the leader to drain the publication outbox immediately after a record
  * is enqueued, instead of waiting for the next poll cycle.
- *
- * Fire-and-forget by design: publication is asynchronous, so the enqueue path
- * must not block on the drain.
  */
 @Service()
 export class WorkflowPublicationNotifier {
@@ -21,7 +18,12 @@ export class WorkflowPublicationNotifier {
 		private readonly outboxConsumer: WorkflowPublicationOutboxConsumer,
 	) {}
 
-	/** Wake the leader's outbox consumer so a freshly enqueued record is drained promptly. */
+	/**
+	 * Wake the leader's outbox consumer so a freshly enqueued record is drained promptly.
+	 *
+	 * NOTE: this should only be called after a record is successfully enqueued,
+	 * otherwise we might try to drain the record before it's actually created.
+	 */
 	requestDrain(): void {
 		const wake = this.instanceSettings.isMultiMain
 			? this.publisher.publishCommand({ command: 'workflow-publish-wake-up' })

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -62,6 +62,7 @@ import { WorkflowValidationService } from './workflow-validation.service';
 
 import { WebhookService } from '@/webhooks/webhook.service';
 import * as WorkflowHelpers from '@/workflow-helpers';
+import { WorkflowPublicationNotifier } from './publication/workflow-publication-notifier';
 import { getErrorDescription, getErrorNodeId, getRequiredRedactionScopes } from './utils';
 import { WorkflowFinderService } from './workflow-finder.service';
 import { WorkflowHistoryService } from './workflow-history/workflow-history.service';
@@ -94,6 +95,7 @@ export class WorkflowService {
 		private readonly licenseState: LicenseState,
 		private readonly projectRepository: ProjectRepository,
 		private readonly redactionEnforcementService: RedactionEnforcementService,
+		private readonly workflowPublicationNotifier: WorkflowPublicationNotifier,
 	) {}
 
 	async getMany(
@@ -1433,6 +1435,10 @@ export class WorkflowService {
 
 			await this.outboxRepository.enqueue(workflowId, versionIdToActivate, trx);
 		});
+
+		// Wake the leader now that the record is committed, so it drains without
+		// waiting for the next poll cycle.
+		this.workflowPublicationNotifier.requestDrain();
 	}
 
 	/**
@@ -1470,5 +1476,9 @@ export class WorkflowService {
 
 			await this.outboxRepository.enqueue(workflowId, deactivatedVersionId, trx);
 		});
+
+		// Wake the leader now that the record is committed, so it drains without
+		// waiting for the next poll cycle.
+		this.workflowPublicationNotifier.requestDrain();
 	}
 }

--- a/packages/cli/test/integration/workflows/workflow.service.test.ts
+++ b/packages/cli/test/integration/workflows/workflow.service.test.ts
@@ -90,6 +90,7 @@ beforeAll(async () => {
 		mock(), // licenseState
 		Container.get(ProjectRepository), // projectRepository
 		mock(), // redactionEnforcementService
+		mock(), // workflowPublicationNotifier
 	);
 });
 


### PR DESCRIPTION
## Summary

Send a wake-up signal when a message is pushed to the workflow publication outbox.

We also poll as a fallback, but this makes the UX much faster.

## Testing

- Unit tests for both branches and the fire-and-forget error path.
- Updated the `WorkflowService` constructor sites (unit + integration).
- Build + typecheck green; affected unit suites pass.

An end-to-end single-main drain test is deferred for now.

https://linear.app/n8n/issue/CAT-3632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

