### PR TITLE
fix(editor): Hide custom scopes for managed OAuth credentials edited from the list

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -762,6 +762,29 @@ describe('CredentialEdit', () => {
 			expect(queryByText('Enabled Scopes')).toBeInTheDocument();
 		});
 
+		test('hides scope fields for a managed-capable credential edited from the list (no active node context)', async () => {
+			const credentialsStore = setupStores(false);
+			credentialsStore.state.credentialTypes = {
+				[oAuth2Api.name]: oAuth2Api,
+				[discordOAuth2ApiManagedCapable.name]: discordOAuth2ApiManagedCapable,
+			};
+
+			const { queryByText } = renderComponent({
+				props: {
+					activeId: 'cred-1',
+					modalName: CREDENTIAL_EDIT_MODAL_KEY,
+					mode: 'edit',
+				},
+			});
+
+			await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+
+			expect(queryByText('Scope')).not.toBeInTheDocument();
+			expect(queryByText('Custom Scopes')).not.toBeInTheDocument();
+			expect(queryByText('Enabled Scopes')).not.toBeInTheDocument();
+			expect(queryByText('Custom Scopes Notice')).not.toBeInTheDocument();
+		});
+
 		it('should not block modal when external hooks throw', async () => {
 			window.n8nExternalHooks = {
 				credentialsEdit: {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -325,6 +325,11 @@ const isOAuthType = computed(() => {
 });
 
 const managedOAuthAvailable = computed(() => {
+	// Detect directly from the credential type so managed mode also resolves when the
+	// credential is edited from the credentials list (no active node context).
+	if (credentialTypeName.value && hasManagedOAuthCredentials(credentialTypeName.value)) {
+		return true;
+	}
 	return (
 		activeNodeType.value?.credentials?.some((type) => hasManagedOAuthCredentials(type.name)) ??
 		false


### PR DESCRIPTION
## Summary

Managed OAuth mode was only detected via an active **node** context (`activeNodeType`). Opening a credential directly from the list has no node context, so managed OAuth2 wasn't detected and the scope fields stayed visible.

This is a targeted extract of the bug fix from #33086

## How to test

1. Start n8n with a managed OAuth overwrite:
   ```bash
   CREDENTIALS_OVERWRITE_DATA='{"slackOAuth2Api":{"clientId":"dummy","clientSecret":"dummy"}}'
   ```
2. From the **Credentials** overview page, add a **Slack OAuth2 API** credential → **no Custom Scopes** and **no OAuth Redirect URL**.
3. Select "Custom OAuth2" → Custom Scopes and Redirect URL reappear.
4. Create the same credential from within a node → still hidden (unchanged behavior).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5362

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->