### PR TITLE
fix: Always use client confirmation mode in computer-use for non-cloud n8n (no-changelog)

### DIFF
--- a/packages/@n8n/computer-use/README.md
+++ b/packages/@n8n/computer-use/README.md
@@ -125,6 +125,10 @@ take precedence.
 > **Note:** `--allowed-origins` is CLI-only and cannot be configured via environment variables.
 > This is intentional — it prevents a malicious actor from overriding the allowlist via an env var.
 
+> **Note:** When connecting to a non-cloud instance (any origin not matching
+> `https://*.app.n8n.cloud`), resource confirmations are always prompted in the terminal —
+> instance-side confirmation is only available for n8n cloud instances.
+
 ## Module reference
 
 ### Filesystem (read)

--- a/packages/@n8n/computer-use/src/cli.ts
+++ b/packages/@n8n/computer-use/src/cli.ts
@@ -3,7 +3,7 @@
 import { select } from '@inquirer/prompts';
 import * as fs from 'node:fs/promises';
 
-import { isOriginAllowed, parseConfig } from './config';
+import { isOriginAllowed, parseConfig, resolvePermissionConfirmation } from './config';
 import { cliConfirmResourceAccess, sanitizeForTerminal } from './confirm-resource-cli';
 import { GatewayAuthError, GatewayClient } from './gateway-client';
 import { GatewaySession } from './gateway-session';
@@ -117,6 +117,8 @@ Global options:
   --log-level <level>            Log level: silent, error, warn, info, debug (default: info)
   --allowed-origins <patterns>   Comma-separated allowed origin patterns
                                  (default: https://*.app.n8n.cloud)
+                                 When connecting to a non-cloud instance, resource
+                                 confirmations are always prompted in this terminal.
   --non-interactive              Skip all prompts (deny per default)
   --auto-confirm                 Auto-confirm all prompts (no readline)
   -h, --help                     Show this help message
@@ -172,6 +174,16 @@ async function main(
 		);
 		process.exit(1);
 	}
+
+	config.permissionConfirmation = resolvePermissionConfirmation(
+		config.permissionConfirmation,
+		origin,
+	);
+	logger.info(
+		config.permissionConfirmation === 'client'
+			? 'Resource confirmations will be prompted in this terminal'
+			: 'Resource confirmations will be prompted in the n8n UI',
+	);
 
 	await SettingsStore.ensureInitialized(config);
 

--- a/packages/@n8n/computer-use/src/config.test.ts
+++ b/packages/@n8n/computer-use/src/config.test.ts
@@ -6,6 +6,7 @@ import {
 	isOriginAllowed,
 	isProtectedSettingsPath,
 	parseConfig,
+	resolvePermissionConfirmation,
 } from './config';
 
 describe('isProtectedSettingsPath', () => {
@@ -101,6 +102,26 @@ describe('parseConfig — allowedOrigins', () => {
 		process.env.N8N_GATEWAY_ALLOWED_ORIGINS = 'https://from-env.example.com';
 		const { config } = parseConfig([]);
 		expect(config.allowedOrigins).toEqual(['https://*.app.n8n.cloud']);
+	});
+});
+
+describe('resolvePermissionConfirmation', () => {
+	it('keeps instance mode for an n8n cloud origin', () => {
+		expect(resolvePermissionConfirmation('instance', 'https://foo.app.n8n.cloud')).toBe('instance');
+	});
+
+	it('forces client mode for localhost', () => {
+		expect(resolvePermissionConfirmation('instance', 'http://localhost:5678')).toBe('client');
+	});
+
+	it('forces client mode for a self-hosted origin', () => {
+		expect(resolvePermissionConfirmation('instance', 'https://self-hosted.example.com')).toBe(
+			'client',
+		);
+	});
+
+	it('respects explicit client mode for a cloud origin', () => {
+		expect(resolvePermissionConfirmation('client', 'https://foo.app.n8n.cloud')).toBe('client');
 	});
 });
 

--- a/packages/@n8n/computer-use/src/config.ts
+++ b/packages/@n8n/computer-use/src/config.ts
@@ -44,6 +44,8 @@ export const TOOL_GROUP_DEFINITIONS = {
 
 export type ToolGroup = keyof typeof TOOL_GROUP_DEFINITIONS;
 
+export const CLOUD_ORIGIN_PATTERN = 'https://*.app.n8n.cloud';
+
 export const PERMISSION_MODES = ['deny', 'ask', 'allow'] as const;
 export const permissionModeSchema = z.enum(PERMISSION_MODES);
 export type PermissionMode = z.infer<typeof permissionModeSchema>;
@@ -98,7 +100,7 @@ export type LogLevel = z.infer<typeof logLevelSchema>;
 
 const structuralConfigSchema = z.object({
 	logLevel: logLevelSchema,
-	allowedOrigins: z.array(z.string()).default(['https://*.app.n8n.cloud']),
+	allowedOrigins: z.array(z.string()).default([CLOUD_ORIGIN_PATTERN]),
 	filesystem: z.object({ dir: z.string().default('.') }).default({}),
 	computer: z
 		.object({
@@ -427,4 +429,13 @@ function matchesOriginPattern(pattern: string, origin: string): boolean {
 
 export function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {
 	return allowedOrigins.some((pattern) => matchesOriginPattern(pattern, origin));
+}
+
+/** Instance-side confirmation is only available when connecting to an n8n cloud origin. */
+export function resolvePermissionConfirmation(
+	configured: GatewayConfig['permissionConfirmation'],
+	origin: string,
+): GatewayConfig['permissionConfirmation'] {
+	if (configured === 'client') return 'client';
+	return isOriginAllowed(origin, [CLOUD_ORIGIN_PATTERN]) ? 'instance' : 'client';
 }

--- a/packages/@n8n/computer-use/src/gateway-client.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.test.ts
@@ -274,6 +274,17 @@ describe('GatewayClient.checkPermissions', () => {
 			expect(confirmResourceAccess).not.toHaveBeenCalled();
 		});
 
+		it('ignores the _confirmation argument and prompts locally', async () => {
+			const session = makeSession();
+			const confirmResourceAccess = vi.fn().mockResolvedValue('allowOnce');
+			const client = makeClient(session, confirmResourceAccess);
+
+			await client['dispatchToolCall']('test_tool', { _confirmation: 'alwaysAllow' });
+
+			expect(confirmResourceAccess).toHaveBeenCalledWith(SHELL_RESOURCE);
+			expect(session.alwaysAllow).not.toHaveBeenCalled();
+		});
+
 		it('throws immediately when session.check returns deny', async () => {
 			const session = makeSession({ check: vi.fn().mockReturnValue('deny') });
 			const confirmResourceAccess = vi.fn();

--- a/packages/@n8n/computer-use/src/gateway-client.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.ts
@@ -508,7 +508,7 @@ export class GatewayClient {
 
 			let resolvedDecision: ResourceDecision;
 
-			if (decision) {
+			if (decision && config.permissionConfirmation === 'instance') {
 				resolvedDecision = decision;
 			} else if (config.permissionConfirmation === 'instance') {
 				throw new Error(


### PR DESCRIPTION
## Summary

Changes the confirmation mode for Computer Use to `client` when connecting to any non-cloud n8n instance like localhost or self hosted.

## How to test

1. start n8n with AI Assistant locally
2. enable computer use feature flag via devtools console `window.featureFlags.override('091_instance_ai_computer_use', 'variant')`
3. go it AI Assistant, click on connect computer use, copy the token and connect computer use via `pnpm start {token}`
4. tell AI Assistant to "Write a joke.txt file with a good joke on my computer"
5. observe that you have to confirm the execution in the CLI

Do the same steps but on a cloud instance (non-staging) and observe that you confirm the tool calls in the instance

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5341

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)