### PR TITLE
fix(MCP Client Node): Don't send undefined token to mcp and include `resource` in token request

### DIFF
--- a/packages/@n8n/client-oauth2/src/credentials-flow.ts
+++ b/packages/@n8n/client-oauth2/src/credentials-flow.ts
@@ -10,6 +10,7 @@ interface CredentialsFlowBody {
 	client_secret?: string;
 	grant_type: 'client_credentials';
 	scope?: string;
+	resource?: string;
 	client_assertion_type?: string;
 	client_assertion?: string;
 }
@@ -33,6 +34,7 @@ export class CredentialsFlow {
 		const body: CredentialsFlowBody = {
 			grant_type: 'client_credentials',
 			...(options.additionalBodyProperties ?? {}),
+			...(options.resource ? { resource: options.resource } : {}),
 		};
 
 		if (options.scopes !== undefined) {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -106,33 +106,7 @@ describe('utils', () => {
 			expect(ctx.helpers.refreshOAuth2Token).not.toHaveBeenCalled();
 		});
 
-		it('should fetch an initial token for mcpOAuth2Api client credentials with stub token data', async () => {
-			const ctx = mockDeep<IExecuteFunctions>();
-			const credentials = {
-				clientId: 'client-id',
-				clientSecret: 'client-secret',
-				accessTokenUrl: 'https://auth.example.com/token',
-				grantType: 'clientCredentials',
-				authentication: 'header',
-				useDynamicClientRegistration: false,
-				resourceUrl: 'https://mcp.example.com/',
-				oauthTokenData: { resource: 'https://mcp.example.com/' },
-			};
-			ctx.getCredentials.mockResolvedValue(credentials);
-			ctx.helpers.refreshOAuth2Token.mockResolvedValue({
-				access_token: 'fresh-access-token',
-			});
-
-			const result = await getAuthHeaders(ctx, 'mcpOAuth2Api');
-
-			expect(ctx.helpers.refreshOAuth2Token.mock.calls).toContainEqual(['mcpOAuth2Api']);
-			expect(result).toEqual({
-				headers: { Authorization: 'Bearer fresh-access-token' },
-				credentials,
-			});
-		});
-
-		it('should not send an undefined bearer token when the initial mcpOAuth2Api refresh fails', async () => {
+		it('should not send an undefined bearer token when mcpOAuth2Api token data is empty', async () => {
 			const ctx = mockDeep<IExecuteFunctions>();
 			const credentials = {
 				clientId: 'client-id',
@@ -145,11 +119,10 @@ describe('utils', () => {
 				oauthTokenData: {},
 			};
 			ctx.getCredentials.mockResolvedValue(credentials);
-			ctx.helpers.refreshOAuth2Token.mockRejectedValue(new Error('Failed to fetch token'));
 
 			const result = await getAuthHeaders(ctx, 'mcpOAuth2Api');
 
-			expect(ctx.helpers.refreshOAuth2Token.mock.calls).toContainEqual(['mcpOAuth2Api']);
+			expect(ctx.helpers.refreshOAuth2Token).not.toHaveBeenCalled();
 			expect(result).toEqual({ credentials });
 			expect(result.headers?.Authorization).not.toBe('Bearer undefined');
 		});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -127,6 +127,27 @@ describe('utils', () => {
 			expect(result.headers?.Authorization).not.toBe('Bearer undefined');
 		});
 
+		it('should not set headers when mcpOAuth2Api token data is undefined', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			const credentials = {
+				clientId: 'client-id',
+				clientSecret: 'client-secret',
+				accessTokenUrl: 'https://auth.example.com/token',
+				grantType: 'clientCredentials',
+				authentication: 'header',
+				useDynamicClientRegistration: false,
+				resourceUrl: 'https://mcp.example.com/',
+				oauthTokenData: undefined,
+			};
+			ctx.getCredentials.mockResolvedValue(credentials);
+
+			const result = await getAuthHeaders(ctx, 'mcpOAuth2Api');
+
+			expect(ctx.helpers.refreshOAuth2Token).not.toHaveBeenCalled();
+			expect(result).toEqual({ credentials });
+			expect(result.headers).toBeUndefined();
+		});
+
 		it('should return the headers and credentials for headerAuth', async () => {
 			const ctx = mockDeep<IExecuteFunctions>();
 			const credentials = {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/__test__/utils.test.ts
@@ -103,6 +103,55 @@ describe('utils', () => {
 				headers: { Authorization: 'Bearer access-token' },
 				credentials,
 			});
+			expect(ctx.helpers.refreshOAuth2Token).not.toHaveBeenCalled();
+		});
+
+		it('should fetch an initial token for mcpOAuth2Api client credentials with stub token data', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			const credentials = {
+				clientId: 'client-id',
+				clientSecret: 'client-secret',
+				accessTokenUrl: 'https://auth.example.com/token',
+				grantType: 'clientCredentials',
+				authentication: 'header',
+				useDynamicClientRegistration: false,
+				resourceUrl: 'https://mcp.example.com/',
+				oauthTokenData: { resource: 'https://mcp.example.com/' },
+			};
+			ctx.getCredentials.mockResolvedValue(credentials);
+			ctx.helpers.refreshOAuth2Token.mockResolvedValue({
+				access_token: 'fresh-access-token',
+			});
+
+			const result = await getAuthHeaders(ctx, 'mcpOAuth2Api');
+
+			expect(ctx.helpers.refreshOAuth2Token.mock.calls).toContainEqual(['mcpOAuth2Api']);
+			expect(result).toEqual({
+				headers: { Authorization: 'Bearer fresh-access-token' },
+				credentials,
+			});
+		});
+
+		it('should not send an undefined bearer token when the initial mcpOAuth2Api refresh fails', async () => {
+			const ctx = mockDeep<IExecuteFunctions>();
+			const credentials = {
+				clientId: 'client-id',
+				clientSecret: 'client-secret',
+				accessTokenUrl: 'https://auth.example.com/token',
+				grantType: 'clientCredentials',
+				authentication: 'header',
+				useDynamicClientRegistration: false,
+				resourceUrl: 'https://mcp.example.com/',
+				oauthTokenData: {},
+			};
+			ctx.getCredentials.mockResolvedValue(credentials);
+			ctx.helpers.refreshOAuth2Token.mockRejectedValue(new Error('Failed to fetch token'));
+
+			const result = await getAuthHeaders(ctx, 'mcpOAuth2Api');
+
+			expect(ctx.helpers.refreshOAuth2Token.mock.calls).toContainEqual(['mcpOAuth2Api']);
+			expect(result).toEqual({ credentials });
+			expect(result.headers?.Authorization).not.toBe('Bearer undefined');
 		});
 
 		it('should return the headers and credentials for headerAuth', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -330,7 +330,7 @@ function createAuthFetch(
 }
 
 export async function getAuthHeaders(
-	ctx: IExecuteFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
+	ctx: Pick<IExecuteFunctions, 'getCredentials'>,
 	authentication: McpAuthenticationOption,
 ): Promise<{
 	headers?: Record<string, string>;
@@ -380,9 +380,9 @@ export async function getAuthHeaders(
 		}
 		case 'multipleHeadersAuth': {
 			const credentials = await ctx
-				.getCredentials<{ headers: { values: Array<{ name: string; value: string }> } }>(
-					'httpMultipleHeadersAuth',
-				)
+				.getCredentials<{
+					headers: { values: Array<{ name: string; value: string }> };
+				}>('httpMultipleHeadersAuth')
 				.catch(() => null);
 
 			if (!credentials) return {};

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -344,12 +344,7 @@ export async function getAuthHeaders(
 		if (!credentials) return {};
 
 		if (!credentials.oauthTokenData?.access_token) {
-			const refreshedHeaders = await tryRefreshOAuth2Token(ctx, authentication);
-
-			return {
-				...(refreshedHeaders ? { headers: refreshedHeaders } : {}),
-				credentials,
-			};
+			return { credentials };
 		}
 
 		return {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/utils.ts
@@ -1,6 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { fetchFollowingRedirects, proxyFetch } from '@n8n/ai-utilities';
 import type { ClientOAuth2TokenData } from '@n8n/client-oauth2';
 import type {
 	ICredentialDataDecryptedObject,
@@ -17,8 +18,6 @@ import {
 	createResultOk,
 	NodeOperationError,
 } from 'n8n-workflow';
-
-import { fetchFollowingRedirects, proxyFetch } from '@n8n/ai-utilities';
 
 import {
 	isMcpOAuth2Authentication,
@@ -206,13 +205,13 @@ export async function connectMcpClient({
 			await client.connect(transport);
 			return createResultOk(client);
 		} catch (error) {
-			const err = error instanceof Error ? error : new Error(String(error));
-			if ((signal && err.name === 'AbortError') || signal?.aborted) {
+			const connectionError = error instanceof Error ? error : new Error(String(error));
+			if ((signal && connectionError.name === 'AbortError') || signal?.aborted) {
 				if (onAbort && signal) {
 					signal.removeEventListener('abort', onAbort);
 					onAbort = undefined;
 				}
-				return createResultError({ type: 'cancelled', error: err });
+				return createResultError({ type: 'cancelled', error: connectionError });
 			}
 
 			// Clean up the abort listener so a failed client doesn't stay pinned to the execution signal
@@ -247,13 +246,13 @@ export async function connectMcpClient({
 		await client.connect(sseTransport);
 		return createResultOk(client);
 	} catch (error) {
-		const err = error instanceof Error ? error : new Error(String(error));
-		if ((signal && err.name === 'AbortError') || signal?.aborted) {
+		const connectionError = error instanceof Error ? error : new Error(String(error));
+		if ((signal && connectionError.name === 'AbortError') || signal?.aborted) {
 			if (onAbort && signal) {
 				signal.removeEventListener('abort', onAbort);
 				onAbort = undefined;
 			}
-			return createResultError({ type: 'cancelled', error: err });
+			return createResultError({ type: 'cancelled', error: connectionError });
 		}
 
 		// Clean up the abort listener so a failed client doesn't stay pinned to the execution signal
@@ -331,7 +330,7 @@ function createAuthFetch(
 }
 
 export async function getAuthHeaders(
-	ctx: Pick<IExecuteFunctions, 'getCredentials'>,
+	ctx: IExecuteFunctions | ILoadOptionsFunctions | ISupplyDataFunctions,
 	authentication: McpAuthenticationOption,
 ): Promise<{
 	headers?: Record<string, string>;
@@ -339,10 +338,19 @@ export async function getAuthHeaders(
 }> {
 	if (isMcpOAuth2Authentication(authentication)) {
 		const credentials = await ctx
-			.getCredentials<{ oauthTokenData: { access_token: string } }>(authentication)
+			.getCredentials<{ oauthTokenData?: { access_token?: string } }>(authentication)
 			.catch(() => null);
 
 		if (!credentials) return {};
+
+		if (!credentials.oauthTokenData?.access_token) {
+			const refreshedHeaders = await tryRefreshOAuth2Token(ctx, authentication);
+
+			return {
+				...(refreshedHeaders ? { headers: refreshedHeaders } : {}),
+				credentials,
+			};
+		}
 
 		return {
 			headers: { Authorization: `Bearer ${credentials.oauthTokenData.access_token}` },

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -5110,7 +5110,10 @@ describe('OauthService', () => {
 			await service.refreshOAuth2CredentialById(credentialId, projectId);
 
 			expect(service.encryptAndSaveData).toHaveBeenCalledWith(credential, {
-				oauthTokenData: refreshedData,
+				oauthTokenData: {
+					refresh_token: 'refresh-tok',
+					...refreshedData,
+				},
 			});
 		});
 
@@ -5139,6 +5142,42 @@ describe('OauthService', () => {
 			expect(result).toEqual({ Authorization: 'Bearer cc-token' });
 			expect(getToken).toHaveBeenCalledTimes(1);
 			expect(mockToken.refresh).not.toHaveBeenCalled();
+		});
+
+		it('passes resource to token refresh and preserves it when the provider does not echo it', async () => {
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const resource = 'https://mcp.example.com/mcp';
+			const refreshed = { data: { access_token: 'cc-token' }, accessToken: 'cc-token' };
+			const getToken = vi.fn().mockResolvedValue(refreshed);
+			const mockToken = { refresh: vi.fn(), client: { credentials: { getToken } } };
+			const credential = makeCredential({ isGlobal: true });
+			let capturedOptions: unknown;
+			vi.mocked(ClientOAuth2).mockImplementation(function (options) {
+				capturedOptions = options;
+				return { createToken: vi.fn().mockReturnValue(mockToken) } as never;
+			});
+
+			credentialsRepository.findOne.mockResolvedValue(credential as never);
+			vi.spyOn(service, 'getOAuthCredentials').mockResolvedValue({
+				clientId: 'id',
+				clientSecret: 'secret',
+				accessTokenUrl: 'https://example.com/token',
+				grantType: 'clientCredentials',
+				authentication: 'header',
+				oauthTokenData: { access_token: 'stale', resource },
+			} as unknown as OAuth2CredentialData);
+			vi.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
+
+			const result = await service.refreshOAuth2CredentialById(credentialId, projectId);
+
+			expect(result).toEqual({ Authorization: 'Bearer cc-token' });
+			expect(capturedOptions).toEqual(expect.objectContaining({ resource }));
+			expect(service.encryptAndSaveData).toHaveBeenCalledWith(credential, {
+				oauthTokenData: {
+					access_token: 'cc-token',
+					resource,
+				},
+			});
 		});
 
 		it('returns null and logs a warning when the refresh call throws', async () => {

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -660,6 +660,49 @@ export class OauthService {
 		return oauthCredentials;
 	}
 
+	private credentialIsAccessibleToProject(credential: CredentialsEntity, projectId: string) {
+		return credential.isGlobal || (credential.shared ?? []).some((s) => s.projectId === projectId);
+	}
+
+	private resolveOAuth2Resource(
+		oauthCredentials: OAuth2CredentialData,
+		oauthTokenData: ClientOAuth2TokenData,
+	) {
+		// oauthTokenData.resource: persisted resource from the original token exchange.
+		// oauthCredentials.resource: resolved resource from discovery/validation during setup.
+		// oauthCredentials.resourceUrl: raw credential input used before a resolved value exists.
+		return oauthTokenData.resource ?? oauthCredentials.resource ?? oauthCredentials.resourceUrl;
+	}
+
+	private createOAuth2ClientForRefresh(oauthCredentials: OAuth2CredentialData, resource?: string) {
+		const scopes = oauthCredentials.scope
+			?.split(' ')
+			.map((s) => s.trim())
+			.filter(Boolean);
+
+		return new ClientOAuth2({
+			clientId: oauthCredentials.clientId,
+			...resolveClientAuthOptions(oauthCredentials),
+			accessTokenUri: oauthCredentials.accessTokenUrl,
+			scopes: scopes?.length ? scopes : undefined,
+			...(resource ? { resource } : {}),
+			ignoreSSLIssues: oauthCredentials.ignoreSSLIssues,
+			authentication: oauthCredentials.authentication ?? 'header',
+		});
+	}
+
+	private mergeRefreshedOAuthTokenData(
+		oauthTokenData: ClientOAuth2TokenData,
+		refreshedData: ClientOAuth2TokenData,
+		resource?: string,
+	) {
+		return {
+			...oauthTokenData,
+			...refreshedData,
+			...(!refreshedData.resource && resource ? { resource } : {}),
+		};
+	}
+
 	/**
 	 * Refresh the OAuth2 token stored on a credential by id, persist the refreshed token data,
 	 * and return the new auth headers to inject into outbound requests.
@@ -674,27 +717,14 @@ export class OauthService {
 		});
 		if (!credential) return null;
 
-		const isAccessible =
-			credential.isGlobal || (credential.shared ?? []).some((s) => s.projectId === projectId);
-		if (!isAccessible) return null;
+		if (!this.credentialIsAccessibleToProject(credential, projectId)) return null;
 
 		const oauthCredentials = await this.getOAuthCredentials<OAuth2CredentialData>(credential);
 		const oauthTokenData = oauthCredentials.oauthTokenData as ClientOAuth2TokenData | undefined;
 		if (!oauthTokenData) return null;
 
-		const scopes = oauthCredentials.scope
-			?.split(' ')
-			.map((s) => s.trim())
-			.filter(Boolean);
-
-		const oAuthClient = new ClientOAuth2({
-			clientId: oauthCredentials.clientId,
-			...resolveClientAuthOptions(oauthCredentials),
-			accessTokenUri: oauthCredentials.accessTokenUrl,
-			scopes: scopes?.length ? scopes : undefined,
-			ignoreSSLIssues: oauthCredentials.ignoreSSLIssues,
-			authentication: oauthCredentials.authentication ?? 'header',
-		});
+		const resource = this.resolveOAuth2Resource(oauthCredentials, oauthTokenData);
+		const oAuthClient = this.createOAuth2ClientForRefresh(oauthCredentials, resource);
 
 		const token = oAuthClient.createToken(
 			{
@@ -719,8 +749,14 @@ export class OauthService {
 			return null;
 		}
 
+		const refreshedTokenData = this.mergeRefreshedOAuthTokenData(
+			oauthTokenData,
+			refreshed.data,
+			resource,
+		);
+
 		try {
-			await this.encryptAndSaveData(credential, { oauthTokenData: refreshed.data });
+			await this.encryptAndSaveData(credential, { oauthTokenData: refreshedTokenData });
 		} catch (error) {
 			this.logger.warn('Refreshed OAuth2 token but failed to persist new token data', {
 				credentialId,

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -144,6 +144,55 @@ describe('refreshOAuth2Token', () => {
 		);
 	});
 
+	test('should include resource when fetching a client credentials token', async () => {
+		mockThis.getCredentials.mockResolvedValue({
+			...mockCredentialData,
+			grantType: 'clientCredentials',
+			oauthTokenData: {
+				...mockCredentialData.oauthTokenData,
+				resource: 'https://mcp.example.com/',
+			},
+		});
+		nock(baseUrl)
+			.post('/token', {
+				client_id: 'test-client-id',
+				client_secret: 'test-client-secret',
+				grant_type: 'client_credentials',
+				scope: 'openid',
+				resource: 'https://mcp.example.com/',
+			})
+			.reply(200, {
+				access_token: 'new-token',
+				refresh_token: 'new-refresh-token',
+			});
+
+		const result = await refreshOAuth2Token.call(
+			mockThis,
+			'test-credentials-type',
+			mockNode,
+			mockAdditionalData,
+		);
+
+		expect(result).toEqual({
+			access_token: 'new-token',
+			refresh_token: 'new-refresh-token',
+		});
+		expect(
+			mockAdditionalData.credentialsHelper.updateCredentialsOauthTokenData,
+		).toHaveBeenCalledWith(
+			mockNode.credentials!['test-credentials-type'],
+			'test-credentials-type',
+			expect.objectContaining({
+				oauthTokenData: expect.objectContaining({
+					access_token: 'new-token',
+					refresh_token: 'new-refresh-token',
+					resource: 'https://mcp.example.com/',
+				}),
+			}),
+			mockAdditionalData,
+		);
+	});
+
 	test('should refresh the OAuth2 token with authorization code grant type', async () => {
 		mockThis.getCredentials.mockResolvedValue(mockCredentialData);
 		nock(baseUrl)

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -48,11 +48,15 @@ function createOAuth2Client(credentials: OAuth2CredentialData): ClientOAuth2 {
 		?.split(' ')
 		.map((s) => s.trim())
 		.filter(Boolean);
+	const resource =
+		credentials.oauthTokenData?.resource ?? credentials.resource ?? credentials.resourceUrl;
+
 	return new ClientOAuth2({
 		clientId: credentials.clientId,
 		...resolveClientAuthOptions(credentials),
 		accessTokenUri: credentials.accessTokenUrl,
 		scopes: scopes?.length ? scopes : undefined,
+		...(resource ? { resource } : {}),
 		ignoreSSLIssues: credentials.ignoreSSLIssues,
 		authentication: credentials.authentication ?? 'header',
 		...(credentials.additionalBodyProperties && {


### PR DESCRIPTION
## Summary

This PR fixes 2 issues:
- when using `Grant type: credentials` n8n would send `Bearer undefined` on first request and cause some mcp servers to respond with 500x codes. n8n now omits a header if token is missing, `onUnauthorized` then refreshes token after first 401 error
- when using new `resourceUrl` parameter it got omitted in some oauth flows. Now it's included in all of them


https://github.com/user-attachments/assets/19f8a7cb-3633-4465-ac60-41ba6659ed96

## How to test

1. Run this [server](https://gist.github.com/yehorkardash/067788c87c4fc84788ca75a81ad7b9b7) locally
2. Copy the provided workflow
3. Run "Create credentials" node first
4. Choose new credentials in mcp client node
5. Run agent node
6. Agent should successfully call the tool and logs of mcp server will show `/oauth/token` and `/mcp` after that

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-5366/community-issue-mcp-client-tool-with-mcp-oauth2-api-client-credentials
closes #33413 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

