### PR TITLE
fix(core): Bound Instance AI checkpoint growth and enforce confirmation expiry (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -148,6 +148,10 @@ export class InstanceAiConfig {
 	@Env('N8N_INSTANCE_AI_SNAPSHOT_RETENTION')
 	snapshotRetention: number = 24 * Time.hours.toMilliseconds;
 
+	/** Retention period in milliseconds for expired checkpoint tombstones before they are hard-deleted. Must exceed snapshotRetention. 0 = never hard-delete. */
+	@Env('N8N_INSTANCE_AI_CHECKPOINT_GC_RETENTION')
+	checkpointGcRetention: number = 7 * Time.days.toMilliseconds;
+
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
 	confirmationTimeout: number = 24 * Time.hours.toMilliseconds;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -340,6 +340,7 @@ describe('GlobalConfig', () => {
 			threadTtlDays: 90,
 			pruneInterval: 3_600_000,
 			snapshotRetention: 86_400_000,
+			checkpointGcRetention: 604_800_000,
 			confirmationTimeout: 86_400_000,
 			outputRedactionEnabled: true,
 			outputRedactionSecrets: true,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -456,12 +456,14 @@ type CheckpointPruneServiceInternals = {
 	scheduleCheckpointPrune: MockedFunction<(delayMs?: number) => void>;
 	checkpointStore: {
 		markExpiredOlderThan: MockedFunction<(olderThan: Date) => Promise<number>>;
+		hardDeleteExpiredOlderThan: MockedFunction<(olderThan: Date) => Promise<number>>;
 	};
 	checkpointPruneTimer?: NodeJS.Timeout;
 	checkpointPruningStopped: boolean;
 	instanceAiConfig: {
 		pruneInterval: number;
 		snapshotRetention: number;
+		checkpointGcRetention: number;
 	};
 	logger: { info: Mock; debug: Mock; warn: Mock };
 };
@@ -477,11 +479,13 @@ function createCheckpointPruneService(): CheckpointPruneServiceInternals {
 	service.pruneExpiredThreads = vi.fn(async () => undefined);
 	service.checkpointStore = {
 		markExpiredOlderThan: vi.fn(async (_olderThan: Date) => 0),
+		hardDeleteExpiredOlderThan: vi.fn(async (_olderThan: Date) => 0),
 	};
 	service.checkpointPruningStopped = true;
 	service.instanceAiConfig = {
 		pruneInterval: 60 * 60 * 1000,
-		snapshotRetention: 7 * 24 * 60 * 60 * 1000,
+		snapshotRetention: 24 * 60 * 60 * 1000,
+		checkpointGcRetention: 7 * 24 * 60 * 60 * 1000,
 	};
 	service.logger = {
 		info: vi.fn(),
@@ -1269,12 +1273,42 @@ describe('InstanceAiService — scheduled pruning', () => {
 
 		await service.runScheduledPrune(now);
 
+		// snapshotRetention = 24h → tombstone anything untouched since 05-12
 		expect(service.checkpointStore.markExpiredOlderThan).toHaveBeenCalledWith(
+			new Date('2026-05-12T12:00:00.000Z'),
+		);
+		// checkpointGcRetention = 7d → hard-delete tombstones expired before 05-06
+		expect(service.checkpointStore.hardDeleteExpiredOlderThan).toHaveBeenCalledWith(
 			new Date('2026-05-06T12:00:00.000Z'),
 		);
 		expect(service.suspendedThreads.pruneStalePendingConfirmations).toHaveBeenCalledWith(now);
 		expect(service.pruneExpiredThreads).toHaveBeenCalled();
 		expect(service.scheduleCheckpointPrune).toHaveBeenCalledWith();
+	});
+
+	it('skips hard-deleting tombstones when the GC retention is disabled', async () => {
+		const service = createCheckpointPruneService();
+		service.instanceAiConfig.checkpointGcRetention = 0;
+
+		await service.runScheduledPrune(new Date('2026-05-13T12:00:00.000Z').getTime());
+
+		expect(service.checkpointStore.hardDeleteExpiredOlderThan).not.toHaveBeenCalled();
+		// The rest of the cycle still runs.
+		expect(service.checkpointStore.markExpiredOlderThan).toHaveBeenCalled();
+		expect(service.scheduleCheckpointPrune).toHaveBeenCalledWith();
+	});
+
+	it('continues the prune cycle when hard-deleting tombstones fails', async () => {
+		const service = createCheckpointPruneService();
+		service.checkpointStore.hardDeleteExpiredOlderThan.mockRejectedValueOnce(new Error('db down'));
+
+		await service.runScheduledPrune(new Date('2026-05-13T12:00:00.000Z').getTime());
+
+		// A GC failure is swallowed and never forces the short retry cadence.
+		expect(service.suspendedThreads.pruneStalePendingConfirmations).toHaveBeenCalled();
+		expect(service.pruneExpiredThreads).toHaveBeenCalled();
+		expect(service.scheduleCheckpointPrune).toHaveBeenCalledWith();
+		expect(service.logger.warn).toHaveBeenCalled();
 	});
 
 	it('starts checkpoint pruning when configured', () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1480,6 +1480,9 @@ type ResolveConfirmationServiceInternals = {
 	suspendedThreads: {
 		dropPendingConfirmation: Mock;
 	};
+	pendingConfirmationRepo: {
+		isPastExpiry: Mock<(...args: [string, Date]) => Promise<boolean>>;
+	};
 	logger: { debug: Mock; warn: Mock; error: Mock; info: Mock };
 };
 
@@ -1495,6 +1498,9 @@ function createResolveConfirmationService(): ResolveConfirmationServiceInternals
 		getActiveRunId: vi.fn(),
 		findSuspendedByRequestId: vi.fn(),
 		rejectPendingConfirmation: vi.fn(),
+	};
+	service.pendingConfirmationRepo = {
+		isPastExpiry: vi.fn(async () => false),
 	};
 	service.resumeSuspendedRun = vi.fn(async () => null);
 	service.suspendedRunRestorer = {
@@ -1706,6 +1712,44 @@ describe('InstanceAiService — resolveConfirmation', () => {
 		expect(service.runState.rejectPendingConfirmation).not.toHaveBeenCalled();
 		expect(service.cancelRun).not.toHaveBeenCalled();
 		expect(service.suspendedThreads.dropPendingConfirmation).toHaveBeenCalledWith('req-1');
+	});
+
+	it('refuses a click on a confirmation whose row is already past its expiry', async () => {
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.pendingConfirmationRepo.isPastExpiry.mockResolvedValue(true);
+		// A still-present in-memory entry must not be resolved once the row expired.
+		service.runState.getPendingConfirmation.mockReturnValue({
+			userId: 'user-1',
+			threadId: 'thread-1',
+		});
+
+		await expect(service.resolveConfirmation('user-1', 'req-1', approval)).rejects.toThrow(
+			/expired/i,
+		);
+
+		expect(service.pendingConfirmationRepo.isPastExpiry).toHaveBeenCalledWith(
+			'req-1',
+			expect.any(Date),
+		);
+		expect(service.runState.resolvePendingConfirmation).not.toHaveBeenCalled();
+		expect(service.suspendedRunRestorer.resolveOrphanedConfirmation).not.toHaveBeenCalled();
+	});
+
+	it('resolves normally when the row is not past its expiry', async () => {
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.pendingConfirmationRepo.isPastExpiry.mockResolvedValue(false);
+		service.runState.getPendingConfirmation.mockReturnValue({
+			userId: 'user-1',
+			threadId: 'thread-1',
+		});
+		service.runState.resolvePendingConfirmation.mockReturnValue(true);
+		service.runState.getActiveRunId.mockReturnValue('run-1');
+
+		const result = await service.resolveConfirmation('user-1', 'req-1', approval);
+
+		expect(result).toEqual({ ok: true, runId: 'run-1' });
 	});
 
 	it('delegates to the orphan-restoration path when no live run resumes', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1481,7 +1481,7 @@ type ResolveConfirmationServiceInternals = {
 		dropPendingConfirmation: Mock;
 	};
 	pendingConfirmationRepo: {
-		isPastExpiry: Mock<(...args: [string, Date]) => Promise<boolean>>;
+		isPastExpiry: Mock<(...args: [string, string, Date]) => Promise<boolean>>;
 	};
 	logger: { debug: Mock; warn: Mock; error: Mock; info: Mock };
 };
@@ -1730,6 +1730,7 @@ describe('InstanceAiService — resolveConfirmation', () => {
 
 		expect(service.pendingConfirmationRepo.isPastExpiry).toHaveBeenCalledWith(
 			'req-1',
+			'user-1',
 			expect.any(Date),
 		);
 		expect(service.runState.resolvePendingConfirmation).not.toHaveBeenCalled();

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -3862,9 +3862,11 @@ export class InstanceAiService {
 		// reach the in-memory fast path after the row's `expiresAt` but before the
 		// prune/liveness sweep drops it. The persisted row is the source of truth
 		// for expiry, so consult it first and refuse a stale click; the sweep still
-		// owns releasing the suspended run. One extra SELECT per click — the click
-		// path isn't hot.
-		if (await this.pendingConfirmationRepo.isPastExpiry(requestId, new Date())) {
+		// owns releasing the suspended run. Scoped by `freshUser.id` so another
+		// user's request ID falls through to the existing not-found handling
+		// rather than leaking an "expired" signal. One extra SELECT per click —
+		// the click path isn't hot.
+		if (await this.pendingConfirmationRepo.isPastExpiry(requestId, freshUser.id, new Date())) {
 			this.logger.debug('Rejecting expired confirmation', { requestId });
 			throw new UserError(CONFIRMATION_EXPIRED_MESSAGE);
 		}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -237,6 +237,9 @@ function isTelemetryConfigurableAgent(
 const INSTANCE_AI_CHECKPOINT_PRUNE_RETRY_MS = 30 * 1000;
 const WORKFLOW_SETUP_ROUTING_CLAIM_TTL_MS = 15 * 60 * 1000;
 
+const CONFIRMATION_EXPIRED_MESSAGE =
+	'This confirmation has expired. Send a new message to continue.';
+
 /**
  * Upper bound on how long `shutdown()` will wait for in-flight executeRun /
  * processResumedStream promises to drain after their abortControllers fire.
@@ -3853,6 +3856,17 @@ export class InstanceAiService {
 				requestId,
 			});
 			return null;
+		}
+
+		// Close the same-process window: a click on a pre-rendered card can still
+		// reach the in-memory fast path after the row's `expiresAt` but before the
+		// prune/liveness sweep drops it. The persisted row is the source of truth
+		// for expiry, so consult it first and refuse a stale click; the sweep still
+		// owns releasing the suspended run. One extra SELECT per click — the click
+		// path isn't hot.
+		if (await this.pendingConfirmationRepo.isPastExpiry(requestId, new Date())) {
+			this.logger.debug('Rejecting expired confirmation', { requestId });
+			throw new UserError(CONFIRMATION_EXPIRED_MESSAGE);
 		}
 
 		const pending = this.runState.getPendingConfirmation(requestId);

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1437,10 +1437,11 @@ export class InstanceAiService {
 
 	/**
 	 * One tick of the recurring leader prune cycle: expire stale checkpoints,
-	 * drop expired pending confirmations, and delete expired conversation
-	 * threads, then schedule the next run. A checkpoint failure reschedules
-	 * with a shorter retry delay; the confirmation and thread steps swallow
-	 * their own errors so they never disrupt the cycle.
+	 * hard-delete tombstones past the GC horizon, drop expired pending
+	 * confirmations, and delete expired conversation threads, then schedule the
+	 * next run. A checkpoint failure reschedules with a shorter retry delay; the
+	 * confirmation and thread steps swallow their own errors so they never
+	 * disrupt the cycle.
 	 */
 	private async runScheduledPrune(now = Date.now()): Promise<void> {
 		const olderThan = new Date(now - this.instanceAiConfig.snapshotRetention);
@@ -1452,6 +1453,7 @@ export class InstanceAiService {
 			} else {
 				this.logger.debug('No stale Instance AI checkpoints to expire');
 			}
+			await this.hardDeleteExpiredCheckpoints(now);
 			await this.suspendedThreads.pruneStalePendingConfirmations(now);
 			await this.pruneExpiredThreads();
 			this.scheduleCheckpointPrune();
@@ -1460,6 +1462,31 @@ export class InstanceAiService {
 				error: getErrorMessage(error),
 			});
 			this.scheduleCheckpointPrune(INSTANCE_AI_CHECKPOINT_PRUNE_RETRY_MS);
+		}
+	}
+
+	/**
+	 * Hard-delete expired checkpoint tombstones (`markExpiredOlderThan` releases
+	 * the blob but keeps the row so a stale resume gets a clear "expired" error;
+	 * this drops the row entirely once it's past the GC horizon so tombstones
+	 * don't grow unbounded). Has its own try/catch so a GC failure never forces
+	 * the checkpoint prune into its short retry cadence. No-op when
+	 * `checkpointGcRetention` is 0.
+	 */
+	private async hardDeleteExpiredCheckpoints(now: number): Promise<void> {
+		const retention = this.instanceAiConfig.checkpointGcRetention;
+		if (retention <= 0) return;
+
+		try {
+			const olderThan = new Date(now - retention);
+			const count = await this.checkpointStore.hardDeleteExpiredOlderThan(olderThan);
+			if (count > 0) {
+				this.logger.info('Hard-deleted expired Instance AI checkpoint tombstones', { count });
+			}
+		} catch (error: unknown) {
+			this.logger.warn('Failed to hard-delete expired Instance AI checkpoint tombstones', {
+				error: getErrorMessage(error),
+			});
 		}
 	}
 

--- a/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
@@ -130,20 +130,31 @@ describe('InstanceAiPendingConfirmationRepository.isPastExpiry', () => {
 		return { repo, countMock };
 	}
 
-	it('is true when a row exists with expiresAt in the past', async () => {
+	it('is true when the user owns a row with expiresAt in the past', async () => {
 		const now = new Date('2026-05-13T12:00:00.000Z');
 		const { repo, countMock } = buildRepoWithCount(1);
 
-		await expect(repo.isPastExpiry('req-1', now)).resolves.toBe(true);
-		// LessThan(now) excludes null expiresAt (timeout disabled) at the SQL layer.
+		await expect(repo.isPastExpiry('req-1', 'user-1', now)).resolves.toBe(true);
+		// Scoped by userId, and LessThan(now) excludes null expiresAt (timeout
+		// disabled) at the SQL layer.
 		const where = countMock.mock.calls[0][0]!.where;
-		expect(where).toMatchObject({ requestId: 'req-1' });
+		expect(where).toMatchObject({ requestId: 'req-1', userId: 'user-1' });
 		expect(where).toHaveProperty('expiresAt');
 	});
 
 	it('is false when no row is past its expiry', async () => {
 		const { repo } = buildRepoWithCount(0);
 
-		await expect(repo.isPastExpiry('req-1', new Date())).resolves.toBe(false);
+		await expect(repo.isPastExpiry('req-1', 'user-1', new Date())).resolves.toBe(false);
+	});
+
+	it('does not treat another user’s expired request as expired', async () => {
+		// The userId scope means the count query matches nothing for a request
+		// owned by someone else, so the caller falls through to its existing
+		// not-found/not-authorized handling instead of leaking an expired signal.
+		const { repo, countMock } = buildRepoWithCount(0);
+
+		await expect(repo.isPastExpiry('req-1', 'attacker-user', new Date())).resolves.toBe(false);
+		expect(countMock.mock.calls[0][0]!.where).toMatchObject({ userId: 'attacker-user' });
 	});
 });

--- a/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
@@ -119,3 +119,31 @@ describe('InstanceAiPendingConfirmationRepository.claim', () => {
 		expect(where).toHaveProperty('expiresAt');
 	});
 });
+
+describe('InstanceAiPendingConfirmationRepository.isPastExpiry', () => {
+	function buildRepoWithCount(countResult: number) {
+		const repo = Object.create(
+			InstanceAiPendingConfirmationRepository.prototype,
+		) as InstanceAiPendingConfirmationRepository;
+		const countMock = vi.fn(async (_opts?: { where: Record<string, unknown> }) => countResult);
+		Object.defineProperty(repo, 'count', { value: countMock, configurable: true });
+		return { repo, countMock };
+	}
+
+	it('is true when a row exists with expiresAt in the past', async () => {
+		const now = new Date('2026-05-13T12:00:00.000Z');
+		const { repo, countMock } = buildRepoWithCount(1);
+
+		await expect(repo.isPastExpiry('req-1', now)).resolves.toBe(true);
+		// LessThan(now) excludes null expiresAt (timeout disabled) at the SQL layer.
+		const where = countMock.mock.calls[0][0]!.where;
+		expect(where).toMatchObject({ requestId: 'req-1' });
+		expect(where).toHaveProperty('expiresAt');
+	});
+
+	it('is false when no row is past its expiry', async () => {
+		const { repo } = buildRepoWithCount(0);
+
+		await expect(repo.isPastExpiry('req-1', new Date())).resolves.toBe(false);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
@@ -65,6 +65,16 @@ export class InstanceAiPendingConfirmationRepository extends Repository<Instance
 		return result.affected ?? 0;
 	}
 
+	/**
+	 * True when a confirmation row exists and its `expiresAt` is already in the
+	 * past. Rows with a null `expiresAt` (timeout disabled) — and a missing row
+	 * — are not expired; the caller handles "not found" on its own path.
+	 */
+	async isPastExpiry(requestId: string, now: Date): Promise<boolean> {
+		const count = await this.count({ where: { requestId, expiresAt: LessThan(now) } });
+		return count > 0;
+	}
+
 	async findByThreadId(threadId: string): Promise<InstanceAiPendingConfirmation[]> {
 		return await this.find({ where: { threadId } });
 	}

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
@@ -66,12 +66,15 @@ export class InstanceAiPendingConfirmationRepository extends Repository<Instance
 	}
 
 	/**
-	 * True when a confirmation row exists and its `expiresAt` is already in the
-	 * past. Rows with a null `expiresAt` (timeout disabled) — and a missing row
-	 * — are not expired; the caller handles "not found" on its own path.
+	 * True when this user's confirmation row exists and its `expiresAt` is
+	 * already in the past. Scoped by `userId` — mirroring `claim` and the
+	 * in-memory path — so another user's request ID is treated as not-expired
+	 * here and left to the caller's existing not-found/not-authorized handling.
+	 * Rows with a null `expiresAt` (timeout disabled) — and a missing row — are
+	 * not expired.
 	 */
-	async isPastExpiry(requestId: string, now: Date): Promise<boolean> {
-		const count = await this.count({ where: { requestId, expiresAt: LessThan(now) } });
+	async isPastExpiry(requestId: string, userId: string, now: Date): Promise<boolean> {
+		const count = await this.count({ where: { requestId, userId, expiresAt: LessThan(now) } });
 		return count > 0;
 	}
 

--- a/packages/cli/src/modules/instance-ai/storage/__tests__/typeorm-agent-checkpoint-store.test.ts
+++ b/packages/cli/src/modules/instance-ai/storage/__tests__/typeorm-agent-checkpoint-store.test.ts
@@ -1,4 +1,5 @@
 import type { SerializableAgentState } from '@n8n/instance-ai';
+import { LessThan } from '@n8n/typeorm';
 import { UserError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -159,6 +160,15 @@ describe('TypeORMAgentCheckpointStore', () => {
 
 		await expect(store.deleteOlderThan(new Date(0))).resolves.toBe(7);
 		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('hard-deletes tombstones expired before the GC horizon', async () => {
+		checkpointRepo.delete.mockResolvedValueOnce({ affected: 3, raw: {} });
+
+		const olderThan = new Date('2026-05-01T00:00:00.000Z');
+		await expect(store.hardDeleteExpiredOlderThan(olderThan)).resolves.toBe(3);
+
+		expect(checkpointRepo.delete).toHaveBeenCalledWith({ expiredAt: LessThan(olderThan) });
 	});
 
 	describe('findSuspendedSubAgentResumeInfo', () => {


### PR DESCRIPTION
## Summary

Two of the three loose ends from [INS-198](https://linear.app/n8n/issue/INS-198) tracked in [INS-383](https://linear.app/n8n/issue/INS-383). (The third — removing the `persistUserMessageOnSuspend` workaround — is already resolved: the `@n8n/agents` SDK now flushes the turn on suspend natively via `persistTurnOnSuspend`.)

**1. Hard-delete expired checkpoint tombstones** (`7463cc5`)
The leader prune cycle only flipped stale checkpoints to tombstones (blob released, row kept so a stale resume gets a clear "expired" error) but never removed them, so tombstone rows grew unbounded. The existing `hardDeleteExpiredOlderThan` is now wired into the prune tick behind a longer horizon:
- mark expired at `snapshotRetention` (24h default)
- hard-delete tombstones past `checkpointGcRetention` (new `N8N_INSTANCE_AI_CHECKPOINT_GC_RETENTION`, 7d default, `0` disables)

The GC step has its own try/catch so a failure never forces the checkpoint prune into its short retry cadence.

**2. Enforce confirmation expiry on the click path** (`110530b`)
`resolveConfirmation` resolved an in-memory pending confirmation without consulting the persisted row's `expiresAt`, so a same-process click on a pre-rendered card could still succeed past expiry — until the prune/liveness sweep dropped it. It now consults the row's `expiresAt` (the source of truth, and multi-main-safe — same predicate `claim()` already uses) before the in-memory fast path and refuses a stale click. One extra SELECT per click; the click path isn't hot.

> Note: the expiry guard earns its keep only while the same-main in-memory fast path exists. If that fast path is later removed (routing every `/confirm` through the DB `claim` path, which already enforces expiry — relevant once #33296 lands), this guard can go with it.

## How to test

Backend-only, no UI change. Covered by unit tests:

```bash
cd packages/cli
pnpm test src/modules/instance-ai/storage/__tests__/typeorm-agent-checkpoint-store.test.ts \
          src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts \
          src/modules/instance-ai/__tests__/instance-ai.service.test.ts
```

- **#1**: prune tick calls `hardDeleteExpiredOlderThan` with the GC horizon, skips it when `checkpointGcRetention` is `0`, and swallows GC failures without disrupting the cycle.
- **#2**: a click on a confirmation whose row is past `expiresAt` is refused with a clear error and never resolves the in-memory entry.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-383

Follow-up to https://linear.app/n8n/issue/INS-198 (HITL state persistence to DB).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33456">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

