### PR TITLE
ci: Force broad E2E test selection for credential definition changes

### DIFF
--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -82,6 +82,7 @@ describe('forcesBroad', () => {
 		'packages/cli/Dockerfile',
 		'Dockerfile.dev',
 		'packages/cli/worker.Dockerfile',
+		'packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts',
 	])('treats %s as runtime-defining (force broad)', (file) => {
 		expect(forcesBroad(file)).toBe(true);
 	});

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -56,11 +56,18 @@ export function filterImpactfulChanges(files: string[]): string[] {
  * image and the container harness. The coverage map can't attribute these (a
  * change here can reach any spec), so they force a broad run rather than being
  * declared uncovered. This is a small, low-churn set, so broad is cheap here.
+ *
+ * Credential definitions belong here for a different reason: they're declarative
+ * metadata loaded into the registry once at boot, so no code in them re-executes
+ * attributably to a spec and the runtime coverage map never records them. Absent
+ * from the map, a credential change would be declared uncovered and skip its
+ * covering specs, so we force broad instead.
  */
 const FORCES_BROAD: Array<(f: string) => boolean> = [
 	(f) => f.startsWith('docker/'),
 	(f) => /(^|\/)Dockerfile(\.|$)|\.Dockerfile$/.test(f),
 	(f) => f.startsWith('packages/testing/containers/'),
+	(f) => f.startsWith('packages/nodes-base/credentials/'),
 ];
 
 /** True if a changed file defines the E2E runtime → the whole suite must run. */

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -147,6 +147,22 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
+	// Credential definitions are declarative metadata absent from the runtime map;
+	// without forcing broad they'd be declared uncovered and skip their specs.
+	it('credential definition change → broad, never declared uncovered', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-cred.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['packages/nodes-base/credentials/MicrosoftOAuth2Api.credentials.ts'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('broad');
+		expect(result.specs).toEqual([...ALL_SPECS].sort());
+		expect(result.uncovered).toBeUndefined();
+	});
+
 	it('package.json change with NO dependency change (version) → uncovered, not broad', () => {
 		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
 		const mapPath = path.join(tempDir, 'map-ver.json');


### PR DESCRIPTION
## Summary

The E2E test-impact (TIA) selector consults a committed **runtime** coverage map (`.github/test-metrics/e2e-impact-map.json`). Credential definition files are declarative metadata loaded into the registry once at boot — no code in them re-executes attributably to a spec, so the runtime coverage map never records them. Absent from the map, a credential change was declared **`uncovered` → runs nothing**, silently skipping its covering specs.

This already caused a real miss: PR #33227 added an always-visible field to `MicrosoftOAuth2Api`, broke `e2e/ai/assistant-credential-help.spec.ts`, yet CI ran only 5/180 specs and flagged the change "uncovered — not run."

This PR adds `packages/nodes-base/credentials/` to `FORCES_BROAD`, so any credential definition change forces a broad (full-suite) E2E run instead of being declared uncovered — mirroring how Dockerfile/container-harness changes are already handled.

**Deliberately out of scope** (deferred, data-gated): a static "credential type → specs" index, and the analogous node `description` metadata blind spot (which `FORCES_BROAD` can't address, since node logic is already mapped and `nodes-base/nodes/**` changes constantly).

## How to test

From `packages/testing/test-impact/`:

```bash
pnpm test changes.test.ts select.test.ts
pnpm lint && pnpm typecheck
```

New coverage:
- `changes.test.ts` — a credential path is treated as runtime-defining (forces broad).
- `select.test.ts` — a credential definition change routes to `mode: 'broad'` with the full spec set and no `uncovered`, contrasting the existing test where an unmapped node file returns `scoped` + `uncovered`.

Behavioral sanity: the PR #33227 scenario (change to `MicrosoftOAuth2Api.credentials.ts`) now routes to broad, which includes the previously-skipped `e2e/ai/assistant-credential-help.spec.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-621

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33429">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->