### PR TITLE
fix: Minor updates to custom instance roles

### DIFF
--- a/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
+++ b/packages/frontend/@n8n/design-system/src/v2/components/Select/Select.vue
@@ -306,6 +306,7 @@ const groups = computed<SelectItemProps[]>(() => {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	min-width: 0;
 }
 
 .selectItem {

--- a/packages/frontend/editor-ui/src/features/roles/components/RoleSelectDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/roles/components/RoleSelectDropdown.vue
@@ -190,9 +190,10 @@ const isUnavailableRoleItem = (item: SelectItemProps) => item.requiresUpgrade ==
 					:content="selectedRole?.displayName"
 					:disabled="!selectedRole || dropdownOpen"
 					placement="top"
+					as-child
 				>
 					<span :class="$style.triggerContent">
-						{{ selectedRole?.displayName }}
+						<span :class="$style.triggerLabel">{{ selectedRole?.displayName }}</span>
 						<N8nIcon v-if="loading" icon="spinner" spin size="small" />
 					</span>
 				</N8nTooltip>
@@ -293,7 +294,9 @@ const isUnavailableRoleItem = (item: SelectItemProps) => item.requiresUpgrade ==
 
 <style lang="scss" module>
 .container {
-	display: inline-block;
+	display: inline-flex;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .searchContainer {
@@ -313,6 +316,7 @@ const isUnavailableRoleItem = (item: SelectItemProps) => item.requiresUpgrade ==
 	background-color: transparent;
 	min-height: auto;
 	max-width: 200px;
+	overflow: hidden;
 
 	&:not([data-disabled]):hover {
 		background-color: transparent;
@@ -324,10 +328,15 @@ const isUnavailableRoleItem = (item: SelectItemProps) => item.requiresUpgrade ==
 	align-items: center;
 	gap: var(--spacing--3xs);
 	font-size: var(--font-size--sm);
+	min-width: 0;
+	overflow: hidden;
+}
+
+.triggerLabel {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	max-width: 180px;
+	min-width: 0;
 }
 
 .itemLabel {

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
@@ -37,6 +37,12 @@ export const INSTANCE_SCOPE_GROUPS = {
 			'logStreaming:manage', // Log Streaming
 			'ldap:manage', // LDAP
 			'otel:manage', // OpenTelemetry
+			'eventBusDestination:create', // Log Streaming
+			'eventBusDestination:read',
+			'eventBusDestination:update',
+			'eventBusDestination:delete',
+			'eventBusDestination:list',
+			'eventBusDestination:test',
 		],
 	},
 	user: {

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
@@ -43,6 +43,9 @@ export const INSTANCE_SCOPE_GROUPS = {
 			'eventBusDestination:delete',
 			'eventBusDestination:list',
 			'eventBusDestination:test',
+			'variable:list',
+			'variable:read',
+			'dataTable:list',
 		],
 	},
 	user: {

--- a/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.vue
@@ -126,7 +126,7 @@ const onLegacyActionSelect = (role: string) => {
 			@update:role="onRoleUpdate"
 			@system-role-upgrade-needed="upgradeModalVisible = true"
 		/>
-		<span v-else>{{ selectedRole?.displayName }}</span>
+		<span v-else :class="$style.roleName">{{ selectedRole?.displayName }}</span>
 		<CustomRolesUpgradeModal v-model="upgradeModalVisible" />
 	</div>
 
@@ -158,7 +158,7 @@ const onLegacyActionSelect = (role: string) => {
 				</ElRadio>
 			</template>
 		</N8nActionDropdown>
-		<span v-else>{{ legacyRoleLabel }}</span>
+		<span v-else :class="$style.roleName">{{ legacyRoleLabel }}</span>
 	</div>
 </template>
 
@@ -166,6 +166,15 @@ const onLegacyActionSelect = (role: string) => {
 /* Wrapper for the feature-flag branch; renders as if it weren't there. */
 .flagBranch {
 	display: contents;
+}
+
+/* Non-editable role name — truncates so it doesn't overflow the adjacent column */
+.roleName {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 200px;
 }
 
 /* Legacy design */

--- a/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersTable.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersTable.vue
@@ -55,6 +55,7 @@ const headers = ref<Array<TableHeader<Item>>>([
 	{
 		title: i18n.baseText('settings.users.table.header.accountType'),
 		key: 'role',
+		width: 200,
 	},
 	{
 		title: i18n.baseText('settings.users.table.header.lastActive'),
@@ -168,7 +169,9 @@ const onRoleChange = ({ role, userId }: { role: string; userId: string }) => {
 					:loading="props.updatingRoleUserId === item.id"
 					@update:role="onRoleChange"
 				/>
-				<N8nText v-else color="text-dark">{{ roles[item.role ?? ROLE.Default]?.label }}</N8nText>
+				<N8nText v-else color="text-dark" :class="$style.roleName">{{
+					roles[item.role ?? ROLE.Default]?.label
+				}}</N8nText>
 			</template>
 			<template #[`item.lastActiveAt`]="{ item }">
 				<SettingsUsersLastActiveCell :data="item" />
@@ -186,3 +189,13 @@ const onRoleChange = ({ role, userId }: { role: string; userId: string }) => {
 		</N8nDataTableServer>
 	</div>
 </template>
+
+<style lang="scss" module>
+.roleName {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 200px;
+}
+</style>


### PR DESCRIPTION
## Summary

Fixes three bugs introduced with custom role / instance-role-scope support:

1. **Missing-scope errors for users with only "Manage Instance Settings"** variable:list, variable:read, and dataTable:list were absent from the manageInstanceSettings scope group in instanceRoleScopes.ts. Users with that custom role would see "Error fetching credentials, variables, and data tables" on the Overview page and an error on the Data Tables page. Added the missing scopes.

2. **403 when saving a log streaming destination** The eventBusDestination:* CRUD scopes (create, read, update, delete, list, test) were missing from the manageInstanceSettings scope group, even though logStreaming:manage was already listed. Any write or read operation against an event-bus destination returned 403. Added the missing granular scopes.

3. **Long custom role names overflow into the Account Type column** The role-name text in SettingsUsersTable, SettingsUsersRoleCell, and RoleSelectDropdown had no reliable truncation. Long names would push past the column boundary and overlap the adjacent "Account Type" cell.

## How to test
**Missing-scope errors**

Create a custom role with only Manage Instance Settings selected.
Assign that role to a non-owner user and log in as that user.
Go to the Overview page — no "Error fetching credentials, variables, and data tables" error should appear.
Navigate to Data Tables — no error.

**403 on log streaming destination**

Log in as the same user (custom role: Manage Instance Settings only).
Go to Settings → Log Streaming, add a new destination, and save.
No 403 should occur.

**Role name truncation**

Create a custom role with a very long name (e.g. 50+ characters).
Assign it to a user and open Settings → Users.
The role name in the Account Type column should be truncated with an ellipsis and not overflow into adjacent columns.
Open the role-change dropdown — the chevron is still visible and the tooltip appears on hover.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-927

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

