### PR TITLE
fix(core): Surface Instance AI confirmations from merged follow-up runs (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
@@ -293,6 +293,32 @@ describe('agent-run-reducer', () => {
 			expect(state.agentsById['root'].status).toBe('active');
 		});
 
+		it("follow-up run under a new agentId routes that run's tool calls and confirmations to the tree", () => {
+			// First run establishes the group's root agent and some content.
+			const state = stateWithRun('run-1', 'orchestrator-run-1');
+			reduceEvent(state, makeToolCall('run-1', 'orchestrator-run-1', 'tc-build', 'build-workflow'));
+			reduceEvent(state, makeRunFinish('run-1', 'orchestrator-run-1', 'completed'));
+
+			// An auto-continue/resume run is merged into the same group but streams
+			// under its own per-run agentId (differs from the original root).
+			reduceEvent(state, makeRunStart('run-2', 'orchestrator-run-2'));
+			reduceEvent(state, makeToolCall('run-2', 'orchestrator-run-2', 'tc-setup', 'workflows'));
+			reduceEvent(state, makeConfirmationRequest('run-2', 'orchestrator-run-2', 'tc-setup'));
+
+			// The resume run's tool call must land in the tree (not dropped as an
+			// orphan) with its confirmation attached, so the FE can surface the card.
+			const setupTc = state.toolCallsById['tc-setup'];
+			expect(setupTc).toBeDefined();
+			expect(setupTc.isLoading).toBe(true);
+			expect(setupTc.confirmation?.requestId).toBe('req-1');
+
+			// It attaches to the group's original root; the tree stays anchored there.
+			const root = toAgentTree(state);
+			expect(root.agentId).toBe('orchestrator-run-1');
+			expect(root.toolCalls.map((tc) => tc.toolCallId)).toContain('tc-setup');
+			expectStateMapsNotPolluted(state);
+		});
+
 		it('run-start with unsafe agentId is ignored', () => {
 			const state = createInitialState();
 

--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -156,7 +156,14 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 				// Follow-up run in a merged group: preserve existing agent tree,
 				// just re-activate the root orchestrator for the new run's events.
 				state.status = 'active';
-				if (root) root.status = 'active';
+				if (root) {
+					root.status = 'active';
+					// A merged follow-up/resume run streams under its own per-run agentId
+					// (e.g. `orchestrator-<runId>`). Alias it to the existing root so its
+					// tool calls and confirmations resolve an agent instead of being
+					// dropped as orphans; rootAgentId and toAgentTree stay on the original.
+					if (rootId !== state.rootAgentId) state.agentsById[rootId] = root;
+				}
 			} else {
 				// First run: initialize from scratch.
 				state.rootAgentId = rootId;


### PR DESCRIPTION
## Summary

When the Instance AI assistant auto-continues after building a workflow (the `resume: workflow setup` path), the credentials/setup card sometimes didn't appear — the run stayed **suspended with Cancel as the only option** (a dead-end the user could only escape by cancelling).

Root cause is in the shared agent-run reducer (`@n8n/api-types`). An auto-continue/resume run merges into the existing message group but streams its events under its own per-run agentId (`orchestrator-<runId>`). The follow-up `run-start` branch only re-activated the existing root and **never registered the new agentId**, so the run's `tool-call` and `confirmation-request` events were dropped by the agent-exists guards — no tool call in the tree ⇒ no confirmation ⇒ no card. Because suspend is delivered via a `run-sync` snapshot (built with the same reducer) that marks the run live, the UI showed an active, cancel-only run with nothing to act on.

**Fix:** alias the merged run's agentId to the existing root so its tool calls/confirmations reduce into the tree. One place fixes both the live FE state and the backend snapshot; `rootAgentId`/`toAgentTree` stay anchored to the original root.

It reproduced intermittently because it only triggered when the orchestrator ended its turn and got auto-continued into a resume run — calling setup inline (same turn) worked.

## How to test

**Automated:** `cd packages/@n8n/api-types && pnpm test agent-run-reducer` — includes a regression test (_"follow-up run under a new agentId routes that run's tool calls and confirmations to the tree"_). Reverting the one-line alias makes it fail with `toolCallsById['tc-setup']` undefined.

**Manual (non-deterministic):** ask the assistant to build a workflow that needs credentials (e.g. "email me when it rains in Berlin"). When it finishes building and auto-continues into setup, the credentials/setup card should render — previously it could hang with only a Cancel button.

## Related Linear tickets, Github issues, and Community forum posts

_None — internal bug surfaced from a staging trace._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if urgent).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

