### PR TITLE
feat: Configure Instance AI providers via environment variables only (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-settings.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-settings.service.test.ts
@@ -70,8 +70,8 @@ describe('InstanceAiSettingsService', () => {
 	});
 
 	describe('updateAdminSettings', () => {
-		it('should reject with 422 when proxy is enabled and request contains proxy-managed admin fields', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
+		it('should reject with 422 when the request contains env-managed admin fields', async () => {
+			aiService.isProxyEnabled.mockReturnValue(false);
 
 			await expect(
 				service.updateAdminSettings({
@@ -81,7 +81,7 @@ describe('InstanceAiSettingsService', () => {
 		});
 
 		it('should include offending field names in the error message', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
+			aiService.isProxyEnabled.mockReturnValue(false);
 
 			await expect(
 				service.updateAdminSettings({
@@ -91,27 +91,39 @@ describe('InstanceAiSettingsService', () => {
 			).rejects.toThrow(/sandboxEnabled.*daytonaCredentialId|daytonaCredentialId.*sandboxEnabled/);
 		});
 
-		it('should allow non-proxy-managed fields when proxy is enabled', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
-			settingsRepository.upsert.mockResolvedValue(undefined as never);
-
-			await expect(service.updateAdminSettings({ subAgentMaxSteps: 50 })).resolves.toBeDefined();
-		});
-
-		it('should allow proxy-managed fields when proxy is disabled', async () => {
+		it('should reject sandbox, search and advanced fields on self-hosted', async () => {
 			aiService.isProxyEnabled.mockReturnValue(false);
-			settingsRepository.upsert.mockResolvedValue(undefined as never);
-
-			await expect(service.updateAdminSettings({ sandboxEnabled: true })).resolves.toBeDefined();
-		});
-
-		it('should require a service URL when enabling n8n sandbox', async () => {
-			aiService.isProxyEnabled.mockReturnValue(false);
-			globalConfig.instanceAi.n8nSandboxServiceUrl = '';
 
 			await expect(service.updateAdminSettings({ sandboxEnabled: true })).rejects.toThrow(
-				/N8N_SANDBOX_SERVICE_URL/,
+				UnprocessableRequestError,
 			);
+			await expect(service.updateAdminSettings({ searchCredentialId: 'cred-1' })).rejects.toThrow(
+				UnprocessableRequestError,
+			);
+			await expect(service.updateAdminSettings({ subAgentMaxSteps: 50 })).rejects.toThrow(
+				UnprocessableRequestError,
+			);
+			await expect(service.updateAdminSettings({ mcpServers: '[]' })).rejects.toThrow(
+				UnprocessableRequestError,
+			);
+		});
+
+		it('should reject env-managed fields even when proxy is enabled', async () => {
+			aiService.isProxyEnabled.mockReturnValue(true);
+
+			await expect(service.updateAdminSettings({ subAgentMaxSteps: 50 })).rejects.toThrow(
+				UnprocessableRequestError,
+			);
+		});
+
+		it('should allow the enable toggle and permissions', async () => {
+			aiService.isProxyEnabled.mockReturnValue(false);
+			settingsRepository.upsert.mockResolvedValue(undefined as never);
+
+			await expect(service.updateAdminSettings({ enabled: true })).resolves.toBeDefined();
+			await expect(
+				service.updateAdminSettings({ permissions: { createWorkflow: 'always_allow' } }),
+			).resolves.toBeDefined();
 		});
 
 		it('should allow unrelated admin updates when existing n8n sandbox URL is missing', async () => {
@@ -126,29 +138,6 @@ describe('InstanceAiSettingsService', () => {
 			).resolves.toMatchObject({
 				localGatewayDisabled: true,
 			});
-		});
-
-		it('should allow disabling n8n sandbox when the service URL is missing', async () => {
-			aiService.isProxyEnabled.mockReturnValue(false);
-			settingsRepository.upsert.mockResolvedValue(undefined as never);
-			globalConfig.instanceAi.sandboxEnabled = true;
-			globalConfig.instanceAi.sandboxProvider = 'n8n-sandbox';
-			globalConfig.instanceAi.n8nSandboxServiceUrl = '';
-
-			await expect(service.updateAdminSettings({ sandboxEnabled: false })).resolves.toMatchObject({
-				sandboxEnabled: false,
-			});
-		});
-
-		it('should reject switching an enabled sandbox to n8n-sandbox without a service URL', async () => {
-			aiService.isProxyEnabled.mockReturnValue(false);
-			globalConfig.instanceAi.sandboxEnabled = true;
-			globalConfig.instanceAi.sandboxProvider = 'daytona';
-			globalConfig.instanceAi.n8nSandboxServiceUrl = '';
-
-			await expect(service.updateAdminSettings({ sandboxProvider: 'n8n-sandbox' })).rejects.toThrow(
-				/N8N_SANDBOX_SERVICE_URL/,
-			);
 		});
 
 		it('should expose workflow builder as unavailable when n8n sandbox URL is missing', () => {
@@ -242,11 +231,10 @@ describe('InstanceAiSettingsService', () => {
 		beforeEach(() => {
 			aiService.isProxyEnabled.mockReturnValue(false);
 			settingsRepository.upsert.mockResolvedValue(undefined as never);
-			globalConfig.instanceAi.mcpServers = '';
 		});
 
 		it('emits on every successful update', async () => {
-			await service.updateAdminSettings({ subAgentMaxSteps: 50 });
+			await service.updateAdminSettings({ mcpAccessEnabled: false });
 
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'instance-ai-settings-updated',
@@ -254,16 +242,8 @@ describe('InstanceAiSettingsService', () => {
 			);
 		});
 
-		it('flags mcpSettingsChanged when mcpServers changes', async () => {
-			await service.updateAdminSettings({ mcpServers: '[{"name":"a","url":"https://a/"}]' });
-
-			expect(eventService.emit).toHaveBeenCalledWith('instance-ai-settings-updated', {
-				mcpSettingsChanged: true,
-			});
-		});
-
 		it('does not flag mcpSettingsChanged for unrelated field changes', async () => {
-			await service.updateAdminSettings({ subAgentMaxSteps: 50 });
+			await service.updateAdminSettings({ permissions: { createWorkflow: 'always_allow' } });
 
 			expect(eventService.emit).toHaveBeenCalledWith('instance-ai-settings-updated', {
 				mcpSettingsChanged: false,
@@ -285,31 +265,24 @@ describe('InstanceAiSettingsService', () => {
 				mcpSettingsChanged: false,
 			});
 		});
-
-		it('does not flag mcpSettingsChanged when mcpServers is set to the same value', async () => {
-			globalConfig.instanceAi.mcpServers = '[{"name":"a","url":"https://a/"}]';
-
-			await service.updateAdminSettings({ mcpServers: '[{"name":"a","url":"https://a/"}]' });
-
-			expect(eventService.emit).toHaveBeenCalledWith('instance-ai-settings-updated', {
-				mcpSettingsChanged: false,
-			});
-		});
 	});
 
 	describe('updateUserPreferences', () => {
 		const user = mock<User>({ id: 'user-1' });
 
-		it('should reject with 422 when proxy is enabled and request contains proxy-managed preference fields', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
+		it('should reject env-managed preference fields on self-hosted', async () => {
+			aiService.isProxyEnabled.mockReturnValue(false);
 
 			await expect(service.updateUserPreferences(user, { credentialId: 'cred-1' })).rejects.toThrow(
+				UnprocessableRequestError,
+			);
+			await expect(service.updateUserPreferences(user, { modelName: 'gpt-4' })).rejects.toThrow(
 				UnprocessableRequestError,
 			);
 		});
 
 		it('should include offending field names in the error message', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
+			aiService.isProxyEnabled.mockReturnValue(false);
 
 			await expect(
 				service.updateUserPreferences(user, {
@@ -319,8 +292,8 @@ describe('InstanceAiSettingsService', () => {
 			).rejects.toThrow(/credentialId.*modelName|modelName.*credentialId/);
 		});
 
-		it('should allow non-proxy-managed fields when proxy is enabled', async () => {
-			aiService.isProxyEnabled.mockReturnValue(true);
+		it('should allow localGatewayDisabled', async () => {
+			aiService.isProxyEnabled.mockReturnValue(false);
 
 			await expect(
 				service.updateUserPreferences(user, { localGatewayDisabled: true }),
@@ -331,17 +304,17 @@ describe('InstanceAiSettingsService', () => {
 			});
 		});
 
-		it('should merge new fields with existing instanceAi settings on update', async () => {
+		it('should merge new preference fields with existing instanceAi settings on update', async () => {
 			aiService.isProxyEnabled.mockReturnValue(false);
 			const existingUser = mock<User>({
 				id: 'user-2',
 				settings: { instanceAi: { credentialId: 'cred-old', modelName: 'gpt-3.5' } },
 			});
 
-			await service.updateUserPreferences(existingUser, { modelName: 'gpt-4' });
+			await service.updateUserPreferences(existingUser, { localGatewayDisabled: true });
 
 			expect(userService.updateSettings).toHaveBeenCalledWith('user-2', {
-				instanceAi: { credentialId: 'cred-old', modelName: 'gpt-4' },
+				instanceAi: { credentialId: 'cred-old', modelName: 'gpt-3.5', localGatewayDisabled: true },
 			});
 		});
 	});

--- a/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-settings.service.ts
@@ -198,19 +198,11 @@ export class InstanceAiSettingsService {
 	async updateAdminSettings(
 		update: InstanceAiAdminSettingsUpdateRequest,
 	): Promise<InstanceAiAdminSettingsResponse> {
-		if (this.isCloud) {
-			this.rejectManagedFields(
-				update,
-				InstanceAiSettingsService.CLOUD_MANAGED_ADMIN_FIELDS,
-				'cloud',
-			);
-		} else if (this.aiService.isProxyEnabled()) {
-			this.rejectManagedFields(
-				update,
-				InstanceAiSettingsService.PROXY_MANAGED_ADMIN_FIELDS,
-				'proxy',
-			);
-		}
+		this.rejectManagedFields(
+			update,
+			InstanceAiSettingsService.MANAGED_ADMIN_FIELDS,
+			this.deploymentLabel(),
+		);
 		this.validateAdminSettingsUpdate(update);
 		const c = this.config;
 		const previousMcpServers = c.mcpServers;
@@ -277,19 +269,11 @@ export class InstanceAiSettingsService {
 		user: User,
 		update: InstanceAiUserPreferencesUpdateRequest,
 	): Promise<InstanceAiUserPreferencesResponse> {
-		if (this.isCloud) {
-			this.rejectManagedFields(
-				update,
-				InstanceAiSettingsService.CLOUD_MANAGED_PREFERENCE_FIELDS,
-				'cloud',
-			);
-		} else if (this.aiService.isProxyEnabled()) {
-			this.rejectManagedFields(
-				update,
-				InstanceAiSettingsService.PROXY_MANAGED_PREFERENCE_FIELDS,
-				'proxy',
-			);
-		}
+		this.rejectManagedFields(
+			update,
+			InstanceAiSettingsService.MANAGED_PREFERENCE_FIELDS,
+			this.deploymentLabel(),
+		);
 		const prefs: UserInstanceAiPreferences = { ...this.readUserPreferences(user) };
 		if (update.credentialId !== undefined) prefs.credentialId = update.credentialId;
 		if (update.modelName !== undefined) prefs.modelName = update.modelName;
@@ -525,34 +509,37 @@ export class InstanceAiSettingsService {
 
 	// ── Private helpers ───────────────────────────────────────────────────
 
-	/** Admin fields managed by the AI service proxy — not user-editable when proxy is active. */
-	private static readonly PROXY_MANAGED_ADMIN_FIELDS: readonly string[] = [
+	/**
+	 * Admin fields sourced from environment variables only — never settable via
+	 * the API on any deployment. The settings UI exposes only the enable toggle
+	 * and permissions; model, search, sandbox and advanced options come from env.
+	 * Cloud and the AI service proxy already managed these externally; self-hosted
+	 * now follows suit for the initial launch.
+	 */
+	private static readonly MANAGED_ADMIN_FIELDS: readonly string[] = [
+		'subAgentMaxSteps',
+		'mcpServers',
 		'sandboxEnabled',
 		'sandboxProvider',
 		'sandboxImage',
 		'sandboxTimeout',
 		'daytonaCredentialId',
+		'n8nSandboxCredentialId',
 		'searchCredentialId',
 	];
 
-	/** User preference fields managed by the AI service proxy. */
-	private static readonly PROXY_MANAGED_PREFERENCE_FIELDS: readonly string[] = [
+	/** User preference fields sourced from environment variables only. */
+	private static readonly MANAGED_PREFERENCE_FIELDS: readonly string[] = [
 		'credentialId',
 		'modelName',
 	];
 
-	/** Admin fields managed by the cloud platform — superset of proxy-managed fields. */
-	private static readonly CLOUD_MANAGED_ADMIN_FIELDS: readonly string[] = [
-		...InstanceAiSettingsService.PROXY_MANAGED_ADMIN_FIELDS,
-		'n8nSandboxCredentialId',
-		'subAgentMaxSteps',
-		'mcpServers',
-	];
-
-	/** User preference fields managed by the cloud platform. */
-	private static readonly CLOUD_MANAGED_PREFERENCE_FIELDS: readonly string[] = [
-		...InstanceAiSettingsService.PROXY_MANAGED_PREFERENCE_FIELDS,
-	];
+	/** Label for the deployment surface that owns the env-managed config, used in error messages. */
+	private deploymentLabel(): string {
+		if (this.isCloud) return 'cloud';
+		if (this.aiService.isProxyEnabled()) return 'proxy';
+		return 'instance';
+	}
 
 	private rejectManagedFields(
 		update: object,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SettingsInstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/SettingsInstanceAiView.test.ts
@@ -69,17 +69,9 @@ vi.mock('@/experiments/instanceAiComputerUse', () => ({
 	useInstanceAiComputerUseExperiment: computerUseExperimentMock,
 }));
 
-function makeStub(name: string) {
-	return { template: `<div data-test-stub="${name}" />` };
-}
-
 const renderComponent = createComponentRenderer(SettingsInstanceAiView, {
 	global: {
 		stubs: {
-			ModelSection: makeStub('ModelSection'),
-			SandboxSection: makeStub('SandboxSection'),
-			SearchSection: makeStub('SearchSection'),
-			AdvancedSection: makeStub('AdvancedSection'),
 			// jsdom can't drive element-plus's ElSwitch (it touches a null input ref),
 			// so stub it with a button that emits the toggled value.
 			ElSwitch: {
@@ -143,118 +135,25 @@ describe('SettingsInstanceAiView', () => {
 		});
 	});
 
-	function queryStub(container: Element, name: string) {
-		return container.querySelector(`[data-test-stub="${name}"]`);
-	}
-
-	describe('section visibility — self-hosted (no proxy, no cloud)', () => {
-		it('shows Model section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'ModelSection')).not.toBeNull();
+	describe('env-only config', () => {
+		// Model, search, sandbox and advanced options are configured via environment
+		// variables only; the settings page exposes just the enable toggle and permissions.
+		it.each([
+			['model', 'instanceAi.settings.section.model'],
+			['search', 'instanceAi.settings.section.search'],
+			['sandbox', 'instanceAi.settings.section.sandbox'],
+			['advanced', 'instanceAi.settings.section.advanced'],
+		])('does not render the %s config section', (_name, titleKey) => {
+			const { queryByText } = renderComponent();
+			expect(queryByText(titleKey)).toBeNull();
 		});
 
-		it('shows Sandbox section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SandboxSection')).not.toBeNull();
-		});
-
-		it('shows Search section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SearchSection')).not.toBeNull();
-		});
-
-		it('shows Advanced section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'AdvancedSection')).not.toBeNull();
-		});
-	});
-
-	describe('section visibility — proxy enabled (non-cloud)', () => {
-		beforeEach(() => {
-			setModuleSettings(settingsStore, { ...defaultModuleSettings, proxyEnabled: true });
-		});
-
-		it('hides Model section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'ModelSection')).toBeNull();
-		});
-
-		it('hides Sandbox section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SandboxSection')).toBeNull();
-		});
-
-		it('hides Search section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SearchSection')).toBeNull();
-		});
-
-		it('shows Advanced section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'AdvancedSection')).not.toBeNull();
-		});
-	});
-
-	describe('section visibility — cloud managed (proxy disabled)', () => {
-		beforeEach(() => {
-			setModuleSettings(settingsStore, {
-				...defaultModuleSettings,
-				proxyEnabled: false,
-				cloudManaged: true,
-			});
-		});
-
-		it('hides Model section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'ModelSection')).toBeNull();
-		});
-
-		it('hides Sandbox section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SandboxSection')).toBeNull();
-		});
-
-		it('hides Advanced section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'AdvancedSection')).toBeNull();
-		});
-	});
-
-	describe('section visibility — cloud managed', () => {
-		beforeEach(() => {
-			setModuleSettings(settingsStore, {
-				...defaultModuleSettings,
-				proxyEnabled: true,
-				cloudManaged: true,
-			});
-		});
-
-		it('hides Model section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'ModelSection')).toBeNull();
-		});
-
-		it('hides Sandbox section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SandboxSection')).toBeNull();
-		});
-
-		it('hides Search section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'SearchSection')).toBeNull();
-		});
-
-		it('hides Advanced section', () => {
-			const { container } = renderComponent();
-			expect(queryStub(container, 'AdvancedSection')).toBeNull();
-		});
-
-		it('shows Permissions section', () => {
+		it('renders the Permissions section', () => {
 			const { getByText } = renderComponent();
 			expect(getByText('settings.n8nAgent.permissions.title')).toBeVisible();
 		});
 
-		it('shows Enable toggle', () => {
+		it('renders the Enable toggle', () => {
 			const { getByTestId } = renderComponent();
 			expect(getByTestId('n8n-agent-enable-toggle')).toBeVisible();
 		});

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/views/SettingsInstanceAiView.vue
@@ -11,10 +11,6 @@ import type { InstanceAiPermissions, InstanceAiPermissionMode } from '@n8n/api-t
 import type { BaseTextKey } from '@n8n/i18n';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
-import ModelSection from '../components/settings/ModelSection.vue';
-import SandboxSection from '../components/settings/SandboxSection.vue';
-import SearchSection from '../components/settings/SearchSection.vue';
-import AdvancedSection from '../components/settings/AdvancedSection.vue';
 
 const i18n = useI18n();
 const documentTitle = useDocumentTitle();
@@ -274,32 +270,6 @@ function handlePermissionChange(key: keyof InstanceAiPermissions, value: Instanc
 									:label="i18n.baseText(PERMISSION_OPTION_LABEL[option])"
 								/>
 							</N8nSelect>
-						</div>
-					</div>
-				</template>
-
-				<div v-if="!store.isProxyEnabled && !store.isCloudManaged" :class="$style.card">
-					<div :class="$style.sectionBlock">
-						<ModelSection />
-					</div>
-				</div>
-
-				<template v-if="isAdmin">
-					<div v-if="!store.isProxyEnabled && !store.isCloudManaged" :class="$style.card">
-						<div :class="$style.sectionBlock">
-							<SandboxSection />
-						</div>
-					</div>
-
-					<div v-if="!store.isProxyEnabled" :class="$style.card">
-						<div :class="$style.sectionBlock">
-							<SearchSection />
-						</div>
-					</div>
-
-					<div v-if="!store.isCloudManaged" :class="$style.card">
-						<div :class="$style.sectionBlock">
-							<AdvancedSection />
 						</div>
 					</div>
 				</template>


### PR DESCRIPTION
## Summary

For the initial self-hosted launch we want Instance AI provider configuration to be driven by environment variables only, and to keep the credential mechanism out of the settings UI - this will be revisited later.

This PR:

- **Hides the Model, Search, Sandbox and Advanced sections** from the Instance AI settings page (`/settings/assistant`) on **every** type of deployment. The page now shows only the enable toggle, the experiment toggles (computer/browser/MCP), and Permissions. The section components (`ModelSection`, `SearchSection`, `SandboxSection`, `AdvancedSection`, `useSettingsField`) are **retained but no longer rendered**, kept there for future work.
- **Guards the backend** so the model/search/sandbox/advanced fields are env-managed on every deployment, not just cloud/proxy. The per-deployment managed-field lists are collapsed into a single `MANAGED_ADMIN_FIELDS` / `MANAGED_PREFERENCE_FIELDS` set that `updateAdminSettings` / `updateUserPreferences` reject with `422` regardless of deployment. This closes the raw-endpoint write path (e.g. POSTing `credentialId` / `searchCredentialId`) in addition to hiding the UI.
- **Keeps** the credential-listing endpoints (`GET /settings/credentials`, `GET /settings/service-credentials`) and all request DTOs unchanged - for now. If we don't end up using these at all we should clean these up later.

Behaviour is unchanged for cloud and proxy-managed instances (those already hid/blocked these fields). The env-var fallbacks (`N8N_INSTANCE_AI_MODEL*`, `INSTANCE_AI_BRAVE_SEARCH_API_KEY`, `N8N_INSTANCE_AI_SANDBOX_*`, etc.) already existed, so no resolution logic changed.

### Notes for reviewers

- The section components are intentionally kept as unused code (they still type-check against the store) so the follow-up can re-enable them without resurrecting from history. We might even want to add configuration to make this available for our own use - but for now to setup credential to use for dev purposes one should do that on database directly.

## How to test

1. As an admin on a self-hosted (non-cloud, non-proxy) instance, open **Settings → AI Assistant**.
2. Confirm the page shows only the enable toggle, the experiment toggles, and the Permissions list — no Model / Search / Sandbox / Advanced sections.
3. Confirm the agent still runs using the env-configured model/search/sandbox.
4. Confirm the write endpoints reject the env-managed fields:
   - `PUT /rest/instance-ai/settings` with `{ "sandboxEnabled": true }` → `422`
   - `PUT /rest/instance-ai/preferences` with `{ "credentialId": "..." }` → `422`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-758

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI