### PR TITLE
chore: Remove Jest support from testing packages

### DIFF
--- a/packages/testing/janitor/README.md
+++ b/packages/testing/janitor/README.md
@@ -211,11 +211,11 @@ ci-filter (in install-and-build)
         │
         └─→ CHANGED_FILES forwarded to test jobs
               │
-              └─→ janitor test-scoped --runner=jest|vitest  (per-package)
+              └─→ janitor test-scoped --runner=vitest  (per-package)
                     │
                     ├─→ SKIP        → exit 0 (no in-package changes)
                     ├─→ RUN_FULL    → spawn runner with no scope flags
-                    └─→ scoped      → jest --findRelatedTests / vitest related
+                    └─→ scoped      → vitest related
 ```
 
 **Usage:**
@@ -242,9 +242,9 @@ joined paths would otherwise overflow the kernel's argv/env size limit and the
 test job's shell couldn't even start. Such a change set affects nearly every
 package anyway, so the full-suite fallback is both safe and correct.
 
-**Per-package bailout (force full suite):** `jest.config.*`, `vitest.config.*`,
+**Per-package bailout (force full suite):** `vitest.config.*`,
 `vite.config.*` (vitest reads vite config), `package.json`, `tsconfig.*`,
-plus setup files at `<pkg>/jest.setup.*`, `<pkg>/vitest.setup.*`, and
+plus setup files at `<pkg>/vitest.setup.*` and
 `<pkg>/src/__tests__/setup.*`. The scope analyzer detects these and emits
 `RUN_FULL`; `test-scoped` then spawns the runner without scope flags.
 

--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -8,7 +8,7 @@
  *   janitor impact                         # Show impact of changes
  *   janitor tcr                            # TCR workflow
  *   janitor affected-packages              # List workspace packages affected by changed files
- *   janitor scope                          # Compute per-package jest/vitest scope list
+ *   janitor scope                          # Compute per-package vitest scope list
  *   janitor --help                         # Show help
  *
  * The `affected-packages` and `scope` subcommands are workspace-wide utilities
@@ -630,7 +630,7 @@ function runAffectedPackages(options: CliOptions): void {
 
 function runTestScopedCmd(options: CliOptions): void {
 	if (!options.runner) {
-		console.error('Error: --runner=jest|vitest is required');
+		console.error('Error: --runner=vitest is required');
 		process.exit(1);
 	}
 	const packageDir = options.packageDir ?? process.cwd();
@@ -641,14 +641,13 @@ function runTestScopedCmd(options: CliOptions): void {
 		rootDir: findWorkspaceRoot(process.cwd()),
 		changedFiles,
 		passthroughArgs: options.passthroughArgs,
-		jestVariant: options.jestVariant,
 	});
 	process.exit(exitCode);
 }
 
 function runScope(options: CliOptions): void {
 	if (!options.runner) {
-		console.error('Error: --runner=jest|vitest is required');
+		console.error('Error: --runner=vitest is required');
 		process.exit(1);
 	}
 
@@ -657,7 +656,6 @@ function runScope(options: CliOptions): void {
 		packageDir: options.packageDir ?? process.cwd(),
 		changedFiles: readChangedFiles(options),
 		rootDir: findWorkspaceRoot(process.cwd()),
-		jestVariant: options.jestVariant,
 	});
 	console.log(formatScope(result));
 }

--- a/packages/testing/janitor/src/cli/arg-parser.test.ts
+++ b/packages/testing/janitor/src/cli/arg-parser.test.ts
@@ -198,21 +198,15 @@ describe('arg-parser', () => {
 			expect(result.testCommand).toBe('pnpm test');
 		});
 
-		it('parses --jest-variant=unit', () => {
-			setArgs(['--jest-variant=unit']);
+		it('parses --runner=vitest', () => {
+			setArgs(['--runner=vitest']);
 			const result = parseArgs();
-			expect(result.jestVariant).toBe('unit');
+			expect(result.runner).toBe('vitest');
 		});
 
-		it('parses --jest-variant=integration', () => {
-			setArgs(['--jest-variant=integration']);
-			const result = parseArgs();
-			expect(result.jestVariant).toBe('integration');
-		});
-
-		it('throws on unknown --jest-variant value', () => {
-			setArgs(['--jest-variant=e2e']);
-			expect(() => parseArgs()).toThrow(/Unknown --jest-variant=e2e/);
+		it('throws on unknown --runner value', () => {
+			setArgs(['--runner=jest']);
+			expect(() => parseArgs()).toThrow(/Unknown --runner=jest/);
 		});
 	});
 

--- a/packages/testing/janitor/src/cli/arg-parser.ts
+++ b/packages/testing/janitor/src/cli/arg-parser.ts
@@ -56,8 +56,7 @@ export interface CliOptions {
 	impact: boolean;
 	// Affected-packages / scope options
 	changedFiles?: string;
-	runner?: 'jest' | 'vitest';
-	jestVariant?: 'unit' | 'integration';
+	runner?: 'vitest';
 	packageDir?: string;
 	/** Anything after `--` — forwarded to the test runner by `test-scoped`. */
 	passthroughArgs: string[];
@@ -192,17 +191,10 @@ const VALUE_FLAG_HANDLERS: Record<string, (options: CliOptions, value: string) =
 		opts.changedFiles = value;
 	},
 	'--runner=': (opts, value) => {
-		if (value === 'jest' || value === 'vitest') {
+		if (value === 'vitest') {
 			opts.runner = value;
 		} else {
-			throw new Error(`Unknown --runner=${value}. Expected 'jest' or 'vitest'.`);
-		}
-	},
-	'--jest-variant=': (opts, value) => {
-		if (value === 'unit' || value === 'integration') {
-			opts.jestVariant = value;
-		} else {
-			throw new Error(`Unknown --jest-variant=${value}. Expected 'unit' or 'integration'.`);
+			throw new Error(`Unknown --runner=${value}. Expected 'vitest'.`);
 		}
 	},
 	'--package-dir=': (opts, value) => {
@@ -259,7 +251,6 @@ function createDefaultOptions(): CliOptions {
 		impact: false,
 		changedFiles: undefined,
 		runner: undefined,
-		jestVariant: undefined,
 		packageDir: undefined,
 		passthroughArgs: [],
 		url: undefined,
@@ -278,7 +269,7 @@ function parseSubcommand(args: string[]): { command: Command; startIdx: number }
 
 /**
  * For test-scoped, unrecognised flags must forward to the underlying runner
- * (jest/vitest) — they can't be silently dropped because consumers compose
+ * (vitest) — they can't be silently dropped because consumers compose
  * extra flags via turbo + npm script chains. For all other subcommands the
  * passthrough list stays empty and unused.
  */

--- a/packages/testing/janitor/src/cli/help.ts
+++ b/packages/testing/janitor/src/cli/help.ts
@@ -236,45 +236,36 @@ runtime via the DI container by every consuming package's integration tests).
 
 export function showScopeHelp(): void {
 	console.log(`
-Scope - Per-package jest/vitest scope from changed files
+Scope - Per-package vitest scope from changed files
 
 Usage:
-  janitor scope --runner=<jest|vitest> [--jest-variant=<unit|integration>] [--package-dir=<dir>] [--changed-files=<list>]
+  janitor scope --runner=vitest [--package-dir=<dir>] [--changed-files=<list>]
 
   --package-dir:   defaults to cwd (matches how pnpm/turbo invoke test scripts).
   --changed-files: newline- OR comma-separated repo-root-relative paths.
                    Defaults to $CHANGED_FILES env var.
-  --jest-variant:  'integration' widens the bailout set to catch runtime-
-                   coupled changes invisible to jest --findRelatedTests
-                   (entities, repositories, migrations, shared fixtures).
-                   Defaults to 'unit'.
 
 Output (single line on stdout):
   SKIP        No in-package files changed
   RUN_FULL    Config file changed, OR no CHANGED_FILES signal (local dev)
-  <files>     Pass to jest --findRelatedTests / vitest related
+  <files>     Pass to vitest related
 `);
 }
 
 export function showTestScopedHelp(): void {
 	console.log(`
-Test-Scoped - Compute scope and spawn jest/vitest with the right flags
+Test-Scoped - Compute scope and spawn vitest with the right flags
 
 Usage:
-  janitor test-scoped --runner=<jest|vitest> [--jest-variant=<unit|integration>] [--package-dir=<dir>] [--changed-files=<list>] [extra runner args]
+  janitor test-scoped --runner=vitest [--package-dir=<dir>] [--changed-files=<list>] [extra runner args]
 
   --package-dir:   defaults to cwd (matches how pnpm/turbo invoke test scripts).
   --changed-files: newline- OR comma-separated repo-root-relative paths.
                    Defaults to $CHANGED_FILES env var.
-  --jest-variant:  'integration' widens the bailout set to catch runtime-
-                   coupled changes invisible to jest --findRelatedTests
-                   (entities, repositories, migrations, shared fixtures).
-                   Defaults to 'unit'.
 
 Local dev (no $CHANGED_FILES set): runs the full suite.
-CI: scopes via jest --findRelatedTests / vitest related --run, or skips
-if the package wasn't touched. Unrecognised flags are forwarded to the
-runner.
+CI: scopes via vitest related --run, or skips if the package wasn't touched.
+Unrecognised flags are forwarded to the runner.
 `);
 }
 

--- a/packages/testing/janitor/src/core/global-triggers.ts
+++ b/packages/testing/janitor/src/core/global-triggers.ts
@@ -17,7 +17,7 @@ export const GLOBAL_TRIGGER_FILES = new Set(['pnpm-lock.yaml', 'package.json']);
 /**
  * Directory prefixes consumed at runtime by packages that don't import them in
  * a way the test runner's import-graph walk can see. A change here is invisible
- * to `jest --findRelatedTests` / `vitest related` on the test file, so we bail
+ * to `vitest related` on the test file, so we bail
  * the workspace to full rather than silently skip:
  *   - `packages/@n8n/db/` — schema + entities resolved through the DI container
  *     by every consuming package's integration tests.

--- a/packages/testing/janitor/src/core/scope-analyzer.test.ts
+++ b/packages/testing/janitor/src/core/scope-analyzer.test.ts
@@ -17,7 +17,7 @@ describe('computeScope', () => {
 	it('returns full when CHANGED_FILES signal is missing (local dev)', () => {
 		const rootDir = makePackageDir('packages/cli');
 		const result = computeScope({
-			runner: 'jest',
+			runner: 'vitest',
 			packageDir: 'packages/cli',
 			rootDir,
 			changedFiles: null,
@@ -29,7 +29,7 @@ describe('computeScope', () => {
 	it('returns skip when no in-package files changed', () => {
 		const rootDir = makePackageDir('packages/cli');
 		const result = computeScope({
-			runner: 'jest',
+			runner: 'vitest',
 			packageDir: 'packages/cli',
 			rootDir,
 			changedFiles: ['packages/other/src/x.ts'],
@@ -41,7 +41,7 @@ describe('computeScope', () => {
 	it('returns scoped list when only source files changed', () => {
 		const rootDir = makePackageDir('packages/cli');
 		const result = computeScope({
-			runner: 'jest',
+			runner: 'vitest',
 			packageDir: 'packages/cli',
 			rootDir,
 			changedFiles: ['packages/cli/src/a.ts', 'packages/cli/src/b.ts'],
@@ -51,18 +51,6 @@ describe('computeScope', () => {
 			files: ['packages/cli/src/a.ts', 'packages/cli/src/b.ts'],
 		});
 		expect(formatScope(result)).toBe('packages/cli/src/a.ts packages/cli/src/b.ts');
-	});
-
-	it('bails to full on jest.config change for jest runner', () => {
-		const rootDir = makePackageDir('packages/cli');
-		const result = computeScope({
-			runner: 'jest',
-			packageDir: 'packages/cli',
-			rootDir,
-			changedFiles: ['packages/cli/jest.config.js'],
-		});
-		expect(result.kind).toBe('full');
-		expect(formatScope(result)).toBe('RUN_FULL');
 	});
 
 	it('bails to full on package.json change', () => {
@@ -90,7 +78,7 @@ describe('computeScope', () => {
 	it('ignores files outside the package even when configs match', () => {
 		const rootDir = makePackageDir('packages/cli');
 		const result = computeScope({
-			runner: 'jest',
+			runner: 'vitest',
 			packageDir: 'packages/cli',
 			rootDir,
 			changedFiles: ['packages/other/package.json'],
@@ -98,20 +86,18 @@ describe('computeScope', () => {
 		expect(result.kind).toBe('skip');
 	});
 
-	it('does NOT bail on vitest.config when runner is jest', () => {
+	it('bails to full on vitest.config change', () => {
 		const rootDir = makePackageDir('packages/cli');
 		const result = computeScope({
-			runner: 'jest',
+			runner: 'vitest',
 			packageDir: 'packages/cli',
 			rootDir,
 			changedFiles: ['packages/cli/vitest.config.ts'],
 		});
-		// vitest.config in a jest-tested package is not a runner bailout trigger.
-		// (It's unusual but the bailout is runner-specific.)
-		expect(result.kind).toBe('scoped');
+		expect(result.kind).toBe('full');
 	});
 
-	it('bails to full on vite.config change for vitest runner (vitest reads vite.config)', () => {
+	it('bails to full on vite.config change (vitest reads vite.config)', () => {
 		const rootDir = makePackageDir('packages/frontend/editor-ui');
 		const result = computeScope({
 			runner: 'vitest',
@@ -122,7 +108,7 @@ describe('computeScope', () => {
 		expect(result.kind).toBe('full');
 	});
 
-	it('bails to full on src/__tests__/setup.ts change for vitest runner', () => {
+	it('bails to full on src/__tests__/setup.ts change', () => {
 		const rootDir = makePackageDir('packages/frontend/editor-ui');
 		const result = computeScope({
 			runner: 'vitest',
@@ -131,126 +117,6 @@ describe('computeScope', () => {
 			changedFiles: ['packages/frontend/editor-ui/src/__tests__/setup.ts'],
 		});
 		expect(result.kind).toBe('full');
-	});
-
-	it('bails to full on src/__tests__/setup.ts change for jest runner', () => {
-		const rootDir = makePackageDir('packages/nodes-base');
-		const result = computeScope({
-			runner: 'jest',
-			packageDir: 'packages/nodes-base',
-			rootDir,
-			changedFiles: ['packages/nodes-base/src/__tests__/setup.ts'],
-		});
-		expect(result.kind).toBe('full');
-	});
-
-	describe('jest integration variant', () => {
-		it('does NOT bail on entity changes for the unit variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/modules/foo/foo.entity.ts'],
-			});
-			expect(result.kind).toBe('scoped');
-		});
-
-		it('bails to full on entity changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/modules/foo/foo.entity.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('bails to full on repository changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/databases/repositories/user.repository.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('bails to full on migration changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/modules/foo/database/AddFoo.migration.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('bails to full on shared integration test fixture changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/test/integration/shared/workflow.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('bails to full on test/migration changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/test/migration/some-helper.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('bails to full on src/modules/<m>/database changes for the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/modules/insights/database/repositories/insights.ts'],
-			});
-			expect(result.kind).toBe('full');
-		});
-
-		it('still scopes when only an ordinary src file changes under the integration variant', () => {
-			const rootDir = makePackageDir('packages/cli');
-			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
-				packageDir: 'packages/cli',
-				rootDir,
-				changedFiles: ['packages/cli/src/controllers/auth.controller.ts'],
-			});
-			expect(result.kind).toBe('scoped');
-		});
-
-		it('jest-variant=integration has no effect on the vitest runner', () => {
-			const rootDir = makePackageDir('packages/frontend/editor-ui');
-			const result = computeScope({
-				runner: 'vitest',
-				jestVariant: 'integration',
-				packageDir: 'packages/frontend/editor-ui',
-				rootDir,
-				changedFiles: ['packages/frontend/editor-ui/src/foo.entity.ts'],
-			});
-			expect(result.kind).toBe('scoped');
-		});
 	});
 
 	describe('global triggers force RUN_FULL', () => {
@@ -263,8 +129,7 @@ describe('computeScope', () => {
 		])('bails to full on %s even when nothing changed in-package', (_label, changed) => {
 			const rootDir = makePackageDir('packages/cli');
 			const result = computeScope({
-				runner: 'jest',
-				jestVariant: 'integration',
+				runner: 'vitest',
 				packageDir: 'packages/cli',
 				rootDir,
 				changedFiles: [changed],
@@ -273,7 +138,7 @@ describe('computeScope', () => {
 			expect(formatScope(result)).toBe('RUN_FULL');
 		});
 
-		it('a universal-sink change forces full for a vitest downstream too', () => {
+		it('a universal-sink change forces full for a downstream package too', () => {
 			const rootDir = makePackageDir('packages/nodes-base');
 			const result = computeScope({
 				runner: 'vitest',
@@ -287,7 +152,7 @@ describe('computeScope', () => {
 		it('does NOT treat a per-package package.json as a global trigger', () => {
 			const rootDir = makePackageDir('packages/cli');
 			const result = computeScope({
-				runner: 'jest',
+				runner: 'vitest',
 				packageDir: 'packages/cli',
 				rootDir,
 				changedFiles: ['packages/other/package.json'],
@@ -298,7 +163,7 @@ describe('computeScope', () => {
 		it('still SKIPs an unrelated cross-package change', () => {
 			const rootDir = makePackageDir('packages/cli');
 			const result = computeScope({
-				runner: 'jest',
+				runner: 'vitest',
 				packageDir: 'packages/cli',
 				rootDir,
 				changedFiles: ['packages/nodes-base/nodes/Slack/Slack.node.ts'],

--- a/packages/testing/janitor/src/core/scope-analyzer.ts
+++ b/packages/testing/janitor/src/core/scope-analyzer.ts
@@ -1,8 +1,7 @@
 /**
  * Filters CHANGED_FILES to a single package and detects config-file bailouts.
  * Output is a shell sentinel (SKIP / RUN_FULL / file list). The actual
- * import-graph walk is the runner's job (jest --findRelatedTests / vitest
- * related).
+ * import-graph walk is the runner's job (vitest related).
  */
 
 import { existsSync } from 'node:fs';
@@ -11,16 +10,7 @@ import { isAbsolute, relative, resolve } from 'node:path';
 import { matchesGlobalTrigger } from './global-triggers.js';
 import { toPosix } from './path-utils.js';
 
-export type Runner = 'jest' | 'vitest';
-/**
- * Jest has two test surfaces in this workspace:
- *   - unit       — pure modules + mocked deps; only the unit bailouts apply
- *   - integration — HTTP / DI container; transitive deps that don't appear in
- *                   the import graph (db schema, shared fixtures, migrations)
- *                   force RUN_FULL. See JEST_INTEGRATION_BAILOUT for the list.
- * `undefined` collapses to the unit variant for callers that don't specify.
- */
-export type JestVariant = 'unit' | 'integration';
+export type Runner = 'vitest';
 
 // Bailout patterns are centralised here (vs the original DEVP-194 spec's
 // per-package `n8nTestChanged.inPackageBailouts` field) because the n8n
@@ -33,33 +23,6 @@ const COMMON_BAILOUT = [
 	/^tsconfig(\..+)?\.json$/,
 	/^\.swcrc$/,
 	/^babel\.config\.[cm]?[jt]s$/,
-];
-const JEST_BAILOUT = [
-	...COMMON_BAILOUT,
-	/^jest\.config\.[cm]?[jt]s$/,
-	/(?:^|\/)(?:jest|test)\.setup\.[cm]?[jt]s$/,
-	/(?:^|\/)__tests__\/setup\.[cm]?[jt]s$/,
-];
-// Integration tests hit HTTP + the DI container, so changes to types that
-// aren't import-graph-visible to the test file still flow through at runtime:
-//   - entity / repository changes — touched at runtime via `Container.get`,
-//     not imported by the test
-//   - migrations — never imported but every integration test depends on the
-//     resulting schema
-//   - `src/databases/**` / `src/modules/*/database/**` — schema scaffolding
-//   - `test/integration/shared/**` — shared fixtures coupled at runtime
-//   - `test/migration/**` — migration test infrastructure
-// Without these, jest --findRelatedTests would return zero tests and CI
-// would falsely report green on changes that genuinely break integration.
-const JEST_INTEGRATION_BAILOUT = [
-	...JEST_BAILOUT,
-	/\.entity\.[cm]?ts$/,
-	/\.repository\.[cm]?ts$/,
-	/\.migration\.[cm]?ts$/,
-	/^src\/databases\//,
-	/^src\/modules\/[^/]+\/database\//,
-	/^test\/integration\/shared\//,
-	/^test\/migration\//,
 ];
 // Frontend packages use vite.config.* for the vitest config too (vitest reads
 // vite.config). Setup files live at src/__tests__/setup.ts per the shared
@@ -78,12 +41,6 @@ export interface ComputeScopeOptions {
 	rootDir: string;
 	/** `null` = no signal → RUN_FULL (local dev with unset env). */
 	changedFiles: string[] | null;
-	/**
-	 * Only relevant when `runner === 'jest'`. Selects the bailout set:
-	 * `'integration'` widens it to catch runtime-coupled changes (entities,
-	 * repositories, migrations, shared fixtures). Defaults to `'unit'`.
-	 */
-	jestVariant?: JestVariant;
 }
 
 export type ScopeResult =
@@ -118,12 +75,7 @@ export function computeScope(options: ComputeScopeOptions): ScopeResult {
 	);
 	if (inPackage.length === 0) return { kind: 'skip', reason: 'No changed files in package' };
 
-	const bailout =
-		options.runner === 'jest'
-			? options.jestVariant === 'integration'
-				? JEST_INTEGRATION_BAILOUT
-				: JEST_BAILOUT
-			: VITEST_BAILOUT;
+	const bailout = VITEST_BAILOUT;
 	for (const file of inPackage) {
 		const relInPkg = file.slice(pkgPrefixSlash.length);
 		if (bailout.some((p) => p.test(relInPkg))) {

--- a/packages/testing/janitor/src/core/test-scoped-runner.test.ts
+++ b/packages/testing/janitor/src/core/test-scoped-runner.test.ts
@@ -6,24 +6,8 @@ import { buildRunnerArgs } from './test-scoped-runner.js';
 const rootDir = '/repo/root';
 
 describe('buildRunnerArgs', () => {
-	it('jest scoped: emits --findRelatedTests with absolute paths', () => {
+	it('scoped: emits `related` with absolute paths and `--run` to avoid watch mode', () => {
 		const args = buildRunnerArgs(
-			'jest',
-			{ kind: 'scoped', files: ['packages/nodes-base/nodes/Foo.node.ts'] },
-			rootDir,
-			['--summarize'],
-		);
-		expect(args[0]).toBe('--findRelatedTests');
-		expect(isAbsolute(args[1])).toBe(true);
-		expect(args[1]).toBe('/repo/root/packages/nodes-base/nodes/Foo.node.ts');
-		// A scoped jest run that resolves to zero related tests must pass, not exit 1.
-		expect(args[2]).toBe('--passWithNoTests');
-		expect(args[3]).toBe('--summarize');
-	});
-
-	it('vitest scoped: emits `related` with absolute paths and `--run` to avoid watch mode', () => {
-		const args = buildRunnerArgs(
-			'vitest',
 			{
 				kind: 'scoped',
 				files: ['packages/frontend/editor-ui/src/x.ts', 'packages/frontend/editor-ui/src/y.ts'],
@@ -41,23 +25,16 @@ describe('buildRunnerArgs', () => {
 
 	it('preserves already-absolute paths', () => {
 		const args = buildRunnerArgs(
-			'jest',
 			{ kind: 'scoped', files: ['/already/absolute/path.ts'] },
 			rootDir,
 			[],
 		);
-		expect(args).toEqual(['--findRelatedTests', '/already/absolute/path.ts', '--passWithNoTests']);
+		expect(args).toEqual(['related', '/already/absolute/path.ts', '--run']);
 	});
 
-	it('jest full: passes through args with no related-tests flag', () => {
-		expect(
-			buildRunnerArgs('jest', { kind: 'full', reason: 'config change' }, rootDir, ['--summarize']),
-		).toEqual(['--summarize']);
-	});
-
-	it('vitest full: prepends `run` subcommand', () => {
-		expect(
-			buildRunnerArgs('vitest', { kind: 'full', reason: 'no signal' }, rootDir, ['--coverage']),
-		).toEqual(['run', '--coverage']);
+	it('full: prepends `run` subcommand', () => {
+		expect(buildRunnerArgs({ kind: 'full', reason: 'no signal' }, rootDir, ['--coverage'])).toEqual(
+			['run', '--coverage'],
+		);
 	});
 });

--- a/packages/testing/janitor/src/core/test-scoped-runner.ts
+++ b/packages/testing/janitor/src/core/test-scoped-runner.ts
@@ -1,9 +1,9 @@
-/** Compute per-package scope and dispatch to jest/vitest with the right flags. */
+/** Compute per-package scope and dispatch to vitest with the right flags. */
 
 import { spawnSync } from 'node:child_process';
 import { isAbsolute, resolve } from 'node:path';
 
-import { computeScope, type JestVariant, type Runner, type ScopeResult } from './scope-analyzer.js';
+import { computeScope, type Runner, type ScopeResult } from './scope-analyzer.js';
 
 export interface TestScopedOptions {
 	runner: Runner;
@@ -11,36 +11,26 @@ export interface TestScopedOptions {
 	rootDir: string;
 	changedFiles: string[] | null;
 	passthroughArgs: string[];
-	jestVariant?: JestVariant;
 }
 
 /**
  * Build the runner argv from a scope result. Paths are resolved to absolute
  * because pnpm/turbo runs `test:changed` with cwd=packageDir, while CHANGED_FILES
- * is repo-root-relative — handing a relative path to `jest --findRelatedTests` or
- * `vitest related` from inside the package would silently match zero files and
- * exit 0 with no tests run.
+ * is repo-root-relative — handing a relative path to `vitest related` from inside
+ * the package would silently match zero files and exit 0 with no tests run.
  */
 export function buildRunnerArgs(
-	runner: Runner,
 	scope: Extract<ScopeResult, { kind: 'scoped' | 'full' }>,
 	rootDir: string,
 	passthroughArgs: string[],
 ): string[] {
 	if (scope.kind === 'full') {
-		return runner === 'vitest' ? ['run', ...passthroughArgs] : [...passthroughArgs];
+		return ['run', ...passthroughArgs];
 	}
 	const absoluteFiles = scope.files.map((f) => (isAbsolute(f) ? f : resolve(rootDir, f)));
-	// `jest --findRelatedTests` exits 1 when the changed files resolve to zero
-	// related tests (e.g. a variant like integration that has no matching tests
-	// for this change). `--passWithNoTests` makes that a pass, matching the
-	// `skip` semantics above and `vitest related`'s behaviour.
-	//
 	// `vitest related` defaults to watch mode and does NOT TTY-detect, so it
 	// would hang the CI runner forever. `--run` forces a single-pass execution.
-	return runner === 'jest'
-		? ['--findRelatedTests', ...absoluteFiles, '--passWithNoTests', ...passthroughArgs]
-		: ['related', ...absoluteFiles, '--run', ...passthroughArgs];
+	return ['related', ...absoluteFiles, '--run', ...passthroughArgs];
 }
 
 export function runTestScoped(options: TestScopedOptions): number {
@@ -49,7 +39,6 @@ export function runTestScoped(options: TestScopedOptions): number {
 		packageDir: options.packageDir,
 		rootDir: options.rootDir,
 		changedFiles: options.changedFiles,
-		jestVariant: options.jestVariant,
 	});
 
 	if (scope.kind === 'skip') {
@@ -63,9 +52,9 @@ export function runTestScoped(options: TestScopedOptions): number {
 		console.log(`[janitor:test-scoped] scoping to ${scope.files.length} file(s)`);
 	}
 
-	const args = buildRunnerArgs(options.runner, scope, options.rootDir, options.passthroughArgs);
+	const args = buildRunnerArgs(scope, options.rootDir, options.passthroughArgs);
 	// Pass cwd explicitly so an override via --package-dir is honoured
-	// (otherwise spawnSync inherits the caller's cwd and jest/vitest would
+	// (otherwise spawnSync inherits the caller's cwd and vitest would
 	// resolve config + tests from the wrong project).
 	return spawnSync(options.runner, args, { stdio: 'inherit', cwd: options.packageDir }).status ?? 1;
 }

--- a/packages/testing/playwright/coverage-options.ts
+++ b/packages/testing/playwright/coverage-options.ts
@@ -28,7 +28,7 @@ export const coverageOptions: CoverageReportOptions = {
 	// Keep first-party application source after source-map expansion; drop deps
 	// and any unmapped dist files. NB nodes-base sources live under `nodes/`,
 	// `credentials/` etc — not `src/` — so don't require `/src/`. The test/mock
-	// exclusions mirror jest.coverage-excludes.js — keep them in sync.
+	// exclusions mirror the per-package vitest coverage excludes — keep them in sync.
 	sourceFilter: (sourcePath) =>
 		!sourcePath.includes('node_modules') &&
 		!sourcePath.includes('/dist/') &&

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -28,7 +28,7 @@ describe('isNonImpactful', () => {
 		'tsconfig.json',
 		'packages/cli/tsconfig.build.json',
 		'biome.jsonc',
-		'packages/testing/test-impact/jest.config.ts',
+		'packages/testing/test-impact/vitest.config.ts',
 		'.eslintrc.js',
 	])('treats %s as non-impactful', (file) => {
 		expect(isNonImpactful(file)).toBe(true);

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -33,7 +33,7 @@ const NON_IMPACTFUL: Array<(f: string) => boolean> = [
 	(f) => f.startsWith('scripts/'),
 	// Named build / lint / test-runner config (NOT all json/yaml)
 	(f) =>
-		/(^|\/)(turbo\.json|tsconfig([.\w-]*)\.json|biome\.jsonc?|jest\.config\.[cm]?[jt]s|\.eslintrc[\w.]*|\.prettierrc[\w.]*)$/.test(
+		/(^|\/)(turbo\.json|tsconfig([.\w-]*)\.json|biome\.jsonc?|vitest\.config\.[cm]?[jt]s|\.eslintrc[\w.]*|\.prettierrc[\w.]*)$/.test(
 			f,
 		),
 ];


### PR DESCRIPTION
## Summary

> [!NOTE]
> --runner is removed in a stacked PR https://github.com/n8n-io/n8n/pull/33373

Jest has been fully removed from the monorepo, so the Jest code paths in the `packages/testing/*` tooling are now dead code. This PR removes them:

**`janitor`** (Jest was a first-class runner here):
- `scope-analyzer`: dropped `JestVariant`, the Jest/Jest-integration bailout sets, and the runner-branching bailout selection; `Runner` is now `'vitest'` and the bailout set is always the vitest one.
- `test-scoped-runner`: `buildRunnerArgs` no longer emits `--findRelatedTests`/`--passWithNoTests`; vitest-only.
- CLI: removed `--jest-variant`; `--runner` now only accepts `vitest`. Help text, error messages, and README updated.
- Tests updated accordingly (removed Jest-specific cases, added a test asserting `--runner=jest` is now rejected).

**`test-impact`**: replaced the non-existent `jest.config.*` in the non-impactful-config regex with `vitest.config.*` (same intent — unit-test-runner config, invisible to E2E).

**`playwright`**: fixed a stale comment referencing the removed `jest.coverage-excludes.js`.

The `--runner=vitest` flag is intentionally left in place for now (still passed by ~10 package.json scripts across the repo); a follow-up stacked PR removes it.

## How to test

Internal test tooling only — no runtime/product behavior changes.

```bash
cd packages/testing/janitor && pnpm typecheck && pnpm lint && pnpm test
cd packages/testing/test-impact && pnpm typecheck && pnpm test
```

All pass (janitor 55 tests, test-impact 51 tests).

## Related Linear tickets, Github issues, and Community forum posts

Part of the Jest → Vitest migration (DEVP-94).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

