### PR TITLE
fix(editor): Fix saving tools added via the agent tools modal (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -938,6 +938,43 @@ describe('AgentBuilderView — three-column shell', () => {
 		);
 	});
 
+	it('applies the tools modal confirm payload as arrays to the local config', async () => {
+		intendedConfig = {
+			name: 'Agent One',
+			instructions: 'You are a helpful assistant.',
+		};
+		mockConfig.value = withDefaultLlm(intendedConfig);
+
+		const wrapper = await renderView();
+		wrapper.findComponent({ name: 'AgentCapabilitiesSection' }).vm.$emit('add-tool');
+		await nextTick();
+
+		expect(openModalWithDataMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: 'agentToolsModal',
+				data: expect.objectContaining({
+					projectId: 'p1',
+					agentId: 'a1',
+				}),
+			}),
+		);
+
+		// The modal confirms with a single object payload — a positional handler
+		// would land the whole object in `config.tools` and fail backend validation.
+		const modalData = openModalWithDataMock.mock.calls[0][0].data as {
+			onConfirm: (payload: { tools?: AgentJsonToolRef[]; mcpServers?: unknown[] }) => void;
+		};
+		const tools: AgentJsonToolRef[] = [{ type: 'custom', id: 'custom_tool' }];
+		modalData.onConfirm({ tools, mcpServers: [] });
+		await nextTick();
+
+		const vm = wrapper.vm as unknown as {
+			localConfig: { tools?: AgentJsonToolRef[]; mcpServers?: unknown[] };
+		};
+		expect(Array.isArray(vm.localConfig.tools)).toBe(true);
+		expect(vm.localConfig.tools).toEqual(tools);
+	});
+
 	it('shows applied skills and opens a skill modal from the capabilities section', async () => {
 		const skill = {
 			name: 'summarize_notes',

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -896,8 +896,18 @@ function onOpenAddToolModal() {
 			mcpServers: localConfig.value?.mcpServers ?? [],
 			projectId: projectId.value,
 			agentId: agentId.value,
-			onConfirm: (tools: AgentJsonToolConfig[], mcpServers: AgentJsonMcpServerConfig[] = []) =>
-				onConfigFieldUpdate({ tools, mcpServers }),
+			// The modal confirms with a single object payload (the modal-data plumbing is
+			// untyped, so a signature drift here isn't caught by TS — a positional handler
+			// would write `{ tools, mcpServers }` into `config.tools` and fail backend
+			// validation).
+			onConfirm: (payload: {
+				tools?: AgentJsonToolConfig[];
+				mcpServers?: AgentJsonMcpServerConfig[];
+			}) =>
+				onConfigFieldUpdate({
+					...(payload.tools && { tools: payload.tools }),
+					...(payload.mcpServers && { mcpServers: payload.mcpServers }),
+				}),
 		},
 	});
 }


### PR DESCRIPTION
## Summary

Adding a tool through the Agent Builder's **Add tools** modal broke the next
autosave with:

> Could not save agent settings
> Invalid agent config: [ { "code": "invalid_type", "expected": "array", "received": "object", "path": [ "tools" ], "message": "Expected array, received object" } ]

Root cause was a callback signature drift between the modal and its consumer.
`AgentToolsModal.vue` confirms with a **single object payload**
(`onConfirm({ tools, mcpServers })`), but `AgentBuilderView.vue`'s
`onOpenAddToolModal()` handler still took **positional** args
(`(tools, mcpServers) => ...`). So the whole `{ tools, mcpServers }` object
landed in the `tools` parameter and was written into `config.tools`; the
autosave `PUT .../config` was then rejected by the backend zod schema
(expected array, received object).

TypeScript couldn't catch this because modal data flows through
`uiStore.openModalWithData` untyped.

The fix updates the handler to read the object payload and spread only the keys
the modal actually sent (so a key the modal omits isn't wiped). The other modal
callbacks in the view were audited and are already correct.

## How to test

1. Open the Agent Builder.
2. Open the tools section → **Add tools** → add any tool (e.g. a code tool) → confirm.
3. The save succeeds and the added tools render — no "Could not save agent settings" error.

A regression test was added to `AgentBuilderView.test.ts` asserting the tools
modal confirm payload is applied to `localConfig.tools` as an array.

## Related Linear tickets, Github issues, and Community forum posts

Found while working on https://linear.app/n8n/issue/AGENT-317

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->