### PR TITLE
feat(core): Add 'n8n-package-exported' logstreaming event

### DIFF
--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -83,6 +83,7 @@ export const eventNamesAudit = [
 	'n8n.audit.package.updated',
 	'n8n.audit.package.deleted',
 	'n8n.audit.n8n-package.imported',
+	'n8n.audit.n8n-package.exported',
 	'n8n.audit.workflow.created',
 	'n8n.audit.workflow.deleted',
 	'n8n.audit.workflow.updated',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -126,6 +126,43 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 
+		it('should log on `n8n-package-exported` event', () => {
+			const event: RelayEventMap['n8n-package-exported'] = {
+				user: {
+					id: 'user-export',
+					email: 'exporter@example.com',
+					firstName: 'Export',
+					lastName: 'User',
+					role: { slug: 'global:admin' },
+				},
+				workflowIds: ['wf-cheddar', 'wf-brie'],
+				folderIds: ['folder-gouda'],
+				projectIds: ['proj-stilton'],
+				// Telemetry-only; must not appear in the audit payload below.
+				counts: {
+					workflows: 2,
+					folders: 1,
+					credentials: 1,
+				},
+			};
+
+			eventService.emit('n8n-package-exported', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.n8n-package.exported',
+				payload: {
+					userId: 'user-export',
+					_email: 'exporter@example.com',
+					_firstName: 'Export',
+					_lastName: 'User',
+					globalRole: 'global:admin',
+					workflowIds: ['wf-cheddar', 'wf-brie'],
+					folderIds: ['folder-gouda'],
+					projectIds: ['proj-stilton'],
+				},
+			});
+		});
+
 		it('should log on `workflow-archived` event', () => {
 			const event: RelayEventMap['workflow-archived'] = {
 				user: {

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2025,9 +2025,11 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 
-		it('should track on `n8n-package-exported` event with entity counts', () => {
+		it('should track on `n8n-package-exported` event with entity counts only, not ids', () => {
 			const event: RelayEventMap['n8n-package-exported'] = {
 				user: { id: 'user123' },
+				workflowIds: ['wf1', 'wf2', 'wf3'],
+				projectIds: ['proj1'],
 				counts: {
 					workflows: 3,
 					folders: 1,

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -104,6 +104,9 @@ export type RelayEventMap = {
 
 	'n8n-package-exported': {
 		user: UserLike;
+		workflowIds?: string[];
+		folderIds?: string[];
+		projectIds?: string[];
 		counts: ExportPackageEventCounts;
 	};
 

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -42,6 +42,7 @@ export class LogStreamingEventRelay extends EventRelay {
 	init() {
 		this.setupListeners({
 			'n8n-package-imported': (event) => this.packageImported(event),
+			'n8n-package-exported': (event) => this.packageExported(event),
 			'workflow-created': (event) => this.workflowCreated(event),
 			'workflow-deleted': (event) => this.workflowDeleted(event),
 			'workflow-archived': (event) => this.workflowArchived(event),
@@ -146,6 +147,14 @@ export class LogStreamingEventRelay extends EventRelay {
 	private packageImported({ user, counts, ...rest }: RelayEventMap['n8n-package-imported']) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.n8n-package.imported',
+			payload: { ...user, ...rest },
+		});
+	}
+
+	@Redactable()
+	private packageExported({ user, counts, ...rest }: RelayEventMap['n8n-package-exported']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.n8n-package.exported',
 			payload: { ...user, ...rest },
 		});
 	}

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
@@ -2,6 +2,9 @@ import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils'
 import { Container } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
+import { EventService } from '@/events/event.service';
+import type { RelayEventMap } from '@/events/maps/relay.event-map';
+
 import { createFolder } from '@test-integration/db/folders';
 import { createMember, createOwner } from '@test-integration/db/users';
 
@@ -66,6 +69,26 @@ describe('folder package export', () => {
 			name: 'to_production',
 			parentFolderId: null,
 		});
+	});
+
+	it('emits n8n-package-exported with the requested folderIds', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'to_production' });
+
+		const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+
+		try {
+			await service.exportPackage({ user: owner, workflowIds: [], folderIds: [folder.id] });
+
+			const exportedEvents = emitSpy.mock.calls.filter(([name]) => name === 'n8n-package-exported');
+			expect(exportedEvents).toHaveLength(1);
+
+			const payload = exportedEvents[0][1] as RelayEventMap['n8n-package-exported'];
+			expect(payload.folderIds).toEqual([folder.id]);
+		} finally {
+			emitSpy.mockRestore();
+		}
 	});
 
 	it('aborts the export when the user cannot access the folder', async () => {

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
@@ -71,7 +71,7 @@ describe('folder package export', () => {
 		});
 	});
 
-	it('emits n8n-package-exported with the requested folderIds', async () => {
+	it('emits n8n-package-exported with the exported folderIds', async () => {
 		const owner = await createOwner();
 		const project = await createTeamProject('Project A', owner);
 		const folder = await createFolder(project, { name: 'to_production' });

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-project.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-project.integration.test.ts
@@ -8,6 +8,9 @@ import {
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
 
+import { EventService } from '@/events/event.service';
+import type { RelayEventMap } from '@/events/maps/relay.event-map';
+
 import { createMember, createOwner } from '@test-integration/db/users';
 
 import { N8nPackagesService } from '../n8n-packages.service';
@@ -71,6 +74,29 @@ describe('project package export', () => {
 			id: project.id,
 			name: 'Empty Project',
 		});
+	});
+
+	it('emits n8n-package-exported with the requested projectIds', async () => {
+		const owner = await createOwner();
+		const firstProject = await createTeamProject('Alpha Project', owner);
+		const secondProject = await createTeamProject('Beta Project', owner);
+
+		const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+
+		try {
+			await service.exportPackage({
+				user: owner,
+				projectIds: [firstProject.id, secondProject.id],
+			});
+
+			const exportedEvents = emitSpy.mock.calls.filter(([name]) => name === 'n8n-package-exported');
+			expect(exportedEvents).toHaveLength(1);
+
+			const payload = exportedEvents[0][1] as RelayEventMap['n8n-package-exported'];
+			expect(payload.projectIds).toEqual([firstProject.id, secondProject.id]);
+		} finally {
+			emitSpy.mockRestore();
+		}
 	});
 
 	it('exports multiple team projects in a single request', async () => {

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-project.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-project.integration.test.ts
@@ -76,7 +76,7 @@ describe('project package export', () => {
 		});
 	});
 
-	it('emits n8n-package-exported with the requested projectIds', async () => {
+	it('emits n8n-package-exported with the exported projectIds', async () => {
 		const owner = await createOwner();
 		const firstProject = await createTeamProject('Alpha Project', owner);
 		const secondProject = await createTeamProject('Beta Project', owner);
@@ -93,7 +93,7 @@ describe('project package export', () => {
 			expect(exportedEvents).toHaveLength(1);
 
 			const payload = exportedEvents[0][1] as RelayEventMap['n8n-package-exported'];
-			expect(payload.projectIds).toEqual([firstProject.id, secondProject.id]);
+			expect([...payload.projectIds!].sort()).toEqual([firstProject.id, secondProject.id].sort());
 		} finally {
 			emitSpy.mockRestore();
 		}

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-credentials.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-credentials.integration.test.ts
@@ -249,7 +249,11 @@ describe('workflow package export — with credentials', () => {
 			const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
 
 			try {
-				await service.exportPackage({ user: owner, workflowIds: [wfA.id, wfB.id, wfC.id] });
+				await service.exportPackage({
+					user: owner,
+					workflowIds: [wfA.id, wfB.id, wfC.id],
+					projectIds: [],
+				});
 
 				const exportedEvents = emitSpy.mock.calls.filter(
 					([name]) => name === 'n8n-package-exported',
@@ -260,6 +264,9 @@ describe('workflow package export — with credentials', () => {
 				expect(payload.counts.workflows).toBe(3);
 				expect(payload.counts.credentials).toBe(2);
 				expect(payload.user.id).toBe(owner.id);
+				expect(payload.workflowIds).toEqual([wfA.id, wfB.id, wfC.id]);
+				// Empty filter must be omitted entirely, not recorded as `[]`.
+				expect(payload).not.toHaveProperty('projectIds');
 			} finally {
 				emitSpy.mockRestore();
 			}

--- a/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-credentials.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-workflow-with-credentials.integration.test.ts
@@ -264,7 +264,7 @@ describe('workflow package export — with credentials', () => {
 				expect(payload.counts.workflows).toBe(3);
 				expect(payload.counts.credentials).toBe(2);
 				expect(payload.user.id).toBe(owner.id);
-				expect(payload.workflowIds).toEqual([wfA.id, wfB.id, wfC.id]);
+				expect([...payload.workflowIds!].sort()).toEqual([wfA.id, wfB.id, wfC.id].sort());
 				// Empty filter must be omitted entirely, not recorded as `[]`.
 				expect(payload).not.toHaveProperty('projectIds');
 			} finally {

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -93,9 +93,15 @@ export class N8nPackagesService {
 
 		this.eventService.emit('n8n-package-exported', {
 			user: request.user,
-			...(request.workflowIds?.length ? { workflowIds: request.workflowIds } : {}),
-			...(request.folderIds?.length ? { folderIds: request.folderIds } : {}),
-			...(request.projectIds?.length ? { projectIds: request.projectIds } : {}),
+			...(workflowExportResult?.entries.length
+				? { workflowIds: workflowExportResult.entries.map(({ id }) => id) }
+				: {}),
+			...(folderExportResult?.entries.length
+				? { folderIds: folderExportResult.entries.map(({ id }) => id) }
+				: {}),
+			...(projectExportResult?.entries.length
+				? { projectIds: projectExportResult.entries.map(({ id }) => id) }
+				: {}),
 			counts: {
 				workflows: workflowExportResult?.entries.length ?? 0,
 				folders: folderExportResult?.entries.length ?? 0,

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -93,6 +93,9 @@ export class N8nPackagesService {
 
 		this.eventService.emit('n8n-package-exported', {
 			user: request.user,
+			...(request.workflowIds?.length ? { workflowIds: request.workflowIds } : {}),
+			...(request.folderIds?.length ? { folderIds: request.folderIds } : {}),
+			...(request.projectIds?.length ? { projectIds: request.projectIds } : {}),
 			counts: {
 				workflows: workflowExportResult?.entries.length ?? 0,
 				folders: folderExportResult?.entries.length ?? 0,


### PR DESCRIPTION
## Summary

Emits an `n8n.audit.n8n-package.exported` audit event through the log-streaming pipeline whenever a package export completes successfully. Enterprise operators who forward n8n audit logs into a SIEM can now see **who** exported **what** and **when**.

Example of what can get log collector

<img width="430" height="692" alt="image" src="https://github.com/user-attachments/assets/44f55f7c-e5c5-4667-b057-0b935713a3d3" />

## How to test

Log streaming is an enterprise module. On a licensed instance:
1. Configure a log-streaming destination (e.g. a webhook) and enable the `n8n.audit.n8n-package.exported` event (it appears automatically in the destination's event picker).
2. Export a workflow via the public API or CLI:
   ```bash
   n8n-cli package export --workflow-id=<id> --output=export.n8np
   ```
3. Confirm the destination receives an `n8n.audit.n8n-package.exported` message containing the redacted user and the `workflowIds` you exported.
4. Repeat with `--project-id=<id>` and confirm the payload carries `projectIds` instead.
5. Trigger a failing export (unknown id) and confirm **no** event is streamed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-612

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->