### PR TITLE
ci: Scope Instance AI evals dispatcher to PR gating (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -195,11 +195,22 @@ workflow eval is the most expensive job in PR CI (LLM-bound builds). Running it
 on every push made cost untenable; firing on every review approval cascaded
 through the dismiss-stale-on-push → re-approve loop, which also blew up.
 The current trigger fires once per `opened` / `reopened` / `ready_for_review`
-on a PR touching the eval surface, and runs the `pr` test-case dataset (~6
-high-reliability, capability-diverse cases) instead of the full ~14. To re-run
-after pushing a fix, use the workflow's manual dispatch button — also lets you
-override `tier` to `full` for broader coverage on a specific PR. The lighter
-`test-evals-discovery.yml` still runs on every push as part of `ci-pull-requests.yml`.
+on a non-fork PR touching the eval surface, and runs the `pr` test-case dataset
+(~6 high-reliability, capability-diverse cases) instead of the full ~14. To
+re-run after pushing a fix, dispatch `ci-instance-ai-evals.yml` with the PR
+number (optionally `tier: full` for broader coverage) — results post back to
+the PR. The lighter `test-evals-discovery.yml` still runs on every push as part
+of `ci-pull-requests.yml`.
+
+**`ci-instance-ai-evals.yml` is the PR gate; `test-evals-instance-ai.yml` is
+the lab bench.** The gate deliberately exposes only PR re-runs. Anything that
+isn't PR gating — baselines, model experiments, arbitrary branch runs — goes
+through `test-evals-instance-ai.yml`'s own dispatch form ("Test: Instance AI
+Exec Evals"): full knob set (branch, filter, tier, iterations, experiment-name,
+model), no per-PR cancellation (dispatches run in parallel, e.g. concurrent
+model-comparison arms), and SHA-keyed docker cache hits on master. Evals never
+run on fork PRs: the event trigger gates on `head.repo.fork`, and the `pr`
+re-run path refuses fork PRs in `resolve` (dispatched runs carry secrets).
 
 **MCP workflow evals (`ci-mcp-evals.yml`) are manual only (`workflow_dispatch`),
 never per-PR or scheduled in this first version.** They reuse the Instance AI

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -205,8 +205,8 @@ of `ci-pull-requests.yml`.
 **`ci-instance-ai-evals.yml` is the PR gate; `test-evals-instance-ai.yml` is
 the lab bench.** The gate deliberately exposes only PR re-runs. Anything that
 isn't PR gating — baselines, model experiments, arbitrary branch runs — goes
-through `test-evals-instance-ai.yml`'s own dispatch form ("Test: Instance AI
-Exec Evals"): full knob set (branch, filter, tier, iterations, experiment-name,
+through `test-evals-instance-ai.yml`'s own dispatch form ("Instance AI
+Evals: Experiments"): full knob set (branch, filter, tier, iterations, experiment-name,
 model), no per-PR cancellation (dispatches run in parallel, e.g. concurrent
 model-comparison arms), and SHA-keyed docker cache hits on master. Evals never
 run on fork PRs: the event trigger gates on `head.repo.fork`, and the `pr`

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,4 +1,4 @@
-name: 'CI: Instance AI Evals'
+name: 'Instance AI Evals: PR Gate'
 
 # The PR gate for Instance AI workflow evals. Auto-runs on PR open/reopen/ready
 # (non-draft, non-fork, path-filtered); manual dispatch re-runs a specific PR
@@ -6,7 +6,7 @@ name: 'CI: Instance AI Evals'
 #
 # This workflow is deliberately NOT the experimentation surface. For baselines,
 # model experiments, or arbitrary branch runs, dispatch test-evals-instance-ai.yml
-# ("Test: Instance AI Exec Evals") directly: it exposes the full knob set
+# ("Instance AI Evals: Experiments") directly: it exposes the full knob set
 # (branch, filter, iterations, experiment-name, model), runs dispatches in
 # parallel (no per-PR cancellation), and hits the SHA-keyed docker image cache.
 on:
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number to re-run against its latest commit. Resolves the PR head at dispatch time and posts results back. For branch/experiment runs use "Test: Instance AI Exec Evals" instead.'
+        description: 'PR number to re-run against its latest commit. Resolves the PR head at dispatch time and posts results back. For branch/experiment runs use "Instance AI Evals: Experiments" instead.'
         required: true
       tier:
         description: 'Test-case dataset for the re-run (e.g. `full` for broader coverage). Empty = `pr`.'

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,7 +1,14 @@
 name: 'CI: Instance AI Evals'
 
-# Auto-runs on PR open/reopen/ready (non-draft, path-filtered). Pushes don't
-# re-trigger (no `synchronize`); use workflow_dispatch for manual runs.
+# The PR gate for Instance AI workflow evals. Auto-runs on PR open/reopen/ready
+# (non-draft, non-fork, path-filtered); manual dispatch re-runs a specific PR
+# and posts results back. Pushes don't re-trigger (no `synchronize`).
+#
+# This workflow is deliberately NOT the experimentation surface. For baselines,
+# model experiments, or arbitrary branch runs, dispatch test-evals-instance-ai.yml
+# ("Test: Instance AI Exec Evals") directly: it exposes the full knob set
+# (branch, filter, iterations, experiment-name, model), runs dispatches in
+# parallel (no per-PR cancellation), and hits the SHA-keyed docker image cache.
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
@@ -13,27 +20,10 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'PR number to re-run against its latest commit. Resolves the PR head at dispatch time and posts results back; takes precedence over `branch`. Leave empty to use `branch`.'
-        required: false
-        default: ''
-      branch:
-        description: 'GitHub branch to test (ignored when `pr` is set)'
-        required: false
-        default: 'master'
+        description: 'PR number to re-run against its latest commit. Resolves the PR head at dispatch time and posts results back. For branch/experiment runs use "Test: Instance AI Exec Evals" instead.'
+        required: true
       tier:
-        description: 'Test-case dataset to run (e.g. `pr`, `full`). Empty => `pr` for a PR, `full` otherwise.'
-        required: false
-        default: ''
-      sandbox-provider:
-        description: 'Sandbox provider (n8n-sandbox or daytona)'
-        required: false
-        default: 'n8n-sandbox'
-      iterations:
-        description: 'Iterations per test case (use 10 for a baseline)'
-        required: false
-        default: '3'
-      experiment-name:
-        description: 'LangSmith experiment name (set to instance-ai-baseline to refresh the baseline)'
+        description: 'Test-case dataset for the re-run (e.g. `full` for broader coverage). Empty = `pr`.'
         required: false
         default: ''
 
@@ -52,7 +42,9 @@ jobs:
     name: Resolve eval target
     if: >-
       github.repository == 'n8n-io/n8n' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      (github.event_name != 'pull_request' ||
+        (github.event.pull_request.draft == false &&
+         github.event.pull_request.head.repo.fork == false))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,7 +65,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           GH_SHA: ${{ github.sha }}
           INPUT_PR: ${{ inputs.pr }}
-          INPUT_BRANCH: ${{ inputs.branch }}
           INPUT_TIER: ${{ inputs.tier }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -89,6 +80,11 @@ jobs:
             # image cache (it's scoped to refs/pull/N/merge), so load-n8n-docker
             # rebuilds from the checkout.
             pr_json=$(gh api "repos/$REPO/pulls/$INPUT_PR")
+            head_repo=$(echo "$pr_json" | jq -r '.head.repo.full_name')
+            if [ "$head_repo" != "$REPO" ]; then
+              echo "::error::PR #$INPUT_PR is from a fork ($head_repo); evals never run on fork PRs"
+              exit 1
+            fi
             head_sha=$(echo "$pr_json" | jq -r '.head.sha')
             head_ref=$(echo "$pr_json" | jq -r '.head.ref')
             merge_sha=$(echo "$pr_json" | jq -r '.merge_commit_sha // empty')
@@ -109,14 +105,9 @@ jobs:
             branch="$GH_SHA"; cache_sha="$GH_SHA"; revision_sha="$GH_SHA"
             head_ref="$EVENT_HEAD_REF"; pr_number="$EVENT_PR_NUMBER"; tier="${INPUT_TIER:-pr}"
           else
-            # Dispatch with an explicit branch (defaults to 'master'). Key the
-            # image cache and LangSmith tags on the ref under test, not
-            # github.sha: github.sha is the workflow's own ref (master when
-            # dispatched there), so keying on it would load master's prebuilt
-            # image even when testing another branch. A branch name misses the
-            # SHA-keyed cache, so load-n8n-docker rebuilds from the checkout.
-            branch="${INPUT_BRANCH:-$GH_SHA}"; cache_sha="$branch"; revision_sha="$branch"
-            head_ref="$branch"; pr_number=""; tier="${INPUT_TIER:-full}"
+            # workflow_dispatch enforces `pr` as required; this is unreachable.
+            echo "::error::manual dispatch requires the pr input"
+            exit 1
           fi
           {
             echo "branch=$branch"
@@ -134,9 +125,6 @@ jobs:
     with:
       branch: ${{ needs.resolve.outputs.branch }}
       tier: ${{ needs.resolve.outputs.tier }}
-      sandbox-provider: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
-      iterations: ${{ inputs.iterations }}
-      experiment-name: ${{ inputs.experiment-name }}
       pr-number: ${{ needs.resolve.outputs.pr_number }}
       cache-sha: ${{ needs.resolve.outputs.cache_sha }}
       revision-sha: ${{ needs.resolve.outputs.revision_sha }}

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -1,4 +1,4 @@
-name: 'Test: Instance AI Exec Evals'
+name: 'Instance AI Evals: Experiments'
 
 on:
   workflow_call:

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -290,7 +290,7 @@ Evals auto-run when a PR is **opened / reopened / marked ready** (path-filtered)
 gh workflow run ci-instance-ai-evals.yml -f pr=<number>
 ```
 
-…or use the **Run workflow** button on the **CI: Instance AI Evals** workflow and set `pr=<number>`. A `resolve` job looks up the PR's current head at dispatch time (preferring the merge ref when it reflects the latest push, so it tests the merged state like a PR-open run; otherwise it uses the head), runs the eval against it, and posts results back to the PR. A dispatched run rebuilds the docker image either way — the prebuilt image cache is scoped to `refs/pull/<n>/merge`, which a dispatch can't restore. GitHub's built-in "Re-run jobs" instead replays the original PR-open commit, so use the dispatch above. Each eval PR comment also embeds this `gh workflow run -f pr=<n>` line.
+…or use the **Run workflow** button on the **Instance AI Evals: PR Gate** workflow and set `pr=<number>`. A `resolve` job looks up the PR's current head at dispatch time (preferring the merge ref when it reflects the latest push, so it tests the merged state like a PR-open run; otherwise it uses the head), runs the eval against it, and posts results back to the PR. A dispatched run rebuilds the docker image either way — the prebuilt image cache is scoped to `refs/pull/<n>/merge`, which a dispatch can't restore. GitHub's built-in "Re-run jobs" instead replays the original PR-open commit, so use the dispatch above. Each eval PR comment also embeds this `gh workflow run -f pr=<n>` line.
 
 ### Refreshing the baseline
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
@@ -283,7 +283,7 @@ describe('formatComparisonMarkdown', () => {
 	it('falls back to a generic re-run instruction when no rerun hint is given', () => {
 		const md = formatComparisonMarkdown(evalFixture, { kind: 'no_baseline' });
 		expect(md).toContain('does not re-run on new commits');
-		expect(md).toContain('dispatching the **CI: Instance AI Evals** workflow');
+		expect(md).toContain('dispatching the **Instance AI Evals: PR Gate** workflow');
 		expect(md).not.toContain('gh workflow run');
 	});
 

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -334,7 +334,7 @@ function renderRerunCallout(rerun?: RerunHint): string {
 	if (!rerun) {
 		return [
 			'> [!IMPORTANT]',
-			"> **This eval does not re-run on new commits.** Re-run it against the PR's latest commit by dispatching the **CI: Instance AI Evals** workflow with your PR number.",
+			"> **This eval does not re-run on new commits.** Re-run it against the PR's latest commit by dispatching the **Instance AI Evals: PR Gate** workflow with your PR number.",
 		].join('\n');
 	}
 	return [


### PR DESCRIPTION
## Summary

`ci-instance-ai-evals.yml` and `test-evals-instance-ai.yml` had converged into near-identical dispatch forms, obscuring the original design (#30815): the dispatcher is the **cost-policy PR gate**, the runner is the **experimentation surface** (baselines, model comparisons, branch runs). Usage census confirms the roles: ~91% of dispatcher runs are `pull_request` events; all runner dispatches ever are baselines/experiments/branch validation.

- **Prune the dispatcher's dispatch form to its one job**: `pr` (now required) + optional `tier` for broader per-PR coverage. `branch`/`sandbox-provider`/`iterations`/`experiment-name` removed — those are lab-bench knobs; the runner's own form has them (plus `filter` and `model`), runs dispatches in parallel (no per-PR cancellation), and hits the SHA-keyed docker cache on master. Behavior of `pull_request`-event runs is unchanged (dropped `with:` entries equal the runner's defaults).
- **Exclude fork PRs everywhere**: the event trigger now gates on `head.repo.fork` — restoring the guard that existed in `ci-pull-requests.yml` before the #30815 split but didn't survive it — and the `pr` re-run path refuses fork PRs in `resolve`, since dispatched runs carry secrets.
- **Rename the display names to match the roles**: `CI: Instance AI Evals` → **"Instance AI Evals: PR Gate"**, `Test: Instance AI Exec Evals` → **"Instance AI Evals: Experiments"** — the pair now sorts together in the Actions sidebar and self-explains. Display names only: file paths, job names (branch-protection-safe), and the `gh workflow run` commands in the eval PR comment are all unchanged. Display-name references updated in the comment generator (+ its test) and the eval README.
- **Document the role split** in `WORKFLOWS.md` so it doesn't need re-excavating.

The re-run instructions in the eval PR comment (`gh workflow run ci-instance-ai-evals.yml -f pr=N`) remain valid unchanged.

## How to test

- `actionlint` passes (validates the `with:` mapping against the reusable workflow's inputs).
- Dispatch on this branch with `-f pr=<open PR>`: resolve outputs the PR's merge-ref SHAs and the eval proceeds (cancel after resolve to avoid spend). With a fork PR number, resolve fails fast with `evals never run on fork PRs`.
- `pull_request`-event path: condition structure unchanged apart from the added fork gate; verified on the next instance-ai PR.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #30815 and #33458.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- WORKFLOWS.md -->
- [ ] Tests included. <!-- CI workflow change; validated via live dispatch -->


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33499">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
