### PR TITLE
test: Include cert fields in Microsoft OAuth2 managed-OAuth mock

### DIFF
--- a/packages/testing/playwright/tests/e2e/ai/assistant-credential-help.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/assistant-credential-help.spec.ts
@@ -131,7 +131,11 @@ test.describe(
 								'authUrl',
 								'accessTokenUrl',
 								'clientId',
+								'authentication',
+								'clientCredentialType',
 								'clientSecret',
+								'privateKey',
+								'certificate',
 								'graphApiBaseUrl',
 							],
 						};
@@ -150,9 +154,7 @@ test.describe(
 				await n8n.ndv.clickCreateNewCredential();
 
 				await expect(n8n.canvas.credentialModal.oauthConnectButton).toHaveCount(1);
-				// 3 visible fields: clientCredentialType (from microsoftOAuth2Api),
-				// customScopes + useShared (from microsoftOutlookOAuth2Api).
-				await expect(n8n.canvas.credentialModal.getCredentialInputs()).toHaveCount(3);
+				await expect(n8n.canvas.credentialModal.getCredentialInputs()).toHaveCount(2);
 				await expect(n8n.aiAssistant.getCredentialEditAssistantButton()).toHaveCount(0);
 			});
 		});

--- a/packages/testing/playwright/tests/e2e/ai/assistant-credential-help.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/assistant-credential-help.spec.ts
@@ -150,7 +150,9 @@ test.describe(
 				await n8n.ndv.clickCreateNewCredential();
 
 				await expect(n8n.canvas.credentialModal.oauthConnectButton).toHaveCount(1);
-				await expect(n8n.canvas.credentialModal.getCredentialInputs()).toHaveCount(2);
+				// 3 visible fields: clientCredentialType (from microsoftOAuth2Api),
+				// customScopes + useShared (from microsoftOutlookOAuth2Api).
+				await expect(n8n.canvas.credentialModal.getCredentialInputs()).toHaveCount(3);
 				await expect(n8n.aiAssistant.getCredentialEditAssistantButton()).toHaveCount(0);
 			});
 		});


### PR DESCRIPTION
## Summary

Fixes the E2E test `AI Assistant::enabled > Credential Help > should not show assistant button when click to connect with some fields` that started failing on `master` after #33227 landed.

#33227 added an always-visible `clientCredentialType` (Client Secret / Certificate) options field to `MicrosoftOAuth2Api`. `microsoftOutlookOAuth2Api` extends it, so the visible-fields count in the test's managed-OAuth scenario grew from 2 → 3.

Rather than bumping the assertion to 3 — which would bake in a UX bug (the auth-method selector shouldn't be user-facing in managed OAuth, since Cloud/admin supplies the auth material) — this PR extends the test's mocked `__overwrittenProperties` to include `clientCredentialType`, `privateKey`, and `certificate` (and `authentication`). That mirrors the *target* end-state: what Cloud's managed OAuth overwrite payload should include once the follow-up server work lands.

The count assertion stays at 2 (`customScopes` + `useShared`), which is the intent the test was originally proving.

Follow-up ticket for the server-side change: **[ENT-131](https://linear.app/n8n/issue/ENT-131/managed-oauth-hide-clientcredentialtype-cert-fields-for)**.

Once merged, the test needs to be removed from the Currents quarantine list.

## How to test

use `CURRENTS_RECORD_KEY=local` to run the test which is in quarantine:

```bash
 CURRENTS_RECORD_KEY=local pnpm test:local:isolated assistant-credential-help.spec.ts  --ui
```

<img width="1657" height="969" alt="Screenshot 2026-07-02 at 11 05 32" src="https://github.com/user-attachments/assets/2d00bf5c-af17-47f6-938a-f136e7147e41" />


## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-130
- Follow-up UX fix: https://linear.app/n8n/issue/ENT-131
- Root-cause PR: #33227

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created (ENT-131).
- [x] Tests included (this PR *is* the test fix).
