### PR TITLE
fix(core): Persist MCP Server Trigger tool calls in queue mode

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -14,6 +14,7 @@ import {
 	type IWorkflowExecuteAdditionalData,
 	Workflow,
 	NodeConnectionTypes,
+	NodeOperationError,
 	createRunExecutionData,
 	type IRunExecutionData,
 	type WorkflowExecuteMode,
@@ -1415,6 +1416,248 @@ describe('JobProcessor', () => {
 					}),
 				}),
 			);
+		});
+
+		it('still returns the tool result to the client when persisting the run data fails', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+			executionPersistence.updateExistingExecution.mockRejectedValueOnce(new Error('db down'));
+
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({}),
+			};
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				execute: vi.fn().mockResolvedValue([[{ json: { response: 42 } }]]),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-persist-fail',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-persist-fail',
+				mcpMessageId: 'msg-persist-fail',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: '2 + 2' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await expect(jobProcessor.processJob(job)).resolves.toEqual({ success: true });
+
+			expect(logger.error).toHaveBeenCalledWith(
+				'Failed to persist tool call run data for MCP Trigger',
+				expect.objectContaining({
+					executionId: 'exec-mcp-persist-fail',
+					sourceNodeName: 'Calculator',
+				}),
+			);
+
+			// The mcp-response with the tool result must still reach the client.
+			const mcpResponseCalls = (job.progress as Mock).mock.calls.filter(
+				(call: unknown[]) => (call[0] as { kind: string }).kind === 'mcp-response',
+			);
+			expect(mcpResponseCalls[mcpResponseCalls.length - 1][0]).toMatchObject({
+				kind: 'mcp-response',
+				executionId: 'exec-mcp-persist-fail',
+			});
+		});
+
+		it('initializes execution data when the completed run lacks it', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+
+			// `executionData: null` leaves the run without an executionData object, forcing
+			// invokeTool to initialize it before recording the tool call.
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({ executionData: null }),
+			};
+			expect(run.data.executionData).toBeUndefined();
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				execute: vi.fn().mockResolvedValue([[{ json: { response: 42 } }]]),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-init-data',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-init-data',
+				mcpMessageId: 'msg-init-data',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: '2 + 2' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(run.data.executionData).toBeDefined();
+			expect(run.data.resultData.runData.Calculator?.[0]?.executionStatus).toBe('success');
+		});
+
+		it('records a NodeOperationError from the tool without re-wrapping it', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				id: 'calc-node',
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({}),
+			};
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			const toolError = new NodeOperationError(toolNode, 'boom');
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				execute: vi.fn().mockRejectedValue(toolError),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-node-error',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-node-error',
+				mcpMessageId: 'msg-node-error',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: 'bad' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(run.data.resultData.runData.Calculator?.[0]?.executionStatus).toBe('error');
+			expect(run.data.resultData.runData.Calculator?.[0]?.error).toBe(toolError);
 		});
 	});
 

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -8,10 +8,13 @@ import { mockInstance } from 'n8n-core/test/utils';
 import {
 	type IPinData,
 	type IRun,
+	type ISupplyDataFunctions,
 	type ITaskData,
+	type IDataObject,
 	type IWorkflowExecuteAdditionalData,
 	Workflow,
 	NodeConnectionTypes,
+	createRunExecutionData,
 	type IRunExecutionData,
 	type WorkflowExecuteMode,
 	type ExecutionError,
@@ -1125,6 +1128,293 @@ describe('JobProcessor', () => {
 
 			expect(mockSupplyData).toHaveBeenCalled();
 			expect(capturedContext).toEqual(runtimeContext);
+		});
+
+		it('persists the tool node run data into the execution after a tool call', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			const triggerNode = {
+				name: 'MCP Server Trigger',
+				type: '@n8n/n8n-nodes-langchain.mcpTrigger',
+				typeVersion: 1,
+				parameters: {},
+				position: [200, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: {
+						id: 'wf-1',
+						nodes: [toolNode, triggerNode],
+						connections: {
+							Calculator: {
+								[NodeConnectionTypes.AiTool]: [
+									[{ node: 'MCP Server Trigger', type: NodeConnectionTypes.AiTool, index: 0 }],
+								],
+							},
+						},
+						staticData: {},
+					},
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+
+			// The completed workflow run must carry a real (mutable) run-execution-data
+			// object, so the tool node's input/output actually land in resultData.runData.
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({}),
+			};
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				execute: vi.fn().mockResolvedValue([[{ json: { response: 42 } }]]),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-record',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-record',
+				mcpMessageId: 'msg-record',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: '2 + 2' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(run.data.resultData.runData.Calculator?.[0]?.executionStatus).toBe('success');
+			expect(run.data.resultData.runData.Calculator?.[0]?.source?.[0]?.previousNode).toBe(
+				'MCP Server Trigger',
+			);
+			expect(executionPersistence.updateExistingExecution).toHaveBeenCalledWith(
+				'exec-mcp-record',
+				expect.objectContaining({
+					data: expect.objectContaining({
+						resultData: expect.objectContaining({
+							runData: expect.objectContaining({ Calculator: expect.any(Array) }),
+						}),
+					}),
+				}),
+			);
+		});
+
+		it('records the tool node as errored when the tool call fails', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({}),
+			};
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				execute: vi.fn().mockRejectedValue(new Error('boom')),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-error',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-error',
+				mcpMessageId: 'msg-error',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: 'bad' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(run.data.resultData.runData.Calculator?.[0]?.executionStatus).toBe('error');
+			expect(executionPersistence.updateExistingExecution).toHaveBeenCalledWith(
+				'exec-mcp-error',
+				expect.objectContaining({
+					data: expect.objectContaining({
+						resultData: expect.objectContaining({
+							runData: expect.objectContaining({ Calculator: expect.any(Array) }),
+						}),
+					}),
+				}),
+			);
+		});
+
+		it('persists run data for a supplyData tool that records via its context', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const executionPersistence = mock<ExecutionPersistence>();
+			const toolNode = {
+				name: 'Calculator',
+				type: '@n8n/n8n-nodes-langchain.toolCalculator',
+				typeVersion: 1,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+			executionPersistence.findSingleExecution.mockResolvedValueOnce(
+				mock<IExecutionResponse>({
+					mode: 'trigger',
+					workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+					data: mock<IRunExecutionData>({ executionData: undefined }),
+				}),
+			);
+
+			const run: IRun = {
+				mode: 'trigger',
+				status: 'success',
+				finished: true,
+				startedAt: new Date(),
+				stoppedAt: new Date(),
+				storedAt: 'db',
+				data: createRunExecutionData({}),
+			};
+			const manualExecutionService = createManualExecutionServiceMock(run);
+			const mcpInstanceSettings = { hostId: 'worker-host-123' } as unknown as InstanceSettings;
+
+			// Native langchain tools return a `logWrapper`-wrapped tool from supplyData that
+			// records into the bound context on invoke. Simulate that here to prove the
+			// supplyData branch's recording lands in the threaded run data (not a throwaway).
+			const nodeTypes = mock<NodeTypes>();
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: {
+					name: 'toolCalculator',
+					outputs: [NodeConnectionTypes.AiTool],
+					properties: [],
+				},
+				supplyData: vi.fn(async function (this: ISupplyDataFunctions) {
+					return {
+						response: {
+							invoke: async (args: IDataObject) => {
+								const { index } = this.addInputData(NodeConnectionTypes.AiTool, [[{ json: args }]]);
+								this.addOutputData(NodeConnectionTypes.AiTool, index, [
+									[{ json: { response: 4 } }],
+								]);
+								return '4';
+							},
+						},
+					};
+				}),
+			} as never);
+
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				executionPersistence,
+				mock(),
+				nodeTypes,
+				mcpInstanceSettings,
+				manualExecutionService,
+				executionsConfig,
+				mock(),
+			);
+
+			const job = mock<Job>();
+			job.data = {
+				workflowId: 'wf-1',
+				executionId: 'exec-mcp-supply',
+				loadStaticData: false,
+				isMcpExecution: true,
+				mcpType: 'trigger',
+				mcpSessionId: 'session-supply',
+				mcpMessageId: 'msg-supply',
+				mcpToolCall: {
+					toolName: 'Calculator',
+					arguments: { input: '2 + 2' },
+					sourceNodeName: 'Calculator',
+				},
+			};
+
+			await jobProcessor.processJob(job);
+
+			expect(run.data.resultData.runData.Calculator?.[0]?.executionStatus).toBe('success');
+			expect(executionPersistence.updateExistingExecution).toHaveBeenCalledWith(
+				'exec-mcp-supply',
+				expect.objectContaining({
+					data: expect.objectContaining({
+						resultData: expect.objectContaining({
+							runData: expect.objectContaining({ Calculator: expect.any(Array) }),
+						}),
+					}),
+				}),
+			);
 		});
 	});
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -19,6 +19,7 @@ import type {
 	IExecutionContext,
 	INodeExecutionData,
 	IRun,
+	IRunExecutionData,
 	IWorkflowExecutionDataProcess,
 	StructuredChunk,
 	CloseFunction,
@@ -28,6 +29,7 @@ import {
 	BINARY_ENCODING,
 	ManualExecutionCancelledError,
 	NodeConnectionTypes,
+	NodeOperationError,
 	Workflow,
 	UnexpectedError,
 	createRunExecutionData,
@@ -36,6 +38,7 @@ import type PCancelable from 'p-cancelable';
 
 import { EventService } from '@/events/event.service';
 import { getLifecycleHooksForScalingWorker } from '@/execution-lifecycle/execution-lifecycle-hooks';
+import { prepareExecutionDataForDbUpdate } from '@/execution-lifecycle/shared/shared-hook-functions';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
 import { ManualExecutionService } from '@/manual-execution.service';
@@ -355,6 +358,7 @@ export class JobProcessor {
 					sourceNodeName,
 					toolArgs,
 					additionalData,
+					run.data,
 					// The execution context (e.g. the OAuth identity for private credentials)
 					// is established on the main and loaded with the execution here; pass it
 					// through so the tool node can resolve dynamic credentials on the worker.
@@ -373,6 +377,25 @@ export class JobProcessor {
 							? { message: error.message, name: error.name }
 							: { message: String(error) },
 				};
+			}
+
+			// Persist the tool call's run data, since the save hook fired before it ran.
+			try {
+				await this.executionPersistence.updateExistingExecution(
+					executionId,
+					prepareExecutionDataForDbUpdate({
+						runData: run,
+						workflowData: execution.workflowData,
+						workflowStatusFinal: run.status,
+						retryOf: execution.retryOf ?? undefined,
+					}),
+				);
+			} catch (error) {
+				this.logger.error('Failed to persist tool call run data for MCP Trigger', {
+					executionId,
+					sourceNodeName,
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 
 			const mcpMsg: McpResponseMessage = {
@@ -475,6 +498,7 @@ export class JobProcessor {
 		>
 			? T
 			: never,
+		runExecutionData: IRunExecutionData,
 		executionContext?: IExecutionContext,
 	): Promise<unknown> {
 		const toolNode = workflow.getNode(sourceNodeName);
@@ -498,12 +522,15 @@ export class JobProcessor {
 			],
 		];
 
-		// Create minimal run execution data, carrying the established execution
-		// context so the tool node's `getExecutionContext()` exposes it to dynamic
-		// credential resolution (otherwise resolution fails with
-		// MissingExecutionContextError for private credentials in queue mode).
-		const runExecutionData = createRunExecutionData({});
-		if (executionContext && runExecutionData.executionData) {
+		// `executionData` must exist for output recording; init it if the run lacks it.
+		runExecutionData.executionData ??= {
+			contextData: {},
+			nodeExecutionStack: [],
+			metadata: {},
+			waitingExecution: {},
+			waitingExecutionSource: {},
+		};
+		if (executionContext) {
 			runExecutionData.executionData.runtimeData = executionContext;
 		}
 
@@ -518,6 +545,11 @@ export class JobProcessor {
 
 		const closeFunctions: CloseFunction[] = [];
 
+		// Parent = the node the tool feeds (the MCP trigger), so the recorded run
+		// data's `source` points back at it, as in direct mode.
+		const [parentNodeName] = workflow.getChildNodes(sourceNodeName, NodeConnectionTypes.AiTool, 1);
+		const parentNode = parentNodeName ? (workflow.getNode(parentNodeName) ?? undefined) : undefined;
+
 		// Create SupplyDataContext for the tool node
 		const context = new SupplyDataContext(
 			workflow,
@@ -531,6 +563,8 @@ export class JobProcessor {
 			NodeConnectionTypes.AiTool,
 			executeData,
 			closeFunctions,
+			undefined,
+			parentNode,
 		);
 
 		try {
@@ -550,7 +584,21 @@ export class JobProcessor {
 					[{ json: validatedToolArgs as INodeExecutionData['json'] }],
 				]);
 
-				const result = await nodeType.execute.call(context as unknown as IExecuteFunctions);
+				let result: Awaited<ReturnType<NonNullable<typeof nodeType.execute>>>;
+				try {
+					result = await nodeType.execute.call(context as unknown as IExecuteFunctions);
+				} catch (error) {
+					// Record the failure so the tool node shows as errored, not stuck
+					// "running"; rethrow so the caller returns an error to the client.
+					context.addOutputData(
+						NodeConnectionTypes.AiTool,
+						0,
+						error instanceof NodeOperationError
+							? error
+							: new NodeOperationError(toolNode, error as Error),
+					);
+					throw error;
+				}
 
 				let response: IDataObject | IDataObject[] | GenericValue | GenericValue[] = [];
 				if (Array.isArray(result)) {


### PR DESCRIPTION
## Summary

In queue mode (`EXECUTIONS_MODE=queue`), MCP Server Trigger tool calls executed correctly at runtime but never appeared in the execution history — the execution showed the trigger with a success check while the tool node (e.g. Calculator) had no data.

**Root cause:** on the worker, the tool runs *after* the workflow's save hook has already persisted the execution. `JobProcessor.invokeTool` recorded the tool call into a throwaway run-data object that was then discarded, so the persisted execution never contained it.

**Fix (all in `packages/cli/src/scaling/job-processor.ts`):**
- Thread the completed run's `run.data` into `invokeTool` so the tool call is recorded onto the run data that gets persisted (both the `supplyData`/`logWrapper` path and the `execute` path record via the same `SupplyDataContext`).
- Set the tool node's parent to the MCP trigger so its `source` points back at the trigger, matching direct mode.
- Record failures via `addOutputData` so a failed tool shows as errored instead of stuck "running".
- Re-persist the execution (`prepareExecutionDataForDbUpdate` + `updateExistingExecution`) after the tool call.

## How to test

Happens only in queue mode

1. Start services: `pnpm --filter n8n-containers services --services postgres,redis` (writes `EXECUTIONS_MODE=queue` + DB/Redis config into `packages/cli/bin/.env`).
2. 1 Terminal Main: `cd packages/cli && pnpm start` 2nd terminal Worker: `cd packages/cli && N8N_RUNNERS_BROKER_PORT=5680 pnpm start worker`.
3. Import below workflow, activate it and copy the production MCP URL (`/mcp/<path>`).
4. Trigger a tool call via `npx @modelcontextprotocol/inspector` (Streamable HTTP) → list tools → invoke Calculator.
5. Open the execution: **before** this fix the Calculator tool call is absent; **after**, it appears with its input/output and `source` pointing at the trigger.

[MCP Server Trigger Test.json](https://github.com/user-attachments/files/29552060/MCP.Server.Trigger.Test.json)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5350

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->