### PR TITLE
fix(AI Agent Node): Return intermediate steps when no tools are used

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/runAgent.ts
@@ -110,7 +110,7 @@ export async function runAgent(
 			}
 		}
 
-		if (options.returnIntermediateSteps && steps.length > 0) {
+		if (options.returnIntermediateSteps) {
 			result.intermediateSteps = steps;
 		}
 
@@ -141,7 +141,7 @@ export async function runAgent(
 			}
 			// Include intermediate steps if requested
 			const result = { ...modelResponse.returnValues };
-			if (options.returnIntermediateSteps && steps.length > 0) {
+			if (options.returnIntermediateSteps) {
 				result.intermediateSteps = steps;
 			}
 			return result;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
@@ -5,7 +5,7 @@ import type { IExecuteFunctions, INode, EngineResponse } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { RequestResponseMetadata } from '@utils/agent-execution';
+import type { RequestResponseMetadata, ToolCallData } from '@utils/agent-execution';
 import * as agentExecution from '@utils/agent-execution';
 import * as tracing from '@utils/tracing';
 
@@ -430,5 +430,161 @@ describe('runAgent - tracing configuration', () => {
 		});
 		expect(mockWithConfig).toHaveBeenCalledWith(mockTracingConfig);
 		expect(mockStreamEvents).toHaveBeenCalled();
+	});
+});
+
+describe('runAgent - intermediate steps', () => {
+	const buildStep = (): ToolCallData => ({
+		action: {
+			tool: 'TestTool',
+			toolInput: { input: 'test' },
+			log: 'Calling TestTool',
+			messageLog: [],
+			toolCallId: 'call_123',
+			type: 'tool_call',
+		},
+		observation: 'tool result',
+	});
+
+	it('should include an empty intermediateSteps array when no tools were used (non-streaming)', async () => {
+		const mockInvoke = vi.fn().mockResolvedValue({
+			returnValues: { output: 'Final answer' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'test input',
+			steps: [],
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: true,
+			},
+			outputParser: undefined,
+		};
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		const result = await runAgent(mockContext, mockExecutor, itemContext, mockModel, undefined);
+
+		expect(result).toHaveProperty('intermediateSteps');
+		expect((result as any).intermediateSteps).toEqual([]);
+	});
+
+	it('should include populated intermediateSteps when tools were used (non-streaming)', async () => {
+		const mockInvoke = vi.fn().mockResolvedValue({
+			returnValues: { output: 'Final answer' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+		const steps = [buildStep()];
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'test input',
+			steps,
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: true,
+			},
+			outputParser: undefined,
+		};
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		const result = await runAgent(mockContext, mockExecutor, itemContext, mockModel, undefined);
+
+		expect((result as any).intermediateSteps).toEqual(steps);
+	});
+
+	it('should not include intermediateSteps when the option is disabled (non-streaming)', async () => {
+		const mockInvoke = vi.fn().mockResolvedValue({
+			returnValues: { output: 'Final answer' },
+		});
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ invoke: mockInvoke }),
+		});
+		const mockModel = mock<BaseChatModel>();
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'test input',
+			steps: [buildStep()],
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: false,
+			},
+			outputParser: undefined,
+		};
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
+
+		const result = await runAgent(mockContext, mockExecutor, itemContext, mockModel, undefined);
+
+		expect(result).not.toHaveProperty('intermediateSteps');
+	});
+
+	it('should include an empty intermediateSteps array when no tools were used (streaming)', async () => {
+		const mockEventStream = (async function* () {})();
+		const mockStreamEvents = vi.fn().mockReturnValue(mockEventStream);
+		const mockExecutor = mock<AgentRunnableSequence>({
+			withConfig: vi.fn().mockReturnValue({ streamEvents: mockStreamEvents }),
+		});
+		const mockModel = mock<BaseChatModel>();
+
+		const itemContext: ItemContext = {
+			itemIndex: 0,
+			input: 'test input',
+			steps: [],
+			tools: [],
+			prompt: mock(),
+			options: {
+				maxIterations: 10,
+				returnIntermediateSteps: true,
+				enableStreaming: true,
+			},
+			outputParser: undefined,
+		};
+
+		const streamingContext = mock<IExecuteFunctions>({
+			getNode: vi.fn().mockReturnValue({ ...mockNode, typeVersion: 2.1 }),
+			isStreaming: vi.fn().mockReturnValue(true),
+			getExecutionCancelSignal: vi.fn().mockReturnValue(new AbortController().signal),
+		});
+		streamingContext.getExecuteData = vi.fn() as any;
+
+		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
+		vi.spyOn(agentExecution, 'saveToMemory').mockResolvedValue();
+		vi.spyOn(agentExecution, 'processEventStream').mockResolvedValue({
+			output: 'Streamed answer',
+		});
+
+		const result = await runAgent(
+			streamingContext,
+			mockExecutor,
+			itemContext,
+			mockModel,
+			undefined,
+		);
+
+		expect(result).toHaveProperty('intermediateSteps');
+		expect((result as any).intermediateSteps).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

The v3 Agent node (Tools Agent) only surfaced `intermediateSteps` in its output when at least one tool was called. When the LLM answered directly without invoking any tool, the `intermediateSteps` key was omitted entirely, breaking downstream nodes that read it.

In v2 this never happened: `intermediateSteps` was always present as an empty array (`[]`) when the option was enabled — LangChain's `AgentExecutor` always populated it on the non-streaming path, and `processEventStream` initialized it up front on the streaming path.

The regression was a `steps.length > 0` guard in `runAgent.ts` (both the streaming and non-streaming paths). Removing it so the presence of `intermediateSteps` is controlled solely by the `returnIntermediateSteps` option restores v2 parity: an empty array when no tools ran, populated when they did, absent when the option is off.

Both `AgentV3` and `AgentToolV3` route through the same `runAgent`, so both are covered.

## How to test

1. Add an AI Agent node (v3) with a chat model and enable **Return Intermediate Steps** in options.
2. Send a prompt the model can answer directly without any tool (or connect no tools).
3. Confirm the output now includes `intermediateSteps: []` instead of omitting the key.
4. Add a tool and send a prompt that triggers it — confirm `intermediateSteps` is populated as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-223


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33450">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

