### PR TITLE
perf(core): Cap oversized tool payloads in Instance AI orchestrator context

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/prune-superseded-artifacts.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/prune-superseded-artifacts.test.ts
@@ -218,4 +218,54 @@ describe('pruneSupersededArtifacts', () => {
 		const messages = [user];
 		expect(pruneSupersededArtifacts(messages)).toBe(messages);
 	});
+
+	it('stubs every load_skill result in history, even without a newer load', () => {
+		const skill = toolCallMessage(
+			'load_skill',
+			{ skillId: 'workflow-builder' },
+			{ ok: true, success: true, skillId: 'workflow-builder', content: '#'.repeat(5000) },
+		);
+
+		const result = pruneSupersededArtifacts([skill]);
+
+		expect(firstBlock(result[0]).output).toMatchObject({
+			superseded: true,
+			artifact: 'skill:workflow-builder',
+		});
+	});
+
+	it('leaves small load_skill results (e.g. errors) alone', () => {
+		const failed = toolCallMessage(
+			'load_skill',
+			{ skillId: 'nope' },
+			{ ok: false, success: false, skillId: 'nope', error: 'Unknown skill: nope' },
+		);
+
+		const result = pruneSupersededArtifacts([failed]);
+
+		expect(firstBlock(result[0]).output).toMatchObject({ ok: false });
+	});
+
+	it('replaces large inline file blocks with a text note and keeps small ones', () => {
+		const withFiles: AgentDbMessage = {
+			id: 'msg-files',
+			createdAt: new Date('2026-01-01T00:00:00Z'),
+			role: 'user',
+			content: [
+				{ type: 'text', text: 'see attached' },
+				{ type: 'file', mediaType: 'image/png', data: 'A'.repeat(100_000) },
+				{ type: 'file', mediaType: 'image/png', data: 'B'.repeat(100) },
+			],
+		};
+
+		const result = pruneSupersededArtifacts([withFiles]);
+
+		if (result[0].type === 'custom') throw new Error('unexpected custom message');
+		const [text, bigFile, smallFile] = result[0].content;
+		expect(text).toEqual({ type: 'text', text: 'see attached' });
+		expect(bigFile).toMatchObject({ type: 'text' });
+		if (bigFile.type !== 'text') throw new Error('expected text stub');
+		expect(bigFile.text).toContain('image/png');
+		expect(smallFile).toMatchObject({ type: 'file', data: 'B'.repeat(100) });
+	});
 });

--- a/packages/@n8n/instance-ai/src/agent/prune-superseded-artifacts.ts
+++ b/packages/@n8n/instance-ai/src/agent/prune-superseded-artifacts.ts
@@ -1,9 +1,15 @@
-import type { AgentDbMessage, ContentToolCall, MessageContent } from '@n8n/agents';
+import type { AgentDbMessage, ContentFile, ContentToolCall, MessageContent } from '@n8n/agents';
 
 type ResolvedToolCall = Extract<ContentToolCall, { state: 'resolved' }>;
 
 interface SupersessionRule {
 	toolName: string;
+	/**
+	 * 'latest' keeps the newest occurrence per artifact and stubs older ones;
+	 * 'none' stubs every history occurrence (the turn that fetched it already
+	 * consumed the content, and the stub says how to re-fetch).
+	 */
+	retain: 'latest' | 'none';
 	/** Stable artifact key, or undefined when the block isn't a supersedable artifact. */
 	artifactKey: (block: ResolvedToolCall) => string | undefined;
 }
@@ -11,8 +17,14 @@ interface SupersessionRule {
 /** Below this serialized-output size a stub saves nothing; leave the block alone. */
 const MIN_PRUNABLE_OUTPUT_CHARS = 1000;
 
+/** File/image blocks in history larger than this are replaced with a text note. */
+const MAX_RETAINED_FILE_CHARS = 32_000;
+
 const SUPERSEDED_NOTE =
 	'Superseded: a newer version of this artifact appears later in the conversation. Re-fetch with the same tool if the old state is needed.';
+
+const CONSUMED_NOTE =
+	'Pruned from context to save tokens. Re-fetch with the same tool if the content is needed again.';
 
 function isJsonObject(value: unknown): value is { [key: string]: unknown } {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -22,6 +34,7 @@ const RULES: SupersessionRule[] = [
 	{
 		// Full workflow snapshots (get-json / get-version / get-as-code / mutation echoes).
 		toolName: 'workflows',
+		retain: 'latest',
 		artifactKey: (block) => {
 			const output = block.output;
 			if (!isJsonObject(output)) return undefined;
@@ -38,25 +51,52 @@ const RULES: SupersessionRule[] = [
 	{
 		// A later read of the same path supersedes earlier reads of it.
 		toolName: 'workspace_read_file',
+		retain: 'latest',
 		artifactKey: (block) =>
 			isJsonObject(block.input) && typeof block.input.path === 'string'
 				? `file:${block.input.path}`
 				: undefined,
 	},
+	{
+		// Skill instructions are consumed in the turn that loaded them; later
+		// turns get a stub and can re-load on demand instead of carrying ~16k
+		// tokens of skill text on every LLM call.
+		toolName: 'load_skill',
+		retain: 'none',
+		artifactKey: (block) => {
+			const output = block.output;
+			if (!isJsonObject(output) || typeof output.skillId !== 'string') return undefined;
+			const filePath = typeof output.filePath === 'string' ? `:${output.filePath}` : '';
+			return `skill:${output.skillId}${filePath}`;
+		},
+	},
 ];
 
 const ruleByTool = new Map(RULES.map((rule) => [rule.toolName, rule]));
 
-function artifactKeyOf(block: MessageContent): string | undefined {
+function artifactKeyOf(block: MessageContent): [SupersessionRule, string] | undefined {
 	if (block.type !== 'tool-call' || block.state !== 'resolved') return undefined;
-	return ruleByTool.get(block.toolName)?.artifactKey(block);
+	const rule = ruleByTool.get(block.toolName);
+	const key = rule?.artifactKey(block);
+	return rule && key !== undefined ? [rule, key] : undefined;
+}
+
+function fileDataChars(data: ContentFile['data']): number {
+	if (typeof data === 'string') return data.length;
+	if (data instanceof Uint8Array) return data.byteLength;
+	if (data instanceof ArrayBuffer) return data.byteLength;
+	return 0;
 }
 
 /**
- * Replace stale artifact snapshots in thread history with a small stub,
- * keeping only the latest occurrence per artifact. Large tool results
- * (full workflow JSON, file reads) dominate the orchestrator prompt and are
- * re-billed on every LLM call; only the newest state is actionable.
+ * Shrink stale artifact payloads in thread history:
+ * - tool results covered by a supersession rule are replaced with a small stub
+ *   (keeping the newest occurrence per artifact for 'latest' rules);
+ * - large inline file/image blocks are replaced with a text note (their content
+ *   was seen in the turn they arrived in).
+ * Large tool results (full workflow JSON, file reads, skill text) dominate the
+ * orchestrator prompt and are re-billed on every LLM call; only the newest
+ * state is actionable.
  *
  * Pure and non-destructive: operates on the in-memory prompt view loaded at
  * turn start (persisted messages are untouched), so the pruned view is stable
@@ -65,26 +105,46 @@ function artifactKeyOf(block: MessageContent): string | undefined {
  */
 export function pruneSupersededArtifacts(messages: AgentDbMessage[]): AgentDbMessage[] {
 	const latestBlockPerArtifact = new Map<string, string>();
+	let hasLargeFileBlock = false;
 	messages.forEach((message, messageIndex) => {
 		if (message.type === 'custom') return;
 		message.content.forEach((block, blockIndex) => {
-			const key = artifactKeyOf(block);
-			if (key !== undefined) latestBlockPerArtifact.set(key, `${messageIndex}:${blockIndex}`);
+			const match = artifactKeyOf(block);
+			if (match) latestBlockPerArtifact.set(match[1], `${messageIndex}:${blockIndex}`);
+			if (block.type === 'file' && fileDataChars(block.data) > MAX_RETAINED_FILE_CHARS) {
+				hasLargeFileBlock = true;
+			}
 		});
 	});
-	if (latestBlockPerArtifact.size === 0) return messages;
+	if (latestBlockPerArtifact.size === 0 && !hasLargeFileBlock) return messages;
 
 	return messages.map((message, messageIndex) => {
 		if (message.type === 'custom') return message;
 		let changed = false;
 		const content = message.content.map((block, blockIndex): MessageContent => {
+			if (block.type === 'file') {
+				const size = fileDataChars(block.data);
+				if (size <= MAX_RETAINED_FILE_CHARS) return block;
+				changed = true;
+				return {
+					type: 'text',
+					text: `[Attachment content removed from older context (${block.mediaType ?? 'file'}, ~${Math.round(size / 1024)}KB). Ask the user to re-attach it or use the parse-file tool if it is needed again.]`,
+				};
+			}
 			if (block.type !== 'tool-call' || block.state !== 'resolved') return block;
-			const key = artifactKeyOf(block);
-			if (key === undefined) return block;
-			if (latestBlockPerArtifact.get(key) === `${messageIndex}:${blockIndex}`) return block;
+			const match = artifactKeyOf(block);
+			if (!match) return block;
+			const [rule, key] = match;
+			if (
+				rule.retain === 'latest' &&
+				latestBlockPerArtifact.get(key) === `${messageIndex}:${blockIndex}`
+			) {
+				return block;
+			}
 			if (JSON.stringify(block.output ?? null).length < MIN_PRUNABLE_OUTPUT_CHARS) return block;
 			changed = true;
-			return { ...block, output: { superseded: true, artifact: key, note: SUPERSEDED_NOTE } };
+			const note = rule.retain === 'latest' ? SUPERSEDED_NOTE : CONSUMED_NOTE;
+			return { ...block, output: { superseded: true, artifact: key, note } };
 		});
 		return changed ? { ...message, content } : message;
 	});

--- a/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
@@ -701,6 +701,50 @@ describe('executions tool', () => {
 				maxItems: undefined,
 			});
 		});
+
+		it('should cap oversized outputs to whole items within the char budget', async () => {
+			const bigItem = { blob: 'x'.repeat(30_000) };
+			const context = createMockContext();
+			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
+				nodeName: 'Set',
+				items: [bigItem, bigItem, bigItem],
+				totalItems: 3,
+				returned: { from: 0, to: 2 },
+			});
+
+			const tool = createExecutionsTool(context);
+			const result = await executeTool<{ items: unknown[]; truncated?: boolean; note?: string }>(
+				tool,
+				{ action: 'get-node-output' as const, executionId: 'exec-1', nodeName: 'Set' },
+				{} as never,
+			);
+
+			expect(result.items).toEqual([bigItem]);
+			expect(result.truncated).toBe(true);
+			expect(result.note).toContain('1 of 3 fetched items');
+		});
+
+		it('should return a sliced string when a single item exceeds the budget', async () => {
+			const context = createMockContext();
+			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
+				nodeName: 'Set',
+				items: [{ blob: 'y'.repeat(120_000) }],
+				totalItems: 1,
+				returned: { from: 0, to: 0 },
+			});
+
+			const tool = createExecutionsTool(context);
+			const result = await executeTool<{ items: unknown[]; truncated?: boolean }>(
+				tool,
+				{ action: 'get-node-output' as const, executionId: 'exec-1', nodeName: 'Set' },
+				{} as never,
+			);
+
+			expect(result.truncated).toBe(true);
+			expect(result.items).toHaveLength(1);
+			expect(typeof result.items[0]).toBe('string');
+			expect((result.items[0] as string).endsWith('… [item truncated]')).toBe(true);
+		});
 	});
 
 	// ── get-resolved-node-parameters ────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
-import type { InstanceAiContext } from '../types';
+import type { InstanceAiContext, NodeOutputResult } from '../types';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -294,14 +294,43 @@ async function handleDebug(context: InstanceAiContext, input: Extract<Input, { a
 	return await context.executionService.getDebugInfo(input.executionId);
 }
 
+/** Item counts are already paged, but a single item can be hundreds of KB. */
+const MAX_NODE_OUTPUT_CHARS = 50_000;
+
+function capNodeOutputItems(result: NodeOutputResult) {
+	let used = 0;
+	const items: unknown[] = [];
+	let truncated = false;
+	for (const item of result.items) {
+		const serialized = JSON.stringify(item) ?? 'null';
+		if (used + serialized.length > MAX_NODE_OUTPUT_CHARS) {
+			truncated = true;
+			if (items.length === 0) {
+				items.push(`${serialized.slice(0, MAX_NODE_OUTPUT_CHARS)}… [item truncated]`);
+			}
+			break;
+		}
+		items.push(item);
+		used += serialized.length;
+	}
+	if (!truncated) return result;
+	return {
+		...result,
+		items,
+		truncated: true,
+		note: `Output capped at ~${MAX_NODE_OUTPUT_CHARS / 1000}k chars: returning ${items.length} of ${result.items.length} fetched items (${result.totalItems} total). Use startIndex/maxItems to page through the rest.`,
+	};
+}
+
 async function handleGetNodeOutput(
 	context: InstanceAiContext,
 	input: Extract<Input, { action: 'get-node-output' }>,
 ) {
-	return await context.executionService.getNodeOutput(input.executionId, input.nodeName, {
+	const result = await context.executionService.getNodeOutput(input.executionId, input.nodeName, {
 		startIndex: input.startIndex,
 		maxItems: input.maxItems,
 	});
+	return capNodeOutputItems(result);
 }
 
 async function handleGetResolvedNodeParameters(


### PR DESCRIPTION
## Summary

Quick wins from the production token analysis (INS-754), stacked on #33466 (reuses its pruning machinery — merge that first):

- **`load_skill` results are stubbed once their turn is over.** The full `workflow-builder` skill (~16k tokens) currently stays in history as a tool result and is re-billed on every LLM call for the rest of the thread. New `retain: 'none'` supersession rule: the turn that loaded the skill sees the full content; later turns get a small stub that says how to re-load. Small results (e.g. load errors) are untouched.
- **`executions[get-node-output]` payloads are capped at ~50k chars.** Item counts were already paged (default 10, max 50), but a single item could be hundreds of KB (142k chars observed). The tool now returns whole items up to the budget with a `truncated` flag and a note pointing at `startIndex`/`maxItems` paging; if the first item alone exceeds the budget, a sliced string view is returned.
- **Large inline file/image blocks (>32k chars) are pruned from history.** One production call hit 519k prompt tokens carrying a 747k-char base64 image with zero cache hits. The image is still fully visible in the turn it was attached; later turns see a text note (media type + size) saying to re-attach or use `parse-file`. Current-turn image handling (downscaling) is out of scope.

Same safety properties as #33466: pure transform on the in-memory prompt view loaded at turn start; persisted thread history is untouched; the pruned view is stable mid-loop and across HITL resumes, so the cache prefix never mutates.

Behavior note: stubbing skill text from history means the orchestrator must re-load a skill if it needs the procedure again in a later turn (the stub says so). Worth validating with builder evals before merge.

## How to test

- Unit tests: `pnpm test src/agent/__tests__/prune-superseded-artifacts.test.ts src/tools/__tests__/executions.tool.test.ts` in `packages/@n8n/instance-ai`.
- Manually: in an AI Assistant thread, (1) trigger a workflow build (loads the `workflow-builder` skill), then send a follow-up message — the next turn's `llm: orchestrator` trace should show the skill result replaced by a `{ superseded: true, artifact: "skill:workflow-builder" }` stub; (2) run a workflow with a large node output and call `get-node-output` — the result should carry `truncated: true` and a paging note; (3) attach an image, ask about it, then send a follow-up — the next turn should show a text note instead of the base64 block.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-754

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->