### PR TITLE
fix(core): Return Data Table rows in a deterministic order when paginating

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table.service.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table.service.integration.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { AddDataTableColumnDto, CreateDataTableColumnDto } from '@n8n/api-types';
+import type {
+	AddDataTableColumnDto,
+	CreateDataTableColumnDto,
+	ListDataTableContentQueryDto,
+} from '@n8n/api-types';
 import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import type { Project } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -1004,6 +1008,45 @@ describe('dataTable', () => {
 				expect(filtered2.count).toBe(1);
 				expect(filtered2.data[0].name).toBe('dataTable2');
 			});
+		});
+	});
+
+	describe('getManyQuery ordering', () => {
+		// The node paginates rows with skip/take, which only stays consistent if every page query
+		// orders identically. The listing query must always end with a unique `id` tiebreaker.
+		async function buildListSql(sortBy?: [string, 'ASC' | 'DESC']) {
+			const { id: dataTableId, columns } = await dataTableService.createDataTable(project1.id, {
+				name: 'orderingTable',
+				columns: [{ name: 'name', type: 'string' }],
+			});
+			const em = dataTableRowsRepository['dataSource'].manager;
+			const [, query] = dataTableRowsRepository['getManyQuery'](
+				dataTableId,
+				{ sortBy } as ListDataTableContentQueryDto,
+				columns,
+				em,
+			);
+			return query.select('*').getQuery();
+		}
+
+		it('orders by id when no sortBy is given', async () => {
+			const sql = await buildListSql();
+			expect(sql).toContain('ORDER BY "dataTable"."id" ASC');
+		});
+
+		it('appends id as a tiebreaker after the sort column', async () => {
+			const sql = await buildListSql(['name', 'ASC']);
+			expect(sql).toContain('"dataTable"."name" ASC');
+			expect(sql).toContain('"dataTable"."id" ASC');
+			expect(sql.indexOf('"dataTable"."name" ASC')).toBeLessThan(
+				sql.indexOf('"dataTable"."id" ASC'),
+			);
+		});
+
+		it('does not append a redundant tiebreaker when already sorting by id', async () => {
+			const sql = await buildListSql(['id', 'DESC']);
+			expect(sql).toContain('"dataTable"."id" DESC');
+			expect(sql).not.toContain('"dataTable"."id" ASC');
 		});
 	});
 

--- a/packages/cli/src/modules/data-table/data-table-rows.repository.ts
+++ b/packages/cli/src/modules/data-table/data-table-rows.repository.ts
@@ -681,12 +681,18 @@ export class DataTableRowsRepository {
 	}
 
 	private applySorting(query: QueryBuilder, dto: ListDataTableContentQueryDto): void {
-		if (!dto.sortBy) {
-			return;
+		if (dto.sortBy) {
+			const [field, order] = dto.sortBy;
+			this.applySortingByField(query, field, order);
 		}
 
-		const [field, order] = dto.sortBy;
-		this.applySortingByField(query, field, order);
+		// Always append the unique `id` as a final tiebreaker so skip/take pagination
+		// returns a stable order across pages (avoids duplicate/missing rows).
+		if (!dto.sortBy || dto.sortBy[0] !== 'id') {
+			const dbType = this.dataSource.options.type;
+			const quotedId = `${quoteIdentifier('dataTable', dbType)}.${quoteIdentifier('id', dbType)}`;
+			query.addOrderBy(quotedId, 'ASC');
+		}
 	}
 
 	private applySortingByField(query: QueryBuilder, field: string, direction: 'DESC' | 'ASC'): void {


### PR DESCRIPTION
## Summary

Exporting all rows from a Data Table (Data Table node → *Get row(s)* with *Return All*, and the public API `GET .../rows`) could return duplicate and missing rows on large tables. This was a pagination-correctness bug, not a size limit.

The listing query emitted no `ORDER BY` when no sort was requested, so `LIMIT/OFFSET` paging relied on unstable physical row order — which the DB is free to change across the repeated `OFFSET` queries once a table is large enough. This fix always appends the unique primary key `id` as a final tiebreaker (after any user sort column), making paging deterministic. It covers the node, public API, and CSV export paths, which all funnel through `getManyQuery()`.

## How to test

1. Seed a large Data Table (tens of thousands of rows).
2. Run the Data Table node with *Get row(s)* → *Return All*, and hit the public API `GET .../rows` — confirm returned `id`s are unique and the count matches the table size.
3. Unit tests: `cd packages/cli && pnpm test:integration data-table.service.integration -t "getManyQuery ordering"`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5536

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33358">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

