### PR TITLE
fix(AWS Bedrock Chat Model Node): Default guardrail version to working draft when not set

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -294,8 +294,9 @@ export class LmChatAwsBedrock implements INodeType {
 										displayName: 'Guardrail Version',
 										name: 'guardrailVersion',
 										type: 'string',
-										default: '',
-										description: 'The version of the guardrail to apply',
+										default: 'DRAFT',
+										description:
+											'The version of the guardrail to apply, e.g. "1". Defaults to the working draft ("DRAFT").',
 									},
 									{
 										displayName: 'Trace',
@@ -387,7 +388,9 @@ export class LmChatAwsBedrock implements INodeType {
 		if (guardrail?.guardrailIdentifier) {
 			modelConfig.guardrailConfig = {
 				guardrailIdentifier: guardrail.guardrailIdentifier,
-				...(guardrail.guardrailVersion ? { guardrailVersion: guardrail.guardrailVersion } : {}),
+				// AWS requires a version whenever guardrailConfig is sent. The field may be blank or
+				// absent (collection defaults only materialize on add); fall back to the working draft.
+				guardrailVersion: guardrail.guardrailVersion || 'DRAFT',
 				...(guardrail.trace ? { trace: guardrail.trace } : {}),
 			};
 		}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -388,9 +388,10 @@ export class LmChatAwsBedrock implements INodeType {
 		if (guardrail?.guardrailIdentifier) {
 			modelConfig.guardrailConfig = {
 				guardrailIdentifier: guardrail.guardrailIdentifier,
-				// AWS requires a version whenever guardrailConfig is sent. The field may be blank or
-				// absent (collection defaults only materialize on add); fall back to the working draft.
-				guardrailVersion: guardrail.guardrailVersion || 'DRAFT',
+				// AWS requires a version whenever guardrailConfig is sent. The field may be blank,
+				// whitespace (e.g. from an expression), or absent (collection defaults only
+				// materialize on add); fall back to the working draft.
+				guardrailVersion: guardrail.guardrailVersion?.trim() || 'DRAFT',
 				...(guardrail.trace ? { trace: guardrail.trace } : {}),
 			};
 		}

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -343,6 +343,26 @@ describe('LmChatAwsBedrock', () => {
 				expect(config).not.toHaveProperty('guardrailConfig');
 			});
 
+			it('defaults the guardrail version to DRAFT when left blank', async () => {
+				const ctx = setupMockContext();
+				ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+					if (paramName === 'model') return 'amazon.nova-pro-v1:0';
+					if (paramName === 'options')
+						return {
+							guardrail: { values: { guardrailIdentifier: 'gr-123', guardrailVersion: '' } },
+						};
+					return undefined;
+				});
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+					expect.objectContaining({
+						guardrailConfig: { guardrailIdentifier: 'gr-123', guardrailVersion: 'DRAFT' },
+					}),
+				);
+			});
+
 			it('passes an inference-profile ARN model ID through verbatim without building a URL', async () => {
 				const arn =
 					'arn:aws:bedrock:eu-west-3:123456789012:inference-profile/eu.amazon.nova-pro-v1:0';

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -343,13 +343,16 @@ describe('LmChatAwsBedrock', () => {
 				expect(config).not.toHaveProperty('guardrailConfig');
 			});
 
-			it('defaults the guardrail version to DRAFT when left blank', async () => {
+			it.each([
+				['left blank', ''],
+				['whitespace-only', '   '],
+			])('defaults the guardrail version to DRAFT when %s', async (_case, version) => {
 				const ctx = setupMockContext();
 				ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
 					if (paramName === 'model') return 'amazon.nova-pro-v1:0';
 					if (paramName === 'options')
 						return {
-							guardrail: { values: { guardrailIdentifier: 'gr-123', guardrailVersion: '' } },
+							guardrail: { values: { guardrailIdentifier: 'gr-123', guardrailVersion: version } },
 						};
 					return undefined;
 				});


### PR DESCRIPTION
## Summary

> **Scope note:** this PR originally added full AWS Guardrails support for ENT-16. That feature landed independently on master in #33668 (Guardrail identifier/version/trace fixedCollection). This PR is now reduced to the one gap left: a blank **Guardrail Version** produced a `guardrailConfig` without a version, which AWS rejects at runtime (`ValidationException` — the Converse API requires `guardrailVersion` whenever `guardrailConfig` is sent).

- `supplyData` now falls back to `DRAFT` (the guardrail's working draft) when the version field is blank or was never added — instead of sending a versionless config that fails the invocation.
- The **Guardrail Version** field defaults to `DRAFT` in the UI and documents the fallback.

## How to test

Unit tests: `pnpm test nodes/llms/LmChatAwsBedrock` in `packages/@n8n/nodes-langchain` — new case: identifier set + version blank → `guardrailConfig: { guardrailIdentifier, guardrailVersion: 'DRAFT' }`.

Manual: on a workflow with the AWS Bedrock Chat Model node, add **Options → Guardrail**, fill only the identifier, run — before this fix AWS rejects the request with a validation error; with it, the guardrail's working draft applies.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-16 (feature itself shipped via #33668)

Docs follow-up: https://linear.app/n8n/issue/ENT-152

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (follow-up: [ENT-152](https://linear.app/n8n/issue/ENT-152))
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI