### PR TITLE
fix(core): Start a new trace for scheduled poll triggers (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/poll-trigger-executor.test.ts
+++ b/packages/core/src/execution-engine/__tests__/poll-trigger-executor.test.ts
@@ -41,6 +41,32 @@ describe('PollTriggerExecutor', () => {
 		expect(logger.scoped).toHaveBeenCalledWith('poll-trigger');
 	});
 
+	describe('tracing', () => {
+		it('starts its own root trace for a scheduled poll', async () => {
+			const startNewTraceSpan = vi.spyOn(tracing, 'startNewTraceSpan');
+			const startSpan = vi.spyOn(tracing, 'startSpan');
+			triggersAndPollers.runPollFunction.mockResolvedValueOnce(null);
+
+			const execute = executor.create(workflow, node, pollFunctions, () => true);
+			await execute();
+
+			expect(startNewTraceSpan).toHaveBeenCalledTimes(1);
+			expect(startSpan).not.toHaveBeenCalled();
+		});
+
+		it('nests the activation poll in the current trace', async () => {
+			const startNewTraceSpan = vi.spyOn(tracing, 'startNewTraceSpan');
+			const startSpan = vi.spyOn(tracing, 'startSpan');
+			triggersAndPollers.runPollFunction.mockResolvedValueOnce(null);
+
+			const execute = executor.create(workflow, node, pollFunctions, () => true);
+			await execute(true);
+
+			expect(startSpan).toHaveBeenCalledTimes(1);
+			expect(startNewTraceSpan).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('initial activation poll (testingTrigger=true)', () => {
 		it('emits the poll result without acquiring the isolate', async () => {
 			const result: INodeExecutionData[][] = [[{ json: { ok: true } }]];

--- a/packages/core/src/execution-engine/poll-trigger-executor.ts
+++ b/packages/core/src/execution-engine/poll-trigger-executor.ts
@@ -40,7 +40,14 @@ export class PollTriggerExecutor {
 		isCurrent: () => boolean,
 	): PollTriggerExecuteFn {
 		return async (testingTrigger = false) => {
-			return await this.tracing.startSpan(
+			// Scheduled polls start their own root trace so they don't attach to the
+			// publication transaction whose async context the poller was created in.
+			// The activation poll genuinely belongs to publication, so leave it nested.
+			const startTraced = testingTrigger
+				? this.tracing.startSpan.bind(this.tracing)
+				: this.tracing.startNewTraceSpan.bind(this.tracing);
+
+			return await startTraced(
 				{
 					name: 'Workflow Trigger Poll',
 					op: 'trigger.poll',

--- a/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/sentry-tracing.test.ts
@@ -10,10 +10,13 @@ describe('SentryTracing', () => {
 	let sentryTracing: SentryTracing;
 	const mockSentry = mock({
 		startSpan: vi.fn(),
+		startNewTrace: vi.fn(),
 	});
 
 	beforeEach(() => {
 		mockClear(mockSentry);
+		// Pass through to the callback so the wrapped span still runs.
+		mockSentry.startNewTrace.mockImplementation((cb) => cb());
 
 		sentryTracing = new SentryTracing(mockSentry);
 	});
@@ -123,6 +126,23 @@ describe('SentryTracing', () => {
 
 			expect(result).toBe('inner-result');
 			expect(mockSentry.startSpan).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('startNewTraceSpan', () => {
+		it('wraps the span in a new trace and returns the callback result', async () => {
+			const options: StartSpanOptions = { name: 'new-trace-span' };
+			const mockSpan = { name: 'mock-span' } as unknown as Sentry.Span;
+			const callback = vi.fn().mockResolvedValue('result');
+
+			mockSentry.startSpan.mockImplementation(async (_opts, cb) => await cb(mockSpan));
+
+			const result = await sentryTracing.startNewTraceSpan(options, callback);
+
+			expect(mockSentry.startNewTrace).toHaveBeenCalledWith(expect.any(Function));
+			expect(mockSentry.startSpan).toHaveBeenCalledWith(options, expect.any(Function));
+			expect(callback).toHaveBeenCalledWith(mockSpan);
+			expect(result).toBe('result');
 		});
 	});
 

--- a/packages/core/src/observability/tracing/__tests__/tracing.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/tracing.test.ts
@@ -14,6 +14,7 @@ describe('tracing', () => {
 	beforeEach(() => {
 		mockTracingImplementation = {
 			startSpan: vi.fn(),
+			startNewTraceSpan: vi.fn(),
 		} as unknown as Mocked<Tracer>;
 
 		tracing.setTracingImplementation(noopTracing);
@@ -29,6 +30,31 @@ describe('tracing', () => {
 			await tracing.startSpan(options, callback);
 
 			expect(mockTracingImplementation.startSpan).toHaveBeenCalledWith(options, callback);
+		});
+	});
+
+	describe('startNewTraceSpan', () => {
+		it('should delegate to the current implementation', async () => {
+			mockTracingImplementation.startNewTraceSpan.mockResolvedValue('test-result');
+			tracing.setTracingImplementation(mockTracingImplementation);
+
+			const options: StartSpanOptions = { name: 'test-span' };
+			const callback = vi.fn().mockResolvedValue('callback-result');
+
+			const result = await tracing.startNewTraceSpan(options, callback);
+
+			expect(mockTracingImplementation.startNewTraceSpan).toHaveBeenCalledWith(options, callback);
+			expect(result).toBe('test-result');
+		});
+
+		it('should use NoopTracing by default', async () => {
+			const options: StartSpanOptions = { name: 'test-span' };
+			const callback = vi.fn().mockResolvedValue('callback-result');
+
+			const result = await tracing.startNewTraceSpan(options, callback);
+
+			expect(callback).toHaveBeenCalledWith(expect.any(EmptySpan));
+			expect(result).toBe('callback-result');
 		});
 	});
 

--- a/packages/core/src/observability/tracing/noop-tracing.ts
+++ b/packages/core/src/observability/tracing/noop-tracing.ts
@@ -62,4 +62,11 @@ export class NoopTracing implements Tracer {
 	async startSpan<T>(_options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await spanCb(this.emptySpan);
 	}
+
+	async startNewTraceSpan<T>(
+		options: StartSpanOpts,
+		spanCb: (span: Span) => Promise<T>,
+	): Promise<T> {
+		return await this.startSpan(options, spanCb);
+	}
 }

--- a/packages/core/src/observability/tracing/sentry-tracing.ts
+++ b/packages/core/src/observability/tracing/sentry-tracing.ts
@@ -7,7 +7,7 @@ import { SpanStatus, type Span, type StartSpanOpts, type Tracer } from './tracin
  * Tracing implementation that uses Sentry to trace spans
  */
 export class SentryTracing implements Tracer {
-	constructor(private readonly sentry: Pick<typeof Sentry, 'startSpan'>) {}
+	constructor(private readonly sentry: Pick<typeof Sentry, 'startSpan' | 'startNewTrace'>) {}
 
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.sentry.startSpan(options, async (span) => {
@@ -23,5 +23,12 @@ export class SentryTracing implements Tracer {
 				throw e;
 			}
 		});
+	}
+
+	async startNewTraceSpan<T>(
+		options: StartSpanOpts,
+		spanCb: (span: Span) => Promise<T>,
+	): Promise<T> {
+		return await this.sentry.startNewTrace(async () => await this.startSpan(options, spanCb));
 	}
 }

--- a/packages/core/src/observability/tracing/tracing.ts
+++ b/packages/core/src/observability/tracing/tracing.ts
@@ -19,6 +19,7 @@ export type SpanAttributes = SentrySpanAttributes;
  */
 export interface Tracer {
 	startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T>;
+	startNewTraceSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T>;
 }
 
 const COMMON_TRACE_ATTRIBUTES = {
@@ -75,6 +76,18 @@ export class Tracing {
 	 */
 	async startSpan<T>(options: StartSpanOpts, spanCb: (span: Span) => Promise<T>): Promise<T> {
 		return await this.tracer.startSpan(options, spanCb);
+	}
+
+	/**
+	 * Start a span inside a brand-new root trace, detaching it from any trace
+	 * active on the current async context. Use for work that should be its own
+	 * transaction rather than a child of whatever trace it was scheduled from.
+	 */
+	async startNewTraceSpan<T>(
+		options: StartSpanOpts,
+		spanCb: (span: Span) => Promise<T>,
+	): Promise<T> {
+		return await this.tracer.startNewTraceSpan(options, spanCb);
 	}
 
 	/** Pick common attributes for a workflow */


### PR DESCRIPTION
## Summary

Every `trigger.poll` span for a scheduled poll trigger was nesting under the workflow **publication** transaction instead of being its own root transaction. This happened because the poll-executor closure is created inside the publication span's async context, and Sentry's `startSpan` attaches to whatever trace is active on that context — so scheduled polls fired later by the cron scheduler inherited it, growing the publication transaction unbounded and hiding individual poll latency/status. This adds a `startNewTraceSpan` method to the tracing abstraction (a new root trace + span in one call) and uses it for scheduled polls; the initial activation poll stays nested under publication as before.

Example here:
https://n8nio.sentry.io/explore/traces/trace/390dcc9238ce7edd3d7a4679ba99237e

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3642

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

