### PR TITLE
ci: Default to `pnpm build` in  setup-nodejs

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -17,7 +17,7 @@ inputs:
   build-command:
     description: 'Command to execute for building the project or an optional command. Leave empty to skip build step.'
     required: false
-    default: 'pnpm build:unchecked'
+    default: 'pnpm build'
   install-command:
     description: 'Command to execute for installing project dependencies. Leave empty to skip install step.'
     required: false


### PR DESCRIPTION
## Summary

Default back to `pnpm build` (from `pnpm build:unchecked`) for `setup-nodejs`.

In the CI layer, we actually lose cache benefits as our setup build step builds with the checked build but our sub-workflows depended on the unchecked version, causing a cache miss.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-605

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33445">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

