### PR TITLE
fix(editor): Track Instance AI prompt suggestion exposure (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/instanceAiPersonalizedPromptSuggestions/spec/instance-ai-personalized-prompt-suggestions.md
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiPersonalizedPromptSuggestions/spec/instance-ai-personalized-prompt-suggestions.md
@@ -241,10 +241,19 @@ Treatment behavior:
 
 Reuse existing event names:
 
+- `Instance AI personalized prompt suggestions exposed`
 - `Instance AI prompt suggestions shown`
 - `Instance AI prompt suggestion selected`
 - `Instance AI prompt suggestion submitted`
 - `Instance AI prompt suggestions cycled` for each `See more` toggle in either direction.
+
+Use `Instance AI personalized prompt suggestions exposed` as the custom PostHog exposure
+event. Fire it when the user reaches the normal Instance AI empty-state surface and has
+an assigned `control`, `variant-cards`, or `variant-list` variant. Do not fire it while
+the proactive starter (082) or split empty state (089) owns the surface, or while the
+workflow builder is unavailable; in that state the chat input is disabled, so the user
+cannot send a prompt. Include `$feature/093_instance_ai_personalized_prompt_suggestions`
+and `variant` on every exposure event, including `control`.
 
 When this experiment is active, add these properties to the relevant existing events:
 
@@ -267,7 +276,11 @@ For `Instance AI prompt suggestions cycled`, include `visible_suggestion_ids`, `
 
 Primary metric:
 
-- Percentage of new users exposed to Instance AI who send a prompt on the same day.
+- Percentage of new users exposed to Instance AI who send a prompt. Baseline: 40%.
+
+Leading metric:
+
+- Percentage of prompt senders who result in a workflow being built. Baseline: not set.
 
 Secondary/diagnostic metrics:
 
@@ -275,7 +288,6 @@ Secondary/diagnostic metrics:
 - Prompt suggestion selected rate.
 - Prompt suggestion submitted rate.
 - `See more` toggle rate.
-- Percentage of prompt senders who result in a workflow being built.
 - Matrix/default coverage: share of treatment users with recognized role/use-case metadata.
 - Source performance split by `suggestion_source`.
 - Cards vs list performance split by `suggestion_format`.

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -9,6 +9,7 @@ import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { useChatInputAutoFocus } from '@n8n/design-system';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useToast } from '@/app/composables/useToast';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { getExperimentTelemetryPayload } from '@/experiments/utils';
 import { INSTANCE_AI_PERSONALIZED_PROMPT_SUGGESTIONS_EXPERIMENT } from '@/app/constants/experiments';
@@ -79,6 +80,8 @@ const INSTANCE_AI_PERSONALIZED_PROMPT_SUGGESTIONS_PLACEHOLDER_KEY: BaseTextKey =
 // the placeholder text — the examples list below it never shifts.
 const INSTANCE_AI_SPLIT_FIXED_ROWS = 5;
 const PERSONALIZED_PROMPT_METADATA_TIMEOUT_MS = 2000;
+const INSTANCE_AI_PERSONALIZED_PROMPT_SUGGESTIONS_EXPOSURE_EVENT =
+	'Instance AI personalized prompt suggestions exposed';
 
 const store = useInstanceAiStore();
 const appSettingsStore = useSettingsStore();
@@ -90,6 +93,7 @@ const { isLowCredits } = storeToRefs(store);
 const rootStore = useRootStore();
 const router = useRouter();
 const toast = useToast();
+const telemetry = useTelemetry();
 const i18n = useI18n();
 const { goToUpgrade } = usePageRedirectionHelper();
 const creditBanner = useCreditWarningBanner(isLowCredits);
@@ -102,12 +106,6 @@ const { isFeatureEnabled: isWorkflowPreviewSuggestionsExperimentEnabled } =
 const { isVariantEnabled: isSplitVariantEnabled } = useInstanceAiSplitEmptyStateExperiment();
 // Experiment cleanup: remove with instanceAiSplitEmptyState.
 const splitPreviewPromptKey = ref<BaseTextKey | null>(null);
-// Experiment cleanup: remove with instanceAiSplitEmptyState. The split layout
-// hosts the view header inside its chat column; the proactive starter (082)
-// keeps precedence.
-const isSplitLayoutActive = computed(
-	() => isSplitVariantEnabled.value && !showProactiveStarter.value,
-);
 const splitWriting = ref(false);
 const {
 	currentVariant: personalizedPromptSuggestionsVariant,
@@ -115,6 +113,19 @@ const {
 	suggestionFormat: personalizedPromptSuggestionsFormat,
 } = useInstanceAiPersonalizedPromptSuggestionsExperiment();
 const showProactiveStarter = computed(() => isProactiveAgentExperimentEnabled.value);
+// Experiment cleanup: remove with instanceAiSplitEmptyState. The split layout
+// hosts the view header inside its chat column; the proactive starter (082)
+// keeps precedence.
+const isSplitLayoutActive = computed(
+	() => isSplitVariantEnabled.value && !showProactiveStarter.value,
+);
+const shouldTrackPersonalizedPromptSuggestionsExposure = computed(
+	() =>
+		typeof personalizedPromptSuggestionsVariant.value === 'string' &&
+		!showProactiveStarter.value &&
+		!isSplitLayoutActive.value &&
+		settingsStore.isWorkflowBuilderAvailable,
+);
 const activeWorkflowPreviewFile = ref<string | null>(null);
 const activeWorkflowPreview = computed(() => {
 	if (!activeWorkflowPreviewFile.value) return null;
@@ -125,6 +136,7 @@ const personalizedPromptSuggestionResolution = ref<PersonalizedPromptSuggestionR
 );
 const personalizedPromptProfileOverride = usePersonalizedPromptProfileOverride();
 let personalizedPromptMetadataTimeout: ReturnType<typeof setTimeout> | null = null;
+let hasTrackedPersonalizedPromptSuggestionsExposure = false;
 
 const personalizedPromptFallbackSuggestions = computed(() =>
 	getTopUsedV2FallbackSuggestions((key) => i18n.baseText(key)),
@@ -194,6 +206,30 @@ watch(
 		() => appSettingsStore.isCloudDeployment,
 	],
 	resolvePersonalizedPromptMetadata,
+	{ immediate: true },
+);
+
+watch(
+	shouldTrackPersonalizedPromptSuggestionsExposure,
+	(shouldTrackExposure) => {
+		const variant = personalizedPromptSuggestionsVariant.value;
+		if (
+			!shouldTrackExposure ||
+			hasTrackedPersonalizedPromptSuggestionsExposure ||
+			typeof variant !== 'string'
+		) {
+			return;
+		}
+
+		telemetry.track(
+			INSTANCE_AI_PERSONALIZED_PROMPT_SUGGESTIONS_EXPOSURE_EVENT,
+			getExperimentTelemetryPayload(
+				INSTANCE_AI_PERSONALIZED_PROMPT_SUGGESTIONS_EXPERIMENT,
+				variant,
+			),
+		);
+		hasTrackedPersonalizedPromptSuggestionsExposure = true;
+	},
 	{ immediate: true },
 );
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts
@@ -29,6 +29,7 @@ const {
 	appSettingsStoreMock,
 	replaceMock,
 	showErrorMock,
+	telemetryTrack,
 } = vi.hoisted(() => ({
 	experimentMocks: {
 		proactiveAgentEnabled: { value: false },
@@ -93,6 +94,7 @@ const {
 	personalizedPromptSuggestionsComponent: { name: 'InstanceAiPersonalizedPromptSuggestionsStub' },
 	replaceMock: vi.fn(),
 	showErrorMock: vi.fn(),
+	telemetryTrack: vi.fn(),
 }));
 
 vi.mock('@/experiments/instanceAiProactiveAgent', () => ({
@@ -226,6 +228,10 @@ vi.mock('@/app/composables/usePageRedirectionHelper', () => ({
 
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({ showError: showErrorMock }),
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: telemetryTrack }),
 }));
 
 vi.mock('@/app/stores/cloudPlan.store', () => ({
@@ -396,6 +402,7 @@ describe('InstanceAiEmptyView', () => {
 		experimentMocks.personalizedPromptTreatmentEnabled.value = false;
 		experimentMocks.personalizedPromptProfileOverride.value = null;
 		experimentMocks.resolvePersonalizedPromptSuggestions.mockClear();
+		telemetryTrack.mockClear();
 		cloudPlanStoreMock.state.initialized = false;
 		cloudPlanStoreMock.currentUserCloudInfo = null;
 		appSettingsStoreMock.isCloudDeployment = false;
@@ -652,6 +659,83 @@ describe('InstanceAiEmptyView', () => {
 
 		expect(getByTestId('instance-ai-empty-state')).toBeInTheDocument();
 		expect(queryByTestId('instance-ai-split-empty-state')).not.toBeInTheDocument();
+	});
+
+	it('tracks personalized prompt suggestions exposure for the control variant', () => {
+		experimentMocks.personalizedPromptVariant.value = 'control';
+
+		renderView();
+
+		const exposureCalls = telemetryTrack.mock.calls.filter(
+			([event]) => event === 'Instance AI personalized prompt suggestions exposed',
+		);
+
+		expect(exposureCalls).toHaveLength(1);
+		expect(exposureCalls[0]).toEqual([
+			'Instance AI personalized prompt suggestions exposed',
+			{
+				variant: 'control',
+				'$feature/093_instance_ai_personalized_prompt_suggestions': 'control',
+			},
+		]);
+	});
+
+	it('tracks personalized prompt suggestions exposure for treatment variants', () => {
+		experimentMocks.personalizedPromptVariant.value = 'variant-cards';
+		experimentMocks.personalizedPromptFormat.value = 'cards';
+		experimentMocks.personalizedPromptTreatmentEnabled.value = true;
+
+		renderView();
+
+		expect(telemetryTrack).toHaveBeenCalledWith(
+			'Instance AI personalized prompt suggestions exposed',
+			{
+				variant: 'variant-cards',
+				'$feature/093_instance_ai_personalized_prompt_suggestions': 'variant-cards',
+			},
+		);
+	});
+
+	it('does not track personalized prompt suggestions exposure when split empty state is active', () => {
+		experimentMocks.personalizedPromptVariant.value = 'control';
+		experimentMocks.splitBelowInputVariant.value = true;
+
+		renderView();
+
+		expect(telemetryTrack).not.toHaveBeenCalledWith(
+			'Instance AI personalized prompt suggestions exposed',
+			expect.anything(),
+		);
+	});
+
+	it('does not track personalized prompt suggestions exposure when the proactive starter is active', () => {
+		experimentMocks.personalizedPromptVariant.value = 'control';
+		experimentMocks.proactiveAgentEnabled.value = true;
+
+		renderView();
+
+		expect(telemetryTrack).not.toHaveBeenCalledWith(
+			'Instance AI personalized prompt suggestions exposed',
+			expect.anything(),
+		);
+	});
+
+	it('does not track personalized prompt suggestions exposure when workflow builder is unavailable', () => {
+		experimentMocks.personalizedPromptVariant.value = 'control';
+		useSettingsStore().moduleSettings = {
+			'instance-ai': {
+				...defaultModuleSettings,
+				sandboxEnabled: false,
+				workflowBuilderAvailable: false,
+			},
+		};
+
+		renderView();
+
+		expect(telemetryTrack).not.toHaveBeenCalledWith(
+			'Instance AI personalized prompt suggestions exposed',
+			expect.anything(),
+		);
 	});
 
 	it('renders the proactive starter and hides the split layout when both 082 and 089 are enabled', () => {


### PR DESCRIPTION
## Summary

- Adds a dedicated exposure event for the Instance AI personalized prompt suggestions experiment.
- Sends the assigned variant and `$feature/093_instance_ai_personalized_prompt_suggestions` payload for PostHog experiment analysis.
- Limits exposure to the normal Instance AI empty-state surface, excluding proactive starter, split empty state, and workflow-builder-unavailable states.
- Documents the exposure contract in the experiment spec and adds regression tests for the tracked and excluded cases.

## How to test

- `pnpm test src/features/ai/instanceAi/__tests__/InstanceAiEmptyView.test.ts`
- `pnpm lint`

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33487">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->