### PR TITLE
feat(core): Enable filtering crashed executions via public API

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -109,9 +109,12 @@ describe('ExecutionRepository', () => {
 			test.each`
 				filterStatus  | entityStatus
 				${'canceled'} | ${'canceled'}
-				${'error'}    | ${In(['error', 'crashed'])}
+				${'crashed'}  | ${'crashed'}
+				${'error'}    | ${'error'}
+				${'new'}      | ${'new'}
 				${'running'}  | ${'running'}
 				${'success'}  | ${'success'}
+				${'unknown'}  | ${'unknown'}
 				${'waiting'}  | ${'waiting'}
 			`('should retrieve all $filterStatus executions', async ({ filterStatus, entityStatus }) => {
 				const limit = 10;
@@ -131,31 +134,20 @@ describe('ExecutionRepository', () => {
 				expect(result).toBe(mockCount);
 			});
 
-			test.each`
-				filterStatus
-				${'crashed'}
-				${'new'}
-				${'unknown'}
-			`(
-				'should find all executions and ignore status filter "$filterStatus"',
-				async ({ filterStatus }) => {
-					const limit = 10;
-					const mockCount = 20;
+			test('should find all executions without status filter', async () => {
+				const limit = 10;
+				const mockCount = 20;
 
-					entityManager.count.mockResolvedValueOnce(mockCount);
-					const result = await executionRepository.getExecutionsCountForPublicApi({
-						limit,
-						status: filterStatus,
-					});
+				entityManager.count.mockResolvedValueOnce(mockCount);
+				const result = await executionRepository.getExecutionsCountForPublicApi({ limit });
 
-					expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
-						where: {},
-						take: limit,
-					});
+				expect(entityManager.count).toHaveBeenCalledWith(ExecutionEntity, {
+					where: {},
+					take: limit,
+				});
 
-					expect(result).toBe(mockCount);
-				},
-			);
+				expect(result).toBe(mockCount);
+			});
 		});
 	});
 

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -650,16 +650,8 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 	private getStatusCondition(status?: ExecutionStatus) {
 		const condition: Pick<FindOptionsWhere<IExecutionFlattedDb>, 'status'> = {};
 
-		if (status === 'success') {
-			condition.status = 'success';
-		} else if (status === 'waiting') {
-			condition.status = 'waiting';
-		} else if (status === 'error') {
-			condition.status = In(['error', 'crashed']);
-		} else if (status === 'canceled') {
-			condition.status = 'canceled';
-		} else if (status === 'running') {
-			condition.status = 'running';
+		if (status) {
+			condition.status = status;
 		}
 
 		return condition;

--- a/packages/cli/test/integration/public-api/executions.test.ts
+++ b/packages/cli/test/integration/public-api/executions.test.ts
@@ -491,14 +491,24 @@ describe('GET /executions', () => {
 	});
 
 	describe('with query status', () => {
-		type AllowedQueryStatus = 'canceled' | 'error' | 'running' | 'success' | 'waiting';
+		type AllowedQueryStatus =
+			| 'canceled'
+			| 'crashed'
+			| 'error'
+			| 'new'
+			| 'running'
+			| 'success'
+			| 'unknown'
+			| 'waiting';
 		test.each`
 			queryStatus   | entityStatus
 			${'canceled'} | ${'canceled'}
+			${'crashed'}  | ${'crashed'}
 			${'error'}    | ${'error'}
-			${'error'}    | ${'crashed'}
+			${'new'}      | ${'new'}
 			${'running'}  | ${'running'}
 			${'success'}  | ${'success'}
+			${'unknown'}  | ${'unknown'}
 			${'waiting'}  | ${'waiting'}
 		`(
 			'should retrieve all $queryStatus executions',


### PR DESCRIPTION
## Summary

Until now executions with status `crashed` were mapped to status `error`. This PR changes the service to return executions with their actual status (when requested via public API).

The changed helper now does exact status matching in execution.repository.ts, and its only public listing/counting path is `GET /executions`, where the status is passed through to both list and count filters in executions.handler.ts. Internal execution listing uses the range-query path, which already accepts status arrays and filters with SQL IN. The editor also still maps its UI “error” filter to ['crashed', 'error'], so internal executions UI behavior is preserved.

## How to test

1. Generate an execution that will crash (e.g. sub-workflow calling itself)
2. Retrieve executions with status `crashed` via public API

```
curl -i -s -H "X-N8N-API-KEY: ${KEY}" \
  "http://localhost:5678/api/v1/executions?status=crashed&limit=20" | jq '.data[] | {id,status}'
```

## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-702](https://linear.app/n8n/issue/LIGO-702/community-issue-get-apiv1executionsstatuscrashed-returns-records-whose)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->