### PR TITLE
ci: Trigger backport when a backport label is added to a merged PR

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,7 +4,7 @@ run-name: Backport pull request ${{ github.event.pull_request.number || inputs.p
 
 on:
   pull_request:
-    types: [closed]
+    types: [closed, labeled]
   workflow_dispatch:
     inputs:
       pull-request-id:
@@ -18,9 +18,11 @@ permissions:
 
 jobs:
   backport:
+    # Runs on: PR merge, a "Backport to ..." label added to a merged PR, or manual dispatch
     if: |
-      github.event.pull_request.merged == true ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'closed' && github.event.pull_request.merged == true) ||
+      (github.event.action == 'labeled' && github.event.pull_request.merged == true && startsWith(github.event.label.name, 'Backport to'))
     runs-on: ubuntu-slim
     outputs:
       created_pull_numbers: ${{ steps.backport.outputs.created_pull_numbers }}


### PR DESCRIPTION
## Summary

Backports previously only ran on PR merge or via manual `workflow_dispatch`, so adding a `Backport to ...` label after merge required manually invoking the util action with the PR number. This adds a `labeled` trigger so applying a `Backport to Beta/Stable/v1` label to an already-merged PR automatically runs the backport.

## How to test

Merge a PR, then add a `Backport to Stable` label to it — the `Util: Backport pull request changes` workflow should trigger and open the backport PR. Adding a non-backport label to a merged PR should not trigger it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-623

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

