### PR TITLE
fix(core): Improve OTEL error type handling

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
@@ -159,6 +159,31 @@ describe('ExecutionLevelTracer', () => {
 			expect(spans[0].attributes['n8n.execution.error_type']).toBe('Error');
 		});
 
+		it('should recover execution error type from serialized task runner errors', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-serialized-error',
+				tracingContext: inboundTracingContext,
+				workflow: defaultWorkflow,
+			});
+
+			tracer.endWorkflow({
+				executionId: 'exec-serialized-error',
+				status: 'error',
+				mode: 'manual',
+				error: {
+					message: 'unknown is not defined [line 1]',
+					description: 'ReferenceError',
+					constructor: { name: 'Object' },
+					stack: 'ReferenceError: unknown is not defined',
+				},
+				isRetry: false,
+			});
+
+			const span = otel.getFinishedSpans()[0];
+			expect(span.attributes['n8n.execution.error_type']).toBe('ReferenceError');
+			expect(span.events[0].attributes?.['exception.type']).toBe('ReferenceError');
+		});
+
 		it('should set retry attributes', () => {
 			tracer.startWorkflow({
 				executionId: 'exec-3',
@@ -371,6 +396,80 @@ describe('ExecutionLevelTracer', () => {
 			// `recordException` receives the `Error` from `toRecordableException` (not `getErrorType`).
 			expect(nodeSpan.events[0].attributes?.['exception.message']).toBe('connection refused');
 			expect(nodeSpan.events[0].attributes?.['exception.type']).toBe('TypeError');
+		});
+
+		it('should recover exception type from serialized JavaScript task runner errors', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-js-error',
+				tracingContext: inboundTracingContext,
+				workflow: defaultWorkflow,
+			});
+			const codeNode = { id: 'n1', name: 'Code', type: 'n8n-nodes-base.code', typeVersion: 2 };
+			tracer.startNode({
+				executionId: 'exec-js-error',
+				node: codeNode,
+			});
+
+			tracer.endNode({
+				executionId: 'exec-js-error',
+				node: codeNode,
+				inputItemCount: 1,
+				outputItemCount: 0,
+				error: {
+					message: 'unknown is not defined [line 1]',
+					description: 'ReferenceError',
+					constructor: { name: 'Object' },
+					stack: 'ReferenceError: unknown is not defined',
+				},
+			});
+			tracer.endWorkflow({
+				executionId: 'exec-js-error',
+				status: 'error',
+				mode: 'manual',
+				isRetry: false,
+			});
+
+			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			expect(nodeSpan.events[0].attributes?.['exception.message']).toBe(
+				'unknown is not defined [line 1]',
+			);
+			expect(nodeSpan.events[0].attributes?.['exception.type']).toBe('ReferenceError');
+		});
+
+		it('should not record Object as the exception type for serialized Python task runner errors', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-python-error',
+				tracingContext: inboundTracingContext,
+				workflow: defaultWorkflow,
+			});
+			const codeNode = { id: 'n1', name: 'Code', type: 'n8n-nodes-base.code', typeVersion: 2 };
+			tracer.startNode({
+				executionId: 'exec-python-error',
+				node: codeNode,
+			});
+
+			tracer.endNode({
+				executionId: 'exec-python-error',
+				node: codeNode,
+				inputItemCount: 1,
+				outputItemCount: 0,
+				error: {
+					message: 'Intentional error',
+					description: '',
+					constructor: { name: 'Object' },
+					stack: 'Traceback (most recent call last):\nValueError: Intentional error',
+				},
+			});
+			tracer.endWorkflow({
+				executionId: 'exec-python-error',
+				status: 'error',
+				mode: 'manual',
+				isRetry: false,
+			});
+
+			const nodeSpan = otel.getFinishedSpans().find((s) => s.name === 'node.execute')!;
+			expect(nodeSpan.events[0].attributes?.['exception.message']).toBe('Intentional error');
+			expect(nodeSpan.events[0].attributes?.['exception.type']).toBe('UnknownError');
 		});
 
 		it('should warn and not create a span when startNode has no parent workflow span', () => {

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -16,6 +16,9 @@ import { ATTR } from './otel.constants';
 import type { TracingContext } from './tracing-context';
 
 const TRACER_NAME = 'n8n-workflow';
+const UNKNOWN_ERROR_TYPE = 'UnknownError';
+const OBJECT_ERROR_TYPE = 'Object';
+
 function isError(status: ExecutionStatus): boolean {
 	return status === 'error' || status === 'crashed';
 }
@@ -292,18 +295,22 @@ function terminateSpan(span: Span, reason: string): void {
 }
 
 function getErrorType(error: unknown): string {
-	if (typeof error !== 'object' || error === null) return 'UnknownError';
+	if (error instanceof Error) return error.constructor.name;
+
+	if (typeof error !== 'object' || error === null) return UNKNOWN_ERROR_TYPE;
 
 	const record = error as Record<string, unknown>;
 
-	const name = record.name;
-	if (typeof name === 'string' && name.trim() !== '') return name;
+	const name = getNonEmptyString(record.name);
+	if (name) return name;
 
-	if (isEndNodeError(error)) {
-		return error.constructor.name;
-	}
+	const constructorName = getConstructorName(record);
+	if (constructorName && constructorName !== OBJECT_ERROR_TYPE) return constructorName;
 
-	return 'UnknownError';
+	const description = getNonEmptyString(record.description);
+	if (description && looksLikeErrorType(description)) return description;
+
+	return UNKNOWN_ERROR_TYPE;
 }
 
 function toRecordableException(error: unknown): Exception | undefined {
@@ -311,10 +318,29 @@ function toRecordableException(error: unknown): Exception | undefined {
 	if (isEndNodeError(error)) {
 		return {
 			message: error.message,
-			name: error.constructor.name,
+			name: getErrorType(error),
 			stack: error.stack,
 		};
 	}
 
 	return undefined;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+
+	const trimmed = value.trim();
+	return trimmed === '' ? undefined : trimmed;
+}
+
+function getConstructorName(record: Record<string, unknown>): string | undefined {
+	const constructor = record.constructor;
+	if (typeof constructor === 'function') return getNonEmptyString(constructor.name);
+	if (typeof constructor !== 'object' || constructor === null) return undefined;
+
+	return getNonEmptyString((constructor as Record<string, unknown>).name);
+}
+
+function looksLikeErrorType(value: string): boolean {
+	return /^[A-Z][\w.]*(Error|Exception)$/.test(value);
 }

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -295,6 +295,11 @@ function terminateSpan(span: Span, reason: string): void {
 }
 
 function getErrorType(error: unknown): string {
+	console.log('--------------------------------');
+	console.log('typeof error', typeof error);
+	console.log(error);
+	console.log('--------------------------------');
+
 	if (error instanceof Error) return error.constructor.name;
 
 	if (typeof error !== 'object' || error === null) return UNKNOWN_ERROR_TYPE;

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -295,11 +295,6 @@ function terminateSpan(span: Span, reason: string): void {
 }
 
 function getErrorType(error: unknown): string {
-	console.log('--------------------------------');
-	console.log('typeof error', typeof error);
-	console.log(error);
-	console.log('--------------------------------');
-
 	if (error instanceof Error) return error.constructor.name;
 
 	if (typeof error !== 'object' || error === null) return UNKNOWN_ERROR_TYPE;

--- a/packages/cli/src/modules/otel/execution-level-tracer.types.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.types.ts
@@ -44,7 +44,13 @@ export type StartNodeParams = {
 	node: NodeTracingParams;
 };
 
-type EndNodeError = { message: string; constructor: { name: string }; stack?: string };
+type EndNodeError = {
+	message: string;
+	constructor: { name: string };
+	stack?: string;
+	name?: string;
+	description?: string | null;
+};
 
 export function isEndNodeError(error: unknown): error is EndNodeError {
 	if (typeof error !== 'object' || error === null) return false;


### PR DESCRIPTION
## Summary

[Bug fix demo video](https://www.loom.com/share/942b27e68eb047ed940bc4585eee249e)

Improve OTEL error type handling for serialized task runner errors so spans use recovered names like `ReferenceError` and fall back to `UnknownError` for object-like Python errors.
Add diagnostic logging in `getErrorType` to inspect serialized errors during execution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-771

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

