### PR TITLE
fix(Brevo Node): Resolve misspelled recipients parameter names

### DIFF
--- a/packages/nodes-base/nodes/Brevo/Brevo.node.ts
+++ b/packages/nodes-base/nodes/Brevo/Brevo.node.ts
@@ -14,7 +14,8 @@ export class Brevo implements INodeType {
 		name: 'sendInBlue',
 		icon: 'file:brevo.svg',
 		group: ['transform'],
-		version: 1,
+		version: [1, 2],
+		defaultVersion: 2,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Consume Brevo API',
 		defaults: {

--- a/packages/nodes-base/nodes/Brevo/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Brevo/EmailDescription.ts
@@ -133,6 +133,26 @@ const sendHtmlEmailFields: INodeProperties[] = [
 			show: {
 				resource: ['email'],
 				operation: ['send'],
+				'@version': [1],
+			},
+		},
+		default: '',
+		required: true,
+		routing: {
+			send: {
+				preSend: [BrevoNode.Validators.validateAndCompileRecipientEmails],
+			},
+		},
+	},
+	{
+		displayName: 'Recipients',
+		name: 'recipients',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['send'],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		default: '',
@@ -191,9 +211,45 @@ const sendHtmlEmailFields: INodeProperties[] = [
 				placeholder: 'Add BCC',
 				type: 'fixedCollection',
 				default: {},
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
 				options: [
 					{
 						name: 'receipientBcc',
+						displayName: 'Recipient',
+						values: [
+							{
+								displayName: 'Recipient',
+								name: 'bcc',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+				],
+				routing: {
+					send: {
+						preSend: [BrevoNode.Validators.validateAndCompileBCCEmails],
+					},
+				},
+			},
+			{
+				displayName: 'Recipients BCC',
+				name: 'recipientsBCC',
+				placeholder: 'Add BCC',
+				type: 'fixedCollection',
+				default: {},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2 } }],
+					},
+				},
+				options: [
+					{
+						name: 'recipientBcc',
 						displayName: 'Recipient',
 						values: [
 							{
@@ -217,9 +273,45 @@ const sendHtmlEmailFields: INodeProperties[] = [
 				placeholder: 'Add CC',
 				type: 'fixedCollection',
 				default: {},
+				displayOptions: {
+					show: {
+						'@version': [1],
+					},
+				},
 				options: [
 					{
 						name: 'receipientCc',
+						displayName: 'Recipient',
+						values: [
+							{
+								displayName: 'Recipient',
+								name: 'cc',
+								type: 'string',
+								default: '',
+							},
+						],
+					},
+				],
+				routing: {
+					send: {
+						preSend: [BrevoNode.Validators.validateAndCompileCCEmails],
+					},
+				},
+			},
+			{
+				displayName: 'Recipients CC',
+				name: 'recipientsCC',
+				placeholder: 'Add CC',
+				type: 'fixedCollection',
+				default: {},
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { gte: 2 } }],
+					},
+				},
+				options: [
+					{
+						name: 'recipientCc',
 						displayName: 'Recipient',
 						values: [
 							{
@@ -334,6 +426,26 @@ const sendHtmlTemplateEmailFields: INodeProperties[] = [
 			show: {
 				resource: ['email'],
 				operation: ['sendTemplate'],
+				'@version': [1],
+			},
+		},
+		default: '',
+		required: true,
+		routing: {
+			send: {
+				preSend: [BrevoNode.Validators.validateAndCompileRecipientEmails],
+			},
+		},
+	},
+	{
+		displayName: 'Recipients',
+		name: 'recipients',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['sendTemplate'],
+				'@version': [{ _cnd: { gte: 2 } }],
 			},
 		},
 		default: '',

--- a/packages/nodes-base/nodes/Brevo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Brevo/GenericFunctions.ts
@@ -188,8 +188,11 @@ export namespace BrevoNode {
 			this: IExecuteSingleFunctions,
 			requestOptions: IHttpRequestOptions,
 		): Promise<IHttpRequestOptions> {
+			const isLegacy = this.getNode().typeVersion < 2;
 			const ccData = this.getNodeParameter(
-				'additionalFields.receipientsCC.receipientCc',
+				isLegacy
+					? 'additionalFields.receipientsCC.receipientCc'
+					: 'additionalFields.recipientsCC.recipientCc',
 			) as JsonObject;
 			const { cc } = ccData;
 			const { body } = requestOptions;
@@ -203,8 +206,11 @@ export namespace BrevoNode {
 			this: IExecuteSingleFunctions,
 			requestOptions: IHttpRequestOptions,
 		): Promise<IHttpRequestOptions> {
+			const isLegacy = this.getNode().typeVersion < 2;
 			const bccData = this.getNodeParameter(
-				'additionalFields.receipientsBCC.receipientBcc',
+				isLegacy
+					? 'additionalFields.receipientsBCC.receipientBcc'
+					: 'additionalFields.recipientsBCC.recipientBcc',
 			) as JsonObject;
 			const { bcc } = bccData;
 			const { body } = requestOptions;
@@ -218,7 +224,8 @@ export namespace BrevoNode {
 			this: IExecuteSingleFunctions,
 			requestOptions: IHttpRequestOptions,
 		): Promise<IHttpRequestOptions> {
-			const to = this.getNodeParameter('receipients') as string;
+			const isLegacy = this.getNode().typeVersion < 2;
+			const to = this.getNodeParameter(isLegacy ? 'receipients' : 'recipients') as string;
 			const { body } = requestOptions;
 			const data = validateEmailStrings({ to });
 			Object.assign(body!, data);

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/create.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/create.json
@@ -1,0 +1,9 @@
+{
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "integer"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/get.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/get.json
@@ -1,0 +1,38 @@
+{
+	"type": "object",
+	"properties": {
+		"attributes": {
+			"type": "object",
+			"properties": {
+				"FIRSTNAME": {
+					"type": "string"
+				}
+			}
+		},
+		"createdAt": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"emailBlacklisted": {
+			"type": "boolean"
+		},
+		"id": {
+			"type": "integer"
+		},
+		"listIds": {
+			"type": "array",
+			"items": {
+				"type": "integer"
+			}
+		},
+		"modifiedAt": {
+			"type": "string"
+		},
+		"smsBlacklisted": {
+			"type": "boolean"
+		}
+	},
+	"version": 2
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/getAll.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/getAll.json
@@ -1,0 +1,41 @@
+{
+	"type": "object",
+	"properties": {
+		"attributes": {
+			"type": "object",
+			"properties": {
+				"FIRSTNAME": {
+					"type": "string"
+				}
+			}
+		},
+		"createdAt": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"emailBlacklisted": {
+			"type": "boolean"
+		},
+		"id": {
+			"type": "integer"
+		},
+		"listIds": {
+			"type": "array",
+			"items": {
+				"type": "integer"
+			}
+		},
+		"listUnsubscribed": {
+			"type": "null"
+		},
+		"modifiedAt": {
+			"type": "string"
+		},
+		"smsBlacklisted": {
+			"type": "boolean"
+		}
+	},
+	"version": 3
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/update.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/update.json
@@ -1,0 +1,9 @@
+{
+	"type": "object",
+	"properties": {
+		"success": {
+			"type": "boolean"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/upsert.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/contact/upsert.json
@@ -1,0 +1,9 @@
+{
+	"type": "object",
+	"properties": {
+		"success": {
+			"type": "boolean"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/email/send.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/email/send.json
@@ -1,0 +1,9 @@
+{
+	"type": "object",
+	"properties": {
+		"messageId": {
+			"type": "string"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/email/sendTemplate.json
+++ b/packages/nodes-base/nodes/Brevo/__schema__/v2.0.0/email/sendTemplate.json
@@ -1,0 +1,9 @@
+{
+	"type": "object",
+	"properties": {
+		"messageId": {
+			"type": "string"
+		}
+	},
+	"version": 1
+}

--- a/packages/nodes-base/nodes/Brevo/test/RecipientValidators.test.ts
+++ b/packages/nodes-base/nodes/Brevo/test/RecipientValidators.test.ts
@@ -1,0 +1,122 @@
+import type { IExecuteSingleFunctions, IHttpRequestOptions, INode } from 'n8n-workflow';
+
+import { BrevoNode } from '../GenericFunctions';
+
+type EmailEntry = { email: string; name?: string };
+
+function makeContext(overrides: {
+	typeVersion: number;
+	params: Record<string, unknown>;
+}): IExecuteSingleFunctions {
+	const getNodeParameter = vi.fn((name: string) => overrides.params[name]);
+
+	return {
+		getNodeParameter,
+		getNode: vi.fn().mockReturnValue({ typeVersion: overrides.typeVersion } as INode),
+	} as unknown as IExecuteSingleFunctions;
+}
+
+describe('Brevo - validateAndCompileRecipientEmails', () => {
+	const validate = BrevoNode.Validators.validateAndCompileRecipientEmails;
+
+	it('reads the legacy misspelled "receipients" parameter on node version 1', async () => {
+		const ctx = makeContext({
+			typeVersion: 1,
+			params: { receipients: 'user@example.com' },
+		});
+
+		const requestOptions: IHttpRequestOptions = { url: '', body: {} };
+		const result = await validate.call(ctx, requestOptions);
+
+		const to = (result.body as { to: EmailEntry[] }).to;
+		expect(to).toEqual([{ email: 'user@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith('receipients');
+	});
+
+	it('reads the correctly spelled "recipients" parameter on node version 2', async () => {
+		const ctx = makeContext({
+			typeVersion: 2,
+			params: { recipients: 'user@example.com' },
+		});
+
+		const result = await validate.call(ctx, { url: '', body: {} });
+
+		const to = (result.body as { to: EmailEntry[] }).to;
+		expect(to).toEqual([{ email: 'user@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith('recipients');
+	});
+});
+
+describe('Brevo - validateAndCompileCCEmails', () => {
+	const validate = BrevoNode.Validators.validateAndCompileCCEmails;
+
+	it('reads the legacy misspelled path on node version 1', async () => {
+		const ctx = makeContext({
+			typeVersion: 1,
+			params: {
+				'additionalFields.receipientsCC.receipientCc': { cc: 'cc@example.com' },
+			},
+		});
+
+		const result = await validate.call(ctx, { url: '', body: {} });
+
+		const cc = (result.body as { cc: EmailEntry[] }).cc;
+		expect(cc).toEqual([{ email: 'cc@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith(
+			'additionalFields.receipientsCC.receipientCc',
+		);
+	});
+
+	it('reads the correctly spelled path on node version 2', async () => {
+		const ctx = makeContext({
+			typeVersion: 2,
+			params: {
+				'additionalFields.recipientsCC.recipientCc': { cc: 'cc@example.com' },
+			},
+		});
+
+		const result = await validate.call(ctx, { url: '', body: {} });
+
+		const cc = (result.body as { cc: EmailEntry[] }).cc;
+		expect(cc).toEqual([{ email: 'cc@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith('additionalFields.recipientsCC.recipientCc');
+	});
+});
+
+describe('Brevo - validateAndCompileBCCEmails', () => {
+	const validate = BrevoNode.Validators.validateAndCompileBCCEmails;
+
+	it('reads the legacy misspelled path on node version 1', async () => {
+		const ctx = makeContext({
+			typeVersion: 1,
+			params: {
+				'additionalFields.receipientsBCC.receipientBcc': { bcc: 'bcc@example.com' },
+			},
+		});
+
+		const result = await validate.call(ctx, { url: '', body: {} });
+
+		const bcc = (result.body as { bcc: EmailEntry[] }).bcc;
+		expect(bcc).toEqual([{ email: 'bcc@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith(
+			'additionalFields.receipientsBCC.receipientBcc',
+		);
+	});
+
+	it('reads the correctly spelled path on node version 2', async () => {
+		const ctx = makeContext({
+			typeVersion: 2,
+			params: {
+				'additionalFields.recipientsBCC.recipientBcc': { bcc: 'bcc@example.com' },
+			},
+		});
+
+		const result = await validate.call(ctx, { url: '', body: {} });
+
+		const bcc = (result.body as { bcc: EmailEntry[] }).bcc;
+		expect(bcc).toEqual([{ email: 'bcc@example.com' }]);
+		expect(ctx.getNodeParameter).toHaveBeenCalledWith(
+			'additionalFields.recipientsBCC.recipientBcc',
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Brevo/test/send.node.test.ts
+++ b/packages/nodes-base/nodes/Brevo/test/send.node.test.ts
@@ -1,0 +1,29 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Brevo, email => send (recipients field spelling)', () => {
+	const credentials = {
+		sendInBlueApi: { apiKey: 'test-api-key' },
+	};
+
+	beforeEach(() => {
+		nock('https://api.brevo.com')
+			.post('/v3/smtp/email', (body) => {
+				// Both v1 (legacy "receipients") and v2 ("recipients") must resolve to
+				// the same outgoing "to" address - proves the rename didn't break delivery.
+				return (
+					Array.isArray(body.to) &&
+					body.to.length === 1 &&
+					body.to[0].email === 'recipient@example.com'
+				);
+			})
+			.reply(201, {
+				messageId: '<202601010000.1234567890@smtp-relay.mailin.fr>',
+			});
+	});
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['send.v1.workflow.json', 'send.v2.workflow.json'],
+		credentials,
+	});
+});

--- a/packages/nodes-base/nodes/Brevo/test/send.v1.workflow.json
+++ b/packages/nodes-base/nodes/Brevo/test/send.v1.workflow.json
@@ -1,0 +1,85 @@
+{
+	"name": "Brevo send email v1 receipients",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "1f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0001",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-660, 560]
+		},
+		{
+			"parameters": {
+				"resource": "email",
+				"operation": "send",
+				"sendHTML": false,
+				"subject": "Hello",
+				"textContent": "Hello from n8n",
+				"sender": "sender@example.com",
+				"receipients": "recipient@example.com",
+				"additionalFields": {}
+			},
+			"id": "1f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0002",
+			"name": "Brevo",
+			"type": "n8n-nodes-base.sendInBlue",
+			"typeVersion": 1,
+			"position": [-420, 560],
+			"credentials": {
+				"sendInBlueApi": {
+					"id": "1",
+					"name": "Brevo account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "1f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0003",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [-200, 560]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"messageId": "<202601010000.1234567890@smtp-relay.mailin.fr>"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Brevo",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Brevo": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"versionId": "2a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+	"id": "brevoSendEmailV1Receipients",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Brevo/test/send.v2.workflow.json
+++ b/packages/nodes-base/nodes/Brevo/test/send.v2.workflow.json
@@ -1,0 +1,85 @@
+{
+	"name": "Brevo send email v2 recipients",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "8f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0001",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [-660, 560]
+		},
+		{
+			"parameters": {
+				"resource": "email",
+				"operation": "send",
+				"sendHTML": false,
+				"subject": "Hello",
+				"textContent": "Hello from n8n",
+				"sender": "sender@example.com",
+				"recipients": "recipient@example.com",
+				"additionalFields": {}
+			},
+			"id": "8f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0002",
+			"name": "Brevo",
+			"type": "n8n-nodes-base.sendInBlue",
+			"typeVersion": 2,
+			"position": [-420, 560],
+			"credentials": {
+				"sendInBlueApi": {
+					"id": "1",
+					"name": "Brevo account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "8f6e6f8a-3f38-4c1e-9f1f-df8b5a2d0003",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [-200, 560]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"messageId": "<202601010000.1234567890@smtp-relay.mailin.fr>"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Brevo",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Brevo": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"versionId": "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+	"id": "brevoSendEmailV2Recipients",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}


### PR DESCRIPTION
## Summary

The Brevo **Email → Send** / **Send Template** node displays "Recipients" in the UI, but the persisted parameter name was misspelled (`receipients`, and similarly `receipientsCC`/`receipientCc`, `receipientsBCC`/`receipientBcc`). Workflow JSON had to use the misspelled key — renaming it to the correctly spelled `recipients` silently broke delivery, since `GenericFunctions.ts` read `getNodeParameter('receipients')` internally.

[PR #29383](https://github.com/n8n-io/n8n/pull/29383) previously fixed the `displayName` shown in the UI, but kept the internal misspelled `name` values to avoid breaking existing workflows, leaving the underlying issue unresolved.

This PR adds **node version 2** with correctly spelled parameters (`recipients`, `recipientsCC`/`recipientCc`, `recipientsBCC`/`recipientBcc`), while **keeping version 1** with the legacy misspelled names unchanged for full backward compatibility with existing workflows. `GenericFunctions.ts` validators branch on `this.getNode().typeVersion` to read the correct parameter path for the active node version.

This follows the same versioning pattern already used across the codebase for this type of change (e.g. `InvoiceNinja`, `Google Translate`, `Code`, `Cal` nodes all use `version: [1, 2]` with `@version`-gated fields).

## How to test

1. **Existing (v1) workflows keep working unmodified** — see `packages/nodes-base/nodes/Brevo/test/send.v1.workflow.json`, which uses the legacy `receipients` field and passes through `send.node.test.ts`.
2. **New/updated (v2) workflows use the correct spelling** — see `packages/nodes-base/nodes/Brevo/test/send.v2.workflow.json`, which uses `recipients` and resolves to the same outgoing API call.
3. Manually: add a Brevo node in the editor, pick "Send" operation. On a fresh node (v2) the exported JSON now contains `"recipients"`. Existing saved workflows (v1) continue to export `"receipients"` and keep working without any migration needed.

Unit tests added for the CC/BCC/recipients validators covering both version code paths (`packages/nodes-base/nodes/Brevo/test/RecipientValidators.test.ts`).

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33395

Related: https://community.n8n.io/t/wrong-parameter-name-receipients-vs-recipients-on-brevo-node/301680

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33400">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

