### PR TITLE
fix(RabbitMQ Node): Resolve routingKey by index

### DIFF
--- a/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/RabbitMQ.node.ts
@@ -27,7 +27,7 @@ export class RabbitMQ implements INodeType {
 		name: 'rabbitmq',
 		icon: 'file:rabbitmq.svg',
 		group: ['transform'],
-		version: [1, 1.1],
+		version: [1, 1.1, 1.2],
 		description: 'Sends messages to a RabbitMQ topic',
 		defaults: {
 			name: 'RabbitMQ',
@@ -76,7 +76,7 @@ export class RabbitMQ implements INodeType {
 				default: 'sendMessage',
 				displayOptions: {
 					show: {
-						'@version': [1.1],
+						'@version': [{ _cnd: { gte: 1.1 } }],
 					},
 				},
 				options: [
@@ -395,6 +395,7 @@ export class RabbitMQ implements INodeType {
 				return [items];
 			}
 			const mode = (this.getNodeParameter('mode', 0) as string) || 'queue';
+			const nodeVersion = this.getNode().typeVersion;
 			const returnItems: INodeExecutionData[] = [];
 			if (mode === 'queue') {
 				const queue = this.getNodeParameter('queue', 0) as string;
@@ -466,7 +467,6 @@ export class RabbitMQ implements INodeType {
 				await channel.connection.close();
 			} else if (mode === 'exchange') {
 				const exchange = this.getNodeParameter('exchange', 0) as string;
-				const routingKey = this.getNodeParameter('routingKey', 0) as string;
 
 				const options = this.getNodeParameter('options', 0, {}) as Options;
 
@@ -478,6 +478,11 @@ export class RabbitMQ implements INodeType {
 
 				const exchangePromises = [];
 				for (let i = 0; i < items.length; i++) {
+					const routingKey = this.getNodeParameter(
+						'routingKey',
+						nodeVersion >= 1.2 ? i : 0,
+					) as string;
+
 					if (sendInputData) {
 						message = JSON.stringify(items[i].json);
 					} else {

--- a/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/test/RabbitMQ.node.test.ts
@@ -1,0 +1,131 @@
+import type { Channel, Connection } from 'amqplib';
+import { mock, mockDeep } from 'vitest-mock-extended';
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+
+import * as GenericFunctions from '../GenericFunctions';
+import { RabbitMQ } from '../RabbitMQ.node';
+
+describe('RabbitMQ node', () => {
+	const node = new RabbitMQ();
+	const mockChannel = mock<Channel>();
+	const mockConnection = mock<Connection>();
+
+	mockChannel.connection = mockConnection;
+
+	const buildExecuteFunctions = (typeVersion: number) => {
+		const executeFunctions = mockDeep<IExecuteFunctions>();
+		const inputItems = [{ json: { seq: 1 } }, { json: { seq: 2 } }, { json: { seq: 3 } }];
+
+		executeFunctions.getInputData.mockReturnValue(inputItems);
+		executeFunctions.getNode.mockReturnValue({
+			id: 'node-id',
+			name: 'RabbitMQ',
+			type: 'n8n-nodes-base.rabbitmq',
+			typeVersion,
+			position: [0, 0],
+			parameters: {},
+		} as INode);
+		executeFunctions.continueOnFail.mockReturnValue(false);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(parameterName, itemIndex, fallbackValue) => {
+				switch (parameterName) {
+					case 'operation':
+						return 'sendMessage';
+					case 'mode':
+						return 'exchange';
+					case 'exchange':
+						return 'test.exchange';
+					case 'sendInputData':
+						return true;
+					case 'options':
+						return {};
+					case 'routingKey':
+						if (itemIndex === 0) return 'key.alpha';
+						if (itemIndex === 1) return 'key.beta';
+						if (itemIndex === 2) return 'key.gamma';
+						return 'key.alpha';
+					default:
+						return fallbackValue;
+				}
+			},
+		);
+
+		return { executeFunctions, inputItems };
+	};
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mockChannel.publish.mockReturnValue(true);
+		vi.spyOn(GenericFunctions, 'rabbitmqConnectExchange').mockResolvedValue(mockChannel);
+	});
+
+	it('includes node version 1.2 and exposes operation selector for it', () => {
+		expect(node.description.version).toContain(1.2);
+
+		const visibleOperation = node.description.properties.find(
+			(property) => property.name === 'operation' && property.type === 'options',
+		);
+		expect(visibleOperation?.displayOptions?.show?.['@version']).toEqual([{ _cnd: { gte: 1.1 } }]);
+	});
+
+	it('keeps v1.1 exchange routing key resolution on item 0', async () => {
+		const { executeFunctions, inputItems } = buildExecuteFunctions(1.1);
+
+		await node.execute.call(executeFunctions);
+
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			1,
+			'test.exchange',
+			'key.alpha',
+			Buffer.from(JSON.stringify(inputItems[0].json)),
+			{ headers: {} },
+		);
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			2,
+			'test.exchange',
+			'key.alpha',
+			Buffer.from(JSON.stringify(inputItems[1].json)),
+			{ headers: {} },
+		);
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			3,
+			'test.exchange',
+			'key.alpha',
+			Buffer.from(JSON.stringify(inputItems[2].json)),
+			{ headers: {} },
+		);
+		expect(executeFunctions.getNodeParameter).not.toHaveBeenCalledWith('routingKey', 1);
+		expect(executeFunctions.getNodeParameter).not.toHaveBeenCalledWith('routingKey', 2);
+	});
+
+	it('evaluates exchange routing key per item in v1.2', async () => {
+		const { executeFunctions, inputItems } = buildExecuteFunctions(1.2);
+
+		await node.execute.call(executeFunctions);
+
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			1,
+			'test.exchange',
+			'key.alpha',
+			Buffer.from(JSON.stringify(inputItems[0].json)),
+			{ headers: {} },
+		);
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			2,
+			'test.exchange',
+			'key.beta',
+			Buffer.from(JSON.stringify(inputItems[1].json)),
+			{ headers: {} },
+		);
+		expect(mockChannel.publish).toHaveBeenNthCalledWith(
+			3,
+			'test.exchange',
+			'key.gamma',
+			Buffer.from(JSON.stringify(inputItems[2].json)),
+			{ headers: {} },
+		);
+		expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith('routingKey', 0);
+		expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith('routingKey', 1);
+		expect(executeFunctions.getNodeParameter).toHaveBeenCalledWith('routingKey', 2);
+	});
+});


### PR DESCRIPTION
## Summary

This PR fixes broken routing key issue in rabbit mq which lead 0 index key being used for all items

## How to test

1. Start rabbitmq
2. Create 2 queues and `test` exchange in management console
3. Run this workflow
4. Verify in console using "Get messages" section

<details>
 <summary>Workflow</summary>
```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -304,
        0
      ],
      "id": "e39fe698-a1e8-4b41-814c-9652de55dc8d",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "jsCode": "return [\n  {\n    value: '1',\n    key: 'test.dynamic.alpha'\n  }, \n  {\n    value: '2',\n    key: 'test.dynamic.beta'\n  }\n]"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        -96,
        0
      ],
      "id": "9c2bd17f-d8af-4f19-8583-301f5165e07a",
      "name": "Code in JavaScript"
    },
    {
      "parameters": {
        "mode": "exchange",
        "exchange": "test1",
        "exchangeType": "direct",
        "routingKey": "={{ $json.queue }}",
        "sendInputData": false,
        "message": "={{ $json.value }}",
        "options": {}
      },
      "type": "n8n-nodes-base.rabbitmq",
      "typeVersion": 1.1,
      "position": [
        160,
        -160
      ],
      "id": "8df958cd-6023-4935-b8a1-8111b3a2617d",
      "name": "v1.1",
      "credentials": {
        "rabbitmq": {
          "id": "Z5kxGUdN8mUGuJHB",
          "name": "RabbitMQ account"
        }
      }
    },
    {
      "parameters": {
        "mode": "exchange",
        "exchange": "test",
        "exchangeType": "direct",
        "routingKey": "={{ $json.key }}",
        "sendInputData": false,
        "message": "={{ $json.value }}",
        "options": {}
      },
      "type": "n8n-nodes-base.rabbitmq",
      "typeVersion": 1.2,
      "position": [
        160,
        0
      ],
      "id": "ec9c19a6-e0dc-4f26-8966-76cfddf29df6",
      "name": "v1.2",
      "credentials": {
        "rabbitmq": {
          "id": "Z5kxGUdN8mUGuJHB",
          "name": "RabbitMQ account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Code in JavaScript",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Code in JavaScript": {
      "main": [
        [
          {
            "node": "v1.2",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts
closes #28525 
https://linear.app/n8n/issue/NODE-4859/community-issue-rabbitmq-node-routing-key-expression-evaluated-only


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

