### PR TITLE
test(ai-builder): Add plan-rejection eval and harden multi-turn eval consistency (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -180,7 +180,7 @@ These only run if specific files changed:
 | `packages/@n8n/ai-workflow-builder.ee/evaluations/programmatic/python/**` | `test-evals-python.yml`  | any        |
 | `packages/@n8n/benchmark/**`                                           | `build-benchmark-image.yml` | master     |
 | `packages/cli/src/public-api/**/*.{css,yaml,yml}`                      | `util-sync-api-docs.yml`    | master     |
-| `packages/@n8n/instance-ai/src/**`, `packages/@n8n/instance-ai/evaluations/**`, `packages/cli/src/modules/instance-ai/**`, `packages/core/src/execution-engine/eval-mock-helpers.ts` | `ci-instance-ai-evals.yml` | on PR `opened` / `reopened` / `ready_for_review` |
+| `packages/@n8n/instance-ai/src/**`, `packages/@n8n/instance-ai/skills/**`, `packages/@n8n/instance-ai/knowledge-base/**`, `packages/@n8n/instance-ai/evaluations/**`, `packages/cli/src/modules/instance-ai/**`, `packages/core/src/execution-engine/eval-mock-helpers.ts` | `ci-instance-ai-evals.yml` | on PR `opened` / `reopened` / `ready_for_review` |
 
 ### On PR Review
 

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -14,6 +14,8 @@ on:
     types: [opened, reopened, ready_for_review]
     paths:
       - 'packages/@n8n/instance-ai/src/**'
+      - 'packages/@n8n/instance-ai/skills/**'
+      - 'packages/@n8n/instance-ai/knowledge-base/**'
       - 'packages/@n8n/instance-ai/evaluations/**'
       - 'packages/cli/src/modules/instance-ai/**'
       - 'packages/core/src/execution-engine/eval-mock-helpers.ts'

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
@@ -1,0 +1,37 @@
+{
+	"description": "Behaviour regression for HITL plan-rejection handling — from LangTracer run-23 capability-gap themes 'plan rejection misreported as approval' (planner reports approved on approved:false; turn hangs with null response) and 'resubmits identical plan after rejection'. The user asks for a plan before building, then rejects the first plan with two concrete changes. The agent must honor the rejection: revise the plan to include the changes and build only the revised version — not proceed with the original as if approved, not resubmit an identical plan, and not report the work done. The rejection feedback is stated in the user's voice; the rejection-HANDLING behaviour is the assertion, not an instruction. Execution anchors on the Slack posts (HTTP-intercepted: which rows, which channel), not on stored state. Note: if the underlying bug is live the turn may hang / not build rather than cleanly fail an expectation — calibrate.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Before you build anything, show me a plan and let me approve it first. The workflow I want: on a schedule, read the new rows from my 'Leads' Google Sheet and post each one to a Slack channel."
+		},
+		{
+			"role": "user",
+			"text": [
+				"[When the agent shows its first plan, reject it. Tell it two changes you want: only post rows where the Status column is 'Urgent', and post them to #urgent-alerts (not whatever channel it picked). Don't approve until the plan clearly reflects BOTH changes.",
+				"If it instead re-shows essentially the same plan without incorporating the two changes, reject again and restate them. Once the plan reflects both, approve. Don't provide credentials — say you'll set them up later.]"
+			]
+		}
+	],
+	"messageBudget": 10,
+	"complexity": "medium",
+	"tags": ["behaviour", "planning", "plan-rejection", "hitl", "schedule", "google-sheets", "slack"],
+	"triggerType": "schedule",
+	"datasets": ["behaviour", "full"],
+	"processExpectations": [
+		"When the user rejected the first plan, the agent treated it as a rejection — it did not proceed to build the original plan as if it had been approved, and did not report the plan as approved or the work as done off the back of the rejected plan.",
+		"After the rejection, the agent revised the plan to incorporate the user's feedback (filter to Status 'Urgent'; post to #urgent-alerts) rather than resubmitting the same plan unchanged, and only built once the revised plan was approved."
+	],
+	"outcomeExpectations": [
+		"The final workflow is driven by a Schedule Trigger that reads rows from the 'Leads' Google Sheet.",
+		"It posts only the rows whose Status is 'Urgent' (a conditional/filter gates out the rest) and posts them to Slack #urgent-alerts — the two changes the user gave when rejecting the first plan, not the channel proposed in the first plan."
+	],
+	"executionScenarios": [
+		{
+			"name": "urgent-rows-only",
+			"description": "The sheet has a mix of Urgent and non-urgent rows; only the Urgent ones are posted, to #urgent-alerts",
+			"dataSetup": "The 'Leads' sheet read returns four rows: two with Status 'Urgent' (companies 'Acme' and 'Globex') and two with Status 'New' ('Initech', 'Umbrella'). Each Slack postMessage call returns a success response with ok=true.",
+			"successCriteria": "The run completes without errors. Only the two 'Urgent' rows (Acme, Globex) are posted to Slack #urgent-alerts; the 'New' rows are not posted anywhere. The posts go to #urgent-alerts, not to the channel from the first plan."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
@@ -1,5 +1,5 @@
 {
-	"description": "Behaviour regression for HITL plan-rejection handling — from LangTracer run-23 capability-gap themes 'plan rejection misreported as approval' (planner reports approved on approved:false; turn hangs with null response) and 'resubmits identical plan after rejection'. The user asks for a plan before building, then rejects the first plan with two concrete changes. The agent must honor the rejection: revise the plan to include the changes and build only the revised version — not proceed with the original as if approved, not resubmit an identical plan, and not report the work done. The rejection feedback is stated in the user's voice; the rejection-HANDLING behaviour is the assertion, not an instruction. Execution anchors on the Slack posts (HTTP-intercepted: which rows, which channel), not on stored state. Note: if the underlying bug is live the turn may hang / not build rather than cleanly fail an expectation — calibrate.",
+	"description": "Behaviour regression for HITL plan-rejection handling — from LangTracer run-23 capability-gap themes 'plan rejection misreported as approval' (planner reports approved on approved:false; turn hangs with null response) and 'resubmits identical plan after rejection'. The user asks for a plan before building, then rejects the first plan with two concrete changes. The agent must honor the rejection: revise the plan to include the changes and build only the revised version — not proceed with the original as if approved, not resubmit an identical plan, and not report the work done. The rejection feedback is stated in the user's voice; the rejection-HANDLING behaviour is the assertion, not an instruction. Build-only (no execution scenario) on purpose: the behaviour is judged by the process + outcome expectations, which held green across 5 calibration iterations. A mock run of the built workflow was dropped because it flaked for reasons unrelated to the behaviour — a dedup step's data table isn't isolated across concurrent eval iterations, and Google Sheets node config varies build to build — so it would only add gate noise.",
 	"conversation": [
 		{
 			"role": "user",
@@ -17,7 +17,7 @@
 	"complexity": "medium",
 	"tags": ["behaviour", "planning", "plan-rejection", "hitl", "schedule", "google-sheets", "slack"],
 	"triggerType": "schedule",
-	"datasets": ["behaviour", "full"],
+	"datasets": ["behaviour", "pr", "full"],
 	"processExpectations": [
 		"When the user rejected the first plan, the agent treated it as a rejection — it did not proceed to build the original plan as if it had been approved, and did not report the plan as approved or the work as done off the back of the rejected plan.",
 		"After the rejection, the agent revised the plan to incorporate the user's feedback (filter to Status 'Urgent'; post to #urgent-alerts) rather than resubmitting the same plan unchanged, and only built once the revised plan was approved."
@@ -25,13 +25,5 @@
 	"outcomeExpectations": [
 		"The final workflow is driven by a Schedule Trigger that reads rows from the 'Leads' Google Sheet.",
 		"It posts only the rows whose Status is 'Urgent' (a conditional/filter gates out the rest) and posts them to Slack #urgent-alerts — the two changes the user gave when rejecting the first plan, not the channel proposed in the first plan."
-	],
-	"executionScenarios": [
-		{
-			"name": "urgent-rows-only",
-			"description": "The sheet has a mix of Urgent and non-urgent rows; only the Urgent ones are posted, to #urgent-alerts",
-			"dataSetup": "The 'Leads' sheet read returns four rows: two with Status 'Urgent' (companies 'Acme' and 'Globex') and two with Status 'New' ('Initech', 'Umbrella'). Each Slack postMessage call returns a success response with ok=true.",
-			"successCriteria": "The run completes without errors. Only the two 'Urgent' rows (Acme, Globex) are posted to Slack #urgent-alerts; the 'New' rows are not posted anywhere. The posts go to #urgent-alerts, not to the channel from the first plan."
-		}
 	]
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/revises-plan-after-rejection.json
@@ -1,5 +1,5 @@
 {
-	"description": "Behaviour regression for HITL plan-rejection handling — from LangTracer run-23 capability-gap themes 'plan rejection misreported as approval' (planner reports approved on approved:false; turn hangs with null response) and 'resubmits identical plan after rejection'. The user asks for a plan before building, then rejects the first plan with two concrete changes. The agent must honor the rejection: revise the plan to include the changes and build only the revised version — not proceed with the original as if approved, not resubmit an identical plan, and not report the work done. The rejection feedback is stated in the user's voice; the rejection-HANDLING behaviour is the assertion, not an instruction. Build-only (no execution scenario) on purpose: the behaviour is judged by the process + outcome expectations, which held green across 5 calibration iterations. A mock run of the built workflow was dropped because it flaked for reasons unrelated to the behaviour — a dedup step's data table isn't isolated across concurrent eval iterations, and Google Sheets node config varies build to build — so it would only add gate noise.",
+	"description": "Behaviour regression for HITL plan-rejection handling — from LangTracer run-23 capability-gap themes 'plan rejection misreported as approval' (planner reports approved on approved:false; turn hangs with null response) and 'resubmits identical plan after rejection'. The user asks for a plan before building, then rejects the first plan with two concrete changes. The agent must honor the rejection: revise the plan to include the changes and build only the revised version — not proceed with the original as if approved, not resubmit an identical plan, and not report the work done. The rejection feedback is stated in the user's voice; the rejection-HANDLING behaviour is the assertion, not an instruction. Execution anchors on the Slack posts (HTTP-intercepted: which rows, which channel), not on stored state. The scenario was restored after #33530: eval executions now pin data-table row-reads to the scenario's stored state and patch setup-pending Sheets locators/mappers, which removed both flake sources that had briefly forced this case to build-only. If the scenario flakes in the gate again, demote the case to behaviour/full rather than re-dropping the scenario.",
 	"conversation": [
 		{
 			"role": "user",
@@ -25,5 +25,13 @@
 	"outcomeExpectations": [
 		"The final workflow is driven by a Schedule Trigger that reads rows from the 'Leads' Google Sheet.",
 		"It posts only the rows whose Status is 'Urgent' (a conditional/filter gates out the rest) and posts them to Slack #urgent-alerts — the two changes the user gave when rejecting the first plan, not the channel proposed in the first plan."
+	],
+	"executionScenarios": [
+		{
+			"name": "urgent-rows-only",
+			"description": "The sheet has a mix of Urgent and non-urgent rows; only the Urgent ones are posted, to #urgent-alerts",
+			"dataSetup": "The 'Leads' sheet read returns four rows: two with Status 'Urgent' (companies 'Acme' and 'Globex') and two with Status 'New' ('Initech', 'Umbrella'). No lead has been seen or posted before — any dedup/stored state starts empty. Each Slack postMessage call returns a success response with ok=true.",
+			"successCriteria": "The run completes without errors. Only the two 'Urgent' rows (Acme, Globex) are posted to Slack #urgent-alerts; the 'New' rows are not posted anywhere. The posts go to #urgent-alerts, not to the channel from the first plan."
+		}
 	]
 }

--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/prompts.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/prompts.ts
@@ -44,6 +44,12 @@ Pick the value to use in this order:
 
 Use \`skipped: true\` only when the question itself is incoherent (no plausible answer of any shape exists). Reluctance to invent is a bug — invent. (The sole exception: a [stage direction] in the script that tells the user to decline or withhold a value — then set skipped to true for that field and do not invent.)
 
+## Named services are concrete values
+
+When the script names a specific service or provider for a step — "email **via Gmail**", "Microsoft Teams", "Slack" — that name is a requirement, not flavour. Carry it verbatim into every answer. Picking a generic option that merely resembles it ("Email" when the script says "via Gmail") tells the agent any provider will do. Select the closest option AND restate the exact service in customText (e.g. "via Gmail"), or answer in free text naming it.
+
+One exception: sometimes the dedicated node genuinely cannot do what the script asks, and a generic node is the right call. Accept the substitution only when the agent says so — its plan, question, or explanation in the conversation must state why the named service's node doesn't fit. A silent swap is never that exception; treat it as a missed requirement.
+
 ## One exception: credentials
 
 Never set credentials. They're deferred and the user will configure them via the UI. Credentials are the one and only thing left blank.
@@ -59,6 +65,7 @@ When the agent shows a plan, summary, or "here's what I'll build" preview, **aud
 Reject when the plan misses any of the following from the script:
 - **Concrete values** — channel IDs, table names, URLs, schedules, specific node configurations. Example: "Use #engineering (C04ENGINEER1), not the generic channel you picked."
 - **Stated behaviours** — sort/order rules ("sort descending by count"), filter conditions ("only include issues outside the creator's team"), branching logic ("if X then post to Y else …"), error handling, deduplication, retry behaviour. These are as load-bearing as concrete values. Example: "The script said 'sort descending by count' but the plan doesn't include a sort step — add an explicit sort by violation count."
+- **Named services** — the script's specific provider for a step. A plan that substitutes a generic equivalent (a plain "Send Email"/SMTP node where the script says Gmail) misses a stated requirement. Example: "Low-urgency notifications should go out through Gmail, not a generic email node." Exception: accept the generic substitute when the agent's plan or conversation explains why the dedicated node cannot do the task; reject silent swaps.
 
 Be specific in the rejection — quote the requirement that's missing or wrong. Don't just say "this is wrong."
 


### PR DESCRIPTION
## Summary

Adds a behaviour regression guard for **HITL plan-rejection handling**: the user asks for a plan, then **rejects the first plan** with two concrete changes (only `Urgent` rows; post to `#urgent-alerts`). The agent must **honor the rejection** — revise the plan to include both changes and build only the revised version — not proceed as if approved, resubmit the same plan, or report the work done.

**Provenance:** a real LangTracer capability-gap cluster theme — *"HITL plan rejection misreported as approval"* (36 traces: planner reports approved on `approved:false`, turn hangs) plus *"resubmits identical plan after rejection."* Fully synthetic (authored prompt + director script) — no PII, durable, unlike a `seedThread`.

**Calibration (`--iterations 5`):** the process + outcome expectations (the behaviour under test) were **green on all 5 runs**. The case is **build-only** by design — an execution scenario was dropped because it flaked for reasons *unrelated* to the behaviour (a dedup step's data table isn't isolated across concurrent eval iterations; the Google Sheets node config varies build to build), which would only add gate noise. Tagged into the **`pr`** gate tier.

Authored end-to-end with the `create-instance-ai-eval` skill (expanded in #33407).

## Also in this PR: notification-router consistency + eval-trigger hardening

`notification-router`'s clarifying-question expectation had been flaking 1/3–2/3 on PR checks since 2026-06-25. Root cause: #32969 deliberately re-tuned the builder to prefer placeholders over pre-build setup questions, so the "asked about the incoming payload shape" clause tests behaviour the product intentionally no longer has (pre/post-06-25 PR comments confirm the cliff; a local N=5 reproduced the exact judge signature — agent assumes `urgency`, user corrects to `level` post-build).

- **6158f8b2** — recalibrate `notification-router`: merge the two process expectations into one doctrine-aligned check ("asked at least one clarifying question about the routing scheme … rather than building purely on assumptions"). Calibration N=5: 5/5.
- **94008b84** — user-proxy: script-named services (e.g. "email **via Gmail**") are requirements — the proxy now restates them verbatim when answering structured questions and audits plans for silent generic substitutions, accepting a generic node only when the agent explains why the dedicated one can't do the task. Fixes a ~10% fidelity flake where "via Gmail" degraded to option label "Email" → generic `emailSend`. Validated N=5 × 2 cases: notification-router 5/5 (incl. the Gmail outcome expectation); this PR's plan-rejection case unaffected (reject/revise 5/5, no over-rejection).
- **736c3293** — CI: `ci-instance-ai-evals.yml` now also triggers on `packages/@n8n/instance-ai/skills/**` and `knowledge-base/**` — prompt-doctrine surfaces that could previously merge without the workflow evals running (the #32969 class of change).

## How to test

From `packages/@n8n/instance-ai/`, against a running Instance-AI-enabled instance:

```bash
pnpm eval:instance-ai --filter revises-plan-after-rejection --keep-workflows --verbose
```

## Follow-up

Ops note: the scenario removed during calibration left a stale `urgent-rows-only` example in the LangSmith dataset (sync doesn't prune); it kept executing as a ghost scenario. Deleted it — the case now has only its `__build_only__` sentinel, so this PR's eval run won't show phantom scenario failures.

Calibration surfaced a harness isolation gap — data tables created by a built workflow aren't isolated across concurrent `--iterations`, so a dedup workflow cross-contaminates runs. Worth a follow-up (refines TRUST-186); does not affect this behaviour case.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


## Merge order

Merge after #33584 (and ideally #33580): the restored execution scenario depends on those eval-seam fixes for deterministic stored-state behavior in the `pr` gate.
