### PR TITLE
fix: Broaden secret detection in browser tool snapshots

### DIFF
--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -33,6 +33,13 @@ const FIXTURES: Array<{ slug: string; secret: string }> = [
 	{ slug: 'slack_bot_token', secret: `xoxb-1111111111-1111111111-${'l'.repeat(24)}` },
 	{ slug: 'slack_user_token', secret: `xoxp-1111111111-1111111111-1111111111-${'m'.repeat(12)}` },
 	{ slug: 'slack_webhook_url', secret: `https://hooks.slack.com/services/${'N'.repeat(43)}` },
+	{
+		slug: 'slack_app_level_token',
+		secret: `xapp-1-${'A'.repeat(11)}-${'1'.repeat(14)}-${'a'.repeat(64)}`,
+	},
+	{ slug: 'slack_config_access_token', secret: `xoxe.xoxp-1-${'a'.repeat(146)}` },
+	{ slug: 'slack_config_refresh_token', secret: `xoxe-1-${'a'.repeat(146)}` },
+	{ slug: 'slack_workflow_token', secret: `xwfp-${'a'.repeat(40)}` },
 	{ slug: 'twilio_api_key_sid', secret: `SK${'0'.repeat(32)}` },
 	{ slug: 'twilio_account_sid', secret: `AC${'1'.repeat(32)}` },
 	{ slug: 'stripe_secret_key', secret: `sk_live_${'o'.repeat(20)}` },

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -76,6 +76,10 @@ export const BUILTIN_PATTERNS: SecretPattern[] = [
 		slug: 'slack_webhook_url',
 		pattern: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]{30,}/,
 	},
+	{ slug: 'slack_app_level_token', pattern: /xapp-\d-[A-Z0-9]+-\d+-[a-z0-9]{32,}/ },
+	{ slug: 'slack_config_access_token', pattern: /xoxe\.xoxp-\d-[A-Za-z0-9-]{100,}/ },
+	{ slug: 'slack_config_refresh_token', pattern: /xoxe-\d-[A-Za-z0-9-]{100,}/ },
+	{ slug: 'slack_workflow_token', pattern: /xwfp-[A-Za-z0-9_-]{20,}/ },
 	// `discord_bot_token` must precede `jwt`: both shapes can match the same
 	// string (three base64url segments separated by `.`), and we want the more
 	// specific provider slug to win when both apply.

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.test.ts
@@ -66,6 +66,142 @@ describe('analyzeHtmlSensitivity', () => {
 		expect(result.ok && result.hits.some((hit) => hit.value === 'alice')).toBe(false);
 	});
 
+	it('finds a text input value flagged by its associated label', () => {
+		const value = 'notreal-SigningSecretRevealedValue9mQ2vW5';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="s">Signing Secret</label><input id="s" type="text" readonly value="${value}">`,
+			),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('finds a secret held in a data-* attribute behind a placeholder value', () => {
+		const secret = 'notreal7c1de9a04bf28e6d3a91f0b5c7e2d84a6';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="c">Client Secret</label><input id="c" type="password" readonly value="1234567890" data-password="${secret}" data-qa="client_secret">`,
+			),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value: secret });
+	});
+
+	it('does not flag a public field whose label is not a secret', () => {
+		const value = '553213193971.11264233855632';
+		const result = analyzeHtmlSensitivity(
+			probe(`<label for="i">Client ID</label><input id="i" readonly value="${value}">`),
+		);
+
+		expect(result.ok && result.hits.some((hit) => hit.value === value)).toBe(false);
+	});
+
+	it('finds an input value flagged by aria-labelledby', () => {
+		const value = 'notreal-AriaLabelledByInputValue4kR8pT';
+		const result = analyzeHtmlSensitivity(
+			probe(`<span id="lbl">Client Secret</span><input aria-labelledby="lbl" value="${value}">`),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('harvests only data-* attributes whose name reads as a secret', () => {
+		const secret = 'notreal7c1de9a04bf28e6d3a91f0b5c7e2d84a6';
+		const tracking = 'trackingId0123456789abcdef';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="c">Client Secret</label><input id="c" type="password" value="1234567890" data-password="${secret}" data-tracking-id="${tracking}" data-hint="reveal the secret value">`,
+			),
+		);
+		const values = result.ok ? result.hits.map((hit) => hit.value) : [];
+
+		expect(values).toContain(secret);
+		expect(values).not.toContain(tracking);
+		expect(values).not.toContain('reveal the secret value');
+	});
+
+	it('finds an input value flagged by a wrapping label', () => {
+		const value = 'notreal-WrappingLabelInputValue6bN3wQ';
+		const result = analyzeHtmlSensitivity(probe(`<label>API Key <input value="${value}"></label>`));
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('finds a textarea value flagged by its associated label', () => {
+		const value = 'notreal-PrivateKeyTextareaValue7hK3mZ';
+		const result = analyzeHtmlSensitivity(
+			probe(`<label for="pk">Private key</label><textarea id="pk">${value}</textarea>`),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('finds a token input whose label reads "Token"', () => {
+		const value = 'notreal-xapp-1-A0B7S6VR5JL-11512837559300-cf6ed2749ec8b364fb78817ee8d8105e';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="t"><span>Token</span></label><input id="t" readonly type="text" value="${value}">`,
+			),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('flags a field labelled by multiple label elements sharing its id', () => {
+		const value = 'notreal-MultiLabelFieldValue3xQ8mZ';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="m">Access</label><label for="m">key</label><input id="m" type="text" readonly value="${value}">`,
+			),
+		);
+
+		expect(result.ok && result.hits).toContainEqual({ type: 'password', value });
+	});
+
+	it('ignores empty and target-less label elements when indexing', () => {
+		const value = 'notreal-EmptyLabelSiblingValue2wP7';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="">orphan</label><label for="e"></label><input id="e" type="text" readonly value="${value}">`,
+			),
+		);
+
+		expect(result.ok && result.hits.some((hit) => hit.value === value)).toBe(false);
+	});
+
+	it('does not flag an unlabelled field that only carries an id', () => {
+		const value = 'notreal-UnlabelledFieldValue5yT2kR';
+		const result = analyzeHtmlSensitivity(
+			probe(`<input id="lonely" type="text" readonly value="${value}">`),
+		);
+
+		expect(result.ok && result.hits.some((hit) => hit.value === value)).toBe(false);
+	});
+
+	it('skips data-* values that are short, spaced, or duplicate the field value', () => {
+		const value = 'notreal-PrimaryFieldSecret8kM4nQ';
+		const result = analyzeHtmlSensitivity(
+			probe(
+				`<label for="c">Client Secret</label><input id="c" type="text" readonly value="${value}" data-secret="tiny" data-password="two words here padded outx" data-credential="${value}">`,
+			),
+		);
+		const values = result.ok ? result.hits.map((hit) => hit.value) : [];
+
+		expect(values).toContain(value);
+		expect(values).not.toContain('tiny');
+		expect(values).not.toContain('two words here padded outx');
+		expect(values.filter((hit) => hit === value)).toHaveLength(1);
+	});
+
+	it('produces no hit for a sensitive field with an empty value', () => {
+		const result = analyzeHtmlSensitivity(
+			probe('<label for="p">Password</label><input id="p" type="text" readonly value="">'),
+		);
+
+		expect(result.ok && result.hits).toEqual([]);
+	});
+
 	it('finds high-entropy values in reveal dialogs', () => {
 		const result = analyzeHtmlSensitivity(
 			probe(`<div role="dialog"><p>You won't see it again.</p><code>${OPAQUE}</code></div>`),

--- a/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/analyze-html.ts
@@ -1,15 +1,19 @@
 import { JSDOM, VirtualConsole } from 'jsdom';
 
 import {
+	getAssociatedLabelText,
 	COPY_BUTTON_PATTERN,
 	elementLabel,
 	elementText,
 	hasButtonMatching,
 	highEntropyCandidates,
 	isSensitiveInput,
+	getLabelTextByControlIdMap,
 	REVEAL_BUTTON_PATTERN,
 	REVEAL_PHRASE_PATTERNS,
+	sensitiveInputValues,
 	SENSITIVE_ARIA_LABEL_PATTERN,
+	SENSITIVE_FIELD_LABEL_PATTERN,
 	SENSITIVE_TESTID_PATTERN,
 	getTestId,
 } from './dom-matchers';
@@ -45,12 +49,19 @@ function analyzeDocument(html: string, hits: Map<string, SecretHit>): void {
 	const bodyText = document.documentElement.textContent ?? '';
 	for (const hit of findRegexSecretHits(bodyText)) addHit(hits, hit);
 
-	// Password-shaped inputs expose their values as attributes in the collected
-	// HTML. These do not need entropy to be considered sensitive.
-	for (const input of Array.from(document.querySelectorAll('input'))) {
-		if (!isSensitiveInput(input)) continue;
-		const value = input.getAttribute('value') ?? '';
-		if (value) addHit(hits, { type: 'password', value });
+	// Inputs/textareas that are password-shaped or whose label reads as a secret
+	// expose their values in the collected HTML; no entropy needed to flag them.
+	const labelsByControlIdMap = getLabelTextByControlIdMap(document);
+	for (const field of Array.from(document.querySelectorAll('input, textarea'))) {
+		const sensitive =
+			isSensitiveInput(field) ||
+			SENSITIVE_FIELD_LABEL_PATTERN.test(
+				getAssociatedLabelText(field, document, labelsByControlIdMap),
+			);
+		if (!sensitive) continue;
+		for (const value of sensitiveInputValues(field)) {
+			addHit(hits, { type: 'password', value });
+		}
 	}
 
 	// Reveal dialogs are the high-risk flow: newly created credentials are often

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.test.ts
@@ -3,6 +3,7 @@ import {
 	REVEAL_BUTTON_PATTERN,
 	REVEAL_PHRASE_PATTERNS,
 	SENSITIVE_ARIA_LABEL_PATTERN,
+	SENSITIVE_FIELD_LABEL_PATTERN,
 	SENSITIVE_TESTID_PATTERN,
 	shannonEntropy,
 } from './dom-matchers';
@@ -98,6 +99,30 @@ describe('SENSITIVE_ARIA_LABEL_PATTERN', () => {
 		'does not match neutral aria-label %p',
 		(label) => {
 			expect(SENSITIVE_ARIA_LABEL_PATTERN.test(label)).toBe(false);
+		},
+	);
+});
+
+describe('SENSITIVE_FIELD_LABEL_PATTERN', () => {
+	it.each([
+		'Client Secret',
+		'Signing Secret',
+		'Token',
+		'Verification Token',
+		'Personal Access Token',
+		'App password',
+		'API Key',
+		'Access key',
+		'Private key',
+		'Account credential',
+	])('matches secret field label %p', (label) => {
+		expect(SENSITIVE_FIELD_LABEL_PATTERN.test(label)).toBe(true);
+	});
+
+	it.each(['Client ID', 'App ID', 'App name', 'Date of App Creation', 'Background color'])(
+		'does not match public field label %p',
+		(label) => {
+			expect(SENSITIVE_FIELD_LABEL_PATTERN.test(label)).toBe(false);
 		},
 	);
 });

--- a/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
+++ b/packages/@n8n/mcp-browser/src/sensitivity/dom-matchers.ts
@@ -6,6 +6,9 @@ export const SENSITIVE_TESTID_PATTERN =
 export const SENSITIVE_ARIA_LABEL_PATTERN =
 	/(api[-_\s]?key|secret[-_\s]?key|access[-_\s]?token|auth[-_\s]?token|client[-_\s]?secret|password|credential)/i;
 
+export const SENSITIVE_FIELD_LABEL_PATTERN =
+	/(secret|password|passcode|passphrase|token|api[-_\s]?key|access[-_\s]?key|private[-_\s]?key|credential)/i;
+
 export const ARIA_PASSWORD_LABEL_PATTERN =
 	/(password|passcode|secret|api[-_\s]?key|token|credential)/i;
 
@@ -49,6 +52,34 @@ export function elementLabel(el: Element, doc: Document): string {
 		.join(' ');
 }
 
+export function getLabelTextByControlIdMap(doc: Document): Map<string, string> {
+	const byId = new Map<string, string>();
+	for (const label of Array.from(doc.querySelectorAll('label[for]'))) {
+		const target = label.getAttribute('for');
+		const text = label.textContent?.trim();
+		if (!target || !text) continue;
+		const existing = byId.get(target);
+		byId.set(target, existing ? `${existing} ${text}` : text);
+	}
+	return byId;
+}
+
+export function getAssociatedLabelText(
+	el: Element,
+	doc: Document,
+	labelsByControlIdMap: Map<string, string>,
+): string {
+	const parts = [elementLabel(el, doc)];
+	const id = el.getAttribute('id');
+	if (id) parts.push(labelsByControlIdMap.get(id) ?? '');
+	const wrapping = el.closest('label');
+	if (wrapping) parts.push(wrapping.textContent ?? '');
+	return parts
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.join(' ');
+}
+
 export function elementText(el: Element): string {
 	const parts: string[] = [];
 	for (const node of Array.from(el.childNodes)) {
@@ -79,6 +110,20 @@ export function isSensitiveInput(el: Element): el is HTMLInputElement | HTMLText
 		(!!testId && SENSITIVE_TESTID_PATTERN.test(testId)) ||
 		(readOnly && noSpell && value.length >= 20)
 	);
+}
+
+export function sensitiveInputValues(el: Element): string[] {
+	const values: string[] = [];
+	const value = (el.getAttribute('value') ?? el.textContent)?.trim() ?? '';
+	if (value) values.push(value);
+	for (const attr of Array.from(el.attributes)) {
+		if (!attr.name.startsWith('data-') || !SENSITIVE_TESTID_PATTERN.test(attr.name)) continue;
+		const candidate = attr.value.trim();
+		if (candidate.length >= 16 && !/\s/.test(candidate) && !values.includes(candidate)) {
+			values.push(candidate);
+		}
+	}
+	return values;
 }
 
 export function hasButtonMatching(scope: Element, pattern: RegExp): boolean {


### PR DESCRIPTION
## Summary

Extends the `@n8n/mcp-browser` sensitivity analyzer (used by the Computer Use / browser-use path) so it recognises secret values in more field shapes and redacts them from tool output before it reaches the model.

- **Label-based field detection:** a form field is treated as sensitive when its associated label reads as a secret — resolved from `aria-label` / `aria-labelledby`, an associated `<label for=id>`, or a wrapping `<label>`. Covers both `<input>` and `<textarea>` (e.g. "Client Secret", "Signing Secret", "Token", "Verification Token", "Private key").
- **Reveal-widget `data-*` values:** where the visible value is only a placeholder and the real value is held in a `data-*` attribute, that value is now collected too. Gated on the attribute *name* reading as a secret, so unrelated long attributes (tracking ids, etc.) are left alone.
- **Additional Slack token patterns:** adds `xapp-` (app-level), `xoxe` / `xoxe.xoxp` (configuration) and `xwfp-` (workflow) token shapes to the redaction ruleset, alongside the existing `xoxb-` / `xoxp-` / webhook patterns. Sourced from https://docs.slack.dev/authentication/tokens.

All detection stays scoped to field labels / attribute names / distinctive token prefixes to avoid over-redacting ordinary page content.

## How to test

drive the browser to a Slack App settings page that renders secret fields (labelled inputs, revealed values, an app-level token dialog) and take a `browser_snapshot`. The secret field values should come back as `[REDACTED:…]` markers rather than in plaintext.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5159

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI