### PR TITLE
refactor(core): Acquire the expression isolate inside getNodesWithUnregisteredWebhooks (no-changelog)

### DIFF
--- a/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts
@@ -83,8 +83,14 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		await this.pool.initialize();
 	}
 
-	async acquire(caller: object): Promise<void> {
-		if (this.bridgesByCaller.has(caller)) return;
+	/**
+	 * Acquire a bridge for the caller. Returns whether a bridge was newly
+	 * acquired: `false` means the caller already held one, so the current
+	 * scope must not release it (release is not reference-counted and would
+	 * return the caller's bridge to the pool mid-use).
+	 */
+	async acquire(caller: object): Promise<boolean> {
+		if (this.bridgesByCaller.has(caller)) return false;
 		let bridge: RuntimeBridge;
 		try {
 			bridge = this.pool.acquire();
@@ -95,6 +101,7 @@ export class ExpressionEvaluator implements IExpressionEvaluator {
 		}
 		this.config.observability?.metrics.counter(EXPRESSION_METRICS.poolAcquired.name, 1);
 		this.bridgesByCaller.set(caller, bridge);
+		return true;
 	}
 
 	evaluate(

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -81,8 +81,12 @@ export interface IExpressionEvaluator {
 	 * Acquire a bridge for an owner object (e.g. an Expression instance).
 	 * Must be called before evaluate(). The same object must be passed as
 	 * the caller argument to evaluate().
+	 *
+	 * Returns whether a bridge was newly acquired: `false` means the owner
+	 * already held one, so the current scope must not release it (release is
+	 * not reference-counted).
 	 */
-	acquire(owner: object): Promise<void>;
+	acquire(owner: object): Promise<boolean>;
 
 	/**
 	 * Release the bridge held for an owner object.

--- a/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
+++ b/packages/cli/src/services/__tests__/dynamic-node-parameters.service.test.ts
@@ -93,7 +93,7 @@ describe('DynamicNodeParametersService', () => {
 		let releaseSpy: MockInstance;
 
 		beforeEach(() => {
-			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(true);
 			releaseSpy = vi.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
 		});
 

--- a/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
@@ -3,7 +3,7 @@ import type { WebhookEntity } from '@n8n/db';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 import type { ErrorReporter, Span, Tracing } from 'n8n-core';
 import type { IWebhookData, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
-import { WebhookPathTakenError } from 'n8n-workflow';
+import { WebhookPathTakenError, WorkflowExpression } from 'n8n-workflow';
 
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import type { WebhookService } from '@/webhooks/webhook.service';
@@ -351,6 +351,50 @@ describe('WebhookTriggerRegistrar', () => {
 			);
 
 			expect(result).toEqual(new Set());
+		});
+
+		test('brackets expression resolution with an acquired isolate', async () => {
+			const callOrder: string[] = [];
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
+				callOrder.push('acquire');
+			});
+			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
+				callOrder.push('release');
+			});
+			vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockImplementation(() => {
+				callOrder.push('resolve');
+				return [];
+			});
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+
+			await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(callOrder).toEqual(['acquire', 'resolve', 'release']);
+		});
+
+		test('releases the isolate when resolution throws', async () => {
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			const releaseIsolate = vi
+				.spyOn(WorkflowExpression.prototype, 'releaseIsolate')
+				.mockResolvedValue(undefined);
+			vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockImplementation(() => {
+				throw new Error('boom');
+			});
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+
+			await expect(
+				registrar.getNodesWithUnregisteredWebhooks(
+					workflow,
+					additionalData,
+					new Set(['webhook-node']),
+				),
+			).rejects.toThrow('boom');
+
+			expect(releaseIsolate).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
@@ -377,6 +377,35 @@ describe('WebhookTriggerRegistrar', () => {
 			expect(callOrder).toEqual(['acquire', 'resolve', 'release']);
 		});
 
+		test('holds the isolate across the registered-webhook lookup', async () => {
+			const callOrder: string[] = [];
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
+				callOrder.push('acquire');
+				return true;
+			});
+			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
+				callOrder.push('release');
+			});
+			vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockImplementation(() => {
+				callOrder.push('resolve');
+				return [desiredWebhook({ node: 'Webhook', httpMethod: 'GET', path: 'users' })];
+			});
+			webhookService.getRegisteredWebhooks.mockImplementation(async () => {
+				callOrder.push('db');
+				return [];
+			});
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+
+			const result = await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			expect(result).toEqual(new Set(['webhook-node']));
+			expect(callOrder).toEqual(['acquire', 'resolve', 'db', 'release']);
+		});
+
 		test('does not release an isolate it did not acquire', async () => {
 			// Simulates a caller that already holds the isolate for this workflow:
 			// acquire is idempotent per caller and reports it did not newly acquire.

--- a/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts
@@ -357,6 +357,7 @@ describe('WebhookTriggerRegistrar', () => {
 			const callOrder: string[] = [];
 			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
 				callOrder.push('acquire');
+				return true;
 			});
 			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
 				callOrder.push('release');
@@ -376,8 +377,28 @@ describe('WebhookTriggerRegistrar', () => {
 			expect(callOrder).toEqual(['acquire', 'resolve', 'release']);
 		});
 
+		test('does not release an isolate it did not acquire', async () => {
+			// Simulates a caller that already holds the isolate for this workflow:
+			// acquire is idempotent per caller and reports it did not newly acquire.
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(false);
+			const releaseIsolate = vi
+				.spyOn(WorkflowExpression.prototype, 'releaseIsolate')
+				.mockResolvedValue(undefined);
+			vi.spyOn(WebhookHelpers, 'getWorkflowWebhooks').mockReturnValue([]);
+			const workflow = createWorkflow([node('webhook-node', 'webhook', { name: 'Webhook' })]);
+
+			await registrar.getNodesWithUnregisteredWebhooks(
+				workflow,
+				additionalData,
+				new Set(['webhook-node']),
+			);
+
+			// Releasing here would return the caller's bridge to the pool mid-bracket.
+			expect(releaseIsolate).not.toHaveBeenCalled();
+		});
+
 		test('releases the isolate when resolution throws', async () => {
-			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(true);
 			const releaseIsolate = vi
 				.spyOn(WorkflowExpression.prototype, 'releaseIsolate')
 				.mockResolvedValue(undefined);

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -185,6 +185,7 @@ describe('WorkflowTriggerActivator', () => {
 		const callOrder: string[] = [];
 		vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
 			callOrder.push('acquire');
+			return true;
 		});
 		vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
 			callOrder.push('release');
@@ -265,6 +266,7 @@ describe('WorkflowTriggerActivator', () => {
 		const callOrder: string[] = [];
 		vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
 			callOrder.push('acquire');
+			return true;
 		});
 		vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
 			callOrder.push('release');
@@ -723,7 +725,7 @@ describe('WorkflowTriggerActivator', () => {
 			errorReporter?: ErrorReporter;
 			workflowStaticDataService?: WorkflowStaticDataService;
 		}) {
-			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(true);
 			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
 			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
 				mock<IWorkflowExecuteAdditionalData>(),

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -167,54 +167,6 @@ describe('WorkflowTriggerActivator', () => {
 			);
 		});
 
-		test('brackets the registrar call with an acquired isolate so path expressions resolve', async () => {
-			const callOrder: string[] = [];
-			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {
-				callOrder.push('acquire');
-			});
-			vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockImplementation(async () => {
-				callOrder.push('release');
-			});
-			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
-				mock<IWorkflowExecuteAdditionalData>(),
-			);
-			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
-			webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks.mockImplementation(async () => {
-				callOrder.push('resolve');
-				return new Set(['w']);
-			});
-			const activator = buildActivator({ webhookTriggerRegistrar });
-
-			await activator.getNodesWithUnregisteredWebhooks(
-				mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
-				{ nodes: [node('w', 'webhook')], connections: {} },
-			);
-
-			expect(callOrder).toEqual(['acquire', 'resolve', 'release']);
-		});
-
-		test('releases the isolate when the registrar throws', async () => {
-			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
-				mock<IWorkflowExecuteAdditionalData>(),
-			);
-			const releaseIsolate = vi
-				.spyOn(WorkflowExpression.prototype, 'releaseIsolate')
-				.mockResolvedValue(undefined);
-			vi.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
-			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
-			webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks.mockRejectedValue(new Error('boom'));
-			const activator = buildActivator({ webhookTriggerRegistrar });
-
-			await expect(
-				activator.getNodesWithUnregisteredWebhooks(
-					mock<WorkflowEntity>({ id: 'wf-1', name: 'Test workflow', staticData: {}, settings: {} }),
-					{ nodes: [node('w', 'webhook')], connections: {} },
-				),
-			).rejects.toThrow('boom');
-
-			expect(releaseIsolate).toHaveBeenCalledTimes(1);
-		});
-
 		test('returns empty without calling the registrar when there are no trigger nodes', async () => {
 			const webhookTriggerRegistrar = mock<WebhookTriggerRegistrar>();
 			const activator = buildActivator({ webhookTriggerRegistrar });

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -168,34 +168,41 @@ export class WebhookTriggerRegistrar {
 		additionalData: IWorkflowExecuteAdditionalData,
 		desiredNodes: Set<INode['id']>,
 	): Promise<Set<INode['id']>> {
-		const desiredWebhooks = this.getWebhookTriggers(workflow, additionalData).filter(
-			(webhookData) => desiredNodes.has(workflow.getNode(webhookData.node)?.id ?? ''),
-		);
-		if (desiredWebhooks.length === 0) {
-			return new Set();
-		}
-
-		const registeredKeys = new Set(
-			(await this.webhookService.getRegisteredWebhooks(workflow.id)).map((webhook) =>
-				this.buildWebhookKey(webhook.method, webhook.webhookPath),
-			),
-		);
-
-		const unregistered = new Set<INode['id']>();
-		for (const webhookData of desiredWebhooks) {
-			const node = workflow.getNode(webhookData.node);
-			if (!node) {
-				continue;
+		// Resolving webhook triggers evaluates each node's `path`/`httpMethod`
+		// expressions (e.g. the Form Trigger's dynamic path), which needs an isolate.
+		await workflow.expression.acquireIsolate();
+		try {
+			const desiredWebhooks = this.getWebhookTriggers(workflow, additionalData).filter(
+				(webhookData) => desiredNodes.has(workflow.getNode(webhookData.node)?.id ?? ''),
+			);
+			if (desiredWebhooks.length === 0) {
+				return new Set();
 			}
 
-			const webhook = this.buildNormalizedWebhook(workflow, webhookData);
-			const key = this.buildWebhookKey(webhook.method, webhook.webhookPath);
-			if (!registeredKeys.has(key)) {
-				unregistered.add(node.id);
-			}
-		}
+			const registeredKeys = new Set(
+				(await this.webhookService.getRegisteredWebhooks(workflow.id)).map((webhook) =>
+					this.buildWebhookKey(webhook.method, webhook.webhookPath),
+				),
+			);
 
-		return unregistered;
+			const unregistered = new Set<INode['id']>();
+			for (const webhookData of desiredWebhooks) {
+				const node = workflow.getNode(webhookData.node);
+				if (!node) {
+					continue;
+				}
+
+				const webhook = this.buildNormalizedWebhook(workflow, webhookData);
+				const key = this.buildWebhookKey(webhook.method, webhook.webhookPath);
+				if (!registeredKeys.has(key)) {
+					unregistered.add(node.id);
+				}
+			}
+
+			return unregistered;
+		} finally {
+			await workflow.expression.releaseIsolate();
+		}
 	}
 
 	/**

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -170,7 +170,10 @@ export class WebhookTriggerRegistrar {
 	): Promise<Set<INode['id']>> {
 		// Resolving webhook triggers evaluates each node's `path`/`httpMethod`
 		// expressions (e.g. the Form Trigger's dynamic path), which needs an isolate.
-		await workflow.expression.acquireIsolate();
+		// Only release if this call newly acquired it: acquire is idempotent per
+		// caller but release is not reference-counted, so releasing an isolate a
+		// caller up-stack still holds would return their bridge to the pool mid-use.
+		const ownsIsolate = await workflow.expression.acquireIsolate();
 		try {
 			const desiredWebhooks = this.getWebhookTriggers(workflow, additionalData).filter(
 				(webhookData) => desiredNodes.has(workflow.getNode(webhookData.node)?.id ?? ''),
@@ -201,7 +204,7 @@ export class WebhookTriggerRegistrar {
 
 			return unregistered;
 		} finally {
-			await workflow.expression.releaseIsolate();
+			if (ownsIsolate) await workflow.expression.releaseIsolate();
 		}
 	}
 

--- a/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/webhook-trigger-registrar.ts
@@ -55,6 +55,13 @@ export class WebhookTriggerRegistrar {
 
 	/**
 	 * Resolve workflow-defined webhook triggers.
+	 *
+	 * NOTE: evaluates each webhook node's `path`/`httpMethod` expressions, so
+	 * when the vm expression engine is active the caller must hold an acquired
+	 * isolate (`workflow.expression.acquireIsolate()`) around this call — it
+	 * throws `No bridge acquired for this context` at runtime otherwise. This
+	 * method cannot bracket internally because it is sync. Unlike
+	 * {@link getNodesWithUnregisteredWebhooks}, which brackets itself.
 	 */
 	getWebhookTriggers(workflow: Workflow, additionalData: IWorkflowExecuteAdditionalData) {
 		return WebhookHelpers.getWorkflowWebhooks(workflow, additionalData, undefined, true);

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -155,18 +155,11 @@ export class WorkflowTriggerActivator {
 			workflowSettings: dbWorkflow.settings,
 		});
 
-		// Resolving webhook triggers evaluates each node's `path`/`httpMethod`
-		// expressions (e.g. the Form Trigger's dynamic path), which needs an isolate.
-		await workflow.expression.acquireIsolate();
-		try {
-			return await this.webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks(
-				workflow,
-				additionalData,
-				desiredNodes,
-			);
-		} finally {
-			await workflow.expression.releaseIsolate();
-		}
+		return await this.webhookTriggerRegistrar.getNodesWithUnregisteredWebhooks(
+			workflow,
+			additionalData,
+			desiredNodes,
+		);
 	}
 
 	/**

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -279,8 +279,10 @@ export class Expression {
 		}
 	}
 
-	async acquireIsolate(): Promise<void> {
-		if (Expression.vmEvaluator) await Expression.vmEvaluator.acquire(this);
+	/** Returns whether an isolate was newly acquired; `false` means this caller already held one and must not release it. */
+	async acquireIsolate(): Promise<boolean> {
+		if (Expression.vmEvaluator) return await Expression.vmEvaluator.acquire(this);
+		return false;
 	}
 
 	async releaseIsolate(): Promise<void> {

--- a/packages/workflow/src/workflow-expression.ts
+++ b/packages/workflow/src/workflow-expression.ts
@@ -270,8 +270,9 @@ export class WorkflowExpression {
 		return this.expression.convertObjectValueToString(value);
 	}
 
-	async acquireIsolate(): Promise<void> {
-		await this.expression.acquireIsolate();
+	/** Returns whether an isolate was newly acquired; `false` means this caller already held one and must not release it. */
+	async acquireIsolate(): Promise<boolean> {
+		return await this.expression.acquireIsolate();
 	}
 
 	async releaseIsolate(): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up to #33341, in three parts:

**1. Move the isolate bracket (the CAT-3636 follow-up).** #33341 acquired the expression isolate in `WorkflowTriggerActivator.getNodesWithUnregisteredWebhooks`, bracketing its call into the registrar. This moves the acquire/release down into `WebhookTriggerRegistrar.getNodesWithUnregisteredWebhooks` — the method that actually resolves each webhook trigger's `path`/`httpMethod` expressions (via `getWebhookTriggers`) — so the acquire lives with the code that needs it. The activator hunk is an exact revert of #33341's.

**2. Make the now-public bracket reentrancy-safe.** `ExpressionEvaluator.acquire` is an idempotent no-op when the caller already holds a bridge, but `release` is not reference-counted — it unconditionally returns the bridge to the pool. With the bracket inside a public service method taking a caller-supplied `Workflow`, a future caller invoking it from inside its own bracket would have its bridge released mid-use (re-introducing the exact CAT-3636 `No bridge acquired` failure, plus handing the pooled bridge to a concurrent workflow). `acquire` now reports whether it *newly* acquired (`false` = already held), and the registrar releases only what it owns. All existing call sites ignore the return value, so the `Promise<void> → Promise<boolean>` widening is backward compatible.

**3. Document the split contract.** `getWebhookTriggers` evaluates the same expressions but is sync, so it cannot self-bracket — its callers must hold the isolate. That contract is now documented on the method; undocumented it compiles and passes unit tests (no vm evaluator there) and only fails at runtime under `N8N_EXPRESSION_ENGINE=vm`.

Deliberately out of scope:
- Compile-time enforcement (builder/typestate on `WorkflowExpression`) — would touch its public API and every resolution call site; separate follow-up.
- `finally { await releaseIsolate() }` can mask the in-flight error if release rejects — pre-existing at all ~25 bracket sites, tracked in https://linear.app/n8n/issue/CAT-3673.

## How to test

Publishing a workflow with a Form Trigger (or any webhook trigger with a dynamic `path`) under the new expression engine (`N8N_EXPRESSION_ENGINE=vm`) reconciles unregistered webhooks without throwing `No bridge acquired for this context. Call acquire() first.`

Unit tests: bracket ordering (`acquire → resolve → db → release`, mutation-verified), release-on-throw, and no-release-when-not-owner, all at the registrar layer:

```
pnpm --filter n8n vitest run \
  src/workflows/triggers/__tests__/webhook-trigger-registrar.test.ts \
  src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
pnpm --filter @n8n/expression-runtime vitest run src/evaluator
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3636

Follow-up to #33341
Spawned follow-up: https://linear.app/n8n/issue/CAT-3673 (release rejection masks in-flight errors, pre-existing)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. (internal refactor; CAT-3673 filed for the pre-existing finally issue)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
