### PR TITLE
fix(core): Harden MCP eval execution against transient network errors (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
@@ -1,0 +1,63 @@
+import {
+	extractErrorMessage,
+	isTransientNetworkError,
+	MAX_EXEC_ATTEMPTS,
+} from '../harness/transient-error';
+
+describe('transient-error', () => {
+	describe('extractErrorMessage', () => {
+		it('folds an Error cause into the message when it adds detail', () => {
+			// undici surfaces network failures as `TypeError: fetch failed` with the
+			// real reason on `.cause`.
+			const error = new TypeError('fetch failed', {
+				cause: new Error('Headers Timeout Error'),
+			});
+			expect(extractErrorMessage(error)).toBe('fetch failed: Headers Timeout Error');
+		});
+
+		it('folds a string cause into the message', () => {
+			const error = new Error('request failed', { cause: 'ECONNRESET' });
+			expect(extractErrorMessage(error)).toBe('request failed: ECONNRESET');
+		});
+
+		it('returns the base message when there is no cause', () => {
+			expect(extractErrorMessage(new Error('boom'))).toBe('boom');
+		});
+
+		it('does not duplicate when cause message equals base message', () => {
+			const error = new Error('same', { cause: new Error('same') });
+			expect(extractErrorMessage(error)).toBe('same');
+		});
+
+		it('stringifies non-Error throwables', () => {
+			expect(extractErrorMessage('plain string')).toBe('plain string');
+		});
+	});
+
+	describe('isTransientNetworkError', () => {
+		it.each([
+			'fetch failed',
+			'fetch failed: Headers Timeout Error',
+			'connect ECONNREFUSED 127.0.0.1:5678',
+			'read ECONNRESET',
+			'request to http://localhost timed out ETIMEDOUT',
+			'getaddrinfo EAI_AGAIN localhost',
+			'socket hang up',
+		])('classifies %j as transient', (message) => {
+			expect(isTransientNetworkError(message)).toBe(true);
+		});
+
+		it.each([
+			'Sheet with ID __evalMockResource not found',
+			'response.content.filter is not a function',
+			'No trigger or start node found in the workflow',
+		])('does not classify builder/mock failure %j as transient', (message) => {
+			expect(isTransientNetworkError(message)).toBe(false);
+		});
+	});
+
+	it('caps retries at a small positive number', () => {
+		expect(MAX_EXEC_ATTEMPTS).toBeGreaterThan(1);
+		expect(MAX_EXEC_ATTEMPTS).toBeLessThanOrEqual(5);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -69,6 +69,11 @@ import {
 	type BuildResult,
 } from '../harness/runner';
 import {
+	extractErrorMessage,
+	isTransientNetworkError,
+	MAX_EXEC_ATTEMPTS,
+} from '../harness/transient-error';
+import {
 	BUILD_ONLY_SCENARIO_NAME,
 	syncDataset,
 	type DatasetExampleInputs,
@@ -583,7 +588,6 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 
 		const execStart = Date.now();
 		const nodeCount = build.workflowJsons[0]?.nodes.length ?? 0;
-		const maxExecAttempts = 5;
 		let result;
 		for (let attempt = 1; ; attempt++) {
 			try {
@@ -595,21 +599,10 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				});
 				break;
 			} catch (error: unknown) {
-				const baseError = error instanceof Error ? error : new Error(String(error));
-				const cause = baseError.cause;
-				const causeText =
-					cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : undefined;
-				const errorMessage =
-					causeText && causeText !== baseError.message
-						? `${baseError.message}: ${causeText}`
-						: baseError.message;
-				const isTransient =
-					/fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up/i.test(
-						errorMessage,
-					);
-				if (isTransient && attempt < maxExecAttempts) {
+				const errorMessage = extractErrorMessage(error);
+				if (isTransientNetworkError(errorMessage) && attempt < MAX_EXEC_ATTEMPTS) {
 					logger.warn(
-						`    [${scenario.name}] execution attempt ${attempt}/${maxExecAttempts} failed (${errorMessage}); retrying`,
+						`    [${scenario.name}] execution attempt ${attempt}/${MAX_EXEC_ATTEMPTS} failed (${errorMessage}); retrying`,
 					);
 					await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
 					continue;

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -31,6 +31,7 @@ import {
 import { reconstructSeedFromThread, type SeedThreadRef } from './langsmith-seed';
 import { type EvalLogger } from './logger';
 import { fetchPrebuiltBuild } from './prebuilt-workflows';
+import { extractErrorMessage, isTransientNetworkError, MAX_EXEC_ATTEMPTS } from './transient-error';
 import { buildWorkflowContextBlock } from './workflow-context';
 import { SONNET_MODEL } from '../../src/utils/eval-agents';
 import { runBinaryChecks } from '../binaryChecks/index';
@@ -286,27 +287,42 @@ export async function runWorkflowTestCase(
 	const scenariosPromise = runWithConcurrency(
 		testCase.executionScenarios ?? [],
 		async (scenario) => {
-			try {
-				return await executeScenario(
-					client,
-					build.workflowId!,
-					scenario,
-					build.workflowJsons,
-					logger,
-					timeoutMs,
-					testCaseArtifactName,
-					build.buildTrace,
-					config.pinAiRoots,
-				);
-			} catch (error: unknown) {
-				const errorMessage = error instanceof Error ? error.message : String(error);
-				logger.error(`    ERROR [${scenario.name}]: ${errorMessage}`);
-				return {
-					scenario,
-					success: false,
-					score: 0,
-					reasoning: `Error: ${errorMessage}`,
-				} satisfies ExecutionScenarioResult;
+			for (let attempt = 1; ; attempt++) {
+				try {
+					return await executeScenario(
+						client,
+						build.workflowId!,
+						scenario,
+						build.workflowJsons,
+						logger,
+						timeoutMs,
+						testCaseArtifactName,
+						build.buildTrace,
+						config.pinAiRoots,
+					);
+				} catch (error: unknown) {
+					const errorMessage = extractErrorMessage(error);
+					if (isTransientNetworkError(errorMessage) && attempt < MAX_EXEC_ATTEMPTS) {
+						logger.warn(
+							`    [${scenario.name}] execution attempt ${attempt}/${MAX_EXEC_ATTEMPTS} failed (${errorMessage}); retrying`,
+						);
+						await delay(500 * attempt);
+						continue;
+					}
+					// executeScenario categorizes builder/mock/verification failures
+					// internally; an error escaping it is an infra/framework problem
+					// (network drop, n8n API error, verifier timeout). Tag it
+					// framework_issue so the report and baseline keep it out of builder
+					// regressions instead of scoring it as an uncategorized failure.
+					logger.error(`    ERROR [${scenario.name}]: ${errorMessage}`);
+					return {
+						scenario,
+						success: false,
+						score: 0,
+						reasoning: `Scenario execution error: ${errorMessage}`,
+						failureCategory: 'framework_issue',
+					} satisfies ExecutionScenarioResult;
+				}
 			}
 		},
 		MAX_CONCURRENT_SCENARIOS,

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Transient-error classification for scenario execution
+//
+// Both scenario-execution paths — the direct harness loop (`runTestCase`) and
+// the LangSmith-traced loop (`cli/index.ts`) — call the running n8n instance
+// over HTTP. Network-level failures there (a dropped socket, a DNS blip, the
+// long `execute-with-llm-mock` request stalling) are infrastructure problems,
+// not builder or mock defects. Sharing the detection + message extraction keeps
+// the two paths from drifting apart and ensures such failures are retried and
+// tagged `framework_issue` consistently, so they stay out of the builder
+// baseline instead of counting as silent failures.
+// ---------------------------------------------------------------------------
+
+/** Max attempts (initial try + retries) for a scenario execution hitting transient errors. */
+export const MAX_EXEC_ATTEMPTS = 5;
+
+/**
+ * Flatten an error to a message, folding in the underlying `cause` when it adds
+ * detail. undici surfaces network failures as a bare `TypeError: fetch failed`
+ * whose `cause` (e.g. `HeadersTimeoutError`, `ECONNRESET`) carries the real
+ * reason — without unwrapping it every such failure looks identical.
+ */
+export function extractErrorMessage(error: unknown): string {
+	const baseError = error instanceof Error ? error : new Error(String(error));
+	const cause = baseError.cause;
+	const causeText =
+		cause instanceof Error ? cause.message : typeof cause === 'string' ? cause : undefined;
+	return causeText && causeText !== baseError.message
+		? `${baseError.message}: ${causeText}`
+		: baseError.message;
+}
+
+/** Network-level failures worth retrying — none indicate a builder or mock defect. */
+export function isTransientNetworkError(message: string): boolean {
+	return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up/i.test(message);
+}


### PR DESCRIPTION
## Summary
The direct-loop scenario execution path caught network errors without retrying and without a failure category, so transient infra failures (dropped socket, DNS blip, the long execute-with-llm-mock request timing out) scored as uncategorized failures and polluted the eval baseline.

Retry transient network errors and tag any escaped execution error as `framework_issue`, matching the LangSmith-traced path, and extract a shared transient-error helper (dedupes the inline detection previously only in cli/index.ts).


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33398">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

