### PR TITLE
refactor(core): Extract shared cached metric query for Prometheus collectors

### DIFF
--- a/packages/cli/src/metrics/prometheus/__tests__/active-workflow-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/active-workflow-metrics.service.test.ts
@@ -69,7 +69,7 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
-			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:active-workflow-count']);
+			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:active-workflow-count:v2']);
 			expect(workflowRepository.getActiveCount.mock.calls).toHaveLength(0);
 			expect(mockGauge.set).toHaveBeenCalledWith(42);
 		});
@@ -84,7 +84,7 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 
 			expect(workflowRepository.getActiveCount.mock.calls).toHaveLength(1);
 			expect(cacheService.set.mock.calls[0]).toEqual([
-				'metrics:active-workflow-count',
+				'metrics:active-workflow-count:v2',
 				15,
 				30 * 1000,
 			]);
@@ -101,7 +101,7 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(cacheService.set.mock.calls[0]).toEqual([
-				'metrics:active-workflow-count',
+				'metrics:active-workflow-count:v2',
 				5,
 				120 * 1000,
 			]);

--- a/packages/cli/src/metrics/prometheus/__tests__/active-workflow-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/active-workflow-metrics.service.test.ts
@@ -62,8 +62,8 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 			return vi.mocked(promClient.Gauge).mock.calls[0][0].collect!;
 		};
 
-		it('should use cached value when cache returns a valid number string', async () => {
-			cacheService.get.mockResolvedValue('42');
+		it('should use cached value when cache hits', async () => {
+			cacheService.get.mockResolvedValue(42);
 			const collectFn = extractCollectFn();
 			const mockGauge = { set: vi.fn() };
 
@@ -85,22 +85,10 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 			expect(workflowRepository.getActiveCount.mock.calls).toHaveLength(1);
 			expect(cacheService.set.mock.calls[0]).toEqual([
 				'metrics:active-workflow-count',
-				'15',
+				15,
 				30 * 1000,
 			]);
 			expect(mockGauge.set).toHaveBeenCalledWith(15);
-		});
-
-		it('should call DB when cached value is not a finite number', async () => {
-			cacheService.get.mockResolvedValue('not-a-number');
-			workflowRepository.getActiveCount.mockResolvedValue(7);
-			const collectFn = extractCollectFn();
-			const mockGauge = { set: vi.fn() };
-
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
-
-			expect(workflowRepository.getActiveCount.mock.calls).toHaveLength(1);
-			expect(mockGauge.set).toHaveBeenCalledWith(7);
 		});
 
 		it('should use the configured interval for the cache TTL', async () => {
@@ -114,7 +102,7 @@ describe('PrometheusActiveWorkflowMetricsService', () => {
 
 			expect(cacheService.set.mock.calls[0]).toEqual([
 				'metrics:active-workflow-count',
-				'5',
+				5,
 				120 * 1000,
 			]);
 		});

--- a/packages/cli/src/metrics/prometheus/__tests__/cached-metric-query.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/cached-metric-query.test.ts
@@ -1,0 +1,57 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { CachedMetricQuery } from '../cached-metric-query';
+
+describe('CachedMetricQuery', () => {
+	const cacheService = mock<CacheService>();
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns the cached value without querying on a cache hit', async () => {
+		cacheService.get.mockResolvedValue(42);
+		const query = vi.fn();
+		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+
+		expect(await cached.get()).toBe(42);
+		expect(query).not.toHaveBeenCalled();
+		expect(cacheService.set).not.toHaveBeenCalled();
+	});
+
+	it('queries, caches with the given TTL, and returns on a cache miss', async () => {
+		cacheService.get.mockResolvedValue(undefined);
+		const query = vi.fn().mockResolvedValue(7);
+		const cached = new CachedMetricQuery<number>(cacheService, 'key', 5000, query);
+
+		expect(await cached.get()).toBe(7);
+		expect(query).toHaveBeenCalledTimes(1);
+		expect(cacheService.set).toHaveBeenCalledWith('key', 7, 5000);
+	});
+
+	it('coalesces concurrent get() calls into a single query and cache read', async () => {
+		cacheService.get.mockResolvedValue(undefined);
+		const query = vi.fn().mockResolvedValue(1);
+		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+
+		const [a, b] = await Promise.all([cached.get(), cached.get()]);
+
+		expect(a).toBe(1);
+		expect(b).toBe(1);
+		expect(query).toHaveBeenCalledTimes(1);
+		expect(cacheService.get).toHaveBeenCalledTimes(1);
+	});
+
+	it('queries again on a fresh get() after the previous one settled', async () => {
+		cacheService.get.mockResolvedValue(undefined);
+		const query = vi.fn().mockResolvedValue(1);
+		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+
+		await cached.get();
+		await cached.get();
+
+		expect(query).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/cli/src/metrics/prometheus/__tests__/cached-metric-query.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/cached-metric-query.test.ts
@@ -14,7 +14,12 @@ describe('CachedMetricQuery', () => {
 	it('returns the cached value without querying on a cache hit', async () => {
 		cacheService.get.mockResolvedValue(42);
 		const query = vi.fn();
-		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+		const cached = new CachedMetricQuery<number>({
+			cacheService,
+			cacheKey: 'key',
+			ttlMs: 1000,
+			query,
+		});
 
 		expect(await cached.get()).toBe(42);
 		expect(query).not.toHaveBeenCalled();
@@ -24,7 +29,12 @@ describe('CachedMetricQuery', () => {
 	it('queries, caches with the given TTL, and returns on a cache miss', async () => {
 		cacheService.get.mockResolvedValue(undefined);
 		const query = vi.fn().mockResolvedValue(7);
-		const cached = new CachedMetricQuery<number>(cacheService, 'key', 5000, query);
+		const cached = new CachedMetricQuery<number>({
+			cacheService,
+			cacheKey: 'key',
+			ttlMs: 5000,
+			query,
+		});
 
 		expect(await cached.get()).toBe(7);
 		expect(query).toHaveBeenCalledTimes(1);
@@ -34,7 +44,12 @@ describe('CachedMetricQuery', () => {
 	it('coalesces concurrent get() calls into a single query and cache read', async () => {
 		cacheService.get.mockResolvedValue(undefined);
 		const query = vi.fn().mockResolvedValue(1);
-		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+		const cached = new CachedMetricQuery<number>({
+			cacheService,
+			cacheKey: 'key',
+			ttlMs: 1000,
+			query,
+		});
 
 		const [a, b] = await Promise.all([cached.get(), cached.get()]);
 
@@ -47,7 +62,12 @@ describe('CachedMetricQuery', () => {
 	it('queries again on a fresh get() after the previous one settled', async () => {
 		cacheService.get.mockResolvedValue(undefined);
 		const query = vi.fn().mockResolvedValue(1);
-		const cached = new CachedMetricQuery<number>(cacheService, 'key', 1000, query);
+		const cached = new CachedMetricQuery<number>({
+			cacheService,
+			cacheKey: 'key',
+			ttlMs: 1000,
+			query,
+		});
 
 		await cached.get();
 		await cached.get();

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
@@ -80,7 +80,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 		];
 
 		it('should use cached value when cache hits', async () => {
-			cacheService.get.mockResolvedValue(JSON.stringify(workflows));
+			cacheService.get.mockResolvedValue(workflows);
 			const collectFn = extractCollectFn();
 			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
 			const mockGauge = { reset: vi.fn(), labels: mockLabels };
@@ -110,11 +110,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(workflowRepository.find).toHaveBeenCalledWith({ select: ['id', 'name'] });
-			expect(cacheService.set).toHaveBeenCalledWith(
-				'metrics:workflow-info',
-				JSON.stringify(workflows),
-				60 * 1000,
-			);
+			expect(cacheService.set).toHaveBeenCalledWith('metrics:workflow-info', workflows, 60 * 1000);
 			expect(mockLabels).toHaveBeenCalledWith({
 				workflow_id: 'wf_1',
 				workflow_name: 'My First Workflow',
@@ -126,7 +122,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 		});
 
 		it('should reset the gauge before setting new values', async () => {
-			cacheService.get.mockResolvedValue(JSON.stringify(workflows));
+			cacheService.get.mockResolvedValue(workflows);
 			const collectFn = extractCollectFn();
 			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
 			const mockGauge = { reset: vi.fn(), labels: mockLabels };
@@ -148,24 +144,13 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 
 			expect(cacheService.set).toHaveBeenCalledWith(
 				'metrics:workflow-info',
-				expect.any(String),
+				expect.any(Array),
 				120 * 1000,
 			);
 		});
 
-		it('should fall back to an empty array when cache contains invalid JSON', async () => {
-			cacheService.get.mockResolvedValue('not-valid-json');
-			const collectFn = extractCollectFn();
-			const mockLabels = vi.fn().mockReturnValue({ set: vi.fn() });
-			const mockGauge = { reset: vi.fn(), labels: mockLabels };
-
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
-
-			expect(mockLabels).not.toHaveBeenCalled();
-		});
-
 		it('should set each workflow label entry to 1', async () => {
-			cacheService.get.mockResolvedValue(JSON.stringify([{ id: 'wf_1', name: 'Test' }]));
+			cacheService.get.mockResolvedValue([{ id: 'wf_1', name: 'Test' }]);
 			const collectFn = extractCollectFn();
 			const mockSet = vi.fn();
 			const mockGauge = { reset: vi.fn(), labels: vi.fn().mockReturnValue({ set: mockSet }) };

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-info-metrics.service.test.ts
@@ -87,7 +87,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
-			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:workflow-info']);
+			expect(cacheService.get.mock.calls[0]).toEqual(['metrics:workflow-info:v2']);
 			expect(workflowRepository.find.mock.calls).toHaveLength(0);
 			expect(mockGauge.reset).toHaveBeenCalled();
 			expect(mockLabels).toHaveBeenCalledWith({
@@ -110,7 +110,11 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(workflowRepository.find).toHaveBeenCalledWith({ select: ['id', 'name'] });
-			expect(cacheService.set).toHaveBeenCalledWith('metrics:workflow-info', workflows, 60 * 1000);
+			expect(cacheService.set).toHaveBeenCalledWith(
+				'metrics:workflow-info:v2',
+				workflows,
+				60 * 1000,
+			);
 			expect(mockLabels).toHaveBeenCalledWith({
 				workflow_id: 'wf_1',
 				workflow_name: 'My First Workflow',
@@ -143,7 +147,7 @@ describe('PrometheusWorkflowInfoMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(cacheService.set).toHaveBeenCalledWith(
-				'metrics:workflow-info',
+				'metrics:workflow-info:v2',
 				expect.any(Array),
 				120 * 1000,
 			);

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-publication-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-publication-metrics.service.test.ts
@@ -226,18 +226,18 @@ describe('PrometheusWorkflowPublicationMetricsService', () => {
 
 			// 60s interval → 60_000ms TTL; Dates are serialized to epoch ms.
 			expect(cacheService.set).toHaveBeenCalledWith(
-				'metrics:workflow-publication:outbox-record-stats',
-				[['pending', { count: 2, oldestMs: createdAt.getTime() }]],
+				'metrics:workflow-publication:outbox-record-stats:v2',
+				{ pending: { count: 2, oldestMs: createdAt.getTime() } },
 				60_000,
 			);
 		});
 
 		it('serves the gauges from cache without querying the database', async () => {
 			const tenSecondsAgo = Date.now() - 10_000;
-			cacheService.get.mockResolvedValue([
-				['pending', { count: 5, oldestMs: tenSecondsAgo }],
-				['completed', { count: 7, oldestMs: tenSecondsAgo }],
-			]);
+			cacheService.get.mockResolvedValue({
+				pending: { count: 5, oldestMs: tenSecondsAgo },
+				completed: { count: 7, oldestMs: tenSecondsAgo },
+			});
 			service.init();
 
 			const set = vi.fn();

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-statistics-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-statistics-metrics.service.test.ts
@@ -209,7 +209,7 @@ describe('PrometheusWorkflowStatisticsMetricsService', () => {
 			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
 
 			expect(cacheService.set.mock.calls[0]).toEqual([
-				'metrics:workflow-statistics:shared',
+				'metrics:workflow-statistics:shared:v2',
 				MOCK_METRICS,
 				30 * 1000,
 			]);

--- a/packages/cli/src/metrics/prometheus/__tests__/workflow-statistics-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/workflow-statistics-metrics.service.test.ts
@@ -210,7 +210,7 @@ describe('PrometheusWorkflowStatisticsMetricsService', () => {
 
 			expect(cacheService.set.mock.calls[0]).toEqual([
 				'metrics:workflow-statistics:shared',
-				expect.any(String),
+				MOCK_METRICS,
 				30 * 1000,
 			]);
 		});
@@ -228,7 +228,7 @@ describe('PrometheusWorkflowStatisticsMetricsService', () => {
 				totalWorkflows: 444,
 				totalCredentials: 333,
 			};
-			cacheService.get.mockResolvedValue(JSON.stringify(cachedMetrics));
+			cacheService.get.mockResolvedValue(cachedMetrics);
 
 			service.init();
 			const collectFn = extractGaugeCollect('production_executions');
@@ -240,37 +240,23 @@ describe('PrometheusWorkflowStatisticsMetricsService', () => {
 		});
 	});
 
-	describe('collect callbacks — in-memory cache deduplication', () => {
-		it('should call DB only once within 1 second for multiple collect calls', async () => {
-			vi.useFakeTimers();
+	describe('collect callbacks — concurrent scrape coalescing', () => {
+		it('should call DB only once when gauges collect concurrently', async () => {
 			service.init();
-			const collectFn = extractGaugeCollect('production_executions');
-			const mockGauge = { set: vi.fn() };
+			const collectA = extractGaugeCollect('production_executions');
+			const collectB = extractGaugeCollect('manual_executions');
+			const gaugeA = { set: vi.fn() };
+			const gaugeB = { set: vi.fn() };
 
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
+			await Promise.all([
+				collectA.call(gaugeA as unknown as promClient.Gauge<string>),
+				collectB.call(gaugeB as unknown as promClient.Gauge<string>),
+			]);
 
-			// DB should only be called once; second call uses in-memory cache
+			// Both gauges share one CachedMetricQuery; concurrent collects coalesce to a single DB read.
 			expect(licenseMetricsRepository.getLicenseRenewalMetrics.mock.calls).toHaveLength(1);
-		});
-
-		it('should call DB again after in-memory cache TTL (1 second) expires', async () => {
-			vi.useFakeTimers();
-			service.init();
-			const collectFn = extractGaugeCollect('production_executions');
-			const mockGauge = { set: vi.fn() };
-
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
-
-			// Advance past the 1 second in-memory TTL
-			vi.advanceTimersByTime(1100);
-
-			// Also need to reset external cache mock to undefined to trigger DB again
-			cacheService.get.mockResolvedValue(undefined);
-
-			await collectFn.call(mockGauge as unknown as promClient.Gauge<string>);
-
-			expect(licenseMetricsRepository.getLicenseRenewalMetrics.mock.calls).toHaveLength(2);
+			expect(gaugeA.set).toHaveBeenCalledWith(100);
+			expect(gaugeB.set).toHaveBeenCalledWith(50);
 		});
 	});
 });

--- a/packages/cli/src/metrics/prometheus/active-workflow-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/active-workflow-metrics.service.ts
@@ -7,6 +7,7 @@ import promClient from 'prom-client';
 import { CacheService } from '@/services/cache/cache.service';
 
 import type { PrometheusMetricsCollector } from './base';
+import { CachedMetricQuery } from './cached-metric-query';
 
 /**
  * Tracks the active workflow count via a Gauge, queried lazily on each scrape.
@@ -26,26 +27,19 @@ export class PrometheusActiveWorkflowMetricsService implements PrometheusMetrics
 	}
 
 	init() {
-		const workflowRepository = this.workflowRepository;
-		const cacheService = this.cacheService;
-		const cacheKey = 'metrics:active-workflow-count';
 		const cacheTtl = this.config.activeWorkflowCountInterval * Time.seconds.toMilliseconds;
+		const query = new CachedMetricQuery<number>(
+			this.cacheService,
+			'metrics:active-workflow-count',
+			cacheTtl,
+			async () => await this.workflowRepository.getActiveCount(),
+		);
 
 		new promClient.Gauge({
 			name: `${this.config.prefix}active_workflow_count`,
 			help: 'Total number of active workflows.',
 			async collect() {
-				const value = await cacheService.get<string>(cacheKey);
-				const numericValue = value !== undefined ? parseInt(value, 10) : undefined;
-
-				if (numericValue !== undefined && Number.isFinite(numericValue)) {
-					this.set(numericValue);
-				} else {
-					const activeWorkflowCount = await workflowRepository.getActiveCount();
-					await cacheService.set(cacheKey, activeWorkflowCount.toString(), cacheTtl);
-
-					this.set(activeWorkflowCount);
-				}
+				this.set(await query.get());
 			},
 		});
 	}

--- a/packages/cli/src/metrics/prometheus/active-workflow-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/active-workflow-metrics.service.ts
@@ -28,12 +28,12 @@ export class PrometheusActiveWorkflowMetricsService implements PrometheusMetrics
 
 	init() {
 		const cacheTtl = this.config.activeWorkflowCountInterval * Time.seconds.toMilliseconds;
-		const query = new CachedMetricQuery<number>(
-			this.cacheService,
-			'metrics:active-workflow-count',
-			cacheTtl,
-			async () => await this.workflowRepository.getActiveCount(),
-		);
+		const query = new CachedMetricQuery<number>({
+			cacheService: this.cacheService,
+			cacheKey: 'metrics:active-workflow-count:v2',
+			ttlMs: cacheTtl,
+			query: async () => await this.workflowRepository.getActiveCount(),
+		});
 
 		new promClient.Gauge({
 			name: `${this.config.prefix}active_workflow_count`,

--- a/packages/cli/src/metrics/prometheus/cached-metric-query.ts
+++ b/packages/cli/src/metrics/prometheus/cached-metric-query.ts
@@ -37,6 +37,8 @@ export class CachedMetricQuery<T extends JsonValue> {
 	}
 
 	private async load(): Promise<T> {
+		// We let the cache store handle the serialization and deserialization of the
+		// value. In-memory cache stores it as is, redis does JSON stringify/parse.
 		const cached = await this.cacheService.get<T>(this.cacheKey);
 		if (cached !== undefined) return cached;
 

--- a/packages/cli/src/metrics/prometheus/cached-metric-query.ts
+++ b/packages/cli/src/metrics/prometheus/cached-metric-query.ts
@@ -1,19 +1,33 @@
+import type { JsonValue } from 'n8n-workflow';
+
 import type { CacheService } from '@/services/cache/cache.service';
+
+type CachedMetricQueryOpts<T extends JsonValue> = {
+	cacheService: CacheService;
+	cacheKey: string;
+	ttlMs: number;
+	query: () => Promise<T>;
+};
 
 /**
  * Serves a cached query result, refreshing on cache miss and caching the fresh
  * value with the given TTL. Concurrent `get()` calls are coalesced so a single
  * scrape's parallel gauge collects share one cache-read + query.
  */
-export class CachedMetricQuery<T> {
+export class CachedMetricQuery<T extends JsonValue> {
+	private readonly cacheService: CacheService;
+	private readonly cacheKey: string;
+	private readonly ttlMs: number;
+	private readonly query: () => Promise<T>;
+
 	private inFlight: Promise<T> | null = null;
 
-	constructor(
-		private readonly cacheService: CacheService,
-		private readonly key: string,
-		private readonly ttlMs: number,
-		private readonly query: () => Promise<T>,
-	) {}
+	constructor({ cacheService, cacheKey, ttlMs, query }: CachedMetricQueryOpts<T>) {
+		this.cacheService = cacheService;
+		this.cacheKey = cacheKey;
+		this.ttlMs = ttlMs;
+		this.query = query;
+	}
 
 	async get(): Promise<T> {
 		this.inFlight ??= this.load().finally(() => {
@@ -23,11 +37,11 @@ export class CachedMetricQuery<T> {
 	}
 
 	private async load(): Promise<T> {
-		const cached = await this.cacheService.get<T>(this.key);
+		const cached = await this.cacheService.get<T>(this.cacheKey);
 		if (cached !== undefined) return cached;
 
 		const value = await this.query();
-		await this.cacheService.set(this.key, value, this.ttlMs);
+		await this.cacheService.set(this.cacheKey, value, this.ttlMs);
 		return value;
 	}
 }

--- a/packages/cli/src/metrics/prometheus/cached-metric-query.ts
+++ b/packages/cli/src/metrics/prometheus/cached-metric-query.ts
@@ -1,0 +1,33 @@
+import type { CacheService } from '@/services/cache/cache.service';
+
+/**
+ * Serves a cached query result, refreshing on cache miss and caching the fresh
+ * value with the given TTL. Concurrent `get()` calls are coalesced so a single
+ * scrape's parallel gauge collects share one cache-read + query.
+ */
+export class CachedMetricQuery<T> {
+	private inFlight: Promise<T> | null = null;
+
+	constructor(
+		private readonly cacheService: CacheService,
+		private readonly key: string,
+		private readonly ttlMs: number,
+		private readonly query: () => Promise<T>,
+	) {}
+
+	async get(): Promise<T> {
+		this.inFlight ??= this.load().finally(() => {
+			this.inFlight = null;
+		});
+		return await this.inFlight;
+	}
+
+	private async load(): Promise<T> {
+		const cached = await this.cacheService.get<T>(this.key);
+		if (cached !== undefined) return cached;
+
+		const value = await this.query();
+		await this.cacheService.set(this.key, value, this.ttlMs);
+		return value;
+	}
+}

--- a/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
@@ -2,12 +2,12 @@ import { PrometheusMetricsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { jsonParse } from 'n8n-workflow';
 import promClient from 'prom-client';
 
 import { CacheService } from '@/services/cache/cache.service';
 
 import type { PrometheusMetricsCollector } from './base';
+import { CachedMetricQuery } from './cached-metric-query';
 
 /**
  * Exposes a gauge (`n8n_workflow_info`) that maps workflow IDs to their human-readable
@@ -28,10 +28,13 @@ export class PrometheusWorkflowInfoMetricsService implements PrometheusMetricsCo
 	}
 
 	init() {
-		const workflowRepository = this.workflowRepository;
-		const cacheService = this.cacheService;
-		const cacheKey = 'metrics:workflow-info';
 		const cacheTtl = this.config.workflowInfoMetricInterval * Time.seconds.toMilliseconds;
+		const query = new CachedMetricQuery<Array<{ id: string; name: string }>>(
+			this.cacheService,
+			'metrics:workflow-info',
+			cacheTtl,
+			async () => await this.workflowRepository.find({ select: ['id', 'name'] }),
+		);
 
 		new promClient.Gauge({
 			name: `${this.config.prefix}workflow_info`,
@@ -40,17 +43,7 @@ export class PrometheusWorkflowInfoMetricsService implements PrometheusMetricsCo
 			async collect() {
 				this.reset();
 
-				const cachedValue = await cacheService.get<string>(cacheKey);
-
-				let workflows: Array<{ id: string; name: string }>;
-
-				if (cachedValue !== undefined) {
-					workflows = jsonParse(String(cachedValue), { fallbackValue: [] });
-				} else {
-					workflows = await workflowRepository.find({ select: ['id', 'name'] });
-					await cacheService.set(cacheKey, JSON.stringify(workflows), cacheTtl);
-				}
-
+				const workflows = await query.get();
 				for (const { id, name } of workflows) {
 					this.labels({ workflow_id: id, workflow_name: name }).set(1);
 				}

--- a/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-info-metrics.service.ts
@@ -29,12 +29,12 @@ export class PrometheusWorkflowInfoMetricsService implements PrometheusMetricsCo
 
 	init() {
 		const cacheTtl = this.config.workflowInfoMetricInterval * Time.seconds.toMilliseconds;
-		const query = new CachedMetricQuery<Array<{ id: string; name: string }>>(
-			this.cacheService,
-			'metrics:workflow-info',
-			cacheTtl,
-			async () => await this.workflowRepository.find({ select: ['id', 'name'] }),
-		);
+		const query = new CachedMetricQuery<Array<{ id: string; name: string }>>({
+			cacheService: this.cacheService,
+			cacheKey: 'metrics:workflow-info:v2',
+			ttlMs: cacheTtl,
+			query: async () => await this.workflowRepository.find({ select: ['id', 'name'] }),
+		});
 
 		new promClient.Gauge({
 			name: `${this.config.prefix}workflow_info`,

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -9,6 +9,7 @@ import { EventService } from '@/events/event.service';
 import { CacheService } from '@/services/cache/cache.service';
 
 import type { PrometheusMetricsCollector } from './base';
+import { CachedMetricQuery } from './cached-metric-query';
 import { DURATION_BUCKETS_SECONDS } from './constant';
 
 const ALL_STATUSES = Object.values(WorkflowPublicationOutboxStatus);
@@ -60,35 +61,34 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 
 	private initOutboxGauges() {
 		const repository = this.outboxRepository;
-		const cacheService = this.cacheService;
 		const prefix = this.config.prefix;
 		// One grouped query (COUNT + MIN createdAt per status) feeds both gauges;
 		// cache it so a tight scrape interval doesn't hammer the outbox table. Within
-		// a scrape, whichever gauge collects first populates the cache for the other.
+		// a scrape, coalescing collapses both gauges' collects to a single query.
 		const cacheTtl = this.config.workflowPublicationMetricInterval * Time.seconds.toMilliseconds;
 
-		const loadStats = async (): Promise<StatusStatsEntries> => {
-			let entries = await cacheService.get<StatusStatsEntries>(RECORD_STATS_CACHE_KEY);
-			if (entries === undefined) {
+		const query = new CachedMetricQuery<StatusStatsEntries>(
+			this.cacheService,
+			RECORD_STATS_CACHE_KEY,
+			cacheTtl,
+			async () => {
 				const stats = await repository.getRecordStatsByStatus();
-				entries = Array.from(
+				return Array.from(
 					stats,
 					([status, { count, oldestCreatedAt }]): [
 						WorkflowPublicationOutboxStatus,
 						StatusStats,
 					] => [status, { count, oldestMs: oldestCreatedAt.getTime() }],
 				);
-				await cacheService.set(RECORD_STATS_CACHE_KEY, entries, cacheTtl);
-			}
-			return entries;
-		};
+			},
+		);
 
 		new promClient.Gauge({
 			name: `${prefix}workflow_publication_outbox_records`,
 			help: 'Number of workflow publication outbox records by status.',
 			labelNames: ['status'],
 			async collect() {
-				const byStatus = new Map(await loadStats());
+				const byStatus = new Map(await query.get());
 				for (const status of ALL_STATUSES) {
 					this.set({ status }, byStatus.get(status)?.count ?? 0);
 				}
@@ -100,7 +100,7 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 			help: 'Age in seconds of the oldest active (pending/in_progress) workflow publication outbox record by status.',
 			labelNames: ['status'],
 			async collect() {
-				const byStatus = new Map(await loadStats());
+				const byStatus = new Map(await query.get());
 				const now = Date.now();
 				for (const status of ACTIVE_STATUSES) {
 					const oldestMs = byStatus.get(status)?.oldestMs;

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -18,12 +18,11 @@ const ACTIVE_STATUSES = [
 	WorkflowPublicationOutboxStatus.InProgress,
 ];
 
-const RECORD_STATS_CACHE_KEY = 'metrics:workflow-publication:outbox-record-stats';
+const RECORD_STATS_CACHE_KEY = 'metrics:workflow-publication:outbox-record-stats:v2';
 
 /** Per-status count and oldest-record epoch ms (`oldestMs`) for a single status. */
 type StatusStats = { count: number; oldestMs: number };
-/** Serializable cache shape for a `Map<status, StatusStats>` (Maps don't round-trip JSON). */
-type StatusStatsEntries = Array<[WorkflowPublicationOutboxStatus, StatusStats]>;
+type StatusStatsByStatus = Partial<Record<WorkflowPublicationOutboxStatus, StatusStats>>;
 
 /**
  * Collects Prometheus metrics for the workflow publication service. Opt-in via
@@ -67,30 +66,28 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 		// a scrape, coalescing collapses both gauges' collects to a single query.
 		const cacheTtl = this.config.workflowPublicationMetricInterval * Time.seconds.toMilliseconds;
 
-		const query = new CachedMetricQuery<StatusStatsEntries>(
-			this.cacheService,
-			RECORD_STATS_CACHE_KEY,
-			cacheTtl,
-			async () => {
+		const query = new CachedMetricQuery<StatusStatsByStatus>({
+			cacheService: this.cacheService,
+			cacheKey: RECORD_STATS_CACHE_KEY,
+			ttlMs: cacheTtl,
+			query: async () => {
 				const stats = await repository.getRecordStatsByStatus();
-				return Array.from(
-					stats,
-					([status, { count, oldestCreatedAt }]): [
-						WorkflowPublicationOutboxStatus,
-						StatusStats,
-					] => [status, { count, oldestMs: oldestCreatedAt.getTime() }],
-				);
+				const byStatus: StatusStatsByStatus = {};
+				for (const [status, { count, oldestCreatedAt }] of stats) {
+					byStatus[status] = { count, oldestMs: oldestCreatedAt.getTime() };
+				}
+				return byStatus;
 			},
-		);
+		});
 
 		new promClient.Gauge({
 			name: `${prefix}workflow_publication_outbox_records`,
 			help: 'Number of workflow publication outbox records by status.',
 			labelNames: ['status'],
 			async collect() {
-				const byStatus = new Map(await query.get());
+				const byStatus = await query.get();
 				for (const status of ALL_STATUSES) {
-					this.set({ status }, byStatus.get(status)?.count ?? 0);
+					this.set({ status }, byStatus[status]?.count ?? 0);
 				}
 			},
 		});
@@ -100,10 +97,10 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 			help: 'Age in seconds of the oldest active (pending/in_progress) workflow publication outbox record by status.',
 			labelNames: ['status'],
 			async collect() {
-				const byStatus = new Map(await query.get());
+				const byStatus = await query.get();
 				const now = Date.now();
 				for (const status of ACTIVE_STATUSES) {
-					const oldestMs = byStatus.get(status)?.oldestMs;
+					const oldestMs = byStatus[status]?.oldestMs;
 					this.set(
 						{ status },
 						oldestMs !== undefined ? (now - oldestMs) * Time.milliseconds.toSeconds : 0,

--- a/packages/cli/src/metrics/prometheus/workflow-statistics-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-statistics-metrics.service.ts
@@ -31,12 +31,12 @@ export class PrometheusWorkflowStatisticsMetricsService implements PrometheusMet
 
 	init() {
 		const cacheTtl = this.config.workflowStatisticsInterval * Time.seconds.toMilliseconds;
-		const query = new CachedMetricQuery<LicenseMetrics>(
-			this.cacheService,
-			'metrics:workflow-statistics:shared',
-			cacheTtl,
-			async () => await this.licenseMetricsRepository.getLicenseRenewalMetrics(),
-		);
+		const query = new CachedMetricQuery<LicenseMetrics>({
+			cacheService: this.cacheService,
+			cacheKey: 'metrics:workflow-statistics:shared:v2',
+			ttlMs: cacheTtl,
+			query: async () => await this.licenseMetricsRepository.getLicenseRenewalMetrics(),
+		});
 
 		const metricsConfig = [
 			{

--- a/packages/cli/src/metrics/prometheus/workflow-statistics-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-statistics-metrics.service.ts
@@ -2,33 +2,23 @@ import { PrometheusMetricsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { LicenseMetricsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { jsonParse } from 'n8n-workflow';
 import promClient from 'prom-client';
 
 import { CacheService } from '@/services/cache/cache.service';
 
 import type { PrometheusMetricsCollector } from './base';
+import { CachedMetricQuery } from './cached-metric-query';
 
 type LicenseMetrics = Awaited<ReturnType<LicenseMetricsRepository['getLicenseRenewalMetrics']>>;
 
 /**
  * Tracks workflow and instance statistics as Gauges (executions, users, workflows, credentials).
- * Values are cached — first in Redis/persistent cache, then in-memory for scrape deduplication —
- * to avoid repeated DB hits per scrape cycle. Cache TTL is controlled by
+ * Values are cached to avoid repeated DB hits per scrape cycle, and concurrent gauge collects
+ * within a scrape are coalesced to a single query. Cache TTL is controlled by
  * `endpoints.metrics.workflowStatisticsInterval`.
  */
 @Service()
 export class PrometheusWorkflowStatisticsMetricsService implements PrometheusMetricsCollector {
-	/** Shared in-memory cache to deduplicate DB calls within a single scrape cycle. */
-	private workflowStatisticsCache: {
-		data: LicenseMetrics;
-		timestamp: number;
-		ttl: number;
-	} | null = null;
-
-	/** Coalesces concurrent collect() calls so only one DB/Redis fetch runs at a time. */
-	private inFlightRequest: Promise<LicenseMetrics> | null = null;
-
 	constructor(
 		private readonly config: PrometheusMetricsConfig,
 		private readonly cacheService: CacheService,
@@ -41,6 +31,12 @@ export class PrometheusWorkflowStatisticsMetricsService implements PrometheusMet
 
 	init() {
 		const cacheTtl = this.config.workflowStatisticsInterval * Time.seconds.toMilliseconds;
+		const query = new CachedMetricQuery<LicenseMetrics>(
+			this.cacheService,
+			'metrics:workflow-statistics:shared',
+			cacheTtl,
+			async () => await this.licenseMetricsRepository.getLicenseRenewalMetrics(),
+		);
 
 		const metricsConfig = [
 			{
@@ -81,7 +77,7 @@ export class PrometheusWorkflowStatisticsMetricsService implements PrometheusMet
 		];
 
 		metricsConfig.forEach((config) => {
-			this.createWorkflowStatisticsGauge(config.name, config.help, config.getValue, cacheTtl);
+			this.createWorkflowStatisticsGauge(config.name, config.help, config.getValue, query);
 		});
 	}
 
@@ -89,61 +85,14 @@ export class PrometheusWorkflowStatisticsMetricsService implements PrometheusMet
 		metricName: string,
 		help: string,
 		getMetricValue: (metrics: LicenseMetrics) => number,
-		cacheTtl: number,
+		query: CachedMetricQuery<LicenseMetrics>,
 	): promClient.Gauge {
-		const fetchMetrics = async () => await this.getWorkflowStatistics(cacheTtl);
 		return new promClient.Gauge({
 			name: `${this.config.prefix}${metricName}`,
 			help,
 			async collect() {
-				this.set(getMetricValue(await fetchMetrics()));
+				this.set(getMetricValue(await query.get()));
 			},
 		});
-	}
-
-	private async getWorkflowStatistics(cacheTtl: number): Promise<LicenseMetrics> {
-		const now = Date.now();
-
-		if (
-			this.workflowStatisticsCache &&
-			now - this.workflowStatisticsCache.timestamp < this.workflowStatisticsCache.ttl
-		) {
-			return this.workflowStatisticsCache.data;
-		}
-
-		this.inFlightRequest ??= this.fetchAndCacheMetrics(cacheTtl).finally(() => {
-			this.inFlightRequest = null;
-		});
-
-		return await this.inFlightRequest;
-	}
-
-	private async fetchAndCacheMetrics(cacheTtl: number): Promise<LicenseMetrics> {
-		const now = Date.now();
-		const fullCacheKey = 'metrics:workflow-statistics:shared';
-		const cachedValue = await this.cacheService.get(fullCacheKey);
-
-		if (typeof cachedValue === 'string') {
-			const parsedValue = jsonParse(cachedValue, { fallbackValue: undefined });
-			if (parsedValue !== undefined) {
-				this.workflowStatisticsCache = {
-					data: parsedValue,
-					timestamp: now,
-					ttl: 1_000, // 1 second — enough to dedupe within a single scrape
-				};
-				return parsedValue;
-			}
-		}
-
-		const metrics = await this.licenseMetricsRepository.getLicenseRenewalMetrics();
-		await this.cacheService.set(fullCacheKey, JSON.stringify(metrics), cacheTtl);
-
-		this.workflowStatisticsCache = {
-			data: metrics,
-			timestamp: now,
-			ttl: 1_000, // 1 second — in-memory cache is only for scrape deduplication
-		};
-
-		return metrics;
 	}
 }

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -322,7 +322,7 @@ describe('PrometheusMetricsService', () => {
 		expect(lines).toContain('n8n_test_active_workflow_count 0');
 
 		const cacheService = Container.get(CacheService);
-		await cacheService.delete('metrics:active-workflow-count');
+		await cacheService.delete('metrics:active-workflow-count:v2');
 
 		response = await agent.get('/metrics');
 


### PR DESCRIPTION
## Summary

Extracts a shared `CachedMetricQuery` helper so the Prometheus metric collectors (active-workflow, workflow-info, workflow-statistics, workflow-publication) no longer each reimplement cache-read → query-on-miss → cache-with-TTL, and coalesces concurrent `get()` calls so a single scrape's parallel gauge collects share one cache read + query. The helper takes a named-options constructor constrained to `JsonValue`, and the publication collector now stores outbox stats as a plain status-keyed object rather than Map entries; cache keys are bumped to `:v2` since the serialized shape changed.

## How to test

Enable Prometheus metrics and scrape `/metrics`; the workflow gauges should report the same values as before, served from cache within each metric's interval. Unit tests: `cd packages/cli && pnpm test metrics/prometheus`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3626

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

