### PR TITLE
ci: Add model input to Instance AI exec evals (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: string
         default: ''
+      model:
+        description: 'Model override for all Instance AI agents in the lane backends, provider/model format. Empty = backend default.'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       branch:
@@ -77,6 +82,10 @@ on:
         default: '3'
       experiment-name:
         description: 'LangSmith experiment name (instance-ai-baseline refreshes the baseline)'
+        required: false
+        default: ''
+      model:
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). For experiments: anthropic/claude-sonnet-4-6, anthropic/claude-sonnet-5.'
         required: false
         default: ''
 
@@ -131,6 +140,7 @@ jobs:
           # Prefer head_ref: inputs.branch may be a merge ref (refs/pull/N/merge).
           SANDBOX_NAME_PREFIX: evals-ci-${{ github.head_ref || inputs.branch || github.ref_name }}
           SANDBOX_PROVIDER: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
+          INSTANCE_AI_MODEL: ${{ inputs.model }}
         run: |
           # Build provider-specific env args
           SANDBOX_ARGS=()
@@ -155,6 +165,12 @@ jobs:
             NETWORK_ARGS+=(--network n8n-eval-net)
           fi
 
+          # Model override for A/B experiments; empty = backend default (instance-ai.config.ts)
+          MODEL_ARGS=()
+          if [ -n "$INSTANCE_AI_MODEL" ]; then
+            MODEL_ARGS+=(-e N8N_INSTANCE_AI_MODEL="$INSTANCE_AI_MODEL")
+          fi
+
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"
           for i in "${!PORTS[@]}"; do
             port="${PORTS[$i]}"
@@ -167,6 +183,7 @@ jobs:
               -e N8N_AI_ASSISTANT_BASE_URL="" \
               -e N8N_INSTANCE_AI_SANDBOX_ENABLED=true \
               "${SANDBOX_ARGS[@]}" \
+              "${MODEL_ARGS[@]}" \
               -e LANGSMITH_TRACING=true \
               -e LANGSMITH_API_KEY="$LANGSMITH_API_KEY" \
               -e LANGSMITH_ENDPOINT="$LANGSMITH_ENDPOINT" \
@@ -214,13 +231,14 @@ jobs:
               }'
           done
 
-      # Belt-and-suspenders: env vars set sandbox config but persisted admin
+      # Belt-and-suspenders: env vars set sandbox/model config but persisted
       # settings can override. Per-lane assertion catches env-injection hiccups
-      # or unexpected DB-side state. A single misconfigured lane would
-      # silently route some builds through tool mode and pollute results.
-      - name: Assert sandbox is enabled on every lane
+      # or unexpected DB-side state. A single misconfigured lane would silently
+      # route some builds through tool mode or the wrong model and pollute results.
+      - name: Assert sandbox and model config on every lane
         env:
           SANDBOX_PROVIDER: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
+          INSTANCE_AI_MODEL: ${{ inputs.model }}
         run: |
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"
           bad=0
@@ -240,9 +258,22 @@ jobs:
             else
               echo "  lane $lane: sandboxEnabled=true sandboxProvider=$SANDBOX_PROVIDER ok"
             fi
+            # /preferences returns the effective model name (user pref || config),
+            # i.e. the name part of provider/model.
+            if [ -n "$INSTANCE_AI_MODEL" ]; then
+              effective=$(curl -sf -b "/tmp/cookies-$port.txt" \
+                "http://localhost:$port/rest/instance-ai/preferences" \
+                | jq -r '.data.modelName')
+              if [ "$effective" != "${INSTANCE_AI_MODEL##*/}" ]; then
+                echo "::error::lane $lane (port $port): expected model '${INSTANCE_AI_MODEL##*/}', got '$effective'"
+                bad=$((bad+1))
+              else
+                echo "  lane $lane: model=$effective ok"
+              fi
+            fi
           done
           if [ "$bad" -gt 0 ]; then
-            echo "::error::$bad lane(s) misconfigured - eval would mix sandbox + tool-mode builds"
+            echo "::error::$bad lane(s) misconfigured - eval results would mix configurations"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Adds a free-form `model` input to the exec-evals workflow (dispatch + workflow_call) for builder-model experiments — e.g. comparing `anthropic/claude-opus-4-8` (backend default) vs `anthropic/claude-sonnet-4-6` vs `anthropic/claude-sonnet-5`.

- The input is injected into each lane container as `N8N_INSTANCE_AI_MODEL` (the existing backend knob, `provider/model` format). It drives the whole Instance AI agent stack — orchestrator, builder, sub-agents — via the shared `resolveAgentModelConfig` chain; no backend change needed. Empty input = backend default.
- Free-form string rather than a `choice` dropdown: experiments want arbitrary model ids, and the three current comparison targets are documented in the input description.
- The per-lane config assertion now also verifies the effective model via `GET /rest/instance-ai/preferences` (which returns the effective model name), so a lane on the wrong model fails the run instead of silently polluting the comparison — same rationale as the existing sandbox assertion.

**Stacked on #33458** (touches the same `docker run` block); retarget/rebase to master once that merges.

## How to test

Manual dispatch on this branch with `model=anthropic/claude-sonnet-4-6`, a single-case filter, and 1 iteration — the "Assert sandbox and model config on every lane" step logs `model=claude-sonnet-4-6 ok` per lane, and the build runs on Sonnet. Empty `model` reproduces today's behavior (default Opus 4.8).

When running comparisons, set `experiment-name` per arm (e.g. `builder-model-sonnet-4-6`) — the PR-comment baseline comparison is Opus-based and not meaningful across models.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #33458.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- CI workflow change; validated via live dispatch -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33474">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->