### PR TITLE
fix(editor): Fix credit banner spacing in Instance AI input (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -375,6 +375,7 @@
 	"aiAssistant.builder.settings.getMoreCredits": "Get more credits",
 	"aiAssistant.builder.settings.creditsTooltip": "Credits are based on token usage. Credits renew on {renewalDate}. Unused credits expire on {expiryDate}.",
 	"aiAssistant.builder.creditBanner.text": "{remaining}/{total} monthly credits left",
+	"aiAssistant.builder.creditBanner.trialText": "{remaining}/{total} credits left in your free trial",
 	"aiAssistant.builder.creditBanner.getMore": "Get more",
 	"aiAssistant.builder.upgradeWhileStreaming.title": "AI Builder is still working",
 	"aiAssistant.builder.upgradeWhileStreaming.message": "The AI Builder is currently generating your workflow. Leaving this page will stop the generation.",

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import CreditWarningBanner from './CreditWarningBanner.vue';
 
@@ -15,7 +15,20 @@ vi.mock('@n8n/i18n', () => {
 	};
 });
 
+let mockUserIsTrialing = false;
+vi.mock('@/app/stores/cloudPlan.store', () => ({
+	useCloudPlanStore: vi.fn(() => ({
+		get userIsTrialing() {
+			return mockUserIsTrialing;
+		},
+	})),
+}));
+
 describe('CreditWarningBanner', () => {
+	beforeEach(() => {
+		mockUserIsTrialing = false;
+	});
+
 	it('rounds remaining and total credits to two decimal places', () => {
 		const wrapper = mount(CreditWarningBanner, {
 			props: { creditsRemaining: 2.468, creditsQuota: 100.04 },
@@ -24,5 +37,24 @@ describe('CreditWarningBanner', () => {
 		const text = wrapper.get('[data-test-id="credit-warning-banner"]').text();
 		expect(text).toContain('"remaining":"2.47"');
 		expect(text).toContain('"total":"100.04"');
+	});
+
+	it('shows the monthly credits text when the user is not trialing', () => {
+		const wrapper = mount(CreditWarningBanner, {
+			props: { creditsRemaining: 0, creditsQuota: 800 },
+		});
+
+		const text = wrapper.get('[data-test-id="credit-warning-banner"]').text();
+		expect(text).toContain('aiAssistant.builder.creditBanner.text');
+	});
+
+	it('shows the free trial credits text when the user is trialing', () => {
+		mockUserIsTrialing = true;
+		const wrapper = mount(CreditWarningBanner, {
+			props: { creditsRemaining: 0, creditsQuota: 800 },
+		});
+
+		const text = wrapper.get('[data-test-id="credit-warning-banner"]').text();
+		expect(text).toContain('aiAssistant.builder.creditBanner.trialText');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nTooltip } from '@n8n/design-system';
+import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { round2 } from './creditFormatting';
 
 const props = defineProps<{
@@ -18,9 +19,13 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
+const cloudPlanStore = useCloudPlanStore();
 
 const bannerText = computed(() => {
-	return i18n.baseText('aiAssistant.builder.creditBanner.text', {
+	const key = cloudPlanStore.userIsTrialing
+		? 'aiAssistant.builder.creditBanner.trialText'
+		: 'aiAssistant.builder.creditBanner.text';
+	return i18n.baseText(key, {
 		interpolate: {
 			remaining: String(round2(props.creditsRemaining ?? 0)),
 			total: String(round2(props.creditsQuota ?? 0)),

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/CreditWarningBanner.vue
@@ -7,6 +7,9 @@ import { round2 } from './creditFormatting';
 const props = defineProps<{
 	creditsRemaining?: number;
 	creditsQuota?: number;
+	// 'attached' fuses onto the chat input below (used in the assistant sidebar);
+	// 'standalone' is a self-contained card that sits above a detached input.
+	variant?: 'attached' | 'standalone';
 }>();
 
 const emit = defineEmits<{
@@ -41,7 +44,10 @@ const tooltipContent = computed(() => {
 </script>
 
 <template>
-	<div :class="$style.banner" data-test-id="credit-warning-banner">
+	<div
+		:class="[$style.banner, { [$style.standalone]: props.variant === 'standalone' }]"
+		data-test-id="credit-warning-banner"
+	>
 		<div :class="$style.content">
 			<span :class="$style.text">{{ bannerText }}</span>
 			<N8nTooltip :content="tooltipContent" placement="top" :show-after="300">
@@ -78,6 +84,13 @@ const tooltipContent = computed(() => {
 	border-bottom: none;
 	margin: 0 var(--spacing--2xs);
 	line-height: var(--line-height--xl);
+}
+
+.standalone {
+	// Full card so it reads as its own element above a detached, rounded input.
+	border-radius: var(--radius--lg);
+	border-bottom: var(--border);
+	margin: 0;
 }
 
 .content {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -385,6 +385,7 @@ function handleShelfSuggestionInsert(payload: {
 				<div :class="$style.proactiveInput">
 					<CreditWarningBanner
 						v-if="creditBanner.visible.value"
+						variant="standalone"
 						:credits-remaining="store.creditsRemaining"
 						:credits-quota="store.creditsQuota"
 						@upgrade-click="goToUpgrade('instance-ai', 'upgrade-instance-ai')"
@@ -454,6 +455,7 @@ function handleShelfSuggestionInsert(payload: {
 				<div ref="centeredInput" :class="$style.centeredInput">
 					<CreditWarningBanner
 						v-if="creditBanner.visible.value"
+						variant="standalone"
 						:credits-remaining="store.creditsRemaining"
 						:credits-quota="store.creditsQuota"
 						@upgrade-click="goToUpgrade('instance-ai', 'upgrade-instance-ai')"

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -783,6 +783,7 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 										/>
 										<CreditWarningBanner
 											v-if="creditBanner.visible.value"
+											variant="standalone"
 											:credits-remaining="store.creditsRemaining"
 											:credits-quota="store.creditsQuota"
 											@upgrade-click="goToUpgrade('instance-ai', 'upgrade-instance-ai')"


### PR DESCRIPTION
## Summary

The `CreditWarningBanner` is styled as a fused "lid" — top corners rounded only, no bottom border, and an inset horizontal margin. That looks correct in the **AI Assistant sidebar** (`AskAssistantChat`), where it sits inside an input-header wrapper that supplies side borders, a matching background, and **no gap** to the input directly below.

In the **Instance AI** empty and thread views, the same banner is a flex child with `gap: var(--spacing--xs)` above a self-contained rounded, shadowed chat input. With the gap, the borderless bottom + top-only radius detach and read as a **cut-off box**:
<img width="1368" height="462" alt="Screenshot 2026-07-02 at 16 15 38" src="https://github.com/user-attachments/assets/1972a269-f391-406e-be3a-d6a158b56acc" />

This adds a `variant` prop to the shared banner:
- `attached` (default) — unchanged fused behavior for the sidebar.
- `standalone` — a self-contained card (all corners rounded, bottom border restored, no inset margin) so it aligns with the full-width input below.
<img width="1232" height="456" alt="Screenshot 2026-07-02 at 16 14 21" src="https://github.com/user-attachments/assets/88fd4229-3826-46b7-b899-9a1ef64d0c30" />

The Instance AI views now pass `variant="standalone"`; the sidebar is untouched.

## How to test

Instance AI is gated behind the Instance AI module / feature flag. With it enabled and the account at low/zero credits so the banner shows:

1. Open Instance AI (empty view and an active thread).
2. Confirm the "X/Y monthly credits left" banner renders as a complete rounded card above the "Ask anything…" input, with no cut-off/open bottom edge.
3. Open the AI Assistant sidebar with the same low-credit state and confirm its banner still fuses onto the input as before (no visual change).

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL if applicable -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

