### PR TITLE
fix(core): Keep Instance AI thread content after page refresh during long runs

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -451,6 +451,7 @@ export {
 	findAgent,
 	toAgentTree,
 	stateFromAgentTree,
+	nodeHasContent,
 } from './schemas/agent-run-reducer';
 
 export type { AgentRunState } from './schemas/agent-run-reducer';

--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -113,14 +113,18 @@ function appendTimelineText(
 }
 
 /**
- * Whether a node carries any content worth preserving across a follow-up
- * `run-start`. Covers every renderable field a turn can populate — not just
- * text/tools/children — so a reasoning-, status-, result-, or error-only tree
- * is not wiped when the next run in the group starts. Optional-chained because
+ * Whether a node carries any renderable content. Covers every renderable field
+ * a turn can populate — not just text/tools/children — so a reasoning-,
+ * status-, result-, or error-only tree still counts. Optional-chained because
  * adopted run-sync trees are not schema-validated, so a malformed node must not
  * throw here.
+ *
+ * Shared contract: the reducer uses it to avoid wiping a merged group's tree
+ * on a follow-up `run-start`, the backend message parser uses it to fall back
+ * from degenerate snapshots, and the frontend uses it to keep a hydrated tree
+ * over a degenerate run-sync frame.
  */
-function nodeHasContent(node: InstanceAiAgentNode | undefined): boolean {
+export function nodeHasContent(node: InstanceAiAgentNode | undefined): boolean {
 	if (!node) return false;
 	return (
 		(node.textContent?.length ?? 0) > 0 ||

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -423,6 +423,7 @@ defineLazyExport(
 	() => loadPlannedTaskPermissions().PLANNED_TASK_PERMISSION_OVERRIDES,
 );
 export type { SuspensionInfo, Resumable } from './utils/stream-helpers';
+export type { AgentTreeSeed } from './utils/agent-tree';
 export const buildAgentTreeFromEvents: typeof AgentTreeMod.buildAgentTreeFromEvents = lazyFunction(
 	() => loadAgentTree().buildAgentTreeFromEvents,
 );

--- a/packages/@n8n/instance-ai/src/utils/agent-tree.ts
+++ b/packages/@n8n/instance-ai/src/utils/agent-tree.ts
@@ -1,8 +1,34 @@
-import { createInitialState, reduceEvent, toAgentTree } from '@n8n/api-types';
+import { createInitialState, isSafeObjectKey, reduceEvent, toAgentTree } from '@n8n/api-types';
 import type { InstanceAiAgentNode, InstanceAiEvent } from '@n8n/api-types';
 
-export function buildAgentTreeFromEvents(events: InstanceAiEvent[]): InstanceAiAgentNode {
-	let state = createInitialState();
+/**
+ * Pre-registered agent identities for rebuilding a tree from a partial event
+ * log. The in-process event bus evicts oldest events first, so a long turn
+ * loses its `run-start` — the only event that registers the root agent. Without
+ * the root, the reducer silently drops every surviving event and the rebuilt
+ * tree comes out empty. Seeding the known root (and the orchestrator ids of
+ * merged follow-up runs, which normally alias onto the root via their own
+ * `run-start`) lets the surviving tail reduce into a renderable tree.
+ */
+export interface AgentTreeSeed {
+	/** Root agent id, e.g. `orchestratorAgentId(<first runId of the group>)`. */
+	rootAgentId: string;
+	/** Agent ids that alias the root, e.g. orchestrator ids of follow-up runs. */
+	aliasAgentIds?: string[];
+}
+
+export function buildAgentTreeFromEvents(
+	events: InstanceAiEvent[],
+	seed?: AgentTreeSeed,
+): InstanceAiAgentNode {
+	let state = createInitialState(seed?.rootAgentId);
+	if (seed) {
+		const root = state.agentsById[state.rootAgentId];
+		for (const alias of seed.aliasAgentIds ?? []) {
+			if (alias === state.rootAgentId || !isSafeObjectKey(alias)) continue;
+			state.agentsById[alias] = root;
+		}
+	}
 	for (const event of events) {
 		state = reduceEvent(state, event);
 	}

--- a/packages/cli/src/modules/instance-ai/__tests__/agent-tree-builder.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/agent-tree-builder.test.ts
@@ -1,8 +1,16 @@
 import type { InstanceAiAgentNode, InstanceAiEvent } from '@n8n/api-types';
 
+interface AgentTreeSeed {
+	rootAgentId: string;
+	aliasAgentIds?: string[];
+}
+
 // `@n8n/instance-ai` source util imported dynamically (no built entry for this
 // deep subpath); loaded in `beforeAll` to avoid top-level `await`.
-let buildAgentTreeFromEvents: (events: InstanceAiEvent[]) => InstanceAiAgentNode;
+let buildAgentTreeFromEvents: (
+	events: InstanceAiEvent[],
+	seed?: AgentTreeSeed,
+) => InstanceAiAgentNode;
 let findAgentNodeInTree: (
 	tree: InstanceAiAgentNode,
 	agentId: string,
@@ -12,7 +20,10 @@ beforeAll(async () => {
 	({ buildAgentTreeFromEvents, findAgentNodeInTree } = (await import(
 		'../../../../../@n8n/instance-ai/src/utils/agent-tree'
 	)) as {
-		buildAgentTreeFromEvents: (events: InstanceAiEvent[]) => InstanceAiAgentNode;
+		buildAgentTreeFromEvents: (
+			events: InstanceAiEvent[],
+			seed?: AgentTreeSeed,
+		) => InstanceAiAgentNode;
 		findAgentNodeInTree: (
 			tree: InstanceAiAgentNode,
 			agentId: string,
@@ -363,6 +374,146 @@ describe('buildAgentTreeFromEvents', () => {
 
 		expect(tree.toolCalls[0].renderHint).toBe('delegate');
 		expect(tree.toolCalls[1].renderHint).toBe('builder');
+	});
+
+	// The in-process event bus evicts oldest events first, so a long turn loses
+	// its run-start — the only event that registers the root agent. These cases
+	// pin the recovery contract: without a seed the surviving tail reduces to an
+	// empty default tree; with the seeded orchestrator identity it stays renderable.
+	describe('seeded rebuild after run-start eviction', () => {
+		/** A surviving event tail whose run-start was evicted from the bus. */
+		const evictedTail: InstanceAiEvent[] = [
+			{
+				type: 'reasoning-delta',
+				runId: 'run-1',
+				agentId: 'orchestrator-run-1',
+				payload: { text: 'Routing to setup.' },
+			},
+			{
+				type: 'text-delta',
+				runId: 'run-1',
+				agentId: 'orchestrator-run-1',
+				payload: { text: 'Setting up the workflow.' },
+			},
+			{
+				type: 'tool-call',
+				runId: 'run-1',
+				agentId: 'orchestrator-run-1',
+				payload: { toolCallId: 'tc-setup', toolName: 'workflows', args: { action: 'setup' } },
+			},
+			{
+				type: 'confirmation-request',
+				runId: 'run-1',
+				agentId: 'orchestrator-run-1',
+				payload: {
+					requestId: 'cr-setup',
+					toolCallId: 'tc-setup',
+					toolName: 'workflows',
+					args: { action: 'setup' },
+					severity: 'info',
+					message: 'Set up the workflow',
+				},
+			},
+		];
+
+		it('drops every event without a seed (documents the failure mode)', () => {
+			const tree = buildAgentTreeFromEvents(evictedTail);
+
+			expect(tree.agentId).toBe('agent-001');
+			expect(tree.textContent).toBe('');
+			expect(tree.toolCalls).toEqual([]);
+		});
+
+		it('rebuilds the tail under the seeded root', () => {
+			const tree = buildAgentTreeFromEvents(evictedTail, { rootAgentId: 'orchestrator-run-1' });
+
+			expect(tree.agentId).toBe('orchestrator-run-1');
+			expect(tree.reasoning).toBe('Routing to setup.');
+			expect(tree.textContent).toBe('Setting up the workflow.');
+			expect(tree.toolCalls).toHaveLength(1);
+			expect(tree.toolCalls[0].confirmation).toMatchObject({
+				requestId: 'cr-setup',
+				message: 'Set up the workflow',
+			});
+			expect(tree.toolCalls[0].isLoading).toBe(true);
+		});
+
+		it('routes merged follow-up run events onto the root via alias ids', () => {
+			const followUpTail: InstanceAiEvent[] = [
+				{
+					type: 'text-delta',
+					runId: 'run-2',
+					agentId: 'orchestrator-run-2',
+					payload: { text: 'Follow-up output' },
+				},
+			];
+
+			const tree = buildAgentTreeFromEvents(followUpTail, {
+				rootAgentId: 'orchestrator-run-1',
+				aliasAgentIds: ['orchestrator-run-2'],
+			});
+
+			expect(tree.agentId).toBe('orchestrator-run-1');
+			expect(tree.textContent).toBe('Follow-up output');
+		});
+
+		it('registers sub-agents spawned under the seeded root', () => {
+			const tailWithSubAgent: InstanceAiEvent[] = [
+				{
+					type: 'agent-spawned',
+					runId: 'run-1',
+					agentId: 'builder-1',
+					payload: { parentId: 'orchestrator-run-1', role: 'workflow-builder', tools: [] },
+				},
+				{
+					type: 'text-delta',
+					runId: 'run-1',
+					agentId: 'builder-1',
+					payload: { text: 'Building...' },
+				},
+			];
+
+			const tree = buildAgentTreeFromEvents(tailWithSubAgent, {
+				rootAgentId: 'orchestrator-run-1',
+			});
+
+			expect(tree.children).toHaveLength(1);
+			expect(tree.children[0]).toMatchObject({
+				agentId: 'builder-1',
+				textContent: 'Building...',
+			});
+		});
+
+		it('still honors run-start when it survives alongside a seed', () => {
+			const fullLog: InstanceAiEvent[] = [
+				{
+					type: 'run-start',
+					runId: 'run-1',
+					agentId: 'orchestrator-run-1',
+					payload: { messageId: 'msg-1' },
+				},
+				...evictedTail,
+			];
+
+			const tree = buildAgentTreeFromEvents(fullLog, {
+				rootAgentId: 'orchestrator-run-1',
+				aliasAgentIds: ['orchestrator-run-2'],
+			});
+
+			expect(tree.agentId).toBe('orchestrator-run-1');
+			expect(tree.textContent).toBe('Setting up the workflow.');
+			expect(tree.toolCalls).toHaveLength(1);
+		});
+
+		it('ignores unsafe alias ids', () => {
+			const tree = buildAgentTreeFromEvents(evictedTail, {
+				rootAgentId: 'orchestrator-run-1',
+				aliasAgentIds: ['__proto__'],
+			});
+
+			expect(tree.agentId).toBe('orchestrator-run-1');
+			expect(tree.toolCalls).toHaveLength(1);
+		});
 	});
 
 	it('should handle confirmation-request events', () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -6,6 +6,7 @@ vi.mock('@n8n/instance-ai', () => {
 		workflowLoopStateSchema: z.string(),
 		attemptRecordSchema: z.object({}),
 		workflowBuildOutcomeSchema: z.string(),
+		orchestratorAgentId: (runId: string) => `orchestrator-${runId}`,
 		buildAgentTreeFromEvents: vi.fn(() => ({
 			agentId: 'agent-root',
 			role: 'orchestrator',
@@ -27,6 +28,7 @@ vi.mock('../eval/execution.service', () => ({
 	EvalExecutionService: vi.fn(),
 }));
 
+import { buildAgentTreeFromEvents } from '@n8n/instance-ai';
 import type {
 	InstanceAiAdminSettingsUpdateRequest,
 	InstanceAiEvalCredentialAllowlistRequest,
@@ -361,6 +363,14 @@ describe('InstanceAiController', () => {
 
 			expect(runSyncFrame).toContain('"agent-root"');
 			expect(runSyncFrame).toContain('"planItems"');
+
+			// The rebuild is seeded with the group's orchestrator identities so a
+			// tail whose run-start was evicted from the bus still reduces into a
+			// renderable tree instead of an empty one.
+			expect(buildAgentTreeFromEvents).toHaveBeenCalledWith(expect.any(Array), {
+				rootAgentId: 'orchestrator-run-1',
+				aliasAgentIds: [],
+			});
 		});
 
 		it('should close SSE stream when thread ownership changes after pre-creation subscribe', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -34,8 +34,8 @@ import {
 	Body,
 	Query,
 } from '@n8n/decorators';
-import type { StoredEvent } from '@n8n/instance-ai';
-import { buildAgentTreeFromEvents } from '@n8n/instance-ai';
+import type { AgentTreeSeed, StoredEvent } from '@n8n/instance-ai';
+import { buildAgentTreeFromEvents, orchestratorAgentId } from '@n8n/instance-ai';
 import { UnsupportedAttachmentError, validateAttachmentMimeTypes } from '@n8n/instance-ai/parsers';
 import type { NextFunction, Request, Response } from 'express';
 import { randomUUID, timingSafeEqual } from 'node:crypto';
@@ -95,6 +95,24 @@ export class InstanceAiController {
 			InstanceAiController.getTreeRichnessScore(eventTree)
 			? persistedTree
 			: eventTree;
+	}
+
+	/**
+	 * Orchestrator identities to seed the bootstrap tree rebuild with: a long
+	 * turn overflows the event bus and loses its `run-start`, and without a
+	 * registered root the reducer drops every surviving event — the frame would
+	 * then carry an empty tree that clobbers the client's hydrated messages.
+	 */
+	private static bootstrapTreeSeed(
+		groupRunIds: string[],
+		snapshotRunIds: string[] | undefined,
+	): AgentTreeSeed | undefined {
+		const runIds = groupRunIds.length > 0 ? groupRunIds : (snapshotRunIds ?? []);
+		if (runIds.length === 0) return undefined;
+		return {
+			rootAgentId: orchestratorAgentId(runIds[0]),
+			aliasAgentIds: runIds.slice(1).map(orchestratorAgentId),
+		};
 	}
 
 	constructor(
@@ -303,7 +321,10 @@ export class InstanceAiController {
 			});
 			if (runEvents.length === 0 && !persistedSnapshot) continue;
 
-			const eventTree = buildAgentTreeFromEvents(runEvents);
+			const eventTree = buildAgentTreeFromEvents(
+				runEvents,
+				InstanceAiController.bootstrapTreeSeed(group.runIds, persistedSnapshot?.runIds),
+			);
 			const agentTree = InstanceAiController.selectBootstrapTree(
 				eventTree,
 				persistedSnapshot?.tree,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -5113,7 +5113,14 @@ export class InstanceAiService {
 				});
 				return;
 			}
-			const agentTree = buildAgentTreeFromEvents(events);
+			// Seed the known orchestrator identities: long turns overflow the event
+			// bus and lose their `run-start`, and without a registered root the
+			// reducer drops every surviving event — persisting an empty tree.
+			const seedRunIds = groupRunIds?.length ? groupRunIds : [runId];
+			const agentTree = buildAgentTreeFromEvents(events, {
+				rootAgentId: orchestratorAgentId(seedRunIds[0]),
+				aliasAgentIds: seedRunIds.slice(1).map(orchestratorAgentId),
+			});
 
 			const tracing = this.tracing.getTraceContext(runId);
 			const saveOptions = {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -842,6 +842,76 @@ describe('createThreadRuntime - SSE and hydration', () => {
 		expect(msg.agentTree?.timeline).toEqual([{ type: 'text', content: 'synced + live' }]);
 	});
 
+	test('run-sync with a degenerate tree does not clobber a hydrated renderable tree', async () => {
+		mockFetchThreadMessages.mockResolvedValueOnce({
+			threadId: activeThreadId,
+			messages: [
+				{
+					id: 'msg-hydrated',
+					runId: 'run-h',
+					messageGroupId: 'group-h',
+					role: 'assistant',
+					createdAt: new Date().toISOString(),
+					content: 'restored',
+					reasoning: '',
+					isStreaming: false,
+					agentTree: {
+						agentId: 'agent-root',
+						role: 'orchestrator',
+						status: 'active',
+						textContent: 'restored',
+						reasoning: '',
+						toolCalls: [],
+						children: [],
+						timeline: [{ type: 'text', content: 'restored' }],
+					},
+				},
+			],
+			nextEventId: 11,
+		});
+
+		await activeRuntime(registry).loadHistoricalMessages();
+
+		// Suspended-run bootstrap whose tree rebuild came back empty (run's
+		// events evicted from the bus and the persisted snapshot degenerate).
+		capturedInstance!.dispatchNamedEvent('run-sync', {
+			runId: 'run-h',
+			messageGroupId: 'group-h',
+			runIds: ['run-h'],
+			agentTree: {
+				agentId: 'agent-001',
+				role: 'orchestrator',
+				status: 'active',
+				textContent: '',
+				reasoning: '',
+				toolCalls: [],
+				children: [],
+				timeline: [],
+			},
+			status: 'suspended',
+			backgroundTasks: [],
+		});
+
+		// The hydrated tree survives; only run/streaming state is refreshed.
+		expect(activeRuntime(registry).messages).toHaveLength(1);
+		const msg = activeRuntime(registry).messages[0];
+		expect(msg.agentTree?.textContent).toBe('restored');
+		expect(msg.content).toBe('restored');
+		expect(msg.isStreaming).toBe(true);
+		expect(activeRuntime(registry).activeRunId).toBe('run-h');
+
+		// Live events after the guarded sync still mutate the kept tree.
+		capturedOnMessage!(
+			makeSSEEvent({
+				type: 'text-delta',
+				runId: 'run-h',
+				agentId: 'agent-root',
+				payload: { text: ' + live' },
+			}),
+		);
+		expect(msg.agentTree?.textContent).toBe('restored + live');
+	});
+
 	test('run-sync skips unsafe group identifiers instead of registering them', () => {
 		capturedOnMessage!(
 			makeSSEEvent({

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -5,6 +5,7 @@ import {
 	buildRunWorkflowSessionGrantKey,
 	instanceAiEventSchema,
 	isSafeObjectKey,
+	nodeHasContent,
 	type InstanceAiConfirmation,
 	type InstanceAiConfirmRequest,
 	type InstanceAiConfirmResponse,
@@ -616,10 +617,6 @@ export function createThreadRuntime(
 
 			const groupId = data.messageGroupId ?? data.runId;
 			if (!isSafeObjectKey(data.runId) || !isSafeObjectKey(groupId)) return;
-			// Adopts the snapshot tree's nodes — `msg.agentTree` below points at the
-			// same objects, so subsequent live events mutate what's rendered.
-			const rebuiltRunState = createRunStateFromTree(data.agentTree);
-			if (!rebuiltRunState) return;
 
 			// Find the message to update — by messageGroupId first, then runId
 			let msg: InstanceAiMessage | undefined;
@@ -632,6 +629,19 @@ export function createThreadRuntime(
 				msg = messages.value.find((m) => m.runId === data.runId);
 			}
 
+			// A degenerate sync tree (e.g. rebuilt after the event bus evicted the
+			// run's events) must not clobber a message that already renders content
+			// from hydration — keep the richer tree and only refresh routing/state.
+			const adoptedTree =
+				msg?.agentTree && nodeHasContent(msg.agentTree) && !nodeHasContent(data.agentTree)
+					? msg.agentTree
+					: data.agentTree;
+
+			// Adopts the tree's nodes — `msg.agentTree` below points at the same
+			// objects, so subsequent live events mutate what's rendered.
+			const rebuiltRunState = createRunStateFromTree(adoptedTree);
+			if (!rebuiltRunState) return;
+
 			if (!msg) {
 				messages.value.push({
 					id: groupId,
@@ -640,20 +650,20 @@ export function createThreadRuntime(
 					runIds: data.runIds,
 					role: 'assistant',
 					createdAt: new Date().toISOString(),
-					content: data.agentTree.textContent,
-					reasoning: data.agentTree.reasoning,
+					content: adoptedTree.textContent,
+					reasoning: adoptedTree.reasoning,
 					isStreaming: false,
-					agentTree: data.agentTree,
+					agentTree: adoptedTree,
 				});
 				msg = messages.value[messages.value.length - 1];
 			}
 
-			msg.agentTree = data.agentTree;
+			msg.agentTree = adoptedTree;
 			msg.runId = data.runId;
 			msg.messageGroupId = groupId;
 			msg.runIds = data.runIds;
-			msg.content = data.agentTree.textContent;
-			msg.reasoning = data.agentTree.reasoning;
+			msg.content = adoptedTree.textContent;
+			msg.reasoning = adoptedTree.reasoning;
 			latestTasks.value = findLatestTasksFromMessages(messages.value);
 			const isOrchestratorLive = data.status === 'active' || data.status === 'suspended';
 			// For background-only groups, the orchestrator already finished.


### PR DESCRIPTION
## Summary

Refreshing the page while an Instance AI thread was mid-run (or suspended at a setup/HITL card) collapsed the conversation to just the user message with a perpetual "Thinking" spinner and an empty artifacts panel.

Two mechanisms combined to cause this:

1. **Empty tree rebuilds after event-bus eviction.** The in-process event bus caps each thread at 500 events / 2 MB, evicting oldest first. A long build turn evicts its `run-start` — the only event that registers the root agent in the reducer — after which every surviving event is silently dropped when the tree is rebuilt. Both `saveAgentTreeSnapshot` (at suspension) and the SSE `run-sync` bootstrap were persisting/emitting completely empty trees for any long turn.
2. **Degenerate `run-sync` frames clobbering hydration.** On reconnect, the frontend unconditionally adopted the bootstrap frame's tree, overwriting the message content that thread hydration had just restored — wiping the whole turn from the UI.

**Fixes:**

- `buildAgentTreeFromEvents` accepts an optional `AgentTreeSeed` that pre-registers the group's orchestrator identities (root + follow-up-run aliases), so a surviving event tail still reduces into a renderable tree. Both call sites (snapshot persistence and SSE bootstrap) now seed from the group's run ids, with the bootstrap falling back to the persisted snapshot's `runIds` after a restart.
- `onRunSync` in the frontend keeps the existing hydrated tree when the incoming frame's tree carries no renderable content, while still refreshing run routing and streaming state. The reducer's `nodeHasContent` check is now exported from `@n8n/api-types` as the shared renderability contract.

## How to test

1. Ask the assistant to build a workflow that ends in a setup step, e.g.: *"When a customer sends a WhatsApp message, use Gemini to match their question against our FAQ in Google Sheets and reply. If it cannot resolve it, create a ticket in Notion and alert the team on Slack."*
2. Wait for the build to finish and the setup card ("Set up WhatsApp OAuth", etc.) to appear.
3. Refresh the page.
4. Before: only the user message renders, with a stuck "Thinking" indicator and no artifacts. After: the full turn (reasoning, tool calls, builder output, setup card) is restored and the setup flow can continue.

Regression tests cover the evicted `run-start` rebuild (with and without seed, follow-up aliases, sub-agent spawn, unsafe ids), the seeded bootstrap contract in the controller, and the frontend guard (degenerate frame does not clobber a hydrated tree, and live events still mutate the kept tree).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-757

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)