### PR TITLE
feat: Capture MCP server domain in node graph telemetry (no-changelog)

### DIFF
--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3654,6 +3654,7 @@ export interface INodeGraphItem {
 	package_version?: string; // only for community nodes
 	used_guardrails?: string[]; // only for @n8n/n8n-nodes-langchain.guardrails
 	mcp_client_auth_method?: string; // for @n8n/n8n-nodes-langchain.mcpClientTool and @n8n/n8n-nodes-langchain.mcpClient
+	mcp_server_domain_base?: string; // registrable domain of MCP server URL, for mcpClientTool / mcpClient
 	ai_model?: string; // AI model for model nodes and standalone AI nodes
 	ai_input_tokens?: number; // AI input (prompt) tokens for model nodes
 	ai_output_tokens?: number; // AI output (completion) tokens for model nodes

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -31,6 +31,7 @@ import {
 import { UnexpectedError } from './errors';
 import type { NodeApiError } from './errors/node-api.error';
 import { DEFAULT_EVALUATION_METRIC } from './evaluation-helpers';
+import { isExpression } from './expressions/expression-helpers';
 import type {
 	IConnection,
 	IConnections,
@@ -590,6 +591,16 @@ export function generateNodesGraph(
 				enabledDefault) as boolean;
 		} else if (node.type === MCP_CLIENT_TOOL_NODE_TYPE || node.type === MCP_CLIENT_NODE_TYPE) {
 			nodeItem.mcp_client_auth_method = (node.parameters?.authentication ?? 'none') as string;
+
+			const mcpServerUrl = (node.parameters?.endpointUrl ??
+				node.parameters?.sseEndpoint ??
+				'') as string;
+			if (!isExpression(mcpServerUrl)) {
+				const mcpServerDomainBase = getDomainBase(mcpServerUrl);
+				if (mcpServerDomainBase) {
+					nodeItem.mcp_server_domain_base = mcpServerDomainBase;
+				}
+			}
 		} else {
 			try {
 				const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -2025,6 +2025,54 @@ describe('generateNodesGraph', () => {
 		});
 	});
 
+	describe('MCP server domain telemetry', () => {
+		// captures registrable domain only, never the full URL
+		test.each([
+			{
+				name: 'v1 sseEndpoint',
+				typeVersion: 1,
+				parameters: { authentication: 'bearerAuth', sseEndpoint: 'https://my-mcp.example.com/sse' },
+				expected: 'example.com',
+			},
+			{
+				name: 'v1.1 endpointUrl',
+				typeVersion: 1.1,
+				parameters: { authentication: 'none', endpointUrl: 'https://sub.example.org/mcp' },
+				expected: 'example.org',
+			},
+			{
+				name: 'no server URL configured',
+				typeVersion: 1,
+				parameters: { authentication: 'none' },
+				expected: undefined,
+			},
+			{
+				name: 'URL is an expression',
+				typeVersion: 1.1,
+				parameters: { authentication: 'none', endpointUrl: '=https://{{ $json.host }}/mcp' },
+				expected: undefined,
+			},
+		])('should capture $expected for $name', ({ typeVersion, parameters, expected }) => {
+			const workflow: Partial<IWorkflowBase> = {
+				nodes: [
+					{
+						parameters,
+						id: 'mcp-client-tool-node-id',
+						name: 'MCP Client Tool Node',
+						type: MCP_CLIENT_TOOL_NODE_TYPE,
+						typeVersion,
+						position: [100, 100],
+					},
+				],
+				connections: {},
+				pinData: {},
+			};
+
+			const nodeItem = generateNodesGraph(workflow, nodeTypes).nodeGraph.nodes['0'];
+			expect(nodeItem.mcp_server_domain_base).toBe(expected);
+		});
+	});
+
 	describe('ai_model telemetry', () => {
 		test('should capture ai_model for LM node with plain string model param', () => {
 			const workflow: Partial<IWorkflowBase> = {


### PR DESCRIPTION
## Summary

The MCP Client Tool and MCP Client nodes previously captured only `mcp_client_auth_method` in node-graph telemetry — the configured server URL was never recorded, so we had no visibility into which MCP servers are used.

This adds a `mcp_server_domain_base` field to `INodeGraphItem`, mirroring how the HTTP Request node records `domain_base`. The value is passed through the existing `getDomainBase()` helper so **only the registrable domain** is captured — never the full URL (same privacy constraint as the HTTP Request v1→v2 change).

Details:
- Reads the server URL from `endpointUrl` (v1.1+) with a fallback to `sseEndpoint` (v1), matching the node's own version logic.
- Skips expression values (`={{ ... }}`): the domain is unknown at design time and the raw expression string would otherwise end up in telemetry.
- Only sets the field when a non-empty domain resolves, so empty configs emit no noise.

## How to test

Unit tests cover the behavior end-to-end:

```bash
cd packages/workflow && pnpm test telemetry-helpers
```

The `MCP server domain telemetry` suite asserts:
- v1 `sseEndpoint: https://my-mcp.example.com/sse` → `example.com`
- v1.1 `endpointUrl: https://sub.example.org/mcp` → `example.org`
- no URL configured → field absent
- expression URL → field absent

Manual check (real telemetry): run n8n locally, add an MCP Client Tool node with a server URL, save the workflow — the `User saved workflow` event's `node_graph_string` now includes `mcp_server_domain_base` (registrable domain only) on the MCP node item.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5318

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33386">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->