### PR TITLE
fix(core): Prevent duplicate zod instances that break npm installs

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,6 +32,12 @@ pre-commit:
       skip:
         - merge
         - rebase
+    zod_peer_deps_check:
+      glob: 'packages/{@n8n/api-types,workflow,core,@n8n/agents}/package.json'
+      run: node scripts/check-zod-peer-deps.mjs
+      skip:
+        - merge
+        - rebase
     skill_links_check:
       glob: '.agents/skills/**'
       run: node scripts/sync-agent-skill-links.mjs --check

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:ci": "turbo run lint lint:styles",
     "sync:skill-links": "node scripts/sync-agent-skill-links.mjs",
     "check:skill-links": "node scripts/sync-agent-skill-links.mjs --check",
+    "check:zod-peer-deps": "node scripts/check-zod-peer-deps.mjs",
     "optimize-svg": "find ./packages -name '*.svg' ! -name 'pipedrive.svg' -print0 | xargs -0 -P16 -L20 npx svgo",
     "setup-backend-module": "node scripts/ensure-zx.mjs && zx scripts/backend-module/setup.mjs",
     "start": "node scripts/os-normalize.mjs --dir packages/cli/bin n8n",

--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -86,8 +86,10 @@
     "langsmith": "catalog:",
     "undici": "catalog:undici-v7",
     "yaml": "catalog:",
-    "zod": "catalog:",
     "zod-to-json-schema": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "catalog:"
   },
   "peerDependenciesMeta": {
     "langsmith": {
@@ -113,7 +115,8 @@
     "nock": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vitest-mock-extended": "catalog:"
+    "vitest-mock-extended": "catalog:",
+    "zod": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -30,13 +30,16 @@
     "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:",
-    "minifaker": "1.34.1"
+    "minifaker": "1.34.1",
+    "zod": "catalog:"
   },
   "dependencies": {
     "@n8n_io/ai-assistant-sdk": "catalog:",
     "n8n-workflow": "workspace:*",
     "xss": "catalog:",
-    "@n8n/permissions": "workspace:*",
+    "@n8n/permissions": "workspace:*"
+  },
+  "peerDependencies": {
     "zod": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"

--- a/packages/@n8n/eslint-config/src/configs/base.ts
+++ b/packages/@n8n/eslint-config/src/configs/base.ts
@@ -351,7 +351,6 @@ export const baseConfig = tseslint.config(
 						'**/*.stories.ts',
 					],
 					optionalDependencies: false,
-					peerDependencies: false,
 				},
 			],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,8 @@
     "reflect-metadata": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vitest-mock-extended": "catalog:"
+    "vitest-mock-extended": "catalog:",
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "zod": "catalog:"
@@ -96,7 +97,6 @@
     "uuid": "catalog:",
     "winston": "3.14.2",
     "xml2js": "catalog:",
-    "zod": "catalog:",
     "qs": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -92,7 +92,9 @@
     "transliteration": "2.3.5",
     "uuid": "catalog:",
     "xml2js": "catalog:",
-    "jsonrepair": "catalog:",
+    "jsonrepair": "catalog:"
+  },
+  "peerDependencies": {
     "zod": "catalog:"
   },
   "license": "LicenseRef-n8n-sustainable-use"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,9 +956,6 @@ importers:
       yaml:
         specifier: 'catalog:'
         version: 2.8.3
-      zod:
-        specifier: 3.25.67
-        version: 3.25.67
       zod-to-json-schema:
         specifier: 'catalog:'
         version: 3.23.3(zod@3.25.67)
@@ -993,6 +990,9 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
 
   packages/@n8n/ai-node-sdk:
     dependencies:
@@ -1254,9 +1254,6 @@ importers:
       xss:
         specifier: 'catalog:'
         version: 1.0.15
-      zod:
-        specifier: 3.25.67
-        version: 3.25.67
     devDependencies:
       '@n8n/config':
         specifier: workspace:*
@@ -1282,6 +1279,9 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
 
   packages/@n8n/backend-common:
     dependencies:
@@ -4375,9 +4375,6 @@ importers:
       xml2js:
         specifier: 'catalog:'
         version: 0.6.2
-      zod:
-        specifier: 3.25.67
-        version: 3.25.67
     devDependencies:
       '@n8n/playwright-janitor':
         specifier: workspace:*
@@ -4439,6 +4436,9 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
 
   packages/extensions/insights:
     dependencies:
@@ -6399,9 +6399,6 @@ importers:
       xml2js:
         specifier: 'catalog:'
         version: 0.6.2
-      zod:
-        specifier: 3.25.67
-        version: 3.25.67
     devDependencies:
       '@langchain/core':
         specifier: 'catalog:'
@@ -6460,6 +6457,9 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
 
 packages:
 

--- a/scripts/check-zod-peer-deps.mjs
+++ b/scripts/check-zod-peer-deps.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Guards against an npm-only startup break: workspace packages that compose zod
+ * schemas across package boundaries must declare `zod` as a **peerDependency**,
+ * not a regular dependency.
+ *
+ * `@n8n/api-types` builds a `z.discriminatedUnion` over schemas created in
+ * `n8n-workflow`. That only works when both packages resolve the *same* physical
+ * zod instance. In the pnpm monorepo the catalog forces one instance, so it always
+ * holds locally. But on `npm install n8n`, if these packages each list `zod` in
+ * `dependencies`, npm can install a separate nested copy per package (langchain
+ * pins `zod@4` at the root, pushing our `zod@3` down), so the cross-package schema
+ * composition resolves different instances and n8n crashes at boot. Declaring zod
+ * as a peerDependency makes the consuming app provide a single shared instance.
+ *
+ * This exact regression shipped in 2.28.0 (#32386 moved zod peer→dependencies),
+ * reverting the fix from #28604. This check keeps zod a peer so it can't recur.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Packages that share zod schema objects across the workspace and are runtime
+// dependencies of the `n8n` cli. zod must be a peer here, never a plain dependency.
+export const PACKAGES_REQUIRING_ZOD_PEER = [
+	'packages/@n8n/api-types',
+	'packages/workflow',
+	'packages/core',
+	'packages/@n8n/agents',
+];
+
+/** Pure, testable core: return a problem string for a manifest, or null if OK. */
+export function checkManifest(name, pkg) {
+	const inDeps = pkg.dependencies?.zod;
+	const inPeer = pkg.peerDependencies?.zod;
+	if (inDeps) {
+		return `${name}: "zod" is in "dependencies" (${inDeps}); it must be a "peerDependency" instead.`;
+	}
+	if (!inPeer) {
+		return `${name}: "zod" is missing from "peerDependencies".`;
+	}
+	return null;
+}
+
+function main() {
+	const problems = [];
+	for (const rel of PACKAGES_REQUIRING_ZOD_PEER) {
+		const file = join(root, rel, 'package.json');
+		if (!existsSync(file)) continue; // package moved/renamed — don't hard-fail here
+		const pkg = JSON.parse(readFileSync(file, 'utf8'));
+		const problem = checkManifest(pkg.name ?? rel, pkg);
+		if (problem) problems.push(problem);
+	}
+
+	if (problems.length > 0) {
+		console.error('');
+		console.error('ERROR: zod must stay a peerDependency in schema-composing packages.');
+		console.error('');
+		console.error('Moving zod into "dependencies" lets npm install duplicate zod copies, which');
+		console.error('breaks cross-package schema composition and crashes n8n at startup on');
+		console.error('`npm install n8n` (regressed once in 2.28.0 via #32386).');
+		console.error('');
+		for (const p of problems) console.error(`  - ${p}`);
+		console.error('');
+		console.error(
+			'Move "zod" to "peerDependencies" (keep it in "devDependencies" for local builds).',
+		);
+		console.error('');
+		process.exit(1);
+	}
+
+	console.log(
+		`OK: zod is a peerDependency in all ${PACKAGES_REQUIRING_ZOD_PEER.length} schema-composing packages.`,
+	);
+}
+
+// `--self-test` exercises the core logic without touching the workspace.
+if (process.argv.includes('--self-test')) {
+	const good = checkManifest('good', { peerDependencies: { zod: 'catalog:' } }) === null;
+	const badDep = checkManifest('bad', { dependencies: { zod: 'catalog:' } }) !== null;
+	const badMissing = checkManifest('missing', {}) !== null;
+	if (good && badDep && badMissing) {
+		console.log('self-test passed');
+		process.exit(0);
+	}
+	console.error(`self-test FAILED (good=${good}, badDep=${badDep}, badMissing=${badMissing})`);
+	process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main();
+}


### PR DESCRIPTION
## Summary

Since **2.28.0**, `npm install n8n` crashes at boot. Reproduced with a clean `npm install n8n@2.28.0` → `n8n`:

```
Error: A discriminator value for key `__type` could not be extracted from all schema options
  at .../@n8n/api-types/node_modules/zod/.../v3/types.js
  at .../@n8n/api-types/dist/dto/log-streaming/create-destination.dto.js   // z.discriminatedUnion('__type', [...])
```
(surfaced to users as a misleading `Cannot find module .../breaking-changes.ee/breaking-changes.module`.)

**Root cause — duplicate `zod` instances.** `@n8n/api-types` builds a `z.discriminatedUnion` over option schemas created inside `n8n-workflow`. That only works when both packages resolve the **same physical zod copy**. #32386 ("Extraneous deps cleanup", in 2.28.0) moved `zod` from `peerDependencies` into `dependencies` in several backend packages, reverting #28604 ("Ensure single zod instance across workspace packages"). On npm this causes duplication: `@langchain/*` pins `zod@4` at the tree root, so every `@n8n/*` package that lists `zod` in `dependencies` gets its **own nested `zod@3`** copy → cross-package schema composition resolves different instances → crash. The pnpm monorepo is unaffected because the catalog forces a single hoisted instance, which is why it only broke npm consumers / not docker.

**Fix.** Restore `zod` to `peerDependencies` (+ `devDependencies`) in the backend packages that share zod schemas across boundaries — `@n8n/api-types`, `n8n-workflow`, `n8n-core`, `@n8n/agents` — so the consuming app provides one shared instance (langchain keeps its own separate zod, which is harmless since it never shares schema objects with n8n's discriminated unions). Also allow peer-dependency imports in the shared eslint config (`import-x/no-extraneous-dependencies`), and add `scripts/check-zod-peer-deps.mjs` (wired via `pnpm check:zod-peer-deps` and a lefthook pre-commit hook) so a future "deps cleanup" cannot silently move `zod` back into `dependencies`.

This keeps `zod` pinned at `3.25.67` — no version bump, so there is no type-inference churn in the LangChain/MCP integration code.

## How to test

Verified end-to-end via a local npm registry (verdaccio) publishing this branch:

- `npm install n8n@<branch>` then `require('@n8n/api-types')` → loads cleanly (previously threw the discriminatedUnion error).
- `@n8n/api-types` and `n8n-workflow` resolve **the same** `node_modules/zod@3.25.67`; `@langchain/*` gets its own isolated `zod@4`.
- Booting n8n from the monorepo reaches `n8n ready on ...`, runs all migrations, and loads every module (incl. `breaking-changes`) with no crash.
- Repo-wide typecheck (100 packages) and lint on the four packages pass.
- Regression guard: `pnpm check:zod-peer-deps` passes; it fails if `zod` is moved back into `dependencies` in any of the four packages.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add the Linear ticket URL for this fix, e.g. https://linear.app/n8n/issue/[TICKET-ID] -->
- Regression from #32386; restores the approach of #28604.
- Related community report: https://community.n8n.io/t/n8n-install-issue-im-installing-from-2-02-version-to-2-28-4-the-issue-is-im-getting-start-not-found/301740

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->