### PR TITLE
fix(nodes-langchain): resolve Vector Store Retriever runtime error on…

### DIFF
--- a/packages/@n8n/ai-utilities/src/guards.ts
+++ b/packages/@n8n/ai-utilities/src/guards.ts
@@ -3,6 +3,7 @@ import type { BaseChatMessageHistory } from '@langchain/core/chat_history';
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { BaseLLM } from '@langchain/core/language_models/llms';
 import type { Tool } from '@langchain/core/tools';
+import type { VectorStore } from '@langchain/core/vectorstores';
 
 function hasMethods<T>(obj: unknown, ...methodNames: Array<string | symbol>): obj is T {
 	return methodNames.every(
@@ -32,4 +33,8 @@ export function isToolsInstance(model: unknown): model is Tool {
 	const namespace = (model as Tool)?.lc_namespace ?? [];
 
 	return namespace.includes('tools');
+}
+
+export function isVectorStore(obj: unknown): obj is VectorStore {
+	return hasMethods<VectorStore>(obj, 'asRetriever', 'similaritySearch');
 }

--- a/packages/@n8n/ai-utilities/src/index.ts
+++ b/packages/@n8n/ai-utilities/src/index.ts
@@ -95,6 +95,7 @@ export {
 	isBaseChatMessageHistory,
 	isChatInstance,
 	isToolsInstance,
+	isVectorStore,
 } from './guards';
 
 // Types

--- a/packages/@n8n/ai-utilities/src/utils/log-wrapper.ts
+++ b/packages/@n8n/ai-utilities/src/utils/log-wrapper.ts
@@ -9,7 +9,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import { BaseRetriever } from '@langchain/core/retrievers';
 import { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
 import type { StructuredTool, Tool } from '@langchain/core/tools';
-import { VectorStore } from '@langchain/core/vectorstores';
+import type { VectorStore } from '@langchain/core/vectorstores';
 import { TextSplitter } from '@langchain/textsplitters';
 import type {
 	IDataObject,
@@ -26,7 +26,12 @@ import {
 	deepCopy,
 } from 'n8n-workflow';
 
-import { isToolsInstance, isBaseChatMemory, isBaseChatMessageHistory } from '../guards';
+import {
+	isToolsInstance,
+	isBaseChatMemory,
+	isBaseChatMessageHistory,
+	isVectorStore,
+} from '../guards';
 import {
 	validateEmbedQueryInput,
 	validateEmbedDocumentsInput,
@@ -451,7 +456,7 @@ export function logWrapper<
 			}
 
 			// ========== VectorStore ==========
-			if (originalInstance instanceof VectorStore) {
+			if (isVectorStore(originalInstance)) {
 				if (prop === 'similaritySearch' && 'similaritySearch' in target) {
 					return async (
 						query: string,

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/RetrieverVectorStore.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/RetrieverVectorStore.node.ts
@@ -1,15 +1,16 @@
 import type { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
-import { VectorStore } from '@langchain/core/vectorstores';
+import type { VectorStore } from '@langchain/core/vectorstores';
 import { ContextualCompressionRetriever } from '@langchain/classic/retrievers/contextual_compression';
 import {
 	NodeConnectionTypes,
+	NodeOperationError,
 	type INodeType,
 	type INodeTypeDescription,
 	type ISupplyDataFunctions,
 	type SupplyData,
 } from 'n8n-workflow';
 
-import { logWrapper } from '@n8n/ai-utilities';
+import { logWrapper, isVectorStore } from '@n8n/ai-utilities';
 
 export class RetrieverVectorStore implements INodeType {
 	description: INodeTypeDescription = {
@@ -86,13 +87,22 @@ export class RetrieverVectorStore implements INodeType {
 
 		let retriever = null;
 
-		if (vectorStore instanceof VectorStore) {
+		if (isVectorStore(vectorStore)) {
 			retriever = vectorStore.asRetriever(topK);
-		} else {
+		} else if (
+			vectorStore &&
+			'vectorStore' in vectorStore &&
+			isVectorStore(vectorStore.vectorStore)
+		) {
 			retriever = new ContextualCompressionRetriever({
 				baseCompressor: vectorStore.reranker,
 				baseRetriever: vectorStore.vectorStore.asRetriever(topK),
 			});
+		} else {
+			throw new NodeOperationError(
+				this.getNode(),
+				'No valid Vector Store connection found. Please check your connections.',
+			);
 		}
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/retrievers/RetrieverVectorStore/test/RetrieverVectorStore.node.test.ts
@@ -2,7 +2,7 @@ import { ContextualCompressionRetriever } from '@langchain/classic/retrievers/co
 import type { BaseDocumentCompressor } from '@langchain/core/retrievers/document_compressors';
 import { VectorStore } from '@langchain/core/vectorstores';
 import type { ISupplyDataFunctions } from 'n8n-workflow';
-import { NodeConnectionTypes } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 
 import { RetrieverVectorStore } from '../RetrieverVectorStore.node';
@@ -129,6 +129,65 @@ describe('RetrieverVectorStore', () => {
 
 			expect(mockContext.getNodeParameter).toHaveBeenCalledWith('topK', 0, 4);
 			expect(mockVectorStore.asRetriever).toHaveBeenCalledWith(4);
+		});
+
+		it('should create a retriever from a duck-typed VectorStore (prototype mismatch)', async () => {
+			const mockDuckVectorStore = {
+				asRetriever: vi.fn().mockReturnValue({ test: 'duck-retriever' }),
+				similaritySearch: vi.fn(),
+			};
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 4;
+				return defaultValue;
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(mockDuckVectorStore);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockContext.getInputConnectionData).toHaveBeenCalledWith(
+				NodeConnectionTypes.AiVectorStore,
+				0,
+			);
+			expect(mockDuckVectorStore.asRetriever).toHaveBeenCalledWith(4);
+			expect(result).toHaveProperty('response', { test: 'duck-retriever' });
+		});
+
+		it('should create a ContextualCompressionRetriever when input contains reranker and duck-typed vectorStore', async () => {
+			const mockDuckVectorStore = {
+				asRetriever: vi.fn().mockReturnValue({ test: 'base-duck-retriever' }),
+				similaritySearch: vi.fn(),
+			};
+
+			const mockReranker = {} as BaseDocumentCompressor;
+
+			const inputWithReranker = {
+				reranker: mockReranker,
+				vectorStore: mockDuckVectorStore,
+			};
+
+			mockContext.getNodeParameter.mockImplementation((param, _itemIndex, defaultValue) => {
+				if (param === 'topK') return 4;
+				return defaultValue;
+			});
+			mockContext.getInputConnectionData.mockResolvedValue(inputWithReranker);
+
+			const result = await retrieverNode.supplyData.call(mockContext, 0);
+
+			expect(mockDuckVectorStore.asRetriever).toHaveBeenCalledWith(4);
+			expect(result.response).toBeInstanceOf(ContextualCompressionRetriever);
+		});
+
+		it('should throw NodeOperationError when input is missing or invalid', async () => {
+			mockContext.getNodeParameter.mockImplementation(
+				(_param, _itemIndex, defaultValue) => defaultValue,
+			);
+			mockContext.getInputConnectionData.mockResolvedValue(undefined);
+			mockContext.getNode = vi.fn().mockReturnValue({ name: 'Vector Store Retriever' });
+
+			await expect(retrieverNode.supplyData.call(mockContext, 0)).rejects.toThrow(
+				NodeOperationError,
+			);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #33452
Linear Ticket: https://linear.app/n8n/issue/GHC-8973

## What this PR does
Resolves a runtime error where the **Vector Store Retriever** node throws `Cannot read properties of undefined (reading 'asRetriever')` when connected to a chain (like the Question and Answer Chain) or other nodes.

### Cause:
The retriever node was performing an `instanceof VectorStore` check. In monorepo configurations, `@n8n/nodes-langchain` and `@n8n/ai-utilities` load different copies of `@langchain/core` from their respective node modules. Because of this package prototype mismatch, the `instanceof` check evaluated to `false`, causing the node to fall back to the reranker wrapper check, where it crashed when accessing `vectorStore.vectorStore` (which was `undefined`).

### Solution:
* Replaced `instanceof VectorStore` with a robust duck-typed helper `isVectorStore` exported from `@n8n/ai-utilities`.
* Added a safe connection check that throws a user-friendly `NodeOperationError` if the required Vector Store input is missing.
* Replaced `instanceof VectorStore` check in the `log-wrapper.ts` telemetry helper to avoid missing search events under prototype mismatches.

## How to test
1. Run the new unit tests for the retriever node:
   ```bash
   pnpm --filter @n8n/nodes-langchain test RetrieverVectorStore
   ```
2. Verify all 8 tests pass (including 3 new tests checking duck-typed vector stores, rerankers, and empty connections).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
