### PR TITLE
ci: Pass model input through the Instance AI evals dispatcher (no-changelog)

### DIFF
--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -36,6 +36,10 @@ on:
         description: 'LangSmith experiment name (set to instance-ai-baseline to refresh the baseline)'
         required: false
         default: ''
+      model:
+        description: 'Model for all Instance AI agents (provider/model). Empty = backend default (anthropic/claude-opus-4-8). For experiments: anthropic/claude-sonnet-4-6, anthropic/claude-sonnet-5.'
+        required: false
+        default: ''
 
 concurrency:
   # Key on the PR number for dispatched re-runs (github.ref would collapse all
@@ -137,6 +141,7 @@ jobs:
       sandbox-provider: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
       iterations: ${{ inputs.iterations }}
       experiment-name: ${{ inputs.experiment-name }}
+      model: ${{ inputs.model }}
       pr-number: ${{ needs.resolve.outputs.pr_number }}
       cache-sha: ${{ needs.resolve.outputs.cache_sha }}
       revision-sha: ${{ needs.resolve.outputs.revision_sha }}


### PR DESCRIPTION
## Summary

#33458 added a `model` input to `test-evals-instance-ai.yml` for builder-model experiments, but the dispatcher workflow (`ci-instance-ai-evals.yml`) — the usual manual kick-off entry point — didn't surface it, so the field is missing from its Run-workflow form.

Adds the same free-form `model` input to the dispatcher and forwards it to the reusable workflow. Empty = backend default (`anthropic/claude-opus-4-8`); PR-triggered runs pass empty (inputs context is empty on `pull_request` events), preserving current behavior.

Note: GitHub renders the dispatch form from the workflow file on the selected "Use workflow from" ref, so the field appears in the default form once this merges to master.

## How to test

- `actionlint` validates the `with:` mapping against the reusable workflow's declared inputs (passes).
- After merge: dispatch `CI: Instance AI Evals` with `model=anthropic/claude-sonnet-4-6` — the "Assert sandbox and model config on every lane" step in the called workflow logs `model=claude-sonnet-4-6 ok` per lane (that end-to-end path was validated in #33458 via run 28596025978).

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #33458.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- 5-line workflow pass-through; statically validated by actionlint, runtime path validated in #33458 -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->