### PR TITLE
feat(core): Export contained workflows when exporting a folder (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/export-folder.integration.test.ts
@@ -1,15 +1,16 @@
-import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
 import { Container } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
 import type { RelayEventMap } from '@/events/maps/relay.event-map';
-
+import { saveCredential } from '@test-integration/db/credentials';
 import { createFolder } from '@test-integration/db/folders';
 import { createMember, createOwner } from '@test-integration/db/users';
 
 import { N8nPackagesService } from '../n8n-packages.service';
 import { readExport } from './utils/tar-support';
+import { buildWorkflowReferencingCredential } from './utils/test-builders';
 
 type ExportEntries = Awaited<ReturnType<typeof readExport>>['entries'];
 
@@ -33,6 +34,8 @@ beforeEach(async () => {
 		'Folder',
 		'WorkflowEntity',
 		'SharedWorkflow',
+		'CredentialsEntity',
+		'SharedCredentials',
 		'ProjectRelation',
 		'Project',
 	]);
@@ -219,5 +222,206 @@ describe('folder package export', () => {
 				folderIds: [accessibleFolder.id, inaccessibleFolder.id],
 			}),
 		).rejects.toThrow(/1 folder\(s\) not found or not accessible/);
+	});
+});
+
+describe('folder package export — with contained workflows', () => {
+	let service: N8nPackagesService;
+
+	beforeAll(() => {
+		service = Container.get(N8nPackagesService);
+	});
+
+	// AC1
+	it('writes a workflow contained in a requested folder under the folder’s workflows/ dir', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'in_progress' });
+		const workflow = await createWorkflow({ name: 'triage', parentFolder: folder }, project);
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [folder.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		const folderEntry = manifest.folders!.find((f) => f.id === folder.id)!;
+		expect(manifest.workflows).toHaveLength(1);
+		const workflowEntry = manifest.workflows!.find((w) => w.id === workflow.id)!;
+		expect(workflowEntry.target).toMatch(new RegExp(`^${folderEntry.target}/workflows/[^/]+$`));
+
+		expect(entries.find((e) => e.name === `${workflowEntry.target}/workflow.json`)).toBeDefined();
+	});
+
+	// AC1b
+	it('nests a workflow inside a nested folder under <parent>/<child>/workflows/', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const parent = await createFolder(project, { name: 'in_progress' });
+		const child = await createFolder(project, { name: 'nested', parentFolder: parent });
+		const workflow = await createWorkflow({ name: 'playground', parentFolder: child }, project);
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [parent.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		const childEntry = manifest.folders!.find((f) => f.id === child.id)!;
+		const workflowEntry = manifest.workflows!.find((w) => w.id === workflow.id)!;
+		expect(workflowEntry.target).toMatch(new RegExp(`^${childEntry.target}/workflows/[^/]+$`));
+		expect(entries.find((e) => e.name === `${workflowEntry.target}/workflow.json`)).toBeDefined();
+	});
+
+	// AC2
+	it('gathers a contained workflow’s credential at the package top level', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'in_progress' });
+		const credential = await saveCredential(
+			{ name: 'Linear API', type: 'httpHeaderAuth', data: { name: 'X-Auth', value: 'secret' } },
+			{ project, role: 'credential:owner' },
+		);
+		const workflow = await buildWorkflowReferencingCredential({
+			name: 'triage',
+			project,
+			credential,
+			parentFolder: folder,
+		});
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [folder.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		// Credential bundles at top-level credentials/, not under the folder.
+		expect(manifest.credentials).toHaveLength(1);
+		expect(manifest.credentials![0].id).toBe(credential.id);
+		expect(manifest.credentials![0].target).toMatch(/^credentials\//);
+		expect(manifest.requirements).toEqual({
+			credentials: [
+				{
+					id: credential.id,
+					name: credential.name,
+					type: 'httpHeaderAuth',
+					usedByWorkflows: [workflow.id],
+				},
+			],
+		});
+		expect(
+			entries.find((e) => e.name === `${manifest.credentials![0].target}/credential.json`),
+		).toBeDefined();
+	});
+
+	// AC3
+	it('aborts the whole export when a contained workflow is not exportable by the caller', async () => {
+		const member = await createMember();
+		const memberProject = await createTeamProject('Member project', member);
+		const folder = await createFolder(memberProject, { name: 'in_progress' });
+
+		const owner = await createOwner();
+		const ownerProject = await createTeamProject('Owner project', owner);
+		// The workflow is shared only with the owner's project but sits in the
+		// member's folder, so the member can folder:read the folder yet cannot
+		// workflow:export the workflow. The per-workflow export gate must abort.
+		await createWorkflow({ name: 'secret', parentFolder: folder }, ownerProject);
+
+		await expect(
+			service.exportPackage({ user: member, workflowIds: [], folderIds: [folder.id] }),
+		).rejects.toThrow(/workflow\(s\) not found or not accessible/);
+	});
+
+	// Edge: a workflow in both folderIds and workflowIds is placed in the folder, once.
+	it('places a workflow listed in both a folder and workflowIds inside the folder only', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'in_progress' });
+		const workflow = await createWorkflow({ name: 'triage', parentFolder: folder }, project);
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [workflow.id],
+			folderIds: [folder.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		const folderEntry = manifest.folders!.find((f) => f.id === folder.id)!;
+		expect(manifest.workflows).toHaveLength(1);
+		expect(manifest.workflows![0].id).toBe(workflow.id);
+		expect(manifest.workflows![0].target).toMatch(
+			new RegExp(`^${folderEntry.target}/workflows/[^/]+$`),
+		);
+
+		// Exactly one workflow.json on disk — no double write, no top-level orphan.
+		expect(entries.filter((e) => e.name.endsWith('/workflow.json'))).toHaveLength(1);
+	});
+
+	// Regression: an empty folder still emits only its shell.
+	it('emits no workflows output for an empty folder', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'empty' });
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [folder.id],
+		});
+		const { manifest, entries } = await readExport(stream);
+
+		expect(manifest.workflows).toBeUndefined();
+		expect(entries.some((e) => e.name.includes('/workflows/'))).toBe(false);
+	});
+
+	// A subfolder whose name slugifies to `workflows` must not collide with the
+	// parent folder's `workflows/` container that holds its contained workflows.
+	it('does not let a subfolder named "workflows" swallow the parent’s contained workflows', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const parent = await createFolder(project, { name: 'in_progress' });
+		const workflow = await createWorkflow({ name: 'triage', parentFolder: parent }, project);
+		const subfolder = await createFolder(project, { name: 'workflows', parentFolder: parent });
+
+		const stream = await service.exportPackage({
+			user: owner,
+			workflowIds: [],
+			folderIds: [parent.id],
+		});
+		const { manifest } = await readExport(stream);
+
+		const subfolderTarget = manifest.folders!.find((f) => f.id === subfolder.id)!.target;
+		const workflowTarget = manifest.workflows!.find((w) => w.id === workflow.id)!.target;
+
+		// The subfolder is suffixed; the workflow stays under the parent's container.
+		expect(subfolderTarget).toMatch(/\/workflows-2$/);
+		expect(workflowTarget.startsWith(`${subfolderTarget}/`)).toBe(false);
+	});
+
+	// Telemetry: counts.workflows includes folder-contained workflows.
+	it('counts folder-contained workflows in the export telemetry', async () => {
+		const owner = await createOwner();
+		const project = await createTeamProject('Project A', owner);
+		const folder = await createFolder(project, { name: 'in_progress' });
+		await createWorkflow({ name: 'triage', parentFolder: folder }, project);
+		await createWorkflow({ name: 'playground', parentFolder: folder }, project);
+
+		const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+
+		try {
+			await service.exportPackage({ user: owner, workflowIds: [], folderIds: [folder.id] });
+
+			const exportedEvents = emitSpy.mock.calls.filter(([name]) => name === 'n8n-package-exported');
+			expect(exportedEvents).toHaveLength(1);
+
+			const payload = exportedEvents[0][1] as RelayEventMap['n8n-package-exported'];
+			expect(payload.counts.workflows).toBe(2);
+			expect(payload.counts.folders).toBe(1);
+		} finally {
+			emitSpy.mockRestore();
+		}
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/__tests__/utils/test-builders.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/utils/test-builders.ts
@@ -1,5 +1,5 @@
 import { createWorkflow } from '@n8n/backend-test-utils';
-import type { CredentialsEntity, Project, WorkflowEntity } from '@n8n/db';
+import type { CredentialsEntity, Folder, Project, WorkflowEntity } from '@n8n/db';
 
 interface BuildWorkflowReferencingCredentialByIdOptions {
 	name: string;
@@ -7,6 +7,8 @@ interface BuildWorkflowReferencingCredentialByIdOptions {
 	credentialId: string;
 	credentialName: string;
 	credentialType: string;
+	/** Places the workflow inside a folder, so folder-with-workflows export can pick it up. */
+	parentFolder?: Folder;
 }
 
 /**
@@ -20,6 +22,7 @@ export async function buildWorkflowReferencingCredentialById({
 	credentialId,
 	credentialName,
 	credentialType,
+	parentFolder,
 }: BuildWorkflowReferencingCredentialByIdOptions): Promise<WorkflowEntity> {
 	return await createWorkflow(
 		{
@@ -38,6 +41,7 @@ export async function buildWorkflowReferencingCredentialById({
 				},
 			],
 			connections: {},
+			parentFolder,
 		},
 		project,
 	);
@@ -47,6 +51,8 @@ interface BuildWorkflowReferencingCredentialOptions {
 	name: string;
 	project: Project;
 	credential: Pick<CredentialsEntity, 'id' | 'name' | 'type'>;
+	/** Places the workflow inside a folder, so folder-with-workflows export can pick it up. */
+	parentFolder?: Folder;
 }
 
 /**
@@ -57,6 +63,7 @@ export async function buildWorkflowReferencingCredential({
 	name,
 	project,
 	credential,
+	parentFolder,
 }: BuildWorkflowReferencingCredentialOptions): Promise<WorkflowEntity> {
 	return await buildWorkflowReferencingCredentialById({
 		name,
@@ -64,5 +71,6 @@ export async function buildWorkflowReferencingCredential({
 		credentialId: credential.id,
 		credentialName: credential.name,
 		credentialType: credential.type,
+		parentFolder,
 	});
 }

--- a/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/__tests__/requirements.types.test.ts
@@ -1,0 +1,32 @@
+import type { WorkflowCredentialRequirement } from '../credential/credential.types';
+import { mergeRequirements } from '../requirements.types';
+
+function cred(credentialId: string, workflowId: string): WorkflowCredentialRequirement {
+	return {
+		workflowId,
+		credentialId,
+		credentialName: `Cred ${credentialId}`,
+		credentialType: 'httpHeaderAuth',
+	};
+}
+
+describe('mergeRequirements', () => {
+	it('concatenates each requirement type across parts, preserving order', () => {
+		const merged = mergeRequirements(
+			{ credentials: [cred('c1', 'w1')] },
+			{ credentials: [cred('c2', 'w2'), cred('c3', 'w3')] },
+		);
+
+		expect(merged.credentials).toEqual([cred('c1', 'w1'), cred('c2', 'w2'), cred('c3', 'w3')]);
+	});
+
+	it('skips undefined parts so optional export results can be passed directly', () => {
+		const merged = mergeRequirements(undefined, { credentials: [cred('c1', 'w1')] }, undefined);
+
+		expect(merged.credentials).toEqual([cred('c1', 'w1')]);
+	});
+
+	it('returns empty requirement lists when given no parts', () => {
+		expect(mergeRequirements()).toEqual({ credentials: [] });
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder.exporter.test.ts
@@ -2,8 +2,10 @@ import type { Folder, User } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
 import type { FolderFinderService } from '@/services/folder-finder.service';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { CapturingWriter } from '../../../io/__tests__/utils/capturing-writer';
+import type { WorkflowExporter } from '../../workflow/workflow.exporter';
 import { FolderExporter } from '../folder.exporter';
 import { FolderSerializer } from '../folder.serializer';
 
@@ -22,17 +24,26 @@ function makeFolder(overrides: Partial<Folder> = {}): Folder {
 function makeExporter(found: Folder[]) {
 	const finder = mock<FolderFinderService>();
 	finder.findFolderSubtreesForUser.mockResolvedValue(found);
-	return new FolderExporter(finder, new FolderSerializer());
+	const workflowFinder = mock<WorkflowFinderService>();
+	workflowFinder.findWorkflowIdsByFolder.mockResolvedValue(new Map());
+	const workflowExporter = mock<WorkflowExporter>();
+	const exporter = new FolderExporter(
+		finder,
+		new FolderSerializer(),
+		workflowFinder,
+		workflowExporter,
+	);
+	return { exporter, workflowFinder, workflowExporter };
 }
 
-// The folder-export behaviour (shells, nesting, re-rooting, sibling ordering,
-// access control) is proven end-to-end in export-folder.integration.test.ts.
-// Only `basePrefix` is left here: it's the composition seam a ProjectExporter
-// uses (LIGO-685) and is unreachable through service.exportPackage, so the
-// integration test cannot cover it.
+// The folder-shell behaviour (nesting, re-rooting, sibling ordering, access
+// control) is proven end-to-end in export-folder.integration.test.ts. Left here
+// are the seams that suite can't reach cheaply: `basePrefix` (used by a future
+// ProjectExporter, LIGO-685) and the contained-workflow wiring — delegation to
+// WorkflowExporter, aggregation of its output, and abort propagation.
 describe('FolderExporter', () => {
 	it('honors basePrefix so the tree composes under a project namespace', async () => {
-		const exporter = makeExporter([makeFolder()]);
+		const { exporter } = makeExporter([makeFolder()]);
 
 		const { entries } = await exporter.export({
 			user,
@@ -42,5 +53,57 @@ describe('FolderExporter', () => {
 		});
 
 		expect(entries[0].target).toMatch(/^projects\/team-ligo\/folders\//);
+	});
+
+	it('delegates contained workflows to WorkflowExporter and aggregates its output', async () => {
+		const { exporter, workflowFinder, workflowExporter } = makeExporter([makeFolder()]);
+		workflowFinder.findWorkflowIdsByFolder.mockResolvedValue(new Map([['fld-1', ['w1']]]));
+		workflowExporter.export.mockResolvedValue({
+			entries: [{ id: 'w1', name: 'W1', target: 'folders/toproduction/workflows/w1' }],
+			requirements: {
+				credentials: [
+					{
+						workflowId: 'w1',
+						credentialId: 'c1',
+						credentialName: 'Cred',
+						credentialType: 'httpHeaderAuth',
+					},
+				],
+			},
+		});
+
+		const result = await exporter.export({
+			user,
+			folderIds: ['fld-1'],
+			writer: new CapturingWriter(),
+		});
+
+		// The folder's own target is passed as basePrefix, so workflows nest under it.
+		expect(workflowExporter.export).toHaveBeenCalledWith(
+			expect.objectContaining({ user, workflowIds: ['w1'], basePrefix: 'folders/toproduction' }),
+		);
+		expect(result.workflowEntries).toEqual([
+			{ id: 'w1', name: 'W1', target: 'folders/toproduction/workflows/w1' },
+		]);
+		expect(result.requirements.credentials).toEqual([
+			{
+				workflowId: 'w1',
+				credentialId: 'c1',
+				credentialName: 'Cred',
+				credentialType: 'httpHeaderAuth',
+			},
+		]);
+	});
+
+	it('propagates a WorkflowExporter abort so the whole folder export rejects', async () => {
+		const { exporter, workflowFinder, workflowExporter } = makeExporter([makeFolder()]);
+		workflowFinder.findWorkflowIdsByFolder.mockResolvedValue(new Map([['fld-1', ['w1']]]));
+		workflowExporter.export.mockRejectedValue(
+			new Error('1 workflow(s) not found or not accessible. Export aborted.'),
+		);
+
+		await expect(
+			exporter.export({ user, folderIds: ['fld-1'], writer: new CapturingWriter() }),
+		).rejects.toThrow(/not found or not accessible/);
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
@@ -9,9 +9,9 @@ import { FolderSerializer } from './folder.serializer';
 import type { PackageWriter } from '../../io/package-writer';
 import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
-import type { WorkflowCredentialRequirement } from '../credential/credential.types';
+import { mergeRequirements } from '../requirements.types';
+import type { WorkflowExportRequirements } from '../requirements.types';
 import { WorkflowExporter } from '../workflow/workflow.exporter';
-import type { WorkflowExportRequirements } from '../workflow/workflow.exporter';
 
 export interface FolderExportRequest {
 	user: User;
@@ -30,7 +30,7 @@ export interface FolderExportResult {
 	entries: ManifestEntry[];
 	/** Workflows contained in the exported folders → `manifest.workflows[]`. */
 	workflowEntries: ManifestEntry[];
-	/** Credentials referenced by contained workflows, gathered at the package top level. */
+	/** What the contained workflows need, gathered at the package top level (credentials today). */
 	requirements: WorkflowExportRequirements;
 }
 
@@ -122,7 +122,7 @@ export class FolderExporter {
 		if (reservedName) allocator.reserve(reservedName);
 		const entries: ManifestEntry[] = [];
 		const workflowEntries: ManifestEntry[] = [];
-		const credentials: WorkflowCredentialRequirement[] = [];
+		const requirementParts: WorkflowExportRequirements[] = [];
 
 		for (const folder of this.orderedByCreation(siblings)) {
 			const target = allocator.allocate(folder.name);
@@ -144,7 +144,7 @@ export class FolderExporter {
 					basePrefix: target,
 				});
 				workflowEntries.push(...contained.entries);
-				credentials.push(...contained.requirements.credentials);
+				requirementParts.push(contained.requirements);
 			}
 
 			const children = childrenByParent.get(folder.id) ?? [];
@@ -160,10 +160,10 @@ export class FolderExporter {
 			);
 			entries.push(...descendants.entries);
 			workflowEntries.push(...descendants.workflowEntries);
-			credentials.push(...descendants.requirements.credentials);
+			requirementParts.push(descendants.requirements);
 		}
 
-		return { entries, workflowEntries, requirements: { credentials } };
+		return { entries, workflowEntries, requirements: mergeRequirements(...requirementParts) };
 	}
 
 	/**

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder.exporter.ts
@@ -3,11 +3,15 @@ import { Service } from '@n8n/di';
 import { UserError } from 'n8n-workflow';
 
 import { FolderFinderService } from '@/services/folder-finder.service';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { FolderSerializer } from './folder.serializer';
 import type { PackageWriter } from '../../io/package-writer';
 import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
+import type { WorkflowCredentialRequirement } from '../credential/credential.types';
+import { WorkflowExporter } from '../workflow/workflow.exporter';
+import type { WorkflowExportRequirements } from '../workflow/workflow.exporter';
 
 export interface FolderExportRequest {
 	user: User;
@@ -22,7 +26,12 @@ export interface FolderExportRequest {
 }
 
 export interface FolderExportResult {
+	/** Folder shells → `manifest.folders[]`. */
 	entries: ManifestEntry[];
+	/** Workflows contained in the exported folders → `manifest.workflows[]`. */
+	workflowEntries: ManifestEntry[];
+	/** Credentials referenced by contained workflows, gathered at the package top level. */
+	requirements: WorkflowExportRequirements;
 }
 
 @Service()
@@ -30,6 +39,8 @@ export class FolderExporter {
 	constructor(
 		private readonly folderFinder: FolderFinderService,
 		private readonly folderSerializer: FolderSerializer,
+		private readonly workflowFinder: WorkflowFinderService,
+		private readonly workflowExporter: WorkflowExporter,
 	) {}
 
 	async export(request: FolderExportRequest): Promise<FolderExportResult> {
@@ -43,10 +54,19 @@ export class FolderExporter {
 
 		const { roots, childrenByParent } = this.buildForest(folders);
 
-		const foldersDir = request.basePrefix ? `${request.basePrefix}/folders` : 'folders';
-		const entries = this.writeLevel(roots, foldersDir, null, childrenByParent, request.writer);
+		const workflowIdsByFolder = await this.workflowFinder.findWorkflowIdsByFolder(
+			folders.map((folder) => folder.id),
+		);
 
-		return { entries };
+		const foldersDir = request.basePrefix ? `${request.basePrefix}/folders` : 'folders';
+		return await this.writeLevel(
+			roots,
+			foldersDir,
+			null,
+			childrenByParent,
+			workflowIdsByFolder,
+			request,
+		);
 	}
 
 	/**
@@ -79,35 +99,71 @@ export class FolderExporter {
 
 	/**
 	 * Writes a set of sibling folders and their descendants under `parentDir`,
-	 * returning a manifest entry for each. A fresh allocator per call scopes slug
-	 * collisions to the parent directory; sub-folders nest directly (no repeated
-	 * `folders/` segment).
+	 * returning the folder shells plus the workflows contained in each folder. A
+	 * fresh allocator per call scopes slug collisions to the parent directory;
+	 * sub-folders nest directly (no repeated `folders/` segment). Contained
+	 * workflows are delegated to `WorkflowExporter` with the folder's own target
+	 * as `basePrefix`, so they land under `<folderTarget>/workflows/...`.
+	 *
+	 * `reservedName` is the `workflows` container dir already written under
+	 * `parentDir` by the parent folder — reserving it makes a sibling folder that
+	 * slugifies to `workflows` get suffixed instead of swallowing those workflows.
 	 */
-	private writeLevel(
+	private async writeLevel(
 		siblings: Folder[],
 		parentDir: string,
 		effectiveParentId: string | null,
 		childrenByParent: Map<string, Folder[]>,
-		writer: PackageWriter,
-	): ManifestEntry[] {
+		workflowIdsByFolder: Map<string, string[]>,
+		request: FolderExportRequest,
+		reservedName?: string,
+	): Promise<FolderExportResult> {
 		const allocator = new UniqueFilenameAllocator(parentDir, 'folder');
+		if (reservedName) allocator.reserve(reservedName);
 		const entries: ManifestEntry[] = [];
+		const workflowEntries: ManifestEntry[] = [];
+		const credentials: WorkflowCredentialRequirement[] = [];
 
 		for (const folder of this.orderedByCreation(siblings)) {
 			const target = allocator.allocate(folder.name);
 			const serialized = this.folderSerializer.serialize(folder, effectiveParentId);
 
-			writer.writeDirectory(target);
-			writer.writeFile(`${target}/folder.json`, JSON.stringify(serialized, null, '\t'));
+			request.writer.writeDirectory(target);
+			request.writer.writeFile(`${target}/folder.json`, JSON.stringify(serialized, null, '\t'));
+
+			entries.push({ id: folder.id, name: folder.name, target });
+
+			const workflowIds = workflowIdsByFolder.get(folder.id);
+			let hasContainedWorkflows = false;
+			if (workflowIds && workflowIds.length > 0) {
+				hasContainedWorkflows = true;
+				const contained = await this.workflowExporter.export({
+					user: request.user,
+					writer: request.writer,
+					workflowIds,
+					basePrefix: target,
+				});
+				workflowEntries.push(...contained.entries);
+				credentials.push(...contained.requirements.credentials);
+			}
 
 			const children = childrenByParent.get(folder.id) ?? [];
-			entries.push(
-				{ id: folder.id, name: folder.name, target },
-				...this.writeLevel(children, target, folder.id, childrenByParent, writer),
+			const descendants = await this.writeLevel(
+				children,
+				target,
+				folder.id,
+				childrenByParent,
+				workflowIdsByFolder,
+				request,
+				// Reserve the workflows container so a child folder can't collide with it.
+				hasContainedWorkflows ? 'workflows' : undefined,
 			);
+			entries.push(...descendants.entries);
+			workflowEntries.push(...descendants.workflowEntries);
+			credentials.push(...descendants.requirements.credentials);
 		}
 
-		return entries;
+		return { entries, workflowEntries, requirements: { credentials } };
 	}
 
 	/**

--- a/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
@@ -1,22 +1,9 @@
 import type { WorkflowCredentialRequirement } from './credential/credential.types';
 
-/**
- * Everything an exported set of workflows needs shipped alongside them, grouped
- * by type. Deliberately keyed the same way as the manifest's `requirements` and
- * the import `bindings` ({ credentials, dataTables, ... }), so a source resource
- * listed here maps 1:1 to the target it is bound to on import. Add a field per
- * new type (data tables, variables).
- */
 export interface WorkflowExportRequirements {
 	credentials: WorkflowCredentialRequirement[];
 }
 
-/**
- * Merges the requirements from any number of export results. The single place
- * that names each requirement field — a new type adds a field above and one line
- * here; every exporter that aggregates results stays untouched. Tolerates
- * `undefined` parts so callers can pass optional export results directly.
- */
 export const mergeRequirements = (
 	...parts: Array<WorkflowExportRequirements | undefined>
 ): WorkflowExportRequirements => ({

--- a/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/requirements.types.ts
@@ -1,0 +1,24 @@
+import type { WorkflowCredentialRequirement } from './credential/credential.types';
+
+/**
+ * Everything an exported set of workflows needs shipped alongside them, grouped
+ * by type. Deliberately keyed the same way as the manifest's `requirements` and
+ * the import `bindings` ({ credentials, dataTables, ... }), so a source resource
+ * listed here maps 1:1 to the target it is bound to on import. Add a field per
+ * new type (data tables, variables).
+ */
+export interface WorkflowExportRequirements {
+	credentials: WorkflowCredentialRequirement[];
+}
+
+/**
+ * Merges the requirements from any number of export results. The single place
+ * that names each requirement field — a new type adds a field above and one line
+ * here; every exporter that aggregates results stays untouched. Tolerates
+ * `undefined` parts so callers can pass optional export results directly.
+ */
+export const mergeRequirements = (
+	...parts: Array<WorkflowExportRequirements | undefined>
+): WorkflowExportRequirements => ({
+	credentials: parts.flatMap((part) => part?.credentials ?? []),
+});

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow.exporter.test.ts
@@ -123,6 +123,26 @@ describe('WorkflowExporter', () => {
 		});
 	});
 
+	it('nests output under `<basePrefix>/workflows` when a basePrefix is given', async () => {
+		// This is the seam the folder exporter uses to place contained workflows
+		// under their folder's directory.
+		const workflow = makeWorkflow({ id: 'wf-nested', name: 'Triage' });
+		const { exporter } = makeExporter([workflow]);
+		const writer = new CapturingWriter();
+
+		const { entries } = await exporter.export({
+			user,
+			workflowIds: [workflow.id],
+			writer,
+			basePrefix: 'folders/in_progress',
+		});
+
+		expect(entries[0].target).toBe('folders/in_progress/workflows/triage');
+		expect(writer.files.map((f) => f.path)).toContain(
+			'folders/in_progress/workflows/triage/workflow.json',
+		);
+	});
+
 	it('disambiguates targets when two workflows share a name', async () => {
 		const a = makeWorkflow({ id: 'wf-aaaaa', name: 'Same Name' });
 		const b = makeWorkflow({ id: 'wf-bbbbb', name: 'Same Name' });

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
@@ -8,6 +8,7 @@ import { UniqueFilenameAllocator } from '../../io/unique-filename-allocator';
 import type { ManifestEntry } from '../../spec/manifest.schema';
 import { CredentialRequirementsExtractor } from '../credential/credential-requirements.extractor';
 import type { WorkflowCredentialRequirement } from '../credential/credential.types';
+import type { WorkflowExportRequirements } from '../requirements.types';
 
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -21,10 +22,6 @@ export interface WorkflowExportRequest {
 	 * so contained workflows nest under `<folderTarget>/workflows/...`.
 	 */
 	basePrefix?: string;
-}
-
-export interface WorkflowExportRequirements {
-	credentials: WorkflowCredentialRequirement[];
 }
 
 export interface WorkflowExportResult {

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
@@ -16,11 +16,8 @@ export interface WorkflowExportRequest {
 	user: User;
 	workflowIds: string[];
 	writer: PackageWriter;
-	/**
-	 * Directory the workflows are written under. Empty for a plain workflow
-	 * export (`workflows/...`); the folder exporter passes the folder's target
-	 * so contained workflows nest under `<folderTarget>/workflows/...`.
-	 */
+
+	// Directory the workflow is written under. e.g. folders/{folderId}/
 	basePrefix?: string;
 }
 

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow.exporter.ts
@@ -15,6 +15,12 @@ export interface WorkflowExportRequest {
 	user: User;
 	workflowIds: string[];
 	writer: PackageWriter;
+	/**
+	 * Directory the workflows are written under. Empty for a plain workflow
+	 * export (`workflows/...`); the folder exporter passes the folder's target
+	 * so contained workflows nest under `<folderTarget>/workflows/...`.
+	 */
+	basePrefix?: string;
 }
 
 export interface WorkflowExportRequirements {
@@ -46,7 +52,10 @@ export class WorkflowExporter {
 
 		const entries: ManifestEntry[] = [];
 		const credentials: WorkflowCredentialRequirement[] = [];
-		const fileNames = new UniqueFilenameAllocator('workflows', 'workflow');
+		const fileNames = new UniqueFilenameAllocator(
+			request.basePrefix ? `${request.basePrefix}/workflows` : 'workflows',
+			'workflow',
+		);
 
 		for (const workflow of workflows) {
 			const target = fileNames.allocate(workflow.name);

--- a/packages/cli/src/modules/n8n-packages/io/__tests__/unique-filename-allocator.test.ts
+++ b/packages/cli/src/modules/n8n-packages/io/__tests__/unique-filename-allocator.test.ts
@@ -47,8 +47,8 @@ describe('UniqueFilenameAllocator', () => {
 	});
 
 	it('suffixes a name that slugifies to a reserved segment', () => {
-		// A folder reserves its `workflows` container so a sibling folder named
-		// "workflows" can't take the same directory.
+		// the word "workflows" needs to be protected otherwise you could create a workflow
+		// with the name "workflows" and overwrite the "workflows" directory of the folder
 		const allocator = new UniqueFilenameAllocator('folders/in-progress', 'folder');
 		allocator.reserve('workflows');
 

--- a/packages/cli/src/modules/n8n-packages/io/__tests__/unique-filename-allocator.test.ts
+++ b/packages/cli/src/modules/n8n-packages/io/__tests__/unique-filename-allocator.test.ts
@@ -45,4 +45,13 @@ describe('UniqueFilenameAllocator', () => {
 		expect(a.allocate('Same Name')).toBe('workflows/same-name');
 		expect(b.allocate('Same Name')).toBe('workflows/same-name');
 	});
+
+	it('suffixes a name that slugifies to a reserved segment', () => {
+		// A folder reserves its `workflows` container so a sibling folder named
+		// "workflows" can't take the same directory.
+		const allocator = new UniqueFilenameAllocator('folders/in-progress', 'folder');
+		allocator.reserve('workflows');
+
+		expect(allocator.allocate('Workflows')).toBe('folders/in-progress/workflows-2');
+	});
 });

--- a/packages/cli/src/modules/n8n-packages/io/unique-filename-allocator.ts
+++ b/packages/cli/src/modules/n8n-packages/io/unique-filename-allocator.ts
@@ -8,12 +8,6 @@ export class UniqueFilenameAllocator {
 		private readonly fallback: string,
 	) {}
 
-	/**
-	 * Marks an already-slugified `segment` under `baseDir` as taken, so a later
-	 * `allocate()` that slugifies to it gets suffixed instead of colliding. Used to
-	 * reserve a fixed sibling dir (e.g. a folder's `workflows/` container) before
-	 * allocating names that could clash with it.
-	 */
 	reserve(segment: string): void {
 		this.used.add(`${this.baseDir}/${segment}`);
 	}

--- a/packages/cli/src/modules/n8n-packages/io/unique-filename-allocator.ts
+++ b/packages/cli/src/modules/n8n-packages/io/unique-filename-allocator.ts
@@ -8,6 +8,16 @@ export class UniqueFilenameAllocator {
 		private readonly fallback: string,
 	) {}
 
+	/**
+	 * Marks an already-slugified `segment` under `baseDir` as taken, so a later
+	 * `allocate()` that slugifies to it gets suffixed instead of colliding. Used to
+	 * reserve a fixed sibling dir (e.g. a folder's `workflows/` container) before
+	 * allocating names that could clash with it.
+	 */
+	reserve(segment: string): void {
+		this.used.add(`${this.baseDir}/${segment}`);
+	}
+
 	allocate(name: string): string {
 		const base = `${this.baseDir}/${generateSlug(name, this.fallback)}`;
 

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -37,20 +37,28 @@ export class N8nPackagesService {
 		const folderIds = request.folderIds ?? [];
 		const projectIds = request.projectIds ?? [];
 
-		const workflowExportResult =
-			workflowIds.length > 0
-				? await this.workflowExporter.export({
-						user: request.user,
-						workflowIds,
-						writer,
-					})
-				: undefined;
-
+		// Folders are exported before workflows so any workflow a folder already
+		// placed can be dropped from the explicit top-level set below — otherwise it
+		// would be written twice and duplicated in the manifest.
 		const folderExportResult =
 			folderIds.length > 0
 				? await this.folderExporter.export({
 						user: request.user,
 						folderIds,
+						writer,
+					})
+				: undefined;
+
+		const folderWorkflowIds = new Set(
+			folderExportResult?.workflowEntries.map((entry) => entry.id) ?? [],
+		);
+		const topLevelWorkflowIds = workflowIds.filter((id) => !folderWorkflowIds.has(id));
+
+		const workflowExportResult =
+			topLevelWorkflowIds.length > 0
+				? await this.workflowExporter.export({
+						user: request.user,
+						workflowIds: topLevelWorkflowIds,
 						writer,
 					})
 				: undefined;
@@ -66,9 +74,19 @@ export class N8nPackagesService {
 
 		const credentialExportResult = await this.credentialExporter.export({
 			user: request.user,
-			requirements: workflowExportResult?.requirements?.credentials ?? [],
+			requirements: [
+				...(workflowExportResult?.requirements.credentials ?? []),
+				...(folderExportResult?.requirements.credentials ?? []),
+			],
 			writer,
 		});
+
+		// Top-level and folder-contained workflows are disjoint (the subtraction
+		// above guarantees it), so concatenation needs no dedupe.
+		const workflowEntries = [
+			...(workflowExportResult?.entries ?? []),
+			...(folderExportResult?.workflowEntries ?? []),
+		];
 
 		const manifest = packageManifestSchema.parse({
 			packageFormatVersion: FORMAT_VERSION,
@@ -81,7 +99,7 @@ export class N8nPackagesService {
 			...(credentialExportResult.requirements.length > 0
 				? { requirements: { credentials: credentialExportResult.requirements } }
 				: {}),
-			...(workflowExportResult?.entries ? { workflows: workflowExportResult.entries } : {}),
+			...(workflowEntries.length > 0 ? { workflows: workflowEntries } : {}),
 			...(folderExportResult?.entries ? { folders: folderExportResult.entries } : {}),
 			...(projectExportResult?.entries ? { projects: projectExportResult.entries } : {}),
 		});
@@ -103,7 +121,7 @@ export class N8nPackagesService {
 				? { projectIds: projectExportResult.entries.map(({ id }) => id) }
 				: {}),
 			counts: {
-				workflows: workflowExportResult?.entries.length ?? 0,
+				workflows: workflowEntries.length,
 				folders: folderExportResult?.entries.length ?? 0,
 				credentials: credentialExportResult.entries.length,
 			},

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -9,6 +9,7 @@ import { ImportPipeline } from './engine/import-pipeline';
 import { CredentialExporter } from './entities/credential/credential.exporter';
 import { FolderExporter } from './entities/folder/folder.exporter';
 import { ProjectExporter } from './entities/project/project.exporter';
+import { mergeRequirements } from './entities/requirements.types';
 import { WorkflowExporter } from './entities/workflow/workflow.exporter';
 import { TarPackageWriter } from './io/tar/tar-package-writer';
 import type {
@@ -72,12 +73,16 @@ export class N8nPackagesService {
 					})
 				: undefined;
 
+		// Merge every export result's requirements once, grouped by type; each
+		// exporter is then handed its own slice (credentials today).
+		const requirements = mergeRequirements(
+			workflowExportResult?.requirements,
+			folderExportResult?.requirements,
+		);
+
 		const credentialExportResult = await this.credentialExporter.export({
 			user: request.user,
-			requirements: [
-				...(workflowExportResult?.requirements.credentials ?? []),
-				...(folderExportResult?.requirements.credentials ?? []),
-			],
+			requirements: requirements.credentials,
 			writer,
 		});
 

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -18,7 +18,7 @@ import type {
 	ImportResult,
 } from './n8n-packages.types';
 import { FORMAT_VERSION } from './spec/constants';
-import { packageManifestSchema } from './spec/manifest.schema';
+import { type ManifestEntry, packageManifestSchema } from './spec/manifest.schema';
 
 @Service()
 export class N8nPackagesService {
@@ -38,9 +38,6 @@ export class N8nPackagesService {
 		const folderIds = request.folderIds ?? [];
 		const projectIds = request.projectIds ?? [];
 
-		// Folders are exported before workflows so any workflow a folder already
-		// placed can be dropped from the explicit top-level set below — otherwise it
-		// would be written twice and duplicated in the manifest.
 		const folderExportResult =
 			folderIds.length > 0
 				? await this.folderExporter.export({
@@ -50,16 +47,16 @@ export class N8nPackagesService {
 					})
 				: undefined;
 
-		const folderWorkflowIds = new Set(
-			folderExportResult?.workflowEntries.map((entry) => entry.id) ?? [],
+		const workflowsForExport = this.filterWorkflowsAlreadyInFolders(
+			folderExportResult?.workflowEntries,
+			workflowIds,
 		);
-		const topLevelWorkflowIds = workflowIds.filter((id) => !folderWorkflowIds.has(id));
 
 		const workflowExportResult =
-			topLevelWorkflowIds.length > 0
+			workflowsForExport.length > 0
 				? await this.workflowExporter.export({
 						user: request.user,
-						workflowIds: topLevelWorkflowIds,
+						workflowIds: workflowsForExport,
 						writer,
 					})
 				: undefined;
@@ -73,8 +70,6 @@ export class N8nPackagesService {
 					})
 				: undefined;
 
-		// Merge every export result's requirements once, grouped by type; each
-		// exporter is then handed its own slice (credentials today).
 		const requirements = mergeRequirements(
 			workflowExportResult?.requirements,
 			folderExportResult?.requirements,
@@ -86,9 +81,7 @@ export class N8nPackagesService {
 			writer,
 		});
 
-		// Top-level and folder-contained workflows are disjoint (the subtraction
-		// above guarantees it), so concatenation needs no dedupe.
-		const workflowEntries = [
+		const allWorkflowsInPackage = [
 			...(workflowExportResult?.entries ?? []),
 			...(folderExportResult?.workflowEntries ?? []),
 		];
@@ -104,14 +97,13 @@ export class N8nPackagesService {
 			...(credentialExportResult.requirements.length > 0
 				? { requirements: { credentials: credentialExportResult.requirements } }
 				: {}),
-			...(workflowEntries.length > 0 ? { workflows: workflowEntries } : {}),
+			...(allWorkflowsInPackage.length > 0 ? { workflows: allWorkflowsInPackage } : {}),
 			...(folderExportResult?.entries ? { folders: folderExportResult.entries } : {}),
 			...(projectExportResult?.entries ? { projects: projectExportResult.entries } : {}),
 		});
 
 		writer.writeFile('manifest.json', JSON.stringify(manifest, null, '\t'));
 
-		// Finalize before emitting so a failed finalization doesn't report a phantom export.
 		const stream = writer.finalize();
 
 		this.eventService.emit('n8n-package-exported', {
@@ -126,7 +118,7 @@ export class N8nPackagesService {
 				? { projectIds: projectExportResult.entries.map(({ id }) => id) }
 				: {}),
 			counts: {
-				workflows: workflowEntries.length,
+				workflows: allWorkflowsInPackage.length,
 				folders: folderExportResult?.entries.length ?? 0,
 				credentials: credentialExportResult.entries.length,
 			},
@@ -137,5 +129,10 @@ export class N8nPackagesService {
 
 	async importPackage(request: ImportPackageRequest): Promise<ImportResult> {
 		return await this.importPipeline.run(request);
+	}
+
+	filterWorkflowsAlreadyInFolders(workflowsInFolders: ManifestEntry[] = [], workflowIds: string[]) {
+		const folderWorkflowIds = new Set(workflowsInFolders.map((entry) => entry.id) ?? []);
+		return workflowIds.filter((id) => !folderWorkflowIds.has(id));
 	}
 }

--- a/packages/cli/src/workflows/__tests__/workflow-finder.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-finder.service.test.ts
@@ -1,0 +1,71 @@
+import type { FolderRepository, SharedWorkflow, SharedWorkflowRepository } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { RoleService } from '@/services/role.service';
+
+import { WorkflowFinderService } from '../workflow-finder.service';
+
+/** Minimal projection of the row shape `findWorkflowIdsByFolder` selects. */
+type FolderRow = { workflow: { id: string; parentFolder: { id: string } | null } };
+
+function makeService(rows?: FolderRow[]) {
+	const sharedWorkflowRepository = mock<SharedWorkflowRepository>();
+	if (rows) {
+		sharedWorkflowRepository.find.mockResolvedValue(rows as unknown as SharedWorkflow[]);
+	}
+	const service = new WorkflowFinderService(
+		sharedWorkflowRepository,
+		mock<FolderRepository>(),
+		mock<RoleService>(),
+	);
+	return { service, sharedWorkflowRepository };
+}
+
+describe('WorkflowFinderService', () => {
+	describe('findWorkflowIdsByFolder', () => {
+		it('returns an empty map without querying when no folder ids are given', async () => {
+			const { service, sharedWorkflowRepository } = makeService();
+
+			const result = await service.findWorkflowIdsByFolder([]);
+
+			expect(result.size).toBe(0);
+			expect(sharedWorkflowRepository.find).not.toHaveBeenCalled();
+		});
+
+		it('groups workflow ids by their parent folder', async () => {
+			const { service } = makeService([
+				{ workflow: { id: 'w1', parentFolder: { id: 'f1' } } },
+				{ workflow: { id: 'w2', parentFolder: { id: 'f1' } } },
+				{ workflow: { id: 'w3', parentFolder: { id: 'f2' } } },
+			]);
+
+			const result = await service.findWorkflowIdsByFolder(['f1', 'f2']);
+
+			expect(result.get('f1')).toEqual(['w1', 'w2']);
+			expect(result.get('f2')).toEqual(['w3']);
+		});
+
+		it('dedupes a workflow that surfaces via several share rows', async () => {
+			const { service } = makeService([
+				{ workflow: { id: 'w1', parentFolder: { id: 'f1' } } },
+				{ workflow: { id: 'w1', parentFolder: { id: 'f1' } } },
+			]);
+
+			const result = await service.findWorkflowIdsByFolder(['f1']);
+
+			expect(result.get('f1')).toEqual(['w1']);
+		});
+
+		it('skips rows whose workflow has no parent folder', async () => {
+			const { service } = makeService([
+				{ workflow: { id: 'w1', parentFolder: null } },
+				{ workflow: { id: 'w2', parentFolder: { id: 'f1' } } },
+			]);
+
+			const result = await service.findWorkflowIdsByFolder(['f1']);
+
+			expect([...result.keys()]).toEqual(['f1']);
+			expect(result.get('f1')).toEqual(['w2']);
+		});
+	});
+});

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -178,10 +178,6 @@ export class WorkflowFinderService {
 		return workflows;
 	}
 
-	/**
-	 * Workflow ids grouped by their parent folder, for the given folders. No access
-	 * filter — export access is gated per folder by WorkflowExporter (workflow:export).
-	 */
 	async findWorkflowIdsByFolder(folderIds: string[]): Promise<Map<string, string[]>> {
 		if (folderIds.length === 0) return new Map();
 

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -179,6 +179,34 @@ export class WorkflowFinderService {
 	}
 
 	/**
+	 * Workflow ids grouped by their parent folder, for the given folders. No access
+	 * filter — export access is gated per folder by WorkflowExporter (workflow:export).
+	 */
+	async findWorkflowIdsByFolder(folderIds: string[]): Promise<Map<string, string[]>> {
+		if (folderIds.length === 0) return new Map();
+
+		const rows = await this.sharedWorkflowRepository.find({
+			where: { workflow: { parentFolder: In(folderIds) } },
+			relations: { workflow: { parentFolder: true } },
+			select: { workflowId: true, workflow: { id: true, parentFolder: { id: true } } },
+		});
+
+		const byFolder = new Map<string, string[]>();
+		const seen = new Set<string>();
+		for (const { workflow } of rows) {
+			const folderId = workflow.parentFolder?.id;
+			// A workflow may appear via several share rows; dedupe so it lands once.
+			if (!folderId || seen.has(workflow.id)) continue;
+			seen.add(workflow.id);
+			const list = byFolder.get(folderId) ?? [];
+			list.push(workflow.id);
+			byFolder.set(folderId, list);
+		}
+
+		return byFolder;
+	}
+
+	/**
 	 * Finds owned workflows in a project that may match package workflows either
 	 * by `sourceWorkflowId` or, when unset, by local id (re-import of workflows
 	 * authored on this instance).


### PR DESCRIPTION
## Summary

Video:
https://www.loom.com/share/a0a68cb1dd704f74b8487dfcefc04da8

Exporting folders via `--folder-id` now also exports the **workflows contained in each folder** (and its nested folders), not just the empty folder shells that LIGO-683 introduced.

- Each `workflow.json` is written under a `workflows/` child of the folder it belongs to (nested folders nest too).
- Contained workflows' **credentials gather at the package top level** (`credentials/` + `manifest.requirements`), exactly as plain workflow export does.
- A workflow listed in **both** `workflowIds` and an exported folder is placed **in the folder only** (dropped from the top-level set) — no double write, no duplicate manifest id.
- If an accessible folder contains a workflow the caller cannot `workflow:export`, the **whole export aborts** (reuses `WorkflowExporter`'s existing access assertion).

Package layout:

```
folders/
  in_progress/
    folder.json
    workflows/
      triage/workflow.json
    nested/
      folder.json
      workflows/
        playground/workflow.json
credentials/
  linear-api/credential.json
manifest.json
```

### Implementation notes

- `WorkflowExporter`: new optional `basePrefix` so contained workflows nest under `<folderTarget>/workflows/…` (plain workflow export unchanged).
- `WorkflowFinderService.findWorkflowIdsByFolder`: membership grouped by parent folder (no access filter — export access is gated per folder by `WorkflowExporter`).
- `FolderExporter`: delegates contained workflows to `WorkflowExporter` per folder and aggregates their entries + credential requirements. It reserves the `workflows` container slug so a subfolder literally named "workflows" is suffixed rather than colliding with the container.
- `N8nPackagesService.exportPackage`: exports folders before workflows, subtracts folder-covered ids from the explicit top-level set, and merges credential requirements.
- No manifest-schema, DTO, OpenAPI, or CLI changes — `folderId` already flows through all layers from LIGO-683; contained-workflow export is purely internal behaviour.

## How to test

The `n8n-packages` module is enabled by default (no special env vars or license needed).

Given a running instance whose DB has a folder containing workflows (ideally one that references a credential, and a nested subfolder with its own workflow), export the folder via the CLI:

```bash
n8n package export --folder-id=<FOLDER_ID> --output=folder.n8np
tar -tf folder.n8np
```

Expect:
- contained workflows at `folders/<slug>/workflows/<wf-slug>/workflow.json` (nested folders nest under `<parent>/<child>/workflows/…`);
- referenced credentials at top-level `credentials/…`;
- `manifest.json` listing them under `workflows`, `credentials`, and `requirements` (with `usedByWorkflows`).

Automated coverage (all green locally):

```bash
cd packages/cli
pnpm test src/modules/n8n-packages src/workflows/__tests__/workflow-finder.service.test.ts
pnpm test:integration src/modules/n8n-packages
```

Integration tests cover: a workflow in a requested folder, nested-folder nesting, credentials gathered at the top level, abort when a contained workflow is not exportable by the caller, the folder-vs-top-level overlap edge (single placement, no orphan), the empty-folder regression, telemetry `counts.workflows`, and the `workflows`-named-subfolder collision.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-684
- Unblocks https://linear.app/n8n/issue/LIGO-685 (export a project with folders/workflows)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33482">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->