### PR TITLE
feat(Merge Node): Add queryParameters option

### DIFF
--- a/packages/nodes-base/nodes/Merge/test/v3/combineBtSql.test.ts
+++ b/packages/nodes-base/nodes/Merge/test/v3/combineBtSql.test.ts
@@ -58,6 +58,21 @@ describe('combineBySql sandbox (isolated-vm)', () => {
 			resetSandboxCache();
 		});
 
+		it('should bind values passed separately', async () => {
+			const result = await runAlaSqlInSandbox(
+				[
+					[
+						{ id: 1, name: 'Sam' },
+						{ id: 2, name: 'Dan' },
+					],
+				],
+				'SELECT name FROM input1 WHERE name = ?',
+				["Sam' OR name = 'Dan"],
+			);
+
+			expect(result).toEqual([]);
+		});
+
 		// ── Host API access ────────────────────────────────────────────────────
 
 		it('should not expose require inside the sandbox', async () => {

--- a/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
+++ b/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
@@ -160,6 +160,63 @@ describe('Test MergeV3, combineBySql operation', () => {
 		expect(returnData[0][0].json).toEqual({ name: 'Dan' });
 	});
 
+	it('handles unsupported query parameter objects', async () => {
+		const nodeParameters = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE name = ?',
+			options: {
+				queryParameters: [{ name: 'Dan' }],
+			},
+		} as unknown as IDataObject;
+
+		await expect(
+			mode.combineBySql.execute.call(
+				createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+				inputsData,
+			),
+		).rejects.toMatchObject({
+			message: 'Query parameter 1 must be a string or number',
+		});
+	});
+
+	it('handles unsupported query parameter functions', async () => {
+		const nodeParameters = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE name = ?',
+			options: {
+				queryParameters: [() => 'Dan'],
+			},
+		} as unknown as IDataObject;
+
+		await expect(
+			mode.combineBySql.execute.call(
+				createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+				inputsData,
+			),
+		).rejects.toMatchObject({
+			message: 'Query parameter 1 must be a string or number',
+		});
+	});
+
+	it('handles unsupported evaluated query parameter values', async () => {
+		const nodeParameters = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE name = ?',
+			options: {
+				queryParameters: false,
+			},
+		} as unknown as IDataObject;
+
+		await expect(
+			mode.combineBySql.execute.call(
+				createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+				inputsData,
+			),
+		).rejects.toMatchObject({
+			message: 'Query parameters must be a string, number, or array',
+		});
+	});
+
 	it('handles query parameter values as text', async () => {
 		const nodeParameters: IDataObject = {
 			operation: 'combineBySql',

--- a/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
+++ b/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
@@ -175,7 +175,7 @@ describe('Test MergeV3, combineBySql operation', () => {
 				inputsData,
 			),
 		).rejects.toMatchObject({
-			message: 'Query parameter 1 must be a string or number',
+			message: 'Query parameter 1 must be a string, number, boolean, or null',
 		});
 	});
 
@@ -194,7 +194,7 @@ describe('Test MergeV3, combineBySql operation', () => {
 				inputsData,
 			),
 		).rejects.toMatchObject({
-			message: 'Query parameter 1 must be a string or number',
+			message: 'Query parameter 1 must be a string, number, boolean, or null',
 		});
 	});
 

--- a/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
+++ b/packages/nodes-base/nodes/Merge/test/v3/operations.test.ts
@@ -123,6 +123,77 @@ describe('Test MergeV3, combineBySql operation', () => {
 			country: 'PL',
 		});
 	});
+
+	it('handles query parameters', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE id = ?',
+			options: {
+				queryParameters: '2',
+			},
+		};
+
+		const returnData = await mode.combineBySql.execute.call(
+			createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+			inputsData,
+		);
+
+		expect(returnData[0]).toHaveLength(1);
+		expect(returnData[0][0].json).toEqual({ name: 'Dan' });
+	});
+
+	it('handles query parameters from evaluated values', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE name = ?',
+			options: {
+				queryParameters: ['Dan'],
+			},
+		};
+
+		const returnData = await mode.combineBySql.execute.call(
+			createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+			inputsData,
+		);
+
+		expect(returnData[0]).toHaveLength(1);
+		expect(returnData[0][0].json).toEqual({ name: 'Dan' });
+	});
+
+	it('handles query parameter values as text', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE name = ?',
+			options: {
+				queryParameters: "Sam' OR name = 'Dan",
+			},
+		};
+
+		const returnData = await mode.combineBySql.execute.call(
+			createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+			inputsData,
+		);
+
+		expect(returnData).toEqual([[]]);
+	});
+
+	it('handles multiple query parameters', async () => {
+		const nodeParameters: IDataObject = {
+			operation: 'combineBySql',
+			query: 'SELECT name FROM input1 WHERE id = ? OR name = ? ORDER BY id',
+			options: {
+				queryParameters: '2,Sam',
+			},
+		};
+
+		const returnData = await mode.combineBySql.execute.call(
+			createMockExecuteFunction(nodeParameters, { ...node, typeVersion: 3.2 }),
+			inputsData,
+		);
+
+		expect(returnData[0].map((item) => item.json.name)).toEqual(['Sam', 'Dan']);
+	});
+
 	it('LEFT JOIN, missing input 2(empty array)', async () => {
 		const nodeParameters: IDataObject = {
 			operation: 'combineBySql',

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -25,6 +25,8 @@ type OperationOptions = {
 	queryParameters?: string | number | unknown[];
 };
 
+type QueryParameterValue = string | number | boolean | null;
+
 export const properties: INodeProperties[] = [
 	numberInputsProperty,
 	{
@@ -126,10 +128,41 @@ function parseQueryParameterValue(value: string): string | number {
 	return value !== '' && !Number.isNaN(numberValue) ? numberValue : value;
 }
 
-function getQueryParameterValues(queryParameters: OperationOptions['queryParameters']): unknown[] {
+function validateQueryParameterValue(
+	node: INode,
+	value: unknown,
+	index: number,
+): QueryParameterValue {
+	if (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	) {
+		return value;
+	}
+
+	throw new NodeOperationError(
+		node,
+		`Query parameter ${index + 1} must be a string, number, boolean, or null`,
+		{ itemIndex: 0 },
+	);
+}
+
+function getQueryParameterValues(
+	node: INode,
+	queryParameters: OperationOptions['queryParameters'],
+): QueryParameterValue[] {
 	if (queryParameters === undefined || queryParameters === '') return [];
-	if (Array.isArray(queryParameters)) return queryParameters;
+	if (Array.isArray(queryParameters)) {
+		return queryParameters.map((value, index) => validateQueryParameterValue(node, value, index));
+	}
 	if (typeof queryParameters === 'number') return [queryParameters];
+	if (typeof queryParameters !== 'string') {
+		throw new NodeOperationError(node, 'Query parameters must be a string, number, or array', {
+			itemIndex: 0,
+		});
+	}
 
 	return queryParameters.split(',').map((entry) => parseQueryParameterValue(entry.trim()));
 }
@@ -188,7 +221,8 @@ export async function execute(
 		query = query.replace(resolvable, this.evaluateExpression(resolvable, 0) as string);
 	}
 
-	const parameters = getQueryParameterValues(options.queryParameters);
+	// the value is resolved once, not on each execution, because merge mode runs once for all items
+	const parameters = getQueryParameterValues(node, options.queryParameters);
 
 	const isSelectQuery = node.typeVersion >= 3.1 ? query.toLowerCase().startsWith('select') : false;
 	const returnSuccessItemIfEmpty =

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -21,7 +21,8 @@ import {
 } from '../../helpers/sandbox-utils';
 
 type OperationOptions = {
-	emptyQueryResult: 'success' | 'empty';
+	emptyQueryResult?: 'success' | 'empty';
+	queryParameters?: string | number | unknown[];
 };
 
 export const properties: INodeProperties[] = [
@@ -39,6 +40,13 @@ export const properties: INodeProperties[] = [
 			rows: 5,
 			editor: 'sqlEditor',
 		},
+	},
+	{
+		displayName:
+			'Use query parameters for dynamic values. Expressions in the query text become part of the SQL. Add values in <b>Options > Query Parameters</b> and reference them with <code>?</code> placeholders.',
+		name: 'queryParametersNotice',
+		type: 'notice',
+		default: '',
 	},
 	{
 		displayName: 'Options',
@@ -63,13 +71,23 @@ export const properties: INodeProperties[] = [
 					},
 				],
 				default: 'empty',
+				displayOptions: {
+					show: {
+						'@version': [3.2],
+					},
+				},
+			},
+			{
+				displayName: 'Query Parameters',
+				name: 'queryParameters',
+				type: 'string',
+				default: '',
+				placeholder: 'value1,value2,value3',
+				description:
+					'Comma-separated list of values to use as query parameters. Reference them in the query with ? placeholders.',
+				hint: 'Reference query parameters with ? placeholders',
 			},
 		],
-		displayOptions: {
-			show: {
-				'@version': [3.2],
-			},
-		},
 	},
 ];
 
@@ -102,10 +120,25 @@ const prepareError = (node: INode, error: Error) => {
 	throw new NodeOperationError(node, error, { message, description, itemIndex: 0 });
 };
 
+function parseQueryParameterValue(value: string): string | number {
+	const numberValue = Number(value);
+
+	return value !== '' && !Number.isNaN(numberValue) ? numberValue : value;
+}
+
+function getQueryParameterValues(queryParameters: OperationOptions['queryParameters']): unknown[] {
+	if (queryParameters === undefined || queryParameters === '') return [];
+	if (Array.isArray(queryParameters)) return queryParameters;
+	if (typeof queryParameters === 'number') return [queryParameters];
+
+	return queryParameters.split(',').map((entry) => parseQueryParameterValue(entry.trim()));
+}
+
 async function executeSelectWithMappedPairedItems(
 	node: INode,
 	inputsData: INodeExecutionData[][],
 	query: string,
+	parameters: unknown[],
 	returnSuccessItemIfEmpty: boolean,
 ): Promise<INodeExecutionData[][]> {
 	const returnData: INodeExecutionData[] = [];
@@ -115,7 +148,11 @@ async function executeSelectWithMappedPairedItems(
 	);
 
 	try {
-		const result = await runAlaSqlInSandbox(tableData, modifySelectQuery(query, inputsData.length));
+		const result = await runAlaSqlInSandbox(
+			tableData,
+			modifySelectQuery(query, inputsData.length),
+			parameters,
+		);
 
 		for (const item of result) {
 			if (Array.isArray(item)) {
@@ -151,6 +188,8 @@ export async function execute(
 		query = query.replace(resolvable, this.evaluateExpression(resolvable, 0) as string);
 	}
 
+	const parameters = getQueryParameterValues(options.queryParameters);
+
 	const isSelectQuery = node.typeVersion >= 3.1 ? query.toLowerCase().startsWith('select') : false;
 	const returnSuccessItemIfEmpty =
 		node.typeVersion <= 3.1 ? true : options.emptyQueryResult === 'success';
@@ -161,6 +200,7 @@ export async function execute(
 				node,
 				inputsData,
 				query,
+				parameters,
 				returnSuccessItemIfEmpty,
 			);
 		} catch (error) {
@@ -217,7 +257,7 @@ export async function execute(
 	);
 
 	try {
-		const result = await runAlaSqlInSandbox(tableData, query);
+		const result = await runAlaSqlInSandbox(tableData, query, parameters);
 
 		for (const item of result) {
 			if (Array.isArray(item)) {

--- a/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
+++ b/packages/nodes-base/nodes/Merge/v3/actions/mode/combineBySql.ts
@@ -84,7 +84,7 @@ export const properties: INodeProperties[] = [
 				default: '',
 				placeholder: 'value1,value2,value3',
 				description:
-					'Comma-separated list of values to use as query parameters. Reference them in the query with ? placeholders.',
+					'Comma-separated list of values to use as query parameters. Reference them in the query with ? placeholders. <a href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.merge/#use-query-parameters" target="_blank">More info</a>.',
 				hint: 'Reference query parameters with ? placeholders',
 			},
 		],

--- a/packages/nodes-base/nodes/Merge/v3/helpers/sandbox-utils.ts
+++ b/packages/nodes-base/nodes/Merge/v3/helpers/sandbox-utils.ts
@@ -136,9 +136,10 @@ export async function withSandboxContext<T>(
 export async function runAlaSqlInSandbox(
 	tableData: unknown[][],
 	query: string,
+	parameters: unknown[] = [],
 ): Promise<IDataObject[]> {
 	try {
-		return await executeAlaSql(tableData, query);
+		return await executeAlaSql(tableData, query, parameters);
 	} catch (error) {
 		// Hitting the isolate's memory limit disposes the isolate. That can mean
 		// this dataset is genuinely too large, but it can also be transient: earlier
@@ -147,13 +148,17 @@ export async function runAlaSqlInSandbox(
 		// rebuilds the disposed isolate on a clean heap, so a transient accumulation
 		// succeeds while a truly oversized dataset fails again and propagates.
 		if (isSandboxMemoryError(error)) {
-			return await executeAlaSql(tableData, query);
+			return await executeAlaSql(tableData, query, parameters);
 		}
 		throw error;
 	}
 }
 
-async function executeAlaSql(tableData: unknown[][], query: string): Promise<IDataObject[]> {
+async function executeAlaSql(
+	tableData: unknown[][],
+	query: string,
+	parameters: unknown[],
+): Promise<IDataObject[]> {
 	const dbId = randomUUID();
 
 	// evalClosure binds ($0, $1, $2) as parameters of an implicit wrapping function,
@@ -161,21 +166,21 @@ async function executeAlaSql(tableData: unknown[][], query: string): Promise<IDa
 	// which strips prototypes and functions so only inert plain data crosses the
 	// isolate boundary.
 	const script = `
-		const rows = $0, dbId = $1, query = $2;
+		const rows = $0, dbId = $1, query = $2, parameters = $3;
 		const db = new alasql.Database(dbId);
 		try {
 			for (let i = 0; i < rows.length; i++) {
 				db.exec('CREATE TABLE input' + (i + 1));
 				db.tables['input' + (i + 1)].data = rows[i];
 			}
-			return JSON.stringify(db.exec(query));
+			return JSON.stringify(db.exec(query, parameters));
 		} finally {
 			delete alasql.databases[dbId];
 		}
 	`;
 
 	return await withSandboxContext(async (context) => {
-		const resultJson = (await context.evalClosure(script, [tableData, dbId, query], {
+		const resultJson = (await context.evalClosure(script, [tableData, dbId, query, parameters], {
 			arguments: { copy: true },
 			result: { copy: true },
 			timeout: 30000,


### PR DESCRIPTION
## Summary

This PR adds queryParameters option similar to Postgres or MySql node implementation. Adds a callout too.
This is a new parameter, so a change for docs is going to be introduced.

<img width="423" height="633" alt="изображение" src="https://github.com/user-attachments/assets/1dfb8588-83c1-4b09-b2bf-044a1fa4894f" />


## How to test

Use the workflow provided in linear comment

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4508/


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->