### PR TITLE
fix(core): Make agent execution project-scoped so published workflows in team projects can message agents

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -1,6 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { ExecutionsConfig, GlobalConfig, WorkflowsConfig } from '@n8n/config';
-import type { WorkflowEntity, User, Project, WorkflowHistory } from '@n8n/db';
+import type { WorkflowEntity, Project, WorkflowHistory } from '@n8n/db';
 import {
 	ExecutionRepository,
 	ExecutionDataRepository,
@@ -1050,7 +1050,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 		});
 
-		it('uses userId and projectId from additionalData when both are present', async () => {
+		it('uses projectId from additionalData when present', async () => {
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
 				userId: 'user-1',
 				projectId: 'project-1',
@@ -1060,13 +1060,11 @@ describe('WorkflowExecuteAdditionalData', () => {
 			await executeAgent(AGENT_ID, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual');
 
 			expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
-			expect(ownershipService.getPersonalProjectOwnerCached).not.toHaveBeenCalled();
 			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
 				THREAD_ID,
-				'user-1',
 				'project-1',
 				'user-1',
 				true,
@@ -1102,7 +1100,6 @@ describe('WorkflowExecuteAdditionalData', () => {
 				MESSAGE,
 				EXEC_ID,
 				THREAD_ID,
-				'user-1',
 				'project-1',
 				'user-1',
 				true,
@@ -1141,7 +1138,6 @@ describe('WorkflowExecuteAdditionalData', () => {
 				MESSAGE,
 				EXEC_ID,
 				THREAD_ID,
-				'user-1',
 				'project-1',
 				'user-1',
 				true,
@@ -1150,55 +1146,33 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 		});
 
-		it('backfills userId and projectId from the workflow owner when both are missing', async () => {
+		it('backfills projectId from the workflow owner when missing', async () => {
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				userId: undefined,
+				userId: 'user-1',
 				projectId: undefined,
 				workflowId: 'workflow-1',
 			});
 			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(
 				mock<Project>({ id: 'project-1' }),
 			);
-			ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(
-				mock<User>({ id: 'owner-1' }),
-			);
 
 			await executeAgent(AGENT_ID, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual');
 
 			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('workflow-1');
-			expect(ownershipService.getPersonalProjectOwnerCached).toHaveBeenCalledWith('project-1');
 			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
 				THREAD_ID,
-				'owner-1',
 				'project-1',
-				undefined,
+				'user-1',
 				true,
 				undefined,
 				undefined,
 			);
 		});
 
-		it('throws when userId is missing and the workflow has no personal-project owner', async () => {
-			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				userId: undefined,
-				projectId: undefined,
-				workflowId: 'workflow-1',
-			});
-			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(
-				mock<Project>({ id: 'project-1' }),
-			);
-			ownershipService.getPersonalProjectOwnerCached.mockResolvedValueOnce(null);
-
-			await expect(
-				executeAgent(AGENT_ID, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual'),
-			).rejects.toThrow('Cannot execute agent without a userId in additional data');
-			expect(agentExecutionOrchestratorService.executeForWorkflow).not.toHaveBeenCalled();
-		});
-
-		it('throws when userId is missing and no workflowId is available to resolve ownership', async () => {
+		it('throws when projectId is missing and no workflowId is available to resolve it', async () => {
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
 				userId: undefined,
 				projectId: undefined,
@@ -1207,8 +1181,37 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 			await expect(
 				executeAgent(AGENT_ID, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual'),
-			).rejects.toThrow('Cannot execute agent without a userId in additional data');
+			).rejects.toThrow(
+				'Cannot execute agent without a projectId or workflowId in additional data',
+			);
 			expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
+			expect(agentExecutionOrchestratorService.executeForWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('executes for trigger runs without any user', async () => {
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				userId: undefined,
+				projectId: undefined,
+				workflowId: 'workflow-1',
+			});
+			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce(
+				mock<Project>({ id: 'project-1' }),
+			);
+
+			await executeAgent(AGENT_ID, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'trigger');
+
+			expect(ownershipService.getPersonalProjectOwnerCached).not.toHaveBeenCalled();
+			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+				AGENT_ID,
+				MESSAGE,
+				EXEC_ID,
+				THREAD_ID,
+				'project-1',
+				undefined,
+				false,
+				undefined,
+				undefined,
+			);
 		});
 
 		it.each<WorkflowExecuteMode>(['manual', 'chat'])(
@@ -1228,7 +1231,6 @@ describe('WorkflowExecuteAdditionalData', () => {
 					MESSAGE,
 					EXEC_ID,
 					THREAD_ID,
-					'user-1',
 					'project-1',
 					'user-1',
 					true,
@@ -1263,7 +1265,6 @@ describe('WorkflowExecuteAdditionalData', () => {
 				MESSAGE,
 				EXEC_ID,
 				THREAD_ID,
-				'user-1',
 				'project-1',
 				'user-1',
 				false,

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -204,7 +204,6 @@ describe('AgentExecutionOrchestratorService', () => {
 		expect(runtimeCacheService.getRuntime).toHaveBeenCalledWith({
 			agentId,
 			projectId,
-			n8nUserId: userId,
 			integrationType: N8N_CHAT_INTEGRATION_TYPE,
 		});
 		expect(integrationMessageContextService.setLatest).toHaveBeenCalledWith(
@@ -499,7 +498,6 @@ describe('AgentExecutionOrchestratorService', () => {
 			'hello',
 			'execution-1',
 			'thread-1',
-			userId,
 			projectId,
 			userId,
 		);
@@ -556,7 +554,6 @@ describe('AgentExecutionOrchestratorService', () => {
 				'hello',
 				'execution-1',
 				'thread-1',
-				userId,
 				projectId,
 				userId,
 				false,
@@ -604,7 +601,6 @@ describe('AgentExecutionOrchestratorService', () => {
 				'hello',
 				'execution-1',
 				'thread-1',
-				userId,
 				projectId,
 				undefined,
 				undefined,
@@ -628,7 +624,6 @@ describe('AgentExecutionOrchestratorService', () => {
 				'hello',
 				'execution-1',
 				'thread-1',
-				userId,
 				projectId,
 				undefined,
 				undefined,
@@ -642,14 +637,7 @@ describe('AgentExecutionOrchestratorService', () => {
 		it('injects no tools without workflowContext', async () => {
 			const { service, toolFn } = setupRuntimeWithToolSpy();
 
-			await service.executeForWorkflow(
-				agentId,
-				'hello',
-				'execution-1',
-				'thread-1',
-				userId,
-				projectId,
-			);
+			await service.executeForWorkflow(agentId, 'hello', 'execution-1', 'thread-1', projectId);
 
 			expect(toolFn).not.toHaveBeenCalled();
 		});
@@ -667,7 +655,6 @@ describe('AgentExecutionOrchestratorService', () => {
 					'hello',
 					'execution-1',
 					'thread-1',
-					userId,
 					projectId,
 					undefined,
 					undefined,
@@ -699,7 +686,6 @@ describe('AgentExecutionOrchestratorService', () => {
 			'hello',
 			'execution-1',
 			'thread-1',
-			userId,
 			projectId,
 			userId,
 			false,

--- a/packages/cli/src/modules/agents/__tests__/agent-integrations.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-integrations.controller.test.ts
@@ -317,7 +317,6 @@ describe('AgentIntegrationsController integration credentials', () => {
 		expect(chatIntegrationService.connect).toHaveBeenCalledWith(
 			'agent-1',
 			integration,
-			'user-1',
 			'project-1',
 		);
 		expect(chatIntegrationService.broadcastIntegrationChange).toHaveBeenCalledWith(
@@ -429,7 +428,6 @@ describe('AgentIntegrationsController integration credentials', () => {
 		expect(chatIntegrationService.connect).toHaveBeenCalledWith(
 			'agent-1',
 			integration,
-			'user-1',
 			'project-1',
 		);
 		expect(chatIntegrationService.broadcastIntegrationChange).toHaveBeenCalledWith(

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
@@ -43,12 +43,6 @@ interface MockSandbox {
 	process: MockProcess;
 }
 
-async function* asyncSandboxes(...items: MockSandbox[]): AsyncIterableIterator<MockSandbox> {
-	for (const item of items) {
-		yield item;
-	}
-}
-
 class DaytonaNotFoundError extends Error {
 	constructor(message: string) {
 		super(message);
@@ -179,7 +173,6 @@ describe('AgentKnowledgeSandboxService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		daytonaInstances.length = 0;
-		listMock.mockReturnValue(asyncSandboxes());
 		createMock.mockResolvedValue(makeSandbox('started'));
 		getMock.mockRejectedValue(new DaytonaNotFoundError('not found'));
 	});
@@ -198,7 +191,7 @@ describe('AgentKnowledgeSandboxService', () => {
 			apiKey: 'test-key',
 		});
 		expect(getMock).toHaveBeenCalledWith(expectedName);
-		expect(getMock.mock.invocationCallOrder[0]).toBeLessThan(listMock.mock.invocationCallOrder[0]);
+		expect(listMock).not.toHaveBeenCalled();
 		expect(createMock).toHaveBeenCalledTimes(1);
 		const [params, options] = createMock.mock.calls[0];
 		expect(params.name).toBe(expectedName);
@@ -271,20 +264,6 @@ describe('AgentKnowledgeSandboxService', () => {
 		expect(sandbox.delete).toHaveBeenCalledWith(300);
 		expect(createMock).toHaveBeenCalledTimes(1);
 		expect(createMock.mock.calls[0][0].name).toBe(expectedName);
-	});
-
-	it('falls back to label scan for old random-name sandboxes', async () => {
-		const legacySandbox = makeSandbox('started', [expectedVolumeMount], {
-			name: 'agents-knowledgebase-legacy-random-name',
-		});
-		listMock.mockReturnValue(asyncSandboxes(legacySandbox));
-		const service = makeService();
-
-		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
-
-		expect(getMock).toHaveBeenCalledWith(buildExpectedSandboxName());
-		expect(listMock).toHaveBeenCalledTimes(1);
-		expect(createMock).not.toHaveBeenCalled();
 	});
 
 	it('creates a sandbox from configured snapshot', async () => {

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
@@ -8,6 +8,7 @@ import type { InstanceSettings } from 'n8n-core';
 
 import type { AiService } from '../../../services/ai.service';
 
+import type { AgentFile } from '../entities/agent-file.entity';
 import { AGENT_KNOWLEDGE_VOLUME_MOUNT_PATH } from '../agent-knowledge-storage';
 import {
 	AGENT_KNOWLEDGE_SANDBOX_NAME_PREFIX,
@@ -107,6 +108,8 @@ function makeService(
 	logger: Logger = mock<Logger>(),
 	aiService: AiService = makeAiService(),
 	instanceSettings: InstanceSettings = mock<InstanceSettings>({ instanceId }),
+	agentFileRepository: AgentFileRepository = mock<AgentFileRepository>(),
+	agentRepository: AgentRepository = mock<AgentRepository>(),
 ): AgentKnowledgeSandboxService {
 	return new AgentKnowledgeSandboxService(
 		{
@@ -124,9 +127,24 @@ function makeService(
 		logger,
 		aiService,
 		instanceSettings,
-		mock<AgentFileRepository>(),
-		mock<AgentRepository>(),
+		agentFileRepository,
+		agentRepository,
 	);
+}
+
+function makeAgentFile(overrides: Partial<AgentFile> = {}): AgentFile {
+	const fileName = overrides.fileName ?? 'file.txt';
+	return {
+		id: 'file-id',
+		agentId,
+		binaryDataId: `daytona-volume:${fileName}`,
+		fileName,
+		mimeType: 'text/plain',
+		fileSizeBytes: 100,
+		createdAt: new Date('2024-01-01T00:00:00.000Z'),
+		updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+		...overrides,
+	} as AgentFile;
 }
 
 function makeFilesystem(): MockFilesystem {
@@ -338,5 +356,81 @@ describe('AgentKnowledgeSandboxService', () => {
 			{ id: projectId },
 			expect.anything(),
 		);
+	});
+
+	describe('globKnowledgeFiles', () => {
+		const fixtureFiles = [
+			makeAgentFile({ id: 'file-alpha', fileName: 'alpha.pdf' }),
+			makeAgentFile({ id: 'file-bravo', fileName: 'bravo.pdf' }),
+			makeAgentFile({ id: 'file-charlie', fileName: 'charlie.txt' }),
+			makeAgentFile({ id: 'file-delta', fileName: 'delta.md' }),
+		];
+
+		function makeGlobService(): AgentKnowledgeSandboxService {
+			const agentFileRepository = mock<AgentFileRepository>();
+			agentFileRepository.findByAgentId.mockResolvedValue(fixtureFiles);
+			const agentRepository = mock<AgentRepository>();
+			agentRepository.existsBy.mockResolvedValue(true);
+			return makeService(
+				{},
+				mock<Logger>(),
+				makeAiService(),
+				mock<InstanceSettings>({ instanceId }),
+				agentFileRepository,
+				agentRepository,
+			);
+		}
+
+		it('lists all files with a catch-all pattern, sorted by display name', async () => {
+			const service = makeGlobService();
+
+			const result = await service.globKnowledgeFiles(projectId, agentId, { pattern: '*' });
+
+			expect(result.files.map((file) => file.displayName)).toEqual([
+				'alpha.pdf',
+				'bravo.pdf',
+				'charlie.txt',
+				'delta.md',
+			]);
+			expect(result.hasMore).toBe(false);
+		});
+
+		it('filters by extension pattern', async () => {
+			const service = makeGlobService();
+
+			const result = await service.globKnowledgeFiles(projectId, agentId, { pattern: '*.pdf' });
+
+			expect(result.files.map((file) => file.displayName)).toEqual(['alpha.pdf', 'bravo.pdf']);
+		});
+
+		it('pages with offset', async () => {
+			const service = makeGlobService();
+
+			const firstPage = await service.globKnowledgeFiles(projectId, agentId, {
+				pattern: '*',
+				limit: 2,
+				offset: 0,
+			});
+			expect(firstPage.files.map((file) => file.displayName)).toEqual(['alpha.pdf', 'bravo.pdf']);
+			expect(firstPage.offset).toBe(0);
+			expect(firstPage.hasMore).toBe(true);
+
+			const secondPage = await service.globKnowledgeFiles(projectId, agentId, {
+				pattern: '*',
+				limit: 2,
+				offset: 2,
+			});
+			expect(secondPage.files.map((file) => file.displayName)).toEqual(['charlie.txt', 'delta.md']);
+			expect(secondPage.offset).toBe(2);
+			expect(secondPage.hasMore).toBe(false);
+		});
+
+		it('still rejects unsafe patterns', async () => {
+			const service = makeGlobService();
+
+			await expect(
+				service.globKnowledgeFiles(projectId, agentId, { pattern: '../secrets' }),
+			).rejects.toThrow('Invalid knowledge file pattern');
+		});
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import type { Logger } from '@n8n/backend-common';
 import type { AgentsConfig } from '@n8n/config';
+import type { AiAssistantClient } from '@n8n_io/ai-assistant-sdk';
 import { createHash } from 'node:crypto';
 import { mock } from 'vitest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
@@ -84,7 +85,6 @@ vi.mock('@n8n/agents/sandbox', () => ({
 }));
 
 const volumeId = 'vol-1';
-const userId = 'user-1';
 const instanceId = 'instance-1';
 const projectId = 'project-1';
 const agentId = 'agent-1';
@@ -96,15 +96,7 @@ const expectedVolumeMount = {
 
 function buildExpectedSandboxName(): string {
 	const hash = createHash('sha256')
-		.update(
-			JSON.stringify({
-				instanceId,
-				projectId,
-				agentId,
-				ownerUserId: userId,
-				sandboxScopeId: userId,
-			}),
-		)
+		.update(JSON.stringify({ instanceId, projectId, agentId }))
 		.digest('hex')
 		.slice(0, 32);
 	return `${AGENT_KNOWLEDGE_SANDBOX_NAME_PREFIX}-${hash}`;
@@ -197,7 +189,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		const service = makeService({}, mock<Logger>(), aiService);
 		const expectedName = buildExpectedSandboxName();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(aiService.getClient).not.toHaveBeenCalled();
 		expect(daytonaInstances).toHaveLength(1);
@@ -215,8 +207,6 @@ describe('AgentKnowledgeSandboxService', () => {
 			'n8n-agents-knowledgebase': 'true',
 			'n8n-project-id': projectId,
 			'n8n-agent-id': agentId,
-			'n8n-user-id': userId,
-			'n8n-agents-sandbox-scope-id': userId,
 		});
 		expect(params.volumes).toEqual([expectedVolumeMount]);
 		expect(params.ephemeral).toBe(false);
@@ -228,7 +218,7 @@ describe('AgentKnowledgeSandboxService', () => {
 	it('forwards sandboxEphemeral config to Daytona create params', async () => {
 		const service = makeService({ sandboxEphemeral: true });
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(getMock).toHaveBeenCalledWith(buildExpectedSandboxName());
 		const [params] = createMock.mock.calls[0];
@@ -239,7 +229,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		const changedVolumeMount = { ...expectedVolumeMount, volumeId: 'vol-2' };
 		const service = makeService({ daytonaVolumeId: changedVolumeMount.volumeId });
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(getMock).toHaveBeenCalledWith(buildExpectedSandboxName());
 		const [params] = createMock.mock.calls[0];
@@ -252,7 +242,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		getMock.mockResolvedValue(sandbox);
 		const service = makeService();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(getMock).toHaveBeenCalledWith(buildExpectedSandboxName());
 		expect(listMock).not.toHaveBeenCalled();
@@ -264,7 +254,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		getMock.mockResolvedValue(sandbox);
 		const service = makeService();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(sandbox.start).toHaveBeenCalledWith(300);
 		expect(createMock).not.toHaveBeenCalled();
@@ -276,7 +266,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		const service = makeService();
 		const expectedName = buildExpectedSandboxName();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(sandbox.delete).toHaveBeenCalledWith(300);
 		expect(createMock).toHaveBeenCalledTimes(1);
@@ -290,7 +280,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		listMock.mockReturnValue(asyncSandboxes(legacySandbox));
 		const service = makeService();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(getMock).toHaveBeenCalledWith(buildExpectedSandboxName());
 		expect(listMock).toHaveBeenCalledTimes(1);
@@ -301,7 +291,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		const service = makeService({ sandboxSnapshot: 'n8n/agent-knowledge:1.2.3' });
 		const expectedName = buildExpectedSandboxName();
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(createMock).toHaveBeenCalledTimes(1);
 		const [params] = createMock.mock.calls[0];
@@ -320,7 +310,7 @@ describe('AgentKnowledgeSandboxService', () => {
 			.mockResolvedValueOnce(makeSandbox('started'));
 		const service = makeService({ sandboxSnapshot: 'n8n/agent-knowledge:missing' }, logger);
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		expect(createMock).toHaveBeenCalledTimes(2);
 		const [snapshotParams] = createMock.mock.calls[0];
@@ -342,10 +332,32 @@ describe('AgentKnowledgeSandboxService', () => {
 	it('ignores whitespace-only sandboxSnapshot', async () => {
 		const service = makeService({ sandboxSnapshot: '   ' });
 
-		await service.withKnowledgeFilesystem(projectId, agentId, userId, async () => {});
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
 
 		const [params] = createMock.mock.calls[0];
 		expect(params.image).toBe('daytonaio/sandbox:0.5.0');
 		expect(params.snapshot).toBeUndefined();
+	});
+
+	it('requests a proxy token scoped to the project id when the proxy is enabled', async () => {
+		const client = mock<AiAssistantClient>();
+		client.getSandboxProxyConfig.mockResolvedValue({ image: 'proxy-image' });
+		client.getBuilderApiProxyToken.mockResolvedValue({
+			accessToken: 'proxy-token',
+			tokenType: 'Bearer',
+		});
+		client.getSandboxProxyBaseUrl.mockReturnValue('https://sandbox-proxy.example');
+		const aiService = makeAiService({
+			isProxyEnabled: vi.fn().mockReturnValue(true),
+			getClient: vi.fn().mockResolvedValue(client),
+		});
+		const service = makeService({}, mock<Logger>(), aiService);
+
+		await service.withKnowledgeFilesystem(projectId, agentId, async () => {});
+
+		expect(client.getBuilderApiProxyToken).toHaveBeenCalledWith(
+			{ id: projectId },
+			expect.anything(),
+		);
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge.controller.test.ts
@@ -53,7 +53,7 @@ describe('AgentKnowledgeController route access scopes', () => {
 });
 
 describe('AgentKnowledgeController file uploads', () => {
-	it('passes the authenticated user id to file upload storage and clears runtime cache', async () => {
+	it('uploads files to storage and clears runtime cache', async () => {
 		const { controller, agentKnowledgeService, runtimeCacheService } = makeController();
 		const files = [{ path: '/tmp/uploaded-file' }];
 		const uploaded = [{ id: 'file-1', name: 'uploaded-file' }];
@@ -72,12 +72,7 @@ describe('AgentKnowledgeController file uploads', () => {
 			),
 		).resolves.toBe(uploaded);
 
-		expect(agentKnowledgeService.uploadFiles).toHaveBeenCalledWith(
-			'agent-1',
-			'project-1',
-			files,
-			'user-1',
-		);
+		expect(agentKnowledgeService.uploadFiles).toHaveBeenCalledWith('agent-1', 'project-1', files);
 		expect(runtimeCacheService.clearRuntimes).toHaveBeenCalledWith('agent-1');
 	});
 
@@ -112,7 +107,7 @@ describe('AgentKnowledgeController file uploads', () => {
 });
 
 describe('AgentKnowledgeController file deletion', () => {
-	it('passes the authenticated user id to file deletion and clears runtime cache', async () => {
+	it('deletes the file and clears runtime cache', async () => {
 		const { controller, agentKnowledgeService, runtimeCacheService } = makeController();
 
 		await expect(
@@ -128,12 +123,7 @@ describe('AgentKnowledgeController file deletion', () => {
 			),
 		).resolves.toEqual({ success: true });
 
-		expect(agentKnowledgeService.deleteFile).toHaveBeenCalledWith(
-			'agent-1',
-			'project-1',
-			'file-1',
-			'user-1',
-		);
+		expect(agentKnowledgeService.deleteFile).toHaveBeenCalledWith('agent-1', 'project-1', 'file-1');
 		expect(runtimeCacheService.clearRuntimes).toHaveBeenCalledWith('agent-1');
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge.service.test.ts
@@ -34,7 +34,6 @@ vi.mock('@n8n/ai-utilities', () => ({
 
 const agentId = 'agent-1';
 const projectId = 'project-1';
-const userId = 'user-1';
 
 function makeMulterFile(overrides: Partial<Express.Multer.File> = {}): Express.Multer.File {
 	return {
@@ -153,7 +152,7 @@ describe('AgentKnowledgeService', () => {
 		agentKnowledgeSandboxService = mock<AgentKnowledgeSandboxService>();
 		logger = mock<Logger>();
 		agentKnowledgeSandboxService.withKnowledgeFilesystem.mockImplementation(
-			async (_projectId, _agentId, _userId, operation) => await operation(filesystem),
+			async (_projectId, _agentId, operation) => await operation(filesystem),
 		);
 		service = new AgentKnowledgeService(
 			agentRepository,
@@ -172,27 +171,22 @@ describe('AgentKnowledgeService', () => {
 		await writeFile(textFilePath, 'hello world');
 		await writeFile(pdfFilePath, '%PDF-1.4');
 
-		const result = await service.uploadFiles(
-			agentId,
-			projectId,
-			[
-				makeMulterFile({
-					originalname: 'notes.txt',
-					mimetype: 'text/plain',
-					path: textFilePath,
-					size: 11,
-					buffer: undefined,
-				}),
-				makeMulterFile({
-					originalname: 'report.pdf',
-					mimetype: 'application/pdf',
-					path: pdfFilePath,
-					size: 8,
-					buffer: undefined,
-				}),
-			],
-			userId,
-		);
+		const result = await service.uploadFiles(agentId, projectId, [
+			makeMulterFile({
+				originalname: 'notes.txt',
+				mimetype: 'text/plain',
+				path: textFilePath,
+				size: 11,
+				buffer: undefined,
+			}),
+			makeMulterFile({
+				originalname: 'report.pdf',
+				mimetype: 'application/pdf',
+				path: pdfFilePath,
+				size: 8,
+				buffer: undefined,
+			}),
+		]);
 
 		expect(result).toEqual([
 			expect.objectContaining({
@@ -230,7 +224,7 @@ describe('AgentKnowledgeService', () => {
 		agentRepository.findByIdAndProjectId.mockResolvedValue({ id: agentId, projectId } as never);
 
 		await expect(
-			service.uploadFiles(agentId, projectId, [makeMulterFile({ originalname: '..' })], userId),
+			service.uploadFiles(agentId, projectId, [makeMulterFile({ originalname: '..' })]),
 		).rejects.toThrow('Invalid knowledge file name');
 
 		expect(agentFileRepository.all()).toEqual([]);
@@ -245,19 +239,14 @@ describe('AgentKnowledgeService', () => {
 		filesystem.uploadFiles = vi.fn().mockRejectedValue(new Error('volume write failed'));
 
 		await expect(
-			service.uploadFiles(
-				agentId,
-				projectId,
-				[
-					makeMulterFile({
-						originalname: 'notes.txt',
-						path: tempFilePath,
-						size: 11,
-						buffer: undefined,
-					}),
-				],
-				userId,
-			),
+			service.uploadFiles(agentId, projectId, [
+				makeMulterFile({
+					originalname: 'notes.txt',
+					path: tempFilePath,
+					size: 11,
+					buffer: undefined,
+				}),
+			]),
 		).rejects.toThrow('volume write failed');
 		expect(agentFileRepository.all()).toEqual([]);
 	});
@@ -277,19 +266,14 @@ describe('AgentKnowledgeService', () => {
 		await writeFile(tempFilePath, 'x');
 
 		await expect(
-			service.uploadFiles(
-				agentId,
-				projectId,
-				[
-					makeMulterFile({
-						originalname: 'notes.txt',
-						path: tempFilePath,
-						size: 1,
-						buffer: undefined,
-					}),
-				],
-				userId,
-			),
+			service.uploadFiles(agentId, projectId, [
+				makeMulterFile({
+					originalname: 'notes.txt',
+					path: tempFilePath,
+					size: 1,
+					buffer: undefined,
+				}),
+			]),
 		).resolves.toEqual([
 			expect.objectContaining({
 				agentId,
@@ -318,17 +302,12 @@ describe('AgentKnowledgeService', () => {
 		);
 
 		await expect(
-			service.uploadFiles(
-				agentId,
-				projectId,
-				[
-					makeMulterFile({
-						originalname: 'notes.txt',
-						size: 1,
-					}),
-				],
-				userId,
-			),
+			service.uploadFiles(agentId, projectId, [
+				makeMulterFile({
+					originalname: 'notes.txt',
+					size: 1,
+				}),
+			]),
 		).rejects.toThrow('Knowledge base limit reached');
 		expect(agentFileRepository.all()).toHaveLength(1);
 		expect(filesystem.uploadFileCalls).toEqual([]);
@@ -347,17 +326,12 @@ describe('AgentKnowledgeService', () => {
 		);
 
 		await expect(
-			service.uploadFiles(
-				agentId,
-				projectId,
-				[
-					makeMulterFile({
-						originalname: 'notes.txt',
-						size: 1,
-					}),
-				],
-				userId,
-			),
+			service.uploadFiles(agentId, projectId, [
+				makeMulterFile({
+					originalname: 'notes.txt',
+					size: 1,
+				}),
+			]),
 		).rejects.toThrow('Knowledge base limit reached');
 		expect(agentFileRepository.all()).toHaveLength(1);
 		expect(filesystem.uploadFileCalls).toEqual([]);
@@ -373,12 +347,11 @@ describe('AgentKnowledgeService', () => {
 			}),
 		);
 
-		await expect(service.deleteFile(agentId, projectId, 'file-1', userId)).resolves.toBeUndefined();
+		await expect(service.deleteFile(agentId, projectId, 'file-1')).resolves.toBeUndefined();
 		expect(agentFileRepository.all()).toEqual([]);
 		expect(agentKnowledgeSandboxService.withKnowledgeFilesystem).toHaveBeenCalledWith(
 			projectId,
 			agentId,
-			userId,
 			expect.any(Function),
 		);
 		expect(filesystem.deleteCalls).toEqual([
@@ -398,12 +371,11 @@ describe('AgentKnowledgeService', () => {
 			new Promise(() => {}) as never,
 		);
 
-		await expect(service.deleteFile(agentId, projectId, 'file-1', userId)).resolves.toBeUndefined();
+		await expect(service.deleteFile(agentId, projectId, 'file-1')).resolves.toBeUndefined();
 		expect(agentFileRepository.all()).toEqual([]);
 		expect(agentKnowledgeSandboxService.withKnowledgeFilesystem).toHaveBeenCalledWith(
 			projectId,
 			agentId,
-			userId,
 			expect.any(Function),
 		);
 	});
@@ -418,7 +390,7 @@ describe('AgentKnowledgeService', () => {
 		);
 		filesystem.deleteFile = vi.fn().mockRejectedValue(new Error('volume delete failed'));
 
-		await expect(service.deleteFile(agentId, projectId, 'file-1', userId)).resolves.toBeUndefined();
+		await expect(service.deleteFile(agentId, projectId, 'file-1')).resolves.toBeUndefined();
 		await Promise.resolve();
 		await Promise.resolve();
 
@@ -431,9 +403,7 @@ describe('AgentKnowledgeService', () => {
 	});
 
 	it('deletes scoped knowledge files in the background', async () => {
-		await expect(
-			service.deleteAllFilesForAgent(projectId, agentId, userId),
-		).resolves.toBeUndefined();
+		await expect(service.deleteAllFilesForAgent(projectId, agentId)).resolves.toBeUndefined();
 
 		expect(filesystem.deleteCalls).toEqual([{ filePath: KNOWLEDGE_FILES_DIR, recursive: true }]);
 	});
@@ -457,14 +427,11 @@ describe('AgentKnowledgeService', () => {
 			new Promise(() => {}) as never,
 		);
 
-		await expect(
-			service.deleteAllFilesForAgent(projectId, agentId, userId),
-		).resolves.toBeUndefined();
+		await expect(service.deleteAllFilesForAgent(projectId, agentId)).resolves.toBeUndefined();
 		expect(agentFileRepository.all()).toEqual([]);
 		expect(agentKnowledgeSandboxService.withKnowledgeFilesystem).toHaveBeenCalledWith(
 			projectId,
 			agentId,
-			userId,
 			expect.any(Function),
 		);
 		expect(filesystem.deleteCalls).toEqual([]);

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-cache.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-cache.service.test.ts
@@ -3,7 +3,7 @@ import type { Agent as RuntimeAgent } from '@n8n/agents';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import { mock } from 'vitest-mock-extended';
-import { OperationalError, UserError } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
@@ -16,7 +16,6 @@ import type { ToolRegistry } from '../tool-registry';
 
 const agentId = 'agent-1';
 const projectId = 'project-1';
-const userId = 'user-1';
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
 	return {
@@ -75,8 +74,8 @@ describe('AgentRuntimeCacheService', () => {
 		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
 
-		const first = await service.getRuntime({ agentId, projectId, n8nUserId: userId });
-		const second = await service.getRuntime({ agentId, projectId, n8nUserId: userId });
+		const first = await service.getRuntime({ agentId, projectId });
+		const second = await service.getRuntime({ agentId, projectId });
 
 		expect(first).toBe(second);
 		expect(first.telemetryConfiguration).toEqual(
@@ -89,7 +88,6 @@ describe('AgentRuntimeCacheService', () => {
 		expect(reconstructionService.reconstructFromAgentEntity).toHaveBeenCalledWith(
 			agent,
 			expect.anything(),
-			userId,
 			undefined,
 		);
 	});
@@ -105,11 +103,10 @@ describe('AgentRuntimeCacheService', () => {
 			.mockResolvedValueOnce(chatRuntime)
 			.mockResolvedValueOnce(n8nChatRuntime);
 
-		const first = await service.getRuntime({ agentId, projectId, n8nUserId: userId });
+		const first = await service.getRuntime({ agentId, projectId });
 		const second = await service.getRuntime({
 			agentId,
 			projectId,
-			n8nUserId: userId,
 			integrationType: 'n8n_chat',
 		});
 
@@ -120,7 +117,6 @@ describe('AgentRuntimeCacheService', () => {
 			2,
 			agent,
 			expect.anything(),
-			userId,
 			'n8n_chat',
 		);
 	});
@@ -137,8 +133,8 @@ describe('AgentRuntimeCacheService', () => {
 		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 		reconstructionService.reconstructFromAgentEntity.mockReturnValue(pendingRuntime);
 
-		const first = service.getRuntime({ agentId, projectId, n8nUserId: userId });
-		const second = service.getRuntime({ agentId, projectId, n8nUserId: userId });
+		const first = service.getRuntime({ agentId, projectId });
+		const second = service.getRuntime({ agentId, projectId });
 
 		await Promise.resolve();
 		expect(reconstructionService.reconstructFromAgentEntity).toHaveBeenCalledTimes(1);
@@ -162,12 +158,12 @@ describe('AgentRuntimeCacheService', () => {
 
 		await expect(
 			Promise.all([
-				service.getRuntime({ agentId, projectId, n8nUserId: userId }),
-				service.getRuntime({ agentId, projectId, n8nUserId: userId }),
+				service.getRuntime({ agentId, projectId }),
+				service.getRuntime({ agentId, projectId }),
 			]),
 		).rejects.toThrow('compile failed');
 
-		await expect(service.getRuntime({ agentId, projectId, n8nUserId: userId })).resolves.toEqual(
+		await expect(service.getRuntime({ agentId, projectId })).resolves.toEqual(
 			expect.objectContaining({ agent: runtime.agent }),
 		);
 		expect(reconstructionService.reconstructFromAgentEntity).toHaveBeenCalledTimes(2);
@@ -188,12 +184,12 @@ describe('AgentRuntimeCacheService', () => {
 			.mockReturnValueOnce(staleRuntimeInitialization)
 			.mockResolvedValueOnce(freshRuntime);
 
-		const staleRequest = service.getRuntime({ agentId, projectId, n8nUserId: userId });
+		const staleRequest = service.getRuntime({ agentId, projectId });
 		await Promise.resolve();
 
 		service.clearRuntimes(agentId);
 
-		await expect(service.getRuntime({ agentId, projectId, n8nUserId: userId })).resolves.toEqual(
+		await expect(service.getRuntime({ agentId, projectId })).resolves.toEqual(
 			expect.objectContaining({ agent: freshRuntime.agent }),
 		);
 
@@ -202,13 +198,13 @@ describe('AgentRuntimeCacheService', () => {
 			`Agent ${agentId} runtime initialization was invalidated`,
 		);
 		expect(staleRuntime.agent.close).toHaveBeenCalled();
-		await expect(service.getRuntime({ agentId, projectId, n8nUserId: userId })).resolves.toEqual(
+		await expect(service.getRuntime({ agentId, projectId })).resolves.toEqual(
 			expect.objectContaining({ agent: freshRuntime.agent }),
 		);
 		expect(reconstructionService.reconstructFromAgentEntity).toHaveBeenCalledTimes(2);
 	});
 
-	it('loads published snapshot data and publishedById when running a published runtime', async () => {
+	it('loads published snapshot data when running a published runtime', async () => {
 		const { service, agentRepository, reconstructionService } = makeService();
 		const activeVersion = {
 			schema: {
@@ -243,21 +239,19 @@ describe('AgentRuntimeCacheService', () => {
 				skills: activeVersion.skills,
 			}),
 			expect.anything(),
-			'publisher-1',
 			'slack',
 		);
 	});
 
-	it('rejects missing agents, missing runtime owners, and unpublished runtime requests', async () => {
+	it('rejects missing agents and unpublished runtime requests', async () => {
 		const { service, agentRepository } = makeService();
 
 		agentRepository.findByIdAndProjectId.mockResolvedValue(null);
-		await expect(service.getRuntime({ agentId, projectId, n8nUserId: userId })).rejects.toThrow(
+		await expect(service.getRuntime({ agentId, projectId })).rejects.toThrow(
 			`Agent ${agentId} not found`,
 		);
 
 		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
-		await expect(service.getRuntime({ agentId, projectId })).rejects.toThrow(UserError);
 		await expect(
 			service.getRuntime({ agentId, projectId, usePublishedVersion: true }),
 		).rejects.toThrow(OperationalError);
@@ -271,7 +265,7 @@ describe('AgentRuntimeCacheService', () => {
 
 		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
 		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
-		await service.getRuntime({ agentId, projectId, n8nUserId: userId });
+		await service.getRuntime({ agentId, projectId });
 
 		service.clearRuntimes(agentId);
 

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
@@ -336,7 +336,6 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 						agentId: string;
 						projectId: string;
 						credentialProvider: unknown;
-						userId: string;
 						runtimeProfile: 'top-level';
 						config: AgentJsonConfig;
 						subAgentDelegation: {
@@ -352,7 +351,6 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 				agentId,
 				projectId,
 				credentialProvider: mock(),
-				userId: 'user-1',
 				runtimeProfile: 'top-level',
 				config: {
 					name: 'Test Agent',

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
@@ -13,7 +13,6 @@ import type {
 	User,
 	CredentialsEntity,
 	ProjectRelationRepository,
-	UserRepository,
 	WorkflowRepository,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
@@ -27,7 +26,6 @@ import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { AiService } from '@/services/ai.service';
 import type { UrlService } from '@/services/url.service';
 import type { Telemetry } from '@/telemetry';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { AgentConfigService } from '../agent-config.service';
 import { AgentCustomToolsService } from '../agent-custom-tools.service';
@@ -113,8 +111,6 @@ function makeRuntimeReconstructionService(
 		mock<AgentFileRepository>(),
 		mock<ActiveExecutions>(),
 		mock<WorkflowRepository>(),
-		mock<UserRepository>(),
-		mock<WorkflowFinderService>(),
 		mock<UrlService>(),
 		mock<N8NCheckpointStorage>(),
 		mock<AgentSecureRuntime>(),

--- a/packages/cli/src/modules/agents/__tests__/agent-sandbox.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-sandbox.controller.test.ts
@@ -26,10 +26,6 @@ describe('AgentSandboxController', () => {
 		});
 
 		expect(res.status).toHaveBeenCalledWith(202);
-		expect(agentKnowledgeService.warmSandbox).toHaveBeenCalledWith(
-			'agent-1',
-			'project-1',
-			'user-1',
-		);
+		expect(agentKnowledgeService.warmSandbox).toHaveBeenCalledWith('agent-1', 'project-1');
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-task.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-task.service.test.ts
@@ -1,7 +1,6 @@
 import type { Mock } from 'vitest';
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
-import type { ProjectRelationRepository } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 import type { InstanceSettings, ScheduledTaskManager } from 'n8n-core';
 
@@ -135,7 +134,6 @@ describe('AgentTaskService', () => {
 	let taskSnapshotRepository: ReturnType<typeof mock<AgentTaskSnapshotRepository>>;
 	let taskRunLockRepository: ReturnType<typeof mock<AgentTaskRunLockRepository>>;
 	let agentRepository: ReturnType<typeof mock<AgentRepository>>;
-	let projectRelationRepository: ReturnType<typeof mock<ProjectRelationRepository>>;
 	let agentExecutionOrchestratorService: ReturnType<typeof mock<AgentExecutionOrchestratorService>>;
 	let agentTaskScheduler: ReturnType<typeof mock<ScheduledTaskManager>>;
 	let publisher: ReturnType<typeof mock<Publisher>>;
@@ -155,7 +153,6 @@ describe('AgentTaskService', () => {
 			taskSnapshotRepository,
 			taskRunLockRepository,
 			agentRepository,
-			projectRelationRepository,
 			agentExecutionOrchestratorService,
 			mock<InstanceSettings>({ isLeader }),
 			agentTaskScheduler,
@@ -188,7 +185,6 @@ describe('AgentTaskService', () => {
 				async (cb: (m: typeof txManager) => Promise<unknown>) => await cb(txManager),
 			),
 		};
-		projectRelationRepository = mock<ProjectRelationRepository>();
 		agentExecutionOrchestratorService = mock<AgentExecutionOrchestratorService>();
 		agentTaskScheduler = mock<ScheduledTaskManager>();
 		agentTaskScheduler.register.mockReturnValue(true);
@@ -441,7 +437,6 @@ describe('AgentTaskService', () => {
 			);
 			(taskSnapshotRepository.findEnabledByVersionId as Mock).mockResolvedValue([makeSnapshot()]);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			taskRunLockRepository.acquire
 				.mockResolvedValueOnce(makeRunLock())
 				.mockResolvedValueOnce(null)
@@ -488,7 +483,6 @@ describe('AgentTaskService', () => {
 			);
 			(taskSnapshotRepository.findEnabledByVersionId as Mock).mockResolvedValue([makeSnapshot()]);
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			taskRunLockRepository.acquire
 				.mockResolvedValueOnce(makeRunLock({ holderId: 'old-leader' }))
 				.mockResolvedValueOnce(null);
@@ -597,7 +591,6 @@ describe('AgentTaskService', () => {
 		it('runs the published agent with the objective', async () => {
 			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 				emptyStream(),
 			);
@@ -624,7 +617,6 @@ describe('AgentTaskService', () => {
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(
 				makeSnapshot({ objective: 'Published objective' }),
 			);
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 				emptyStream(),
 			);
@@ -646,17 +638,6 @@ describe('AgentTaskService', () => {
 			expect(agentExecutionOrchestratorService.executeForTaskPublished).not.toHaveBeenCalled();
 		});
 
-		it('skips when no project member is available', async () => {
-			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
-			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue([]);
-
-			await runTaskOf(service, AGENT_ID, 'task-1');
-
-			expect(agentExecutionOrchestratorService.executeForTaskPublished).not.toHaveBeenCalled();
-			expect(taskRepository.update).not.toHaveBeenCalled();
-		});
-
 		it('skips when the published task snapshot is not enabled', async () => {
 			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(
@@ -671,7 +652,6 @@ describe('AgentTaskService', () => {
 		it('logs when execution throws', async () => {
 			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 				throwingStream(),
 			);
@@ -688,7 +668,6 @@ describe('AgentTaskService', () => {
 		it('allows a later scheduled run after a failed execution completes', async () => {
 			(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
 			(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-			(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 			(agentExecutionOrchestratorService.executeForTaskPublished as Mock)
 				.mockReturnValueOnce(throwingStream())
 				.mockReturnValueOnce(emptyStream());
@@ -712,7 +691,6 @@ describe('AgentTaskService', () => {
 				}
 				(agentRepository.findOne as Mock).mockResolvedValue(publishedAgentWithTask(true));
 				(taskSnapshotRepository.findByVersionAndTaskId as Mock).mockResolvedValue(makeSnapshot());
-				(projectRelationRepository.findUserIdsByProjectId as Mock).mockResolvedValue(['user-1']);
 				(agentExecutionOrchestratorService.executeForTaskPublished as Mock).mockReturnValue(
 					blockingStream(),
 				);

--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -30,7 +30,6 @@ import type { EphemeralNodeExecutor } from '@/node-execution';
 import type { OauthService } from '@/oauth/oauth.service';
 import type { AiService } from '@/services/ai.service';
 import type { UrlService } from '@/services/url.service';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
 import type { AgentKnowledgeSandboxService } from '../agent-knowledge-sandbox.service';
@@ -105,8 +104,6 @@ function makeReconstructionService(
 		mock<AgentFileRepository>(),
 		mock<ActiveExecutions>(),
 		mock<WorkflowRepository>(),
-		mock<UserRepository>(),
-		mock<WorkflowFinderService>(),
 		mock<UrlService>(),
 		overrides.n8nCheckpointStorage ?? mock<N8NCheckpointStorage>(),
 		secureRuntime,

--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -166,7 +166,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — MCP w
 		const { service, credentialProvider } = setup();
 		const entity = makeAgentEntity();
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		expect(buildMcpClientForServerMock).not.toHaveBeenCalled();
 	});
@@ -190,7 +190,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — MCP w
 			],
 		});
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		expect(buildMcpClientForServerMock).toHaveBeenCalledTimes(2);
 		expect(buildMcpClientForServerMock.mock.calls[0][0]).toMatchObject({ name: 'github' });
@@ -230,7 +230,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 		const { service, credentialProvider } = setup();
 		const entity = makeAgentEntity(undefined, subAgents !== undefined ? { subAgents } : {});
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		const toolNames = getInjectedToolNames();
 		expect(toolNames).toContain(DELEGATE_SUB_AGENT_TOOL_NAME);
@@ -293,7 +293,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 		const credentialProvider = mock<CredentialProvider>();
 		const service = makeReconstructionService();
 
-		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider);
 
 		expect(getInjectedDelegatePolicy()).toMatchObject({
 			maxChildren: SUB_AGENT_MAX_CHILDREN_DEFAULT,
@@ -305,7 +305,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 		const service = makeReconstructionService();
 		const entity = makeAgentEntity(undefined, { subAgents: { maxChildren: 2 } });
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		expect(getInjectedDelegatePolicy()).toMatchObject({
 			maxChildren: 2,
@@ -332,7 +332,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 			},
 		});
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		expect(getInjectedAvailableSubAgents()).toEqual([
 			{
@@ -364,7 +364,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 			},
 		});
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		expect(getInjectedInlineSubAgentModelsByDifficulty()).toEqual({
 			low: {
@@ -400,7 +400,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 			},
 		);
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		const resolveInlineSubAgentProviderTools = getInjectedResolveInlineSubAgentProviderTools();
 		expect(resolveInlineSubAgentProviderTools).toBeDefined();
@@ -417,7 +417,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — sub-a
 		const credentialProvider = mock<CredentialProvider>();
 		const service = makeReconstructionService();
 
-		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider);
 
 		expect(getInjectedInlineSubAgentModelsByDifficulty()).toBeUndefined();
 	});
@@ -450,12 +450,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — n8n c
 		// Agent entity with NO credential integrations connected.
 		const entity = makeAgentEntity();
 
-		await service.reconstructFromAgentEntity(
-			entity,
-			credentialProvider,
-			'user-1',
-			N8N_CHAT_INTEGRATION_TYPE,
-		);
+		await service.reconstructFromAgentEntity(entity, credentialProvider, N8N_CHAT_INTEGRATION_TYPE);
 
 		const toolNames = getInjectedToolNames();
 		expect(toolNames).toContain(N8N_CHAT_ACTION_TOOL_NAME);
@@ -467,7 +462,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — n8n c
 		// Same entity, reconstruct WITHOUT integrationType.
 		const entity = makeAgentEntity();
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(entity, credentialProvider);
 
 		const toolNames = getInjectedToolNames();
 		expect(toolNames).not.toContain(N8N_CHAT_ACTION_TOOL_NAME);
@@ -478,7 +473,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — n8n c
 		const { service, credentialProvider } = setup();
 		const entity = makeAgentEntity();
 
-		await service.reconstructFromAgentEntity(entity, credentialProvider, 'user-1', 'slack');
+		await service.reconstructFromAgentEntity(entity, credentialProvider, 'slack');
 
 		const toolNames = getInjectedToolNames();
 		expect(toolNames).not.toContain(N8N_CHAT_ACTION_TOOL_NAME);
@@ -503,7 +498,7 @@ describe('AgentRuntimeReconstructionService.reconstructFromAgentEntity — check
 		const credentialProvider = mock<CredentialProvider>();
 		const service = makeReconstructionService([], { n8nCheckpointStorage });
 
-		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider, 'user-1');
+		await service.reconstructFromAgentEntity(makeAgentEntity(), credentialProvider);
 
 		expect(n8nCheckpointStorage.getStorage).toHaveBeenCalledWith('agent-1');
 		expect(builtAgent.checkpoint).toHaveBeenCalledWith(scopedStorage);
@@ -535,7 +530,6 @@ describe('AgentRuntimeReconstructionService.reconstructFromResolvedSource — su
 			toolDescriptors: {},
 			toolCodeByName: {},
 			skills: {},
-			userId: 'user-1',
 			runtimeProfile: 'sub-agent',
 			parentAgentIdForDelegation: 'parent-agent-1',
 		});

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -119,13 +119,9 @@ describe('AgentsService', () => {
 
 		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
 
-		await expect(service.delete(agentId, projectId, 'user-1')).resolves.toBe(true);
+		await expect(service.delete(agentId, projectId)).resolves.toBe(true);
 
-		expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
-			projectId,
-			agentId,
-			'user-1',
-		);
+		expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(projectId, agentId);
 		expect(agentKnowledgeService.deleteAllFilesForAgent.mock.invocationCallOrder[0]).toBeLessThan(
 			agentRepository.remove.mock.invocationCallOrder[0],
 		);
@@ -151,7 +147,7 @@ describe('AgentsService', () => {
 		agentKnowledgeService.deleteAllFilesForAgent.mockRejectedValue(new Error('storage down'));
 		testChatService.clearAllTestChatMessages.mockRejectedValue(new Error('memory down'));
 
-		await expect(service.delete(agentId, projectId, 'user-1')).resolves.toBe(true);
+		await expect(service.delete(agentId, projectId)).resolves.toBe(true);
 		expect(agentRepository.remove).toHaveBeenCalledWith(agent);
 	});
 
@@ -159,7 +155,7 @@ describe('AgentsService', () => {
 		const { service, agentRepository } = makeService();
 		agentRepository.findByIdAndProjectId.mockResolvedValue(null);
 
-		await expect(service.delete(agentId, projectId, 'user-1')).resolves.toBe(false);
+		await expect(service.delete(agentId, projectId)).resolves.toBe(false);
 		expect(agentRepository.remove).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/workflow-tool-factory.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/workflow-tool-factory.test.ts
@@ -1,10 +1,9 @@
-import type { WorkflowRepository, UserRepository, WorkflowEntity } from '@n8n/db';
+import type { WorkflowRepository, WorkflowEntity } from '@n8n/db';
 import type { INode } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ActiveExecutions } from '@/active-executions';
 import type { WorkflowRunner } from '@/workflow-runner';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import {
 	normalizeTriggerInput,
@@ -83,29 +82,18 @@ function makeWorkflow(
 	} as unknown as WorkflowEntity;
 }
 
-function makeContext(workflowForUser: WorkflowEntity | null): WorkflowToolContext {
+function makeContext(foundWorkflow: WorkflowEntity | null): WorkflowToolContext {
 	const workflowRepository = mock<WorkflowRepository>();
-	const userRepository = mock<UserRepository>();
-	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowRunner = mock<WorkflowRunner>();
 	const activeExecutions = mock<ActiveExecutions>();
 
-	// findOne returns a candidate workflow
-	workflowRepository.findOne.mockResolvedValue(workflowForUser ?? makeWorkflow());
-
-	// userRepository returns a dummy user
-	userRepository.findOne.mockResolvedValue({ id: 'user-1' } as never);
-
-	// workflowFinderService returns the full workflow for the user
-	workflowFinderService.findWorkflowForUser.mockResolvedValue(workflowForUser);
+	workflowRepository.findOne.mockResolvedValue(foundWorkflow);
 
 	return {
 		workflowRepository,
 		workflowRunner,
 		activeExecutions,
-		workflowFinderService,
-		userRepository,
-		userId: 'user-1',
+		projectId: 'project-1',
 	};
 }
 
@@ -171,6 +159,27 @@ describe('resolveWorkflowTool() — metadata attachment', () => {
 			workflowId: 'wf-id-99',
 			workflowName: 'canonical-name',
 		});
+	});
+
+	it('scopes the workflow lookup to the project', async () => {
+		const workflow = makeWorkflow({ id: 'wf-scoped-1', name: 'Scoped Workflow' });
+		const context = makeContext(workflow);
+
+		await resolveWorkflowTool({ type: 'workflow', workflow: 'Scoped Workflow' }, context);
+
+		expect(context.workflowRepository.findOne).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { name: 'Scoped Workflow', shared: { projectId: 'project-1' } },
+			}),
+		);
+	});
+
+	it('throws when the workflow is not shared with the project', async () => {
+		const context = makeContext(null);
+
+		await expect(
+			resolveWorkflowTool({ type: 'workflow', workflow: 'Missing Workflow' }, context),
+		).rejects.toThrow('Workflow "Missing Workflow" not found');
 	});
 });
 

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -245,7 +245,6 @@ export class AgentExecutionOrchestratorService {
 		const runtime = await this.runtimeCacheService.getRuntime({
 			agentId,
 			projectId,
-			...(userId ? { n8nUserId: userId } : {}),
 			usePublishedVersion,
 			integrationType,
 		});
@@ -307,7 +306,6 @@ export class AgentExecutionOrchestratorService {
 		const runtime = await this.runtimeCacheService.getRuntime({
 			agentId,
 			projectId,
-			n8nUserId: userId,
 			integrationType: N8N_CHAT_INTEGRATION_TYPE,
 		});
 
@@ -409,7 +407,6 @@ export class AgentExecutionOrchestratorService {
 		const runtime = await this.runtimeCacheService.getRuntime({
 			agentId,
 			projectId,
-			n8nUserId: userId,
 		});
 
 		yield* this.streamChatResponse({
@@ -513,7 +510,6 @@ export class AgentExecutionOrchestratorService {
 	async compileIsolated(
 		agentEntity: Agent,
 		credentialProvider: CredentialProvider,
-		userId: string,
 		outputSchema?: JSONSchema7,
 		extraTools?: BuiltTool[],
 	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
@@ -526,7 +522,6 @@ export class AgentExecutionOrchestratorService {
 				await this.agentRuntimeReconstructionService.reconstructFromAgentEntity(
 					agentEntity,
 					credentialProvider,
-					userId,
 				);
 			// Apply a per-call structured-output schema before casting to runtime.
 			if (outputSchema) {
@@ -567,7 +562,6 @@ export class AgentExecutionOrchestratorService {
 		message: string,
 		executionId: string,
 		threadId: string,
-		userId: string,
 		projectId: string,
 		telemetryUserId?: string,
 		useDraftVersion?: boolean,
@@ -598,7 +592,6 @@ export class AgentExecutionOrchestratorService {
 		const compiled = await this.compileIsolated(
 			agentData,
 			credentialProvider,
-			userId,
 			outputSchema,
 			extraTools.length ? extraTools : undefined,
 		);

--- a/packages/cli/src/modules/agents/agent-integrations.controller.ts
+++ b/packages/cli/src/modules/agents/agent-integrations.controller.ts
@@ -84,7 +84,7 @@ export class AgentIntegrationsController {
 			undefined,
 			{ syncIntegrations: false },
 		);
-		await this.chatIntegrationService.connect(agentId, integration, req.user.id, agent.projectId);
+		await this.chatIntegrationService.connect(agentId, integration, agent.projectId);
 		await this.chatIntegrationService.broadcastIntegrationChange(agentId, integration, 'connect');
 
 		return {

--- a/packages/cli/src/modules/agents/agent-knowledge-retrieval.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-retrieval.ts
@@ -32,7 +32,6 @@ const searchPatternSchema = z.string().trim().min(1).max(MAX_SEARCH_PATTERN_LENG
 const globPatternSchema = z.string().trim().min(1).max(MAX_GLOB_PATTERN_LENGTH);
 const searchOutputModeSchema = z.enum(['content', 'files_with_matches', 'count']);
 const searchContextFlagSchema = z.number().int().min(0).max(MAX_SEARCH_CONTEXT_LINES);
-const broadExtensionGlobPattern = /^(?:\*\*\/)?\*\.[A-Za-z0-9][A-Za-z0-9.-]*$/;
 
 export const searchKnowledgeInputSchema = z
 	.object({
@@ -73,7 +72,7 @@ export const searchKnowledgeInputSchema = z
 export const globKnowledgeFilesInputSchema = z
 	.object({
 		pattern: globPatternSchema.describe(
-			'Specific simple filename pattern matched against uploaded knowledge file names, not file contents. Supports * and ? wildcards and is case-insensitive by default. Use when the user gives title or filename clues, e.g. *query*configuration* or *semantic*competition*. Do not use catch-all, extension-only, absolute, or placeholder patterns.',
+			'Filename pattern matched against uploaded knowledge file names, not file contents. Supports * and ? wildcards and is case-insensitive by default. Use `*` to list every uploaded file, `*.pdf` to filter by extension, or name fragments like `*bert*` when the user gives title or filename clues.',
 		),
 		limit: z
 			.number()
@@ -83,6 +82,14 @@ export const globKnowledgeFilesInputSchema = z
 			.optional()
 			.describe(
 				'Optional maximum number of candidate files to return. Use a small value such as 5-20 and make the pattern more specific if hasMore is true.',
+			),
+		offset: z
+			.number()
+			.int()
+			.min(0)
+			.optional()
+			.describe(
+				'Optional number of matching files to skip, for paging. When hasMore is true, call again with offset = previous offset + number of returned files.',
 			),
 		caseSensitive: z
 			.boolean()
@@ -104,14 +111,6 @@ export const globKnowledgeFilesInputSchema = z
 				code: z.ZodIssueCode.custom,
 				path: ['pattern'],
 				message: 'Invalid knowledge file pattern',
-			});
-		}
-
-		if (input.pattern === '*' || broadExtensionGlobPattern.test(input.pattern)) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				path: ['pattern'],
-				message: 'Use a narrower filename pattern than catch-all or extension-only patterns',
 			});
 		}
 	});
@@ -258,6 +257,7 @@ export type SearchKnowledgeResult =
 export interface GlobKnowledgeFilesResult {
 	files: AgentKnowledgeFileReference[];
 	limit: number;
+	offset: number;
 	hasMore: boolean;
 }
 

--- a/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
@@ -63,10 +63,6 @@ const MAX_SANDBOX_ERROR_DETAIL_CHARS = 2_000;
 const LABEL_KNOWLEDGE_BASE = 'n8n-agents-knowledgebase';
 const LABEL_PROJECT_ID = 'n8n-project-id';
 const LABEL_AGENT_ID = 'n8n-agent-id';
-const LABEL_USER_ID = 'n8n-user-id';
-const LABEL_SANDBOX_SCOPE_ID = 'n8n-agents-sandbox-scope-id';
-
-const SANDBOX_SCOPE_LABEL_MAX_LEN = 63;
 
 const SANDBOX_STATE_STARTED: SandboxState = 'started';
 
@@ -116,21 +112,14 @@ function emptySearchKnowledgeResult(
 	return { outputMode, matches: [], limit, hasMore: false, truncated: false };
 }
 
-function buildSandboxScopeKey(
-	projectId: string,
-	agentId: string,
-	ownerUserId: string,
-	sandboxScopeId: string,
-): string {
-	return `${projectId}:${agentId}:${ownerUserId}:${normalizeSandboxScopeLabel(sandboxScopeId)}`;
+function buildSandboxScopeKey(projectId: string, agentId: string): string {
+	return `${projectId}:${agentId}`;
 }
 
 function buildSandboxName(scope: {
 	instanceId: string;
 	projectId: string;
 	agentId: string;
-	ownerUserId: string;
-	sandboxScopeId: string;
 }): string {
 	const hash = createHash('sha256').update(JSON.stringify(scope)).digest('hex').slice(0, 32);
 	return `${AGENT_KNOWLEDGE_SANDBOX_NAME_PREFIX}-${hash}`;
@@ -141,39 +130,12 @@ function isDaytonaNotFoundError(error: unknown): boolean {
 	return error instanceof DaytonaNotFoundError;
 }
 
-function buildScopeLabels(
-	projectId: string,
-	agentId: string,
-	ownerUserId: string,
-	sandboxScopeId: string,
-): Record<string, string> {
+function buildScopeLabels(projectId: string, agentId: string): Record<string, string> {
 	return {
 		[LABEL_KNOWLEDGE_BASE]: 'true',
 		[LABEL_PROJECT_ID]: projectId,
 		[LABEL_AGENT_ID]: agentId,
-		[LABEL_USER_ID]: ownerUserId,
-		[LABEL_SANDBOX_SCOPE_ID]: normalizeSandboxScopeLabel(sandboxScopeId),
 	};
-}
-
-function normalizeSandboxScopeLabel(scopeId: string): string {
-	const normalized = scopeId
-		.replace(/[^A-Za-z0-9_.-]+/g, '-')
-		.replace(/^[-.]+|[-.]+$/g, '')
-		.replace(/[-.]+/g, '-');
-	const digest = createHash('sha256').update(scopeId).digest('hex').slice(0, 8);
-
-	if (!normalized) {
-		return `scope-${digest}`;
-	}
-
-	if (normalized.length <= SANDBOX_SCOPE_LABEL_MAX_LEN && normalized === scopeId) {
-		return normalized;
-	}
-
-	const prefixMaxLen = SANDBOX_SCOPE_LABEL_MAX_LEN - digest.length - 1;
-	const prefix = normalized.slice(0, prefixMaxLen).replace(/[-.]+$/, '');
-	return prefix ? `${prefix}-${digest}` : `scope-${digest}`;
 }
 
 function isVolumeMountFailure(error: unknown): boolean {
@@ -248,26 +210,24 @@ export class AgentKnowledgeSandboxService {
 	async withKnowledgeFilesystem<T>(
 		projectId: string,
 		agentId: string,
-		userId: string,
 		operation: (filesystem: AgentKnowledgeFilesystem) => Promise<T>,
 	): Promise<T> {
 		// Callers (AgentKnowledgeService) verify project↔agent ownership before
 		// invoking filesystem operations, so only configuration is asserted here.
 		this.assertKnowledgeConfiguration(projectId, agentId);
-		const sandbox = await this.acquireSandbox(projectId, agentId, userId);
+		const sandbox = await this.acquireSandbox(projectId, agentId);
 		const filesystem = this.createFilesystemAdapter(sandbox);
 		return await operation(filesystem);
 	}
 
-	async warmSandbox(projectId: string, agentId: string, userId: string): Promise<void> {
+	async warmSandbox(projectId: string, agentId: string): Promise<void> {
 		this.assertKnowledgeConfiguration(projectId, agentId);
-		await this.acquireSandbox(projectId, agentId, userId);
+		await this.acquireSandbox(projectId, agentId);
 	}
 
 	async searchKnowledge(
 		projectId: string,
 		agentId: string,
-		userId: string,
 		request: SearchKnowledgeRequest,
 	): Promise<SearchKnowledgeResult> {
 		const validatedRequest = parseSearchKnowledgeRequest(request);
@@ -292,7 +252,7 @@ export class AgentKnowledgeSandboxService {
 			validatedRequest,
 			scopedFiles.map((file) => file.file),
 		);
-		const result = await this.executeKnowledgeOperation(projectId, agentId, userId, command);
+		const result = await this.executeKnowledgeOperation(projectId, agentId, command);
 
 		assertKnowledgeFilesDirectoryAvailable('search', result);
 		if (result.exitCode === 1) {
@@ -345,7 +305,6 @@ export class AgentKnowledgeSandboxService {
 	async globKnowledgeFiles(
 		projectId: string,
 		agentId: string,
-		_userId: string,
 		request: GlobKnowledgeFilesRequest,
 	): Promise<GlobKnowledgeFilesResult> {
 		const validatedRequest = parseGlobKnowledgeFilesRequest(request);
@@ -368,14 +327,13 @@ export class AgentKnowledgeSandboxService {
 	async readKnowledge(
 		projectId: string,
 		agentId: string,
-		userId: string,
 		request: ReadKnowledgeRequest,
 	): Promise<ReadKnowledgeResult> {
 		const validatedRequest = parseReadKnowledgeRequest(request);
 		const references = await this.loadKnowledgeReferenceLookup(projectId, agentId);
 		const file = this.resolveRequiredFile(validatedRequest, references);
 		const command = buildReadKnowledgeCommand(file.file, validatedRequest);
-		const result = await this.executeKnowledgeOperation(projectId, agentId, userId, command);
+		const result = await this.executeKnowledgeOperation(projectId, agentId, command);
 
 		assertKnowledgeFilesDirectoryAvailable('read', result);
 		if (result.exitCode !== 0) {
@@ -395,12 +353,11 @@ export class AgentKnowledgeSandboxService {
 	private async executeKnowledgeOperation(
 		projectId: string,
 		agentId: string,
-		userId: string,
 		command: string,
 	): Promise<AgentKnowledgeCommandResult> {
 		const timeoutSeconds = Math.ceil(this.agentsConfig.sandboxTimeout / 1000);
 		const scopedCommand = buildScopedKnowledgeShellCommand(command);
-		const sandbox = await this.acquireSandbox(projectId, agentId, userId);
+		const sandbox = await this.acquireSandbox(projectId, agentId);
 		const result = await sandbox.process.executeCommand(
 			scopedCommand,
 			undefined,
@@ -506,48 +463,34 @@ export class AgentKnowledgeSandboxService {
 		};
 	}
 
-	private async acquireSandbox(
-		projectId: string,
-		agentId: string,
-		ownerUserId: string,
-		sandboxScopeId: string = ownerUserId,
-	): Promise<Sandbox> {
-		const cacheKey = buildSandboxScopeKey(projectId, agentId, ownerUserId, sandboxScopeId);
+	private async acquireSandbox(projectId: string, agentId: string): Promise<Sandbox> {
+		const cacheKey = buildSandboxScopeKey(projectId, agentId);
 		let pending = this.pendingSandboxAcquisitions.get(cacheKey);
 
 		if (!pending) {
-			pending = this.acquireSandboxFresh(projectId, agentId, ownerUserId, sandboxScopeId).finally(
-				() => {
-					this.pendingSandboxAcquisitions.delete(cacheKey);
-				},
-			);
+			pending = this.acquireSandboxFresh(projectId, agentId).finally(() => {
+				this.pendingSandboxAcquisitions.delete(cacheKey);
+			});
 			this.pendingSandboxAcquisitions.set(cacheKey, pending);
 		}
 
 		return await pending;
 	}
 
-	private async acquireSandboxFresh(
-		projectId: string,
-		agentId: string,
-		ownerUserId: string,
-		sandboxScopeId: string,
-	): Promise<Sandbox> {
+	private async acquireSandboxFresh(projectId: string, agentId: string): Promise<Sandbox> {
 		const { Daytona } = loadDaytona();
-		const connection = await this.resolveDaytonaConnection(ownerUserId);
+		const connection = await this.resolveDaytonaConnection(projectId);
 		const daytona = new Daytona({
 			apiUrl: connection.apiUrl,
 			apiKey: connection.apiKey,
 		});
-		const labels = buildScopeLabels(projectId, agentId, ownerUserId, sandboxScopeId);
+		const labels = buildScopeLabels(projectId, agentId);
 		const timeoutSeconds = Math.ceil(this.agentsConfig.sandboxTimeout / 1000);
 		const volumeMount = this.buildVolumeMount(projectId, agentId);
 		const name = buildSandboxName({
 			instanceId: this.instanceSettings.instanceId,
 			projectId,
 			agentId,
-			ownerUserId,
-			sandboxScopeId,
 		});
 
 		const sandboxByName = await this.resolveSandboxByName(
@@ -629,7 +572,9 @@ export class AgentKnowledgeSandboxService {
 		return sandbox;
 	}
 
-	private async resolveDaytonaConnection(userId: string): Promise<AgentKnowledgeDaytonaConnection> {
+	private async resolveDaytonaConnection(
+		projectId: string,
+	): Promise<AgentKnowledgeDaytonaConnection> {
 		const directImage = this.agentsConfig.sandboxImage || DEFAULT_SANDBOX_IMAGE;
 		const snapshot = this.agentsConfig.sandboxSnapshot.trim() || undefined;
 
@@ -645,7 +590,11 @@ export class AgentKnowledgeSandboxService {
 
 		const client = await this.aiService.getClient();
 		const proxyConfig = await client.getSandboxProxyConfig();
-		const token = await client.getBuilderApiProxyToken({ id: userId }, { userMessageId: nanoid() });
+		// The proxy does not enforce per-user identity; the project id is the stable scope for agents.
+		const token = await client.getBuilderApiProxyToken(
+			{ id: projectId },
+			{ userMessageId: nanoid() },
+		);
 
 		return {
 			mode: 'proxy',

--- a/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
@@ -75,7 +75,6 @@ const DEAD_SANDBOX_STATES = new Set<SandboxState>([
 
 const DEFAULT_SANDBOX_IMAGE = 'daytonaio/sandbox:0.5.0';
 const AUTO_STOP_INTERVAL_MINUTES = 5;
-const SANDBOX_LIST_PAGE_SIZE = 100;
 
 interface KnowledgeVolumeMount {
 	volumeId: string;
@@ -503,22 +502,6 @@ export class AgentKnowledgeSandboxService {
 		if (sandboxByName) {
 			this.logger.debug('Reused agent knowledge sandbox', { projectId, agentId, name });
 			return sandboxByName;
-		}
-
-		// list() is a cursor-paginated async iterator in the Daytona SDK; it transparently fetches
-		// subsequent pages as we iterate.
-		for await (const sandbox of daytona.list({ labels, limit: SANDBOX_LIST_PAGE_SIZE })) {
-			if (!isUsableSandbox(sandbox) || !hasMatchingVolumeMount(sandbox, volumeMount)) {
-				continue;
-			}
-
-			if (sandbox.state !== SANDBOX_STATE_STARTED) {
-				await sandbox.start(timeoutSeconds);
-			}
-
-			const reusableSandbox = await this.resolveReusableSandbox(daytona, sandbox, connection);
-			this.logger.debug('Reused agent knowledge sandbox', { projectId, agentId });
-			return reusableSandbox;
 		}
 
 		const image = connection.image;

--- a/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
@@ -309,17 +309,19 @@ export class AgentKnowledgeSandboxService {
 		const validatedRequest = parseGlobKnowledgeFilesRequest(request);
 		const references = await this.loadKnowledgeReferenceLookup(projectId, agentId);
 		const limit = validatedRequest.limit ?? DEFAULT_GLOB_FILES_LIMIT;
+		const offset = validatedRequest.offset ?? 0;
 
 		if (references.files.length === 0) {
-			return { files: [], limit, hasMore: false };
+			return { files: [], limit, offset, hasMore: false };
 		}
 
 		const matches = matchKnowledgeFilesByGlob(references.files, validatedRequest);
 
 		return {
-			files: matches.slice(0, limit),
+			files: matches.slice(offset, offset + limit),
 			limit,
-			hasMore: matches.length > limit,
+			offset,
+			hasMore: matches.length > offset + limit,
 		};
 	}
 
@@ -696,14 +698,15 @@ function matchKnowledgeFilesByGlob(
 	const regex = globPatternToRegExp(request.pattern, caseSensitive);
 	const patternTokens = tokenizeKnowledgeFilePattern(request.pattern, caseSensitive);
 	return files
-		.map((file, index) => ({ file, index }))
-		.filter(({ file }) => regex.test(file.file) || regex.test(file.displayName))
-		.map(({ file, index }) => ({
+		.filter((file) => regex.test(file.file) || regex.test(file.displayName))
+		.map((file) => ({
 			file,
-			index,
 			bucket: getKnowledgeFileMatchBucket(file, patternTokens, caseSensitive),
 		}))
-		.sort((left, right) => left.bucket - right.bucket || left.index - right.index)
+		.sort(
+			(left, right) =>
+				left.bucket - right.bucket || left.file.displayName.localeCompare(right.file.displayName),
+		)
 		.map(({ file }) => file);
 }
 

--- a/packages/cli/src/modules/agents/agent-knowledge.controller.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.controller.ts
@@ -70,12 +70,7 @@ export class AgentKnowledgeController {
 				throw new BadRequestError('No files uploaded');
 			}
 
-			const uploadedFiles = await this.agentKnowledgeService.uploadFiles(
-				agentId,
-				projectId,
-				files,
-				req.user.id,
-			);
+			const uploadedFiles = await this.agentKnowledgeService.uploadFiles(agentId, projectId, files);
 			this.runtimeCacheService.clearRuntimes(agentId);
 			return uploadedFiles;
 		} catch (error) {
@@ -90,14 +85,14 @@ export class AgentKnowledgeController {
 	@Delete('/:agentId/files/:fileId')
 	@ProjectScope('agent:update')
 	async deleteFile(
-		req: AuthenticatedRequest<{ projectId: string }>,
+		_req: AuthenticatedRequest<{ projectId: string }>,
 		_res: Response,
 		@Param('projectId') projectId: string,
 		@Param('agentId') agentId: string,
 		@Param('fileId') fileId: string,
 	) {
 		this.assertKnowledgeBaseEnabled();
-		await this.agentKnowledgeService.deleteFile(agentId, projectId, fileId, req.user.id);
+		await this.agentKnowledgeService.deleteFile(agentId, projectId, fileId);
 		this.runtimeCacheService.clearRuntimes(agentId);
 		return { success: true };
 	}

--- a/packages/cli/src/modules/agents/agent-knowledge.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.service.ts
@@ -59,7 +59,6 @@ export class AgentKnowledgeService {
 		agentId: string,
 		projectId: string,
 		files: Express.Multer.File[],
-		userId: string,
 	): Promise<AgentFileDto[]> {
 		try {
 			await this.ensureAgentBelongsToProject(agentId, projectId);
@@ -70,7 +69,6 @@ export class AgentKnowledgeService {
 			await this.agentKnowledgeSandboxService.withKnowledgeFilesystem(
 				projectId,
 				agentId,
-				userId,
 				async (filesystem) => {
 					const volumeUploads: AgentKnowledgeFileUpload[] = [];
 					try {
@@ -102,17 +100,12 @@ export class AgentKnowledgeService {
 		return files.map((file) => toAgentFileDto(file));
 	}
 
-	async warmSandbox(agentId: string, projectId: string, userId: string): Promise<void> {
+	async warmSandbox(agentId: string, projectId: string): Promise<void> {
 		await this.ensureAgentBelongsToProject(agentId, projectId);
-		await this.agentKnowledgeSandboxService.warmSandbox(projectId, agentId, userId);
+		await this.agentKnowledgeSandboxService.warmSandbox(projectId, agentId);
 	}
 
-	async deleteFile(
-		agentId: string,
-		projectId: string,
-		fileId: string,
-		userId: string,
-	): Promise<void> {
+	async deleteFile(agentId: string, projectId: string, fileId: string): Promise<void> {
 		await this.ensureAgentBelongsToProject(agentId, projectId);
 
 		const file = await this.agentFileRepository.findByIdAndAgentId(fileId, agentId);
@@ -121,12 +114,12 @@ export class AgentKnowledgeService {
 		}
 
 		await this.agentFileRepository.delete({ id: fileId, agentId });
-		this.deleteVolumeFileInBackground(projectId, agentId, userId, file);
+		this.deleteVolumeFileInBackground(projectId, agentId, file);
 	}
 
-	async deleteAllFilesForAgent(projectId: string, agentId: string, userId: string): Promise<void> {
+	async deleteAllFilesForAgent(projectId: string, agentId: string): Promise<void> {
 		await this.agentFileRepository.delete({ agentId });
-		this.deleteKnowledgeDirectoryInBackground(projectId, agentId, userId);
+		this.deleteKnowledgeDirectoryInBackground(projectId, agentId);
 	}
 
 	private async reserveAgentFile(
@@ -216,14 +209,9 @@ export class AgentKnowledgeService {
 		}
 	}
 
-	private deleteVolumeFileInBackground(
-		projectId: string,
-		agentId: string,
-		userId: string,
-		file: AgentFile,
-	): void {
+	private deleteVolumeFileInBackground(projectId: string, agentId: string, file: AgentFile): void {
 		void this.agentKnowledgeSandboxService
-			.withKnowledgeFilesystem(projectId, agentId, userId, async (filesystem) => {
+			.withKnowledgeFilesystem(projectId, agentId, async (filesystem) => {
 				await this.deleteVolumeFile(filesystem, file);
 			})
 			.catch((error) => {
@@ -235,13 +223,9 @@ export class AgentKnowledgeService {
 			});
 	}
 
-	private deleteKnowledgeDirectoryInBackground(
-		projectId: string,
-		agentId: string,
-		userId: string,
-	): void {
+	private deleteKnowledgeDirectoryInBackground(projectId: string, agentId: string): void {
 		void this.agentKnowledgeSandboxService
-			.withKnowledgeFilesystem(projectId, agentId, userId, async (filesystem) => {
+			.withKnowledgeFilesystem(projectId, agentId, async (filesystem) => {
 				await this.deleteKnowledgeDirectory(filesystem);
 			})
 			.catch((error) => {

--- a/packages/cli/src/modules/agents/agent-runtime-cache.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-cache.service.ts
@@ -4,7 +4,6 @@ import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { UserError } from 'n8n-workflow';
 
 import { CredentialsService } from '@/credentials/credentials.service';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -24,9 +23,8 @@ import { getPublishedAgentSnapshot } from './utils/agent-published-snapshot';
 export interface GetRuntimeParams {
 	agentId: string;
 	projectId: string;
-	n8nUserId?: string;
 	integrationType?: string;
-	/** When true, load the published snapshot; n8nUserId is derived from publishedById when omitted. */
+	/** When true, load the published snapshot. */
 	usePublishedVersion?: boolean;
 }
 
@@ -47,7 +45,7 @@ interface RuntimeInitialization {
 export class AgentRuntimeCacheService {
 	/**
 	 * Cached agent runtimes.  Keys follow the pattern:
-	 *   Draft:     `{agentId}:draft:{n8nUserId}[:{integrationType}]`
+	 *   Draft:     `{agentId}:draft[:{integrationType}]`
 	 *   Published: `{agentId}:published[:{integrationType}]`
 	 *
 	 * TTL = 30 minutes — entries are evicted when the agent is idle so that
@@ -76,7 +74,6 @@ export class AgentRuntimeCacheService {
 			return parts.join(':');
 		}
 		const parts = [params.agentId, 'draft'];
-		if (params.n8nUserId) parts.push(params.n8nUserId);
 		if (params.integrationType) parts.push(params.integrationType);
 		return parts.join(':');
 	}
@@ -196,26 +193,15 @@ export class AgentRuntimeCacheService {
 		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
 
-		let n8nUserId = params.n8nUserId;
-		let agentData: Agent = agentEntity;
-
-		if (usePublishedVersion) {
-			agentData = getPublishedAgentSnapshot(agentEntity);
-
-			// Resolve n8n user from publishedById when not provided by the caller.
-			n8nUserId ??= agentEntity.activeVersion?.publishedById ?? undefined;
-		}
-
-		if (!n8nUserId) {
-			throw new UserError('Agent user owner id is required');
-		}
+		const agentData: Agent = usePublishedVersion
+			? getPublishedAgentSnapshot(agentEntity)
+			: agentEntity;
 
 		const credentialProvider = createAgentCredentialProvider(this.credentialsService, projectId);
 		const { agent: agentInstance, toolRegistry } =
 			await this.agentRuntimeReconstructionService.reconstructFromAgentEntity(
 				agentData,
 				credentialProvider,
-				n8nUserId,
 				integrationType,
 			);
 

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -308,16 +308,20 @@ export class AgentRuntimeReconstructionService {
 		return (_params: AgentJsonMemoryConfig) => this.n8nMemory.getImplementation(agentId);
 	}
 
+	/**
+	 * `ownerId` is the proxy token subject — the proxy treats it as an opaque scope and
+	 * does not verify it against n8n users. Agent runtimes pass their project id; a user
+	 * id works equally if a caller ever has one.
+	 */
 	private async resolveManagedEmbeddingProviderOptions(
-		projectId: string,
+		ownerId: string,
 	): Promise<ManagedEmbeddingProviderOptions | null> {
 		if (!this.aiService.isProxyEnabled()) return null;
 		// TODO: switch to n8n connect endpoints, don't use ai-proxy endpoints
 		const client = await this.aiService.getClient();
 		const baseURL = client.getApiProxyBaseUrl().replace(/\/$/, '') + '/openai/';
 		const tokenManager = new ProxyTokenManager(async () => {
-			// The proxy does not enforce per-user identity; the project id is the stable scope for agents.
-			return await client.getBuilderApiProxyToken({ id: projectId }, { userMessageId: nanoid() });
+			return await client.getBuilderApiProxyToken({ id: ownerId }, { userMessageId: nanoid() });
 		});
 
 		return {

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -27,7 +27,7 @@ import {
 import { Logger } from '@n8n/backend-common';
 import { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { AgentsConfig, SsrfProtectionConfig } from '@n8n/config';
-import { UserRepository, WorkflowRepository } from '@n8n/db';
+import { WorkflowRepository } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
@@ -41,7 +41,6 @@ import { AiService } from '@/services/ai.service';
 import { ProxyTokenManager } from '@/services/proxy-token-manager';
 import { createAiMcpFetch, createAiProxyFetch } from '@/utils/ai-proxy-fetch';
 import { WorkflowRunner } from '@/workflow-runner';
-import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { Agent } from './entities/agent.entity';
 import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
@@ -132,8 +131,6 @@ export class AgentRuntimeReconstructionService {
 		private readonly agentFileRepository: AgentFileRepository,
 		private readonly activeExecutions: ActiveExecutions,
 		private readonly workflowRepository: WorkflowRepository,
-		private readonly userRepository: UserRepository,
-		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly urlService: UrlService,
 		private readonly n8nCheckpointStorage: N8NCheckpointStorage,
 		private readonly secureRuntime: AgentSecureRuntime,
@@ -235,7 +232,7 @@ export class AgentRuntimeReconstructionService {
 		} = options;
 
 		const toolExecutor = this.secureRuntime.createToolExecutor(toolCodeByName);
-		const toolResolver = this.makeToolResolver(projectId, userId);
+		const toolResolver = this.makeToolResolver(projectId);
 		const resolvedTools: BuiltTool[] = [];
 
 		// Transport for LLM calls
@@ -350,20 +347,14 @@ export class AgentRuntimeReconstructionService {
 			},
 		};
 	}
-	private makeToolResolver(projectId: string, userId: string): ToolResolver {
+	private makeToolResolver(projectId: string): ToolResolver {
 		return async (ref: AgentJsonToolConfig) => {
 			if (ref.type === 'workflow') {
-				if (!userId) {
-					throw new UserError('userId is required when agent uses workflow tools');
-				}
 				const { resolveWorkflowTool } = await import('./tools/workflow-tool-factory');
 				return await resolveWorkflowTool(ref, {
 					workflowRepository: this.workflowRepository,
 					workflowRunner: await getWorkflowRunner(),
 					activeExecutions: this.activeExecutions,
-					workflowFinderService: this.workflowFinderService,
-					userRepository: this.userRepository,
-					userId,
 					projectId,
 					webhookBaseUrl: this.urlService.getWebhookBaseUrl(),
 				});

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -264,7 +264,7 @@ export class AgentRuntimeReconstructionService {
 			memoryFactory: this.getMemoryFactory(memoryOwnerAgentId),
 			buildMcpClient,
 			resolveManagedEmbeddingProviderOptions: async () =>
-				await this.resolveManagedEmbeddingProviderOptions(userId),
+				await this.resolveManagedEmbeddingProviderOptions(projectId),
 			modelFetch: aiProxyFetch,
 		});
 
@@ -316,14 +316,15 @@ export class AgentRuntimeReconstructionService {
 	}
 
 	private async resolveManagedEmbeddingProviderOptions(
-		userId: string,
+		projectId: string,
 	): Promise<ManagedEmbeddingProviderOptions | null> {
 		if (!this.aiService.isProxyEnabled()) return null;
 		// TODO: switch to n8n connect endpoints, don't use ai-proxy endpoints
 		const client = await this.aiService.getClient();
 		const baseURL = client.getApiProxyBaseUrl().replace(/\/$/, '') + '/openai/';
 		const tokenManager = new ProxyTokenManager(async () => {
-			return await client.getBuilderApiProxyToken({ id: userId }, { userMessageId: nanoid() });
+			// The proxy does not enforce per-user identity; the project id is the stable scope for agents.
+			return await client.getBuilderApiProxyToken({ id: projectId }, { userMessageId: nanoid() });
 		});
 
 		return {
@@ -412,7 +413,6 @@ export class AgentRuntimeReconstructionService {
 				createKnowledgeRetrievalTools({
 					projectId,
 					agentId,
-					userId,
 					sandboxService: this.agentKnowledgeSandboxService,
 				}),
 			);

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -86,8 +86,6 @@ export interface ReconstructAgentRuntimeParams {
 	toolDescriptors: Record<string, ToolDescriptor>;
 	toolCodeByName: Record<string, string>;
 	skills: Record<string, AgentSkill>;
-	/** Required for workflow tool resolution. */
-	userId: string;
 	runtimeProfile: AgentRuntimeProfile;
 	/** Delegating parent agent id for sub-agent runs; defaults to memoryOwnerAgentId for top-level. */
 	parentAgentIdForDelegation?: string;
@@ -148,7 +146,6 @@ export class AgentRuntimeReconstructionService {
 	async reconstructFromAgentEntity(
 		agentEntity: Agent,
 		credentialProvider: CredentialProvider,
-		userId: string,
 		integrationType?: string,
 	): Promise<{ agent: RuntimeAgent; toolRegistry: ToolRegistry }> {
 		const config = agentEntity.schema;
@@ -176,7 +173,6 @@ export class AgentRuntimeReconstructionService {
 			toolDescriptors,
 			toolCodeByName: toolsByName,
 			skills: agentEntity.skills ?? {},
-			userId,
 			runtimeProfile: 'top-level',
 			parentAgentIdForDelegation: agentEntity.id,
 			integrationType,
@@ -208,7 +204,6 @@ export class AgentRuntimeReconstructionService {
 		toolDescriptors: Record<string, ToolDescriptor>;
 		toolCodeByName: Record<string, string>;
 		skills: Record<string, AgentSkill>;
-		userId: string;
 		runtimeProfile: AgentRuntimeProfile;
 		parentAgentIdForDelegation?: string;
 		integrationType?: string;
@@ -223,7 +218,6 @@ export class AgentRuntimeReconstructionService {
 			toolDescriptors,
 			toolCodeByName,
 			skills,
-			userId,
 			runtimeProfile,
 			parentAgentIdForDelegation,
 			integrationType,
@@ -273,7 +267,6 @@ export class AgentRuntimeReconstructionService {
 			agentId: memoryOwnerAgentId,
 			projectId,
 			credentialProvider,
-			userId,
 			runtimeProfile,
 			config,
 			subAgentDelegation,
@@ -378,7 +371,6 @@ export class AgentRuntimeReconstructionService {
 		agentId: string;
 		projectId: string;
 		credentialProvider: CredentialProvider;
-		userId: string;
 		runtimeProfile: AgentRuntimeProfile;
 		config: AgentJsonConfig;
 		subAgentDelegation: SubAgentDelegationConfig;
@@ -391,7 +383,6 @@ export class AgentRuntimeReconstructionService {
 			agentId,
 			projectId,
 			credentialProvider,
-			userId,
 			runtimeProfile,
 			config,
 			subAgentDelegation,
@@ -483,7 +474,6 @@ export class AgentRuntimeReconstructionService {
 				parentAgentId: parentAgentIdForDelegation,
 				projectId,
 				credentialProvider,
-				userId,
 				delegation: subAgentDelegation,
 			});
 			this.attachWriteTodosTool(agent, agentId);
@@ -500,11 +490,9 @@ export class AgentRuntimeReconstructionService {
 		parentAgentId: string;
 		projectId: string;
 		credentialProvider: CredentialProvider;
-		userId: string;
 		delegation: SubAgentDelegationConfig;
 	}): Promise<void> {
-		const { agent, config, parentAgentId, projectId, credentialProvider, userId, delegation } =
-			params;
+		const { agent, config, parentAgentId, projectId, credentialProvider, delegation } = params;
 		const inlineSubAgentModelsByDifficulty = await this.resolveInlineSubAgentModelsByDifficulty(
 			config,
 			credentialProvider,
@@ -515,7 +503,6 @@ export class AgentRuntimeReconstructionService {
 				...delegation,
 				projectId,
 				parentAgentId,
-				userId,
 				credentialProvider,
 				policy: this.buildSubAgentPolicy(config),
 				...(inlineSubAgentModelsByDifficulty !== undefined

--- a/packages/cli/src/modules/agents/agent-sandbox.controller.ts
+++ b/packages/cli/src/modules/agents/agent-sandbox.controller.ts
@@ -20,7 +20,7 @@ export class AgentSandboxController {
 	@Post('/:agentId/sandbox/knowledge/warmup')
 	@ProjectScope('agent:execute')
 	async warmKnowledgeSandbox(
-		req: AuthenticatedRequest<{ projectId: string }>,
+		_req: AuthenticatedRequest<{ projectId: string }>,
 		res: Response,
 		@Param('projectId') projectId: string,
 		@Param('agentId') agentId: string,
@@ -28,7 +28,7 @@ export class AgentSandboxController {
 		this.assertKnowledgeBaseEnabled();
 		res.status(202);
 		setImmediate(() => {
-			void this.warmKnowledgeSandboxInBackground(projectId, agentId, req.user.id);
+			void this.warmKnowledgeSandboxInBackground(projectId, agentId);
 		});
 
 		return { accepted: true };
@@ -43,11 +43,10 @@ export class AgentSandboxController {
 	private async warmKnowledgeSandboxInBackground(
 		projectId: string,
 		agentId: string,
-		userId: string,
 	): Promise<void> {
 		try {
 			if (!isAgentKnowledgeBaseEnabled(this.agentsConfig)) return;
-			await this.agentKnowledgeService.warmSandbox(agentId, projectId, userId);
+			await this.agentKnowledgeService.warmSandbox(agentId, projectId);
 		} catch (error) {
 			this.logger.warn('Failed to warm agent knowledge sandbox', {
 				projectId,

--- a/packages/cli/src/modules/agents/agent-task.service.ts
+++ b/packages/cli/src/modules/agents/agent-task.service.ts
@@ -1,7 +1,6 @@
 import type { AgentTaskDto, CreateAgentTaskDto, UpdateAgentTaskDto } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import { ProjectRelationRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { IsNull, Not } from '@n8n/typeorm';
@@ -58,7 +57,6 @@ export class AgentTaskService {
 		private readonly taskSnapshotRepository: AgentTaskSnapshotRepository,
 		private readonly taskRunLockRepository: AgentTaskRunLockRepository,
 		private readonly agentRepository: AgentRepository,
-		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly agentExecutionOrchestratorService: AgentExecutionOrchestratorService,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly scheduledTaskManager: ScheduledTaskManager,
@@ -438,16 +436,6 @@ export class AgentTaskService {
 				return;
 			}
 
-			const executionUserId = await this.resolveExecutionUserId(agent);
-			if (!executionUserId) {
-				this.logger.warn('[AgentTaskService] No project member available for task run', {
-					taskId,
-					agentId,
-					projectId,
-				});
-				return;
-			}
-
 			const { message, threadId } = this.buildTaskRunMessage(taskId, snapshot.objective);
 
 			this.logger.info('[AgentTaskService] Task fired', {
@@ -561,18 +549,6 @@ export class AgentTaskService {
 				taskId: task.id,
 			}),
 		);
-	}
-
-	private async resolveExecutionUserId(agent: Agent): Promise<string | undefined> {
-		const userIds = await this.projectRelationRepository.findUserIdsByProjectId(agent.projectId);
-		if (userIds.length === 0) return undefined;
-
-		const publishedById = agent.activeVersion?.publishedById;
-		if (publishedById && userIds.includes(publishedById)) {
-			return publishedById;
-		}
-
-		return undefined;
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -79,7 +79,7 @@ export class AgentsController {
 		_res: Response,
 		@Param('agentId') agentId: string,
 	) {
-		const deleted = await this.agentsService.delete(agentId, req.params.projectId, req.user.id);
+		const deleted = await this.agentsService.delete(agentId, req.params.projectId);
 
 		if (!deleted) {
 			throw new NotFoundError(`Agent "${agentId}" not found`);

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -100,7 +100,7 @@ export class AgentsService {
 		return agents.filter((agent) => agent.activeVersionId !== null);
 	}
 
-	async delete(agentId: string, projectId: string, userId: string): Promise<boolean> {
+	async delete(agentId: string, projectId: string): Promise<boolean> {
 		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 
 		if (!agent) {
@@ -108,7 +108,7 @@ export class AgentsService {
 		}
 
 		try {
-			await this.agentKnowledgeService.deleteAllFilesForAgent(projectId, agentId, userId);
+			await this.agentKnowledgeService.deleteAllFilesForAgent(projectId, agentId);
 		} catch (error) {
 			this.logger.warn('Failed to delete knowledge files on agent delete', {
 				agentId,

--- a/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
@@ -3,13 +3,11 @@ import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import type { CredentialsEntity } from '@n8n/db';
-import { ProjectRelationRepository, UserRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'vitest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
 import type { StateAdapter } from 'chat';
 
-import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import type { CredentialsService } from '@/credentials/credentials.service';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { UrlService } from '@/services/url.service';
@@ -68,28 +66,32 @@ const slackIntegration: AgentIntegrationConfig = {
 	credentialId: 'cred-1',
 };
 
+/** Configures a CredentialsService mock so `decryptCredentialForProject` finds `cred`. */
+function mockProjectCredential(
+	credentialsService: ReturnType<typeof mock<CredentialsService>>,
+	cred: CredentialsEntity,
+) {
+	credentialsService.findAllCredentialIdsForProject.mockResolvedValue([cred]);
+	credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
+	credentialsService.decrypt.mockResolvedValue({});
+}
+
 function buildServiceWith(
 	opts: {
 		isLeader?: boolean;
 		multiMainEnabled?: boolean;
 		registry?: ChatIntegrationRegistry;
 		agentRepository?: ReturnType<typeof mock<AgentRepository>>;
-		credentialsFinderService?: ReturnType<typeof mock<CredentialsFinderService>>;
 		credentialsService?: ReturnType<typeof mock<CredentialsService>>;
 		publisher?: ReturnType<typeof mock<Publisher>>;
-		projectRelationRepository?: ReturnType<typeof mock<ProjectRelationRepository>>;
 		urlService?: ReturnType<typeof mock<UrlService>>;
 		chatSubscriptionStateService?: ReturnType<typeof mock<AgentChatSubscriptionStateService>>;
 	} = {},
 ) {
 	const registry = opts.registry ?? new ChatIntegrationRegistry();
 	const agentRepository = opts.agentRepository ?? mock<AgentRepository>();
-	const credentialsFinderService =
-		opts.credentialsFinderService ?? mock<CredentialsFinderService>();
 	const credentialsService = opts.credentialsService ?? mock<CredentialsService>();
 	const publisher = opts.publisher ?? mock<Publisher>();
-	const projectRelationRepository =
-		opts.projectRelationRepository ?? mock<ProjectRelationRepository>();
 	const urlService = opts.urlService ?? mock<UrlService>();
 	const chatSubscriptionStateService =
 		opts.chatSubscriptionStateService ?? mock<AgentChatSubscriptionStateService>();
@@ -98,13 +100,10 @@ function buildServiceWith(
 		multiMainSetup: { enabled: opts.multiMainEnabled ?? false },
 	} as Partial<GlobalConfig>);
 
-	Container.set(ProjectRelationRepository, projectRelationRepository);
-
 	const service = new ChatIntegrationService(
 		mockLogger(),
 		agentRepository,
 		credentialsService,
-		credentialsFinderService,
 		urlService,
 		registry,
 		instanceSettings,
@@ -117,10 +116,8 @@ function buildServiceWith(
 		service,
 		registry,
 		agentRepository,
-		credentialsFinderService,
 		credentialsService,
 		publisher,
-		projectRelationRepository,
 		urlService,
 		chatSubscriptionStateService,
 	};
@@ -128,7 +125,6 @@ function buildServiceWith(
 
 describe('ChatIntegrationService.syncToConfig — publish gate', () => {
 	let service: ChatIntegrationService;
-	let projectRelationRepository: ReturnType<typeof mock<ProjectRelationRepository>>;
 	let chatSubscriptionStateService: ReturnType<typeof mock<AgentChatSubscriptionStateService>>;
 	let connectSpy: MockInstance;
 	let disconnectSpy: MockInstance;
@@ -136,7 +132,7 @@ describe('ChatIntegrationService.syncToConfig — publish gate', () => {
 
 	beforeEach(() => {
 		Container.reset();
-		({ service, projectRelationRepository, chatSubscriptionStateService } = buildServiceWith());
+		({ service, chatSubscriptionStateService } = buildServiceWith());
 		connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
 		disconnectSpy = vi.spyOn(service, 'disconnect').mockResolvedValue();
 		broadcastSpy = vi.spyOn(service, 'broadcastIntegrationChange').mockResolvedValue();
@@ -191,7 +187,6 @@ describe('ChatIntegrationService.syncToConfig — publish gate', () => {
 
 	it('does not reconnect an already-live integration when republishing', async () => {
 		const agent = makeAgent({ activeVersionId: 'published-version-1' });
-		projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['user-1']);
 		const internal = service as unknown as { connections: Map<string, unknown> };
 		internal.connections.set('agent-1:slack:cred-1', {});
 
@@ -211,7 +206,6 @@ describe('ChatIntegrationService', () => {
 			mock(),
 			mock(),
 			mock(),
-			mock(),
 			mock<InstanceSettings>({ isLeader: true }),
 			mock(),
 			mock<GlobalConfig>({ multiMainSetup: { enabled: false } } as Partial<GlobalConfig>),
@@ -226,17 +220,8 @@ describe('ChatIntegrationService', () => {
 		const registry = new ChatIntegrationRegistry();
 		registry.register(integration);
 
-		Container.set(
-			UserRepository,
-			mock<UserRepository>({
-				findOne: vi.fn().mockResolvedValue({ id: 'user-1' }),
-			}),
-		);
-
-		const credentialsFinderService = mock<CredentialsFinderService>();
-		credentialsFinderService.findCredentialForUser.mockResolvedValue({} as CredentialsEntity);
 		const credentialsService = mock<CredentialsService>();
-		credentialsService.decrypt.mockResolvedValue({});
+		mockProjectCredential(credentialsService, { id: 'cred-1' } as CredentialsEntity);
 		const urlService = mock<UrlService>();
 		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/');
 
@@ -257,15 +242,14 @@ describe('ChatIntegrationService', () => {
 		try {
 			const { service } = buildServiceWith({
 				registry,
-				credentialsFinderService,
 				credentialsService,
 				urlService,
 				chatSubscriptionStateService,
 			});
 
-			await expect(
-				service.connect('agent-1', slackIntegration, 'user-1', 'project-1'),
-			).rejects.toThrow('chat construction failed');
+			await expect(service.connect('agent-1', slackIntegration, 'project-1')).rejects.toThrow(
+				'chat construction failed',
+			);
 
 			expect(chatSubscriptionStateService.createStateAdapter).toHaveBeenCalledTimes(1);
 			expect(state.disconnect).toHaveBeenCalledTimes(1);
@@ -273,6 +257,79 @@ describe('ChatIntegrationService', () => {
 			loadMemoryStateSpy.mockRestore();
 			loadChatSdkSpy.mockRestore();
 		}
+	});
+
+	describe('connect — project-scoped credential resolution', () => {
+		it('connects using a project-accessible credential without any user', async () => {
+			const createAdapter = vi.fn().mockResolvedValue({ name: 'slack' });
+			const integration = new FakeIntegration('slack', false);
+			(integration as unknown as { createAdapter: typeof createAdapter }).createAdapter =
+				createAdapter;
+			const registry = new ChatIntegrationRegistry();
+			registry.register(integration);
+
+			const cred = { id: 'cred-1' } as CredentialsEntity;
+			const credentialsService = mock<CredentialsService>();
+			mockProjectCredential(credentialsService, cred);
+			const urlService = mock<UrlService>();
+			urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.test/');
+
+			const state = mock<StateAdapter>();
+			state.disconnect.mockResolvedValue(undefined);
+			const chatSubscriptionStateService = mock<AgentChatSubscriptionStateService>();
+			chatSubscriptionStateService.createStateAdapter.mockReturnValue(state);
+
+			const loadMemoryStateSpy = vi.spyOn(esmLoader, 'loadMemoryState').mockResolvedValue({
+				createMemoryState: vi.fn(() => mock<StateAdapter>()),
+			} as never);
+			// Chat construction is unrelated to credential resolution — fail fast
+			// here so the test doesn't need to stand up the full bridge/orchestrator.
+			const loadChatSdkSpy = vi.spyOn(esmLoader, 'loadChatSdk').mockResolvedValue({
+				Chat: vi.fn(() => {
+					throw new Error('chat construction failed');
+				}),
+			} as never);
+
+			try {
+				const { service } = buildServiceWith({
+					registry,
+					credentialsService,
+					urlService,
+					chatSubscriptionStateService,
+				});
+
+				await expect(service.connect('agent-1', slackIntegration, 'project-1')).rejects.toThrow(
+					'chat construction failed',
+				);
+
+				expect(credentialsService.findAllCredentialIdsForProject).toHaveBeenCalledWith('project-1');
+				expect(credentialsService.decrypt).toHaveBeenCalledWith(cred, true);
+			} finally {
+				loadMemoryStateSpy.mockRestore();
+				loadChatSdkSpy.mockRestore();
+			}
+		});
+
+		it('fails to connect when the credential is not accessible to the project', async () => {
+			const createAdapter = vi.fn();
+			const integration = new FakeIntegration('slack', false);
+			(integration as unknown as { createAdapter: typeof createAdapter }).createAdapter =
+				createAdapter;
+			const registry = new ChatIntegrationRegistry();
+			registry.register(integration);
+
+			const credentialsService = mock<CredentialsService>();
+			credentialsService.findAllCredentialIdsForProject.mockResolvedValue([]);
+			credentialsService.findAllGlobalCredentialIds.mockResolvedValue([]);
+
+			const { service } = buildServiceWith({ registry, credentialsService });
+
+			await expect(service.connect('agent-1', slackIntegration, 'project-1')).rejects.toThrow(
+				'not accessible to project',
+			);
+
+			expect(createAdapter).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('disconnectAll', () => {
@@ -527,14 +584,10 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				}),
 			]);
 
-			const projectRelationRepository = mock<ProjectRelationRepository>();
-			projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['u1']);
-
 			const { service } = buildServiceWith({
 				isLeader: false,
 				registry,
 				agentRepository,
-				projectRelationRepository,
 			});
 
 			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
@@ -547,7 +600,6 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			expect(connectSpy).toHaveBeenCalledWith(
 				'agent-1',
 				{ type: 'linear', credentialId: 'c2' },
-				'u1',
 				'project-1',
 				{ skipExternalHooks: true },
 			);
@@ -568,14 +620,10 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				}),
 			]);
 
-			const projectRelationRepository = mock<ProjectRelationRepository>();
-			projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['u1']);
-
 			const { service } = buildServiceWith({
 				isLeader: true,
 				registry,
 				agentRepository,
-				projectRelationRepository,
 			});
 
 			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
@@ -584,7 +632,7 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 
 			expect(connectSpy).toHaveBeenCalledTimes(2);
 			for (const call of connectSpy.mock.calls) {
-				expect(call[4]).toEqual({ skipExternalHooks: false });
+				expect(call[3]).toEqual({ skipExternalHooks: false });
 			}
 		});
 
@@ -599,14 +647,10 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				}),
 			]);
 
-			const projectRelationRepository = mock<ProjectRelationRepository>();
-			projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['u1']);
-
 			const { service } = buildServiceWith({
 				isLeader: true,
 				registry,
 				agentRepository,
-				projectRelationRepository,
 			});
 
 			// Pretend this integration is already connected (e.g. leader-takeover
@@ -701,14 +745,10 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			const agentRepository = mock<AgentRepository>();
 			agentRepository.findOne.mockResolvedValue(makeAgent({ id: 'a1', projectId: 'p1' }));
 
-			const projectRelationRepository = mock<ProjectRelationRepository>();
-			projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['u1']);
-
 			const { service } = buildServiceWith({
 				isLeader: false,
 				registry,
 				agentRepository,
-				projectRelationRepository,
 			});
 
 			const connectSpy = vi.spyOn(service, 'connect').mockResolvedValue();
@@ -721,59 +761,32 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 
 			// External hooks already ran on the originator. The peer must skip them
 			// to avoid duplicate external side effects.
-			expect(connectSpy).toHaveBeenCalledWith(
-				'a1',
-				{ type: 'linear', credentialId: 'c1' },
-				'u1',
-				'p1',
-				{
-					skipExternalHooks: true,
-				},
-			);
+			expect(connectSpy).toHaveBeenCalledWith('a1', { type: 'linear', credentialId: 'c1' }, 'p1', {
+				skipExternalHooks: true,
+			});
 		});
 
-		it('falls through user list until one succeeds', async () => {
+		it('logs and does not throw when the credential is not accessible to the project', async () => {
 			const registry = new ChatIntegrationRegistry();
 			registry.register(new FakeIntegration('linear', false));
 
 			const agentRepository = mock<AgentRepository>();
 			agentRepository.findOne.mockResolvedValue(makeAgent({ id: 'a1', projectId: 'p1' }));
 
-			const projectRelationRepository = mock<ProjectRelationRepository>();
-			projectRelationRepository.findUserIdsByProjectId.mockResolvedValue([
-				'u-no-access',
-				'u-with-access',
-			]);
-
 			const { service } = buildServiceWith({
 				registry,
 				agentRepository,
-				projectRelationRepository,
 			});
 
-			const connectSpy = vi
-				.spyOn(service, 'connect')
-				.mockImplementationOnce(async () => {
-					throw new Error('no access');
-				})
-				.mockImplementationOnce(async () => undefined);
+			vi.spyOn(service, 'connect').mockRejectedValue(new Error('not accessible to project'));
 
-			await service.handleIntegrationChanged({
-				agentId: 'a1',
-				integration: { type: 'linear', credentialId: 'c1' },
-				action: 'connect',
-			});
-
-			expect(connectSpy).toHaveBeenCalledTimes(2);
-			expect(connectSpy).toHaveBeenLastCalledWith(
-				'a1',
-				{ type: 'linear', credentialId: 'c1' },
-				'u-with-access',
-				'p1',
-				{
-					skipExternalHooks: true,
-				},
-			);
+			await expect(
+				service.handleIntegrationChanged({
+					agentId: 'a1',
+					integration: { type: 'linear', credentialId: 'c1' },
+					action: 'connect',
+				}),
+			).resolves.toBeUndefined();
 		});
 
 		it('no-ops when the agent has been deleted', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-app-setup.service.test.ts
@@ -354,7 +354,6 @@ describe('SlackAppSetupService', () => {
 		expect(chatIntegrationService.connect).toHaveBeenCalledWith(
 			'agent-1',
 			integration,
-			'user-1',
 			'project-1',
 		);
 		expect(agentIntegrationPersistenceService.saveCredentialIntegration).toHaveBeenCalledWith(

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -5,14 +5,11 @@ import {
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { User } from '@n8n/db';
-import { ProjectRelationRepository, UserRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import type { Channel, Chat as ChatSdk, StateAdapter, Thread, UserInfo } from 'chat';
 import { InstanceSettings } from 'n8n-core';
 
-import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { PubSubCommandMap } from '@/scaling/pubsub/pubsub.event-map';
@@ -112,7 +109,6 @@ export class ChatIntegrationService {
 		private readonly logger: Logger,
 		private readonly agentRepository: AgentRepository,
 		private readonly credentialsService: CredentialsService,
-		private readonly credentialsFinderService: CredentialsFinderService,
 		private readonly urlService: UrlService,
 		private readonly integrationRegistry: ChatIntegrationRegistry,
 		private readonly instanceSettings: InstanceSettings,
@@ -173,7 +169,6 @@ export class ChatIntegrationService {
 	async connect(
 		agentId: string,
 		integration: AgentIntegrationConfig,
-		userId: string,
 		projectId: string,
 		options: ConnectOptions = {},
 	): Promise<void> {
@@ -186,10 +181,11 @@ export class ChatIntegrationService {
 
 		const integrationImpl = this.integrationRegistry.require(integration.type);
 
-		const user = await this.resolveUser(userId);
-
 		// Decrypt the integration credential to get platform tokens
-		const decryptedData = await this.decryptCredential(integration.credentialId, user);
+		const decryptedData = await this.decryptCredentialForProject(
+			integration.credentialId,
+			projectId,
+		);
 
 		const ctx: AgentChatIntegrationContext = {
 			agentId,
@@ -427,42 +423,20 @@ export class ChatIntegrationService {
 			return;
 		}
 
-		// TODO: AgentIntegration has no record of *who* connected the
-		// integration, so we have no anchor user identity to decrypt credentials
-		// with on reconnect / sync. We fall back to probing project members until
-		// one has `credential:read` on the integration credential.
-		// Replace with a proper solution (fetching credentials should not depend on any specific user)
-		const userIds = additions.length
-			? await Container.get(ProjectRelationRepository).findUserIdsByProjectId(agent.projectId)
-			: [];
-
 		for (const integration of additions) {
 			const key = this.connectionKey(agent.id, integration.type, integration.credentialId);
 			if (this.connections.has(key)) continue;
 
-			let connected = false;
-			for (const userId of userIds) {
-				try {
-					await this.connect(agent.id, integration, userId, agent.projectId);
-
-					connected = true;
-					break;
-				} catch (error) {
-					this.logger.debug('[ChatIntegrationService] Connect attempt failed during sync', {
-						agentId: agent.id,
-						userId,
-						type: integration.type,
-						error,
-					});
-				}
-			}
-			if (connected) {
+			try {
+				await this.connect(agent.id, integration, agent.projectId);
 				await this.broadcastIntegrationChange(agent.id, integration, 'connect');
-			} else {
-				this.logger.warn(
-					'[ChatIntegrationService] Could not connect integration during sync — no project member had credential access',
-					{ agentId: agent.id, type: integration.type, credentialId: integration.credentialId },
-				);
+			} catch (error) {
+				this.logger.warn('[ChatIntegrationService] Could not connect integration during sync', {
+					agentId: agent.id,
+					type: integration.type,
+					credentialId: integration.credentialId,
+					error,
+				});
 			}
 		}
 	}
@@ -564,38 +538,16 @@ export class ChatIntegrationService {
 				const key = this.connectionKey(agent.id, integration.type, integration.credentialId);
 				if (this.connections.has(key)) continue;
 
-				const userIds = await Container.get(ProjectRelationRepository).findUserIdsByProjectId(
-					agent.projectId,
-				);
-				if (userIds.length === 0) {
-					this.logger.warn(
-						`[ChatIntegrationService] No users found for project ${agent.projectId} — skipping reconnect for agent ${agent.id}`,
-					);
-					continue;
-				}
-
 				// External setup runs once per cluster — the leader claims that role
 				// on startup; followers only build local runtime state.
 				const skipExternalHooks = !this.instanceSettings.isLeader;
 				const options = this.connectOptionsFor(integration, skipExternalHooks);
 
-				// Try each project member until one succeeds — the first user may not
-				// have access to the integration credential.
-				let connected = false;
-				for (const userId of userIds) {
-					try {
-						await this.connect(agent.id, integration, userId, agent.projectId, options);
-						connected = true;
-						break;
-					} catch (error) {
-						this.logger.debug(
-							`[ChatIntegrationService] User ${userId} could not reconnect ${integration.type} for agent ${agent.id}: ${error instanceof Error ? error.message : String(error)}`,
-						);
-					}
-				}
-				if (!connected) {
+				try {
+					await this.connect(agent.id, integration, agent.projectId, options);
+				} catch (error) {
 					this.logger.error(
-						`[ChatIntegrationService] Failed to reconnect ${integration.type} for agent ${agent.id} — no project member could access the credential`,
+						`[ChatIntegrationService] Failed to reconnect ${integration.type} for agent ${agent.id} — credential not accessible to the project: ${error instanceof Error ? error.message : String(error)}`,
 					);
 				}
 			}
@@ -646,26 +598,17 @@ export class ChatIntegrationService {
 			return;
 		}
 
-		const userIds = await Container.get(ProjectRelationRepository).findUserIdsByProjectId(
-			agent.projectId,
-		);
-		for (const userId of userIds) {
-			try {
-				// The originating main already ran integration-defined external setup.
-				// Peers only build local runtime state to avoid duplicate external
-				// side effects.
-				const options: ConnectOptions = { skipExternalHooks: true };
-				await this.connect(agentId, integration, userId, agent.projectId, options);
-				return;
-			} catch (error) {
-				this.logger.debug(
-					`[ChatIntegrationService] User ${userId} could not connect ${type} for agent ${agentId}: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
+		try {
+			// The originating main already ran integration-defined external setup.
+			// Peers only build local runtime state to avoid duplicate external
+			// side effects.
+			const options: ConnectOptions = { skipExternalHooks: true };
+			await this.connect(agentId, integration, agent.projectId, options);
+		} catch (error) {
+			this.logger.error(
+				`[ChatIntegrationService] Failed to connect ${type} for agent ${agentId} — credential not accessible to the project: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
-		this.logger.error(
-			`[ChatIntegrationService] Failed to connect ${type} for agent ${agentId} — no project member could access the credential`,
-		);
 	}
 
 	// ---------------------------------------------------------------------------
@@ -708,28 +651,20 @@ export class ChatIntegrationService {
 		this.logger.info(`[ChatIntegrationService] Disconnected: ${key}`);
 	}
 
-	private async resolveUser(userId: string): Promise<User> {
-		const user = await Container.get(UserRepository).findOne({
-			where: { id: userId },
-			relations: ['role'],
-		});
-		if (!user) {
-			throw new Error(`User ${userId} not found`);
-		}
-		return user;
-	}
-
-	private async decryptCredential(
+	private async decryptCredentialForProject(
 		credentialId: string,
-		user: User,
+		projectId: string,
 	): Promise<Record<string, unknown>> {
-		const credential = await this.credentialsFinderService.findCredentialForUser(
-			credentialId,
-			user,
-			['credential:read'],
-		);
+		const projectCredentials =
+			await this.credentialsService.findAllCredentialIdsForProject(projectId);
+		const globalCredentials = await this.credentialsService.findAllGlobalCredentialIds(true);
+		const credential =
+			projectCredentials.find((c) => c.id === credentialId) ??
+			globalCredentials.find((c) => c.id === credentialId);
 		if (!credential) {
-			throw new Error(`Credential ${credentialId} not found or not accessible`);
+			throw new Error(
+				`Credential ${credentialId} not found or not accessible to project ${projectId}`,
+			);
 		}
 		const decrypted = await this.credentialsService.decrypt(credential, true);
 		return decrypted as Record<string, unknown>;

--- a/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
+++ b/packages/cli/src/modules/agents/integrations/slack-app-setup.service.ts
@@ -268,12 +268,7 @@ export class SlackAppSetupService {
 				syncIntegrations: false,
 			},
 		);
-		await this.chatIntegrationService.connect(
-			session.agentId,
-			integration,
-			session.userId,
-			session.projectId,
-		);
+		await this.chatIntegrationService.connect(session.agentId, integration, session.projectId);
 		await this.chatIntegrationService.broadcastIntegrationChange(
 			session.agentId,
 			integration,

--- a/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/cli/src/modules/agents/sub-agents/__tests__/delegate-sub-agent-tool.test.ts
@@ -19,7 +19,6 @@ import type {
 } from '../sub-agent-foreground-runner';
 
 const projectId = 'project-1';
-const userId = 'user-1';
 
 const source: SubAgentSource = {
 	agentId: 'agent-2',
@@ -73,7 +72,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 			resolveInlineSubAgentProviderTools,
 		});
@@ -94,7 +92,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 			inlineSubAgentModelsByDifficulty,
 		});
@@ -109,7 +106,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 			policy: { maxChildren: 2 },
 		});
@@ -148,7 +144,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			},
 			expect.objectContaining({
 				projectId,
-				userId,
 				credentialProvider,
 			}),
 		);
@@ -159,7 +154,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 		});
 
@@ -195,7 +189,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 				},
 			],
 			projectId,
-			userId,
 			credentialProvider,
 		});
 
@@ -218,7 +211,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 		});
 
@@ -246,7 +238,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 		});
 		const runSubAgent = getInlineDelegateSubAgentToolOptions(tool)?.runSubAgent;
@@ -283,7 +274,6 @@ describe('createN8nDelegateSubAgentTool', () => {
 			runner,
 			sourcesById: { 'agent-2': source },
 			projectId,
-			userId,
 			credentialProvider,
 		});
 

--- a/packages/cli/src/modules/agents/sub-agents/__tests__/sub-agent-foreground-runner.test.ts
+++ b/packages/cli/src/modules/agents/sub-agents/__tests__/sub-agent-foreground-runner.test.ts
@@ -24,7 +24,6 @@ import type {
 } from '../sub-agent-source-resolver';
 
 const projectId = 'project-1';
-const userId = 'user-1';
 const parentThreadId = 'parent-thread-1';
 const parentAgentId = 'parent-agent-1';
 
@@ -127,7 +126,6 @@ describe('SubAgentForegroundRunner', () => {
 	it('resolves reconstruction from the container at run time', async () => {
 		await runner.runForeground(spawnRequest, {
 			projectId,
-			userId,
 			credentialProvider,
 		});
 
@@ -137,7 +135,6 @@ describe('SubAgentForegroundRunner', () => {
 	it('rebuilds the child through the shared reconstruction service and runs it with a fresh prompt', async () => {
 		const result = await runner.runForeground(spawnRequest, {
 			projectId,
-			userId,
 			credentialProvider,
 		});
 
@@ -159,7 +156,6 @@ describe('SubAgentForegroundRunner', () => {
 			toolDescriptors: runtimeSource.toolDescriptors,
 			toolCodeByName: runtimeSource.toolCodeByName,
 			skills: runtimeSource.skills,
-			userId,
 			runtimeProfile: 'sub-agent',
 			parentAgentIdForDelegation: undefined,
 		});
@@ -196,7 +192,6 @@ describe('SubAgentForegroundRunner', () => {
 			{ ...spawnRequest, parentResourceId: 'draft-chat:user-1' },
 			{
 				projectId,
-				userId,
 				credentialProvider,
 			},
 		);
@@ -233,7 +228,6 @@ describe('SubAgentForegroundRunner', () => {
 			},
 			{
 				projectId,
-				userId,
 				parentAgentId,
 				credentialProvider,
 			},
@@ -242,7 +236,6 @@ describe('SubAgentForegroundRunner', () => {
 		expect(reconstructionService.reconstructFromResolvedSource).toHaveBeenCalledWith(
 			expect.objectContaining({
 				memoryOwnerAgentId: 'agent-2',
-				userId,
 				runtimeProfile: 'sub-agent',
 				parentAgentIdForDelegation: parentAgentId,
 			}),
@@ -288,7 +281,6 @@ describe('SubAgentForegroundRunner', () => {
 		await expect(
 			runner.runForeground(spawnRequest, {
 				projectId,
-				userId,
 				credentialProvider,
 			}),
 		).resolves.toMatchObject({
@@ -313,7 +305,6 @@ describe('SubAgentForegroundRunner', () => {
 		await expect(
 			runner.runForeground(spawnRequest, {
 				projectId,
-				userId,
 				credentialProvider,
 			}),
 		).resolves.toMatchObject({
@@ -341,7 +332,6 @@ describe('SubAgentForegroundRunner', () => {
 
 		const run = runner.runForeground(spawnRequest, {
 			projectId,
-			userId,
 			credentialProvider,
 			abortSignal: parentAbort.signal,
 		});

--- a/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
+++ b/packages/cli/src/modules/agents/sub-agents/sub-agent-foreground-runner.ts
@@ -23,8 +23,6 @@ import { SubAgentSourceResolver } from './sub-agent-source-resolver';
 
 export interface SubAgentForegroundRunContext {
 	projectId: string;
-	/** n8n user ID — required for workflow/node tool resolution during reconstruction. */
-	userId: string;
 	/** Saved n8n agent id of the delegating parent agent, used to link the child session back. */
 	parentAgentId?: string;
 	credentialProvider: CredentialProvider;
@@ -91,7 +89,6 @@ export class SubAgentForegroundRunner {
 			toolDescriptors: runtimeSource.toolDescriptors,
 			toolCodeByName: runtimeSource.toolCodeByName,
 			skills: runtimeSource.skills,
-			userId: context.userId,
 			runtimeProfile: 'sub-agent',
 			parentAgentIdForDelegation: context.parentAgentId,
 		});

--- a/packages/cli/src/modules/agents/tools/knowledge/__tests__/search-knowledge.tool.test.ts
+++ b/packages/cli/src/modules/agents/tools/knowledge/__tests__/search-knowledge.tool.test.ts
@@ -6,7 +6,6 @@ import { createKnowledgeRetrievalTools } from '../search-knowledge.tool';
 
 const projectId = 'project-1';
 const agentId = 'agent-1';
-const userId = 'user-1';
 
 function buildTool(
 	sandboxService: AgentKnowledgeSandboxService,
@@ -15,7 +14,6 @@ function buildTool(
 	const tool = createKnowledgeRetrievalTools({
 		projectId,
 		agentId,
-		userId,
 		sandboxService,
 	})
 		.map((builder) => builder.build())
@@ -51,7 +49,7 @@ describe('createKnowledgeRetrievalTools', () => {
 			persistence: { threadId: 'thread-1', resourceId: 'integration:slack:U123' },
 		});
 
-		expect(sandboxService.searchKnowledge).toHaveBeenCalledWith(projectId, agentId, userId, input);
+		expect(sandboxService.searchKnowledge).toHaveBeenCalledWith(projectId, agentId, input);
 	});
 
 	it('reads knowledge with the user-scoped sandbox even when memory uses an integration resource', async () => {
@@ -70,6 +68,6 @@ describe('createKnowledgeRetrievalTools', () => {
 			persistence: { threadId: 'thread-1', resourceId: 'integration:slack:U123' },
 		});
 
-		expect(sandboxService.readKnowledge).toHaveBeenCalledWith(projectId, agentId, userId, input);
+		expect(sandboxService.readKnowledge).toHaveBeenCalledWith(projectId, agentId, input);
 	});
 });

--- a/packages/cli/src/modules/agents/tools/knowledge/__tests__/search-knowledge.tool.test.ts
+++ b/packages/cli/src/modules/agents/tools/knowledge/__tests__/search-knowledge.tool.test.ts
@@ -9,7 +9,7 @@ const agentId = 'agent-1';
 
 function buildTool(
 	sandboxService: AgentKnowledgeSandboxService,
-	toolName: 'search_text' | 'read_file',
+	toolName: 'find_file' | 'search_text' | 'read_file',
 ): BuiltTool {
 	const tool = createKnowledgeRetrievalTools({
 		projectId,
@@ -33,7 +33,25 @@ function getToolHandler(tool: BuiltTool): NonNullable<BuiltTool['handler']> {
 }
 
 describe('createKnowledgeRetrievalTools', () => {
-	it('searches knowledge with the user-scoped sandbox even when memory uses an integration resource', async () => {
+	it('finds files with the project-scoped sandbox using a catch-all pattern', async () => {
+		const sandboxService = mock<AgentKnowledgeSandboxService>();
+		sandboxService.globKnowledgeFiles.mockResolvedValue({
+			files: [],
+			limit: 20,
+			offset: 0,
+			hasMore: false,
+		});
+		const tool = buildTool(sandboxService, 'find_file');
+		const input = { pattern: '*' };
+
+		await getToolHandler(tool)(input, {
+			persistence: { threadId: 'thread-1', resourceId: 'integration:slack:U123' },
+		});
+
+		expect(sandboxService.globKnowledgeFiles).toHaveBeenCalledWith(projectId, agentId, input);
+	});
+
+	it('searches knowledge with the project-scoped sandbox even when memory uses an integration resource', async () => {
 		const sandboxService = mock<AgentKnowledgeSandboxService>();
 		sandboxService.searchKnowledge.mockResolvedValue({
 			outputMode: 'content',
@@ -52,7 +70,7 @@ describe('createKnowledgeRetrievalTools', () => {
 		expect(sandboxService.searchKnowledge).toHaveBeenCalledWith(projectId, agentId, input);
 	});
 
-	it('reads knowledge with the user-scoped sandbox even when memory uses an integration resource', async () => {
+	it('reads knowledge with the project-scoped sandbox even when memory uses an integration resource', async () => {
 		const sandboxService = mock<AgentKnowledgeSandboxService>();
 		sandboxService.readKnowledge.mockResolvedValue({
 			file: 'notes.txt',

--- a/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
+++ b/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
@@ -237,12 +237,10 @@ function toReadKnowledgeModelOutput(output: unknown): unknown {
 export function createKnowledgeRetrievalTools({
 	projectId,
 	agentId,
-	userId,
 	sandboxService,
 }: {
 	projectId: string;
 	agentId: string;
-	userId: string;
 	sandboxService: AgentKnowledgeSandboxService;
 }) {
 	const globTool = new Tool('find_file')
@@ -253,7 +251,7 @@ export function createKnowledgeRetrievalTools({
 		.handler(
 			async (input) =>
 				await runKnowledgeTool(
-					async () => await sandboxService.globKnowledgeFiles(projectId, agentId, userId, input),
+					async () => await sandboxService.globKnowledgeFiles(projectId, agentId, input),
 				),
 		)
 		.toModelOutput(toGlobKnowledgeModelOutput);
@@ -266,7 +264,7 @@ export function createKnowledgeRetrievalTools({
 		.handler(
 			async (input) =>
 				await runKnowledgeTool(
-					async () => await sandboxService.searchKnowledge(projectId, agentId, userId, input),
+					async () => await sandboxService.searchKnowledge(projectId, agentId, input),
 				),
 		)
 		.toModelOutput(toSearchKnowledgeModelOutput);
@@ -279,7 +277,7 @@ export function createKnowledgeRetrievalTools({
 		.handler(
 			async (input) =>
 				await runKnowledgeTool(
-					async () => await sandboxService.readKnowledge(projectId, agentId, userId, input),
+					async () => await sandboxService.readKnowledge(projectId, agentId, input),
 				),
 		)
 		.toModelOutput(toReadKnowledgeModelOutput);

--- a/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
+++ b/packages/cli/src/modules/agents/tools/knowledge/search-knowledge.tool.ts
@@ -96,17 +96,19 @@ function isReadKnowledgeResult(output: unknown): output is ReadKnowledgeResult {
 function toGlobKnowledgeModelOutput(output: unknown): unknown {
 	if (isKnowledgeToolErrorOutput(output) || !isGlobKnowledgeFilesResult(output)) return output;
 
-	const files = output.files.slice(0, MODEL_OUTPUT_GLOB_FILE_LIMIT).map((file) => ({
+	const files = output.files.map((file) => ({
 		file: file.file,
 		fileId: file.fileId,
 		displayName: file.displayName,
+		mimeType: file.mimeType,
+		fileSizeBytes: file.fileSizeBytes,
 	}));
 
 	return {
 		files,
-		returnedFiles: output.files.length,
-		shownFiles: files.length,
-		hasMore: output.hasMore || output.files.length > MODEL_OUTPUT_GLOB_FILE_LIMIT,
+		returnedFiles: files.length,
+		offset: output.offset,
+		hasMore: output.hasMore,
 	};
 }
 
@@ -245,7 +247,7 @@ export function createKnowledgeRetrievalTools({
 }) {
 	const globTool = new Tool('find_file')
 		.description(
-			'Find uploaded knowledge files by filename pattern only, such as `*knowledge*`, `*agent*tool*`, or `*sandbox*`. Use first for knowledge lookup to discover plausible candidate files; call until enough candidates are found, then copy returned file values into search_text path or read_file. Use for explicit document, title, standard, paper, dataset, author, product, or file-like clues. Do not use catch-all or extension-only patterns. Returns file and fileId metadata; does not read file contents.',
+			'Find uploaded knowledge files by filename pattern, such as `*knowledge*`, `*agent*tool*`, or `*sandbox*`. Use `*` to list every uploaded file, an extension pattern like `*.pdf` to filter by type, or a name fragment when the user gives title or filename clues. Use first for knowledge lookup to discover plausible candidate files; call until enough candidates are found, then copy returned file values into search_text path or read_file. Results are paged: page through the full list with `limit` and `offset` while `hasMore` is true. Returns file, fileId, mimeType, and fileSizeBytes metadata; does not read file contents.',
 		)
 		.input(globKnowledgeFilesInputSchema)
 		.handler(
@@ -258,7 +260,7 @@ export function createKnowledgeRetrievalTools({
 
 	const searchTool = new Tool('search_text')
 		.description(
-			'Search uploaded knowledge file contents with a ripgrep regex `pattern` inside exact candidate files. Requires `path`: pass one exact file value or an array of exact file values returned by find_file, search_text, or read_file. Does not perform global search and does not accept omitted path, empty path, `*`, fileId, absolute paths, guessed paths, arrays of non-strings, offsets, or semantic questions. `output_mode` defaults to content for snippets; use files_with_matches for matching files only or count for per-file match counts. Use `head_limit` to bound results and small `-C` values for nearby context. Answer from snippets when enough; use read_file only for quotes, citations, exact wording, source text, or larger missing context.',
+			'Search uploaded knowledge file contents with a ripgrep regex `pattern` inside exact candidate files. Requires `path`: pass one exact file value or an array of exact file values returned by find_file, search_text, or read_file. Does not perform global search and does not accept omitted path, empty path, `*`, fileId, absolute paths, guessed paths, arrays of non-strings, offsets, or semantic questions. Searching more than 20 files requires batching `path` arrays across multiple calls (max 20 paths per call). `output_mode` defaults to content for snippets; use files_with_matches for matching files only or count for per-file match counts. Use `head_limit` to bound results and small `-C` values for nearby context. Answer from snippets when enough; use read_file only for quotes, citations, exact wording, source text, or larger missing context.',
 		)
 		.input(searchKnowledgeInputSchema)
 		.handler(

--- a/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
+++ b/packages/cli/src/modules/agents/tools/workflow-tool-factory.ts
@@ -5,7 +5,7 @@ import {
 	type AgentJsonToolConfig,
 	type SUPPORTED_WORKFLOW_TOOL_TRIGGERS,
 } from '@n8n/api-types';
-import type { UserRepository, WorkflowRepository, WorkflowEntity } from '@n8n/db';
+import type { WorkflowRepository, WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { isRecord } from '@n8n/utils/is-record';
 import type {
@@ -32,7 +32,6 @@ import { z } from 'zod';
 import type { ActiveExecutions } from '@/active-executions';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import type { WorkflowRunner } from '@/workflow-runner';
-import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { sanitizeToolName } from '../json-config/agent-config-composition';
 
@@ -82,10 +81,7 @@ export interface WorkflowToolContext {
 	workflowRepository: WorkflowRepository;
 	workflowRunner: WorkflowRunner;
 	activeExecutions: ActiveExecutions;
-	workflowFinderService: WorkflowFinderService;
-	userRepository: UserRepository;
-	userId: string;
-	projectId?: string;
+	projectId: string;
 	/** Base URL for webhooks/forms (e.g. http://localhost:5678/) */
 	webhookBaseUrl?: string;
 }
@@ -326,7 +322,6 @@ export async function executeWorkflow(
 	const runData: IWorkflowExecutionDataProcess = {
 		executionMode,
 		workflowData: workflow,
-		userId: context.userId,
 		startNodes: [{ name: triggerNode.name, sourceData: null }],
 		pinData: mergedPinData,
 		executionData: createRunExecutionData({
@@ -561,16 +556,13 @@ async function buildWorkflowTool(
 	descriptor: Extract<AgentJsonToolConfig, { type: 'workflow' }>,
 	context: WorkflowToolContext,
 ): Promise<BuiltTool> {
-	const { workflowRepository, workflowFinderService, userRepository } = context;
+	const { workflowRepository } = context;
 	const workflowName = descriptor.workflow;
 
-	// Step 1: Find the workflow by name, scoped to the project if available.
-	const whereClause: Record<string, unknown> = { name: workflowName };
-	if (context.projectId) {
-		whereClause.shared = { projectId: context.projectId };
-	}
+	// Find the workflow by name. Access control is project sharing: the
+	// workflow must be shared with the agent's project.
 	const candidateWorkflow = await workflowRepository.findOne({
-		where: whereClause,
+		where: { name: workflowName, shared: { projectId: context.projectId } },
 		relations: ['shared'],
 	});
 
@@ -578,19 +570,7 @@ async function buildWorkflowTool(
 		throw new Error(`Workflow "${workflowName}" not found`);
 	}
 
-	// Step 2: Verify the user has execute access via RBAC.
-	const user = await userRepository.findOne({ where: { id: context.userId }, relations: ['role'] });
-	if (!user) {
-		throw new Error(`User "${context.userId}" not found`);
-	}
-
-	const workflow = await workflowFinderService.findWorkflowForUser(candidateWorkflow.id, user, [
-		'workflow:execute',
-	]);
-
-	if (!workflow) {
-		throw new Error(`Workflow "${workflowName}" not found or user does not have execute access`);
-	}
+	const workflow = candidateWorkflow;
 
 	validateCompatibility(workflow);
 	const { node: triggerNode, triggerType } = detectTriggerNode(workflow);

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -622,12 +622,10 @@ describe('ProjectService', () => {
 			expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
 				project.id,
 				'agent-1',
-				user.id,
 			);
 			expect(agentKnowledgeService.deleteAllFilesForAgent).toHaveBeenCalledWith(
 				project.id,
 				'agent-2',
-				user.id,
 			);
 			expect(agentKnowledgeService.deleteAllFilesForAgent.mock.invocationCallOrder[1]).toBeLessThan(
 				projectRepository.remove.mock.invocationCallOrder[0],

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -236,7 +236,7 @@ export class ProjectService {
 			const agents = await agentRepository.findByProjectId(project.id);
 			for (const agent of agents) {
 				try {
-					await agentKnowledgeService.deleteAllFilesForAgent(project.id, agent.id, user.id);
+					await agentKnowledgeService.deleteAllFilesForAgent(project.id, agent.id);
 				} catch (error) {
 					this.logger.warn('Failed to delete knowledge files on project delete', {
 						agentId: agent.id,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -351,29 +351,20 @@ export async function executeAgent(
 	outputSchema?: JSONSchema7,
 	workflowContext?: ExecuteAgentWorkflowContext,
 ): Promise<ExecuteAgentData> {
-	let userId = additionalData.userId;
 	const telemetryUserId = additionalData.userId;
 	let projectId = additionalData.projectId;
 
 	// Trigger-fired and webhook executions build `additionalData` without a
-	// `userId` (see `getBase` callers in `active-workflow-manager`,
-	// `webhooks/*`, `scaling/job-processor`). Resolve the workflow's owning
-	// project to derive both `userId` and `projectId` so the agent runs under
-	// the workflow owner's identity, mirroring the projectId backfill below.
-	if ((!userId || !projectId) && additionalData.workflowId) {
+	// `projectId` (see `getBase` callers in `active-workflow-manager`,
+	// `webhooks/*`, `scaling/job-processor`). Resolve it from the workflow's
+	// owning project so the agent runs under the correct project scope.
+	if (!projectId && additionalData.workflowId) {
 		const { OwnershipService } = await import('@/services/ownership.service');
 		const ownershipService = Container.get(OwnershipService);
 		const project = await ownershipService.getWorkflowProjectCached(additionalData.workflowId);
-		projectId = projectId ?? project.id;
-		if (!userId) {
-			const owner = await ownershipService.getPersonalProjectOwnerCached(project.id);
-			userId = owner?.id;
-		}
+		projectId = project.id;
 	}
 
-	if (!userId) {
-		throw new UnexpectedError('Cannot execute agent without a userId in additional data');
-	}
 	if (!projectId) {
 		throw new UnexpectedError(
 			'Cannot execute agent without a projectId or workflowId in additional data',
@@ -392,7 +383,6 @@ export async function executeAgent(
 		message,
 		executionId,
 		threadId,
-		userId,
 		projectId,
 		telemetryUserId,
 		useDraftVersion,


### PR DESCRIPTION
## Summary

The Message an Agent node failed in every published workflow living in a team project with
`Cannot execute agent without a userId in additional data`. Trigger-fired executions carry no
user, and the fallback resolved one via the personal-project owner lookup — which returns
nothing for team projects, since they have no `project:personalOwner` relation.

Rather than inventing another user to run under, this PR removes the agent runtime's dependency
on a user identity altogether and scopes it to the agent's project — the same model core
workflow execution has always used (credentials and sub-workflow policy are checked against
the workflow's projects, not a user). Done in four steps, one commit each:

1. **Workflow tools** — replaced the per-user RBAC check (`findWorkflowForUser` +
   `workflow:execute`) with a project-sharing check: the target workflow must be shared with
   the agent's project. Sub-executions no longer stamp a `userId`.
2. **Knowledge sandbox & AI proxy identity** — Daytona sandbox scope (name hash, labels,
   dedup key) and `getBuilderApiProxyToken` now use the project id instead of a user id. The
   proxy does not enforce per-user identity; the project id is the stable scope for agents.
3. **Chat integrations** — integration credentials are decrypted project-scoped (credential
   shared with the agent's project), replacing the "probe every project member until one can
   decrypt" fallback on reconnect/sync. User RBAC still applies at configuration time in the
   controller.
4. **Runtime chain cleanup** — deleted the `userId` parameter from runtime reconstruction,
   the runtime cache (draft cache keys are no longer per-user), sub-agent delegation,
   `executeForWorkflow`, and the `executeAgent` entry point. Scheduled agent tasks no longer
   require the publishing user to still be a project member.

### Behavior changes beyond the bug fix

- Integration reconnects now work when the credential sharer left the project or was deleted;
  conversely, a member-owned credential that was never shared with the project no longer
  connects (project sharing is now the source of truth).
- Sub-workflow executions started by agent workflow tools no longer show a triggering user
  (matches production workflow behavior).
- Scheduled agent tasks run as long as the agent is published, independent of the publisher's
  membership.

## How to test

1. Create a **team project** with an agent (published) and a workflow containing a Schedule
   Trigger + Message an Agent node pointing at that agent.
2. Publish the workflow and wait for a scheduled run — it executes the agent instead of
   throwing `Cannot execute agent without a userId in additional data`. (Personal-project
   workflows and manual/draft runs behave as before.)
3. For the integration path: connect e.g. Slack to an agent in a team project, restart the
   instance, and verify the integration reconnects without any project member holding
   `credential:read` on the credential personally.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-10403

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [ ] Docs updated or follow-up ticket created
- [x] Tests included
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 PR Summary generated by AI