### PR TITLE
fix(core): Guard against undefined node parameters in webhook path indexing

### DIFF
--- a/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
+++ b/packages/cli/src/modules/workflow-index/__tests__/workflow-index.service.test.ts
@@ -393,6 +393,30 @@ describe('WorkflowIndexService', () => {
 			);
 		});
 
+		it('should not throw when a webhook node has undefined parameters', async () => {
+			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
+
+			const workflow = createWorkflow([
+				{
+					id: 'node-1',
+					name: 'node-1',
+					type: 'n8n-nodes-base.webhook',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: undefined as unknown as INode['parameters'],
+				},
+			]);
+
+			await expect(service.updateIndexForDraft(workflow)).resolves.not.toThrow();
+
+			const call = mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mock.calls[0];
+			const dependencies = call[1].dependencies;
+
+			expect(dependencies).not.toContainEqual(
+				expect.objectContaining({ dependencyType: 'webhookPath' }),
+			);
+		});
+
 		it('should extract dataTableId from all data-table-related node types', async () => {
 			mockWorkflowDependencyRepository.updateDependenciesForWorkflow.mockResolvedValue(true);
 

--- a/packages/cli/src/modules/workflow-index/workflow-index.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-index.service.ts
@@ -330,7 +330,7 @@ export class WorkflowIndexService {
 		if (node.type !== 'n8n-nodes-base.webhook') {
 			return;
 		}
-		const webhookPath = node.parameters.path as string;
+		const webhookPath = node.parameters?.path as string;
 		if (webhookPath) {
 			dependencyUpdates.add({
 				dependencyType: 'webhookPath',


### PR DESCRIPTION
## Summary

`WorkflowIndexService.addWebhookPathDependencies` read `node.parameters.path` without null-guarding `node.parameters`. A webhook node whose `parameters` is `undefined` threw `TypeError: Cannot read properties of undefined (reading 'path')` during indexing.

`INode.parameters` is typed as non-optional, but that is a compile-time guarantee over untrusted JSON — `workflow.nodes` deserializes straight from `WorkflowEntity.nodes` (a `@JsonColumn()` blob) with no runtime schema validation. A node persisted without a `parameters` key (via the public REST API, a workflow import, hand-crafted JSON, or an older n8n version) round-trips as `parameters: undefined`. The sibling extractor `addDataTableDependencies` already `?.`-guards for this reason; this method simply missed it.

Fix: use optional chaining (`node.parameters?.path`) to match the sibling extractors.

## How to test

Run the module's unit tests:

```bash
cd packages/cli && pnpm test src/modules/workflow-index/__tests__/workflow-index.service.test.ts
```

The added test `should not throw when a webhook node has undefined parameters` fails on the old code and passes with the fix. No `webhookPath` dependency is emitted for such a node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3635

Sentry: INSTANCE-BACKEND-23NG (1413 events, 172 affected users)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33366">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

