### PR TITLE
fix(core): Exclude streaming endpoints from Sentry request tracing (no-changelog)

### DIFF
--- a/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
+++ b/packages/core/src/observability/tracing/__tests__/span-sampling.test.ts
@@ -255,16 +255,27 @@ describe('shouldIgnoreIncomingRequest', () => {
 		'/rest/telemetry/proxy/v1/track?foo=bar',
 		'/healthz',
 		'/healthz/readiness',
+		'/rest/instance-ai/events/abc-123',
+		'/mcp-server/http',
+		'/mcp-server/http?x=1',
+		'/mcp',
+		'/mcp/some/webhook',
+		'/mcp-test/some/webhook',
 	])('ignores noise path %s', (path) => {
 		expect(shouldIgnoreIncomingRequest(path)).toBe(true);
 	});
 
-	it.each(['/rest/workflows', '/rest/phony', '/', '/healthcheck'])(
-		'keeps signal-bearing path %s',
-		(path) => {
-			expect(shouldIgnoreIncomingRequest(path)).toBe(false);
-		},
-	);
+	it.each([
+		'/rest/workflows',
+		'/rest/phony',
+		'/',
+		'/healthcheck',
+		'/mcp-oauth/authorize', // real auth traffic must stay traced
+		'/rest/instance-ai/threads', // non-events instance-ai routes
+		'/mcpx', // no boundary match
+	])('keeps signal-bearing path %s', (path) => {
+		expect(shouldIgnoreIncomingRequest(path)).toBe(false);
+	});
 });
 
 describe('shouldIgnoreOutgoingRequest', () => {

--- a/packages/core/src/observability/tracing/span-sampling.ts
+++ b/packages/core/src/observability/tracing/span-sampling.ts
@@ -31,12 +31,27 @@ const NOISE_INCOMING_PATHS = [
 	/^\/rest\/telemetry\/proxy\//,
 ];
 
+/**
+ * Long-lived stream / MCP endpoints whose transaction duration is connection
+ * lifetime, not handler work. Recording them pollutes latency percentiles, so
+ * skip span creation entirely.
+ */
+const STREAMING_INCOMING_PATHS = [
+	/^\/rest\/instance-ai\/events(\/|$)/, // SSE stream (EventSource)
+	/^\/mcp-server\/http(\/|$)/, // Streamable-HTTP MCP
+	/^\/mcp(\/|$)/, // MCP webhook trigger (endpoints.mcp default)
+	/^\/mcp-test(\/|$)/, // test MCP webhook (endpoints.mcpTest default)
+];
+
 const TELEMETRY_HOSTNAME = 'telemetry.n8n.io';
 
 /** Whether an incoming request path should be skipped before a server span is created. */
 export function shouldIgnoreIncomingRequest(urlPath: string): boolean {
 	const path = urlPath.split('?')[0];
-	return NOISE_INCOMING_PATHS.some((re) => re.test(path));
+	return (
+		NOISE_INCOMING_PATHS.some((re) => re.test(path)) ||
+		STREAMING_INCOMING_PATHS.some((re) => re.test(path))
+	);
 }
 
 /** Outbound telemetry batch calls carry no tracing signal. */


### PR DESCRIPTION
## Summary

Long-lived stream/poll endpoints were recorded as ordinary request transactions in Sentry, so their multi-minute connection lifetimes polluted every latency percentile and dominated the "slowest endpoints" view. This adds the SSE and MCP streaming paths (`/rest/instance-ai/events/*`, `/mcp-server/http`, `/mcp/*`, and `/mcp-test/*`) to the existing head-level `ignoreIncomingRequests` filter, so no server span is ever created for them. The whole path is excluded for all HTTP methods, matching the existing path-only predicate style used for `/rest/ph`, telemetry proxies, and `/healthz`. Regexes are anchored so real auth traffic (`/mcp-oauth/*`) and non-events instance-ai routes stay traced.

## How to test

Run the unit tests over the predicate: `cd packages/core && pnpm test src/observability/tracing/__tests__/span-sampling.test.ts`. New assertions confirm the four streaming paths are ignored while `/mcp-oauth/authorize`, `/rest/instance-ai/threads`, and `/mcpx` remain traced.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3601

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

