### PR TITLE
fix(Form Trigger Node): Trim whitespace from email fields

### DIFF
--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -2900,6 +2900,22 @@ describe('addFormResponseDataToReturnItem', () => {
 		expect(returnItem.json['Number Field']).toBe(42);
 	});
 
+	it('should trim text fields correctly', () => {
+		const formFields: FormFieldsParameter = [{ fieldLabel: 'Text Field', fieldType: 'text' }];
+		const bodyData: IDataObject = { 'field-0': '   some text   ' };
+
+		addFormResponseDataToReturnItem(returnItem, formFields, bodyData);
+		expect(returnItem.json['Text Field']).toBe('some text');
+	});
+
+	it('should trim email fields correctly', () => {
+		const formFields: FormFieldsParameter = [{ fieldLabel: 'Email Field', fieldType: 'email' }];
+		const bodyData: IDataObject = { 'field-0': ' test@example.com   ' };
+
+		addFormResponseDataToReturnItem(returnItem, formFields, bodyData);
+		expect(returnItem.json['Email Field']).toBe('test@example.com');
+	});
+
 	it('should trim text fields', () => {
 		const formFields: FormFieldsParameter = [{ fieldLabel: 'Text Field', fieldType: 'text' }];
 		const bodyData: IDataObject = { 'field-0': '   hello world   ' };

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -406,7 +406,7 @@ export function addFormResponseDataToReturnItem(
 		if (field.fieldType === 'number') {
 			value = Number(value);
 		}
-		if (field.fieldType === 'text') {
+		if (field.fieldType === 'text' || field.fieldType === 'email') {
 			value = String(value).trim();
 		}
 		if (


### PR DESCRIPTION
Fixes #33502

### Problem
The `email` field type in n8n Form Triggers was accepting trailing and leading whitespaces (e.g., `"abc@example.com "`). Because email inputs bypassed the `.trim()` logic that was applied to text fields, these spaces propagated downstream and caused validation failures in subsequent nodes (like Send Email or CRM integrations).

### Solution
- Updated `addFormResponseDataToReturnItem` in `utils.ts` to explicitly apply strict string trimming to `email` field types exactly like `text` fields.
- Added comprehensive unit tests for both `text` and `email` field trimming in `utils.test.ts` to prevent regressions.

---

### Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->