### PR TITLE
feat(core): Auto-name workflow versions created or updated via MCP

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -172,6 +172,8 @@ describe('create-workflow-from-code MCP tool', () => {
 			skillsUsed?: string[];
 			name?: string;
 			description?: string;
+			versionName?: string;
+			versionDescription?: string;
 			projectId?: string;
 			folderId?: string;
 		},
@@ -183,6 +185,8 @@ describe('create-workflow-from-code MCP tool', () => {
 				skillsUsed: input.skillsUsed,
 				name: input.name as string,
 				description: input.description as string,
+				versionName: input.versionName as string,
+				versionDescription: input.versionDescription as string,
 				projectId: input.projectId as string,
 				folderId: input.folderId as string,
 			},
@@ -314,7 +318,7 @@ describe('create-workflow-from-code MCP tool', () => {
 			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
 				user,
 				expect.any(WorkflowEntity),
-				{ projectId: 'personal-project-1', source: 'n8n-mcp' },
+				expect.objectContaining({ projectId: 'personal-project-1', source: 'n8n-mcp' }),
 			);
 		});
 
@@ -324,7 +328,37 @@ describe('create-workflow-from-code MCP tool', () => {
 			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
 				user,
 				expect.any(WorkflowEntity),
-				{ projectId: 'custom-project-id', source: 'n8n-mcp' },
+				expect.objectContaining({ projectId: 'custom-project-id', source: 'n8n-mcp' }),
+			);
+		});
+
+		test('passes client-provided version metadata to the service', async () => {
+			await callHandler({
+				code: 'const wf = ...',
+				versionName: 'Initial Slack notification workflow',
+				versionDescription: 'Posts to #ops when the webhook fires',
+			});
+
+			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
+				user,
+				expect.any(WorkflowEntity),
+				expect.objectContaining({
+					versionName: 'Initial Slack notification workflow',
+					versionDescription: 'Posts to #ops when the webhook fires',
+				}),
+			);
+		});
+
+		test('falls back to generated version metadata when the client omits it', async () => {
+			await callHandler({ code: 'const wf = ...' });
+
+			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
+				user,
+				expect.any(WorkflowEntity),
+				expect.objectContaining({
+					versionName: 'Initial version',
+					versionDescription: 'Created with 2 nodes: Webhook, Set',
+				}),
 			);
 		});
 

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -349,8 +349,8 @@ describe('create-workflow-from-code MCP tool', () => {
 			);
 		});
 
-		test('falls back to generated version metadata when the client sends blank values', async () => {
-			await callHandler({ code: 'const wf = ...', versionName: '   ' });
+		test('falls back to generated version metadata when the client omits it', async () => {
+			await callHandler({ code: 'const wf = ...' });
 
 			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
 				user,

--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -349,8 +349,8 @@ describe('create-workflow-from-code MCP tool', () => {
 			);
 		});
 
-		test('falls back to generated version metadata when the client omits it', async () => {
-			await callHandler({ code: 'const wf = ...' });
+		test('falls back to generated version metadata when the client sends blank values', async () => {
+			await callHandler({ code: 'const wf = ...', versionName: '   ' });
 
 			expect(workflowCreationService.createWorkflow).toHaveBeenCalledWith(
 				user,

--- a/packages/cli/src/modules/mcp/__tests__/restore-workflow-version.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/restore-workflow-version.tool.test.ts
@@ -111,6 +111,47 @@ describe('restore-workflow-version MCP tool', () => {
 			expect(collaborationService.broadcastWorkflowUpdate).toHaveBeenCalledWith('wf-1', user.id);
 		});
 
+		test('names the new version after the restored version', async () => {
+			(workflowFinderService.findWorkflowForUser as Mock).mockResolvedValue(createWorkflow());
+			(workflowHistoryService.getVersion as Mock).mockResolvedValue(
+				createWorkflowHistoryVersion({
+					workflowId: 'wf-1',
+					versionId: 'v1',
+					nodes: versionNodes,
+					name: 'Added Slack alert',
+					createdAt: new Date('2024-01-01T00:00:00.000Z'),
+				}),
+			);
+			(workflowService.update as Mock).mockResolvedValue({ id: 'wf-1', versionId: 'v2' });
+
+			const tool = buildTool();
+			await tool.handler({ workflowId: 'wf-1', versionId: 'v1' }, callContext);
+
+			expect((workflowService.update as Mock).mock.calls[0][3]).toMatchObject({
+				versionName: 'Restored "Added Slack alert"',
+				versionDescription: 'Restored to version v1 (created 2024-01-01T00:00:00.000Z)',
+			});
+		});
+
+		test('falls back to the version id when the restored version is unnamed', async () => {
+			(workflowFinderService.findWorkflowForUser as Mock).mockResolvedValue(createWorkflow());
+			(workflowHistoryService.getVersion as Mock).mockResolvedValue(
+				createWorkflowHistoryVersion({
+					workflowId: 'wf-1',
+					versionId: 'abcdef1234567890',
+					nodes: versionNodes,
+				}),
+			);
+			(workflowService.update as Mock).mockResolvedValue({ id: 'wf-1', versionId: 'v2' });
+
+			const tool = buildTool();
+			await tool.handler({ workflowId: 'wf-1', versionId: 'abcdef1234567890' }, callContext);
+
+			expect((workflowService.update as Mock).mock.calls[0][3]).toMatchObject({
+				versionName: 'Restored version abcdef12',
+			});
+		});
+
 		test('clears the current node groups when restoring a version that had none', async () => {
 			(workflowFinderService.findWorkflowForUser as Mock).mockResolvedValue(createWorkflow());
 			(workflowHistoryService.getVersion as Mock).mockResolvedValue(

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -193,7 +193,13 @@ describe('update-workflow MCP tool', () => {
 		);
 
 	const callHandler = async (
-		input: { workflowId: string; skillsUsed?: string[]; operations: unknown[] },
+		input: {
+			workflowId: string;
+			skillsUsed?: string[];
+			operations: unknown[];
+			versionName?: string;
+			versionDescription?: string;
+		},
 		tool = createTool(),
 	) =>
 		await tool.handler(
@@ -201,6 +207,8 @@ describe('update-workflow MCP tool', () => {
 				workflowId: input.workflowId,
 				skillsUsed: input.skillsUsed,
 				operations: input.operations as never,
+				versionName: input.versionName as string,
+				versionDescription: input.versionDescription as string,
 			},
 			{} as never,
 		);
@@ -279,6 +287,42 @@ describe('update-workflow MCP tool', () => {
 
 			expect(result.isError).toBeUndefined();
 			expect(() => buildStrictOutputSchema(tool).parse(result.structuredContent)).not.toThrow();
+		});
+	});
+
+	describe('version metadata', () => {
+		test('passes client-provided versionName and versionDescription to the update', async () => {
+			await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+				versionName: 'Pointed B at the new API',
+				versionDescription: 'Switched the request URL after the API migration',
+			});
+
+			expect(updateMock.mock.calls[0][3]).toEqual(
+				expect.objectContaining({
+					versionName: 'Pointed B at the new API',
+					versionDescription: 'Switched the request URL after the API migration',
+				}),
+			);
+		});
+
+		test('falls back to diff-based version metadata when the client omits it', async () => {
+			await callHandler({
+				workflowId: 'wf-1',
+				operations: [
+					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
+				],
+			});
+
+			expect(updateMock.mock.calls[0][3]).toEqual(
+				expect.objectContaining({
+					versionName: 'Updated B',
+					versionDescription: 'Updated nodes: B',
+				}),
+			);
 		});
 	});
 
@@ -878,7 +922,7 @@ describe('update-workflow MCP tool', () => {
 				user,
 				expect.any(WorkflowEntity),
 				'wf-1',
-				{ aiBuilderAssisted: true, source: 'n8n-mcp' },
+				expect.objectContaining({ aiBuilderAssisted: true, source: 'n8n-mcp' }),
 			);
 			expect(updateMock.mock.calls[0][1].name).toBe('Renamed');
 			expect(updateMock.mock.calls[0][1].meta).toEqual(

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -309,13 +309,12 @@ describe('update-workflow MCP tool', () => {
 			);
 		});
 
-		test('falls back to diff-based version metadata when the client sends a blank name', async () => {
+		test('falls back to diff-based version metadata when the client omits it', async () => {
 			await callHandler({
 				workflowId: 'wf-1',
 				operations: [
 					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
 				],
-				versionName: '   ',
 			});
 
 			expect(updateMock.mock.calls[0][3]).toEqual(

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -309,12 +309,13 @@ describe('update-workflow MCP tool', () => {
 			);
 		});
 
-		test('falls back to diff-based version metadata when the client omits it', async () => {
+		test('falls back to diff-based version metadata when the client sends a blank name', async () => {
 			await callHandler({
 				workflowId: 'wf-1',
 				operations: [
 					{ type: 'updateNodeParameters', nodeName: 'B', parameters: { url: 'https://new' } },
 				],
+				versionName: '   ',
 			});
 
 			expect(updateMock.mock.calls[0][3]).toEqual(

--- a/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
@@ -4,7 +4,6 @@ import {
 	buildCreateVersionMetadata,
 	buildRestoreVersionMetadata,
 	buildUpdateVersionMetadata,
-	MAX_VERSION_DESCRIPTION_LENGTH,
 	MAX_VERSION_NAME_LENGTH,
 	resolveVersionMetadata,
 } from '../tools/workflow-builder/version-metadata';
@@ -195,18 +194,5 @@ describe('resolveVersionMetadata', () => {
 		);
 
 		expect(metadata).toEqual(fallback);
-	});
-
-	test('truncates over-long client values', () => {
-		const metadata = resolveVersionMetadata(
-			{
-				versionName: 'x'.repeat(MAX_VERSION_NAME_LENGTH + 10),
-				versionDescription: 'y'.repeat(MAX_VERSION_DESCRIPTION_LENGTH + 10),
-			},
-			fallback,
-		);
-
-		expect(metadata.name.length).toBe(MAX_VERSION_NAME_LENGTH);
-		expect(metadata.description.length).toBe(MAX_VERSION_DESCRIPTION_LENGTH);
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
@@ -81,6 +81,16 @@ describe('buildUpdateVersionMetadata', () => {
 		expect(metadata.description).toBe('Updated nodes: Set');
 	});
 
+	test('reports a renamed node by its new name', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook, makeNode('2', 'Slack')], connections: {} },
+			{ nodes: [webhook, makeNode('2', 'Gmail')], connections: {} },
+		);
+
+		expect(metadata.name).toBe('Updated Gmail');
+		expect(metadata.description).toBe('Updated nodes: Gmail');
+	});
+
 	test('combines added, removed, and updated clauses', () => {
 		const metadata = buildUpdateVersionMetadata(
 			{ nodes: [webhook, set], connections: {} },

--- a/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
@@ -1,0 +1,166 @@
+import type { IConnections, INode } from 'n8n-workflow';
+
+import {
+	buildCreateVersionMetadata,
+	buildUpdateVersionMetadata,
+	MAX_VERSION_DESCRIPTION_LENGTH,
+	MAX_VERSION_NAME_LENGTH,
+	resolveVersionMetadata,
+} from '../tools/workflow-builder/version-metadata';
+
+const makeNode = (id: string, name: string, parameters: INode['parameters'] = {}): INode => ({
+	id,
+	name,
+	type: 'n8n-nodes-base.set',
+	typeVersion: 1,
+	position: [0, 0],
+	parameters,
+});
+
+const mainConnection = (from: string, to: string): IConnections => ({
+	[from]: { main: [[{ node: to, type: 'main', index: 0 }]] },
+});
+
+describe('buildCreateVersionMetadata', () => {
+	test('names the initial version and lists the nodes', () => {
+		const metadata = buildCreateVersionMetadata([makeNode('1', 'Webhook'), makeNode('2', 'Set')]);
+
+		expect(metadata.name).toBe('Initial version');
+		expect(metadata.description).toBe('Created with 2 nodes: Webhook, Set');
+	});
+
+	test('uses singular form for a single node', () => {
+		const metadata = buildCreateVersionMetadata([makeNode('1', 'Webhook')]);
+
+		expect(metadata.description).toBe('Created with 1 node: Webhook');
+	});
+
+	test('collapses long node lists', () => {
+		const nodes = Array.from({ length: 7 }, (_, i) => makeNode(`${i}`, `Node ${i}`));
+
+		const metadata = buildCreateVersionMetadata(nodes);
+
+		expect(metadata.description).toBe(
+			'Created with 7 nodes: Node 0, Node 1, Node 2, Node 3, Node 4 and 2 more',
+		);
+	});
+});
+
+describe('buildUpdateVersionMetadata', () => {
+	const webhook = makeNode('1', 'Webhook');
+	const set = makeNode('2', 'Set');
+
+	test('summarizes an added node', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook], connections: {} },
+			{ nodes: [webhook, makeNode('2', 'Gmail')], connections: mainConnection('Webhook', 'Gmail') },
+		);
+
+		expect(metadata.name).toBe('Added Gmail');
+		expect(metadata.description).toBe('Added nodes: Gmail\nConnections: 1 added, 0 removed');
+	});
+
+	test('capitalizes a removal-only change', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook, set], connections: {} },
+			{ nodes: [webhook], connections: {} },
+		);
+
+		expect(metadata.name).toBe('Removed Set');
+		expect(metadata.description).toBe('Removed nodes: Set');
+	});
+
+	test('summarizes a modified node', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook, set], connections: {} },
+			{ nodes: [webhook, makeNode('2', 'Set', { keepOnlySet: true })], connections: {} },
+		);
+
+		expect(metadata.name).toBe('Updated Set');
+		expect(metadata.description).toBe('Updated nodes: Set');
+	});
+
+	test('combines added, removed, and updated clauses', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook, set], connections: {} },
+			{
+				nodes: [makeNode('1', 'Webhook', { path: 'hook' }), makeNode('3', 'Gmail')],
+				connections: {},
+			},
+		);
+
+		expect(metadata.name).toBe('Added Gmail; removed Set; updated Webhook');
+		expect(metadata.description).toBe(
+			'Added nodes: Gmail\nRemoved nodes: Set\nUpdated nodes: Webhook',
+		);
+	});
+
+	test('reports a connection-only change as rewiring', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook, set], connections: mainConnection('Webhook', 'Set') },
+			{ nodes: [webhook, set], connections: {} },
+		);
+
+		expect(metadata.name).toBe('Rewired connections');
+		expect(metadata.description).toBe('Connections: 0 added, 1 removed');
+	});
+
+	test('falls back to a generic name when nothing structural changed', () => {
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook], connections: {} },
+			{ nodes: [webhook], connections: {} },
+		);
+
+		expect(metadata.name).toBe('Updated workflow');
+		expect(metadata.description).toBe('Updated workflow');
+	});
+
+	test('caps the generated name length', () => {
+		const longName = 'A very long node name that goes on and on'.repeat(3);
+		const metadata = buildUpdateVersionMetadata(
+			{ nodes: [webhook], connections: {} },
+			{ nodes: [webhook, makeNode('2', longName)], connections: {} },
+		);
+
+		expect(metadata.name.length).toBeLessThanOrEqual(MAX_VERSION_NAME_LENGTH);
+		expect(metadata.name.endsWith('…')).toBe(true);
+	});
+});
+
+describe('resolveVersionMetadata', () => {
+	const fallback = { name: 'Fallback name', description: 'Fallback description' };
+
+	test('prefers client-provided values', () => {
+		const metadata = resolveVersionMetadata(
+			{ versionName: 'Added Slack alert', versionDescription: 'Notifies #ops on failure' },
+			fallback,
+		);
+
+		expect(metadata).toEqual({
+			name: 'Added Slack alert',
+			description: 'Notifies #ops on failure',
+		});
+	});
+
+	test('falls back per field when values are missing or blank', () => {
+		const metadata = resolveVersionMetadata(
+			{ versionName: '   ', versionDescription: undefined },
+			fallback,
+		);
+
+		expect(metadata).toEqual(fallback);
+	});
+
+	test('truncates over-long client values', () => {
+		const metadata = resolveVersionMetadata(
+			{
+				versionName: 'x'.repeat(MAX_VERSION_NAME_LENGTH + 10),
+				versionDescription: 'y'.repeat(MAX_VERSION_DESCRIPTION_LENGTH + 10),
+			},
+			fallback,
+		);
+
+		expect(metadata.name.length).toBe(MAX_VERSION_NAME_LENGTH);
+		expect(metadata.description.length).toBe(MAX_VERSION_DESCRIPTION_LENGTH);
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/version-metadata.test.ts
@@ -2,6 +2,7 @@ import type { IConnections, INode } from 'n8n-workflow';
 
 import {
 	buildCreateVersionMetadata,
+	buildRestoreVersionMetadata,
 	buildUpdateVersionMetadata,
 	MAX_VERSION_DESCRIPTION_LENGTH,
 	MAX_VERSION_NAME_LENGTH,
@@ -124,6 +125,41 @@ describe('buildUpdateVersionMetadata', () => {
 
 		expect(metadata.name.length).toBeLessThanOrEqual(MAX_VERSION_NAME_LENGTH);
 		expect(metadata.name.endsWith('…')).toBe(true);
+	});
+});
+
+describe('buildRestoreVersionMetadata', () => {
+	test('uses the restored version name when it has one', () => {
+		const metadata = buildRestoreVersionMetadata({
+			versionId: 'abcdef1234567890',
+			name: 'Added Slack alert',
+			createdAt: new Date('2024-01-01T00:00:00.000Z'),
+		});
+
+		expect(metadata.name).toBe('Restored "Added Slack alert"');
+		expect(metadata.description).toBe(
+			'Restored to version abcdef1234567890 (created 2024-01-01T00:00:00.000Z)',
+		);
+	});
+
+	test('falls back to a shortened version id for unnamed versions', () => {
+		const metadata = buildRestoreVersionMetadata({
+			versionId: 'abcdef1234567890',
+			name: null,
+			createdAt: new Date('2024-01-01T00:00:00.000Z'),
+		});
+
+		expect(metadata.name).toBe('Restored version abcdef12');
+	});
+
+	test('caps the name when the restored version name is very long', () => {
+		const metadata = buildRestoreVersionMetadata({
+			versionId: 'abcdef1234567890',
+			name: 'x'.repeat(200),
+			createdAt: new Date('2024-01-01T00:00:00.000Z'),
+		});
+
+		expect(metadata.name.length).toBeLessThanOrEqual(MAX_VERSION_NAME_LENGTH);
 	});
 });
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -59,10 +59,10 @@ const inputSchema = {
 		.describe('Workflow description. Longer text is shortened to 255 chars before saving.'),
 	versionName: z
 		.string()
+		.min(1)
 		.max(80)
-		.optional()
 		.describe(
-			'Short summary of this initial version, shown in the workflow\'s version history (e.g. "Initial Slack notification workflow"). Always provide it.',
+			'Short summary of this initial version, shown in the workflow\'s version history (e.g. "Initial Slack notification workflow").',
 		),
 	versionDescription: z
 		.string()
@@ -193,7 +193,7 @@ export const createCreateWorkflowFromCodeTool = (
 		skillsUsed?: string[];
 		name?: string;
 		description?: string;
-		versionName?: string;
+		versionName: string;
 		versionDescription?: string;
 		projectId?: string;
 		folderId?: string;
@@ -208,7 +208,6 @@ export const createCreateWorkflowFromCodeTool = (
 				hasName: !!name,
 				hasProjectId: !!projectId,
 				hasFolderId: !!folderId,
-				hasVersionName: !!versionName,
 				hasVersionDescription: !!versionDescription,
 			},
 		};

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -7,7 +7,12 @@ import { validateWorkflowCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials, stripNullCredentialStubs } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
-import { buildCreateVersionMetadata, resolveVersionMetadata } from './version-metadata';
+import {
+	buildCreateVersionMetadata,
+	resolveVersionMetadata,
+	versionDescriptionInputSchema,
+	versionNameInputSchema,
+} from './version-metadata';
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getSdkReferenceHint } from '../workflow-validation.utils';
@@ -57,20 +62,12 @@ const inputSchema = {
 		.string()
 		.optional()
 		.describe('Workflow description. Longer text is shortened to 255 chars before saving.'),
-	versionName: z
-		.string()
-		.min(1)
-		.max(80)
-		.describe(
-			'Short summary of this initial version, shown in the workflow\'s version history (e.g. "Initial Slack notification workflow").',
-		),
-	versionDescription: z
-		.string()
-		.max(1000)
-		.optional()
-		.describe(
-			'Longer description of what this version does, shown in the version history alongside the version name.',
-		),
+	versionName: versionNameInputSchema.describe(
+		'Short summary of this initial version, shown in the workflow\'s version history (e.g. "Initial Slack notification workflow"). Always provide it.',
+	),
+	versionDescription: versionDescriptionInputSchema.describe(
+		'Longer description of what this version does, shown in the version history alongside the version name.',
+	),
 	projectId: z
 		.string()
 		.optional()
@@ -193,7 +190,7 @@ export const createCreateWorkflowFromCodeTool = (
 		skillsUsed?: string[];
 		name?: string;
 		description?: string;
-		versionName: string;
+		versionName?: string;
 		versionDescription?: string;
 		projectId?: string;
 		folderId?: string;
@@ -208,6 +205,7 @@ export const createCreateWorkflowFromCodeTool = (
 				hasName: !!name,
 				hasProjectId: !!projectId,
 				hasFolderId: !!folderId,
+				hasVersionName: !!versionName,
 				hasVersionDescription: !!versionDescription,
 			},
 		};

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -7,6 +7,7 @@ import { validateWorkflowCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials, stripNullCredentialStubs } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
+import { buildCreateVersionMetadata, resolveVersionMetadata } from './version-metadata';
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getSdkReferenceHint } from '../workflow-validation.utils';
@@ -56,6 +57,20 @@ const inputSchema = {
 		.string()
 		.optional()
 		.describe('Workflow description. Longer text is shortened to 255 chars before saving.'),
+	versionName: z
+		.string()
+		.max(80)
+		.optional()
+		.describe(
+			'Short summary of this initial version, shown in the workflow\'s version history (e.g. "Initial Slack notification workflow"). Always provide it.',
+		),
+	versionDescription: z
+		.string()
+		.max(1000)
+		.optional()
+		.describe(
+			'Longer description of what this version does, shown in the version history alongside the version name.',
+		),
 	projectId: z
 		.string()
 		.optional()
@@ -169,6 +184,8 @@ export const createCreateWorkflowFromCodeTool = (
 		skillsUsed,
 		name,
 		description,
+		versionName,
+		versionDescription,
 		projectId,
 		folderId,
 	}: {
@@ -176,6 +193,8 @@ export const createCreateWorkflowFromCodeTool = (
 		skillsUsed?: string[];
 		name?: string;
 		description?: string;
+		versionName?: string;
+		versionDescription?: string;
 		projectId?: string;
 		folderId?: string;
 	}) => {
@@ -189,6 +208,8 @@ export const createCreateWorkflowFromCodeTool = (
 				hasName: !!name,
 				hasProjectId: !!projectId,
 				hasFolderId: !!folderId,
+				hasVersionName: !!versionName,
+				hasVersionDescription: !!versionDescription,
 			},
 		};
 
@@ -289,10 +310,17 @@ export const createCreateWorkflowFromCodeTool = (
 				throw new Error(credentialCheck.error);
 			}
 
+			const versionMetadata = resolveVersionMetadata(
+				{ versionName, versionDescription },
+				buildCreateVersionMetadata(newWorkflow.nodes),
+			);
+
 			const savedWorkflow = await workflowCreationService.createWorkflow(user, newWorkflow, {
 				projectId: effectiveProjectId,
 				parentFolderId: folderId,
 				source: 'n8n-mcp',
+				versionName: versionMetadata.name,
+				versionDescription: versionMetadata.description,
 			});
 
 			const baseUrl = urlService.getInstanceBaseUrl();

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/restore-workflow-version.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/restore-workflow-version.tool.ts
@@ -13,6 +13,7 @@ import { WorkflowAccessError } from '../../mcp.errors';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getMcpWorkflowVersion } from '../workflow-history.utils';
 import { getMcpWorkflow } from '../workflow-validation.utils';
+import { buildRestoreVersionMetadata } from './version-metadata';
 
 const inputSchema = z.object({
 	workflowId: z.string().describe('The ID of the workflow to restore'),
@@ -98,9 +99,13 @@ export const createRestoreWorkflowVersionTool = (
 				nodeGroups: version.nodeGroups ?? [],
 			});
 
+			const versionMetadata = buildRestoreVersionMetadata(version);
+
 			const updatedWorkflow = await workflowService.update(user, workflowUpdateData, workflowId, {
 				forceSave: true,
 				source: 'n8n-mcp',
+				versionName: versionMetadata.name,
+				versionDescription: versionMetadata.description,
 			});
 
 			void collaborationService.broadcastWorkflowUpdate(workflowId, user.id).catch(() => {});

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -13,6 +13,7 @@ import { validateCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
+import { buildUpdateVersionMetadata, resolveVersionMetadata } from './version-metadata';
 import {
 	applyOperations,
 	partialUpdateOperationSchema,
@@ -214,6 +215,20 @@ const inputSchema: z.ZodRawShape = {
 		.max(MAX_OPERATIONS_PER_CALL)
 		.describe(
 			`Ordered operations to apply atomically (max ${MAX_OPERATIONS_PER_CALL}). If any op fails, nothing is saved.`,
+		),
+	versionName: z
+		.string()
+		.max(80)
+		.optional()
+		.describe(
+			'Short summary of what this update changes, shown in the workflow\'s version history (e.g. "Added Slack notification after HTTP request"). Always provide it.',
+		),
+	versionDescription: z
+		.string()
+		.max(1000)
+		.optional()
+		.describe(
+			'Longer description of what changed and why, shown in the version history alongside the version name.',
 		),
 };
 
@@ -457,10 +472,14 @@ export const createUpdateWorkflowTool = (
 		workflowId,
 		skillsUsed,
 		operations,
+		versionName,
+		versionDescription,
 	}: {
 		workflowId: string;
 		skillsUsed?: string[];
 		operations: OperationInput[];
+		versionName?: string;
+		versionDescription?: string;
 	}) => {
 		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
@@ -471,6 +490,8 @@ export const createUpdateWorkflowTool = (
 				...(sanitizedSkillsUsed !== undefined ? { skillsUsed: sanitizedSkillsUsed } : {}),
 				opCount: operations.length,
 				opTypes: operations.map((op) => op.type),
+				hasVersionName: !!versionName,
+				hasVersionDescription: !!versionDescription,
 			},
 		};
 
@@ -696,9 +717,21 @@ export const createUpdateWorkflowTool = (
 				}
 			}
 
+			// Fallback is diff-based; it only ends up persisted when the update
+			// actually produces a new history version (node/connection/group changes).
+			const versionMetadata = resolveVersionMetadata(
+				{ versionName, versionDescription },
+				buildUpdateVersionMetadata(
+					{ nodes: existingWorkflow.nodes, connections: existingWorkflow.connections },
+					{ nodes: workflowUpdateData.nodes, connections: workflowUpdateData.connections },
+				),
+			);
+
 			const updatedWorkflow = await workflowService.update(user, workflowUpdateData, workflowId, {
 				aiBuilderAssisted: hasNonTagOperations,
 				source: 'n8n-mcp',
+				versionName: versionMetadata.name,
+				versionDescription: versionMetadata.description,
 				...(tagIds !== undefined ? { tagIds } : {}),
 			});
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -218,10 +218,10 @@ const inputSchema: z.ZodRawShape = {
 		),
 	versionName: z
 		.string()
+		.min(1)
 		.max(80)
-		.optional()
 		.describe(
-			'Short summary of what this update changes, shown in the workflow\'s version history (e.g. "Added Slack notification after HTTP request"). Always provide it.',
+			'Short summary of what this update changes, shown in the workflow\'s version history (e.g. "Added Slack notification after HTTP request").',
 		),
 	versionDescription: z
 		.string()
@@ -478,7 +478,7 @@ export const createUpdateWorkflowTool = (
 		workflowId: string;
 		skillsUsed?: string[];
 		operations: OperationInput[];
-		versionName?: string;
+		versionName: string;
 		versionDescription?: string;
 	}) => {
 		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
@@ -490,7 +490,6 @@ export const createUpdateWorkflowTool = (
 				...(sanitizedSkillsUsed !== undefined ? { skillsUsed: sanitizedSkillsUsed } : {}),
 				opCount: operations.length,
 				opTypes: operations.map((op) => op.type),
-				hasVersionName: !!versionName,
 				hasVersionDescription: !!versionDescription,
 			},
 		};

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -13,7 +13,12 @@ import { validateCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
-import { buildUpdateVersionMetadata, resolveVersionMetadata } from './version-metadata';
+import {
+	buildUpdateVersionMetadata,
+	resolveVersionMetadata,
+	versionDescriptionInputSchema,
+	versionNameInputSchema,
+} from './version-metadata';
 import {
 	applyOperations,
 	partialUpdateOperationSchema,
@@ -216,20 +221,12 @@ const inputSchema: z.ZodRawShape = {
 		.describe(
 			`Ordered operations to apply atomically (max ${MAX_OPERATIONS_PER_CALL}). If any op fails, nothing is saved.`,
 		),
-	versionName: z
-		.string()
-		.min(1)
-		.max(80)
-		.describe(
-			'Short summary of what this update changes, shown in the workflow\'s version history (e.g. "Added Slack notification after HTTP request").',
-		),
-	versionDescription: z
-		.string()
-		.max(1000)
-		.optional()
-		.describe(
-			'Longer description of what changed and why, shown in the version history alongside the version name.',
-		),
+	versionName: versionNameInputSchema.describe(
+		'Short summary of what this update changes, shown in the workflow\'s version history (e.g. "Added Slack notification after HTTP request"). Always provide it.',
+	),
+	versionDescription: versionDescriptionInputSchema.describe(
+		'Longer description of what changed and why, shown in the version history alongside the version name.',
+	),
 };
 
 // The MCP SDK publishes this schema with `additionalProperties: false` and
@@ -478,7 +475,7 @@ export const createUpdateWorkflowTool = (
 		workflowId: string;
 		skillsUsed?: string[];
 		operations: OperationInput[];
-		versionName: string;
+		versionName?: string;
 		versionDescription?: string;
 	}) => {
 		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
@@ -490,6 +487,7 @@ export const createUpdateWorkflowTool = (
 				...(sanitizedSkillsUsed !== undefined ? { skillsUsed: sanitizedSkillsUsed } : {}),
 				opCount: operations.length,
 				opTypes: operations.map((op) => op.type),
+				hasVersionName: !!versionName,
 				hasVersionDescription: !!versionDescription,
 			},
 		};

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -96,6 +96,28 @@ export function buildUpdateVersionMetadata(
 }
 
 /**
+ * Deterministic version metadata for a version created by restoring a previous
+ * one. A restore is fully described by its source version, so there is no
+ * client-provided variant.
+ */
+export function buildRestoreVersionMetadata(restoredFrom: {
+	versionId: string;
+	name: string | null;
+	createdAt: Date;
+}): VersionMetadata {
+	const label = restoredFrom.name
+		? `"${restoredFrom.name}"`
+		: `version ${restoredFrom.versionId.slice(0, 8)}`;
+	return {
+		name: truncate(`Restored ${label}`, MAX_VERSION_NAME_LENGTH),
+		description: truncate(
+			`Restored to version ${restoredFrom.versionId} (created ${restoredFrom.createdAt.toISOString()})`,
+			MAX_VERSION_DESCRIPTION_LENGTH,
+		),
+	};
+}
+
+/**
  * Resolves the version metadata to persist: the MCP client's own summary when
  * provided, otherwise the deterministic fallback.
  */

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -54,6 +54,9 @@ export function buildUpdateVersionMetadata(
 	next: { nodes: INode[]; connections: IConnections },
 ): VersionMetadata {
 	const nodeDiff = compareWorkflowsNodes(previous.nodes, next.nodes);
+	// The diff stores the pre-change node for modified entries; report the
+	// post-change name so a renamed node is listed by a name that still exists.
+	const nextNodesById = new Map(next.nodes.map((node) => [node.id, node]));
 
 	const added: string[] = [];
 	const removed: string[] = [];
@@ -61,7 +64,9 @@ export function buildUpdateVersionMetadata(
 	for (const { status, node } of nodeDiff.values()) {
 		if (status === NodeDiffStatus.Added) added.push(node.name);
 		else if (status === NodeDiffStatus.Deleted) removed.push(node.name);
-		else if (status === NodeDiffStatus.Modified) modified.push(node.name);
+		else if (status === NodeDiffStatus.Modified) {
+			modified.push(nextNodesById.get(node.id)?.name ?? node.name);
+		}
 	}
 
 	const connectionsDiff = compareConnections(previous.connections, next.connections);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -130,12 +130,9 @@ export function resolveVersionMetadata(
 	provided: { versionName?: string; versionDescription?: string },
 	fallback: VersionMetadata,
 ): VersionMetadata {
-	const name = provided.versionName?.trim();
-	const description = provided.versionDescription?.trim();
+	// ponytail: no re-truncation of provided values — the tool input schemas cap lengths
 	return {
-		name: name ? truncate(name, MAX_VERSION_NAME_LENGTH) : fallback.name,
-		description: description
-			? truncate(description, MAX_VERSION_DESCRIPTION_LENGTH)
-			: fallback.description,
+		name: provided.versionName?.trim() || fallback.name,
+		description: provided.versionDescription?.trim() || fallback.description,
 	};
 }

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -1,8 +1,18 @@
 import type { IConnections, INode } from 'n8n-workflow';
 import { compareConnections, compareWorkflowsNodes, NodeDiffStatus } from 'n8n-workflow';
+import z from 'zod';
 
 export const MAX_VERSION_NAME_LENGTH = 80;
 export const MAX_VERSION_DESCRIPTION_LENGTH = 1000;
+
+// Optional (not required) so MCP clients holding a cached tool schema from
+// before these params existed keep working; omission falls back to the
+// deterministic diff-based metadata.
+export const versionNameInputSchema = z.string().min(1).max(MAX_VERSION_NAME_LENGTH).optional();
+export const versionDescriptionInputSchema = z
+	.string()
+	.max(MAX_VERSION_DESCRIPTION_LENGTH)
+	.optional();
 
 const MAX_LISTED_NODES = 5;
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -130,7 +130,7 @@ export function resolveVersionMetadata(
 	provided: { versionName?: string; versionDescription?: string },
 	fallback: VersionMetadata,
 ): VersionMetadata {
-	// ponytail: no re-truncation of provided values — the tool input schemas cap lengths
+	// No re-truncation of provided values; the tool input schemas cap lengths.
 	return {
 		name: provided.versionName?.trim() || fallback.name,
 		description: provided.versionDescription?.trim() || fallback.description,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/version-metadata.ts
@@ -1,0 +1,114 @@
+import type { IConnections, INode } from 'n8n-workflow';
+import { compareConnections, compareWorkflowsNodes, NodeDiffStatus } from 'n8n-workflow';
+
+export const MAX_VERSION_NAME_LENGTH = 80;
+export const MAX_VERSION_DESCRIPTION_LENGTH = 1000;
+
+const MAX_LISTED_NODES = 5;
+
+export type VersionMetadata = { name: string; description: string };
+
+function truncate(text: string, maxLength: number): string {
+	return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
+}
+
+function listNames(names: string[]): string {
+	if (names.length <= MAX_LISTED_NODES) return names.join(', ');
+	const shown = names.slice(0, MAX_LISTED_NODES).join(', ');
+	return `${shown} and ${names.length - MAX_LISTED_NODES} more`;
+}
+
+function countConnections(diff: Record<string, Record<string, unknown[]>>): number {
+	let count = 0;
+	for (const inputs of Object.values(diff)) {
+		for (const entries of Object.values(inputs)) {
+			count += entries.length;
+		}
+	}
+	return count;
+}
+
+/**
+ * Deterministic version metadata for the first version of a workflow created
+ * via MCP. Used when the MCP client did not provide a version name itself.
+ */
+export function buildCreateVersionMetadata(nodes: INode[]): VersionMetadata {
+	const nodeNames = nodes.map((node) => node.name);
+	return {
+		name: 'Initial version',
+		description: truncate(
+			`Created with ${nodes.length} node${nodes.length === 1 ? '' : 's'}: ${listNames(nodeNames)}`,
+			MAX_VERSION_DESCRIPTION_LENGTH,
+		),
+	};
+}
+
+/**
+ * Deterministic diff-based version metadata for a workflow update via MCP.
+ * Summarizes node additions/removals/changes and connection rewiring between
+ * the previous and the resulting workflow. Used when the MCP client did not
+ * provide a version name itself.
+ */
+export function buildUpdateVersionMetadata(
+	previous: { nodes: INode[]; connections: IConnections },
+	next: { nodes: INode[]; connections: IConnections },
+): VersionMetadata {
+	const nodeDiff = compareWorkflowsNodes(previous.nodes, next.nodes);
+
+	const added: string[] = [];
+	const removed: string[] = [];
+	const modified: string[] = [];
+	for (const { status, node } of nodeDiff.values()) {
+		if (status === NodeDiffStatus.Added) added.push(node.name);
+		else if (status === NodeDiffStatus.Deleted) removed.push(node.name);
+		else if (status === NodeDiffStatus.Modified) modified.push(node.name);
+	}
+
+	const connectionsDiff = compareConnections(previous.connections, next.connections);
+	const connectionsAdded = countConnections(connectionsDiff.added);
+	const connectionsRemoved = countConnections(connectionsDiff.removed);
+
+	const nameParts: string[] = [];
+	if (added.length) nameParts.push(`added ${listNames(added)}`);
+	if (removed.length) nameParts.push(`removed ${listNames(removed)}`);
+	if (modified.length) nameParts.push(`updated ${listNames(modified)}`);
+	if (!nameParts.length && (connectionsAdded || connectionsRemoved)) {
+		nameParts.push('rewired connections');
+	}
+
+	const descriptionParts: string[] = [];
+	if (added.length) descriptionParts.push(`Added nodes: ${listNames(added)}`);
+	if (removed.length) descriptionParts.push(`Removed nodes: ${listNames(removed)}`);
+	if (modified.length) descriptionParts.push(`Updated nodes: ${listNames(modified)}`);
+	if (connectionsAdded || connectionsRemoved) {
+		descriptionParts.push(`Connections: ${connectionsAdded} added, ${connectionsRemoved} removed`);
+	}
+
+	// e.g. a node-groups-only change produces no node or connection diff
+	if (!nameParts.length) nameParts.push('updated workflow');
+	if (!descriptionParts.length) descriptionParts.push('Updated workflow');
+
+	const name = nameParts.join('; ');
+	return {
+		name: truncate(name.charAt(0).toUpperCase() + name.slice(1), MAX_VERSION_NAME_LENGTH),
+		description: truncate(descriptionParts.join('\n'), MAX_VERSION_DESCRIPTION_LENGTH),
+	};
+}
+
+/**
+ * Resolves the version metadata to persist: the MCP client's own summary when
+ * provided, otherwise the deterministic fallback.
+ */
+export function resolveVersionMetadata(
+	provided: { versionName?: string; versionDescription?: string },
+	fallback: VersionMetadata,
+): VersionMetadata {
+	const name = provided.versionName?.trim();
+	const description = provided.versionDescription?.trim();
+	return {
+		name: name ? truncate(name, MAX_VERSION_NAME_LENGTH) : fallback.name,
+		description: description
+			? truncate(description, MAX_VERSION_DESCRIPTION_LENGTH)
+			: fallback.description,
+	};
+}

--- a/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-creation.service.test.ts
@@ -14,6 +14,7 @@ import { userHasScopes } from '@/permissions.ee/check-access';
 import type { ProjectService } from '@/services/project.service.ee';
 import * as WorkflowHelpers from '@/workflow-helpers';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import type { WorkflowValidationService } from '@/workflows/workflow-validation.service';
 import type { EnterpriseWorkflowService } from '@/workflows/workflow.service.ee';
 
@@ -32,6 +33,7 @@ describe('WorkflowCreationService', () => {
 	let projectRepositoryMock: MockProxy<ProjectRepository>;
 	let workflowValidationServiceMock: MockProxy<WorkflowValidationService>;
 	let instanceRedactionEnforcementServiceMock: MockProxy<InstanceRedactionEnforcementService>;
+	let workflowHistoryServiceMock: MockProxy<WorkflowHistoryService>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -43,6 +45,7 @@ describe('WorkflowCreationService', () => {
 		projectRepositoryMock = mock<ProjectRepository>();
 		workflowValidationServiceMock = mock<WorkflowValidationService>();
 		instanceRedactionEnforcementServiceMock = mock<InstanceRedactionEnforcementService>();
+		workflowHistoryServiceMock = mock<WorkflowHistoryService>();
 		workflowValidationServiceMock.validateCredentialNodeRestrictions.mockReturnValue({
 			isValid: true,
 		});
@@ -54,7 +57,7 @@ describe('WorkflowCreationService', () => {
 			mock(), // logger
 			mock(), // sharedWorkflowRepository
 			mock(), // tagService
-			mock(), // workflowHistoryService
+			workflowHistoryServiceMock,
 			mock(), // externalHooks
 			projectServiceMock,
 			mock(), // eventService
@@ -116,6 +119,43 @@ describe('WorkflowCreationService', () => {
 			await expect(
 				workflowCreationService.createWorkflow(user, newWorkflow, { projectId: 'project-1' }),
 			).rejects.toThrow('Workflow structure is invalid.');
+		});
+
+		it('passes source and version metadata to the initial history version', async () => {
+			licenseStateMock.isSharingLicensed.mockReturnValue(false);
+			licenseStateMock.isDataRedactionLicensed.mockReturnValue(false);
+			projectServiceMock.getProjectWithScope.mockResolvedValue({ id: 'project-1' } as never);
+			const { transactionManager } = setupTransactionMocks();
+			transactionManager.save.mockImplementation(async (entity: unknown) => entity);
+			workflowHistoryServiceMock.saveVersion.mockRejectedValue(new Error('Stopping for test'));
+
+			const user = mock<User>();
+			const newWorkflow = new WorkflowEntity();
+			newWorkflow.name = 'Test';
+			newWorkflow.nodes = [];
+			newWorkflow.connections = {};
+
+			await expect(
+				workflowCreationService.createWorkflow(user, newWorkflow, {
+					projectId: 'project-1',
+					source: 'n8n-mcp',
+					versionName: 'Initial Slack alert workflow',
+					versionDescription: 'Posts to #ops when the webhook fires',
+				}),
+			).rejects.toThrow('Stopping for test');
+
+			expect(workflowHistoryServiceMock.saveVersion).toHaveBeenCalledWith(
+				user,
+				newWorkflow,
+				newWorkflow.id,
+				false,
+				'n8n-mcp',
+				transactionManager,
+				{
+					name: 'Initial Slack alert workflow',
+					description: 'Posts to #ops when the webhook fires',
+				},
+			);
 		});
 
 		describe('credential retrieval', () => {

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -511,6 +511,8 @@ describe('WorkflowService', () => {
 				'workflow-1',
 				false,
 				'ui',
+				undefined,
+				undefined,
 			);
 		});
 

--- a/packages/cli/src/workflows/workflow-creation.service.ts
+++ b/packages/cli/src/workflows/workflow-creation.service.ts
@@ -73,6 +73,8 @@ export class WorkflowCreationService {
 			uiContext?: string;
 			publicApi?: boolean;
 			source?: WorkflowActionSource;
+			versionName?: string;
+			versionDescription?: string;
 		} = {},
 	): Promise<WorkflowEntity> {
 		const {
@@ -84,6 +86,8 @@ export class WorkflowCreationService {
 			uiContext,
 			publicApi = false,
 			source = 'ui',
+			versionName,
+			versionDescription,
 		} = options;
 
 		// Ensure workflow is created as inactive
@@ -221,8 +225,11 @@ export class WorkflowCreationService {
 				workflow,
 				workflow.id,
 				autosaved,
-				undefined,
+				source,
 				transactionManager,
+				versionName || versionDescription
+					? { name: versionName, description: versionDescription }
+					: undefined,
 			);
 
 			return await this.workflowFinderService.findWorkflowForUser(

--- a/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
+++ b/packages/cli/src/workflows/workflow-history/__tests__/workflow-history.service.test.ts
@@ -182,6 +182,59 @@ describe('WorkflowHistoryService', () => {
 			);
 		});
 
+		it('should persist version name and description when metadata is provided', async () => {
+			// Arrange
+			const workflow = getWorkflow({ addNodeWithoutCreds: true });
+			const workflowId = '123';
+			workflow.connections = {};
+			workflow.id = workflowId;
+			workflow.versionId = '456';
+
+			// Act
+			await workflowHistoryService.saveVersion(
+				testUser,
+				workflow,
+				workflowId,
+				false,
+				'n8n-mcp',
+				undefined,
+				{ name: 'Added Slack alert', description: 'Notifies #ops on failure' },
+			);
+
+			// Assert
+			expect(workflowHistoryRepository.insert).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'Added Slack alert',
+					description: 'Notifies #ops on failure',
+				}),
+			);
+		});
+
+		it('should not set name or description when metadata is partial', async () => {
+			// Arrange
+			const workflow = getWorkflow({ addNodeWithoutCreds: true });
+			const workflowId = '123';
+			workflow.connections = {};
+			workflow.id = workflowId;
+			workflow.versionId = '456';
+
+			// Act
+			await workflowHistoryService.saveVersion(
+				testUser,
+				workflow,
+				workflowId,
+				false,
+				'n8n-mcp',
+				undefined,
+				{ name: 'Added Slack alert' },
+			);
+
+			// Assert
+			const inserted = workflowHistoryRepository.insert.mock.calls[0][0];
+			expect(inserted).toEqual(expect.objectContaining({ name: 'Added Slack alert' }));
+			expect(inserted).not.toHaveProperty('description');
+		});
+
 		it('should throw an error when nodes or connections are missing', async () => {
 			// Arrange
 			const workflow = getWorkflow({ addNodeWithoutCreds: true });

--- a/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
+++ b/packages/cli/src/workflows/workflow-history/workflow-history.service.ts
@@ -179,6 +179,7 @@ export class WorkflowHistoryService {
 		autosaved = false,
 		source?: WorkflowActionSource,
 		transactionManager?: EntityManager,
+		versionMetadata?: { name?: string; description?: string },
 	) {
 		if (!workflow.nodes || !workflow.connections) {
 			throw new UnexpectedError(
@@ -202,6 +203,8 @@ export class WorkflowHistoryService {
 				versionId: workflow.versionId,
 				workflowId,
 				autosaved,
+				...(versionMetadata?.name ? { name: versionMetadata.name } : {}),
+				...(versionMetadata?.description ? { description: versionMetadata.description } : {}),
 			});
 		} catch (e) {
 			const error = ensureError(e);

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -339,6 +339,8 @@ export class WorkflowService {
 			expectedChecksum?: string;
 			autosaved?: boolean;
 			source?: WorkflowActionSource;
+			versionName?: string;
+			versionDescription?: string;
 		} = {},
 	): Promise<WorkflowEntity> {
 		const {
@@ -351,6 +353,8 @@ export class WorkflowService {
 			aiBuilderAssisted = false,
 			autosaved = false,
 			source = 'ui',
+			versionName,
+			versionDescription,
 		} = options;
 		const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
 			'workflow:update',
@@ -549,6 +553,10 @@ export class WorkflowService {
 				workflowId,
 				autosaved,
 				source,
+				undefined,
+				versionName || versionDescription
+					? { name: versionName, description: versionDescription }
+					: undefined,
 			);
 		}
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -98,6 +98,7 @@ export * from './node-parameters/node-parameter-value-type-guard';
 export * from './node-parameters/path-utils';
 export * from './evaluation-helpers';
 export * from './workflow-diff';
+export * from './connections-diff';
 export * from './workflow-environments-helper';
 export { evaluateJmespathQuery, JmespathQueryError } from './jmespath-query';
 


### PR DESCRIPTION
## Summary

When MCP clients (Claude Code, Cursor, etc.) create or update workflows, the resulting versions had opaque hash-based names ("Version a8b9c") and no description of what changed, making version history unusable for traceability.

This PR gives every MCP-touched version a meaningful name and description:

- `create_workflow_from_code` and `update_workflow` accept `versionName` (max 80 chars) and `versionDescription` (max 1000 chars). Since the caller is an LLM that knows exactly what it changed and why, this produces high-quality names with no extra latency or AI infrastructure. Both params are optional so clients with cached tool schemas keep working, but the tool descriptions instruct clients to always provide a summary.
- When the client omits them (or sends a blank name), the backend generates a deterministic diff-based fallback using the existing `WorkflowChangeSet`/`compareConnections` utilities:
  - Create: "Initial version" + "Created with N nodes: A, B, C"
  - Update: "Added Gmail; removed Slack; updated Webhook" + per-category node lists and connection change counts (renamed nodes are reported by their new name)
- `restore_workflow_version` names the version it creates deterministically: `Restored "<source version name>"`, or `Restored version <short id>` for unnamed sources.
- The metadata is persisted on the `workflow_history` row via the existing (previously always-null) `name`/`description` columns, so it shows up in the version history UI.
- The initial version of an MCP-created workflow now also carries the "(via MCP)" author label; previously only update versions got it.
- `versionName`/`versionDescription` presence is tracked in the MCP tool telemetry.

No DB migration needed; the columns already exist from the named-versions feature. Generated strings are intentionally English-only (stored data, matching the existing "(via MCP)" author label) and are not license-gated (the `feat:namedVersions` license gates the manual rename UI, not stored metadata).

## How to test

1. Connect an MCP client to your instance and create a workflow via `create_workflow_from_code` with a `versionName`.
2. Open the workflow's version history in the editor: the first version should carry the client's summary and be authored "<name> (via MCP)".
3. Update the workflow via `update_workflow` (e.g. add a node): the new version should carry the client's summary.
4. Restore an earlier version via `restore_workflow_version`: the new version should be named `Restored "<name>"`.
5. Omit `versionName` (or send whitespace): the diff-based fallback name/description should appear.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5093

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI