### PR TITLE
fix(Salesforce Node): Fix document uploads and surface errors on JWT auth

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import { DateTime } from 'luxon';
 import type {
 	IExecuteFunctions,
@@ -65,6 +66,24 @@ function assignOptions(options: IRequestOptions | IHttpRequestOptions, option: I
 	Object.assign(options, rest);
 }
 
+/**
+ * Builds a `FormData` instance from the legacy `formData` option shape
+ * (`{ value, options }` per field), which the JWT path's request helper needs
+ * since it only understands a `FormData` body, not the `formData` option.
+ */
+function toFormData(fields: IDataObject): FormData {
+	const form = new FormData();
+	for (const [key, field] of Object.entries(fields)) {
+		if (typeof field === 'object' && field !== null && 'value' in field && 'options' in field) {
+			const { value, options } = field as { value: unknown; options: FormData.AppendOptions };
+			form.append(key, value, options);
+		} else {
+			form.append(key, field);
+		}
+	}
+	return form;
+}
+
 export async function salesforceApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -83,6 +102,7 @@ export async function salesforceApiRequest(
 			// across requests; the credential's authenticate hook attaches the Bearer
 			// header and resolves the relative URL against the cached instance URL.
 			const credentialsType = 'salesforceJwtApi';
+			const { formData, ...restOption } = option;
 			const options: IHttpRequestOptions = {
 				headers: {
 					'Content-Type': 'application/json',
@@ -94,11 +114,17 @@ export async function salesforceApiRequest(
 				json: true,
 			};
 
-			if (!Object.keys(options.body as IDataObject).length) {
+			if (formData) {
+				// The authenticated helper only understands a FormData body; convert the
+				// legacy `formData` option and drop the JSON Content-Type so form-data can
+				// set the multipart boundary itself.
+				options.body = toFormData(formData as IDataObject);
+				delete options.headers!['Content-Type'];
+			} else if (!Object.keys(options.body as IDataObject).length) {
 				delete options.body;
 			}
 
-			assignOptions(options, option);
+			assignOptions(options, restOption);
 			this.logger.debug(
 				`Authentication for "Salesforce" node is using "jwt". Invoking URI ${options.url}`,
 			);

--- a/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Salesforce/GenericFunctions.ts
@@ -8,6 +8,7 @@ import type {
 	JsonObject,
 	IHttpRequestMethods,
 	IHttpRequestOptions,
+	IN8nHttpFullResponse,
 	IRequestOptions,
 	IPollFunctions,
 } from 'n8n-workflow';
@@ -66,16 +67,12 @@ function assignOptions(options: IRequestOptions | IHttpRequestOptions, option: I
 	Object.assign(options, rest);
 }
 
-/**
- * Builds a `FormData` instance from the legacy `formData` option shape
- * (`{ value, options }` per field), which the JWT path's request helper needs
- * since it only understands a `FormData` body, not the `formData` option.
- */
+/** Builds a `FormData` instance from the legacy `formData` option shape. */
 function toFormData(fields: IDataObject): FormData {
 	const form = new FormData();
 	for (const [key, field] of Object.entries(fields)) {
-		if (typeof field === 'object' && field !== null && 'value' in field && 'options' in field) {
-			const { value, options } = field as { value: unknown; options: FormData.AppendOptions };
+		if (typeof field === 'object' && field !== null && 'value' in field) {
+			const { value, options } = field as { value: unknown; options?: FormData.AppendOptions };
 			form.append(key, value, options);
 		} else {
 			form.append(key, field);
@@ -112,23 +109,46 @@ export async function salesforceApiRequest(
 				qs,
 				url: `/services/data/${SALESFORCE_API_VERSION}${uri || endpoint}`,
 				json: true,
+				// Return the full response and let non-401 error statuses through, so the
+				// Salesforce error body is available here instead of being discarded when the
+				// authenticated helper wraps the Axios error. 401 still throws so the
+				// credential's token refresh runs.
+				returnFullResponse: true,
+				ignoreHttpStatusErrors: { ignore: true, except: [401] },
 			};
 
 			if (formData) {
-				// The authenticated helper only understands a FormData body; convert the
-				// legacy `formData` option and drop the JSON Content-Type so form-data can
-				// set the multipart boundary itself.
+				// The authenticated helper only understands a FormData body, not the legacy option.
 				options.body = toFormData(formData as IDataObject);
-				delete options.headers!['Content-Type'];
 			} else if (!Object.keys(options.body as IDataObject).length) {
 				delete options.body;
 			}
 
 			assignOptions(options, restOption);
+
+			if (formData) {
+				// Drop the JSON Content-Type after merging caller options so form-data can
+				// set the multipart boundary itself.
+				delete options.headers!['Content-Type'];
+			}
+
 			this.logger.debug(
 				`Authentication for "Salesforce" node is using "jwt". Invoking URI ${options.url}`,
 			);
-			return await this.helpers.httpRequestWithAuthentication.call(this, credentialsType, options);
+			const response = (await this.helpers.httpRequestWithAuthentication.call(
+				this,
+				credentialsType,
+				options,
+			)) as IN8nHttpFullResponse;
+
+			if (response.statusCode >= 300) {
+				throw Object.assign(
+					new Error(`${response.statusCode} - ${JSON.stringify(response.body)}`),
+					{ statusCode: response.statusCode, error: response.body },
+				);
+			}
+
+			return response.body;
 		} else {
 			// https://help.salesforce.com/articleView?id=remoteaccess_oauth_web_server_flow.htm&type=5
 			const credentialsType = 'salesforceOAuth2Api';
@@ -155,9 +175,9 @@ export async function salesforceApiRequest(
 			cause?: { response?: { data?: unknown } };
 		};
 
-		// Salesforce REST errors arrive as an array on `error.error` (OAuth2 path via the
-		// legacy request helper) or on the wrapped Axios error's response data under
-		// `error.cause` (JWT path via the authenticated request helper).
+		// Salesforce REST errors arrive as an array on `error.error` — set by the OAuth2
+		// legacy helper and by the JWT error reshaping above. `error.cause.response.data`
+		// is a fallback for an Axios error still wrapped by the authenticated helper.
 		const responseData = salesforceError.cause?.response?.data;
 		const sfErrors: SalesforceApiError[] = Array.isArray(salesforceError.error)
 			? salesforceError.error

--- a/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
@@ -735,7 +735,7 @@ describe('Salesforce -> GenericFunctions', () => {
 
 		describe('JWT Authentication Flow', () => {
 			it('routes the request through the credential without signing or exchanging tokens', async () => {
-				mockRequest.mockResolvedValue({ records: [] });
+				mockRequest.mockResolvedValue({ statusCode: 200, body: { records: [] } });
 
 				await salesforceApiRequest.call(mockExecuteFunctions, 'GET', '/test-endpoint', {}, {});
 
@@ -749,6 +749,8 @@ describe('Salesforce -> GenericFunctions', () => {
 					qs: {},
 					url: '/services/data/v59.0/test-endpoint',
 					json: true,
+					returnFullResponse: true,
+					ignoreHttpStatusErrors: { ignore: true, except: [401] },
 				});
 
 				// The token exchange now lives in the credential, not the node.
@@ -757,7 +759,7 @@ describe('Salesforce -> GenericFunctions', () => {
 			});
 
 			it('forwards body and query parameters', async () => {
-				mockRequest.mockResolvedValue({});
+				mockRequest.mockResolvedValue({ statusCode: 200, body: {} });
 
 				const testBody = { name: 'Test Account', type: 'Customer' };
 				const testQs = { fields: 'Id,Name', limit: '10' };
@@ -779,6 +781,8 @@ describe('Salesforce -> GenericFunctions', () => {
 					qs: testQs,
 					url: '/services/data/v59.0/test-endpoint',
 					json: true,
+					returnFullResponse: true,
+					ignoreHttpStatusErrors: { ignore: true, except: [401] },
 				});
 			});
 
@@ -868,7 +872,7 @@ describe('Salesforce -> GenericFunctions', () => {
 			});
 
 			it('sends the formData option as a multipart FormData body', async () => {
-				mockRequest.mockResolvedValue({ id: 'cv1', success: true });
+				mockRequest.mockResolvedValue({ statusCode: 201, body: { id: 'cv1', success: true } });
 
 				const formData = uploadFormData({
 					Title: 'Doc',
@@ -876,7 +880,7 @@ describe('Salesforce -> GenericFunctions', () => {
 					PathOnClient: 'Doc.pdf',
 				});
 
-				await salesforceApiRequest.call(
+				const result = await salesforceApiRequest.call(
 					mockExecuteFunctions,
 					'POST',
 					'/sobjects/ContentVersion',
@@ -896,10 +900,11 @@ describe('Salesforce -> GenericFunctions', () => {
 				expect((sentOptions.body as FormData).getHeaders()['content-type']).toMatch(
 					/^multipart\/form-data/,
 				);
+				expect(result).toEqual({ id: 'cv1', success: true });
 			});
 
 			it('preserves each formData field, its per-part content type and filename', async () => {
-				mockRequest.mockResolvedValue({ id: 'cv1', success: true });
+				mockRequest.mockResolvedValue({ statusCode: 201, body: { id: 'cv1', success: true } });
 
 				await salesforceApiRequest.call(
 					mockExecuteFunctions,
@@ -918,6 +923,45 @@ describe('Salesforce -> GenericFunctions', () => {
 				expect(serialized).toContain('name="VersionData"');
 				expect(serialized).toContain('filename="Doc.pdf"');
 				expect(serialized).toContain('file content');
+			});
+
+			it('returns the response body on a successful status', async () => {
+				mockRequest.mockResolvedValue({ statusCode: 200, body: { records: [{ Id: '1' }] } });
+
+				const result = await salesforceApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/query',
+					{},
+					{},
+				);
+
+				expect(result).toEqual({ records: [{ Id: '1' }] });
+			});
+
+			it('surfaces the Salesforce error body when the response is an error status', async () => {
+				// The helper returns non-401 error responses instead of throwing, so the node
+				// reshapes them into the same error shape the OAuth2 path produces.
+				mockRequest.mockResolvedValue({
+					statusCode: 400,
+					body: [
+						{
+							message: 'Annual Revenue cannot be negative.',
+							errorCode: 'FIELD_CUSTOM_VALIDATION_EXCEPTION',
+							fields: ['AnnualRevenue'],
+						},
+					],
+				});
+
+				await expect(
+					salesforceApiRequest.call(mockExecuteFunctions, 'POST', '/sobjects/Lead', {}),
+				).rejects.toMatchObject({
+					description: 'Annual Revenue cannot be negative.',
+					context: {
+						errorCode: 'FIELD_CUSTOM_VALIDATION_EXCEPTION',
+						fields: 'AnnualRevenue',
+					},
+				});
 			});
 		});
 

--- a/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/GenericFunctions.test.ts
@@ -1,3 +1,4 @@
+import FormData from 'form-data';
 import { mockDeep } from 'vitest-mock-extended';
 import type { IDataObject, INodePropertyOptions, IExecuteFunctions } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
@@ -52,6 +53,19 @@ import jwt from 'jsonwebtoken';
 import type { Mock, Mocked } from 'vitest';
 
 const mockJwt = jwt as Mocked<typeof jwt>;
+
+// The `formData` option shape the node builds for a ContentVersion upload; only
+// the `entity_content` payload varies between tests.
+const uploadFormData = (entityContent: IDataObject) => ({
+	entity_content: {
+		value: JSON.stringify(entityContent),
+		options: { contentType: 'application/json' },
+	},
+	VersionData: {
+		value: Buffer.from('file content'),
+		options: { filename: 'Doc.pdf' },
+	},
+});
 
 describe('Salesforce -> GenericFunctions', () => {
 	describe('getValue', () => {
@@ -649,6 +663,43 @@ describe('Salesforce -> GenericFunctions', () => {
 		});
 	});
 
+	describe('salesforceApiRequest - OAuth2 form data', () => {
+		let mockExecuteFunctions: Mocked<IExecuteFunctions>;
+		let mockRequest: Mock;
+
+		beforeEach(() => {
+			mockExecuteFunctions = mockDeep<IExecuteFunctions>();
+			mockRequest = vi.fn();
+			mockExecuteFunctions.helpers.requestOAuth2 = mockRequest;
+			mockExecuteFunctions.getNodeParameter.mockImplementation((param: string) =>
+				param === 'authentication' ? 'oAuth2' : undefined,
+			);
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: { instance_url: 'https://test.salesforce.com' },
+			});
+		});
+
+		it('forwards the formData option to the OAuth2 request helper for multipart uploads', async () => {
+			mockRequest.mockResolvedValue({ id: 'cv1', success: true });
+
+			const formData = uploadFormData({ Title: 'Doc' });
+
+			await salesforceApiRequest.call(
+				mockExecuteFunctions,
+				'POST',
+				'/sobjects/ContentVersion',
+				{},
+				{},
+				undefined,
+				{ formData },
+			);
+
+			// The legacy OAuth2 request helper builds the multipart body from the
+			// `formData` option, so the node forwards it unchanged.
+			expect(mockRequest.mock.calls[0][1]).toMatchObject({ formData });
+		});
+	});
+
 	describe('salesforceApiRequest - JWT Authentication', () => {
 		let mockExecuteFunctions: Mocked<IExecuteFunctions>;
 		let mockRequest: Mock;
@@ -814,6 +865,59 @@ describe('Salesforce -> GenericFunctions', () => {
 				expect(mockExecuteFunctions.logger.debug).toHaveBeenCalledWith(
 					'Authentication for "Salesforce" node is using "jwt". Invoking URI /services/data/v59.0/test-endpoint',
 				);
+			});
+
+			it('sends the formData option as a multipart FormData body', async () => {
+				mockRequest.mockResolvedValue({ id: 'cv1', success: true });
+
+				const formData = uploadFormData({
+					Title: 'Doc',
+					ContentLocation: 'S',
+					PathOnClient: 'Doc.pdf',
+				});
+
+				await salesforceApiRequest.call(
+					mockExecuteFunctions,
+					'POST',
+					'/sobjects/ContentVersion',
+					{},
+					{},
+					undefined,
+					{ formData },
+				);
+
+				// The authenticated helper only understands a FormData body, not the legacy
+				// `formData` option, so the option must be converted to a FormData instance
+				// and the JSON Content-Type dropped so form-data can set the boundary.
+				const sentOptions = mockRequest.mock.calls[0][1];
+				expect(sentOptions).not.toHaveProperty('formData');
+				expect(sentOptions.body).toBeInstanceOf(FormData);
+				expect(sentOptions.headers?.['Content-Type']).toBeUndefined();
+				expect((sentOptions.body as FormData).getHeaders()['content-type']).toMatch(
+					/^multipart\/form-data/,
+				);
+			});
+
+			it('preserves each formData field, its per-part content type and filename', async () => {
+				mockRequest.mockResolvedValue({ id: 'cv1', success: true });
+
+				await salesforceApiRequest.call(
+					mockExecuteFunctions,
+					'POST',
+					'/sobjects/ContentVersion',
+					{},
+					{},
+					undefined,
+					{ formData: uploadFormData({ Title: 'Doc' }) },
+				);
+
+				const body = mockRequest.mock.calls[0][1].body as FormData;
+				const serialized = body.getBuffer().toString();
+				expect(serialized).toContain('name="entity_content"');
+				expect(serialized).toContain('Content-Type: application/json');
+				expect(serialized).toContain('name="VersionData"');
+				expect(serialized).toContain('filename="Doc.pdf"');
+				expect(serialized).toContain('file content');
 			});
 		});
 


### PR DESCRIPTION
## Summary

Two related regressions on the Salesforce node's **JWT authentication** path, both introduced when the JWT path was migrated from the legacy request helper to the modern authenticated HTTP helper (`httpRequestWithAuthentication`). OAuth2 users were unaffected.

1. **Document → Upload failed with HTTP 400.** The upload builds a multipart request using the legacy `formData` request option, which the modern helper ignores — so the request went out with an empty body. The JWT path now converts the `formData` option into a real `FormData` body (dropping the JSON `Content-Type` so `form-data` sets the multipart boundary), which the helper understands.

2. **Salesforce error messages were hidden.** The modern helper wraps the Axios error into a `NodeApiError` that discards the Salesforce response body (Salesforce returns errors as a JSON array), so users only saw a generic `Request failed with status code 400`. The JWT path now requests the full response and lets non-401 error statuses through (`ignoreHttpStatusErrors: { except: [401] }`, so 401 still throws and the credential's token refresh keeps working), then reshapes error responses into the same shape the OAuth2 path produces — surfacing the real Salesforce message and error code consistently across both auth methods.

## How to test

Using a **Salesforce JWT** credential (the bug does not reproduce on OAuth2):

<details>
<summary>Workflow JSON</summary>
```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        -112,
        0
      ],
      "id": "477d27e1-2fa6-4433-9767-0822765eb5e4",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "authentication": "jwt",
        "resource": "task",
        "status": "In Progress",
        "additionalFields": {
          "description": "Test Task by Berni"
        }
      },
      "type": "n8n-nodes-base.salesforce",
      "typeVersion": 1.1,
      "position": [
        112,
        0
      ],
      "id": "5cae56ce-5862-4329-a48c-152e8908ef12",
      "name": "Create a task",
      "credentials": {
        "salesforceJwtApi": {
          "id": "NSDRu1Aw6cZ7UVpH",
          "name": "Salesforce JWT account"
        }
      }
    },
    {
      "parameters": {
        "authentication": "jwt",
        "resource": "task",
        "operation": "update",
        "taskId": "=00TJ80001323hmtMAB",
        "updateFields": {
          "description": "Updated",
          "subject": "Other"
        }
      },
      "type": "n8n-nodes-base.salesforce",
      "typeVersion": 1.1,
      "position": [
        336,
        0
      ],
      "id": "18b9c0be-ff69-4e2f-a817-2c396d0fb651",
      "name": "Update a task",
      "notesInFlow": true,
      "credentials": {
        "salesforceJwtApi": {
          "id": "NSDRu1Aw6cZ7UVpH",
          "name": "Salesforce JWT account"
        }
      },
      "notes": "Should fail"
    },
    {
      "parameters": {
        "formTitle": "FIle",
        "formDescription": "Test File",
        "formFields": {
          "values": [
            {
              "fieldLabel": "File Upload",
              "fieldType": "file",
              "requiredField": true
            }
          ]
        },
        "responseMode": "lastNode",
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.6,
      "position": [
        -112,
        224
      ],
      "id": "d8e6a062-129b-4e16-9892-338ff30a9054",
      "name": "On form submission",
      "webhookId": "a9352745-3bc5-4bec-9a81-e75016beaae3"
    },
    {
      "parameters": {
        "authentication": "jwt",
        "resource": "document",
        "title": "=Test Berni {{ $now.toISO() }}",
        "binaryPropertyName": "File_Upload",
        "additionalFields": {}
      },
      "type": "n8n-nodes-base.salesforce",
      "typeVersion": 1.1,
      "position": [
        112,
        224
      ],
      "id": "95dc5c46-d76f-481b-8ee9-30365c474072",
      "name": "Upload a document",
      "credentials": {
        "salesforceJwtApi": {
          "id": "NSDRu1Aw6cZ7UVpH",
          "name": "Salesforce JWT account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Create a task",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Create a task": {
      "main": [
        [
          {
            "node": "Update a task",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "On form submission": {
      "main": [
        [
          {
            "node": "Upload a document",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "4e88fdf2ca2358b3af9fbecc28c6de3cd7b5ec37486b1d0dd8bae0f15bd2a988"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5372

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33490">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->