### PR TITLE
fix(core): Persist AI Assistant domain-access approvals across restarts and mains

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -276,6 +276,10 @@ export {
 
 export {
 	buildRunWorkflowSessionGrantKey,
+	buildFetchUrlGrantKey,
+	FETCH_URL_ALLOW_ALL_GRANT_KEY,
+	WEB_SEARCH_GRANT_KEY,
+	parseDomainAccessGrants,
 	instanceAiEventTypeSchema,
 	instanceAiRunStatusSchema,
 	instanceAiConfirmationSeveritySchema,
@@ -413,6 +417,7 @@ export type {
 	InstanceAiFileAttachment,
 	InstanceAiWorkflowAttachment,
 	DomainAccessAction,
+	DomainAccessGrants,
 	DomainAccessMeta,
 	WebSearchMeta,
 	InstanceAiCredentialFlow,

--- a/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/instance-ai.schema.test.ts
@@ -1,11 +1,15 @@
 import {
 	AI_GATEWAY_MANAGED_TAG,
 	applyBranchReadOnlyOverrides,
+	buildFetchUrlGrantKey,
 	DEFAULT_INSTANCE_AI_PERMISSIONS,
+	FETCH_URL_ALLOW_ALL_GRANT_KEY,
 	InstanceAiAdminSettingsUpdateRequest,
 	instanceAiEventSchema,
 	isDisplayableConfirmationRequest,
 	isInstanceAiSandboxProvider,
+	parseDomainAccessGrants,
+	WEB_SEARCH_GRANT_KEY,
 	workflowSetupNodeSchema,
 	type InstanceAiConfirmationInputType,
 	type InstanceAiConfirmationRequestPayload,
@@ -327,5 +331,41 @@ describe('isDisplayableConfirmationRequest', () => {
 		} satisfies Record<InstanceAiConfirmationInputType, true>;
 
 		expect(Object.keys(handled)).toHaveLength(6);
+	});
+});
+
+describe('domain-access grant keys', () => {
+	it('builds and parses per-host grant keys round-trip', () => {
+		const key = buildFetchUrlGrantKey('example.com');
+		expect(key).toBe('fetch-url:example.com');
+
+		const parsed = parseDomainAccessGrants(new Set([key]));
+		expect(parsed.approvedDomains.has('example.com')).toBe(true);
+		expect(parsed.allDomainsApproved).toBe(false);
+		expect(parsed.webSearchApproved).toBe(false);
+	});
+
+	it('parses the blanket allow-all and web-search keys', () => {
+		const parsed = parseDomainAccessGrants(
+			new Set([FETCH_URL_ALLOW_ALL_GRANT_KEY, WEB_SEARCH_GRANT_KEY]),
+		);
+		expect(parsed.allDomainsApproved).toBe(true);
+		expect(parsed.webSearchApproved).toBe(true);
+		expect(parsed.approvedDomains.size).toBe(0);
+	});
+
+	it('ignores unrelated grant keys (e.g. executions:run)', () => {
+		const parsed = parseDomainAccessGrants(
+			new Set([buildFetchUrlGrantKey('a.com'), 'executions:run:wf-1']),
+		);
+		expect(parsed.approvedDomains).toEqual(new Set(['a.com']));
+		expect(parsed.allDomainsApproved).toBe(false);
+		expect(parsed.webSearchApproved).toBe(false);
+	});
+
+	it('does not treat the allow-all key as a host', () => {
+		const parsed = parseDomainAccessGrants(new Set([FETCH_URL_ALLOW_ALL_GRANT_KEY]));
+		expect(parsed.approvedDomains.size).toBe(0);
+		expect(parsed.allDomainsApproved).toBe(true);
 	});
 });

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -36,6 +36,52 @@ export function buildRunWorkflowSessionGrantKey(workflowId: string): string {
 	return `executions:run:${workflowId}`;
 }
 
+// --- Domain-access grants ("always allow" for web access) ---
+// These keys mirror the research tool's action names (`fetch-url`, `web-search`) the same
+// way `executions:run:<id>` mirrors the executions `run` action, so a persisted grant row
+// names the exact tool action the user approved.
+
+/** Grant key for persistently allowing fetches from a specific host. */
+export function buildFetchUrlGrantKey(host: string): string {
+	return `fetch-url:${host}`;
+}
+
+/** Grant key for allowing fetches from any host (blanket allow). */
+export const FETCH_URL_ALLOW_ALL_GRANT_KEY = 'fetch-url:*';
+
+/** Grant key for persistently allowing web search. */
+export const WEB_SEARCH_GRANT_KEY = 'web-search';
+
+/** Domain-access state reconstructed from a set of persisted grant keys. */
+export interface DomainAccessGrants {
+	approvedDomains: Set<string>;
+	allDomainsApproved: boolean;
+	webSearchApproved: boolean;
+}
+
+/**
+ * Parse persisted grant keys back into domain-access state. Single source of truth for the
+ * key format ↔ tracker state mapping; ignores unrelated grant keys (e.g. `executions:run:*`).
+ */
+export function parseDomainAccessGrants(keys: ReadonlySet<string>): DomainAccessGrants {
+	const approvedDomains = new Set<string>();
+	let allDomainsApproved = false;
+	let webSearchApproved = false;
+
+	const fetchUrlPrefix = 'fetch-url:';
+	for (const key of keys) {
+		if (key === FETCH_URL_ALLOW_ALL_GRANT_KEY) {
+			allDomainsApproved = true;
+		} else if (key === WEB_SEARCH_GRANT_KEY) {
+			webSearchApproved = true;
+		} else if (key.startsWith(fetchUrlPrefix)) {
+			approvedDomains.add(key.slice(fetchUrlPrefix.length));
+		}
+	}
+
+	return { approvedDomains, allDomainsApproved, webSearchApproved };
+}
+
 // ---------------------------------------------------------------------------
 // Branded ID types — prevent swapping runId/agentId/threadId/toolCallId
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/src/domain-access/__tests__/domain-access-tracker.test.ts
+++ b/packages/@n8n/instance-ai/src/domain-access/__tests__/domain-access-tracker.test.ts
@@ -1,3 +1,9 @@
+import {
+	buildFetchUrlGrantKey,
+	FETCH_URL_ALLOW_ALL_GRANT_KEY,
+	WEB_SEARCH_GRANT_KEY,
+} from '@n8n/api-types';
+
 import { createDomainAccessTracker } from '../domain-access-tracker';
 
 describe('DomainAccessTracker', () => {
@@ -22,26 +28,26 @@ describe('DomainAccessTracker', () => {
 	});
 
 	describe('persistent approvals', () => {
-		it('remembers approved domains', () => {
+		it('remembers approved domains', async () => {
 			const tracker = createDomainAccessTracker();
 			expect(tracker.isHostAllowed('example.com')).toBe(false);
 
-			tracker.approveDomain('example.com');
+			await tracker.approveDomain('example.com');
 			expect(tracker.isHostAllowed('example.com')).toBe(true);
 		});
 
-		it('approvals are exact-host only', () => {
+		it('approvals are exact-host only', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveDomain('api.example.com');
+			await tracker.approveDomain('api.example.com');
 
 			expect(tracker.isHostAllowed('api.example.com')).toBe(true);
 			expect(tracker.isHostAllowed('example.com')).toBe(false);
 			expect(tracker.isHostAllowed('other.example.com')).toBe(false);
 		});
 
-		it('persists across calls without runId', () => {
+		it('persists across calls without runId', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveDomain('example.com');
+			await tracker.approveDomain('example.com');
 
 			// No runId — still allowed via persistent set
 			expect(tracker.isHostAllowed('example.com')).toBe(true);
@@ -49,11 +55,11 @@ describe('DomainAccessTracker', () => {
 	});
 
 	describe('approveAllDomains', () => {
-		it('allows all domains after blanket approval', () => {
+		it('allows all domains after blanket approval', async () => {
 			const tracker = createDomainAccessTracker();
 			expect(tracker.isHostAllowed('anything.example.com')).toBe(false);
 
-			tracker.approveAllDomains();
+			await tracker.approveAllDomains();
 			expect(tracker.isHostAllowed('anything.example.com')).toBe(true);
 			expect(tracker.isHostAllowed('evil.site')).toBe(true);
 			expect(tracker.isAllDomainsApproved()).toBe(true);
@@ -82,9 +88,9 @@ describe('DomainAccessTracker', () => {
 			expect(tracker.isHostAllowed('example.com')).toBe(false);
 		});
 
-		it('clearRun removes transient approvals only', () => {
+		it('clearRun removes transient approvals only', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveDomain('persistent.com');
+			await tracker.approveDomain('persistent.com');
 			tracker.approveOnce('run-1', 'transient.com');
 
 			tracker.clearRun('run-1');
@@ -112,9 +118,9 @@ describe('DomainAccessTracker', () => {
 			expect(tracker.isWebSearchAllowed('any-run')).toBe(false);
 		});
 
-		it('approveWebSearch grants persistent thread-level approval', () => {
+		it('approveWebSearch grants persistent thread-level approval', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveWebSearch();
+			await tracker.approveWebSearch();
 			expect(tracker.isWebSearchAllowed()).toBe(true);
 			expect(tracker.isWebSearchAllowed('run-1')).toBe(true);
 		});
@@ -134,18 +140,89 @@ describe('DomainAccessTracker', () => {
 			expect(tracker.isWebSearchAllowed('run-1')).toBe(false);
 		});
 
-		it('clearRun does not affect persistent web-search approval', () => {
+		it('clearRun does not affect persistent web-search approval', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveWebSearch();
+			await tracker.approveWebSearch();
 			tracker.approveWebSearchOnce('run-1');
 			tracker.clearRun('run-1');
 			expect(tracker.isWebSearchAllowed()).toBe(true);
 		});
 
-		it('approveAllDomains does not implicitly grant web-search', () => {
+		it('approveAllDomains does not implicitly grant web-search', async () => {
 			const tracker = createDomainAccessTracker();
-			tracker.approveAllDomains();
+			await tracker.approveAllDomains();
 			expect(tracker.isWebSearchAllowed()).toBe(false);
+		});
+	});
+
+	describe('seeding from persisted grant keys', () => {
+		it('seeds per-host, blanket, and web-search approvals from grantedKeys', () => {
+			const tracker = createDomainAccessTracker({
+				grantedKeys: new Set([buildFetchUrlGrantKey('example.com'), WEB_SEARCH_GRANT_KEY]),
+			});
+
+			expect(tracker.isHostAllowed('example.com')).toBe(true);
+			expect(tracker.isHostAllowed('other.com')).toBe(false);
+			expect(tracker.isWebSearchAllowed()).toBe(true);
+			expect(tracker.isAllDomainsApproved()).toBe(false);
+		});
+
+		it('seeds blanket approval from the allow-all grant key', () => {
+			const tracker = createDomainAccessTracker({
+				grantedKeys: new Set([FETCH_URL_ALLOW_ALL_GRANT_KEY]),
+			});
+
+			expect(tracker.isAllDomainsApproved()).toBe(true);
+			expect(tracker.isHostAllowed('anything.com')).toBe(true);
+		});
+
+		it('ignores unrelated grant keys', () => {
+			const tracker = createDomainAccessTracker({
+				grantedKeys: new Set(['executions:run:abc123']),
+			});
+
+			expect(tracker.isAllDomainsApproved()).toBe(false);
+			expect(tracker.isWebSearchAllowed()).toBe(false);
+			expect(tracker.isHostAllowed('example.com')).toBe(false);
+		});
+	});
+
+	describe('write-through persistence', () => {
+		it('persists the fetch-url grant key on approveDomain', async () => {
+			const persistGrant = vi.fn().mockResolvedValue(undefined);
+			const tracker = createDomainAccessTracker({ persistGrant });
+
+			await tracker.approveDomain('example.com');
+
+			expect(persistGrant).toHaveBeenCalledWith(buildFetchUrlGrantKey('example.com'));
+		});
+
+		it('persists the allow-all grant key on approveAllDomains', async () => {
+			const persistGrant = vi.fn().mockResolvedValue(undefined);
+			const tracker = createDomainAccessTracker({ persistGrant });
+
+			await tracker.approveAllDomains();
+
+			expect(persistGrant).toHaveBeenCalledWith(FETCH_URL_ALLOW_ALL_GRANT_KEY);
+		});
+
+		it('persists the web-search grant key on approveWebSearch', async () => {
+			const persistGrant = vi.fn().mockResolvedValue(undefined);
+			const tracker = createDomainAccessTracker({ persistGrant });
+
+			await tracker.approveWebSearch();
+
+			expect(persistGrant).toHaveBeenCalledWith(WEB_SEARCH_GRANT_KEY);
+		});
+
+		it('does not persist transient (allow_once) approvals', () => {
+			const persistGrant = vi.fn().mockResolvedValue(undefined);
+			const tracker = createDomainAccessTracker({ persistGrant });
+
+			tracker.approveOnce('run-1', 'example.com');
+			tracker.approveWebSearchOnce('run-1');
+
+			expect(persistGrant).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/domain-access/__tests__/domain-gating.test.ts
+++ b/packages/@n8n/instance-ai/src/domain-access/__tests__/domain-gating.test.ts
@@ -42,9 +42,9 @@ describe('checkDomainAccess', () => {
 		expect(payload.severity).toBe('info');
 	});
 
-	it('allows previously approved domains', () => {
+	it('allows previously approved domains', async () => {
 		const tracker = createDomainAccessTracker();
-		tracker.approveDomain('example.com');
+		await tracker.approveDomain('example.com');
 
 		const result = checkDomainAccess({
 			url: 'https://example.com/page',
@@ -88,25 +88,25 @@ describe('checkDomainAccess', () => {
 });
 
 describe('applyDomainAccessResume', () => {
-	it('returns proceed: false when denied', () => {
-		const result = applyDomainAccessResume({
+	it('returns proceed: false when denied', async () => {
+		const result = await applyDomainAccessResume({
 			resumeData: { approved: false },
 			host: 'example.com',
 		});
 		expect(result.proceed).toBe(false);
 	});
 
-	it('returns proceed: true when approved', () => {
-		const result = applyDomainAccessResume({
+	it('returns proceed: true when approved', async () => {
+		const result = await applyDomainAccessResume({
 			resumeData: { approved: true },
 			host: 'example.com',
 		});
 		expect(result.proceed).toBe(true);
 	});
 
-	it('allow_domain persists exact host in tracker', () => {
+	it('allow_domain persists exact host in tracker', async () => {
 		const tracker = createDomainAccessTracker();
-		applyDomainAccessResume({
+		await applyDomainAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_domain' },
 			host: 'example.com',
 			tracker,
@@ -116,9 +116,9 @@ describe('applyDomainAccessResume', () => {
 		expect(tracker.isHostAllowed('other.example.com')).toBe(false);
 	});
 
-	it('allow_all approves all domains', () => {
+	it('allow_all approves all domains', async () => {
 		const tracker = createDomainAccessTracker();
-		applyDomainAccessResume({
+		await applyDomainAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_all' },
 			host: 'example.com',
 			tracker,
@@ -128,9 +128,9 @@ describe('applyDomainAccessResume', () => {
 		expect(tracker.isHostAllowed('anything.com')).toBe(true);
 	});
 
-	it('allow_once sets transient run-scoped approval', () => {
+	it('allow_once sets transient run-scoped approval', async () => {
 		const tracker = createDomainAccessTracker();
-		applyDomainAccessResume({
+		await applyDomainAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_once' },
 			host: 'example.com',
 			tracker,
@@ -142,9 +142,9 @@ describe('applyDomainAccessResume', () => {
 		expect(tracker.isHostAllowed('example.com')).toBe(false);
 	});
 
-	it('default action (no domainAccessAction) behaves like allow_once', () => {
+	it('default action (no domainAccessAction) behaves like allow_once', async () => {
 		const tracker = createDomainAccessTracker();
-		applyDomainAccessResume({
+		await applyDomainAccessResume({
 			resumeData: { approved: true },
 			host: 'example.com',
 			tracker,
@@ -192,9 +192,9 @@ describe('checkWebSearchAccess', () => {
 		expect(payload.message).toContain('how to deploy n8n');
 	});
 
-	it('allows when tracker has persistent web-search approval', () => {
+	it('allows when tracker has persistent web-search approval', async () => {
 		const tracker = createDomainAccessTracker();
-		tracker.approveWebSearch();
+		await tracker.approveWebSearch();
 		const result = checkWebSearchAccess({
 			query: 'q',
 			tracker,
@@ -240,10 +240,10 @@ describe('checkWebSearchAccess', () => {
 		expect(result.allowed).toBe(false);
 	});
 
-	it('does not leak fetch-url tracker approvals into web-search', () => {
+	it('does not leak fetch-url tracker approvals into web-search', async () => {
 		const tracker = createDomainAccessTracker();
-		tracker.approveDomain('example.com');
-		tracker.approveAllDomains();
+		await tracker.approveDomain('example.com');
+		await tracker.approveAllDomains();
 		const result = checkWebSearchAccess({
 			query: 'q',
 			tracker,
@@ -255,16 +255,16 @@ describe('checkWebSearchAccess', () => {
 });
 
 describe('applyWebSearchAccessResume', () => {
-	it('returns proceed: false when denied', () => {
-		const result = applyWebSearchAccessResume({
+	it('returns proceed: false when denied', async () => {
+		const result = await applyWebSearchAccessResume({
 			resumeData: { approved: false },
 		});
 		expect(result.proceed).toBe(false);
 	});
 
-	it('allow_once sets transient run-scoped approval', () => {
+	it('allow_once sets transient run-scoped approval', async () => {
 		const tracker = createDomainAccessTracker();
-		applyWebSearchAccessResume({
+		await applyWebSearchAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_once' },
 			tracker,
 			runId: 'run-1',
@@ -274,9 +274,9 @@ describe('applyWebSearchAccessResume', () => {
 		expect(tracker.isWebSearchAllowed()).toBe(false);
 	});
 
-	it('default action behaves like allow_once', () => {
+	it('default action behaves like allow_once', async () => {
 		const tracker = createDomainAccessTracker();
-		applyWebSearchAccessResume({
+		await applyWebSearchAccessResume({
 			resumeData: { approved: true },
 			tracker,
 			runId: 'run-1',
@@ -285,9 +285,9 @@ describe('applyWebSearchAccessResume', () => {
 		expect(tracker.isWebSearchAllowed()).toBe(false);
 	});
 
-	it('allow_domain grants persistent (thread-level) approval', () => {
+	it('allow_domain grants persistent (thread-level) approval', async () => {
 		const tracker = createDomainAccessTracker();
-		applyWebSearchAccessResume({
+		await applyWebSearchAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_domain' },
 			tracker,
 			runId: 'run-1',
@@ -296,9 +296,9 @@ describe('applyWebSearchAccessResume', () => {
 		expect(tracker.isWebSearchAllowed('any-other-run')).toBe(true);
 	});
 
-	it('allow_all also grants persistent approval (no broader scope for search)', () => {
+	it('allow_all also grants persistent approval (no broader scope for search)', async () => {
 		const tracker = createDomainAccessTracker();
-		applyWebSearchAccessResume({
+		await applyWebSearchAccessResume({
 			resumeData: { approved: true, domainAccessAction: 'allow_all' },
 			tracker,
 		});

--- a/packages/@n8n/instance-ai/src/domain-access/domain-access-tracker.ts
+++ b/packages/@n8n/instance-ai/src/domain-access/domain-access-tracker.ts
@@ -1,11 +1,20 @@
-import { isAllowedDomain } from '@n8n/api-types';
+import {
+	buildFetchUrlGrantKey,
+	FETCH_URL_ALLOW_ALL_GRANT_KEY,
+	isAllowedDomain,
+	parseDomainAccessGrants,
+	WEB_SEARCH_GRANT_KEY,
+} from '@n8n/api-types';
 
 /**
  * Tracks domain-level approvals for the current thread.
  *
  * Two tiers of approval:
- * - **Persistent** (thread-level): `approveDomain(host)` and `approveAllDomains()`.
- *   These survive across runs within the same thread.
+ * - **Persistent** (thread-level): `approveDomain(host)`, `approveAllDomains()` and
+ *   `approveWebSearch()`. These are written through to the caller's `persistGrant`
+ *   callback (backed by `instance_ai_thread_grants`) so they survive restart and are
+ *   visible across mains. The tracker is seeded from the persisted grant keys at
+ *   construction via `grantedKeys`.
  * - **Transient** (run-level): `approveOnce(runId, host)`.
  *   These are scoped to a single run and cleared with `clearRun(runId)`.
  *
@@ -23,9 +32,9 @@ export interface DomainAccessTracker {
 	/** Check whether a host is allowed. Optionally pass a runId to also check transient approvals. */
 	isHostAllowed(host: string, runId?: string): boolean;
 	/** Persistently approve an exact hostname for this thread. */
-	approveDomain(host: string): void;
+	approveDomain(host: string): Promise<void>;
 	/** Approve all domains for this thread (blanket allow). */
-	approveAllDomains(): void;
+	approveAllDomains(): Promise<void>;
 	/** Whether all domains are approved. */
 	isAllDomainsApproved(): boolean;
 	/** Grant a one-time transient approval scoped to a specific run. */
@@ -36,17 +45,29 @@ export interface DomainAccessTracker {
 	/** Check whether web-search is allowed. Optionally pass a runId for transient approvals. */
 	isWebSearchAllowed(runId?: string): boolean;
 	/** Persistently approve web-search for this thread. */
-	approveWebSearch(): void;
+	approveWebSearch(): Promise<void>;
 	/** Grant a one-time transient web-search approval scoped to a specific run. */
 	approveWebSearchOnce(runId: string): void;
 }
 
-export function createDomainAccessTracker(): DomainAccessTracker {
-	const approvedDomains = new Set<string>();
-	const transientApprovals = new Map<string, Set<string>>(); // runId → Set<host>
-	let allDomainsApproved = false;
+export interface DomainAccessTrackerOptions {
+	/** Persisted grant keys to seed persistent approvals from (e.g. loaded per run). */
+	grantedKeys?: ReadonlySet<string>;
+	/** Write-through callback invoked when a persistent approval is granted. */
+	persistGrant?: (key: string) => Promise<void>;
+}
 
-	let webSearchApproved = false;
+export function createDomainAccessTracker(
+	options: DomainAccessTrackerOptions = {},
+): DomainAccessTracker {
+	const { persistGrant } = options;
+	const seed = parseDomainAccessGrants(options.grantedKeys ?? new Set());
+
+	const approvedDomains = seed.approvedDomains;
+	const transientApprovals = new Map<string, Set<string>>(); // runId → Set<host>
+	let allDomainsApproved = seed.allDomainsApproved;
+
+	let webSearchApproved = seed.webSearchApproved;
 	const transientWebSearchApprovals = new Set<string>(); // Set<runId>
 
 	return {
@@ -61,12 +82,14 @@ export function createDomainAccessTracker(): DomainAccessTracker {
 			return false;
 		},
 
-		approveDomain(host: string): void {
+		async approveDomain(host: string): Promise<void> {
 			approvedDomains.add(host);
+			await persistGrant?.(buildFetchUrlGrantKey(host));
 		},
 
-		approveAllDomains(): void {
+		async approveAllDomains(): Promise<void> {
 			allDomainsApproved = true;
+			await persistGrant?.(FETCH_URL_ALLOW_ALL_GRANT_KEY);
 		},
 
 		isAllDomainsApproved(): boolean {
@@ -93,8 +116,9 @@ export function createDomainAccessTracker(): DomainAccessTracker {
 			return false;
 		},
 
-		approveWebSearch(): void {
+		async approveWebSearch(): Promise<void> {
 			webSearchApproved = true;
+			await persistGrant?.(WEB_SEARCH_GRANT_KEY);
 		},
 
 		approveWebSearchOnce(runId: string): void {

--- a/packages/@n8n/instance-ai/src/domain-access/domain-gating.ts
+++ b/packages/@n8n/instance-ai/src/domain-access/domain-gating.ts
@@ -158,12 +158,12 @@ export function checkWebSearchAccess(options: {
  * Process the user's domain-level decision from resume data.
  * Updates the tracker state and returns whether the tool should proceed.
  */
-export function applyDomainAccessResume(options: {
+export async function applyDomainAccessResume(options: {
 	resumeData: { approved: boolean; domainAccessAction?: string };
 	host: string;
 	tracker?: DomainAccessTracker;
 	runId?: string;
-}): { proceed: boolean } {
+}): Promise<{ proceed: boolean }> {
 	const { resumeData, host, tracker, runId } = options;
 
 	if (!resumeData.approved) {
@@ -175,10 +175,10 @@ export function applyDomainAccessResume(options: {
 	if (tracker) {
 		switch (action) {
 			case 'allow_domain':
-				tracker.approveDomain(host);
+				await tracker.approveDomain(host);
 				break;
 			case 'allow_all':
-				tracker.approveAllDomains();
+				await tracker.approveAllDomains();
 				break;
 			case 'allow_once':
 			default:
@@ -200,11 +200,11 @@ export function applyDomainAccessResume(options: {
  *   - allow_domain → persistent (this thread)
  *   - allow_all   → persistent (no broader scope makes sense for search)
  */
-export function applyWebSearchAccessResume(options: {
+export async function applyWebSearchAccessResume(options: {
 	resumeData: { approved: boolean; domainAccessAction?: string };
 	tracker?: DomainAccessTracker;
 	runId?: string;
-}): { proceed: boolean } {
+}): Promise<{ proceed: boolean }> {
 	const { resumeData, tracker, runId } = options;
 
 	if (!resumeData.approved) {
@@ -217,7 +217,7 @@ export function applyWebSearchAccessResume(options: {
 		switch (action) {
 			case 'allow_domain':
 			case 'allow_all':
-				tracker.approveWebSearch();
+				await tracker.approveWebSearch();
 				break;
 			case 'allow_once':
 			default:

--- a/packages/@n8n/instance-ai/src/tools/research.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/research.tool.ts
@@ -97,7 +97,7 @@ async function handleWebSearch(
 
 	// ── Resume path: apply user's decision ─────────────────────────
 	if (resumeData !== undefined && resumeData !== null) {
-		const { proceed } = applyWebSearchAccessResume({
+		const { proceed } = await applyWebSearchAccessResume({
 			resumeData,
 			tracker: context.domainAccessTracker,
 			runId: context.runId,
@@ -164,7 +164,7 @@ async function handleFetchUrl(
 		} catch {
 			host = input.url;
 		}
-		const { proceed } = applyDomainAccessResume({
+		const { proceed } = await applyDomainAccessResume({
 			resumeData,
 			host,
 			tracker: context.domainAccessTracker,

--- a/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
+++ b/packages/cli/src/modules/instance-ai/browser/browser-local-mcp-server.ts
@@ -114,7 +114,7 @@ export class BrowserLocalMcpServer implements LocalMcpServer {
 		if (typeof confirmation === 'string') {
 			switch (confirmation) {
 				case 'allowForSession':
-					gate.tracker.approveDomain(host);
+					await gate.tracker.approveDomain(host);
 					return undefined;
 				case 'allowOnce':
 					gate.tracker.approveOnce(gate.runId, host);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1782,12 +1782,6 @@ export class InstanceAiService {
 			context.branchReadOnly = true;
 		}
 
-		let domainTracker = this.domainAccessTrackersByThread.get(threadId);
-		if (!domainTracker) {
-			domainTracker = createDomainAccessTracker();
-			this.domainAccessTrackersByThread.set(threadId, domainTracker);
-		}
-		context.domainAccessTracker = domainTracker;
 		context.runId = runId;
 
 		// Per-user, thread-level "always allow" grants are persisted in the DB so they survive
@@ -1797,10 +1791,22 @@ export class InstanceAiService {
 		// run — the next run reloads it from the DB anyway.
 		const sessionGrants = await this.loadThreadSessionGrants(threadId, user.id);
 		context.sessionApprovedToolKeys = sessionGrants;
-		context.grantSessionToolApproval = async (key: string) => {
+		const grantSessionToolApproval = async (key: string) => {
 			await this.persistThreadSessionGrant(threadId, user.id, key);
 			sessionGrants.add(key);
 		};
+		context.grantSessionToolApproval = grantSessionToolApproval;
+
+		// Domain-access approvals are stored as grant keys in `instance_ai_thread_grants` (via
+		// the same load/persist path as above), so they survive restart and are visible
+		// cross-main. Recreate the tracker per run seeded from the freshly loaded grants;
+		// transient (allow_once) approvals are run-scoped and don't carry across runs.
+		const domainTracker = createDomainAccessTracker({
+			grantedKeys: sessionGrants,
+			persistGrant: grantSessionToolApproval,
+		});
+		this.domainAccessTrackersByThread.set(threadId, domainTracker);
+		context.domainAccessTracker = domainTracker;
 		if (this.isRunDebugEnabled()) {
 			context.recordWorkflowCodeSnapshot = (snapshot) => {
 				this.runDebugBuffer.ensure(runId, threadId);


### PR DESCRIPTION
## Summary

Domain-access approvals in Instance AI (allowed hosts, "allow all", and web search) were tracked purely in process memory by `DomainAccessTracker`. As a result they were:

- **Lost on restart** — every approved host had to be re-approved on the next fetch.
- **Invisible cross-main** — in multi-main without sticky routing, a host approved on one main was unknown to another, so the user was re-prompted.
- **Lost on thread reopen** — reopening a thread later re-prompted for already-approved hosts.

This persists those approvals as grant keys in the existing `instance_ai_thread_grants` table (introduced in INS-414, whose entity was explicitly designed to host other gated actions). It reuses the same per-run load / write-through path already used for `executions` session grants, so approvals now survive restart and are visible cross-main — **no migration required**.

Grant keys mirror the research tool's action names, so a persisted row names the exact action the user approved:

| Approval | Grant key |
|---|---|
| Allow a host | `fetch-url:<host>` |
| Allow all hosts | `fetch-url:*` |
| Allow web search | `web-search` |

Transient "allow once" approvals stay in memory — they are scoped to a single run that dies with the process anyway.

### Notable design choices
- **Load once per run** (matching existing executions-grant behavior) rather than re-reading on every `isHostAllowed` check as the original ticket suggested — simpler and consistent. Finer cross-main mid-run freshness can be added later if ever needed.
- **Per-user scoping** — approvals are keyed by `(threadId, userId)` like executions grants, so a future shared thread won't leak one participant's approval.
- Host is derived from `URL.hostname` (protocol/port stripped) on both the write and check paths, so keys stay consistent and are port-agnostic.

## How to test

1. In an Instance AI thread, ask the agent to fetch a non-allowlisted URL and approve **"always allow for this domain"**.
2. Restart the server (or route to a second main) and fetch the same host again → **no re-prompt**.
3. Repeat for **"allow all"** and **web search**.
4. Confirm **"allow once"** still re-prompts on a new run.

Automated coverage: `parseDomainAccessGrants`/builders (api-types), tracker seeding + write-through (instance-ai), async resume helpers, and the existing service/repository suites all pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33454">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

