### PR TITLE
test(ai-builder): Pin eval experiments to the Staging LangSmith workspace (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -49,6 +49,7 @@ import { cleanupCredentials } from '../credentials/seeder';
 import { loadTestCases } from '../data/source';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
 import { captureThreadRunDebug } from '../harness/capture-run-debug';
+import { EVAL_WORKSPACE_NAME, resolveEvalWorkspaceId } from '../harness/langsmith-seed';
 import { createLogger } from '../harness/logger';
 import type { EvalLogger } from '../harness/logger';
 import {
@@ -294,7 +295,14 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	const isolationWarning = partialIsolationWarning(args.dataset, args.baselinePrefix);
 	if (isolationWarning) logger.warn(isolationWarning);
 
-	const lsClient = new Client();
+	// Pin eval writes to the eval workspace; our PAT would otherwise default to Prod.
+	const workspaceId = await resolveEvalWorkspaceId();
+	if (workspaceId) {
+		logger.info(
+			`Pinning eval experiments to LangSmith workspace "${EVAL_WORKSPACE_NAME}" (${workspaceId})`,
+		);
+	}
+	const lsClient = new Client(workspaceId ? { workspaceId } : {});
 	const datasetName = await syncDataset(lsClient, args.dataset, logger, testCasesWithFiles);
 
 	// Stash transcripts by threadId so reshapeLangSmithRuns can merge them in —

--- a/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
@@ -134,6 +134,23 @@ async function listAccessibleWorkspaces(
 	}
 }
 
+/** Workspace eval writes are pinned to; resolved to an id by name so no UUID lives in the repo. */
+export const EVAL_WORKSPACE_NAME = 'Staging';
+
+/** Eval workspace id by name; undefined for a workspace-scoped key (already locked to one), throws when a PAT lacks it. */
+export async function resolveEvalWorkspaceId(
+	name: string = EVAL_WORKSPACE_NAME,
+): Promise<string | undefined> {
+	const { apiUrl, apiKey } = configFor();
+	const workspaces = await listAccessibleWorkspaces(apiUrl, apiKey);
+	const match = workspaces.find((w) => w.name === name);
+	if (match) return match.id;
+	if (workspaces.length <= 1) return undefined; // scoped/single-workspace key: nothing to choose
+	throw new Error(
+		`LangSmith workspace "${name}" not found among [${workspaces.map((w) => w.name).join(', ')}]. Check LANGSMITH_API_KEY (org PAT) + LANGSMITH_ENDPOINT (region).`,
+	);
+}
+
 /** Seams for unit-testing workspace discovery without the network. */
 export interface SeedDiscoveryDeps {
 	listWorkspaces: () => Promise<Array<{ id: string; name: string }>>;


### PR DESCRIPTION
## Summary

The eval CLI created its LangSmith client with `new Client()` and no `workspaceId`. Our LangSmith API key is an **org PAT that spans three workspaces** (`Staging` / `Prod` / `Feature`), so the SDK fell back to the PAT's *default* workspace (`Prod`). As a result, eval experiments were written to `Prod` and the `instance-ai-workflow-evals` dataset drifted across all three workspaces (Staging 83 / Prod 89 / Feature 116 examples, none complete) — and out of reach of the eval-analytics export, which reads a single workspace.

This pins the eval client to the canonical **Staging** workspace, so dataset sync, experiments, and run traces all land in one place.

- `resolveEvalWorkspaceId()` looks the workspace up **by name** at runtime (reusing the existing `listAccessibleWorkspaces` helper), so no workspace UUID is committed to this public repo.
- A workspace-scoped key (can't enumerate workspaces, or is already locked to one) is left **unpinned** — it's already where it belongs. Only a multi-workspace PAT that is genuinely missing `Staging` throws, surfacing a real misconfig instead of silently misrouting.
- Scoped to the workflow-eval CLI (`cli/index.ts`), which owns/creates the dataset via `syncDataset`. `subagent` and `pairwise` *read* pre-existing datasets by name that currently live in other workspaces; pinning those needs the datasets migrated to `Staging` first (follow-up).

## How to test

- `pnpm --filter @n8n/instance-ai typecheck` and `pnpm --filter @n8n/instance-ai lint` pass.
- On an eval run with the org PAT, the log prints `Pinning eval experiments to LangSmith workspace "Staging" (<id>)`, and the experiment + `instance-ai-workflow-evals` dataset appear in the **Staging** workspace rather than **Prod**.
- The eval CI on this PR exercises the pinned path end-to-end.

## Related Linear tickets, Github issues, and Community forum posts

Part of the eval-analytics pipeline — https://linear.app/n8n/issue/TRUST-197 (enables the roster work in https://linear.app/n8n/issue/TRUST-204).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- resolveEvalWorkspaceId is unit-testable via the existing SeedDiscoveryDeps seam — happy to add on request; the CI eval run exercises the pin end-to-end. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->