### PR TITLE
fix(core): Fix instance AI title refinement logic (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
@@ -157,15 +157,20 @@ describe('InstanceAiService — refineTitleIfNeeded input cleaning', () => {
 		expect(patchThread).toHaveBeenCalledTimes(1);
 	});
 
-	it('fetches full history rather than a recency-limited window', async () => {
+	it('fetches a wide history window rather than only the last few messages', async () => {
 		const service = createService([userMessage(withCurrentDateTime('hey', '\n2026-07-03 09:30'))]);
 		generateTitleForRun.mockResolvedValue(null);
 
 		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
 
-		// No limit — a recency window would drop the user's request behind a build's
-		// assistant messages.
-		expect(service.agentMemory.getMessages).toHaveBeenCalledWith('thread-1');
+		// A small recency window would drop the user's request behind a build's
+		// assistant messages, so the window must be wide enough to clear them.
+		expect(service.agentMemory.getMessages).toHaveBeenCalledWith(
+			'thread-1',
+			expect.objectContaining({ limit: expect.any(Number) }),
+		);
+		const [, opts] = service.agentMemory.getMessages.mock.calls[0];
+		expect(opts.limit).toBeGreaterThanOrEqual(50);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
@@ -1,0 +1,126 @@
+import type { z as zType } from 'zod';
+
+// Manual mocks — must be declared before any imports that touch the mocked modules.
+const { generateTitleForRun, patchThread } = vi.hoisted(() => ({
+	generateTitleForRun: vi.fn(),
+	patchThread: vi.fn(),
+}));
+
+vi.mock('@n8n/instance-ai', async () => {
+	const { z } = await vi.importActual<{ z: typeof zType }>('zod');
+	return {
+		McpClientManager: class {
+			disconnect = vi.fn();
+		},
+		createDomainAccessTracker: vi.fn(),
+		createSandbox: vi.fn(),
+		createWorkspace: vi.fn(),
+		createLazyRuntimeWorkspace: vi.fn(),
+		createLazyWorkspaceRuntimeSkillSource: vi.fn(({ source }) => source),
+		setupSandboxWorkspace: vi.fn(),
+		loadInstanceAiRuntimeSkillSource: vi.fn(() => ({
+			registry: { skillsHash: 'runtime-skills-hash', skills: [] },
+			loadSkill: vi.fn(),
+		})),
+		workflowBuildOutcomeSchema: z.object({}),
+		handleBuildOutcome: vi.fn(),
+		handleVerificationVerdict: vi.fn(),
+		createInstanceAgent: vi.fn(),
+		createAllTools: vi.fn(),
+		// No trace context so refineTitleIfNeeded takes the direct title-generation path.
+		createInternalOperationTraceContext: vi.fn(async () => undefined),
+		releaseTraceClient: vi.fn(),
+		generateTitleForRun,
+		patchThread,
+	};
+});
+
+import type { ModelConfig } from '@n8n/instance-ai';
+
+import { withCurrentDateTime, AUTO_FOLLOW_UP_MESSAGE } from '../internal-messages';
+import { InstanceAiService } from '../instance-ai.service';
+
+/**
+ * Regression: stored user messages carry service-injected blocks (the
+ * <current-date-time> suffix, task-context prefixes). Title refinement must
+ * strip them before deciding whether the message is substantial enough to
+ * title — otherwise a bare "hey" (which title generation defers on) arrives
+ * padded to hundreds of chars and gets titled anyway (e.g. "Casual greeting").
+ */
+describe('InstanceAiService — refineTitleIfNeeded input cleaning', () => {
+	type StoredMessage = { role: string; content: Array<{ type: string; text: string }> };
+	type Internals = {
+		agentMemory: {
+			getThread: ReturnType<typeof vi.fn>;
+			getMessages: ReturnType<typeof vi.fn>;
+		};
+		tracing: { getTraceContextForContinuation: ReturnType<typeof vi.fn> };
+		eventBus: { publish: ReturnType<typeof vi.fn> };
+		logger: { warn: ReturnType<typeof vi.fn> };
+		refineTitleIfNeeded: (threadId: string, userId: string, modelId: ModelConfig) => Promise<void>;
+	};
+
+	const modelId = { provider: 'anthropic', model: 'test-model' } as unknown as ModelConfig;
+
+	function createService(storedMessages: StoredMessage[]): Internals {
+		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
+		service.agentMemory = {
+			getThread: vi.fn(async () => ({ id: 'thread-1', title: 'hey', metadata: {} })),
+			getMessages: vi.fn(async () => storedMessages),
+		};
+		service.tracing = { getTraceContextForContinuation: vi.fn(() => undefined) };
+		service.eventBus = { publish: vi.fn() };
+		service.logger = { warn: vi.fn() };
+		return service;
+	}
+
+	function userMessage(text: string): StoredMessage {
+		return { role: 'user', content: [{ type: 'text', text }] };
+	}
+
+	beforeEach(() => {
+		generateTitleForRun.mockReset();
+		patchThread.mockReset();
+	});
+
+	it('strips the injected date-time block before generating a title', async () => {
+		const stored = withCurrentDateTime('hey', '\n## Current Date and Time\n\n2026-07-03 09:30');
+		const service = createService([userMessage(stored)]);
+		// Simulate the trivial-message deferral inside title generation.
+		generateTitleForRun.mockResolvedValue(null);
+
+		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
+
+		expect(generateTitleForRun).toHaveBeenCalledTimes(1);
+		expect(generateTitleForRun).toHaveBeenCalledWith(modelId, 'hey');
+		// Deferred title generation must not mark the thread as refined.
+		expect(patchThread).not.toHaveBeenCalled();
+	});
+
+	it('strips task-context prefix blocks from the title prompt', async () => {
+		const stored = withCurrentDateTime(
+			'<running-tasks>\ntask-1: syncing\n</running-tasks>\n\nbuild me a slack notification workflow',
+			'\n2026-07-03 09:30',
+		);
+		const service = createService([userMessage(stored)]);
+		generateTitleForRun.mockResolvedValue('Slack notification workflow');
+
+		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
+
+		expect(generateTitleForRun).toHaveBeenCalledWith(
+			modelId,
+			'build me a slack notification workflow',
+		);
+		expect(patchThread).toHaveBeenCalledTimes(1);
+	});
+
+	it('ignores auto-follow-up messages entirely', async () => {
+		const stored = withCurrentDateTime(AUTO_FOLLOW_UP_MESSAGE, '\n2026-07-03 09:30');
+		const service = createService([userMessage(stored)]);
+
+		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
+
+		expect(generateTitleForRun).not.toHaveBeenCalled();
+		expect(patchThread).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts
@@ -78,6 +78,10 @@ describe('InstanceAiService — refineTitleIfNeeded input cleaning', () => {
 		return { role: 'user', content: [{ type: 'text', text }] };
 	}
 
+	function assistantMessage(text: string): StoredMessage {
+		return { role: 'assistant', content: [{ type: 'text', text }] };
+	}
+
 	beforeEach(() => {
 		generateTitleForRun.mockReset();
 		patchThread.mockReset();
@@ -122,5 +126,94 @@ describe('InstanceAiService — refineTitleIfNeeded input cleaning', () => {
 
 		expect(generateTitleForRun).not.toHaveBeenCalled();
 		expect(patchThread).not.toHaveBeenCalled();
+	});
+
+	it('titles from the opening user turns even when a build buries them under assistant messages', async () => {
+		// A build emits many assistant/reasoning/tool messages after the request,
+		// so a recency-limited window would miss the user's messages entirely.
+		const stored = [
+			userMessage(withCurrentDateTime('hey', '\n2026-07-03 09:30')),
+			assistantMessage("Hi! I'm your n8n assistant."),
+			userMessage(
+				withCurrentDateTime(
+					'lets build a workflow that greets me on telegram every morning',
+					'\n2026-07-03 09:31',
+				),
+			),
+			assistantMessage('Reasoning about the workflow...'),
+			assistantMessage('Build succeeded.'),
+			assistantMessage('Verification is ready.'),
+			assistantMessage('Verified — both nodes ran.'),
+		];
+		const service = createService(stored);
+		generateTitleForRun.mockResolvedValue('Morning telegram greeting');
+
+		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
+
+		expect(generateTitleForRun).toHaveBeenCalledWith(
+			modelId,
+			'hey\nlets build a workflow that greets me on telegram every morning',
+		);
+		expect(patchThread).toHaveBeenCalledTimes(1);
+	});
+
+	it('fetches full history rather than a recency-limited window', async () => {
+		const service = createService([userMessage(withCurrentDateTime('hey', '\n2026-07-03 09:30'))]);
+		generateTitleForRun.mockResolvedValue(null);
+
+		await service.refineTitleIfNeeded('thread-1', 'user-1', modelId);
+
+		// No limit — a recency window would drop the user's request behind a build's
+		// assistant messages.
+		expect(service.agentMemory.getMessages).toHaveBeenCalledWith('thread-1');
+	});
+});
+
+/**
+ * Regression: a run that suspends for HITL and completes on the resume path
+ * must still be titled. The resume-path finalizeRun caller previously dropped
+ * modelId, so the guard skipped refinement and the thread kept its heuristic
+ * first-message title (e.g. a trivial "hey").
+ */
+describe('InstanceAiService — finalizeRun title refinement guard', () => {
+	type FinalizeInternals = {
+		publishRunFinish: ReturnType<typeof vi.fn>;
+		emitRunMetrics: ReturnType<typeof vi.fn>;
+		saveAgentTreeSnapshot: ReturnType<typeof vi.fn>;
+		refineTitleIfNeeded: ReturnType<typeof vi.fn>;
+		finalizeRun: (
+			threadId: string,
+			runId: string,
+			status: 'completed' | 'cancelled' | 'errored',
+			snapshotStorage: unknown,
+			options?: { userId?: string; modelId?: ModelConfig },
+		) => Promise<void>;
+	};
+
+	const modelId = { provider: 'anthropic', model: 'test-model' } as unknown as ModelConfig;
+
+	function createService(): FinalizeInternals {
+		const service = Object.create(InstanceAiService.prototype) as unknown as FinalizeInternals;
+		service.publishRunFinish = vi.fn();
+		service.emitRunMetrics = vi.fn();
+		service.saveAgentTreeSnapshot = vi.fn(async () => {});
+		service.refineTitleIfNeeded = vi.fn(async () => {});
+		return service;
+	}
+
+	it('refines the title when a completed run supplies userId and modelId', async () => {
+		const service = createService();
+
+		await service.finalizeRun('thread-1', 'run-1', 'completed', {}, { userId: 'user-1', modelId });
+
+		expect(service.refineTitleIfNeeded).toHaveBeenCalledWith('thread-1', 'user-1', modelId);
+	});
+
+	it('skips refinement when modelId is missing', async () => {
+		const service = createService();
+
+		await service.finalizeRun('thread-1', 'run-1', 'completed', {}, { userId: 'user-1' });
+
+		expect(service.refineTitleIfNeeded).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -122,6 +122,7 @@ import {
 	EDITOR_CONTEXT_CLOSE_TAG,
 	CREDENTIAL_CONTEXT_OPEN_TAG,
 	CREDENTIAL_CONTEXT_CLOSE_TAG,
+	cleanStoredUserMessage,
 	withCurrentDateTime,
 } from './internal-messages';
 import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liveness';
@@ -5028,8 +5029,11 @@ export class InstanceAiService {
 			const history = await memory.getMessages(threadId, { limit: 5 });
 			const userTexts = history.flatMap((m) => {
 				if (!('role' in m) || m.role !== 'user') return [];
-				const text = this.extractStoredMessageText(m.content);
-				return text.length > 0 ? [text] : [];
+				// Stored user messages carry service-injected blocks (<current-date-time>,
+				// task context). Strip them or a trivial "hey" looks substantial enough to
+				// title, and the injected blocks leak into the title prompt.
+				const text = cleanStoredUserMessage(this.extractStoredMessageText(m.content));
+				return text && text.length > 0 ? [text] : [];
 			});
 			if (userTexts.length === 0) return;
 			const userText = userTexts.join('\n');

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4409,6 +4409,9 @@ export class InstanceAiService {
 			);
 			await this.finalizeRun(opts.threadId, opts.runId, result.status, opts.snapshotStorage, {
 				userId: opts.user.id,
+				// Forward modelId so title refinement fires on the resume path too — a run
+				// that suspends for HITL and completes here would otherwise never be titled.
+				...(opts.modelId !== undefined ? { modelId: opts.modelId } : {}),
 				archivedWorkflowIds,
 				workSummary: result.workSummary,
 				usage: result.usage,
@@ -5024,17 +5027,24 @@ export class InstanceAiService {
 			// Skip if thread already has an LLM-refined title
 			if (thread.metadata?.titleRefined) return;
 
-			// Concat recent user messages so retries after a trivial first message
-			// (e.g. "hey") have enough signal to produce a good title.
-			const history = await memory.getMessages(threadId, { limit: 5 });
-			const userTexts = history.flatMap((m) => {
-				if (!('role' in m) || m.role !== 'user') return [];
+			// Title the conversation from its opening user turns. Fetch the whole
+			// history (ascending) rather than the most recent N messages: a build
+			// emits many assistant/reasoning/tool messages, so a recency-limited
+			// window is dominated by them and the user's actual request scrolls out
+			// entirely, leaving nothing to title. Concatenating the first few user
+			// messages also covers the trivial-first-message retry ("hey" followed
+			// by a real request).
+			const history = await memory.getMessages(threadId);
+			const userTexts: string[] = [];
+			for (const m of history) {
+				if (!('role' in m) || m.role !== 'user') continue;
 				// Stored user messages carry service-injected blocks (<current-date-time>,
 				// task context). Strip them or a trivial "hey" looks substantial enough to
 				// title, and the injected blocks leak into the title prompt.
 				const text = cleanStoredUserMessage(this.extractStoredMessageText(m.content));
-				return text && text.length > 0 ? [text] : [];
-			});
+				if (text && text.length > 0) userTexts.push(text);
+				if (userTexts.length >= 5) break;
+			}
 			if (userTexts.length === 0) return;
 			const userText = userTexts.join('\n');
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -304,6 +304,8 @@ function getAbortReason(signal: AbortSignal): string {
 
 const MAX_CONCURRENT_BACKGROUND_TASKS_PER_THREAD = 5;
 
+const TITLE_REFINE_HISTORY_LIMIT = 50;
+
 function stringifyForContextValue(value: unknown): string {
 	if (typeof value === 'string') return value;
 	try {
@@ -5027,14 +5029,8 @@ export class InstanceAiService {
 			// Skip if thread already has an LLM-refined title
 			if (thread.metadata?.titleRefined) return;
 
-			// Title the conversation from its opening user turns. Fetch the whole
-			// history (ascending) rather than the most recent N messages: a build
-			// emits many assistant/reasoning/tool messages, so a recency-limited
-			// window is dominated by them and the user's actual request scrolls out
-			// entirely, leaving nothing to title. Concatenating the first few user
-			// messages also covers the trivial-first-message retry ("hey" followed
-			// by a real request).
-			const history = await memory.getMessages(threadId);
+			// Title the conversation from its opening user turns.
+			const history = await memory.getMessages(threadId, { limit: TITLE_REFINE_HISTORY_LIMIT });
 			const userTexts: string[] = [];
 			for (const m of history) {
 				if (!('role' in m) || m.role !== 'user') continue;


### PR DESCRIPTION
## Summary

Sending a bare greeting like "hey" to the AI Assistant produced an LLM-invented thread title (e.g. "Casual greeting"), even though title generation has a trivial-message deferral (`isTrivialMessage` in `@n8n/agents` title generation) that is meant to skip titling until the conversation has enough signal.

The cause: `refineTitleIfNeeded` builds the title-model input from **stored** user messages, and stored messages carry service-injected blocks — every user message gets a `<current-date-time>…</current-date-time>` suffix appended before persistence, and some carry task-context prefixes (`<running-tasks>`, `<editor-context>`, …). The trivial check therefore saw a ~260-char message instead of `hey`, called the title model, and the injected clock/task text also leaked into the title prompt.

Fix: run each stored user text through the existing `cleanStoredUserMessage` parser (the same one the UI uses) before the trivial check and before joining texts into the title prompt. Side benefit: auto-follow-up `(continue)` messages are now excluded from title input as well, since the parser maps them to `null`.

## How to test

1. Start n8n with the AI Assistant enabled and send just `hey` in a new thread.
2. Before: after the reply, the thread gets an LLM-generated title such as "Casual greeting".
3. After: the thread keeps the heuristic title (`hey`) — titling is deferred until a later message has enough substance, at which point the generated title reflects the actual request without timestamp/task noise.

Unit coverage in `packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.refineTitle.test.ts` (all three cases fail without the service change):
- date-time suffix is stripped, so the trivial-message deferral engages and the thread is not marked title-refined
- task-context prefixes are stripped from the title prompt
- auto-follow-up messages are ignored entirely

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-763

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

