### PR TITLE
chore(editor): Add ESLint no-restricted-imports guard for element-plus and reka-ui

### DIFF
--- a/packages/frontend/AGENTS.md
+++ b/packages/frontend/AGENTS.md
@@ -7,6 +7,7 @@ Extra information, specific to the frontend codebase. Use this when doing any fr
 - PREFER using **semantic tokens** for styling from `@n8n/design-system/src/css/_tokens.scss` or `@n8n/design-system/src/css/_primitives.scss`.
 - AVOID using legacy tokens from `@n8n/design-system/src/css/_tokens.legacy.scss`
 - PREFER using existing components from `@n8n/design-system` over creating new ones
+- AVOID importing `element-plus` or `reka-ui` directly in `editor-ui` — import the equivalent `@n8n/design-system` component instead (an ESLint `no-restricted-imports` warning enforces this; type-only imports are allowed during migration). Common mappings: Collapsible → `N8nCollapsiblePanel`, DropdownMenu → `N8nDropdownMenu`, `Primitive` → native HTML.
 - When rendering `el-plus` popovers/dropdowns/selects inside `N8nDialog`, prefer to keep them in the dialog stacking context with `:teleported="false"` unless they intentionally need to escape.
 - Available icon names are in `packages/frontend/@n8n/design-system/src/components/N8nIcon/icons.ts`.
   Use keys from `updatedIconSet` only — `deprecatedIconSet` entries must not be used in new code.

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -191,6 +191,16 @@ export default defineConfig(
 					message:
 						'Use injectWorkflowExecutionStateStore().value.getActiveExecutionRunDataByNodeName() instead of workflowsStore.getWorkflowResultDataByNodeName()',
 				},
+				// Guard: Design System boundary — dynamic import() bypasses the
+				// no-restricted-imports rule below, so literal specifiers are caught here.
+				{
+					selector: 'ImportExpression > Literal[value=/^element-plus(\\/|$)/]',
+					message: ELEMENT_PLUS_RESTRICTION_MESSAGE,
+				},
+				{
+					selector: 'ImportExpression > Literal[value=/^reka-ui(\\/|$)/]',
+					message: REKA_UI_RESTRICTION_MESSAGE,
+				},
 			],
 			// Guard: Design System boundary — import UI components from @n8n/design-system,
 			// not element-plus/reka-ui directly. Type-only imports allowed during migration.

--- a/packages/frontend/editor-ui/eslint.config.mjs
+++ b/packages/frontend/editor-ui/eslint.config.mjs
@@ -2,6 +2,12 @@ import { defineConfig } from 'eslint/config';
 import { frontendConfig } from '@n8n/eslint-config/frontend';
 import oxlint from 'eslint-plugin-oxlint';
 
+// Shared between the bare and subpath entries of the Design System boundary guard below.
+const ELEMENT_PLUS_RESTRICTION_MESSAGE =
+	'Import from @n8n/design-system instead (see packages/frontend/AGENTS.md)';
+const REKA_UI_RESTRICTION_MESSAGE =
+	'Import from @n8n/design-system instead. Collapsible → N8nCollapsiblePanel, DropdownMenu → N8nDropdownMenu, Primitive → native HTML';
+
 export default defineConfig(
 	frontendConfig,
 	{
@@ -184,6 +190,38 @@ export default defineConfig(
 						"MemberExpression[property.name='getWorkflowResultDataByNodeName'][object.name='workflowsStore']",
 					message:
 						'Use injectWorkflowExecutionStateStore().value.getActiveExecutionRunDataByNodeName() instead of workflowsStore.getWorkflowResultDataByNodeName()',
+				},
+			],
+			// Guard: Design System boundary — import UI components from @n8n/design-system,
+			// not element-plus/reka-ui directly. Type-only imports allowed during migration.
+			// Level: 'warn' during migration. Flip to 'error' when existing violations are migrated.
+			'@typescript-eslint/no-restricted-imports': [
+				'warn',
+				{
+					paths: [
+						{
+							name: 'element-plus',
+							message: ELEMENT_PLUS_RESTRICTION_MESSAGE,
+							allowTypeImports: true,
+						},
+						{
+							name: 'reka-ui',
+							message: REKA_UI_RESTRICTION_MESSAGE,
+							allowTypeImports: true,
+						},
+					],
+					patterns: [
+						{
+							group: ['element-plus/*'],
+							message: ELEMENT_PLUS_RESTRICTION_MESSAGE,
+							allowTypeImports: true,
+						},
+						{
+							group: ['reka-ui/*'],
+							message: REKA_UI_RESTRICTION_MESSAGE,
+							allowTypeImports: true,
+						},
+					],
 				},
 			],
 			// TODO: Remove these


### PR DESCRIPTION
## Summary

Phase 1 of the [Design System Boundary Enforcement RFC](https://www.notion.so/n8n/Design-System-Boundary-Enforcement-for-AI-Agents-3495b6e0c94f8183b67ed1ad9984a5b3): adds a warn-level `@typescript-eslint/no-restricted-imports` rule to `packages/frontend/editor-ui/eslint.config.mjs` that flags direct `element-plus` and `reka-ui` imports (bare and subpath) and points developers/AI agents at `@n8n/design-system`.

- Severity is `warn` during migration; a later phase flips it to `error` once existing violations are migrated.
- `allowTypeImports: true` — type-only imports are allowed temporarily.
- Uses the `@typescript-eslint` variant of the rule (not base `no-restricted-imports`) because the base rule's schema rejects the `allowTypeImports` option.
- Literal dynamic `import()` specifiers are guarded too, via `no-restricted-syntax` `ImportExpression` selectors — the static-import rule never visits those nodes. Non-literal specifiers (`import(someVar)`) remain out of reach of static analysis.
- Rule lives only in editor-ui's config, so `@n8n/design-system`'s own legitimate element-plus/reka-ui imports are unaffected.
- Currently surfaces **90 warnings** (73 element-plus + 17 reka-ui across 90 files) — the RFC's ~95 count had drifted.

Note: the package `lint` script runs `eslint --quiet`, so warn-level diagnostics don't appear there (same as the existing `no-restricted-syntax` workflowsStore guard) — they surface in IDEs and on manual no-`--quiet` runs. This is the intended Phase-1 behavior; enforcement comes with the `error` escalation.

## How to test

```bash
# CI lint path still passes (config valid, exit 0)
pnpm --filter=n8n-editor-ui lint

# See the new warnings (rule id: @typescript-eslint/no-restricted-imports)
cd packages/frontend/editor-ui
pnpm exec eslint src/app/composables/useToast.ts   # 1 warning for the element-plus value import

# Type-only imports are NOT flagged
pnpm exec eslint src/Interface.ts                   # no no-restricted-imports warning

# Design system package unaffected
pnpm --filter=@n8n/design-system lint
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-563

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
