### PR TITLE
fix(editor): Show AI Gateway hints for supported nodes used as tools

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/aiGateway.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/aiGateway.store.test.ts
@@ -343,6 +343,20 @@ describe('aiGateway.store', () => {
 			);
 		});
 
+		it('should fall back to the base node name for Tool-suffixed node types', async () => {
+			mockGetGatewayConfig.mockResolvedValue(MOCK_CONFIG);
+			const store = useAiGatewayStore();
+			await store.fetchConfig();
+
+			// "openAiTool" is not a config key, but its base "openAi" is.
+			expect(
+				store.isActionSupported('@n8n/n8n-nodes-langchain.openAiTool', 'text', 'message'),
+			).toBe(true);
+			expect(store.isActionSupported('@n8n/n8n-nodes-langchain.openAiTool', 'file', 'upload')).toBe(
+				false,
+			);
+		});
+
 		describe('operation-only nodes (no resource)', () => {
 			it('should return true when operation is in the OPERATION_ONLY list', async () => {
 				mockGetGatewayConfig.mockResolvedValue(MOCK_CONFIG);
@@ -456,6 +470,19 @@ describe('aiGateway.store', () => {
 
 			expect(store.isNodePropertyHidden(null, 'modelSource')).toBe(false);
 		});
+
+		it('should fall back to the base node name for Tool-suffixed node types', async () => {
+			mockGetGatewayConfig.mockResolvedValue(MOCK_CONFIG);
+			const store = useAiGatewayStore();
+			await store.fetchConfig();
+
+			const toolNode = {
+				type: 'n8n-nodes-browserbase.browserbaseTool',
+				credentials: { browserbaseApi: { id: null, name: '', __aiGatewayManaged: true } },
+			} as unknown as INode;
+
+			expect(store.isNodePropertyHidden(toolNode, 'modelSource')).toBe(true);
+		});
 	});
 
 	describe('isNodeTypeVersionSupported()', () => {
@@ -515,6 +542,16 @@ describe('aiGateway.store', () => {
 			// config not loaded → no minNodeTypeVersion entry → no version gate → pass through
 			// node support when config is unloaded is handled by isCredentialTypeSupported / isNodeSupported
 			expect(store.isNodeTypeVersionSupported('some-package.SomeNode', 1.1)).toBe(true);
+		});
+
+		it('should fall back to the base node name for Tool-suffixed node types', async () => {
+			mockGetGatewayConfig.mockResolvedValue(CONFIG_WITH_VERSION_REQ);
+			const store = useAiGatewayStore();
+			await store.fetchConfig();
+
+			// "SomeNodeTool" has no entry, but the base "SomeNode" requires >= 1.1.
+			expect(store.isNodeTypeVersionSupported('some-package.SomeNodeTool', 1.1)).toBe(true);
+			expect(store.isNodeTypeVersionSupported('some-package.SomeNodeTool', 1.0)).toBe(false);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/aiGateway.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/aiGateway.store.ts
@@ -17,6 +17,11 @@ function toError(e: unknown): Error {
 	return e instanceof Error ? e : new Error(String(e));
 }
 
+// Tool-variant node types carry a "Tool"/"HitlTool" suffix (e.g. "openAiTool"),
+// but the gateway config is keyed by the base node name ("openAi").
+const stripToolSuffix = (nodeName: string) =>
+	nodeName.replace(/HitlTool$/, '').replace(/Tool$/, '');
+
 export const useAiGatewayStore = defineStore(STORES.AI_GATEWAY, () => {
 	const rootStore = useRootStore();
 
@@ -98,7 +103,9 @@ export const useAiGatewayStore = defineStore(STORES.AI_GATEWAY, () => {
 		operation: string,
 	): boolean {
 		if (!config.value) return true;
-		const nodeActions = config.value.supportedActions?.[nodeName];
+		const nodeActions =
+			config.value.supportedActions?.[nodeName] ??
+			config.value.supportedActions?.[stripToolSuffix(nodeName)];
 		if (!nodeActions) return true;
 		const ops = nodeActions[resource ?? OPERATION_ONLY];
 		if (!ops) return false;
@@ -106,7 +113,9 @@ export const useAiGatewayStore = defineStore(STORES.AI_GATEWAY, () => {
 	}
 
 	function isNodeTypeVersionSupported(nodeName: string, typeVersion: number): boolean {
-		const minVersion = config.value?.minNodeTypeVersion?.[nodeName];
+		const minVersion =
+			config.value?.minNodeTypeVersion?.[nodeName] ??
+			config.value?.minNodeTypeVersion?.[stripToolSuffix(nodeName)];
 		if (minVersion === undefined) return true;
 		return typeVersion >= minVersion;
 	}
@@ -119,7 +128,9 @@ export const useAiGatewayStore = defineStore(STORES.AI_GATEWAY, () => {
 		);
 		if (!hasGatewayCredential) return false;
 
-		const properties = config.value?.hiddenNodeProperties?.[node.type];
+		const properties =
+			config.value?.hiddenNodeProperties?.[node.type] ??
+			config.value?.hiddenNodeProperties?.[stripToolSuffix(node.type)];
 		if (!properties) return false;
 		return properties.includes(propertyName);
 	}


### PR DESCRIPTION
## Summary

The AI Gateway "unsupported action" notice (and related hint logic) shows correctly on a standalone node, but not when the same supported node is used as a tool.

Root cause: when a node is used as a tool, its type gets a `Tool`/`HitlTool` suffix appended (e.g. `@n8n/n8n-nodes-langchain.openAiTool`), but the AI Gateway config keys `supportedActions`, `minNodeTypeVersion`, and `hiddenNodeProperties` by the **base** node name (`...openAi`). The store lookups used the raw type, missed the tool-suffixed key, and fell through to their permissive "no restriction" defaults, so the notice never fired for tool nodes.

Fix: in `aiGateway.store.ts`, fall back to the stripped base name in the three lookups (`isActionSupported`, `isNodeTypeVersionSupported`, `isNodePropertyHidden`). The raw type is tried first, so base nodes (and any real node ending in `Tool`) keep matching their own entry; the stripped name is only a fallback. Fixing it in the store means all NDV call sites benefit without further changes.

## How to test

1. Enable the AI Gateway and attach the managed `n8n Connect` credential to a node used as a tool (e.g. import the workflow below).
2. Select an unsupported resource/operation.
3. The `ai-gateway-unsupported-action-notice` warning banner should now render above the operation, matching standalone-node behavior.

<details>
<summary>Example workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": { "binaryPropertyName": "={{ $('Chat').item.binary.data0 }}" },
      "id": "5636ec80-1e3c-4b2d-9743-6ae6978c193e",
      "name": "parse_document",
      "type": "@llamaindex/n8n-nodes-llamacloud.llamaParsePlatformTool",
      "typeVersion": 1,
      "position": [480, 752],
      "credentials": {}
    }
  ],
  "connections": { "parse_document": { "ai_tool": [[]] } }
}
```

</details>

Unit tests (from `packages/frontend/editor-ui`): `vitest run src/app/stores/aiGateway.store.test.ts` (47 passed, 3 new tool-suffix cases).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-156

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->