### PR TITLE
perf(core): Return workflow structure summaries by default from Instance AI inspect actions

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -411,12 +411,34 @@ describe('workflows tool', () => {
 	});
 
 	describe('get action', () => {
-		it('should call workflowService.get with workflowId', async () => {
+		it('should return a structural summary without node parameters', async () => {
 			const detail = {
 				id: 'wf1',
 				name: 'Test WF',
-				nodes: [],
-				connections: {},
+				nodes: [
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						parameters: { path: 'x' },
+						position: [0, 0],
+					},
+					{
+						name: 'IF',
+						type: 'n8n-nodes-base.if',
+						parameters: { conditions: {} },
+						position: [1, 0],
+					},
+					{ name: 'Set', type: 'n8n-nodes-base.set', parameters: {}, position: [2, 0] },
+				],
+				connections: {
+					Webhook: { main: [[{ node: 'IF', type: 'main', index: 0 }]] },
+					IF: {
+						main: [
+							[{ node: 'Set', type: 'main', index: 0 }],
+							[{ node: 'Webhook', type: 'main', index: 0 }],
+						],
+					},
+				},
 				versionId: 'v1',
 				activeVersionId: null,
 				isArchived: false,
@@ -430,7 +452,68 @@ describe('workflows tool', () => {
 			const result = await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
 
 			expect(context.workflowService.get).toHaveBeenCalledWith('wf1');
-			expect(result).toEqual(detail);
+			expect(result).toMatchObject({
+				id: 'wf1',
+				name: 'Test WF',
+				versionId: 'v1',
+				nodeCount: 3,
+				connections: ['Webhook → IF', 'IF → Set', 'IF [1]→ Webhook'],
+			});
+			expect((result as { nodes: unknown }).nodes).toEqual([
+				{ name: 'Webhook', type: 'n8n-nodes-base.webhook' },
+				{ name: 'IF', type: 'n8n-nodes-base.if' },
+				{ name: 'Set', type: 'n8n-nodes-base.set' },
+			]);
+		});
+	});
+
+	describe('get-version action', () => {
+		const versionDetail = {
+			versionId: 'v1',
+			name: 'Checkpoint',
+			description: null,
+			authors: 'me',
+			createdAt: '2024-01-01',
+			autosaved: false,
+			isActive: false,
+			isCurrentDraft: false,
+			nodes: [
+				{ name: 'Set', type: 'n8n-nodes-base.set', parameters: { big: 'blob' }, position: [0, 0] },
+			],
+			connections: {},
+		};
+
+		it('should return a structural summary by default', async () => {
+			const context = createMockContext();
+			context.workflowService.getVersion = vi.fn().mockResolvedValue(versionDetail);
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(
+				tool,
+				{ action: 'get-version', workflowId: 'wf1', versionId: 'v1' },
+				{} as never,
+			);
+
+			expect(result).toMatchObject({
+				versionId: 'v1',
+				nodeCount: 1,
+				nodes: [{ name: 'Set', type: 'n8n-nodes-base.set' }],
+			});
+			expect(JSON.stringify(result)).not.toContain('blob');
+		});
+
+		it('should return the complete version payload when full is true', async () => {
+			const context = createMockContext();
+			context.workflowService.getVersion = vi.fn().mockResolvedValue(versionDetail);
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(
+				tool,
+				{ action: 'get-version', workflowId: 'wf1', versionId: 'v1', full: true },
+				{} as never,
+			);
+
+			expect(result).toEqual(versionDetail);
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -419,7 +419,7 @@ describe('workflows tool', () => {
 					name: 'Webhook',
 					type: 'n8n-nodes-base.webhook',
 					typeVersion: 2,
-					parameters: { path: 'x' },
+					parameters: { path: 'x', big: 'x'.repeat(5000) },
 					position: [0, 0],
 				},
 				{
@@ -447,7 +447,7 @@ describe('workflows tool', () => {
 			updatedAt: '2024-01-01',
 		};
 
-		it('should return the structure as SDK code without node parameters', async () => {
+		it('should return the structure as SDK code for large workflows', async () => {
 			const context = createMockContext();
 			(context.workflowService.get as Mock).mockResolvedValue(detail);
 
@@ -466,6 +466,41 @@ describe('workflows tool', () => {
 			expect(codegenInput).toMatchObject({ name: 'Test WF' });
 			expect(JSON.stringify(codegenInput)).not.toContain('conditions');
 			expect(JSON.stringify(result)).not.toContain('conditions');
+		});
+
+		it('should return the complete payload when full is true', async () => {
+			const context = createMockContext();
+			(context.workflowService.get as Mock).mockResolvedValue(detail);
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(
+				tool,
+				{ action: 'get', workflowId: 'wf1', full: true },
+				{} as never,
+			);
+
+			expect(result).toEqual(detail);
+		});
+
+		it('should include parameters inline for small workflows', async () => {
+			const small = {
+				...detail,
+				nodes: [
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						parameters: { path: 'x' },
+						position: [0, 0],
+					},
+				],
+			};
+			const context = createMockContext();
+			(context.workflowService.get as Mock).mockResolvedValue(small);
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+
+			expect(result).toEqual(small);
 		});
 
 		it('should fall back to a plain structure listing when codegen fails', async () => {
@@ -499,7 +534,7 @@ describe('workflows tool', () => {
 					{
 						name: 'Set',
 						type: 'n8n-nodes-base.set',
-						parameters: { big: 'blob' },
+						parameters: { big: 'blob'.repeat(2000) },
 						position: [0, 0],
 					},
 				],

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -1,4 +1,5 @@
 import type { InstanceAiPermissions } from '@n8n/api-types';
+import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import type { Mock } from 'vitest';
 
 import { executeTool } from '../../__tests__/tool-test-utils';
@@ -174,7 +175,6 @@ describe('workflows tool', () => {
 				},
 			],
 			[{ action: 'list-versions', workflowId: 'w1' }],
-			[{ action: 'get-version', workflowId: 'w1', versionId: 'v1' }],
 			[{ action: 'restore-version', workflowId: 'w1', versionId: 'v1' }],
 			[{ action: 'update-version', workflowId: 'w1', versionId: 'v1', name: 'v1' }],
 		])('should reject action %p when it is not explicitly allowed', (input) => {
@@ -411,40 +411,43 @@ describe('workflows tool', () => {
 	});
 
 	describe('get action', () => {
-		it('should return a structural summary without node parameters', async () => {
-			const detail = {
-				id: 'wf1',
-				name: 'Test WF',
-				nodes: [
-					{
-						name: 'Webhook',
-						type: 'n8n-nodes-base.webhook',
-						parameters: { path: 'x' },
-						position: [0, 0],
-					},
-					{
-						name: 'IF',
-						type: 'n8n-nodes-base.if',
-						parameters: { conditions: {} },
-						position: [1, 0],
-					},
-					{ name: 'Set', type: 'n8n-nodes-base.set', parameters: {}, position: [2, 0] },
-				],
-				connections: {
-					Webhook: { main: [[{ node: 'IF', type: 'main', index: 0 }]] },
-					IF: {
-						main: [
-							[{ node: 'Set', type: 'main', index: 0 }],
-							[{ node: 'Webhook', type: 'main', index: 0 }],
-						],
-					},
+		const detail = {
+			id: 'wf1',
+			name: 'Test WF',
+			nodes: [
+				{
+					name: 'Webhook',
+					type: 'n8n-nodes-base.webhook',
+					typeVersion: 2,
+					parameters: { path: 'x' },
+					position: [0, 0],
 				},
-				versionId: 'v1',
-				activeVersionId: null,
-				isArchived: false,
-				createdAt: '2024-01-01',
-				updatedAt: '2024-01-01',
-			};
+				{
+					name: 'IF',
+					type: 'n8n-nodes-base.if',
+					typeVersion: 2.2,
+					parameters: { conditions: {} },
+					position: [1, 0],
+				},
+				{ name: 'Set', type: 'n8n-nodes-base.set', parameters: {}, position: [2, 0] },
+			],
+			connections: {
+				Webhook: { main: [[{ node: 'IF', type: 'main', index: 0 }]] },
+				IF: {
+					main: [
+						[{ node: 'Set', type: 'main', index: 0 }],
+						[{ node: 'Webhook', type: 'main', index: 0 }],
+					],
+				},
+			},
+			versionId: 'v1',
+			activeVersionId: null,
+			isArchived: false,
+			createdAt: '2024-01-01',
+			updatedAt: '2024-01-01',
+		};
+
+		it('should return the structure as SDK code without node parameters', async () => {
 			const context = createMockContext();
 			(context.workflowService.get as Mock).mockResolvedValue(detail);
 
@@ -457,63 +460,84 @@ describe('workflows tool', () => {
 				name: 'Test WF',
 				versionId: 'v1',
 				nodeCount: 3,
-				connections: ['Webhook → IF', 'IF → Set', 'IF [1]→ Webhook'],
+				structure: '// generated code',
 			});
-			expect((result as { nodes: unknown }).nodes).toEqual([
-				{ name: 'Webhook', type: 'n8n-nodes-base.webhook' },
-				{ name: 'IF', type: 'n8n-nodes-base.if' },
-				{ name: 'Set', type: 'n8n-nodes-base.set' },
-			]);
+			const codegenInput = vi.mocked(generateWorkflowCode).mock.calls[0][0];
+			expect(codegenInput).toMatchObject({ name: 'Test WF' });
+			expect(JSON.stringify(codegenInput)).not.toContain('conditions');
+			expect(JSON.stringify(result)).not.toContain('conditions');
 		});
-	});
 
-	describe('get-version action', () => {
-		const versionDetail = {
-			versionId: 'v1',
-			name: 'Checkpoint',
-			description: null,
-			authors: 'me',
-			createdAt: '2024-01-01',
-			autosaved: false,
-			isActive: false,
-			isCurrentDraft: false,
-			nodes: [
-				{ name: 'Set', type: 'n8n-nodes-base.set', parameters: { big: 'blob' }, position: [0, 0] },
-			],
-			connections: {},
-		};
-
-		it('should return a structural summary by default', async () => {
+		it('should fall back to a plain structure listing when codegen fails', async () => {
 			const context = createMockContext();
-			context.workflowService.getVersion = vi.fn().mockResolvedValue(versionDetail);
+			(context.workflowService.get as Mock).mockResolvedValue(detail);
+			vi.mocked(generateWorkflowCode).mockImplementationOnce(() => {
+				throw new Error('unsupported graph');
+			});
+
+			const tool = createWorkflowsTool(context, 'full');
+			const result = await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
+
+			const structure = (result as { structure: string }).structure;
+			expect(structure).toContain('- Webhook (n8n-nodes-base.webhook)');
+			expect(structure).toContain('- IF [1]→ Webhook');
+			expect(structure).not.toContain('conditions');
+		});
+
+		it('should return a version structure summary when versionId is provided', async () => {
+			const context = createMockContext();
+			context.workflowService.getVersion = vi.fn().mockResolvedValue({
+				versionId: 'v1',
+				name: 'Checkpoint',
+				description: null,
+				authors: 'me',
+				createdAt: '2024-01-01',
+				autosaved: false,
+				isActive: false,
+				isCurrentDraft: false,
+				nodes: [
+					{
+						name: 'Set',
+						type: 'n8n-nodes-base.set',
+						parameters: { big: 'blob' },
+						position: [0, 0],
+					},
+				],
+				connections: {},
+			});
 
 			const tool = createWorkflowsTool(context, 'full');
 			const result = await executeTool(
 				tool,
-				{ action: 'get-version', workflowId: 'wf1', versionId: 'v1' },
+				{ action: 'get', workflowId: 'wf1', versionId: 'v1' },
 				{} as never,
 			);
 
+			expect(context.workflowService.getVersion).toHaveBeenCalledWith('wf1', 'v1');
 			expect(result).toMatchObject({
+				workflowId: 'wf1',
 				versionId: 'v1',
 				nodeCount: 1,
-				nodes: [{ name: 'Set', type: 'n8n-nodes-base.set' }],
+				structure: '// generated code',
 			});
 			expect(JSON.stringify(result)).not.toContain('blob');
 		});
 
-		it('should return the complete version payload when full is true', async () => {
+		it('should explain when versionId is passed but version history is unavailable', async () => {
 			const context = createMockContext();
-			context.workflowService.getVersion = vi.fn().mockResolvedValue(versionDetail);
 
 			const tool = createWorkflowsTool(context, 'full');
 			const result = await executeTool(
 				tool,
-				{ action: 'get-version', workflowId: 'wf1', versionId: 'v1', full: true },
+				{ action: 'get', workflowId: 'wf1', versionId: 'v1' },
 				{} as never,
 			);
 
-			expect(result).toEqual(versionDetail);
+			expect(result).toEqual({
+				workflowId: 'wf1',
+				versionId: 'v1',
+				error: 'Workflow version history is not available on this instance',
+			});
 		});
 	});
 
@@ -546,8 +570,29 @@ describe('workflows tool', () => {
 				{} as never,
 			);
 
-			expect(context.workflowService.getAsWorkflowJSON).toHaveBeenCalledWith('wf1');
+			expect(context.workflowService.getAsWorkflowJSON).toHaveBeenCalledWith('wf1', undefined);
 			expect(result).toEqual(workflow);
+		});
+
+		it('should forward versionId to the full fetches', async () => {
+			const context = createMockContext();
+			const tool = createWorkflowsTool(context, 'full');
+
+			await executeTool(
+				tool,
+				{ action: 'get-json', workflowId: 'wf1', versionId: 'v7' },
+				{} as never,
+			);
+			await executeTool(
+				tool,
+				{ action: 'get-as-code', workflowId: 'wf1', versionId: 'v7' },
+				{} as never,
+			);
+
+			expect((context.workflowService.getAsWorkflowJSON as Mock).mock.calls).toEqual([
+				['wf1', 'v7'],
+				['wf1', 'v7'],
+			]);
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -9,6 +9,7 @@ import {
 	applyNodeChanges,
 	buildCompletedReport,
 } from '../workflows/setup-workflow.service';
+import { STRUCTURE_ONLY_NOTE } from '../workflows/summarize-workflow';
 import { createWorkflowsTool, type WorkflowAction } from '../workflows.tool';
 
 // Mock the setup-workflow.service module to avoid pulling in heavy dependencies
@@ -455,17 +456,21 @@ describe('workflows tool', () => {
 			const result = await executeTool(tool, { action: 'get', workflowId: 'wf1' }, {} as never);
 
 			expect(context.workflowService.get).toHaveBeenCalledWith('wf1');
-			expect(result).toMatchObject({
+			expect(result).toEqual({
 				id: 'wf1',
 				name: 'Test WF',
 				versionId: 'v1',
+				activeVersionId: null,
+				isArchived: false,
+				createdAt: '2024-01-01',
+				updatedAt: '2024-01-01',
 				nodeCount: 3,
 				structure: '// generated code',
+				note: STRUCTURE_ONLY_NOTE,
 			});
 			const codegenInput = vi.mocked(generateWorkflowCode).mock.calls[0][0];
 			expect(codegenInput).toMatchObject({ name: 'Test WF' });
 			expect(JSON.stringify(codegenInput)).not.toContain('conditions');
-			expect(JSON.stringify(result)).not.toContain('conditions');
 		});
 
 		it('should return the complete payload when full is true', async () => {
@@ -549,13 +554,20 @@ describe('workflows tool', () => {
 			);
 
 			expect(context.workflowService.getVersion).toHaveBeenCalledWith('wf1', 'v1');
-			expect(result).toMatchObject({
+			expect(result).toEqual({
 				workflowId: 'wf1',
 				versionId: 'v1',
+				name: 'Checkpoint',
+				description: null,
+				authors: 'me',
+				createdAt: '2024-01-01',
+				autosaved: false,
+				isActive: false,
+				isCurrentDraft: false,
 				nodeCount: 1,
 				structure: '// generated code',
+				note: STRUCTURE_ONLY_NOTE,
 			});
-			expect(JSON.stringify(result)).not.toContain('blob');
 		});
 
 		it('should explain when versionId is passed but version history is unavailable', async () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -1,7 +1,7 @@
 /**
  * Consolidated workflows tool — list, get, get-json, get-as-code, delete/archive,
- * unarchive, setup, publish, unpublish, list-versions, get-version,
- * restore-version, update-version.
+ * unarchive, setup, publish, unpublish, list-versions, restore-version,
+ * update-version.
  */
 import { Tool } from '@n8n/agents';
 import { isRecord } from '@n8n/utils/is-record';
@@ -18,11 +18,7 @@ import {
 	applyNodeChanges,
 	buildCompletedReport,
 } from './workflows/setup-workflow.service';
-import {
-	STRUCTURE_ONLY_NOTE,
-	summarizeConnections,
-	summarizeNodes,
-} from './workflows/summarize-workflow';
+import { STRUCTURE_ONLY_NOTE, summarizeWorkflowStructure } from './workflows/summarize-workflow';
 import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
 
@@ -52,27 +48,30 @@ const getAction = z.object({
 	action: z
 		.literal('get')
 		.describe(
-			'Inspect a workflow: metadata, node names/types, and connection structure. Node parameters are omitted — use get-json or get-as-code when you need them.',
+			'Inspect a workflow: metadata plus its structure as SDK code with node parameters omitted — use get-json or get-as-code when you need them. Pass versionId to inspect a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
+	versionId: z.string().optional().describe('Version ID'),
 });
 
 const getJsonAction = z.object({
 	action: z
 		.literal('get-json')
 		.describe(
-			'Get full WorkflowJSON for workspace-file workflow edits. Write it to a .workflow.json file, edit the file, then save with build-workflow.',
+			'Get full WorkflowJSON for workspace-file workflow edits. Write it to a .workflow.json file, edit the file, then save with build-workflow. Pass versionId for a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
+	versionId: z.string().optional().describe('Version ID'),
 });
 
 const getAsCodeAction = z.object({
 	action: z
 		.literal('get-as-code')
 		.describe(
-			'Convert an existing workflow to TypeScript SDK code. Call before precise patches when you need the current code.',
+			'Convert an existing workflow to TypeScript SDK code. Call before precise patches when you need the current code. Pass versionId for a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
+	versionId: z.string().optional().describe('Version ID'),
 });
 
 const deleteAction = z.object({
@@ -151,20 +150,6 @@ const listVersionsAction = z.object({
 	skip: z.number().int().min(0).optional().describe('Number of results to skip (default 0)'),
 });
 
-const getVersionAction = z.object({
-	action: z
-		.literal('get-version')
-		.describe(
-			'Get details of a specific workflow version. Returns structure only by default; pass full: true for node parameters.',
-		),
-	workflowId: z.string().describe('ID of the workflow'),
-	versionId: z.string().describe('Version ID'),
-	full: z
-		.boolean()
-		.optional()
-		.describe('Return complete node data including parameters (large). Default false.'),
-});
-
 const restoreVersionAction = z.object({
 	action: z.literal('restore-version').describe('Restore a workflow to a previous version'),
 	workflowId: z.string().describe('ID of the workflow'),
@@ -216,7 +201,6 @@ type Input =
 	| z.infer<typeof publishExtendedAction>
 	| z.infer<typeof unpublishAction>
 	| z.infer<typeof listVersionsAction>
-	| z.infer<typeof getVersionAction>
 	| z.infer<typeof restoreVersionAction>
 	| z.infer<typeof updateVersionAction>;
 
@@ -238,7 +222,6 @@ export type WorkflowAction =
 	| 'publish'
 	| 'unpublish'
 	| 'list-versions'
-	| 'get-version'
 	| 'restore-version'
 	| 'update-version';
 
@@ -266,7 +249,6 @@ const WORKFLOW_ACTION_ORDER = [
 	'publish',
 	'unpublish',
 	'list-versions',
-	'get-version',
 	'restore-version',
 	'update-version',
 ] as const satisfies readonly WorkflowAction[];
@@ -284,7 +266,6 @@ const WORKFLOW_ACTION_LABELS = {
 	publish: 'publish',
 	unpublish: 'unpublish',
 	'list-versions': 'list versions',
-	'get-version': 'inspect versions',
 	'restore-version': 'restore versions',
 	'update-version': 'update version metadata',
 } satisfies Record<WorkflowAction, string>;
@@ -315,7 +296,6 @@ function getSupportedWorkflowActionSchemas(
 		...(hasVersions
 			? {
 					'list-versions': listVersionsAction,
-					'get-version': getVersionAction,
 					'restore-version': restoreVersionAction,
 				}
 			: {}),
@@ -386,12 +366,31 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 async function handleGet(context: InstanceAiContext, input: Extract<Input, { action: 'get' }>) {
 	// Convert hallucinated-id errors into structured not-found responses so the agent stops guessing.
 	try {
+		if (input.versionId) {
+			if (!context.workflowService.getVersion) {
+				return {
+					workflowId: input.workflowId,
+					versionId: input.versionId,
+					error: 'Workflow version history is not available on this instance',
+				};
+			}
+			const { nodes, connections, ...meta } = await context.workflowService.getVersion(
+				input.workflowId,
+				input.versionId,
+			);
+			return {
+				workflowId: input.workflowId,
+				...meta,
+				nodeCount: nodes.length,
+				structure: await summarizeWorkflowStructure(meta.name ?? '', nodes, connections),
+				note: STRUCTURE_ONLY_NOTE,
+			};
+		}
 		const { nodes, connections, ...meta } = await context.workflowService.get(input.workflowId);
 		return {
 			...meta,
 			nodeCount: nodes.length,
-			nodes: summarizeNodes(nodes),
-			connections: summarizeConnections(connections),
+			structure: await summarizeWorkflowStructure(meta.name, nodes, connections),
 			note: STRUCTURE_ONLY_NOTE,
 		};
 	} catch (error) {
@@ -417,7 +416,7 @@ async function handleGetJson(
 	input: Extract<Input, { action: 'get-json' }>,
 ) {
 	try {
-		return await context.workflowService.getAsWorkflowJSON(input.workflowId);
+		return await context.workflowService.getAsWorkflowJSON(input.workflowId, input.versionId);
 	} catch (error) {
 		return {
 			workflowId: input.workflowId,
@@ -433,7 +432,7 @@ async function handleGetAsCode(
 ) {
 	const { generateWorkflowCode } = await import('@n8n/workflow-sdk');
 	try {
-		const json = await context.workflowService.getAsWorkflowJSON(input.workflowId);
+		const json = await context.workflowService.getAsWorkflowJSON(input.workflowId, input.versionId);
 		const code = generateWorkflowCode(json);
 		return { workflowId: input.workflowId, name: json.name, code };
 	} catch (error) {
@@ -1028,22 +1027,6 @@ async function handleListVersions(
 	return { versions };
 }
 
-async function handleGetVersion(
-	context: InstanceAiContext,
-	input: Extract<Input, { action: 'get-version' }>,
-) {
-	const version = await context.workflowService.getVersion!(input.workflowId, input.versionId);
-	if (input.full) return version;
-	const { nodes, connections, ...meta } = version;
-	return {
-		...meta,
-		nodeCount: nodes.length,
-		nodes: summarizeNodes(nodes),
-		connections: summarizeConnections(connections),
-		note: 'Node parameters omitted to keep context small. Pass full: true when you need the complete version payload.',
-	};
-}
-
 async function handleRestoreVersion(
 	context: InstanceAiContext,
 	input: Extract<Input, { action: 'restore-version' }>,
@@ -1210,8 +1193,6 @@ export function createWorkflowsTool(
 					return await handleUnpublish(context, workflowInput, ctx);
 				case 'list-versions':
 					return await handleListVersions(context, workflowInput);
-				case 'get-version':
-					return await handleGetVersion(context, workflowInput);
 				case 'restore-version':
 					return await handleRestoreVersion(context, workflowInput, ctx);
 				case 'update-version':

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -18,7 +18,11 @@ import {
 	applyNodeChanges,
 	buildCompletedReport,
 } from './workflows/setup-workflow.service';
-import { STRUCTURE_ONLY_NOTE, summarizeWorkflowStructure } from './workflows/summarize-workflow';
+import {
+	isSmallPayload,
+	STRUCTURE_ONLY_NOTE,
+	summarizeWorkflowStructure,
+} from './workflows/summarize-workflow';
 import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
 
@@ -48,10 +52,14 @@ const getAction = z.object({
 	action: z
 		.literal('get')
 		.describe(
-			'Inspect a workflow: metadata plus its structure as SDK code with node parameters omitted — use get-json or get-as-code when you need them. Pass versionId to inspect a past version instead of the current draft.',
+			'Inspect a workflow: metadata plus its structure as SDK code. Large workflows omit node parameters unless full is set; small ones include them. Pass versionId to inspect a past version instead of the current draft.',
 		),
 	workflowId: z.string().describe('ID of the workflow'),
 	versionId: z.string().optional().describe('Version ID'),
+	full: z
+		.boolean()
+		.optional()
+		.describe('Return complete node data including parameters (large). Default false.'),
 });
 
 const getJsonAction = z.object({
@@ -374,10 +382,11 @@ async function handleGet(context: InstanceAiContext, input: Extract<Input, { act
 					error: 'Workflow version history is not available on this instance',
 				};
 			}
-			const { nodes, connections, ...meta } = await context.workflowService.getVersion(
-				input.workflowId,
-				input.versionId,
-			);
+			const version = await context.workflowService.getVersion(input.workflowId, input.versionId);
+			if (input.full || isSmallPayload(version)) {
+				return { workflowId: input.workflowId, ...version };
+			}
+			const { nodes, connections, ...meta } = version;
 			return {
 				workflowId: input.workflowId,
 				...meta,
@@ -386,7 +395,9 @@ async function handleGet(context: InstanceAiContext, input: Extract<Input, { act
 				note: STRUCTURE_ONLY_NOTE,
 			};
 		}
-		const { nodes, connections, ...meta } = await context.workflowService.get(input.workflowId);
+		const detail = await context.workflowService.get(input.workflowId);
+		if (input.full || isSmallPayload(detail)) return detail;
+		const { nodes, connections, ...meta } = detail;
 		return {
 			...meta,
 			nodeCount: nodes.length,

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -18,6 +18,11 @@ import {
 	applyNodeChanges,
 	buildCompletedReport,
 } from './workflows/setup-workflow.service';
+import {
+	STRUCTURE_ONLY_NOTE,
+	summarizeConnections,
+	summarizeNodes,
+} from './workflows/summarize-workflow';
 import { validateWorkflowConfig } from './workflows/validate-workflow.service';
 import { getReferencedWorkflowIds } from './workflows/workflow-json-utils';
 
@@ -46,7 +51,9 @@ const listAction = z.object({
 const getAction = z.object({
 	action: z
 		.literal('get')
-		.describe('Get full details of a specific workflow. Use for workflow inspection.'),
+		.describe(
+			'Inspect a workflow: metadata, node names/types, and connection structure. Node parameters are omitted — use get-json or get-as-code when you need them.',
+		),
 	workflowId: z.string().describe('ID of the workflow'),
 });
 
@@ -145,9 +152,17 @@ const listVersionsAction = z.object({
 });
 
 const getVersionAction = z.object({
-	action: z.literal('get-version').describe('Get full details of a specific workflow version'),
+	action: z
+		.literal('get-version')
+		.describe(
+			'Get details of a specific workflow version. Returns structure only by default; pass full: true for node parameters.',
+		),
 	workflowId: z.string().describe('ID of the workflow'),
 	versionId: z.string().describe('Version ID'),
+	full: z
+		.boolean()
+		.optional()
+		.describe('Return complete node data including parameters (large). Default false.'),
 });
 
 const restoreVersionAction = z.object({
@@ -371,7 +386,14 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 async function handleGet(context: InstanceAiContext, input: Extract<Input, { action: 'get' }>) {
 	// Convert hallucinated-id errors into structured not-found responses so the agent stops guessing.
 	try {
-		return await context.workflowService.get(input.workflowId);
+		const { nodes, connections, ...meta } = await context.workflowService.get(input.workflowId);
+		return {
+			...meta,
+			nodeCount: nodes.length,
+			nodes: summarizeNodes(nodes),
+			connections: summarizeConnections(connections),
+			note: STRUCTURE_ONLY_NOTE,
+		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : 'Failed to fetch workflow';
 		const available = await context.workflowService
@@ -1010,7 +1032,16 @@ async function handleGetVersion(
 	context: InstanceAiContext,
 	input: Extract<Input, { action: 'get-version' }>,
 ) {
-	return await context.workflowService.getVersion!(input.workflowId, input.versionId);
+	const version = await context.workflowService.getVersion!(input.workflowId, input.versionId);
+	if (input.full) return version;
+	const { nodes, connections, ...meta } = version;
+	return {
+		...meta,
+		nodeCount: nodes.length,
+		nodes: summarizeNodes(nodes),
+		connections: summarizeConnections(connections),
+		note: 'Node parameters omitted to keep context small. Pass full: true when you need the complete version payload.',
+	};
 }
 
 async function handleRestoreVersion(

--- a/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
@@ -1,16 +1,41 @@
 import { isRecord } from '@n8n/utils/is-record';
+import type { IConnection, IConnections } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
 
 import type { WorkflowNode } from '../../types';
 
 export const STRUCTURE_ONLY_NOTE =
-	'Node parameters omitted to keep context small. Use get-json or get-as-code when you need parameter-level detail.';
+	'Node parameters omitted to keep context small. Use get-json or get-as-code (optionally with versionId) when you need parameter-level detail.';
 
-export function summarizeNodes(nodes: WorkflowNode[]): Array<{ name: string; type: string }> {
-	return nodes.map(({ name, type }) => ({ name, type }));
+const CONNECTION_TYPES = new Set<string>(Object.values(NodeConnectionTypes));
+
+function isConnection(value: unknown): value is IConnection {
+	return (
+		isRecord(value) &&
+		typeof value.node === 'string' &&
+		typeof value.type === 'string' &&
+		CONNECTION_TYPES.has(value.type) &&
+		typeof value.index === 'number'
+	);
+}
+
+/** Rebuild a typed connections map from the loosely-typed service payload. */
+function toConnections(connections: Record<string, unknown>): IConnections {
+	const result: IConnections = {};
+	for (const [from, byType] of Object.entries(connections)) {
+		if (!isRecord(byType)) continue;
+		for (const [connectionType, outputs] of Object.entries(byType)) {
+			if (!Array.isArray(outputs)) continue;
+			(result[from] ??= {})[connectionType] = outputs.map((targets) =>
+				Array.isArray(targets) ? targets.filter(isConnection) : null,
+			);
+		}
+	}
+	return result;
 }
 
 /** Flatten n8n's connections map into edges like "A → B" or "A -(ai_tool)→ B". */
-export function summarizeConnections(connections: Record<string, unknown>): string[] {
+function summarizeConnections(connections: Record<string, unknown>): string[] {
 	const edges: string[] = [];
 	for (const [from, byType] of Object.entries(connections)) {
 		if (!isRecord(byType)) continue;
@@ -28,4 +53,37 @@ export function summarizeConnections(connections: Record<string, unknown>): stri
 		}
 	}
 	return edges;
+}
+
+/**
+ * Render a workflow's structure as SDK code with node parameters stripped —
+ * the same format the agent reads from get-as-code, minus the config payloads.
+ * Falls back to a plain node/edge listing when codegen rejects the graph.
+ */
+export async function summarizeWorkflowStructure(
+	name: string,
+	nodes: WorkflowNode[],
+	connections: Record<string, unknown>,
+): Promise<string> {
+	try {
+		const { generateWorkflowCode } = await import('@n8n/workflow-sdk');
+		return generateWorkflowCode({
+			name,
+			nodes: nodes.map((node) => ({
+				id: node.name,
+				name: node.name,
+				type: node.type,
+				typeVersion: node.typeVersion ?? 1,
+				position: [node.position[0] ?? 0, node.position[1] ?? 0],
+			})),
+			connections: toConnections(connections),
+		});
+	} catch {
+		return [
+			'Nodes:',
+			...nodes.map((node) => `- ${node.name} (${node.type})`),
+			'Connections:',
+			...summarizeConnections(connections).map((edge) => `- ${edge}`),
+		].join('\n');
+	}
 }

--- a/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
@@ -5,7 +5,14 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import type { WorkflowNode } from '../../types';
 
 export const STRUCTURE_ONLY_NOTE =
-	'Node parameters omitted to keep context small. Use get-json or get-as-code (optionally with versionId) when you need parameter-level detail.';
+	'Node parameters omitted to keep context small. Pass full: true to include them in one call, or use get-json / get-as-code (optionally with versionId) for parameter-level detail.';
+
+// Below this, summarizing saves too little to be worth a possible second full fetch.
+export const PARAMETERS_INLINE_LIMIT_BYTES = 4096;
+
+export function isSmallPayload(detail: unknown): boolean {
+	return JSON.stringify(detail).length <= PARAMETERS_INLINE_LIMIT_BYTES;
+}
 
 const CONNECTION_TYPES = new Set<string>(Object.values(NodeConnectionTypes));
 

--- a/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/summarize-workflow.ts
@@ -1,0 +1,31 @@
+import { isRecord } from '@n8n/utils/is-record';
+
+import type { WorkflowNode } from '../../types';
+
+export const STRUCTURE_ONLY_NOTE =
+	'Node parameters omitted to keep context small. Use get-json or get-as-code when you need parameter-level detail.';
+
+export function summarizeNodes(nodes: WorkflowNode[]): Array<{ name: string; type: string }> {
+	return nodes.map(({ name, type }) => ({ name, type }));
+}
+
+/** Flatten n8n's connections map into edges like "A → B" or "A -(ai_tool)→ B". */
+export function summarizeConnections(connections: Record<string, unknown>): string[] {
+	const edges: string[] = [];
+	for (const [from, byType] of Object.entries(connections)) {
+		if (!isRecord(byType)) continue;
+		for (const [connectionType, outputs] of Object.entries(byType)) {
+			if (!Array.isArray(outputs)) continue;
+			outputs.forEach((targets, outputIndex) => {
+				if (!Array.isArray(targets)) return;
+				for (const target of targets) {
+					if (!isRecord(target) || typeof target.node !== 'string') continue;
+					const typeLabel = connectionType === 'main' ? '' : `-(${connectionType})`;
+					const branchLabel = outputIndex > 0 ? `[${outputIndex}]` : '';
+					edges.push(`${from} ${typeLabel}${branchLabel}→ ${target.node}`);
+				}
+			});
+		}
+	}
+	return edges;
+}

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -73,6 +73,7 @@ export interface WorkflowDetail extends WorkflowSummary {
 export interface WorkflowNode {
 	name: string;
 	type: string;
+	typeVersion?: number;
 	parameters?: Record<string, unknown>;
 	position: number[];
 	webhookId?: string;
@@ -264,8 +265,9 @@ export interface InstanceAiWorkflowService {
 		scope?: 'project' | 'instance';
 	}): Promise<WorkflowSummary[]>;
 	get(workflowId: string): Promise<WorkflowDetail>;
-	/** Get the workflow as the SDK's WorkflowJSON (full node data for generateWorkflowCode). */
-	getAsWorkflowJSON(workflowId: string): Promise<WorkflowJSON>;
+	/** Get the workflow as the SDK's WorkflowJSON (full node data for generateWorkflowCode).
+	 *  Pass a versionId to get a past version's graph instead of the current draft. */
+	getAsWorkflowJSON(workflowId: string, versionId?: string): Promise<WorkflowJSON>;
 	/** Cheap version-only lookup. The adapter projects just `versionId` and
 	 *  `updatedAt` from the workflow row, skipping `nodes`/`connections`/etc.
 	 *  Use to validate per-session caches when the body isn't needed. */

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1677,6 +1677,9 @@ function createWorkflowAdapterForTests(overrides?: {
 		activateWorkflow: vi.fn().mockResolvedValue({ activeVersionId: 'version-1' }),
 		update: vi.fn().mockResolvedValue(savedWorkflow),
 	};
+	const mockWorkflowHistoryService = {
+		getVersion: vi.fn(),
+	};
 	const mockEnterpriseWorkflowService = {
 		preventTampering: vi.fn(async (data: unknown) => data),
 	};
@@ -1725,7 +1728,9 @@ function createWorkflowAdapterForTests(overrides?: {
 				.mockReturnValue({ branchReadOnly: overrides?.branchReadOnly ?? false }),
 		} as unknown as SourceControlPreferencesService,
 		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[22],
-		{} as unknown as ConstructorParameters<typeof InstanceAiAdapterService>[23],
+		mockWorkflowHistoryService as unknown as ConstructorParameters<
+			typeof InstanceAiAdapterService
+		>[23],
 		mockEnterpriseWorkflowService as unknown as ConstructorParameters<
 			typeof InstanceAiAdapterService
 		>[24],
@@ -1764,6 +1769,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		mockSharedWorkflowRepository,
 		mockAiBuilderTemporaryWorkflowRepository,
 		mockWorkflowService,
+		mockWorkflowHistoryService,
 		mockEnterpriseWorkflowService,
 		mockTelemetry,
 		mockLogger,
@@ -1826,6 +1832,32 @@ describe('createWorkflowAdapter', () => {
 				onError: 'continueErrorOutput',
 			}),
 		);
+	});
+
+	it('returns the version graph with current workflow metadata when a versionId is passed', async () => {
+		const { adapter, mockWorkflowHistoryService, mockUser } = createWorkflowAdapterForTests();
+		mockWorkflowHistoryService.getVersion.mockResolvedValue({
+			versionId: 'v-old',
+			nodes: [
+				{
+					id: 'old-id',
+					name: 'Old Node',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 3,
+					position: [0, 0],
+					parameters: { keep: true },
+				},
+			],
+			connections: { 'Old Node': {} },
+			nodeGroups: null,
+		});
+
+		const result = await adapter.getAsWorkflowJSON('wf-new', 'v-old');
+
+		expect(mockWorkflowHistoryService.getVersion).toHaveBeenCalledWith(mockUser, 'wf-new', 'v-old');
+		expect(result.name).toBe('Test Workflow');
+		expect(result.nodes[0]).toEqual(expect.objectContaining({ name: 'Old Node', typeVersion: 3 }));
+		expect(result.connections).toEqual({ 'Old Node': {} });
 	});
 
 	it('lists active workflows by default', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -492,12 +492,14 @@ export class InstanceAiAdapterService {
 				});
 			},
 
-			async getAsWorkflowJSON(workflowId: string) {
+			async getAsWorkflowJSON(workflowId: string, versionId?: string) {
 				const wf = await workflowFinderService.findWorkflowForUser(workflowId, user, [
 					'workflow:read',
 				]);
 				if (!wf) throw new Error(`Workflow ${workflowId} not found or not accessible`);
-				return toWorkflowJSON(wf, { redactParameters });
+				if (!versionId) return toWorkflowJSON(wf, { redactParameters });
+				const version = await workflowHistoryService.getVersion(user, workflowId, versionId);
+				return toWorkflowJSON(wf, { redactParameters, graph: version });
 			},
 
 			async getWorkflowHead(workflowId: string) {
@@ -782,6 +784,7 @@ export class InstanceAiAdapterService {
 						(n): WorkflowNode => ({
 							name: n.name,
 							type: n.type,
+							typeVersion: n.typeVersion,
 							parameters: redactParameters ? undefined : (n.parameters as Record<string, unknown>),
 							position: n.position,
 						}),
@@ -3101,13 +3104,18 @@ function sanitizeCredentialReferencesForSave(nodes: WorkflowJSON['nodes']): Work
 
 function toWorkflowJSON(
 	workflow: WorkflowEntity,
-	options?: { redactParameters?: boolean },
+	options?: {
+		redactParameters?: boolean;
+		/** Substitute a history version's graph while keeping workflow-level fields. */
+		graph?: Pick<WorkflowEntity, 'nodes' | 'connections' | 'nodeGroups'>;
+	},
 ): WorkflowJSON {
 	const redact = options?.redactParameters ?? false;
+	const source = options?.graph ?? workflow;
 	return {
 		id: workflow.id,
 		name: workflow.name,
-		nodes: (workflow.nodes ?? []).map((n) => ({
+		nodes: (source.nodes ?? []).map((n) => ({
 			id: n.id ?? '',
 			name: n.name,
 			type: n.type,
@@ -3124,9 +3132,9 @@ function toWorkflowJSON(
 			alwaysOutputData: n.alwaysOutputData,
 			onError: n.onError,
 		})),
-		connections: workflow.connections as WorkflowJSON['connections'],
+		connections: source.connections as WorkflowJSON['connections'],
 		settings: workflow.settings as WorkflowJSON['settings'],
-		...(workflow.nodeGroups ? { nodeGroups: workflow.nodeGroups } : {}),
+		...(source.nodeGroups ? { nodeGroups: source.nodeGroups } : {}),
 	};
 }
 
@@ -3147,6 +3155,7 @@ function toWorkflowDetail(
 			(n): WorkflowNode => ({
 				name: n.name,
 				type: n.type,
+				typeVersion: n.typeVersion,
 				parameters: redact ? undefined : n.parameters,
 				position: n.position,
 				webhookId: n.webhookId,

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -3106,7 +3106,7 @@ function toWorkflowJSON(
 	workflow: WorkflowEntity,
 	options?: {
 		redactParameters?: boolean;
-		/** Substitute a history version's graph while keeping workflow-level fields. */
+		/** Substitute a history version's graph; id/name/settings stay from the live entity, as history rows only carry a version label. */
 		graph?: Pick<WorkflowEntity, 'nodes' | 'connections' | 'nodeGroups'>;
 	},
 ): WorkflowJSON {


### PR DESCRIPTION
## Summary

Split out of #33466 (see the caching discussion there).

Full `WorkflowJSON` snapshots were ≈59% of tool-result bytes in orchestrator prompts (production trace decomposition, EU LangSmith, 2026-07-02). Most of them came from *inspect* calls that never needed node parameters, and each snapshot is re-read by every subsequent LLM call in the turn.

This separates inspecting a workflow from fetching its payload:

- **`workflows[get]`** now returns metadata plus the workflow structure rendered as SDK code with node parameters stripped: the same format the agent reads from `get-as-code` and writes when building, minus the config payloads. Subnodes and multi-output branches render as `subnodes: {...}` and `onTrue()/onFalse()`. A note points at `get-json` / `get-as-code` for parameter-level detail, and a plain node/edge listing is the fallback if codegen rejects the graph.
- **`get-version` is merged into `get`**: pass an optional `versionId` to inspect a past version and get the same structural summary.
- **`get-json` / `get-as-code`** accept an optional `versionId` to fetch the full payload of a past version. This replaces the earlier `full: true` flag on `get-version` and keeps the explicit full fetches as the single parameter-level path.

Addresses review feedback: merging `get`/`get-version` with `versionId` on the full fetches, and reusing the SDK code view instead of introducing a bespoke edge-list format.

Eval validation: the original edge-list variant was validated against the full builder eval suite on #33466 at 79.0% (PR) vs 76.6% (pinned master baseline), no regression. A re-run against the SDK-code variant has been triggered on this PR.

## How to test

Unit tests in `packages/@n8n/instance-ai`: `pnpm test src/tools/__tests__/workflows.tool.test.ts`. Adapter tests in `packages/cli`: `pnpm test src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts`.

Manually, in an AI Assistant thread: ask to inspect a workflow ("what does workflow X look like?"). The `workflows[get]` tool result should contain a `structure` field with SDK code and no node parameters; asking the assistant to edit the workflow should still work via `get-json` / `get-as-code`, and passing a `versionId` to `get` should summarize a past version.

## Related Linear tickets, Github issues, and Community forum posts

Split from #33466 (INS-753 / INS-754).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
