### PR TITLE
feat(core): Add managed-auth telemetry to credential lifecycle events (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -189,6 +189,46 @@ describe('CredentialsOverwrites', () => {
 		});
 	});
 
+	describe('supportsManagedAuth', () => {
+		it('should return true when an overwrite is configured for the type', () => {
+			expect(credentialsOverwrites.supportsManagedAuth('test')).toBe(true);
+		});
+
+		it('should return true for a base type that has its own overwrite', () => {
+			credentialTypes.getParentTypes.calledWith('parent').mockReturnValue([]);
+			expect(credentialsOverwrites.supportsManagedAuth('parent')).toBe(true);
+		});
+
+		it('should return false when no overwrite is configured for the type', () => {
+			credentialTypes.getParentTypes.mockReturnValueOnce([]);
+			expect(credentialsOverwrites.supportsManagedAuth('unknownCredential')).toBe(false);
+		});
+	});
+
+	describe('usesManagedAuth', () => {
+		it('should return true when an overwritten field is left empty', () => {
+			expect(
+				credentialsOverwrites.usesManagedAuth('test', { username: '', password: 'pass' }),
+			).toBe(true);
+		});
+
+		it('should return false when the user supplied all overwritten fields', () => {
+			expect(
+				credentialsOverwrites.usesManagedAuth('test', {
+					username: 'own-user',
+					password: 'own-pass',
+				}),
+			).toBe(false);
+		});
+
+		it('should return false when no overwrite is configured for the type', () => {
+			credentialTypes.getParentTypes.mockReturnValueOnce([]);
+			expect(credentialsOverwrites.usesManagedAuth('unknownCredential', { username: 'user' })).toBe(
+				false,
+			);
+		});
+	});
+
 	describe('getOverwrites', () => {
 		it('should return undefined for unrecognized credential type', () => {
 			credentialTypes.recognizes.mockReturnValue(false);

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -227,6 +227,17 @@ describe('CredentialsOverwrites', () => {
 				false,
 			);
 		});
+
+		it('should return false for a skip-list type when the user customized an overwritten field', () => {
+			// applyOverwrite skips injection entirely here, so the credential is not managed
+			globalConfig.credentials.overwrite.skipTypes = [
+				'test',
+			] as unknown as CommaSeparatedStringArray<string>;
+
+			expect(
+				credentialsOverwrites.usesManagedAuth('test', { username: 'custom-user', password: '' }),
+			).toBe(false);
+		});
 	});
 
 	describe('getOverwrites', () => {

--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -6,6 +6,7 @@ import type { Response } from 'express';
 import { mock } from 'vitest-mock-extended';
 
 import { OAuth1CredentialController } from '@/controllers/oauth/oauth1-credential.controller';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import { OauthService } from '@/oauth/oauth.service';
@@ -14,6 +15,7 @@ import type { OAuthRequest } from '@/requests';
 describe('OAuth1CredentialController', () => {
 	const oauthService = mockInstance(OauthService);
 	const eventService = mockInstance(EventService);
+	const credentialsOverwrites = mockInstance(CredentialsOverwrites);
 
 	mockInstance(Logger);
 	mockInstance(ExternalHooks);
@@ -233,6 +235,8 @@ describe('OAuth1CredentialController', () => {
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
+			credentialsOverwrites.supportsManagedAuth.mockReturnValue(true);
+			credentialsOverwrites.usesManagedAuth.mockReturnValue(false);
 
 			await controller.handleCallback(dynamicReq, res);
 
@@ -240,6 +244,8 @@ describe('OAuth1CredentialController', () => {
 				user: { id: 'user-42' },
 				credentialType: 'twitterOAuth1Api',
 				credentialId: 'cred-1',
+				supportsManagedAuth: true,
+				usesManagedAuth: false,
 			});
 		});
 

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -8,6 +8,7 @@ import { UserError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { OAuth2CredentialController } from '@/controllers/oauth/oauth2-credential.controller';
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import { OAuthJweServiceProxy } from '@/oauth/oauth-jwe-service.proxy';
@@ -26,6 +27,7 @@ describe('OAuth2CredentialController', () => {
 	const externalHooks = mockInstance(ExternalHooks);
 	const oauthJweServiceProxy = mockInstance(OAuthJweServiceProxy);
 	const eventService = mockInstance(EventService);
+	const credentialsOverwrites = mockInstance(CredentialsOverwrites);
 
 	mockInstance(Logger);
 
@@ -373,6 +375,8 @@ describe('OAuth2CredentialController', () => {
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
+			credentialsOverwrites.supportsManagedAuth.mockReturnValue(true);
+			credentialsOverwrites.usesManagedAuth.mockReturnValue(false);
 
 			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
 				query: {
@@ -398,6 +402,8 @@ describe('OAuth2CredentialController', () => {
 				user: { id: '123' },
 				credentialType: 'genericOAuth2',
 				credentialId: '1',
+				supportsManagedAuth: true,
+				usesManagedAuth: false,
 			});
 			expect(oauthService.encryptAndSaveData).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith('oauth-callback');
@@ -1132,6 +1138,8 @@ describe('OAuth2CredentialController', () => {
 					access_token: 'decrypted',
 					refresh_token: 'r',
 				});
+				credentialsOverwrites.supportsManagedAuth.mockReturnValue(true);
+				credentialsOverwrites.usesManagedAuth.mockReturnValue(true);
 
 				const req = mock<OAuthRequest.OAuth2Credential.Callback>({
 					query: { code: 'auth_code', state: validState },
@@ -1156,6 +1164,8 @@ describe('OAuth2CredentialController', () => {
 					user: { id: '123' },
 					credentialType: 'genericOAuth2',
 					credentialId: '1',
+					supportsManagedAuth: true,
+					usesManagedAuth: true,
 				});
 				expect(oauthService.encryptAndSaveData).not.toHaveBeenCalled();
 			});

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -3,6 +3,7 @@ import { Get, RestController } from '@n8n/decorators';
 import { Response } from 'express';
 import { ensureError, jsonStringify } from 'n8n-workflow';
 
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { EventService } from '@/events/event.service';
 import { OauthService, type OAuth1CredentialData } from '@/oauth/oauth.service';
 import { OAuthRequest } from '@/requests';
@@ -13,6 +14,7 @@ export class OAuth1CredentialController {
 		private readonly oauthService: OauthService,
 		private readonly logger: Logger,
 		private readonly eventService: EventService,
+		private readonly credentialsOverwrites: CredentialsOverwrites,
 	) {}
 
 	/** Get Authorization url */
@@ -44,7 +46,7 @@ export class OAuth1CredentialController {
 				);
 			}
 
-			const [credential, , oauthCredentials, state, flowState] =
+			const [credential, decryptedDataOriginal, oauthCredentials, state, flowState] =
 				await this.oauthService.resolveCredential<OAuth1CredentialData>(req);
 
 			const oauthTokenData = await this.oauthService.getOAuth1AccessToken(oauthCredentials, {
@@ -88,6 +90,11 @@ export class OAuth1CredentialController {
 						user: { id: state.userId },
 						credentialType: credential.type,
 						credentialId: credential.id,
+						supportsManagedAuth: this.credentialsOverwrites.supportsManagedAuth(credential.type),
+						usesManagedAuth: this.credentialsOverwrites.usesManagedAuth(
+							credential.type,
+							decryptedDataOriginal,
+						),
 					});
 				}
 

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -9,6 +9,7 @@ import split from 'lodash/split';
 import type { ICredentialDataDecryptedObject, IDataObject } from 'n8n-workflow';
 import { ensureError, jsonParse, jsonStringify } from 'n8n-workflow';
 
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { EventService } from '@/events/event.service';
 import { ExternalHooks } from '@/external-hooks';
 import { OAuthJweServiceProxy } from '@/oauth/oauth-jwe-service.proxy';
@@ -23,6 +24,7 @@ export class OAuth2CredentialController {
 		private readonly externalHooks: ExternalHooks,
 		private readonly oauthJweServiceProxy: OAuthJweServiceProxy,
 		private readonly eventService: EventService,
+		private readonly credentialsOverwrites: CredentialsOverwrites,
 	) {}
 
 	/** Get Authorization url */
@@ -148,6 +150,11 @@ export class OAuth2CredentialController {
 						user: { id: state.userId },
 						credentialType: credential.type,
 						credentialId: credential.id,
+						supportsManagedAuth: this.credentialsOverwrites.supportsManagedAuth(credential.type),
+						usesManagedAuth: this.credentialsOverwrites.usesManagedAuth(
+							credential.type,
+							decryptedDataOriginal,
+						),
 					});
 				}
 

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -234,9 +234,9 @@ export class CredentialsOverwrites {
 		const overwrites = this.get(type);
 		if (overwrites === undefined) return false;
 
-		return Object.keys(overwrites).some((key) => {
-			const value = data[key];
-			return value === null || value === undefined || value === '';
-		});
+		// Managed iff applying the overwrite actually injects a value. Delegating to
+		// applyOverwrite keeps this in lockstep with the skip-list / customization rules.
+		const applied = this.applyOverwrite(type, data as ICredentialDataDecryptedObject);
+		return Object.keys(overwrites).some((key) => applied[key] !== data[key]);
 	}
 }

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -225,4 +225,18 @@ export class CredentialsOverwrites {
 	getAll(): ICredentialsOverwrite {
 		return this.overwriteData;
 	}
+
+	supportsManagedAuth(type: string): boolean {
+		return this.get(type) !== undefined;
+	}
+
+	usesManagedAuth(type: string, data: Record<string, unknown>): boolean {
+		const overwrites = this.get(type);
+		if (overwrites === undefined) return false;
+
+		return Object.keys(overwrites).some((key) => {
+			const value = data[key];
+			return value === null || value === undefined || value === '';
+		});
+	}
 }

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -35,6 +35,7 @@ describe('CredentialsController', () => {
 	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
 	const credentialsFinderService = mock<CredentialsFinderService>();
 	const licenseState = mock<LicenseState>();
+	const credentialsOverwrites = mock<ConstructorParameters<typeof CredentialsController>[12]>();
 
 	// Mock the credentialsRepository with a working create method
 	const credentialsRepository = mock<CredentialsRepository>();
@@ -85,6 +86,7 @@ describe('CredentialsController', () => {
 		eventService,
 		credentialsFinderService,
 		mock(), // connectionStatusProxy
+		credentialsOverwrites,
 	);
 
 	let req: AuthenticatedRequest;
@@ -173,6 +175,30 @@ describe('CredentialsController', () => {
 			const [eventName, eventPayload] = emitSpy.mock.calls[0];
 			expect(eventName).toBe('credentials-created');
 			expect(eventPayload).toMatchObject({ jweEnabled: true });
+		});
+
+		it('should emit "credentials-created" with managed-auth flags derived from overwrites', async () => {
+			const newCredentialsPayload = createNewCredentialsPayload();
+			req.body = newCredentialsPayload;
+			const { data, ...payloadWithoutData } = newCredentialsPayload;
+			const createdCredentials = createdCredentialsWithScopes(payloadWithoutData);
+
+			createUnmanagedCredentialSpy.mockResolvedValue(createdCredentials);
+			findCredentialOwningProjectSpy.mockResolvedValue(mock<Project>());
+			credentialsOverwrites.supportsManagedAuth.mockReturnValue(true);
+			credentialsOverwrites.usesManagedAuth.mockReturnValue(true);
+
+			await credentialsController.createCredentials(req, res, newCredentialsPayload);
+
+			expect(credentialsOverwrites.supportsManagedAuth).toHaveBeenCalledWith(
+				createdCredentials.type,
+			);
+			expect(credentialsOverwrites.usesManagedAuth).toHaveBeenCalledWith(
+				createdCredentials.type,
+				newCredentialsPayload.data,
+			);
+			const [, eventPayload] = emitSpy.mock.calls[0];
+			expect(eventPayload).toMatchObject({ supportsManagedAuth: true, usesManagedAuth: true });
 		});
 
 		it('should emit "private-credential-created" when credential is created as resolvable', async () => {
@@ -347,6 +373,33 @@ describe('CredentialsController', () => {
 			expect(emitSpy).toHaveBeenCalledWith(
 				'credentials-updated',
 				expect.objectContaining({ jweEnabled: true }),
+			);
+		});
+
+		it('should emit "credentials-updated" with managed-auth flags derived from overwrites', async () => {
+			const ownerReq = {
+				user: { id: 'owner-id', role: GLOBAL_OWNER_ROLE },
+				params: { credentialId },
+				body: {
+					name: 'Updated Credential',
+					type: 'oAuth2Api',
+					data: { clientId: 'cid' },
+				},
+			} as unknown as CredentialRequest.Update;
+
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(existingCredential);
+			updateSpy.mockResolvedValue({ ...existingCredential, name: 'Updated Credential' });
+			credentialsOverwrites.supportsManagedAuth.mockReturnValue(true);
+			credentialsOverwrites.usesManagedAuth.mockReturnValue(true);
+
+			await credentialsController.updateCredentials(ownerReq);
+
+			expect(credentialsOverwrites.supportsManagedAuth).toHaveBeenCalledWith(
+				existingCredential.type,
+			);
+			expect(emitSpy).toHaveBeenCalledWith(
+				'credentials-updated',
+				expect.objectContaining({ supportsManagedAuth: true, usesManagedAuth: true }),
 			);
 		});
 

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -37,6 +37,7 @@ import { CredentialsService } from './credentials.service';
 import { EnterpriseCredentialsService } from './credentials.service.ee';
 import { getExternalSecretExpressionPaths } from './external-secrets.utils';
 
+import { CredentialsOverwrites } from '@/credentials-overwrites';
 import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -64,6 +65,7 @@ export class CredentialsController {
 		private readonly eventService: EventService,
 		private readonly credentialsFinderService: CredentialsFinderService,
 		private readonly connectionStatusProxy: CredentialConnectionStatusProxy,
+		private readonly credentialsOverwrites: CredentialsOverwrites,
 	) {}
 
 	@Get('/', { middlewares: listQueryMiddleware })
@@ -179,6 +181,8 @@ export class CredentialsController {
 			isDynamic: newCredential.isResolvable ?? false,
 			usesExternalSecrets: getExternalSecretExpressionPaths(payload.data).length > 0,
 			jweEnabled: payload.data.jweEnabled === true,
+			supportsManagedAuth: this.credentialsOverwrites.supportsManagedAuth(newCredential.type),
+			usesManagedAuth: this.credentialsOverwrites.usesManagedAuth(newCredential.type, payload.data),
 		});
 
 		if (newCredential.isResolvable) {
@@ -281,15 +285,16 @@ export class CredentialsController {
 
 		this.logger.debug('Credential updated', { credentialId });
 
+		const updatedData = preparedCredentialData.data as unknown as ICredentialDataDecryptedObject;
 		this.eventService.emit('credentials-updated', {
 			user: req.user,
 			credentialType: credential.type,
 			credentialId: credential.id,
 			isDynamic: newCredentialData.isResolvable ?? false,
 			usesExternalSecrets: getExternalSecretExpressionPaths(preparedCredentialData.data).length > 0,
-			jweEnabled:
-				(preparedCredentialData.data as unknown as ICredentialDataDecryptedObject).jweEnabled ===
-				true,
+			jweEnabled: updatedData.jweEnabled === true,
+			supportsManagedAuth: this.credentialsOverwrites.supportsManagedAuth(credential.type),
+			usesManagedAuth: this.credentialsOverwrites.usesManagedAuth(credential.type, updatedData),
 		});
 
 		const wasResolvable = Boolean(credential.isResolvable);

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1157,6 +1157,8 @@ describe('TelemetryEventRelay', () => {
 				user: { id: 'user123' },
 				credentialId: 'cred123',
 				credentialType: 'gmailOAuth2',
+				supportsManagedAuth: true,
+				usesManagedAuth: true,
 			};
 
 			eventService.emit('private-credential-user-connected', event);
@@ -1166,6 +1168,8 @@ describe('TelemetryEventRelay', () => {
 				user_role: undefined,
 				credential_type: 'gmailOAuth2',
 				credential_id: 'cred123',
+				credential_supports_managed_auth: true,
+				credential_uses_managed_auth: true,
 			});
 		});
 	});

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -954,6 +954,8 @@ describe('TelemetryEventRelay', () => {
 				projectId: 'project123',
 				projectType: 'personal',
 				isDynamic: false,
+				supportsManagedAuth: true,
+				usesManagedAuth: true,
 			};
 
 			eventService.emit('credentials-created', event);
@@ -968,6 +970,8 @@ describe('TelemetryEventRelay', () => {
 				is_private: false,
 				uses_external_secrets: false,
 				jwe_enabled: false,
+				credential_supports_managed_auth: true,
+				credential_uses_managed_auth: true,
 			});
 		});
 
@@ -1024,6 +1028,8 @@ describe('TelemetryEventRelay', () => {
 				is_private: true,
 				uses_external_secrets: false,
 				jwe_enabled: false,
+				credential_supports_managed_auth: false,
+				credential_uses_managed_auth: false,
 			});
 		});
 

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -494,6 +494,8 @@ export type RelayEventMap = {
 		user: UserLike;
 		credentialType: string;
 		credentialId: string;
+		supportsManagedAuth?: boolean;
+		usesManagedAuth?: boolean;
 	};
 
 	// #endregion

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -422,6 +422,8 @@ export type RelayEventMap = {
 		isDynamic?: boolean;
 		usesExternalSecrets?: boolean;
 		jweEnabled?: boolean;
+		supportsManagedAuth?: boolean;
+		usesManagedAuth?: boolean;
 	};
 
 	'credentials-shared': {
@@ -440,6 +442,8 @@ export type RelayEventMap = {
 		isDynamic?: boolean;
 		usesExternalSecrets?: boolean;
 		jweEnabled?: boolean;
+		supportsManagedAuth?: boolean;
+		usesManagedAuth?: boolean;
 	};
 
 	'credentials-deleted': {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -624,6 +624,8 @@ export class TelemetryEventRelay extends EventRelay {
 		isDynamic,
 		usesExternalSecrets,
 		jweEnabled,
+		supportsManagedAuth,
+		usesManagedAuth,
 	}: RelayEventMap['credentials-created']) {
 		this.telemetry.track('User created credentials', {
 			user_id: user.id,
@@ -636,6 +638,8 @@ export class TelemetryEventRelay extends EventRelay {
 			is_private: isDynamic ?? false,
 			uses_external_secrets: usesExternalSecrets ?? false,
 			jwe_enabled: jweEnabled ?? false,
+			credential_supports_managed_auth: supportsManagedAuth ?? false,
+			credential_uses_managed_auth: usesManagedAuth ?? false,
 		});
 	}
 
@@ -665,6 +669,8 @@ export class TelemetryEventRelay extends EventRelay {
 		isDynamic,
 		usesExternalSecrets,
 		jweEnabled,
+		supportsManagedAuth,
+		usesManagedAuth,
 	}: RelayEventMap['credentials-updated']) {
 		this.telemetry.track('User updated credentials', {
 			user_id: user.id,
@@ -674,6 +680,8 @@ export class TelemetryEventRelay extends EventRelay {
 			is_private: isDynamic ?? false,
 			uses_external_secrets: usesExternalSecrets ?? false,
 			jwe_enabled: jweEnabled ?? false,
+			credential_supports_managed_auth: supportsManagedAuth ?? false,
+			credential_uses_managed_auth: usesManagedAuth ?? false,
 		});
 	}
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -771,12 +771,16 @@ export class TelemetryEventRelay extends EventRelay {
 		user,
 		credentialId,
 		credentialType,
+		supportsManagedAuth,
+		usesManagedAuth,
 	}: RelayEventMap['private-credential-user-connected']) {
 		this.telemetry.track('User connected to private credential', {
 			user_id: user.id,
 			user_role: user.role?.slug,
 			credential_type: credentialType,
 			credential_id: credentialId,
+			credential_supports_managed_auth: supportsManagedAuth ?? false,
+			credential_uses_managed_auth: usesManagedAuth ?? false,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Adds telemetry so we can distinguish, from the warehouse, whether a credential uses n8n's **managed OAuth** (Cloud-injected client ID/secret via credential overwrites) or the **user's own OAuth app**. Today analytics relies on name heuristics (`name contains 'oauth'`) plus hand-maintained lists of which types are managed, which is error-prone and drifts as we ship managed support for more services.

Two signals are added to existing credential telemetry events — `credentials-created`, `credentials-updated`, and `private-credential-user-connected` (the OAuth connection event for dynamic/private credentials) — **both derived from the credential-overwrites config** (no static per-type flag, so nothing to maintain and nothing drifts):

- `credential_supports_managed_auth` — an overwrite is configured for this credential type (i.e. n8n offers a managed app for it on this instance).
- `credential_uses_managed_auth` — an overwrite exists **and** applying it would actually inject a value (the user left the overwritten client ID/secret empty). This distinguishes "managed available but user brought their own app" (`supports=true, uses=false`) from "no managed option" (`supports=false`).

Implementation:
- Two derived helpers on `CredentialsOverwrites` (`supportsManagedAuth`, `usesManagedAuth`), reusing the existing overwrite-resolution (`extends`-chain aware). `usesManagedAuth` delegates to `applyOverwrite` so the signal stays in lockstep with the overwrite skip-list / customization rules (a skip-list credential the user customized is correctly reported as *not* managed).
- Emitted from `CredentialsController` on create/update and from the OAuth1/OAuth2 credential controllers on connect; typed in `relay.event-map.ts`; mapped to telemetry properties in `telemetry.event-relay.ts`.

**Scope note:** only existing telemetry events are decorated with the flags — no new events are introduced

## How to test

No UI changes; this is backend telemetry. To observe locally:

1. Configure a managed app for an OAuth type, e.g. `CREDENTIALS_OVERWRITE_DATA='{"googleOAuth2Api":{"clientId":"x","clientSecret":"y"}}'`, and start n8n.
2. Create that credential type **leaving client ID/secret blank** → the `User created credentials` event carries `credential_supports_managed_auth: true` and `credential_uses_managed_auth: true`.
3. Create it again **filling in your own** client ID/secret → `supports=true, uses=false`.
4. Create a credential of a type with no overwrite configured → both `false`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5273

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->