### PR TITLE
feat(Postgres PGVector Store Node): Make pgvector extension creation opt-in

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,0 +1,271 @@
+// cspell:ignore pgvector langchain vectorstores vectorstore
+import { PGVectorStore } from '@langchain/community/vectorstores/pgvector';
+import type { Document } from '@langchain/core/documents';
+import type { Embeddings } from '@langchain/core/embeddings';
+import type { VectorStoreNodeConstructorArgs } from '@n8n/ai-utilities';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import type { Pool } from 'pg';
+import { mock } from 'vitest-mock-extended';
+
+const { capturedConfigRef } = vi.hoisted(() => ({
+	capturedConfigRef: { current: undefined as VectorStoreNodeConstructorArgs<any> | undefined },
+}));
+
+vi.mock('@n8n/ai-utilities', () => ({
+	metadataFilterField: {},
+	createVectorStoreNode: (config: VectorStoreNodeConstructorArgs<any>) => {
+		capturedConfigRef.current = config;
+
+		return class TestVectorStoreNode {
+			async getVectorStoreClient(...args: Parameters<typeof config.getVectorStoreClient>) {
+				if (!capturedConfigRef.current) throw new Error('Vector store config not captured');
+				return await capturedConfigRef.current.getVectorStoreClient(...args);
+			}
+
+			async populateVectorStore(...args: Parameters<typeof config.populateVectorStore>) {
+				if (!capturedConfigRef.current) throw new Error('Vector store config not captured');
+				return await capturedConfigRef.current.populateVectorStore(...args);
+			}
+		};
+	},
+}));
+
+const configurePostgresMock = vi.fn();
+
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: (...args: unknown[]) => configurePostgresMock(...args),
+}));
+
+import { ExtendedPGVectorStore, VectorStorePGVector } from './VectorStorePGVector.node';
+
+type FakeClient = { release: ReturnType<typeof vi.fn> };
+type FakePool = {
+	query: ReturnType<typeof vi.fn>;
+	connect: ReturnType<typeof vi.fn<() => Promise<FakeClient>>>;
+};
+
+function createFakePool(): FakePool {
+	const client: FakeClient = { release: vi.fn() };
+	return {
+		query: vi.fn().mockResolvedValue({ rows: [] }),
+		connect: vi.fn().mockResolvedValue(client),
+	};
+}
+
+function extensionQueries(pool: FakePool): string[] {
+	return pool.query.mock.calls
+		.map(([query]) => query as string)
+		.filter((query) => query.includes('CREATE EXTENSION'));
+}
+
+function tableQueries(pool: FakePool): string[] {
+	return pool.query.mock.calls
+		.map(([query]) => query as string)
+		.filter((query) => query.includes('CREATE TABLE'));
+}
+
+const fakeEmbeddings = {
+	embedDocuments: vi.fn().mockResolvedValue([[0.1, 0.2]]),
+	embedQuery: vi.fn().mockResolvedValue([0.1, 0.2]),
+} as unknown as Embeddings;
+
+const documents: Document[] = [{ pageContent: 'hello', metadata: {} }];
+
+describe('VectorStorePGVector.node', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('ExtendedPGVectorStore.ensureTableInDatabase', () => {
+		it('does not create the pgvector extension by default', async () => {
+			const pool = createFakePool();
+			const store = new ExtendedPGVectorStore(fakeEmbeddings, {
+				pool: pool as unknown as Pool,
+				tableName: 'n8n_vectors',
+			});
+
+			await store.ensureTableInDatabase();
+
+			expect(extensionQueries(pool)).toHaveLength(0);
+			expect(tableQueries(pool)).toHaveLength(1);
+			expect(tableQueries(pool)[0]).toContain('CREATE TABLE IF NOT EXISTS n8n_vectors');
+		});
+
+		it('creates the pgvector extension when createExtension is true', async () => {
+			const pool = createFakePool();
+			const store = new ExtendedPGVectorStore(fakeEmbeddings, {
+				pool: pool as unknown as Pool,
+				tableName: 'n8n_vectors',
+				createExtension: true,
+			});
+
+			await store.ensureTableInDatabase();
+
+			expect(extensionQueries(pool)).toEqual(['CREATE EXTENSION IF NOT EXISTS vector;']);
+			expect(tableQueries(pool)).toHaveLength(1);
+		});
+
+		it('schema-qualifies the extension creation when extensionSchemaName is set', async () => {
+			const pool = createFakePool();
+			const store = new ExtendedPGVectorStore(fakeEmbeddings, {
+				pool: pool as unknown as Pool,
+				tableName: 'n8n_vectors',
+				extensionSchemaName: 'myschema',
+				createExtension: true,
+			});
+
+			await store.ensureTableInDatabase();
+
+			expect(extensionQueries(pool)).toEqual([
+				'CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA "myschema";',
+			]);
+		});
+
+		it('skips all queries when skipInitializationCheck is true', async () => {
+			const pool = createFakePool();
+			const store = new ExtendedPGVectorStore(fakeEmbeddings, {
+				pool: pool as unknown as Pool,
+				tableName: 'n8n_vectors',
+				createExtension: true,
+				skipInitializationCheck: true,
+			});
+
+			await store.ensureTableInDatabase();
+
+			expect(pool.query).not.toHaveBeenCalled();
+		});
+
+		it('includes the vector dimensions in the column type when provided', async () => {
+			const pool = createFakePool();
+			const store = new ExtendedPGVectorStore(fakeEmbeddings, {
+				pool: pool as unknown as Pool,
+				tableName: 'n8n_vectors',
+			});
+
+			await store.ensureTableInDatabase(1536);
+
+			expect(tableQueries(pool)[0]).toContain('vector(1536)');
+		});
+	});
+
+	describe('getVectorStoreClient', () => {
+		const baseParams: Record<string, unknown> = {
+			tableName: 'n8n_vectors',
+			'options.collection.values': {},
+			'options.columnNames.values': {
+				idColumnName: 'id',
+				vectorColumnName: 'embedding',
+				contentColumnName: 'text',
+				metadataColumnName: 'metadata',
+			},
+			'options.distanceStrategy': 'cosine',
+		};
+
+		function createContext(overrides: Record<string, unknown> = {}) {
+			const context = mock<IExecuteFunctions>();
+			context.getNodeParameter.mockImplementation(((
+				name: string,
+				_itemIndex: number,
+				fallback?: unknown,
+			) => {
+				const params = { ...baseParams, ...overrides };
+				return name in params ? params[name] : fallback;
+			}) as IExecuteFunctions['getNodeParameter']);
+			context.getCredentials.mockResolvedValue({});
+			return context;
+		}
+
+		it('does not create the extension when the option is left at its default', async () => {
+			const pool = createFakePool();
+			configurePostgresMock.mockResolvedValue({ db: { $pool: pool } });
+			const context = createContext();
+
+			await capturedConfigRef.current!.getVectorStoreClient(context, undefined, fakeEmbeddings, 0);
+
+			expect(extensionQueries(pool)).toHaveLength(0);
+		});
+
+		it('creates the extension when options.createExtension is true', async () => {
+			const pool = createFakePool();
+			configurePostgresMock.mockResolvedValue({ db: { $pool: pool } });
+			const context = createContext({ 'options.createExtension': true });
+
+			await capturedConfigRef.current!.getVectorStoreClient(context, undefined, fakeEmbeddings, 0);
+
+			expect(extensionQueries(pool)).toHaveLength(1);
+		});
+	});
+
+	describe('populateVectorStore', () => {
+		const baseParams: Record<string, unknown> = {
+			tableName: 'n8n_vectors',
+			'options.collection.values': {},
+			'options.columnNames.values': {
+				idColumnName: 'id',
+				vectorColumnName: 'embedding',
+				contentColumnName: 'text',
+				metadataColumnName: 'metadata',
+			},
+		};
+
+		function createContext(overrides: Record<string, unknown> = {}) {
+			const context = mock<IExecuteFunctions>();
+			context.getNodeParameter.mockImplementation(((
+				name: string,
+				_itemIndex: number,
+				fallback?: unknown,
+			) => {
+				const params = { ...baseParams, ...overrides };
+				return name in params ? params[name] : fallback;
+			}) as IExecuteFunctions['getNodeParameter']);
+			context.getCredentials.mockResolvedValue({});
+			return context;
+		}
+
+		it('initializes the store, adds documents and releases the client, without using fromDocuments', async () => {
+			const fromDocumentsSpy = vi.spyOn(PGVectorStore, 'fromDocuments');
+			const pool = createFakePool();
+			configurePostgresMock.mockResolvedValue({ db: { $pool: pool } });
+			const context = createContext();
+
+			await capturedConfigRef.current!.populateVectorStore(context, fakeEmbeddings, documents, 0);
+
+			expect(fromDocumentsSpy).not.toHaveBeenCalled();
+			expect(extensionQueries(pool)).toHaveLength(0);
+			expect(
+				pool.query.mock.calls.some(([query]) => (query as string).includes('INSERT INTO')),
+			).toBe(true);
+			const client = await pool.connect();
+			expect(client.release).toHaveBeenCalled();
+		});
+
+		it('creates the extension during insert when options.createExtension is true', async () => {
+			const pool = createFakePool();
+			configurePostgresMock.mockResolvedValue({ db: { $pool: pool } });
+			const context = createContext({ 'options.createExtension': true });
+
+			await capturedConfigRef.current!.populateVectorStore(context, fakeEmbeddings, documents, 0);
+
+			expect(extensionQueries(pool)).toHaveLength(1);
+		});
+	});
+
+	describe('node description', () => {
+		it('exposes a createExtension option (default false) on insert and retrieve fields', () => {
+			void VectorStorePGVector;
+			const config = capturedConfigRef.current!;
+
+			for (const fields of [config.insertFields ?? [], config.retrieveFields ?? []]) {
+				const optionsField = fields.find((field) => field.name === 'options');
+				const createExtensionOption = (
+					optionsField?.options as unknown as Array<Record<string, unknown>> | undefined
+				)?.find((option) => option.name === 'createExtension');
+
+				expect(createExtensionOption).toMatchObject({
+					type: 'boolean',
+					default: false,
+				});
+			}
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -156,6 +156,15 @@ const distanceStrategyField: INodeProperties = {
 	],
 };
 
+const createExtensionField: INodeProperties = {
+	displayName: 'Create Extension',
+	name: 'createExtension',
+	type: 'boolean',
+	default: false,
+	description:
+		'Whether to create the pgvector extension if it does not exist. Requires database superuser privileges.',
+};
+
 const insertFields: INodeProperties[] = [
 	{
 		displayName: 'Options',
@@ -163,7 +172,7 @@ const insertFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		options: [collectionField, columnNamesField],
+		options: [collectionField, columnNamesField, createExtensionField],
 	},
 ];
 
@@ -174,7 +183,13 @@ const retrieveFields: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Option',
 		default: {},
-		options: [distanceStrategyField, collectionField, columnNamesField, metadataFilterField],
+		options: [
+			distanceStrategyField,
+			collectionField,
+			columnNamesField,
+			metadataFilterField,
+			createExtensionField,
+		],
 	},
 ];
 
@@ -185,9 +200,20 @@ const retrieveFields: INodeProperties[] = [
  * expecting it from the parameter
  */
 export class ExtendedPGVectorStore extends PGVectorStore {
+	private readonly _createExtension: boolean;
+
+	constructor(
+		embeddings: EmbeddingsInterface,
+		args: PGVectorStoreArgs & { createExtension?: boolean },
+	) {
+		const { createExtension, ...rest } = args;
+		super(embeddings, rest);
+		this._createExtension = createExtension ?? false;
+	}
+
 	static async initialize(
 		embeddings: EmbeddingsInterface,
-		args: PGVectorStoreArgs & { dimensions?: number },
+		args: PGVectorStoreArgs & { dimensions?: number; createExtension?: boolean },
 	): Promise<ExtendedPGVectorStore> {
 		const { dimensions, ...rest } = args;
 		const postgresqlVectorStore = new this(embeddings, rest);
@@ -199,6 +225,38 @@ export class ExtendedPGVectorStore extends PGVectorStore {
 		}
 
 		return postgresqlVectorStore;
+	}
+
+	/**
+	 * Creates the destination table (and, if opted in, the pgvector extension) if they
+	 * don't already exist. Extension creation is opt-in because it requires database
+	 * superuser privileges, which many managed Postgres users don't have.
+	 */
+	override async ensureTableInDatabase(dimensions?: number): Promise<void> {
+		if (this.skipInitializationCheck) return;
+
+		if (this._createExtension) {
+			const vectorQuery =
+				this.extensionSchemaName == null
+					? 'CREATE EXTENSION IF NOT EXISTS vector;'
+					: `CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA "${this.extensionSchemaName}";`;
+			await this.pool.query(vectorQuery);
+		}
+
+		const extensionName =
+			this.extensionSchemaName == null ? 'vector' : `"${this.extensionSchemaName}"."vector"`;
+		const vectorColumnType = dimensions ? `${extensionName}(${dimensions})` : extensionName;
+
+		const tableQuery = `
+      CREATE TABLE IF NOT EXISTS ${this.computedTableName} (
+        "${this.idColumnName}" uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+        "${this.contentColumnName}" text,
+        "${this.metadataColumnName}" jsonb,
+        "${this.vectorColumnName}" ${vectorColumnType}
+      );
+    `;
+
+		await this.pool.query(tableQuery);
 	}
 
 	async similaritySearchVectorWithScore(
@@ -270,7 +328,13 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			'cosine',
 		) as DistanceStrategy;
 
-		return await ExtendedPGVectorStore.initialize(embeddings, config);
+		const createExtension = context.getNodeParameter(
+			'options.createExtension',
+			0,
+			false,
+		) as boolean;
+
+		return await ExtendedPGVectorStore.initialize(embeddings, { ...config, createExtension });
 	},
 
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
@@ -306,7 +370,17 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			metadataColumnName: 'metadata',
 		}) as ColumnOptions;
 
-		const vectorStore = await PGVectorStore.fromDocuments(documents, embeddings, config);
+		const createExtension = context.getNodeParameter(
+			'options.createExtension',
+			0,
+			false,
+		) as boolean;
+
+		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, {
+			...config,
+			createExtension,
+		});
+		await vectorStore.addDocuments(documents);
 		vectorStore.client?.release();
 	},
 


### PR DESCRIPTION
## Summary

Adds a **Create Extension** option (default `false`) to the **Postgres PGVector Store**
node (`vectorStorePGVector`).

Previously, initializing the vector store always ran `CREATE EXTENSION IF NOT EXISTS vector`
(inherited from `@langchain/community`'s `PGVectorStore.ensureTableInDatabase`), which
requires Postgres **superuser** privileges. Non-admin database users hit a permission
error on every operation (load/insert/retrieve), even when the `vector` extension was
already installed by an administrator.

With this change, extension creation is now **opt-in**:

- Added a new "Create Extension" boolean field (under **Options**) to the insert and
  retrieve/load field sets.
- `ExtendedPGVectorStore` now accepts a `createExtension` flag and overrides
  `ensureTableInDatabase` so `CREATE EXTENSION IF NOT EXISTS vector` only runs when the
  option is enabled (still schema-aware via `extensionSchemaName`, and still a no-op when
  `skipInitializationCheck` is set). Table creation (`CREATE TABLE IF NOT EXISTS ...`)
  always runs as before.
- `getVectorStoreClient` and `populateVectorStore` both read `options.createExtension`
  and pass it through to `ExtendedPGVectorStore.initialize`.
- `populateVectorStore` (insert mode) no longer uses `PGVectorStore.fromDocuments`
  (which always created the extension and didn't support the new option); it now uses
  `ExtendedPGVectorStore.initialize` + `addDocuments`, keeping the same client-release
  cleanup.

**Behavior change:** by default, the node no longer attempts to create the `vector`
extension automatically. Users who relied on the old auto-creation behavior need to
either enable the new "Create Extension" option or have the extension pre-installed by
a database administrator.

## How to test

1. Connect the **Postgres PGVector Store** node to a Postgres database using a
   **non-superuser** role, with the `vector` extension either already installed, or not
   installed at all.
2. With **Create Extension** left at its default (off), run an insert/load/retrieve
   operation:
   - If the extension is already installed: it works without errors.
   - If not installed: table creation still runs; only extension creation is skipped
     (matches the option being off).
3. Enable **Create Extension** and run again as a superuser: the node runs
   `CREATE EXTENSION IF NOT EXISTS vector` before creating the table, same as previous
   behavior.
4. Unit tests: `cd packages/@n8n/nodes-langchain && pnpm test VectorStorePGVector.node.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

- https://github.com/n8n-io/n8n/issues/15739
- https://community.n8n.io/t/postgres-pgvector-store-got-created/151319

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

