### PR TITLE
fix(editor): Prevent duplicate AI Gateway unsupported-action notice

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -2063,6 +2063,49 @@ describe('ParameterInputList', () => {
 			expect(queryAllByTestId('ai-gateway-unsupported-action-notice')).toHaveLength(1);
 		});
 
+		it('should anchor the notice to the first "operation" property when there is no options selector', async () => {
+			// Fallback path: a node whose only `operation` property is not an options selector
+			// (e.g. a routing notice). The notice must still render exactly once, on that property.
+			vi.mocked(useAiGateway).mockReturnValue({
+				isEnabled: { value: true } as never,
+				isCredentialTypeSupported: vi.fn(() => true),
+				isNodeTypeVersionSupported: vi.fn(() => true),
+				isActionSupported: vi.fn(() => false),
+				isNodePropertyHidden: vi.fn(() => false),
+				balance: { value: undefined } as never,
+				budget: { value: undefined } as never,
+				fetchError: { value: null } as never,
+				fetchConfig: vi.fn(),
+				fetchWallet: vi.fn(),
+				saveAfterToggle: vi.fn(),
+			});
+
+			ndvStore.activeNode = {
+				...TEST_NODE_NO_ISSUES,
+				credentials: { openAiApi: { id: null, name: '', __aiGatewayManaged: true } },
+			};
+
+			const operationRoutingNotice: INodeProperties = {
+				displayName: 'GET /teamCreditUsage',
+				name: 'operation',
+				type: 'notice',
+				default: '',
+			};
+
+			const { queryAllByTestId } = renderComponent({
+				props: {
+					parameters: [resourceParameter, operationRoutingNotice],
+					nodeValues: {
+						parameters: { resource: 'audio', operation: 'transcribe' },
+					},
+					path: 'parameters',
+				},
+			});
+			await flushPromises();
+
+			expect(queryAllByTestId('ai-gateway-unsupported-action-notice')).toHaveLength(1);
+		});
+
 		it('should not show unsupported action notice when credential is not gateway-managed', async () => {
 			ndvStore.activeNode = {
 				...TEST_NODE_NO_ISSUES,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -2020,6 +2020,49 @@ describe('ParameterInputList', () => {
 			).not.toBeInTheDocument();
 		});
 
+		it('should show the unsupported action notice only once when multiple properties are named "operation"', async () => {
+			// Some community nodes expose more than one visible property named `operation`
+			// (e.g. the selector plus a routing notice), which previously rendered the notice twice.
+			vi.mocked(useAiGateway).mockReturnValue({
+				isEnabled: { value: true } as never,
+				isCredentialTypeSupported: vi.fn(() => true),
+				isNodeTypeVersionSupported: vi.fn(() => true),
+				isActionSupported: vi.fn(() => false),
+				isNodePropertyHidden: vi.fn(() => false),
+				balance: { value: undefined } as never,
+				budget: { value: undefined } as never,
+				fetchError: { value: null } as never,
+				fetchConfig: vi.fn(),
+				fetchWallet: vi.fn(),
+				saveAfterToggle: vi.fn(),
+			});
+
+			ndvStore.activeNode = {
+				...TEST_NODE_NO_ISSUES,
+				credentials: { openAiApi: { id: null, name: '', __aiGatewayManaged: true } },
+			};
+
+			const operationRoutingNotice: INodeProperties = {
+				displayName: 'GET /teamCreditUsage',
+				name: 'operation',
+				type: 'notice',
+				default: '',
+			};
+
+			const { queryAllByTestId } = renderComponent({
+				props: {
+					parameters: [resourceParameter, operationParameter, operationRoutingNotice],
+					nodeValues: {
+						parameters: { resource: 'audio', operation: 'transcribe' },
+					},
+					path: 'parameters',
+				},
+			});
+			await flushPromises();
+
+			expect(queryAllByTestId('ai-gateway-unsupported-action-notice')).toHaveLength(1);
+		});
+
 		it('should not show unsupported action notice when credential is not gateway-managed', async () => {
 			ndvStore.activeNode = {
 				...TEST_NODE_NO_ISSUES,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -579,6 +579,18 @@ const isAiGatewayUnsupportedAction = computed(() => {
 	return !aiGateway.isActionSupported(node.value.type, resource, operation);
 });
 
+// The unsupported-action notice must render exactly once.
+const aiGatewayUnsupportedNoticeIndex = computed(() => {
+	if (!isAiGatewayUnsupportedAction.value) return -1;
+	const items = parameterItems.value;
+	const selectorIndex = items.findIndex(
+		(item) => item.parameter.name === 'operation' && item.parameter.type === 'options',
+	);
+	return selectorIndex !== -1
+		? selectorIndex
+		: items.findIndex((item) => item.parameter.name === 'operation');
+});
+
 const aiGatewayOperationDisplayName = computed(() => {
 	const params = props.path
 		? (get(props.nodeValues, props.path) as INodeParameters | undefined)
@@ -952,7 +964,7 @@ watch(
 			</div>
 
 			<N8nNotice
-				v-if="item.parameter.name === 'operation' && isAiGatewayUnsupportedAction"
+				v-if="index === aiGatewayUnsupportedNoticeIndex"
 				theme="warning"
 				:class="$style.unsupportedActionNotice"
 				data-test-id="ai-gateway-unsupported-action-notice"


### PR DESCRIPTION
## Summary

The "not supported via n8n Connect" (AI Gateway unsupported-action) notice was rendered **once per node property named `operation`**. Nodes that expose more than one visible property named `operation` — e.g. an operation selector plus a routing `notice` (`GET /teamCreditUsage`), which is common in community nodes like **Firecrawl** — therefore showed the notice **twice** for those resources.

The notice is now anchored to a single index (the operation *selector*, falling back to the first `operation` property) so it renders exactly once. Built-in nodes have a single `operation` property, so their behavior is unchanged.

This only reproduces on instances with the AI Gateway enabled (a gateway-managed credential is required for the notice to show at all), which is why it didn't reproduce on instances without it.

## How to test

1. On an instance with AI Gateway enabled, install the Firecrawl community node (`@mendable/n8n-nodes-firecrawl`).
2. Select the `n8n Connect` credential.
3. Choose a resource/operation that is not supported via n8n Connect (e.g. Account → Get team credit usage).
4. Confirm the unsupported-action notice appears **once** (previously it appeared twice).
5. Verify supported operations show no notice, and built-in nodes are unaffected.

Covered by a new unit test in `ParameterInputList.test.ts` asserting the notice renders exactly once when multiple properties are named `operation`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-155

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33428">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->