### PR TITLE
fix(core): Fix Instance AI orchestrator prompt caching across resumes (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/workspace-root.test.ts
@@ -2,6 +2,7 @@ import {
 	DAYTONA_HOME,
 	N8N_SANDBOX_HOME,
 	getPromptWorkspaceRoot,
+	getPromptSandboxInstructions,
 	getWorkspaceRoot,
 	WORKSPACE_DIR,
 	type SandboxWorkspace,
@@ -14,6 +15,16 @@ describe('getPromptWorkspaceRoot', () => {
 
 	it('returns n8n-sandbox workspace root', () => {
 		expect(getPromptWorkspaceRoot('n8n-sandbox')).toBe('/home/user/workspace');
+	});
+});
+
+describe('getPromptSandboxInstructions', () => {
+	// Same text across providers keeps the agent's cached prompt prefix stable.
+	it('returns the same stable text for every provider', () => {
+		expect(getPromptSandboxInstructions('daytona')).toBe(
+			getPromptSandboxInstructions('n8n-sandbox'),
+		);
+		expect(getPromptSandboxInstructions('daytona')).toContain('Cloud sandbox');
 	});
 });
 

--- a/packages/@n8n/agents/src/workspace/sandbox/index.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/index.ts
@@ -9,6 +9,8 @@ export {
 	N8N_SANDBOX_HOME,
 	N8N_SANDBOX_WORKSPACE_ROOT,
 	getPromptWorkspaceRoot,
+	getPromptSandboxInstructions,
+	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	type SandboxWorkspace,
 } from './workspace-root';

--- a/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/workspace-root.ts
@@ -16,6 +16,38 @@ export function getPromptWorkspaceRoot(provider: SandboxProvider): string {
 	}
 }
 
+/**
+ * Stable, cache-safe sandbox description for the agent's system prompt.
+ *
+ * MUST NOT vary across agent rebuilds/resumes: the orchestrator prompt is
+ * rebuilt on every resume, so any change here shifts the cached prompt prefix
+ * and busts Anthropic prompt caching for the rest of the thread. The live
+ * sandbox's `getInstructions()` is deliberately NOT used here because a
+ * lazily-resolved workspace reports different text depending on whether its
+ * (per-build, in-memory) handle happens to be resolved yet — the workspace is
+ * available regardless. Runtime-varying details (resolution state, live command
+ * timeout) are excluded; the workspace root is added to the prompt separately.
+ */
+export function getPromptSandboxInstructions(_provider: SandboxProvider): string {
+	return 'Cloud sandbox with isolated execution (TypeScript runtime).';
+}
+
+/**
+ * Stable, cache-safe filesystem description for the agent's system prompt.
+ *
+ * Same rationale as {@link getPromptSandboxInstructions}: the lazily-resolved
+ * (and scoped) filesystem reports different text before vs after its per-build
+ * handle resolves, which would shift the cached prompt prefix across resumes.
+ * Derived from the (static) workspace root so it matches the resolved scoped
+ * filesystem's own instructions while staying byte-stable.
+ */
+export function getPromptFilesystemInstructions(provider: SandboxProvider): string {
+	return [
+		`Filesystem access is scoped to ${getPromptWorkspaceRoot(provider)}.`,
+		'Paths are relative to the workspace root unless you pass an absolute path under that root.',
+	].join(' ');
+}
+
 export interface SandboxWorkspace extends SandboxCommandTarget {
 	filesystem?: {
 		provider?: string;

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -439,6 +439,10 @@ export const getWorkspaceRoot: typeof SharedSandboxMod.getWorkspaceRoot = lazyFu
 export const getPromptWorkspaceRoot: typeof SharedSandboxMod.getPromptWorkspaceRoot = lazyFunction(
 	() => loadSharedSandbox().getPromptWorkspaceRoot,
 );
+export const getPromptSandboxInstructions: typeof SharedSandboxMod.getPromptSandboxInstructions =
+	lazyFunction(() => loadSharedSandbox().getPromptSandboxInstructions);
+export const getPromptFilesystemInstructions: typeof SharedSandboxMod.getPromptFilesystemInstructions =
+	lazyFunction(() => loadSharedSandbox().getPromptFilesystemInstructions);
 export const setupSandboxWorkspace: typeof SandboxSetupMod.setupSandboxWorkspace = lazyFunction(
 	() => loadSandboxSetup().setupSandboxWorkspace,
 );

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
@@ -180,8 +180,8 @@ describe('createLazyRuntimeWorkspace', () => {
 		});
 
 		// Before resolution: the stable text, not the "on first use" fallback.
-		const sandboxBefore = lazyWorkspace.sandbox?.getInstructions();
-		const filesystemBefore = lazyWorkspace.filesystem?.getInstructions();
+		const sandboxBefore = lazyWorkspace.sandbox?.getInstructions?.();
+		const filesystemBefore = lazyWorkspace.filesystem?.getInstructions?.();
 		expect(sandboxBefore).toBe('Stable sandbox instructions.');
 		expect(filesystemBefore).toBe('Stable filesystem instructions.');
 
@@ -190,8 +190,8 @@ describe('createLazyRuntimeWorkspace', () => {
 		// After resolution: byte-identical — the live resolved text must not leak
 		// in, since that would shift the agent's cached prompt prefix on resume.
 		expect(lazyWorkspace.sandbox?.status).toBe('running');
-		expect(lazyWorkspace.sandbox?.getInstructions()).toBe(sandboxBefore);
-		expect(lazyWorkspace.filesystem?.getInstructions()).toBe(filesystemBefore);
+		expect(lazyWorkspace.sandbox?.getInstructions?.()).toBe(sandboxBefore);
+		expect(lazyWorkspace.filesystem?.getInstructions?.()).toBe(filesystemBefore);
 		expect(lazyWorkspace.getInstructions()).not.toContain('Real sandbox instructions.');
 		expect(lazyWorkspace.getInstructions()).not.toContain('Real filesystem instructions.');
 	});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/lazy-runtime-workspace.test.ts
@@ -170,6 +170,32 @@ describe('createLazyRuntimeWorkspace', () => {
 		expect(lazyWorkspace.getInstructions()).toContain('Real filesystem instructions.');
 	});
 
+	it('returns stable sandbox and filesystem instructions regardless of resolution', async () => {
+		const { workspace } = createMockWorkspace();
+		const ensureWorkspace = vi.fn(async () => await Promise.resolve(workspace));
+		const lazyWorkspace = createLazyRuntimeWorkspace({
+			ensureWorkspace,
+			sandboxInstructions: 'Stable sandbox instructions.',
+			filesystemInstructions: 'Stable filesystem instructions.',
+		});
+
+		// Before resolution: the stable text, not the "on first use" fallback.
+		const sandboxBefore = lazyWorkspace.sandbox?.getInstructions();
+		const filesystemBefore = lazyWorkspace.filesystem?.getInstructions();
+		expect(sandboxBefore).toBe('Stable sandbox instructions.');
+		expect(filesystemBefore).toBe('Stable filesystem instructions.');
+
+		await lazyWorkspace.filesystem?.readFile('/workspace/report.md');
+
+		// After resolution: byte-identical — the live resolved text must not leak
+		// in, since that would shift the agent's cached prompt prefix on resume.
+		expect(lazyWorkspace.sandbox?.status).toBe('running');
+		expect(lazyWorkspace.sandbox?.getInstructions()).toBe(sandboxBefore);
+		expect(lazyWorkspace.filesystem?.getInstructions()).toBe(filesystemBefore);
+		expect(lazyWorkspace.getInstructions()).not.toContain('Real sandbox instructions.');
+		expect(lazyWorkspace.getInstructions()).not.toContain('Real filesystem instructions.');
+	});
+
 	it('destroys the resolved workspace when the lazy workspace is destroyed', async () => {
 		const { workspace, filesystem, sandbox } = createMockWorkspace();
 		const ensureWorkspace = vi.fn(async () => await Promise.resolve(workspace));

--- a/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/lazy-runtime-workspace.ts
@@ -23,6 +23,16 @@ export interface LazyRuntimeWorkspaceOptions {
 	ensureWorkspace: RuntimeWorkspaceResolver;
 	id?: string;
 	name?: string;
+	/**
+	 * Stable sandbox / filesystem instructions surfaced to the agent's system
+	 * prompt. When set, each is returned verbatim regardless of lazy-resolution
+	 * state so the cached prompt prefix stays byte-stable across agent
+	 * rebuilds/resumes (see {@link LazyRuntimeSandbox.getInstructions} and
+	 * {@link LazyRuntimeFilesystem.getInstructions}). Omit only when prompt
+	 * caching is irrelevant.
+	 */
+	sandboxInstructions?: string;
+	filesystemInstructions?: string;
 }
 
 type WorkspaceResolvedListener = (workspace: Workspace) => void;
@@ -32,14 +42,16 @@ export function createLazyRuntimeWorkspace({
 	ensureWorkspace,
 	id = 'instance-ai-runtime-workspace',
 	name = 'Instance AI runtime workspace',
+	sandboxInstructions,
+	filesystemInstructions,
 }: LazyRuntimeWorkspaceOptions): Workspace {
 	const resolver = new LazyRuntimeWorkspaceResolver(ensureWorkspace);
 
 	return new Workspace({
 		id,
 		name,
-		filesystem: new LazyRuntimeFilesystem(resolver),
-		sandbox: new LazyRuntimeSandbox(resolver),
+		filesystem: new LazyRuntimeFilesystem(resolver, filesystemInstructions),
+		sandbox: new LazyRuntimeSandbox(resolver, sandboxInstructions),
 	});
 }
 
@@ -147,7 +159,10 @@ class LazyRuntimeFilesystem extends BaseFilesystem {
 	readonly provider = 'lazy';
 	status: ProviderStatus = 'pending';
 
-	constructor(private readonly resolver: LazyRuntimeWorkspaceResolver) {
+	constructor(
+		private readonly resolver: LazyRuntimeWorkspaceResolver,
+		private readonly staticInstructions?: string,
+	) {
 		super();
 		this.resolver.onResolved((workspace) => {
 			this.status = workspace.filesystem?.status ?? this.status;
@@ -176,6 +191,12 @@ class LazyRuntimeFilesystem extends BaseFilesystem {
 	}
 
 	getInstructions(): string {
+		// Prefer the caller-provided stable text so the agent's cached prompt
+		// prefix stays byte-stable across rebuilds/resumes. Branching on the
+		// resolved (scoped) filesystem would otherwise flip the prompt text once
+		// the workspace resolves and bust prompt caching (see LazyRuntimeSandbox).
+		if (this.staticInstructions) return this.staticInstructions;
+
 		const instructions = this.resolver.current?.filesystem?.getInstructions?.();
 		if (instructions) return instructions;
 
@@ -246,7 +267,10 @@ class LazyRuntimeSandbox extends BaseSandbox {
 	readonly provider = 'lazy';
 	status: ProviderStatus = 'pending';
 
-	constructor(private readonly resolver: LazyRuntimeWorkspaceResolver) {
+	constructor(
+		private readonly resolver: LazyRuntimeWorkspaceResolver,
+		private readonly staticInstructions?: string,
+	) {
 		super();
 		this.resolver.onResolved((workspace) => {
 			this.status = workspace.sandbox?.status ?? this.status;
@@ -299,6 +323,13 @@ class LazyRuntimeSandbox extends BaseSandbox {
 	}
 
 	override getInstructions(): string {
+		// Prefer the caller-provided stable text: it is returned regardless of
+		// resolution state so the agent's cached prompt prefix stays byte-stable
+		// across rebuilds/resumes. Branching on the live sandbox (which is only
+		// resolved once a workspace tool runs in this rebuilt instance) would
+		// otherwise flip the prompt text between resumes and bust prompt caching.
+		if (this.staticInstructions) return this.staticInstructions;
+
 		const instructions = this.resolver.current?.sandbox?.getInstructions?.();
 		if (instructions) return instructions;
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -19,6 +19,10 @@ vi.mock('@n8n/instance-ai', async () => {
 		createLazyWorkspaceRuntimeSkillSource: vi.fn(({ source }) => source),
 		createScopedWorkspace: vi.fn((workspace: unknown) => workspace),
 		getPromptWorkspaceRoot: vi.fn(() => '/home/daytona/workspace'),
+		getPromptSandboxInstructions: vi.fn(() => 'Cloud sandbox with isolated execution.'),
+		getPromptFilesystemInstructions: vi.fn(
+			() => 'Filesystem access is scoped to /home/daytona/workspace.',
+		),
 		getWorkspaceRoot: vi.fn(async () => '/home/daytona/workspace'),
 		setupSandboxWorkspace: vi.fn(),
 		loadInstanceAiRuntimeSkillSource: vi.fn(() => ({

--- a/packages/cli/src/modules/instance-ai/__tests__/run-debug-gating.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/run-debug-gating.test.ts
@@ -60,6 +60,11 @@ describe('InstanceAiService run debug gating', () => {
 		// Both terminal paths opt into raw-usage recovery so stopped/errored runs bill.
 		expect(streamOptions.recoverUsageOnAbort).toBe(true);
 		expect(resumeOptions.recoverUsageOnAbort).toBe(true);
+		// Both paths must carry the request-level Anthropic cache directive; without it
+		// on resume, HITL turns reprocess the whole conversation uncached (INS-759).
+		const cacheDirective = { anthropic: { cacheControl: { type: 'ephemeral' } } };
+		expect(streamOptions.providerOptions).toEqual(cacheDirective);
+		expect(resumeOptions.providerOptions).toEqual(cacheDirective);
 	});
 
 	it('attaches step hooks and creates run records when run debug is enabled', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -26,6 +26,8 @@ import {
 	createLazyWorkspaceRuntimeSkillSource,
 	createScopedWorkspace,
 	getPromptWorkspaceRoot,
+	getPromptSandboxInstructions,
+	getPromptFilesystemInstructions,
 	getWorkspaceRoot,
 	loadInstanceAiRuntimeSkillSource,
 	createInstanceAiTraceContext,
@@ -1936,6 +1938,11 @@ export class InstanceAiService {
 				};
 
 				runtimeWorkspace = createLazyRuntimeWorkspace({
+					// Stable across resumes: keeps the sandbox/filesystem description out
+					// of the cache-busting path (the lazy handle isn't rehydrated per
+					// rebuild, so resolution-dependent text would shift the cached prefix).
+					sandboxInstructions: getPromptSandboxInstructions(sandboxConfig.provider),
+					filesystemInstructions: getPromptFilesystemInstructions(sandboxConfig.provider),
 					ensureWorkspace: async () =>
 						await scopeWorkspaceForAgent((await getSetupSandboxEntry())?.workspace),
 				});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -843,6 +843,12 @@ export class InstanceAiService {
 			// Keep billing stopped/errored resumed runs (see stream-options builder).
 			recoverUsageOnAbort: true,
 			persistence: { resourceId: user.id, threadId },
+			// Must mirror buildOrchestratorAgentStreamOptions: without this request-level
+			// cache directive, resumed (HITL) turns send no cache_control, so Anthropic
+			// reprocesses the whole conversation uncached on every resume (~100K tokens).
+			providerOptions: {
+				anthropic: { cacheControl: { type: 'ephemeral' } },
+			},
 			...(this.isRunDebugEnabled()
 				? createRunDebugStepHooks(this.runDebugBuffer, { runId, threadId })
 				: {}),


### PR DESCRIPTION
## Summary

Instance AI orchestrator requests were losing Anthropic prompt-cache hits in two independent ways, causing the conversation prefix to be reprocessed instead of read from cache — especially on multi-turn builds that pass through setup / human-in-the-loop (HITL) steps. This PR fixes both.

### 1. Unstable cached system prefix

The orchestrator's cached system prompt embedded lazy workspace instructions whose text depended on the *lazy-resolution state of the (per-resume) rebuilt agent instance* rather than actual sandbox availability. On each HITL/setup resume the in-memory workspace handle starts unresolved, so both the sandbox and scoped-filesystem instruction strings flipped between a fallback and the resolved text — changing the cached prefix and invalidating the cache.

Both strings are concatenated by `Workspace.getInstructions()`:
- `LazyRuntimeSandbox.getInstructions()` — *"…create the runtime sandbox on first use."* ↔ *"Cloud sandbox with isolated execution…"*
- `LazyRuntimeFilesystem.getInstructions()` — scoped filesystem text *"Filesystem access is scoped to `<root>`."* (via `createScopedWorkspace`)

Fix: return **stable, provider-derived** instruction strings for both the lazy sandbox and filesystem, verbatim regardless of resolution state, so the system prefix stays byte-stable across rebuilds/resumes.
- `getPromptSandboxInstructions` / `getPromptFilesystemInstructions` in `@n8n/agents`
- `sandboxInstructions` / `filesystemInstructions` options on `createLazyRuntimeWorkspace`
- wired at workspace creation in `instance-ai.service.ts`

### 2. Missing cache directive on HITL resume turns

Fresh/foreground runs pass a request-level `providerOptions.anthropic.cacheControl` marker (`buildOrchestratorAgentStreamOptions`) — this is what makes the conversation prefix cacheable. The resume path (`buildOrchestratorResumeAgentOptions`) **omitted it**, so resumed (HITL) turns sent no cache directive and reprocessed the entire conversation prefix instead of reading it from cache on every resume.

Fix: mirror the same request-level cache directive on the resume path.

## Impact

Both bugs caused the conversation prefix (the bulk of every request) to be reprocessed instead of read from cache. Measured across real builds, per-turn cache-read rate (`cacheRead / total input`):

- **Resumed (HITL) turns: ~19% → ~99.8%** — the conversation prefix is now read from cache instead of reprocessed on every resume.
- Foreground turns were already ~87% and are unchanged.
- Net: multi-turn builds that pass through setup/HITL steps sustain the same high cache-hit rate as foreground, rather than dropping into the ~60–70% range that cold resumes pulled them down to.

No change to behavior or output — only what gets read from cache vs. reprocessed.

## How to test

1. Ask the assistant to build a workflow that ends in a setup / HITL step (e.g. a WhatsApp + Gemini + Sheets flow).
2. Continue through the setup/approval cards (which suspend and resume the run).
3. Inspect the thread's LLM usage: the system-prompt content stays constant across every turn including resumes, and resumed turns read the cached conversation prefix (cache-read) rather than reprocessing it (uncached).

Regression tests:
- `packages/@n8n/instance-ai/.../lazy-runtime-workspace.test.ts` — sandbox + filesystem instructions are byte-identical before/after resolution.
- `packages/@n8n/agents/.../workspace-root.test.ts` — stable prompt-instruction helpers.
- `packages/cli/.../run-debug-gating.test.ts` — both the stream and resume option builders carry the request-level cache directive.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-759
