### PR TITLE
test: Enable restoreMocks by default in shared vitest configs

### DIFF
--- a/packages/@n8n/agents/vite.config.ts
+++ b/packages/@n8n/agents/vite.config.ts
@@ -52,7 +52,6 @@ function rewriteSourceRequire(): Plugin {
 
 export default mergeConfig(
 	createVitestConfig({
-		restoreMocks: true,
 		// Integration tests run via vitest.integration.config.mjs (real providers, long timeouts).
 		exclude: [...configDefaults.exclude, '**/__tests__/integration/**'],
 	}),

--- a/packages/@n8n/ai-utilities/vite.config.ts
+++ b/packages/@n8n/ai-utilities/vite.config.ts
@@ -2,26 +2,21 @@ import { createVitestConfig } from '@n8n/vitest-config/node';
 import path from 'node:path';
 import { mergeConfig } from 'vite';
 
-export default mergeConfig(
-	createVitestConfig({
-		restoreMocks: true,
-	}),
-	{
-		resolve: {
-			alias: [
-				{ find: 'src', replacement: path.resolve(__dirname, './src') },
-				// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
-				// Workspace deps CJS-require zod while tests ESM-import it, so
-				// `schema instanceof ZodSchema` in src/converters/tool.ts fails across the
-				// two. Pin the top-level `zod` import to the CJS file so both share one
-				// module instance. `require.resolve` follows zod's `require` export condition,
-				// so it tracks the installed (catalog) version automatically. Subpaths like
-				// `zod/v4` keep their normal resolution.
-				{
-					find: /^zod$/,
-					replacement: require.resolve('zod'),
-				},
-			],
-		},
+export default mergeConfig(createVitestConfig({}), {
+	resolve: {
+		alias: [
+			{ find: 'src', replacement: path.resolve(__dirname, './src') },
+			// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
+			// Workspace deps CJS-require zod while tests ESM-import it, so
+			// `schema instanceof ZodSchema` in src/converters/tool.ts fails across the
+			// two. Pin the top-level `zod` import to the CJS file so both share one
+			// module instance. `require.resolve` follows zod's `require` export condition,
+			// so it tracks the installed (catalog) version automatically. Subpaths like
+			// `zod/v4` keep their normal resolution.
+			{
+				find: /^zod$/,
+				replacement: require.resolve('zod'),
+			},
+		],
 	},
-);
+});

--- a/packages/@n8n/ai-workflow-builder.ee/vitest.config.base.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/vitest.config.base.ts
@@ -5,29 +5,22 @@ import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decora
 // Shared base config for both the unit (vite.config.ts) and integration
 // (vitest.config.integration.ts) runs. Test include/exclude is intentionally
 // left to the extending configs so they don't merge-concatenate each other's globs.
-export const baseConfig = mergeConfig(
-	createVitestConfigWithDecorators({
-		// The n8n root jest.config sets `restoreMocks: true`, and most test files silently
-		// rely on it — omit this and mocks bleed between tests.
-		restoreMocks: true,
-	}),
-	{
-		resolve: {
-			alias: [
-				{ find: '@', replacement: path.resolve(__dirname, './src') },
-				// zod has dual ESM/CJS exports (`./dist/esm/index.js` for `import`,
-				// `./dist/cjs/index.js` for `require`) — two separate files with two separate
-				// `ZodType` classes. Workspace deps CJS-require zod, test files ESM-import it, and
-				// `instanceof z.ZodX` checks in source fail between them. Pin the top-level `zod`
-				// import to the CJS file so both code paths share a single module instance.
-				{
-					find: /^zod$/,
-					replacement: path.resolve(
-						__dirname,
-						'../../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
-					),
-				},
-			],
-		},
+export const baseConfig = mergeConfig(createVitestConfigWithDecorators({}), {
+	resolve: {
+		alias: [
+			{ find: '@', replacement: path.resolve(__dirname, './src') },
+			// zod has dual ESM/CJS exports (`./dist/esm/index.js` for `import`,
+			// `./dist/cjs/index.js` for `require`) — two separate files with two separate
+			// `ZodType` classes. Workspace deps CJS-require zod, test files ESM-import it, and
+			// `instanceof z.ZodX` checks in source fail between them. Pin the top-level `zod`
+			// import to the CJS file so both code paths share a single module instance.
+			{
+				find: /^zod$/,
+				replacement: path.resolve(
+					__dirname,
+					'../../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
+				),
+			},
+		],
 	},
-);
+});

--- a/packages/@n8n/chat-hub/vite.config.ts
+++ b/packages/@n8n/chat-hub/vite.config.ts
@@ -1,5 +1,3 @@
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
-export default createVitestConfig({
-	restoreMocks: true,
-});
+export default createVitestConfig();

--- a/packages/@n8n/computer-use/vite.config.ts
+++ b/packages/@n8n/computer-use/vite.config.ts
@@ -2,22 +2,16 @@ import path from 'node:path';
 import { mergeConfig } from 'vite';
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
-export default mergeConfig(
-	createVitestConfig({
-		// The n8n root jest.config sets `restoreMocks: true`, and tests rely on it.
-		restoreMocks: true,
-	}),
-	{
-		resolve: {
-			alias: [
-				// @inquirer/prompts and its sub-packages are ESM-only. Tests redirect
-				// any @inquirer/* import to this mock (mirrors the former Jest
-				// moduleNameMapper).
-				{
-					find: /^@inquirer\/.*$/,
-					replacement: path.resolve(__dirname, './src/__mocks__/@inquirer/prompts.ts'),
-				},
-			],
-		},
+export default mergeConfig(createVitestConfig({}), {
+	resolve: {
+		alias: [
+			// @inquirer/prompts and its sub-packages are ESM-only. Tests redirect
+			// any @inquirer/* import to this mock (mirrors the former Jest
+			// moduleNameMapper).
+			{
+				find: /^@inquirer\/.*$/,
+				replacement: path.resolve(__dirname, './src/__mocks__/@inquirer/prompts.ts'),
+			},
+		],
 	},
-);
+});

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -1,6 +1,7 @@
 import { Container } from '@n8n/di';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import type { MockInstance } from 'vitest';
 
 import type { DatabaseConfig } from '../src/index';
 import { GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
@@ -13,7 +14,8 @@ vi.mock('node:fs', () => ({
 	readFileSync: readFileSyncMock,
 }));
 
-const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+// `restoreMocks` restores spies before each test, so this is re-established in beforeEach.
+let consoleWarnMock: MockInstance;
 
 // Ignore the sanitize function from the GlobalConfig nested types
 type ConfigShape<T> = T extends ReadonlyArray<infer U>
@@ -34,6 +36,7 @@ describe('GlobalConfig', () => {
 	beforeEach(() => {
 		Container.reset();
 		vi.clearAllMocks();
+		consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
 	});
 
 	const originalEnv = process.env;

--- a/packages/@n8n/db/vite.config.ts
+++ b/packages/@n8n/db/vite.config.ts
@@ -137,18 +137,13 @@ function tscDecoratorTransform(): Plugin {
 	};
 }
 
-export default mergeConfig(
-	createVitestConfigWithDecorators({
-		restoreMocks: true,
-	}),
-	{
-		plugins: [tscDecoratorTransform()],
-		test: {
-			// Vitest 4's default exclude is only node_modules/.git — it does NOT cover dist.
-			// Without this, compiled test files left in dist (tsc never deletes orphaned
-			// output) get collected and fail (CJS `require('vitest')`). The build also
-			// excludes test files now, but this guards against pre-existing stale artifacts.
-			exclude: [...configDefaults.exclude, '**/dist/**'],
-		},
+export default mergeConfig(createVitestConfigWithDecorators({}), {
+	plugins: [tscDecoratorTransform()],
+	test: {
+		// Vitest 4's default exclude is only node_modules/.git — it does NOT cover dist.
+		// Without this, compiled test files left in dist (tsc never deletes orphaned
+		// output) get collected and fail (CJS `require('vitest')`). The build also
+		// excludes test files now, but this guards against pre-existing stale artifacts.
+		exclude: [...configDefaults.exclude, '**/dist/**'],
 	},
-);
+});

--- a/packages/@n8n/instance-ai/vite.config.ts
+++ b/packages/@n8n/instance-ai/vite.config.ts
@@ -84,29 +84,22 @@ function rewriteLazyRequireForTests(): Plugin {
 	};
 }
 
-export default mergeConfig(
-	createVitestConfig({
-		// Parity with the previous root Jest config, which set `restoreMocks: true`.
-		// Most test files rely on mocks being restored automatically between tests.
-		restoreMocks: true,
-	}),
-	{
-		plugins: [rewriteLazyRequireForTests()],
-		resolve: {
-			alias: [
-				{ find: '@', replacement: path.resolve(__dirname, './src') },
-				// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
-				// Workspace deps CJS-require zod while test files ESM-import it, so
-				// `instanceof` checks (e.g. in sanitize-mcp-schemas) fail across the two
-				// module instances. Pin the top-level `zod` import to the CJS file so all
-				// code paths share one instance. `require.resolve` follows zod's `require`
-				// export condition, so it tracks the installed (catalog) version
-				// automatically. Subpaths like `zod/v4` resolve normally.
-				{
-					find: /^zod$/,
-					replacement: require.resolve('zod'),
-				},
-			],
-		},
+export default mergeConfig(createVitestConfig({}), {
+	plugins: [rewriteLazyRequireForTests()],
+	resolve: {
+		alias: [
+			{ find: '@', replacement: path.resolve(__dirname, './src') },
+			// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
+			// Workspace deps CJS-require zod while test files ESM-import it, so
+			// `instanceof` checks (e.g. in sanitize-mcp-schemas) fail across the two
+			// module instances. Pin the top-level `zod` import to the CJS file so all
+			// code paths share one instance. `require.resolve` follows zod's `require`
+			// export condition, so it tracks the installed (catalog) version
+			// automatically. Subpaths like `zod/v4` resolve normally.
+			{
+				find: /^zod$/,
+				replacement: require.resolve('zod'),
+			},
+		],
 	},
-);
+});

--- a/packages/@n8n/local-gateway/vite.config.ts
+++ b/packages/@n8n/local-gateway/vite.config.ts
@@ -1,5 +1,3 @@
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
-export default createVitestConfig({
-	restoreMocks: true,
-});
+export default createVitestConfig();

--- a/packages/@n8n/mcp-browser/vite.config.ts
+++ b/packages/@n8n/mcp-browser/vite.config.ts
@@ -1,6 +1,5 @@
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
 export default createVitestConfig({
-	restoreMocks: true,
 	testTimeout: 30_000,
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClient/__test__/McpClient.node.test.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mock, mockDeep } from 'vitest-mock-extended';
 
 import * as sharedUtils from '../../shared/utils';
@@ -8,8 +9,8 @@ import { McpClient } from '../McpClient.node';
 import { getToolParameters } from '../resourceMapping';
 
 describe('McpClient', () => {
-	const mapToNodeOperationError = vi.spyOn(sharedUtils, 'mapToNodeOperationError');
-	const connectMcpClientForCredential = vi.spyOn(sharedUtils, 'connectMcpClientForCredential');
+	let mapToNodeOperationError: MockInstance;
+	let connectMcpClientForCredential: MockInstance;
 	const executeFunctions = mockDeep<IExecuteFunctions>();
 	const client = mockDeep<Client>();
 	const defaultParams = {
@@ -24,6 +25,9 @@ describe('McpClient', () => {
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+
+		mapToNodeOperationError = vi.spyOn(sharedUtils, 'mapToNodeOperationError');
+		connectMcpClientForCredential = vi.spyOn(sharedUtils, 'connectMcpClientForCredential');
 
 		executeFunctions.getNode.mockReturnValue({
 			id: '123',

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/Anthropic.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/Anthropic.node.test.ts
@@ -1,4 +1,5 @@
 import type { IExecuteFunctions, IBinaryData } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as helpers from '@utils/helpers';
@@ -13,14 +14,19 @@ import * as transport from './transport';
 
 describe('Anthropic Node', () => {
 	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
-	const getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
-	const downloadFileMock = vi.spyOn(utils, 'downloadFile');
-	const uploadFileMock = vi.spyOn(utils, 'uploadFile');
-	const getBaseUrlMock = vi.spyOn(utils, 'getBaseUrl');
+	let apiRequestMock: MockInstance;
+	let getConnectedToolsMock: MockInstance;
+	let downloadFileMock: MockInstance;
+	let uploadFileMock: MockInstance;
+	let getBaseUrlMock: MockInstance;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
+		getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
+		downloadFileMock = vi.spyOn(utils, 'downloadFile');
+		uploadFileMock = vi.spyOn(utils, 'uploadFile');
+		getBaseUrlMock = vi.spyOn(utils, 'getBaseUrl');
 	});
 
 	describe('Text -> Message', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/router.test.ts
@@ -1,5 +1,5 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
-import type { Mock } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as document from './document';
@@ -11,45 +11,54 @@ import * as text from './text';
 
 describe('Anthropic router', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const mockDocument = vi.spyOn(document.analyze, 'execute');
-	const mockFile = vi.spyOn(file.upload, 'execute');
-	const mockImage = vi.spyOn(image.analyze, 'execute');
-	const mockPrompt = vi.spyOn(prompt.generate, 'execute');
-	const mockText = vi.spyOn(text.message, 'execute');
-	const operationMocks = [
-		[mockDocument, 'document', 'analyze'],
-		[mockFile, 'file', 'upload'],
-		[mockImage, 'image', 'analyze'],
-		[mockText, 'text', 'message'],
-		[mockPrompt, 'prompt', 'generate'],
+	let mockDocument: MockInstance;
+	let mockFile: MockInstance;
+	let mockImage: MockInstance;
+	let mockPrompt: MockInstance;
+	let mockText: MockInstance;
+	const operationMocks: Array<[() => MockInstance, string, string]> = [
+		[() => mockDocument, 'document', 'analyze'],
+		[() => mockFile, 'file', 'upload'],
+		[() => mockImage, 'image', 'analyze'],
+		[() => mockText, 'text', 'message'],
+		[() => mockPrompt, 'prompt', 'generate'],
 	];
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mockDocument = vi.spyOn(document.analyze, 'execute');
+		mockFile = vi.spyOn(file.upload, 'execute');
+		mockImage = vi.spyOn(image.analyze, 'execute');
+		mockPrompt = vi.spyOn(prompt.generate, 'execute');
+		mockText = vi.spyOn(text.message, 'execute');
 	});
 
-	it.each(operationMocks)('should call the correct method', async (mock, resource, operation) => {
-		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
-			parameter === 'resource' ? resource : operation,
-		);
-		mockExecuteFunctions.getInputData.mockReturnValue([
-			{
-				json: {},
-			},
-		]);
-		(mock as Mock).mockResolvedValue([
-			{
-				json: {
-					foo: 'bar',
+	it.each(operationMocks)(
+		'should call the correct method',
+		async (getMock, resource, operation) => {
+			const mock = getMock();
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
+				parameter === 'resource' ? resource : operation,
+			);
+			mockExecuteFunctions.getInputData.mockReturnValue([
+				{
+					json: {},
 				},
-			},
-		]);
+			]);
+			(mock as Mock).mockResolvedValue([
+				{
+					json: {
+						foo: 'bar',
+					},
+				},
+			]);
 
-		const result = await router.call(mockExecuteFunctions);
+			const result = await router.call(mockExecuteFunctions);
 
-		expect(mock).toHaveBeenCalledWith(0);
-		expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
-	});
+			expect(mock).toHaveBeenCalledWith(0);
+			expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
+		},
+	);
 
 	it('should return an error if the operation is not supported', async () => {
 		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/helpers/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/helpers/utils.test.ts
@@ -1,4 +1,5 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import { downloadFile, getBaseUrl, getMimeType, splitByComma, uploadFile } from './utils';
@@ -6,10 +7,11 @@ import * as transport from '../transport';
 
 describe('Anthropic -> utils', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
+	let apiRequestMock: MockInstance;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
 	});
 
 	describe('getMimeType', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/methods/listSearch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/methods/listSearch.test.ts
@@ -1,4 +1,5 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { modelSearch } from './listSearch';
@@ -17,10 +18,11 @@ const mockResponse = {
 
 describe('Anthropic -> listSearch', () => {
 	const mockExecuteFunctions = mock<ILoadOptionsFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
+	let apiRequestMock: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
 	});
 
 	describe('modelSearch', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/GoogleGemini.node.test.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, IBinaryData, INode } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as helpers from '@utils/helpers';
@@ -14,14 +15,19 @@ import * as transport from './transport';
 
 describe('GoogleGemini Node', () => {
 	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
-	const getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
-	const downloadFileMock = vi.spyOn(utils, 'downloadFile');
-	const uploadFileMock = vi.spyOn(utils, 'uploadFile');
-	const transferFileMock = vi.spyOn(utils, 'transferFile');
+	let apiRequestMock: MockInstance;
+	let getConnectedToolsMock: MockInstance;
+	let downloadFileMock: MockInstance;
+	let uploadFileMock: MockInstance;
+	let transferFileMock: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
+		getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
+		downloadFileMock = vi.spyOn(utils, 'downloadFile');
+		uploadFileMock = vi.spyOn(utils, 'uploadFile');
+		transferFileMock = vi.spyOn(utils, 'transferFile');
 		executeFunctionsMock.getNode.mockReturnValue({ typeVersion: 1 } as INode);
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/router.test.ts
@@ -1,5 +1,5 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
-import type { Mock } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as audio from './audio';
@@ -13,55 +13,69 @@ import * as video from './video';
 
 describe('Google Gemini router', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const mockAudio = vi.spyOn(audio.analyze, 'execute');
-	const mockDocument = vi.spyOn(document.analyze, 'execute');
-	const mockFile = vi.spyOn(file.upload, 'execute');
-	const mockFileSearchCreateStore = vi.spyOn(fileSearch.createStore, 'execute');
-	const mockFileSearchDeleteStore = vi.spyOn(fileSearch.deleteStore, 'execute');
-	const mockFileSearchListStores = vi.spyOn(fileSearch.listStores, 'execute');
-	const mockFileSearchUploadToStore = vi.spyOn(fileSearch.uploadToStore, 'execute');
-	const mockImage = vi.spyOn(image.analyze, 'execute');
-	const mockText = vi.spyOn(text.message, 'execute');
-	const mockVideo = vi.spyOn(video.analyze, 'execute');
-	const operationMocks = [
-		[mockAudio, 'audio', 'analyze'],
-		[mockDocument, 'document', 'analyze'],
-		[mockFile, 'file', 'upload'],
-		[mockFileSearchCreateStore, 'fileSearch', 'createStore'],
-		[mockFileSearchDeleteStore, 'fileSearch', 'deleteStore'],
-		[mockFileSearchListStores, 'fileSearch', 'listStores'],
-		[mockFileSearchUploadToStore, 'fileSearch', 'uploadToStore'],
-		[mockImage, 'image', 'analyze'],
-		[mockText, 'text', 'message'],
-		[mockVideo, 'video', 'analyze'],
+	let mockAudio: MockInstance;
+	let mockDocument: MockInstance;
+	let mockFile: MockInstance;
+	let mockFileSearchCreateStore: MockInstance;
+	let mockFileSearchDeleteStore: MockInstance;
+	let mockFileSearchListStores: MockInstance;
+	let mockFileSearchUploadToStore: MockInstance;
+	let mockImage: MockInstance;
+	let mockText: MockInstance;
+	let mockVideo: MockInstance;
+	const operationMocks: Array<[() => MockInstance, string, string]> = [
+		[() => mockAudio, 'audio', 'analyze'],
+		[() => mockDocument, 'document', 'analyze'],
+		[() => mockFile, 'file', 'upload'],
+		[() => mockFileSearchCreateStore, 'fileSearch', 'createStore'],
+		[() => mockFileSearchDeleteStore, 'fileSearch', 'deleteStore'],
+		[() => mockFileSearchListStores, 'fileSearch', 'listStores'],
+		[() => mockFileSearchUploadToStore, 'fileSearch', 'uploadToStore'],
+		[() => mockImage, 'image', 'analyze'],
+		[() => mockText, 'text', 'message'],
+		[() => mockVideo, 'video', 'analyze'],
 	];
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockAudio = vi.spyOn(audio.analyze, 'execute');
+		mockDocument = vi.spyOn(document.analyze, 'execute');
+		mockFile = vi.spyOn(file.upload, 'execute');
+		mockFileSearchCreateStore = vi.spyOn(fileSearch.createStore, 'execute');
+		mockFileSearchDeleteStore = vi.spyOn(fileSearch.deleteStore, 'execute');
+		mockFileSearchListStores = vi.spyOn(fileSearch.listStores, 'execute');
+		mockFileSearchUploadToStore = vi.spyOn(fileSearch.uploadToStore, 'execute');
+		mockImage = vi.spyOn(image.analyze, 'execute');
+		mockText = vi.spyOn(text.message, 'execute');
+		mockVideo = vi.spyOn(video.analyze, 'execute');
 	});
 
-	it.each(operationMocks)('should call the correct method', async (mock, resource, operation) => {
-		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
-			parameter === 'resource' ? resource : operation,
-		);
-		mockExecuteFunctions.getInputData.mockReturnValue([
-			{
-				json: {},
-			},
-		]);
-		(mock as Mock).mockResolvedValue([
-			{
-				json: {
-					foo: 'bar',
+	it.each(operationMocks)(
+		'should call the correct method',
+		async (getMock, resource, operation) => {
+			const mock = getMock();
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
+				parameter === 'resource' ? resource : operation,
+			);
+			mockExecuteFunctions.getInputData.mockReturnValue([
+				{
+					json: {},
 				},
-			},
-		]);
+			]);
+			(mock as Mock).mockResolvedValue([
+				{
+					json: {
+						foo: 'bar',
+					},
+				},
+			]);
 
-		const result = await router.call(mockExecuteFunctions);
+			const result = await router.call(mockExecuteFunctions);
 
-		expect(mock).toHaveBeenCalledWith(0);
-		expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
-	});
+			expect(mock).toHaveBeenCalledWith(0);
+			expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
+		},
+	);
 
 	it('should return an error if the operation is not supported', async () => {
 		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/helpers/utils.test.ts
@@ -1,5 +1,6 @@
 import type { IBinaryData, IExecuteFunctions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import {
@@ -16,11 +17,12 @@ import * as transport from '../transport';
 
 describe('GoogleGemini -> utils', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
+	let apiRequestMock: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers({ shouldAdvanceTime: true });
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
 	});
 
 	describe('getFilenameFromMimeType', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/methods/listSearch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/methods/listSearch.test.ts
@@ -1,4 +1,5 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import {
@@ -53,10 +54,11 @@ const mockResponse = {
 
 describe('GoogleGemini -> listSearch', () => {
 	const mockExecuteFunctions = mock<ILoadOptionsFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
+	let apiRequestMock: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
 	});
 
 	describe('modelSearch', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Moonshot/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Moonshot/actions/router.test.ts
@@ -1,5 +1,5 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
-import type { Mock } from 'vitest';
+import type { Mock, MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as image from './image';
@@ -8,29 +8,35 @@ import * as text from './text';
 
 describe('Moonshot router', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const mockImage = vi.spyOn(image.analyze, 'execute');
-	const mockText = vi.spyOn(text.message, 'execute');
-	const operationMocks = [
-		[mockImage, 'image', 'analyze'],
-		[mockText, 'text', 'message'],
+	let mockImage: MockInstance;
+	let mockText: MockInstance;
+	const operationMocks: Array<[() => MockInstance, string, string]> = [
+		[() => mockImage, 'image', 'analyze'],
+		[() => mockText, 'text', 'message'],
 	];
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		mockImage = vi.spyOn(image.analyze, 'execute');
+		mockText = vi.spyOn(text.message, 'execute');
 	});
 
-	it.each(operationMocks)('should call the correct method', async (mock, resource, operation) => {
-		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
-			parameter === 'resource' ? resource : operation,
-		);
-		mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
-		(mock as Mock).mockResolvedValue([{ json: { foo: 'bar' } }]);
+	it.each(operationMocks)(
+		'should call the correct method',
+		async (getMock, resource, operation) => {
+			const mock = getMock();
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>
+				parameter === 'resource' ? resource : operation,
+			);
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+			(mock as Mock).mockResolvedValue([{ json: { foo: 'bar' } }]);
 
-		const result = await router.call(mockExecuteFunctions);
+			const result = await router.call(mockExecuteFunctions);
 
-		expect(mock).toHaveBeenCalledWith(0);
-		expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
-	});
+			expect(mock).toHaveBeenCalledWith(0);
+			expect(result).toEqual([[{ json: { foo: 'bar' } }]]);
+		},
+	);
 
 	it('should return an error if the resource is not supported', async () => {
 		mockExecuteFunctions.getNodeParameter.mockImplementation((parameter) =>

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/Ollama.node.test.ts
@@ -1,4 +1,5 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { z } from 'zod';
 
@@ -11,11 +12,13 @@ import * as transport from './transport';
 
 describe('Ollama Node', () => {
 	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
-	const getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
+	let apiRequestMock: MockInstance;
+	let getConnectedToolsMock: MockInstance;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
+		getConnectedToolsMock = vi.spyOn(helpers, 'getConnectedTools');
 	});
 
 	describe('Text -> Message', () => {
@@ -140,7 +143,6 @@ describe('Ollama Node', () => {
 				}
 			});
 			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }, { type: 'ai_tool' }]);
-			// @ts-expect-error: Mocking a tool, we do not implement the full interface
 			getConnectedToolsMock.mockResolvedValue([mockTool]);
 
 			apiRequestMock.mockResolvedValueOnce({
@@ -203,7 +205,6 @@ describe('Ollama Node', () => {
 				}
 			});
 			executeFunctionsMock.getNodeInputs.mockReturnValue([{ type: 'main' }, { type: 'ai_tool' }]);
-			// @ts-expect-error: Mocking a tool, we do not implement the full interface
 			getConnectedToolsMock.mockResolvedValue([mockTool]);
 
 			apiRequestMock.mockResolvedValueOnce({

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/methods/listSearch.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Ollama/methods/listSearch.test.ts
@@ -1,4 +1,5 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as transport from '../transport';
@@ -6,10 +7,11 @@ import { modelSearch } from './listSearch';
 
 describe('Ollama List Search Methods', () => {
 	const loadOptionsFunctionsMock = mockDeep<ILoadOptionsFunctions>();
-	const apiRequestMock = vi.spyOn(transport, 'apiRequest');
+	let apiRequestMock: MockInstance;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		apiRequestMock = vi.spyOn(transport, 'apiRequest');
 	});
 
 	describe('modelSearch', () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/classify.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/test/v2/actions/text/classify.operation.test.ts
@@ -1,4 +1,5 @@
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as transport from '../../../../transport';
@@ -14,10 +15,11 @@ describe('OpenAI Classify Operation', () => {
 		position: [0, 0],
 		parameters: {},
 	} as INode;
-	const apiRequestSpy = vi.spyOn(transport, 'apiRequest');
+	let apiRequestSpy: MockInstance;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
+		apiRequestSpy = vi.spyOn(transport, 'apiRequest');
 	});
 
 	it('should use omni-moderation-latest model when version is 2.1', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v1/actions/router.test.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as audio from './audio';
@@ -7,10 +8,11 @@ import { router } from './router';
 
 describe('OpenAI router', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const mockAudio = vi.spyOn(audio.transcribe, 'execute');
+	let mockAudio: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockAudio = vi.spyOn(audio.transcribe, 'execute');
 	});
 
 	it('should handle NodeApiError undefined error chaining', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/router.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/v2/actions/router.test.ts
@@ -1,5 +1,6 @@
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import * as audio from './audio';
@@ -7,10 +8,11 @@ import { router } from './router';
 
 describe('OpenAI router', () => {
 	const mockExecuteFunctions = mockDeep<IExecuteFunctions>();
-	const mockAudio = vi.spyOn(audio.transcribe, 'execute');
+	let mockAudio: MockInstance;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockAudio = vi.spyOn(audio.transcribe, 'execute');
 	});
 
 	it('should handle NodeApiError undefined error chaining', async () => {

--- a/packages/@n8n/task-runner/vite.config.ts
+++ b/packages/@n8n/task-runner/vite.config.ts
@@ -4,7 +4,6 @@ import { mergeConfig } from 'vite';
 
 export default mergeConfig(
 	createVitestConfigWithDecorators({
-		restoreMocks: true,
 		testTimeout: 10_000,
 	}),
 	{

--- a/packages/@n8n/vitest-config/frontend.ts
+++ b/packages/@n8n/vitest-config/frontend.ts
@@ -8,6 +8,9 @@ export const createVitestConfig = (options: InlineConfig = {}) => {
 		test: {
 			silent: true,
 			globals: true,
+			// Restore `vi.spyOn` spies to their original implementation before each test, so
+			// spies set up once don't leak across tests. Packages may override via `options`.
+			restoreMocks: true,
 			environment: 'jsdom',
 			setupFiles: ['./src/__tests__/setup.ts'],
 			reporters: process.env.CI === 'true' ? ['default', 'junit'] : ['default'],

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -29,6 +29,9 @@ export const forkPoolOptions = (): InlineConfig => {
 export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig => ({
 	silent: true,
 	globals: true,
+	// Restore `vi.spyOn` spies to their original implementation before each test, so
+	// spies set up once don't leak across tests. Packages may override via `options`.
+	restoreMocks: true,
 	environment: 'node',
 	...forkPoolOptions(),
 	reporters: process.env.CI === 'true' ? ['default', 'junit'] : ['default'],

--- a/packages/@n8n/workflow-sdk/vitest.config.ts
+++ b/packages/@n8n/workflow-sdk/vitest.config.ts
@@ -1,7 +1,5 @@
 import { createVitestConfig } from '@n8n/vitest-config/node';
 
 export default createVitestConfig({
-	// The n8n root jest.config sets `restoreMocks: true`, and the test files rely on it.
-	restoreMocks: true,
 	globalSetup: ['./scripts/vitest-global-setup.ts'],
 });

--- a/packages/cli/vitest.config.base.ts
+++ b/packages/cli/vitest.config.base.ts
@@ -24,34 +24,25 @@ const alias = {
  * variant configs (`vitest.config.*.ts`) merge their own `include`/pool tweaks
  * on top of this.
  */
-export const baseConfig = mergeConfig(
-	createVitestConfigWithDecorators({
-		restoreMocks: true,
-	}),
-	{
-		// `workspaceDistExternals` must run before `tscEntityTransform`: once a
-		// workspace package is externalized to its built dist, the entity transform
-		// (which only targets first-party `src/**/*.entity.ts`) never sees it.
-		plugins: [workspaceDistExternals(), tscEntityTransform()],
-		resolve: { alias },
-		test: {
-			// Run each test file in its own forked process.
-			// This is load-bearing: cli tests register service
-			// mocks into the `@n8n/di` Container (`mockInstance`), and a shared worker
-			// would leak that state across files.
-			pool: 'forks',
-			globalSetup: ['./test/global-setup.ts'],
-			setupFiles: [
-				'./test/setup-test-folder.ts',
-				'./test/setup-mocks.ts',
-				'./test/extend-expect.ts',
-			],
-			// Vitest's default exclude does not cover dist; compiled test files left in
-			// dist would otherwise be collected and fail as CJS.
-			exclude: [...configDefaults.exclude, '**/dist/**'],
-			coverage: {
-				exclude: ['src/databases/migrations/**', ...(configDefaults.coverage.exclude ?? [])],
-			},
+export const baseConfig = mergeConfig(createVitestConfigWithDecorators(), {
+	// `workspaceDistExternals` must run before `tscEntityTransform`: once a
+	// workspace package is externalized to its built dist, the entity transform
+	// (which only targets first-party `src/**/*.entity.ts`) never sees it.
+	plugins: [workspaceDistExternals(), tscEntityTransform()],
+	resolve: { alias },
+	test: {
+		// Run each test file in its own forked process.
+		// This is load-bearing: cli tests register service
+		// mocks into the `@n8n/di` Container (`mockInstance`), and a shared worker
+		// would leak that state across files.
+		pool: 'forks',
+		globalSetup: ['./test/global-setup.ts'],
+		setupFiles: ['./test/setup-test-folder.ts', './test/setup-mocks.ts', './test/extend-expect.ts'],
+		// Vitest's default exclude does not cover dist; compiled test files left in
+		// dist would otherwise be collected and fail as CJS.
+		exclude: [...configDefaults.exclude, '**/dist/**'],
+		coverage: {
+			exclude: ['src/databases/migrations/**', ...(configDefaults.coverage.exclude ?? [])],
 		},
 	},
-);
+});

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -11,6 +11,7 @@ import { useRBACStore } from '@/app/stores/rbac.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import type { Scope } from '@n8n/permissions';
 import type { RouteRecordName } from 'vue-router';
+import type { MockInstance } from 'vitest';
 import * as init from '@/app/init';
 
 const App = {
@@ -22,7 +23,8 @@ let settingsStore: ReturnType<typeof useSettingsStore>;
 
 describe('router', () => {
 	let server: ReturnType<typeof setupServer>;
-	const initializeAuthenticatedFeaturesSpy = vi.spyOn(init, 'initializeAuthenticatedFeatures');
+	// `restoreMocks` restores this spy before each test, so it is re-created in beforeEach.
+	let initializeAuthenticatedFeaturesSpy: MockInstance;
 
 	beforeAll(async () => {
 		server = setupServer();
@@ -33,13 +35,22 @@ describe('router', () => {
 		renderComponent({ pinia });
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		settingsStore = useSettingsStore();
 		const usersStore = useUsersStore();
-		initializeAuthenticatedFeaturesSpy.mockImplementation(async () => {
-			await usersStore.initialize();
-		});
-	});
+		initializeAuthenticatedFeaturesSpy = vi
+			.spyOn(init, 'initializeAuthenticatedFeatures')
+			.mockImplementation(async () => {
+				await usersStore.initialize();
+			});
+		// Reset to a neutral route (an id no test targets) so each test's push is a
+		// real navigation that triggers the guard. `restoreMocks` clears call history
+		// per test, so a duplicate navigation (e.g. the '/' → '/workflows' redirect
+		// leaving us at '/workflows') would otherwise record zero calls and fail the
+		// toHaveBeenCalled assertion.
+		await router.replace('/workflow/router-test-reset');
+		initializeAuthenticatedFeaturesSpy.mockClear();
+	}, 20000);
 
 	afterAll(() => {
 		server.shutdown();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, type MockInstance } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import {
 	useChatPanelStore,
@@ -49,16 +49,11 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 let settingsStore: ReturnType<typeof useSettingsStore>;
 let posthogStore: ReturnType<typeof usePostHog>;
 
-const apiSpy = vi.spyOn(chatAPI, 'chatWithAssistant');
+// `restoreMocks` restores spies before each test, so these are (re)established
+// in beforeEach rather than once at module scope.
+let apiSpy: MockInstance;
 
 const track = vi.fn();
-const spy = vi.spyOn(telemetryModule, 'useTelemetry');
-spy.mockImplementation(
-	() =>
-		({
-			track,
-		}) as unknown as Telemetry,
-);
 
 const setAssistantEnabled = (enabled: boolean) => {
 	settingsStore.setSettings(
@@ -85,6 +80,10 @@ vi.mock('vue-router', () => ({
 describe('AI Assistant store', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		apiSpy = vi.spyOn(chatAPI, 'chatWithAssistant');
+		vi.spyOn(telemetryModule, 'useTelemetry').mockImplementation(
+			() => ({ track }) as unknown as Telemetry,
+		);
 		currentRouteParams = {};
 		mockWorkflowDocumentStore.allNodes = [];
 		setActivePinia(createPinia());

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -120,16 +120,11 @@ let pinia: ReturnType<typeof createTestingPinia>;
 let getNodeTypeSpy: Mock;
 let getCredentialsByTypeSpy: Mock;
 
-const apiSpy = vi.spyOn(chatAPI, 'chatWithBuilder');
+// `restoreMocks` restores spies before each test, so these are (re)established
+// in beforeEach rather than once at module scope.
+let apiSpy: MockInstance;
 
 const track = vi.fn();
-const spy = vi.spyOn(telemetryModule, 'useTelemetry');
-spy.mockImplementation(
-	() =>
-		({
-			track,
-		}) as unknown as Telemetry,
-);
 
 const currentRouteName = ENABLED_VIEWS[0];
 vi.mock('vue-router', () => ({
@@ -177,6 +172,11 @@ describe('AI Builder store', () => {
 		posthogStore = usePostHog();
 		posthogStore.init();
 		track.mockReset();
+
+		apiSpy = vi.spyOn(chatAPI, 'chatWithBuilder');
+		vi.spyOn(telemetryModule, 'useTelemetry').mockImplementation(
+			() => ({ track }) as unknown as Telemetry,
+		);
 
 		workflowsStore = mockedStore(useWorkflowsStore);
 		nodeTypesStore = mockedStore(useNodeTypesStore);
@@ -1307,10 +1307,11 @@ describe('AI Builder store', () => {
 	});
 
 	describe('fetchBuilderCredits', () => {
-		const mockGetBuilderCredits = vi.spyOn(chatAPI, 'getBuilderCredits');
+		// `restoreMocks` restores this spy before each test, so re-create it here.
+		let mockGetBuilderCredits: MockInstance;
 
 		beforeEach(() => {
-			mockGetBuilderCredits.mockClear();
+			mockGetBuilderCredits = vi.spyOn(chatAPI, 'getBuilderCredits');
 		});
 
 		it('should fetch and update credits when AI builder is enabled', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.test.ts
@@ -18,12 +18,6 @@ import type { INodeUi } from '@/Interface';
 
 // Mock telemetry
 const track = vi.fn();
-vi.spyOn(telemetryModule, 'useTelemetry').mockImplementation(
-	() =>
-		({
-			track,
-		}) as unknown as Telemetry,
-);
 
 // Mock posthog
 let featureEnabled = true;
@@ -65,6 +59,10 @@ describe('useFocusedNodesStore', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// `restoreMocks` restores this spy before each test, so re-establish it here.
+		vi.spyOn(telemetryModule, 'useTelemetry').mockImplementation(
+			() => ({ track }) as unknown as Telemetry,
+		);
 		featureEnabled = true;
 
 		setActivePinia(

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.test.ts
@@ -33,7 +33,8 @@ import type { VNode } from 'vue';
 
 const WAIT_NODE_TYPE = 'waitNode';
 
-const windowOpenSpy = vi.spyOn(window, 'open');
+// `restoreMocks` restores spies before each test, so this is (re)established in beforeEach.
+let windowOpenSpy: MockInstance;
 
 vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: () => ({
@@ -103,16 +104,11 @@ describe('displayForm', () => {
 		ok: true,
 	} as unknown as Response;
 
-	beforeAll(() => {
-		fetchMock = vi.spyOn(global, 'fetch');
-	});
-
-	afterAll(() => {
-		fetchMock.mockRestore();
-	});
-
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// `restoreMocks` restores spies before each test, so re-establish them here.
+		windowOpenSpy = vi.spyOn(window, 'open');
+		fetchMock = vi.spyOn(global, 'fetch');
 	});
 
 	it('should not call openPopUpWindow if node has already run or is pinned', async () => {

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
@@ -83,7 +83,8 @@ describe('useContextMenu', () => {
 	const selectedNodes = nodes.slice(0, 2);
 	const testWorkflowId = 'test-workflow-id';
 
-	beforeAll(() => {
+	// `restoreMocks` restores spies before each test, so re-establish them per-test.
+	beforeEach(() => {
 		setActivePinia(createPinia());
 		sourceControlStore = useSourceControlStore();
 		vi.spyOn(sourceControlStore, 'preferences', 'get').mockReturnValue({

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
@@ -64,7 +64,8 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 }));
 
 describe('viewsData', () => {
-	beforeAll(() => {
+	// `restoreMocks` restores spies before each test, so re-establish them per-test.
+	beforeEach(() => {
 		setActivePinia(createTestingPinia());
 
 		const templatesStore = useTemplatesStore();

--- a/packages/nodes-base/vite.config.ts
+++ b/packages/nodes-base/vite.config.ts
@@ -8,7 +8,6 @@ process.env.TZ = 'UTC';
 
 export default mergeConfig(
 	createVitestConfigWithDecorators({
-		restoreMocks: true,
 		globalSetup: ['./test/globalSetup.ts'],
 		setupFiles: ['./test/setup.ts'],
 		exclude: ['**/node_modules/**', '**/dist/**', '**/*.integration.test.ts'],


### PR DESCRIPTION
## Summary

Sets `restoreMocks: true` in the shared base vitest configs
(`@n8n/vitest-config` `node.ts` + `frontend.ts`) so `vi.spyOn` spies are
restored to their original implementation before every test, across all
packages that consume the base config. Previously this was set ad-hoc in ~13
package configs (with several test files silently relying on it); making it the
default removes that duplication and gives every new package correct spy
hygiene for free.

**What changed**
- Enable `restoreMocks: true` in `@n8n/vitest-config/node.ts` and `frontend.ts`.
- Remove the now-redundant per-package `restoreMocks: true` overrides (and stale
  "the root jest.config sets restoreMocks" comments) from 13 packages: cli,
  nodes-base, db, task-runner, ai-utilities, agents, chat-hub, mcp-browser,
  computer-use, workflow-sdk, instance-ai, ai-workflow-builder.ee, local-gateway.
- Fix the test files that set up a `vi.spyOn(...)` once (at module/describe/`beforeAll`
  scope) and relied on it across tests — the only pattern that breaks under
  `restoreMocks`. The fix is uniform: move the spy into `beforeEach` (using
  `let x: MockInstance` when it's referenced in assertions).
  - `@n8n/nodes-langchain` — 15 vendor test files (Anthropic, GoogleGemini,
    Ollama, Moonshot, OpenAi, McpClient).
  - `editor-ui` — 7 files (builder/assistant/focusedNodes stores, router,
    useContextMenu, viewsData, executions.utils).
  - `@n8n/config` — 1 file (a module-scope `console.warn` spy).

> [!NOTE]
> In vitest 4.x, `restoreMocks: true` restores **only `vi.spyOn` spies** — it does
> not wipe plain `vi.fn()` mocks (chained or construction form), `vitest-mock-extended`
> mocks, or `vi.mock` factories. So the migration surface was narrow and mechanical.

## How to test

Purely a test-infra change — no runtime/product behavior is affected. CI runs
the full suites. Locally:

```bash
# base config change takes effect after building the config package
pnpm --filter @n8n/vitest-config build

pnpm --filter @n8n/n8n-nodes-langchain test
pnpm --filter n8n-editor-ui test
pnpm --filter @n8n/config test
```

All green locally: editor-ui (915 files / 12,617 tests), nodes-langchain
(2,556), workflow-sdk (11,802), db (340), config (111). `typecheck` + `lint`
pass for the packages with test-file changes.

## Related Linear tickets, Github issues, and Community forum posts

_No associated Linear ticket — ad-hoc test-config cleanup._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

