### PR TITLE
test: De-flake resource locator list options test (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
@@ -131,8 +131,10 @@ test.describe(
 
 			// A page of list options is 5 items. The dropdown auto-fetches a second
 			// page when the first one doesn't fill the viewport, so assert a full
-			// first page is visible rather than an exact total count.
-			await expect(n8n.ndv.getVisiblePopper()).toHaveCount(1);
+			// first page is visible rather than an exact total count. Item
+			// visibility already proves the dropdown is open, so avoid asserting on
+			// the popper count — unrelated tooltips (e.g. the error tooltip induced
+			// below) also match the visible-popper selector and make it flaky.
 			await expect(n8n.ndv.getResourceLocatorItems().nth(4)).toBeVisible();
 
 			await n8n.ndv.setInvalidExpression({ fieldName: 'fieldId' });
@@ -144,7 +146,6 @@ test.describe(
 
 			await n8n.ndv.getResourceLocatorInput('rlc').click();
 
-			await expect(n8n.ndv.getVisiblePopper()).toHaveCount(1);
 			await expect(n8n.ndv.getResourceLocatorItems().nth(4)).toBeVisible();
 		});
 	},

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
@@ -131,10 +131,11 @@ test.describe(
 
 			// A page of list options is 5 items. The dropdown auto-fetches a second
 			// page when the first one doesn't fill the viewport, so assert a full
-			// first page is visible rather than an exact total count. Item
-			// visibility already proves the dropdown is open, so avoid asserting on
-			// the popper count — unrelated tooltips (e.g. the error tooltip induced
-			// below) also match the visible-popper selector and make it flaky.
+			// first page is visible rather than an exact total count. Assert a
+			// popper is present (not an exact count) — unrelated tooltips (e.g. the
+			// error tooltip induced below) also match the visible-popper selector,
+			// so requiring exactly one is flaky.
+			await expect(n8n.ndv.getVisiblePopper().first()).toBeVisible();
 			await expect(n8n.ndv.getResourceLocatorItems().nth(4)).toBeVisible();
 
 			await n8n.ndv.setInvalidExpression({ fieldName: 'fieldId' });
@@ -146,6 +147,7 @@ test.describe(
 
 			await n8n.ndv.getResourceLocatorInput('rlc').click();
 
+			await expect(n8n.ndv.getVisiblePopper().first()).toBeVisible();
 			await expect(n8n.ndv.getResourceLocatorItems().nth(4)).toBeVisible();
 		});
 	},


### PR DESCRIPTION
## Summary

De-flakes the quarantined e2e test `Resource Locator > should retrieve list options when other params throw errors`. The test asserted `getVisiblePopper()` `toHaveCount(1)`, but that selector matches every visible popper — including the transient error tooltip induced when the test intentionally makes `fieldId` throw — so the count was sometimes 2 and the assertion timed out non-deterministically. Removed both popper-count assertions; the retained `rlc-item` visibility assertion already proves the real contract (a full page of list options loads even when another param errors) and that the dropdown is open, so no coverage is lost.

## How to test

Run `pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/ndv/resource-locator.spec.ts` repeatedly; the "should retrieve list options when other params throw errors" test should pass consistently. Unquarantine the test in Currents once this merges.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5512

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

