### PR TITLE
ci: Strip refs/heads prefix from branch Docker image tags

### DIFF
--- a/.github/scripts/docker/docker-config.mjs
+++ b/.github/scripts/docker/docker-config.mjs
@@ -78,6 +78,7 @@ class BuildContext {
 	sanitizeBranch(branch) {
 		if (!branch) return 'unknown';
 		return branch
+			.replace(/^refs\/heads\//, '')
 			.toLowerCase()
 			.replace(/[^a-z0-9._-]/g, '-')
 			.replace(/^[.-]/, '')


### PR DESCRIPTION
## Summary

Branch Docker images are supposed to be tagged `branch-{branch_name}`, but when the `Docker: Build and Push` workflow is dispatched with a fully-qualified ref (e.g. `refs/heads/feat/my-branch`), GitHub does not normalize `github.ref_name`, so the tag comes out as `branch-refs-heads-feat-my-branch`.

This strips a leading `refs/heads/` in `sanitizeBranch()` so both dispatch formats produce the same tag.

## How to test

Run the tag generation locally with both ref formats — they now produce the same version:

```bash
node .github/scripts/docker/docker-config.mjs --event workflow_dispatch --branch "refs/heads/feat/my-branch"
node .github/scripts/docker/docker-config.mjs --event workflow_dispatch --branch "feat/my-branch"
# both output "version": "branch-feat-my-branch"
```

Or dispatch `docker-build-push.yml` with a fully-qualified ref and verify the pushed image is tagged `branch-{branch_name}` without the `refs-heads-` prefix.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
