### PR TITLE
refactor(core): Move createDeferredPromise into @n8n/utils (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/support/workflow-executor.ts
@@ -15,6 +15,7 @@
  * dependency, following the NodeTestHarness pattern.
  */
 
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	IExecuteFunctions,
 	INode,
@@ -26,7 +27,7 @@ import type {
 	IVersionedNodeType,
 	IWorkflowExecuteAdditionalData,
 } from 'n8n-workflow';
-import { createDeferredPromise, createRunExecutionData, NodeHelpers, Workflow } from 'n8n-workflow';
+import { createRunExecutionData, NodeHelpers, Workflow } from 'n8n-workflow';
 import path from 'path';
 
 import { findRepoRoot } from './environment';
@@ -294,7 +295,8 @@ export async function executeWorkflowWithPinData(
 		// Find start node. getStartNode() only recognises nodes with a trigger()/poll()
 		// method or those in STARTING_NODE_TYPES. Webhook-based triggers like ChatTrigger
 		// are missed, so fall back to any node whose description group includes 'trigger'.
-		const startNode = workflowInstance.getStartNode() ?? findTriggerByGroup(workflow.nodes, imports.nodeTypes);
+		const startNode =
+			workflowInstance.getStartNode() ?? findTriggerByGroup(workflow.nodes, imports.nodeTypes);
 		if (!startNode) {
 			return {
 				success: false,

--- a/packages/@n8n/utils/src/promise/deferred-promise.test.ts
+++ b/packages/@n8n/utils/src/promise/deferred-promise.test.ts
@@ -1,4 +1,4 @@
-import { createDeferredPromise } from '../src/deferred-promise';
+import { createDeferredPromise } from './deferred-promise';
 
 describe('DeferredPromise', () => {
 	it('should resolve the promise with the correct value', async () => {

--- a/packages/@n8n/utils/src/promise/deferred-promise.ts
+++ b/packages/@n8n/utils/src/promise/deferred-promise.ts
@@ -1,0 +1,17 @@
+type ResolveFn<T> = (result: T | PromiseLike<T>) => void;
+type RejectFn = (error: Error) => void;
+
+export interface IDeferredPromise<T> {
+	promise: Promise<T>;
+	resolve: ResolveFn<T>;
+	reject: RejectFn;
+}
+
+export function createDeferredPromise<T = void>(): IDeferredPromise<T> {
+	const deferred: Partial<IDeferredPromise<T>> = {};
+	deferred.promise = new Promise<T>((resolve, reject) => {
+		deferred.resolve = resolve;
+		deferred.reject = reject;
+	});
+	return deferred as IDeferredPromise<T>;
+}

--- a/packages/cli/src/__tests__/active-executions.test.ts
+++ b/packages/cli/src/__tests__/active-executions.test.ts
@@ -3,9 +3,9 @@ import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import { ExecutionsConfig } from '@n8n/config';
 import type { GlobalConfig } from '@n8n/config';
 import type { ExecutionRepository } from '@n8n/db';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { Response } from 'express';
 import type {
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	IRun,
 	IWorkflowExecutionDataProcess,

--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { WorkflowsConfig } from '@n8n/config';
 import type { WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { InstanceSettings } from 'n8n-core';
 import {
 	ActiveWorkflowTriggers,
@@ -23,7 +24,7 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { createDeferredPromise, sleep, Workflow, WorkflowActivationError } from 'n8n-workflow';
+import { sleep, Workflow, WorkflowActivationError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActivationErrorsService } from '@/activation-errors.service';

--- a/packages/cli/src/__tests__/wait-tracker.test.ts
+++ b/packages/cli/src/__tests__/wait-tracker.test.ts
@@ -1,18 +1,13 @@
-import type { Mock } from 'vitest';
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { Project, IExecutionResponse, ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { InstanceSettings } from 'n8n-core';
 import type { IWorkflowBase, IRun, INode, IExecuteData, ITaskData } from 'n8n-workflow';
-import {
-	createDeferredPromise,
-	createRunExecutionData,
-	UnexpectedError,
-	WAIT_INDEFINITELY,
-} from 'n8n-workflow';
-import type { MockInstance } from 'vitest';
+import { createRunExecutionData, UnexpectedError, WAIT_INDEFINITELY } from 'n8n-workflow';
+import type { Mock, MockInstance } from 'vitest';
 import { mock, captor } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';

--- a/packages/cli/src/active-executions.ts
+++ b/packages/cli/src/active-executions.ts
@@ -3,8 +3,8 @@ import { ExecutionsConfig } from '@n8n/config';
 import type { CreateExecutionPayload, IExecutionDb } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	IRun,
 	ExecutionStatus,
@@ -13,7 +13,6 @@ import type {
 	WebhookResponseMode,
 } from 'n8n-workflow';
 import {
-	createDeferredPromise,
 	ExecutionCancelledError,
 	sleep,
 	SystemShutdownExecutionCancelledError,

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -6,12 +6,12 @@ import type {
 	IWorkflowDb,
 } from '@n8n/db';
 import type { AssignableGlobalRole } from '@n8n/permissions';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { Application, Response } from 'express';
 import type {
 	ExecutionError,
 	ICredentialDataDecryptedObject,
 	ICredentialsDecrypted,
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	IRun,
 	ITelemetryTrackProperties,

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -8,6 +8,7 @@ import {
 import type { UserRepository, WorkflowRepository, WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { isRecord } from '@n8n/utils/is-record';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	IDataObject,
 	IExecuteResponsePromiseData,
@@ -17,7 +18,6 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import {
-	createDeferredPromise,
 	createRunExecutionData,
 	CHAT_TRIGGER_NODE_TYPE,
 	FORM_TRIGGER_NODE_TYPE,

--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
@@ -9,13 +9,9 @@ import type { Project, WorkflowEntity, IWorkflowDb, SharedWorkflowRepository } f
 import type { WorkflowExecuteAfterContext } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { In } from '@n8n/typeorm';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { DateTime } from 'luxon';
-import {
-	createDeferredPromise,
-	type ExecutionStatus,
-	type IRun,
-	type WorkflowExecuteMode,
-} from 'n8n-workflow';
+import { type ExecutionStatus, type IRun, type WorkflowExecuteMode } from 'n8n-workflow';
 import assert from 'node:assert';
 import { mock } from 'vitest-mock-extended';
 

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -16,13 +16,9 @@ import {
 	WORKFLOW_PREVIEW_APP_URI,
 	type McpAppTelemetryConfig,
 } from '@n8n/mcp-apps/server';
+import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { InstanceSettings } from 'n8n-core';
-import {
-	createDeferredPromise,
-	ManualExecutionCancelledError,
-	type IDeferredPromise,
-	type IRun,
-} from 'n8n-workflow';
+import { ManualExecutionCancelledError, type IRun } from 'n8n-workflow';
 
 import {
 	createAddDataTableColumnTool,

--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type express from 'express';
-import { mock, type MockProxy } from 'vitest-mock-extended';
 import {
 	BinaryDataService,
 	ErrorReporter,
@@ -14,19 +13,18 @@ vi.mock('n8n-core', async () => ({
 	isWebhookHtmlSandboxingDisabled: vi.fn(),
 	getHtmlSandboxCSP: vi.fn(),
 }));
+import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	Workflow,
 	INode,
 	IDataObject,
 	IWebhookResponseData,
-	IDeferredPromise,
 	IN8nHttpFullResponse,
 	IWorkflowBase,
 	IRunExecutionData,
 	IExecuteData,
 } from 'n8n-workflow';
 import {
-	createDeferredPromise,
 	FORM_NODE_TYPE,
 	WAIT_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
@@ -36,6 +34,7 @@ import {
 } from 'n8n-workflow';
 import type { Readable } from 'stream';
 import { finished } from 'stream/promises';
+import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import {
 	autoDetectResponseMode,
@@ -391,7 +390,7 @@ describe('handleHostedChatResponse', () => {
 			end: vi.fn(),
 		} as unknown as express.Response;
 		const responseMode = 'hostedChat';
-		let didSendResponse = false;
+		const didSendResponse = false;
 		const executionId = '123';
 		const resumeToken = 'a'.repeat(64);
 
@@ -415,7 +414,7 @@ describe('handleHostedChatResponse', () => {
 			end: vi.fn(),
 		} as unknown as express.Response;
 		const executionId = 'testExecutionId';
-		let didSendResponse = false;
+		const didSendResponse = false;
 		const responseMode = 'responseNode';
 
 		const result = handleHostedChatResponse(res, responseMode, didSendResponse, executionId);
@@ -431,7 +430,7 @@ describe('handleHostedChatResponse', () => {
 			end: vi.fn(),
 		} as unknown as express.Response;
 		const executionId = 'testExecutionId';
-		let didSendResponse = true;
+		const didSendResponse = true;
 		const responseMode = 'hostedChat';
 
 		const result = handleHostedChatResponse(res, responseMode, didSendResponse, executionId);

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -8,6 +8,7 @@ import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig, GlobalConfig } from '@n8n/config';
 import type { Project } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { createDeferredPromise, type IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type express from 'express';
 import merge from 'lodash/merge';
 import {
@@ -19,7 +20,6 @@ import {
 import type {
 	IBinaryData,
 	IDataObject,
-	IDeferredPromise,
 	IExecuteData,
 	IExecuteResponsePromiseData,
 	IN8nHttpFullResponse,
@@ -40,7 +40,6 @@ import type {
 } from 'n8n-workflow';
 import {
 	CHAT_TRIGGER_NODE_TYPE,
-	createDeferredPromise,
 	createRunExecutionData,
 	ExecutionCancelledError,
 	FORM_NODE_TYPE,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -4,6 +4,7 @@ import { Logger } from '@n8n/backend-common';
 import { ExecutionsConfig } from '@n8n/config';
 import { ExecutionRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ExecutionLifecycleHooks } from 'n8n-core';
 import {
 	ErrorReporter,
@@ -14,7 +15,6 @@ import {
 } from 'n8n-core';
 import type {
 	ExecutionError,
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	INode,
 	IPinData,

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
 import type { WorkflowEntity } from '@n8n/db';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ErrorReporter, StorageConfig } from 'n8n-core';
-import { createDeferredPromise, sleep, UnexpectedError } from 'n8n-workflow';
+import { sleep, UnexpectedError } from 'n8n-workflow';
 import type {
 	ExecutionError,
 	IConnections,

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -1,15 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { WorkflowsConfig } from '@n8n/config';
 import type { IWorkflowDb, WorkflowEntity, WorkflowRepository } from '@n8n/db';
-import { mock, type MockProxy } from 'vitest-mock-extended';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ErrorReporter, Span, Tracing } from 'n8n-core';
 import type { IWebhookData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
-import {
-	createDeferredPromise,
-	WebhookPathTakenError,
-	WorkflowActivationError,
-	WorkflowExpression,
-} from 'n8n-workflow';
+import { WebhookPathTakenError, WorkflowActivationError, WorkflowExpression } from 'n8n-workflow';
+import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import type { ActivationErrorsService } from '@/activation-errors.service';
 import { TRIGGER_ACTIVATION_MAX_ATTEMPTS } from '@/constants';

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@n8n/backend-common';
+import type { IWorkflowDb } from '@n8n/db';
 import { Service } from '@n8n/di';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import {
 	ErrorReporter,
 	PollContext,
@@ -8,11 +10,8 @@ import {
 	type IGetExecutePollFunctions,
 	type IGetExecuteTriggerFunctions,
 } from 'n8n-core';
-
-import { ActiveExecutions } from '@/active-executions';
 import type {
 	ExecutionError,
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	INode,
 	INodeExecutionData,
@@ -24,6 +23,7 @@ import type {
 } from 'n8n-workflow';
 import { Workflow, UnexpectedError, createRunExecutionData } from 'n8n-workflow';
 
+import { ActiveExecutions } from '@/active-executions';
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import { EventService } from '@/events/event.service';
 import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workflow';
@@ -31,7 +31,6 @@ import { ExecutionService } from '@/executions/execution.service';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
-import type { IWorkflowDb } from '@n8n/db';
 
 export type TriggerFailureHandler = (opts: {
 	error: Error;

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -3,6 +3,7 @@ import { GlobalConfig, WorkflowsConfig } from '@n8n/config';
 import type { Project, User, CreateExecutionPayload, WorkflowEntity } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { Response } from 'express';
 import {
 	DirectedGraph,
@@ -11,7 +12,6 @@ import {
 	anyReachableRootHasRunData,
 } from 'n8n-core';
 import type {
-	IDeferredPromise,
 	IExecuteData,
 	IExecuteResponsePromiseData,
 	INode,

--- a/packages/core/nodes-testing/node-test-harness.ts
+++ b/packages/core/nodes-testing/node-test-harness.ts
@@ -3,6 +3,7 @@ import callsites from 'callsites';
 import glob from 'fast-glob';
 import { mock } from './mock-extended';
 import isEmpty from 'lodash/isEmpty';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
 	IRun,
@@ -10,12 +11,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	WorkflowTestData,
 } from 'n8n-workflow';
-import {
-	createDeferredPromise,
-	createRunExecutionData,
-	UnexpectedError,
-	Workflow,
-} from 'n8n-workflow';
+import { createRunExecutionData, UnexpectedError, Workflow } from 'n8n-workflow';
 import nock from 'nock';
 import { readFileSync, mkdtempSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@n8n/backend-common';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	INode,
 	INodeExecutionData,
@@ -10,12 +11,7 @@ import type {
 	TriggerTime,
 	CronExpression,
 } from 'n8n-workflow';
-import {
-	createDeferredPromise,
-	LoggerProxy,
-	TriggerCloseError,
-	WorkflowActivationError,
-} from 'n8n-workflow';
+import { LoggerProxy, TriggerCloseError, WorkflowActivationError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-node-error-reporting.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-node-error-reporting.test.ts
@@ -10,9 +10,9 @@ vi.mock('@n8n/di', () => ({
 }));
 
 import { Container } from '@n8n/di';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import {
 	ApplicationError,
-	createDeferredPromise,
 	NodeConnectionTypes,
 	OperationalError,
 	UnexpectedError,

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -11,6 +11,7 @@
 // PD denotes that the node has pinned data
 
 import { TOOL_EXECUTOR_NODE_NAME } from '@n8n/constants';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import pick from 'lodash/pick';
 import type {
 	ExecutionBaseError,
@@ -35,7 +36,6 @@ import type {
 } from 'n8n-workflow';
 import {
 	UnexpectedError,
-	createDeferredPromise,
 	createRunExecutionData,
 	NodeApiError,
 	NodeConnectionTypes,

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	AINodeConnectionType,
 	CallbackManager,
@@ -19,12 +20,7 @@ import type {
 	WorkflowExecuteMode,
 	EngineResponse,
 } from 'n8n-workflow';
-import {
-	UnexpectedError,
-	createDeferredPromise,
-	jsonParse,
-	NodeConnectionTypes,
-} from 'n8n-workflow';
+import { UnexpectedError, jsonParse, NodeConnectionTypes } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {

--- a/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
 	IGetNodeParameterOptions,
@@ -12,7 +13,7 @@ import type {
 	IExecuteData,
 	IDataObject,
 } from 'n8n-workflow';
-import { UnexpectedError, createDeferredPromise, NodeConnectionTypes } from 'n8n-workflow';
+import { UnexpectedError, NodeConnectionTypes } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
 	INode,
@@ -7,7 +8,7 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { UnexpectedError, createDeferredPromise } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { getBinaryHelperFunctions } from './utils/binary-helper-functions';

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import get from 'lodash/get';
 import type {
 	AINodeConnectionType,
@@ -19,7 +20,7 @@ import type {
 	ISourceData,
 	NodeExecutionHint,
 } from 'n8n-workflow';
-import { createDeferredPromise, jsonParse, NodeConnectionTypes } from 'n8n-workflow';
+import { jsonParse, NodeConnectionTypes } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {

--- a/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type {
 	ICredentialDataDecryptedObject,
 	INode,
@@ -7,7 +8,7 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { UnexpectedError, createDeferredPromise } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { getBinaryHelperFunctions } from './utils/binary-helper-functions';

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -1,3 +1,4 @@
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { Request, Response } from 'express';
 import type {
 	AINodeConnectionType,
@@ -19,7 +20,7 @@ import type {
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { UnexpectedError, createDeferredPromise, createEmptyRunExecutionData } from 'n8n-workflow';
+import { UnexpectedError, createEmptyRunExecutionData } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { copyBinaryFile, getBinaryHelperFunctions } from './utils/binary-helper-functions';

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -1,4 +1,5 @@
 import { Service } from '@n8n/di';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
@@ -9,7 +10,6 @@ import type {
 	WorkflowExecuteMode,
 	WorkflowActivateMode,
 	ITriggerResponse,
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	IRun,
 	ExecutionError,

--- a/packages/core/test/helpers/index.ts
+++ b/packages/core/test/helpers/index.ts
@@ -1,7 +1,7 @@
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import { readdirSync, readFileSync } from 'fs';
 import type {
 	IDataObject,
-	IDeferredPromise,
 	INodeType,
 	INodeTypes,
 	IRun,

--- a/packages/nodes-base/nodes/Amqp/helpers/handleMessage.test.ts
+++ b/packages/nodes-base/nodes/Amqp/helpers/handleMessage.test.ts
@@ -1,9 +1,10 @@
-import { mockDeep } from 'vitest-mock-extended';
-import type { ITriggerFunctions, IDeferredPromise, IRun } from 'n8n-workflow';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import type { ITriggerFunctions, IRun } from 'n8n-workflow';
 import type { EventContext } from 'rhea';
+import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
 
 import { handleMessage } from './handleMessage';
-import type { Mock, Mocked } from 'vitest';
 
 interface MockReceiver {
 	has_credit: Mock<() => boolean>;

--- a/packages/nodes-base/nodes/Amqp/helpers/handleMessage.ts
+++ b/packages/nodes-base/nodes/Amqp/helpers/handleMessage.ts
@@ -1,10 +1,5 @@
-import {
-	deepCopy,
-	type IDeferredPromise,
-	type IRun,
-	type ITriggerFunctions,
-	jsonParse,
-} from 'n8n-workflow';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import { deepCopy, type IRun, type ITriggerFunctions, jsonParse } from 'n8n-workflow';
 import type { EventContext } from 'rhea';
 
 type MessageId = string | number | Buffer | undefined;

--- a/packages/nodes-base/nodes/Kafka/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Kafka/test/utils.test.ts
@@ -1,15 +1,15 @@
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
+import { createResultError, createResultOk } from '@n8n/utils/result';
 import type * as _importType0 from 'n8n-workflow';
 import type {
 	ITriggerFunctions,
 	IRun,
 	INode,
 	Logger,
-	IDeferredPromise,
 	ICredentialDataDecryptedObject,
 	NodeEgressFilter,
 } from 'n8n-workflow';
-import { createResultError, createResultOk } from '@n8n/utils/result';
 import { NodeOperationError, sleep } from 'n8n-workflow';
 import http from 'node:http';
 import https from 'node:https';

--- a/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/RabbitMQ/GenericFunctions.ts
@@ -1,7 +1,7 @@
 import { formatPemBlock } from '@n8n/utils/format-pem-block';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import * as amqplib from 'amqplib';
 import type {
-	IDeferredPromise,
 	IExecuteResponsePromiseData,
 	IDataObject,
 	IExecuteFunctions,

--- a/packages/nodes-base/test/nodes/TriggerHelpers.ts
+++ b/packages/nodes-base/test/nodes/TriggerHelpers.ts
@@ -1,4 +1,5 @@
 import type { SsrfBridge } from '@n8n/backend-network';
+import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type * as express from 'express';
 import { type IncomingHttpHeaders } from 'http';
 import get from 'lodash/get';
@@ -7,7 +8,6 @@ import set from 'lodash/set';
 import { PollContext, returnJsonArray, ScheduledTaskManager } from 'n8n-core';
 import type { InstanceSettings, ExecutionLifecycleHooks } from 'n8n-core';
 import {
-	createDeferredPromise,
 	type IBinaryData,
 	type ICredentialDataDecryptedObject,
 	type IDataObject,

--- a/packages/workflow/src/deferred-promise.ts
+++ b/packages/workflow/src/deferred-promise.ts
@@ -1,3 +1,0 @@
-// Thin re-export kept for backwards compatibility with external consumers of
-// `n8n-workflow`. The implementation now lives in `@n8n/utils`.
-export * from '@n8n/utils/promise/deferred-promise';

--- a/packages/workflow/src/deferred-promise.ts
+++ b/packages/workflow/src/deferred-promise.ts
@@ -1,17 +1,3 @@
-type ResolveFn<T> = (result: T | PromiseLike<T>) => void;
-type RejectFn = (error: Error) => void;
-
-export interface IDeferredPromise<T> {
-	promise: Promise<T>;
-	resolve: ResolveFn<T>;
-	reject: RejectFn;
-}
-
-export function createDeferredPromise<T = void>(): IDeferredPromise<T> {
-	const deferred: Partial<IDeferredPromise<T>> = {};
-	deferred.promise = new Promise<T>((resolve, reject) => {
-		deferred.resolve = resolve;
-		deferred.reject = reject;
-	});
-	return deferred as IDeferredPromise<T>;
-}
+// Thin re-export kept for backwards compatibility with external consumers of
+// `n8n-workflow`. The implementation now lives in `@n8n/utils`.
+export * from '@n8n/utils/promise/deferred-promise';

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -8,7 +8,6 @@ export * from './constants';
 export * from './common';
 export * from './cron';
 export * from './data-table.types';
-export * from './deferred-promise';
 export * from './execution-context';
 export * from './execution-context-establishment-hooks';
 export * from './redaction-channels';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -27,7 +27,6 @@ import type {
 	IDataTableProjectAggregateService,
 	IDataTableProjectService,
 } from './data-table.types';
-import type { IDeferredPromise } from './deferred-promise';
 import type { ExecutionCancelledError } from './errors';
 import type { ExpressionError } from './errors/expression.error';
 import type { NodeApiError } from './errors/node-api.error';
@@ -39,6 +38,7 @@ import type {
 	WorkflowExecuteModeValues as WorkflowExecuteMode,
 } from './execution-context';
 import type { ExecutionStatus } from './execution-status';
+import type { IDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { Result } from '@n8n/utils/result';
 import type { Workflow } from './workflow';
 import type { EnvProviderState } from './workflow-data-proxy-env-provider';


### PR DESCRIPTION
## Summary

Phase 2 of the utilities migration ([CAT-3592](https://linear.app/n8n/issue/CAT-3592)), following the pattern established in Phase 1 (#33375).

Moves `createDeferredPromise` and its `IDeferredPromise` type from `packages/workflow/src/deferred-promise.ts` into `@n8n/utils/promise/deferred-promise` (17 lines, zero deps). The co-located test moves alongside it.

The `n8n-workflow` re-export is dropped entirely — all consumers now import both symbols from `@n8n/utils` directly (~33 internal import sites across `core`/`cli`/`nodes-base`/`task-runner`/`ai-workflow-builder` updated). `workflow/src/interfaces.ts` now imports the type from `@n8n/utils` as well.

No behavior change — this is a pure relocation.

## How to test

Automated only:
- `pnpm build` (full)
- `pnpm --filter @n8n/utils test`
- `pnpm typecheck` + `pnpm lint` in touched packages

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3592

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.




---


<a href="https://stagereview.app/n8n-io/n8n/pull/33441" rel="nofollow noreferrer noopener" target="_blank">
  
    
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  
</a>




<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33441?utm_source=github" rel="nofollow noreferrer noopener" target="_blank"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></a>
