### PR TITLE
perf(core): Cap oversized get-node-output payloads in Instance AI executions tool

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
@@ -704,22 +704,32 @@ describe('executions tool', () => {
 
 		it('should cap oversized outputs to whole items within the char budget', async () => {
 			const bigItem = { blob: 'x'.repeat(30_000) };
+			const schema = { type: 'object', properties: { blob: { type: 'string' } } };
 			const context = createMockContext();
 			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
 				nodeName: 'Set',
 				items: [bigItem, bigItem, bigItem],
 				totalItems: 3,
-				returned: { from: 0, to: 2 },
+				returned: { from: 0, to: 3 },
+				schema,
 			});
 
 			const tool = createExecutionsTool(context);
-			const result = await executeTool<{ items: unknown[]; truncated?: boolean; note?: string }>(
+			const result = await executeTool<{
+				items: unknown[];
+				returned: { from: number; to: number };
+				schema?: unknown;
+				truncated?: boolean;
+				note?: string;
+			}>(
 				tool,
 				{ action: 'get-node-output' as const, executionId: 'exec-1', nodeName: 'Set' },
 				{} as never,
 			);
 
 			expect(result.items).toEqual([bigItem]);
+			expect(result.returned).toEqual({ from: 0, to: 1 });
+			expect(result.schema).toEqual(schema);
 			expect(result.truncated).toBe(true);
 			expect(result.note).toContain('1 of 3 fetched items');
 		});
@@ -730,7 +740,7 @@ describe('executions tool', () => {
 				nodeName: 'Set',
 				items: [{ blob: 'y'.repeat(120_000) }],
 				totalItems: 1,
-				returned: { from: 0, to: 0 },
+				returned: { from: 0, to: 1 },
 			});
 
 			const tool = createExecutionsTool(context);

--- a/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/executions.tool.test.ts
@@ -701,6 +701,50 @@ describe('executions tool', () => {
 				maxItems: undefined,
 			});
 		});
+
+		it('should cap oversized outputs to whole items within the char budget', async () => {
+			const bigItem = { blob: 'x'.repeat(30_000) };
+			const context = createMockContext();
+			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
+				nodeName: 'Set',
+				items: [bigItem, bigItem, bigItem],
+				totalItems: 3,
+				returned: { from: 0, to: 2 },
+			});
+
+			const tool = createExecutionsTool(context);
+			const result = await executeTool<{ items: unknown[]; truncated?: boolean; note?: string }>(
+				tool,
+				{ action: 'get-node-output' as const, executionId: 'exec-1', nodeName: 'Set' },
+				{} as never,
+			);
+
+			expect(result.items).toEqual([bigItem]);
+			expect(result.truncated).toBe(true);
+			expect(result.note).toContain('1 of 3 fetched items');
+		});
+
+		it('should return a sliced string when a single item exceeds the budget', async () => {
+			const context = createMockContext();
+			(context.executionService.getNodeOutput as Mock).mockResolvedValue({
+				nodeName: 'Set',
+				items: [{ blob: 'y'.repeat(120_000) }],
+				totalItems: 1,
+				returned: { from: 0, to: 0 },
+			});
+
+			const tool = createExecutionsTool(context);
+			const result = await executeTool<{ items: unknown[]; truncated?: boolean }>(
+				tool,
+				{ action: 'get-node-output' as const, executionId: 'exec-1', nodeName: 'Set' },
+				{} as never,
+			);
+
+			expect(result.truncated).toBe(true);
+			expect(result.items).toHaveLength(1);
+			expect(typeof result.items[0]).toBe('string');
+			expect((result.items[0] as string).endsWith('… [item truncated]')).toBe(true);
+		});
 	});
 
 	// ── get-resolved-node-parameters ────────────────────────────────────────

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -76,7 +76,12 @@ const debugAction = z.object({
 const getNodeOutputAction = z.object({
 	action: z
 		.literal('get-node-output')
-		.describe('Retrieve raw output of a specific node from an execution'),
+		.describe(
+			'Retrieve raw output of a specific node from an execution. Also returns a `schema` of ' +
+				'the item shape — prefer it over paging when you only need structure. If the ' +
+				"node's run failed, `error` carries the failure; use `debug` for the failed " +
+				"node's input data and resolved parameters.",
+		),
 	executionId: z.string().describe('Execution ID'),
 	nodeName: z.string().describe("Name of the node (must exist in the execution's workflow)"),
 	startIndex: z.number().int().min(0).optional().describe('Item index to start from (default 0)'),
@@ -317,8 +322,9 @@ function capNodeOutputItems(result: NodeOutputResult) {
 	return {
 		...result,
 		items,
+		returned: { from: result.returned.from, to: result.returned.from + items.length },
 		truncated: true,
-		note: `Output capped at ~${MAX_NODE_OUTPUT_CHARS / 1000}k chars: returning ${items.length} of ${result.items.length} fetched items (${result.totalItems} total). Use startIndex/maxItems to page through the rest.`,
+		note: `Output capped at ~${MAX_NODE_OUTPUT_CHARS / 1000}k chars: returning ${items.length} of ${result.items.length} fetched items (${result.totalItems} total). See \`schema\` for the full item shape; use startIndex/maxItems only if you need specific values from other items.`,
 	};
 }
 

--- a/packages/@n8n/instance-ai/src/tools/executions.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/executions.tool.ts
@@ -11,7 +11,7 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
-import type { InstanceAiContext } from '../types';
+import type { InstanceAiContext, NodeOutputResult } from '../types';
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -294,14 +294,43 @@ async function handleDebug(context: InstanceAiContext, input: Extract<Input, { a
 	return await context.executionService.getDebugInfo(input.executionId);
 }
 
+/** Item counts are already paged, but a single item can be hundreds of KB. */
+const MAX_NODE_OUTPUT_CHARS = 50_000;
+
+function capNodeOutputItems(result: NodeOutputResult) {
+	let used = 0;
+	const items: unknown[] = [];
+	let truncated = false;
+	for (const item of result.items) {
+		const serialized = JSON.stringify(item) ?? 'null';
+		if (used + serialized.length > MAX_NODE_OUTPUT_CHARS) {
+			truncated = true;
+			if (items.length === 0) {
+				items.push(`${serialized.slice(0, MAX_NODE_OUTPUT_CHARS)}… [item truncated]`);
+			}
+			break;
+		}
+		items.push(item);
+		used += serialized.length;
+	}
+	if (!truncated) return result;
+	return {
+		...result,
+		items,
+		truncated: true,
+		note: `Output capped at ~${MAX_NODE_OUTPUT_CHARS / 1000}k chars: returning ${items.length} of ${result.items.length} fetched items (${result.totalItems} total). Use startIndex/maxItems to page through the rest.`,
+	};
+}
+
 async function handleGetNodeOutput(
 	context: InstanceAiContext,
 	input: Extract<Input, { action: 'get-node-output' }>,
 ) {
-	return await context.executionService.getNodeOutput(input.executionId, input.nodeName, {
+	const result = await context.executionService.getNodeOutput(input.executionId, input.nodeName, {
 		startIndex: input.startIndex,
 		maxItems: input.maxItems,
 	});
+	return capNodeOutputItems(result);
 }
 
 async function handleGetResolvedNodeParameters(

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -100,6 +100,10 @@ export interface NodeOutputResult {
 	items: unknown[];
 	totalItems: number;
 	returned: { from: number; to: number };
+	/** JSON schema inferred from the first returned item, so the output shape survives item truncation. */
+	schema?: unknown;
+	/** Formatted error when the node's last run failed. */
+	error?: string;
 }
 
 export interface ResolvedExpressionFailure {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1082,6 +1082,43 @@ describe('extractNodeOutput', () => {
 		expect(result.totalItems).toBe(1);
 		expect(result.items).toHaveLength(0);
 		expect(result.returned).toEqual({ from: 100, to: 100 });
+		expect(result.schema).toBeUndefined();
+	});
+
+	it('includes a schema inferred from the first returned item', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: { 'Set Node': [makeTaskData([{ id: 1, name: 'a' }])] },
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Set Node');
+
+		expect(result.schema).toEqual({
+			type: 'object',
+			properties: { id: { type: 'number' }, name: { type: 'string' } },
+			required: ['id', 'name'],
+		});
+	});
+
+	it('surfaces the formatted error when the node run failed', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'error',
+				runData: {
+					'Http Node': [
+						makeTaskData([], { error: { message: 'Request failed', description: '404 from API' } }),
+					],
+				},
+			}),
+		);
+
+		const result = await extractNodeOutput('exec-1', 'Http Node');
+
+		expect(result.items).toHaveLength(0);
+		expect(result.error).toContain('Request failed');
+		expect(result.error).toContain('404 from API');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -43,7 +43,7 @@ import {
 	wrapUntrustedData,
 	deriveCredentialHosts,
 } from '@n8n/instance-ai';
-import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import { generateJsonSchemaFromData, type WorkflowJSON } from '@n8n/workflow-sdk';
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import type { User, ExecutionSummaries } from '@n8n/db';
@@ -2907,6 +2907,9 @@ export async function extractNodeOutput(
 		),
 		totalItems,
 		returned: { from: startIndex, to: startIndex + capped.length },
+		...(collected.length > 0 && { schema: generateJsonSchemaFromData(collected[0]) }),
+		// Upstream details allowed: getNodeOutput early-returns when the AI privacy setting is off.
+		...(lastRun?.error && { error: formatExecutionError(lastRun.error, true) }),
 	};
 }
 


### PR DESCRIPTION
## Summary

Split out of #33466 (see the caching discussion there).

`executions[get-node-output]` item *counts* are already paged via `startIndex`/`maxItems`, but a single item can be hundreds of KB, so one call could still put an unbounded payload into the orchestrator context, where it is re-read by every subsequent LLM call in the turn.

This caps the serialized result at ~50k chars:

- Whole items are returned up to the budget, with `truncated: true` and a note telling the agent how many of the fetched items were returned and to page through the rest with `startIndex`/`maxItems`.
- If the first item alone exceeds the budget, a sliced string view of it is returned so the agent still sees the item's shape.

Production trace decomposition (EU LangSmith, 2026-07-02) showed raw execution outputs among the largest tool-result payloads in orchestrator prompts after workflow snapshots.

## How to test

Unit tests in `packages/@n8n/instance-ai`: `pnpm test src/tools/__tests__/executions.tool.test.ts`.

Manually, in an AI Assistant thread: run a workflow with a large node output (e.g. an HTTP node fetching a big JSON array) and ask about the node's output. The `executions[get-node-output]` tool result should carry `truncated: true` and the paging note instead of the full payload.

## Related Linear tickets, Github issues, and Community forum posts

Split from #33466 (INS-753 / INS-754).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)