### PR TITLE
fix(editor): Limit assistant resource auto-linking

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiMarkdown.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiMarkdown.test.ts
@@ -37,12 +37,14 @@ describe('InstanceAiMarkdown', () => {
 		thread = {
 			id: 'thread-1',
 			resourceNameIndex: new Map<string, ResourceEntry>(),
+			linkableResourceNameIndex: new Map<string, ResourceEntry>(),
 		} as unknown as ThreadRuntime;
 	});
 
 	function getProcessedContent(content: string, registry?: Map<string, ResourceEntry>): string {
 		if (registry) {
 			thread.resourceNameIndex = registry;
+			thread.linkableResourceNameIndex = registry;
 		}
 		const { getByTestId } = renderComponent({ props: { content } });
 		return getByTestId('markdown-output').textContent ?? '';
@@ -57,6 +59,15 @@ describe('InstanceAiMarkdown', () => {
 		const registry = makeRegistry([{ type: 'workflow', id: 'wf-1', name: 'My Workflow' }]);
 		const result = getProcessedContent('Check out My Workflow please', registry);
 		expect(result).toContain('[My Workflow](n8n-resource://workflow/wf-1)');
+	});
+
+	it('should not replace resource names that are only in the metadata index', () => {
+		thread.resourceNameIndex = makeRegistry([{ type: 'data-table', id: 'dt-1', name: 'table' }]);
+		thread.linkableResourceNameIndex = new Map<string, ResourceEntry>();
+
+		const result = getProcessedContent('Now let me set up the data table for evals');
+
+		expect(result).toBe('Now let me set up the data table for evals');
 	});
 
 	it('should NOT replace names shorter than 3 characters', () => {
@@ -155,14 +166,14 @@ describe('InstanceAiMarkdown', () => {
 		const content = 'Check out My Workflow please';
 
 		it('should render raw content without decoration while streaming', () => {
-			thread.resourceNameIndex = registry();
+			thread.linkableResourceNameIndex = registry();
 			const { getByTestId } = renderComponent({ props: { content, streaming: true } });
 
 			expect(getByTestId('markdown-output').textContent).toBe(content);
 		});
 
 		it('should apply decoration when the block settles (streaming flips false)', async () => {
-			thread.resourceNameIndex = registry();
+			thread.linkableResourceNameIndex = registry();
 			const { getByTestId, rerender } = renderComponent({ props: { content, streaming: true } });
 
 			expect(getByTestId('markdown-output').textContent).not.toContain('n8n-resource://');
@@ -175,7 +186,7 @@ describe('InstanceAiMarkdown', () => {
 		});
 
 		it('should decorate immediately when streaming is not set (history-loaded messages)', () => {
-			thread.resourceNameIndex = registry();
+			thread.linkableResourceNameIndex = registry();
 			const { getByTestId } = renderComponent({ props: { content } });
 
 			expect(getByTestId('markdown-output').textContent).toContain(

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -263,6 +263,7 @@ describe('InstanceAiThreadView', () => {
 			currentTasks: null,
 			producedArtifacts: new Map(),
 			resourceNameIndex: new Map(),
+			linkableResourceNameIndex: new Map(),
 			feedbackByResponseId: {},
 			rateableResponseId: null,
 			pendingConfirmations: [],

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -48,11 +48,11 @@ function makeMessage(overrides: Partial<InstanceAiMessage> = {}): InstanceAiMess
 
 function setup(workflowNameLookup?: (id: string) => string | undefined) {
 	const messages = ref<InstanceAiMessage[]>([]);
-	const { producedArtifacts, resourceNameIndex } = useResourceRegistry(
+	const { producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = useResourceRegistry(
 		() => messages.value,
 		workflowNameLookup,
 	);
-	return { messages, producedArtifacts, resourceNameIndex };
+	return { messages, producedArtifacts, resourceNameIndex, linkableResourceNameIndex };
 }
 
 // ---------------------------------------------------------------------------
@@ -62,7 +62,7 @@ function setup(workflowNameLookup?: (id: string) => string | undefined) {
 describe('useResourceRegistry', () => {
 	describe('producedArtifacts — workflow registration', () => {
 		test('registers workflow with workflowName from result', async () => {
-			const { messages, producedArtifacts, resourceNameIndex } = setup();
+			const { messages, producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -82,10 +82,11 @@ describe('useResourceRegistry', () => {
 				expect.objectContaining({ type: 'workflow', id: 'wf-1', name: 'My Workflow' }),
 			);
 			expect(resourceNameIndex.get('my workflow')?.id).toBe('wf-1');
+			expect(linkableResourceNameIndex.get('my workflow')?.id).toBe('wf-1');
 		});
 
 		test('falls back to args.name when result has no workflowName', async () => {
-			const { messages, producedArtifacts } = setup();
+			const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -105,6 +106,7 @@ describe('useResourceRegistry', () => {
 			expect(producedArtifacts.get('wf-2')).toEqual(
 				expect.objectContaining({ type: 'workflow', id: 'wf-2', name: 'From Args' }),
 			);
+			expect(linkableResourceNameIndex.get('from args')?.id).toBe('wf-2');
 		});
 
 		test('falls back to Untitled when neither workflowName nor args.name is present', async () => {
@@ -342,7 +344,7 @@ describe('useResourceRegistry', () => {
 		});
 
 		test('mutation result enriches an existing data-table entry with projectId', async () => {
-			const { messages, producedArtifacts } = setup();
+			const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -377,12 +379,13 @@ describe('useResourceRegistry', () => {
 					projectId: 'proj-2',
 				}),
 			);
+			expect(linkableResourceNameIndex.get('signups')?.id).toBe('dt-1');
 		});
 	});
 
 	describe('list results do not populate producedArtifacts', () => {
 		test('workflows action=list result is indexed by name only, never in producedArtifacts', async () => {
-			const { messages, producedArtifacts, resourceNameIndex } = setup();
+			const { messages, producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -407,10 +410,11 @@ describe('useResourceRegistry', () => {
 			expect(producedArtifacts.size).toBe(0);
 			expect(resourceNameIndex.get('workspace workflow 1')?.id).toBe('wf-list-1');
 			expect(resourceNameIndex.get('workspace workflow 2')?.id).toBe('wf-list-2');
+			expect(linkableResourceNameIndex.size).toBe(0);
 		});
 
 		test('data-tables action=list result is indexed by name only', async () => {
-			const { messages, producedArtifacts, resourceNameIndex } = setup();
+			const { messages, producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = setup();
 
 			messages.value = [
 				makeMessage({
@@ -431,6 +435,7 @@ describe('useResourceRegistry', () => {
 
 			expect(producedArtifacts.size).toBe(0);
 			expect(resourceNameIndex.get('existing table')?.id).toBe('dt-a');
+			expect(linkableResourceNameIndex.get('existing table')).toBeUndefined();
 		});
 
 		test('a later write promotes a previously-listed resource into producedArtifacts', async () => {
@@ -538,7 +543,7 @@ describe('useResourceRegistry', () => {
 		test.each(['insert-data-table-rows', 'update-data-table-rows', 'delete-data-table-rows'])(
 			'registers data table from %s result with name and projectId',
 			async (toolName) => {
-				const { messages, producedArtifacts } = setup();
+				const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 
 				messages.value = [
 					makeMessage({
@@ -565,6 +570,7 @@ describe('useResourceRegistry', () => {
 					name: 'Orders',
 					projectId: 'proj-1',
 				});
+				expect(linkableResourceNameIndex.get('orders')?.id).toBe('dt-mut-1');
 			},
 		);
 
@@ -600,7 +606,7 @@ describe('useResourceRegistry', () => {
 		test.each(['schema', 'query'] as const)(
 			'registers data table from data-tables %s result with resolved metadata',
 			async (action) => {
-				const { messages, producedArtifacts } = setup();
+				const { messages, producedArtifacts, linkableResourceNameIndex } = setup();
 
 				messages.value = [
 					makeMessage({
@@ -628,6 +634,7 @@ describe('useResourceRegistry', () => {
 					name: 'Signups',
 					projectId: 'proj-4',
 				});
+				expect(linkableResourceNameIndex.get('signups')).toBeUndefined();
 			},
 		);
 	});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMarkdown.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiMarkdown.vue
@@ -150,7 +150,7 @@ function replaceUnprotectedMarkdownText(
 }
 
 function decorateResourceNames(content: string): string {
-	const registry = thread.resourceNameIndex;
+	const registry = thread.linkableResourceNameIndex;
 	if (registry.size === 0) return content;
 
 	// Build entries sorted longest-name-first to avoid partial-match conflicts

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -337,7 +337,7 @@ export function createThreadRuntime(
 	const hasMessages = computed(() => messages.value.length > 0);
 	const isHydratingThread = computed(() => hydrationStatus.value === 'hydrating');
 
-	const { producedArtifacts, resourceNameIndex } = useResourceRegistry(
+	const { producedArtifacts, resourceNameIndex, linkableResourceNameIndex } = useResourceRegistry(
 		() => messages.value,
 		(id) => workflowsListStore.getWorkflowById(id)?.name,
 		() => archivedWorkflowIds.value,
@@ -1082,6 +1082,7 @@ export function createThreadRuntime(
 		isHydratingThread,
 		producedArtifacts,
 		resourceNameIndex,
+		linkableResourceNameIndex,
 		feedbackByResponseId,
 		rateableResponseId,
 		currentTasks,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -28,13 +28,19 @@ export type ResourceEntry = {
 interface Collections {
 	/** Resources produced/mutated by the agent in this thread, keyed by resource ID. */
 	produced: Map<string, ResourceEntry>;
-	/** Every resource seen in any tool call, keyed by lowercased name — for markdown linking. */
+	/** Every resource seen in any tool call, keyed by lowercased name. */
 	byName: Map<string, ResourceEntry>;
+	/** Produced resources keyed by lowercased name; safe for markdown auto-linking. */
+	linkableByName: Map<string, ResourceEntry>;
 }
 
 function optionalString(val: unknown): string | undefined {
 	return typeof val === 'string' ? val : undefined;
 }
+
+type RecordProducedOptions = {
+	linkable?: boolean;
+};
 
 /**
  * Upsert a produced artifact. When an entry for the same `id` already exists,
@@ -44,8 +50,16 @@ function optionalString(val: unknown): string | undefined {
  * `build-workflow` call that carries only a `workflowId`) don't regress a
  * known name to 'Untitled'.
  */
-function recordProduced(col: Collections, entry: ResourceEntry): void {
+function recordProduced(
+	col: Collections,
+	entry: ResourceEntry,
+	options: RecordProducedOptions = {},
+): void {
 	const existing = col.produced.get(entry.id);
+	const existingLinkKey = existing?.name.toLowerCase();
+	const wasLinkable =
+		existingLinkKey !== undefined && col.linkableByName.get(existingLinkKey)?.id === entry.id;
+	const shouldLink = options.linkable !== false || wasLinkable;
 	const merged: ResourceEntry = existing
 		? {
 				type: entry.type,
@@ -59,8 +73,10 @@ function recordProduced(col: Collections, entry: ResourceEntry): void {
 	col.produced.set(entry.id, merged);
 	if (existing && existing.name.toLowerCase() !== merged.name.toLowerCase()) {
 		col.byName.delete(existing.name.toLowerCase());
+		if (wasLinkable) col.linkableByName.delete(existing.name.toLowerCase());
 	}
 	col.byName.set(merged.name.toLowerCase(), merged);
+	if (shouldLink) col.linkableByName.set(merged.name.toLowerCase(), merged);
 }
 
 function indexByName(col: Collections, entry: ResourceEntry): void {
@@ -191,12 +207,20 @@ function extractFromToolCall(tc: InstanceAiToolCallState, col: Collections): voi
 			optionalString(result.dataTableName) ??
 			existing?.name ??
 			result.dataTableId;
-		recordProduced(col, {
-			type: 'data-table',
-			id: result.dataTableId,
-			name,
-			projectId: result.projectId,
-		});
+		const dataTableAction = optionalString(tc.args?.action);
+		const isReadOnlyLookup =
+			tc.toolName === 'data-tables' &&
+			(dataTableAction === 'schema' || dataTableAction === 'query');
+		recordProduced(
+			col,
+			{
+				type: 'data-table',
+				id: result.dataTableId,
+				name,
+				projectId: result.projectId,
+			},
+			{ linkable: !isReadOnlyLookup },
+		);
 	}
 }
 
@@ -252,8 +276,10 @@ function enrichWorkflowNames(
 		const storeName = workflowNameLookup(entry.id);
 		if (storeName && storeName !== entry.name) {
 			col.byName.delete(entry.name.toLowerCase());
+			col.linkableByName.delete(entry.name.toLowerCase());
 			entry.name = storeName;
 			col.byName.set(storeName.toLowerCase(), entry);
+			col.linkableByName.set(storeName.toLowerCase(), entry);
 		}
 	}
 }
@@ -271,9 +297,12 @@ function enrichWorkflowNames(
  *   existing entry instead of creating a duplicate.
  *
  * - `resourceNameIndex` (keyed by lowercased name) — every named resource
- *   seen in any tool call, including list results. Used only for markdown
- *   name→link replacement so references to listed workflows/tables still
- *   resolve.
+ *   seen in any tool call, including list results. Used for resource metadata
+ *   lookups after explicit links have rendered.
+ *
+ * - `linkableResourceNameIndex` (keyed by lowercased name) — only resources
+ *   produced or mutated by the agent. Used for markdown name→link replacement
+ *   so passive list/search results cannot rewrite ordinary prose.
  */
 export function useResourceRegistry(
 	messages: () => InstanceAiMessage[],
@@ -284,6 +313,7 @@ export function useResourceRegistry(
 	// nothing trigger nothing.
 	const producedArtifacts = reactive(new Map<string, ResourceEntry>());
 	const resourceNameIndex = reactive(new Map<string, ResourceEntry>());
+	const linkableResourceNameIndex = reactive(new Map<string, ResourceEntry>());
 
 	// Derived from `messages` so every state-arrival path (hydration, run-sync
 	// replacement, rollback, reset) self-heals on the next derivation. Must
@@ -294,6 +324,7 @@ export function useResourceRegistry(
 			const col: Collections = {
 				produced: new Map<string, ResourceEntry>(),
 				byName: new Map<string, ResourceEntry>(),
+				linkableByName: new Map<string, ResourceEntry>(),
 			};
 
 			for (const msg of messages()) {
@@ -319,11 +350,12 @@ export function useResourceRegistry(
 		(col) => {
 			reconcileMap(producedArtifacts, col.produced);
 			reconcileMap(resourceNameIndex, col.byName);
+			reconcileMap(linkableResourceNameIndex, col.linkableByName);
 		},
 		{ immediate: true },
 	);
 
-	return { producedArtifacts, resourceNameIndex };
+	return { producedArtifacts, resourceNameIndex, linkableResourceNameIndex };
 }
 
 /** Sync `target` to `next` with minimal writes — unchanged entries trigger no subscribers. */


### PR DESCRIPTION
## Summary

Limit Assistant markdown auto-linking to resources the agent actively created or mutated, while keeping listed/read resources available for metadata lookup. This prevents passive Data Table lookups from rewriting ordinary prose like “data table” into links to unrelated existing tables.

## How to test

- Create an existing Data Table named `table`
- Ask the Assistant to build a workflow that needs a new evaluation Data Table
- Confirm ordinary prose occurrences of “data table” are not linked to the pre-existing `table`
- Confirm created or mutated resources can still be auto-linked when referenced by name

Automated coverage:

- `pnpm test src/features/ai/instanceAi/__tests__/InstanceAiMarkdown.test.ts src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-737

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Not needed: UI bug fix with regression tests.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33389">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->