### PR TITLE
fix(core): Support element refs when capturing browser secrets (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-browser/src/adapters/playwright.get-element-value.test.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.get-element-value.test.ts
@@ -1,0 +1,85 @@
+import type { Page } from 'playwright-core';
+
+import { PlaywrightAdapter } from './playwright';
+import { configureLogger } from '../logger';
+import type { ResolvedConfig } from '../types';
+
+configureLogger({ level: 'silent' });
+
+const config: ResolvedConfig = {
+	defaultBrowser: 'chrome',
+	browsers: new Map(),
+	adapter: 'playwright',
+	mode: 'local',
+};
+
+interface FakeLocator {
+	count: ReturnType<typeof vi.fn>;
+	inputValue: ReturnType<typeof vi.fn>;
+	innerText: ReturnType<typeof vi.fn>;
+}
+
+function adapterWithLocator(pageId: string, locator: FakeLocator): PlaywrightAdapter {
+	const adapter = new PlaywrightAdapter(config);
+	const page = {
+		locator: vi.fn().mockReturnValue(locator),
+	} as unknown as Page;
+	const pageStates = (adapter as unknown as { pageStates: Map<string, { page: Page }> }).pageStates;
+	pageStates.set(pageId, { page });
+	return adapter;
+}
+
+describe('PlaywrightAdapter.getElementValue', () => {
+	it('returns the live input value for a ref target', async () => {
+		const locator: FakeLocator = {
+			count: vi.fn().mockResolvedValue(1),
+			inputValue: vi.fn().mockResolvedValue('xoxb-signing-secret'),
+			innerText: vi.fn(),
+		};
+		const adapter = adapterWithLocator('p1', locator);
+
+		const value = await adapter.getElementValue('p1', { ref: 'e5' });
+
+		expect(value).toBe('xoxb-signing-secret');
+		expect(locator.inputValue).toHaveBeenCalled();
+	});
+
+	it('falls back to inner text when the element is not an input', async () => {
+		const locator: FakeLocator = {
+			count: vi.fn().mockResolvedValue(1),
+			inputValue: vi.fn().mockRejectedValue(new Error('Node is not an <input>')),
+			innerText: vi.fn().mockResolvedValue('secret-in-code-block'),
+		};
+		const adapter = adapterWithLocator('p1', locator);
+
+		const value = await adapter.getElementValue('p1', { ref: 'e5' });
+
+		expect(value).toBe('secret-in-code-block');
+	});
+
+	it('falls back to inner text when the input value is empty', async () => {
+		const locator: FakeLocator = {
+			count: vi.fn().mockResolvedValue(1),
+			inputValue: vi.fn().mockResolvedValue(''),
+			innerText: vi.fn().mockResolvedValue('text-content'),
+		};
+		const adapter = adapterWithLocator('p1', locator);
+
+		const value = await adapter.getElementValue('p1', { ref: 'e5' });
+
+		expect(value).toBe('text-content');
+	});
+
+	it('reads the value for a selector target', async () => {
+		const locator: FakeLocator = {
+			count: vi.fn().mockResolvedValue(1),
+			inputValue: vi.fn().mockResolvedValue('from-selector'),
+			innerText: vi.fn(),
+		};
+		const adapter = adapterWithLocator('p1', locator);
+
+		const value = await adapter.getElementValue('p1', { selector: '#token' });
+
+		expect(value).toBe('from-selector');
+	});
+});

--- a/packages/@n8n/mcp-browser/src/adapters/playwright.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.ts
@@ -1039,8 +1039,16 @@ export class PlaywrightAdapter {
 		}
 	}
 
-	getElementValue(_pageId: string, _target: ElementTarget): never {
-		throw new Error('Not implemented');
+	async getElementValue(pageId: string, target: ElementTarget): Promise<string> {
+		const locator = await this.resolveLocator(pageId, target);
+		let value = '';
+		try {
+			value = await locator.inputValue();
+		} catch {
+			// Not an <input>/<textarea>/<select>.
+		}
+		if (value !== '') return value;
+		return await locator.innerText();
 	}
 
 	private async resolveLocator(pageId: string, target: ElementTarget): Promise<Locator> {


### PR DESCRIPTION
## Summary

In the current instance-based browser use (Instance AI / Browser Use), `browser_capture_secret` failed whenever the model passed a snapshot **ref** for the element to capture — which is the default the model prefers. Instance AI (with browser use) runs the browser in `mode: 'remote'`, which always uses the `PlaywrightAdapter`, and that adapter's `getElementValue` was an unimplemented stub:

```ts
getElementValue(_pageId: string, _target: ElementTarget): never {
    throw new Error('Not implemented');
}
```

So the tool threw `Error: Not implemented`, forcing the model to retry with the `redactedKey` path instead. Combined with the double-encoding bug in [NODE-5360](https://linear.app/n8n/issue/NODE-5360), this made it impossible to capture a Slack app's signing secret.

This PR implements `getElementValue` in `PlaywrightAdapter`, reusing the existing `resolveLocator` helper (which already resolves both `ref` and `selector` targets) and mirroring the sibling `AgentBrowserAdapter`: prefer the live input value, and fall back to inner text when the element has no value (not an input, or empty). This also fixes local (non-remote) Playwright usage, which shares the same adapter.

Scope note: NODE-5360 (double-encoding of redaction markers) is a separate, related bug and is **not** addressed here.

## How to test

run Instance AI and ask it to create Slack credentials with client id + secret via browser use. Confirm `browser_capture_secret` with a `ref` no longer throws "Not implemented" and the value lands in the secrets buffer.
Open the page before yourself to speed this up

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5361

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI