### PR TITLE
fix(core): Preserve Instance AI agent activity when its run snapshot is empty

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/message-parser.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/message-parser.test.ts
@@ -702,6 +702,108 @@ describe('parseStoredMessages', () => {
 			]);
 		});
 
+		it('should reconstruct tool calls when an empty snapshot is consumed as a leading orphan', () => {
+			// Real-world (thread 36a79497 / fal.ai build): a completed run whose snapshot was
+			// rebuilt from an already-evicted event bus, persisting an empty `agent-001` tree
+			// tagged with the turn's messageGroupId. Its createdAt sits at run start — before
+			// every assistant row — so it is consumed as a chronological *orphan* rather than
+			// paired. The empty orphan must not clobber the message-derived flat tree when the
+			// dedup pass collapses the turn.
+			const tc = (toolCallId: string, toolName: string) => ({
+				type: 'tool-call' as const,
+				toolCallId,
+				toolName,
+				input: {},
+				state: 'resolved' as const,
+				output: {},
+			});
+			const messages: StoredAgentMessage[] = [
+				{ id: 'u', role: 'user', content: 'generate content with fal.ai', createdAt: makeDate(0) },
+				{
+					id: 'a1',
+					role: 'assistant',
+					content: [tc('t1', 'workspace_write_file')],
+					createdAt: makeDate(20),
+				},
+				{ id: 'a2', role: 'assistant', content: [tc('t2', 'workflows')], createdAt: makeDate(30) },
+				{
+					id: 'a3',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'The workflow is built and verified.' }],
+					createdAt: makeDate(40),
+				},
+			];
+			const emptyTree: InstanceAiAgentNode = {
+				agentId: 'agent-001',
+				role: 'orchestrator',
+				status: 'completed',
+				textContent: '',
+				reasoning: '',
+				toolCalls: [],
+				children: [],
+				timeline: [],
+			};
+			const snapshots = [
+				{
+					tree: emptyTree,
+					runId: 'run_h4',
+					messageGroupId: 'mg_1',
+					runIds: ['run_h4'],
+					// Before every assistant row → consumed as a leading orphan, not paired.
+					createdAt: makeDate(5),
+					updatedAt: makeDate(5),
+				},
+			];
+
+			const result = parseStoredMessages(messages, snapshots);
+
+			const assistants = result.filter((m) => m.role === 'assistant');
+			expect(assistants).toHaveLength(1);
+			// The empty orphan snapshot must not overwrite the reconstructed activity.
+			expect(assistants[0].agentTree?.toolCalls.map((t) => t.toolName)).toEqual([
+				'workspace_write_file',
+				'workflows',
+			]);
+			expect(assistants[0].agentTree?.textContent).toBe('The workflow is built and verified.');
+		});
+
+		it('should not surface an empty paired snapshot tree on a content-less assistant row', () => {
+			// Same invariant as the orphan guard, on the *pairing* path: a non-renderable
+			// snapshot must never be authoritative. Here the empty snapshot pairs with an
+			// assistant row that also has no text/tools, so there is no flat tree to fall
+			// back to either — the row must end up with no tree, not the empty `agent-001`
+			// snapshot tree leaking through.
+			const messages: StoredAgentMessage[] = [
+				{ id: 'u', role: 'user', content: 'do nothing', createdAt: makeDate(0) },
+				{ id: 'a', role: 'assistant', content: [], createdAt: makeDate(1) },
+			];
+			const emptyTree: InstanceAiAgentNode = {
+				agentId: 'agent-001',
+				role: 'orchestrator',
+				status: 'completed',
+				textContent: '',
+				reasoning: '',
+				toolCalls: [],
+				children: [],
+				timeline: [],
+			};
+
+			const result = parseStoredMessages(messages, [
+				{
+					tree: emptyTree,
+					runId: 'run_x',
+					messageGroupId: 'mg_x',
+					createdAt: makeDate(1),
+					updatedAt: makeDate(1),
+				},
+			]);
+
+			const assistant = result.find((m) => m.role === 'assistant');
+			expect(assistant?.agentTree).toBeUndefined();
+			// Grouping metadata from the snapshot is still attached.
+			expect(assistant?.messageGroupId).toBe('mg_x');
+		});
+
 		it('should hydrate orphan snapshots without a matching assistant message', () => {
 			const snapshotCreatedAt = makeDate(1);
 			const tree = makeSnapshotTree('I finished the run, but I did not generate a final response.');

--- a/packages/cli/src/modules/instance-ai/message-parser.ts
+++ b/packages/cli/src/modules/instance-ai/message-parser.ts
@@ -353,7 +353,10 @@ export function parseStoredMessages(
 
 	function pushSnapshotMessage(snapshot: AgentTreeSnapshot): void {
 		const built = buildSnapshotMessage(snapshot);
-		messagesWithSnapshotTree.add(built);
+		// A degenerate (empty) orphan snapshot must not count as authoritative: when the
+		// turn also has message rows, their reconstructed flat tree must win the dedup
+		// collapse instead of this empty tree clobbering it. Mirrors the paired-row guard.
+		if (isRenderableTree(snapshot.tree)) messagesWithSnapshotTree.add(built);
 		messages.push(built);
 	}
 
@@ -446,9 +449,11 @@ export function parseStoredMessages(
 			// Prefer the snapshot tree, but when it carries no renderable content (e.g. an
 			// empty `cancelled` tree from a run whose events were lost before the snapshot
 			// was built) fall back to the message-derived flat tree so the turn's work still
-			// renders on reload.
+			// renders on reload. A non-renderable snapshot is never authoritative — if there
+			// is no flat tree either, leave the tree undefined rather than re-admitting the
+			// empty one.
 			const snapshotIsRenderable = snapshot !== undefined && isRenderableTree(snapshot.tree);
-			const agentTree = snapshotIsRenderable ? snapshot.tree : (messageFlatTree ?? snapshot?.tree);
+			const agentTree = snapshotIsRenderable ? snapshot.tree : messageFlatTree;
 
 			const assistantMessage: InstanceAiMessage = {
 				id: msg.id,


### PR DESCRIPTION
## Summary

When a thread's Instance AI **run snapshot** (the durable copy of the agent tree) is rebuilt from an already-evicted in-memory event bus, it can be persisted **empty** (`agent-001` root, no tool calls / children / timeline). On reload, `GET /rest/instance-ai/threads/:id/messages` let that empty tree win, so the assistant bubble rendered with **no tool calls** even though the full activity was recorded in the `instance_ai_messages` rows.

`#33335` added a message-derived flat-tree fallback for exactly this, but only guarded the *paired* snapshot path. This PR closes the two remaining leaks so a **non-renderable snapshot is never authoritative**:

1. **Orphan path** (`pushSnapshotMessage`) no longer marks an empty snapshot as snapshot-backed, so it can't clobber the reconstructed tree in the dedup collapse. This is the path the real-world thread hit — the snapshot's `createdAt` sits at run-start, before the work rows, so it's consumed as a leading orphan rather than paired.
2. **Paired path** drops the dead `?? snapshot?.tree` fallback (it only ever fired for a non-renderable tree, re-admitting the empty one).

The agent tree is reconstructed from the message rows instead. Fixes already-affected threads on read — no re-persist / migration needed.

> Note: the reconstructed tree is **flat** (orchestrator + its own tool calls). Sub-agent `children` live only in the event stream, so preserving those requires a separate root-cause fix (capturing the tree before event-bus eviction). Out of scope here.

## How to test

1. Open a thread whose assistant response currently shows an empty agent bubble (an empty `instance_ai_run_snapshots.tree` while `instance_ai_messages` has tool-call content), or run the unit tests below.
2. Reload — the assistant message now renders its tool-call activity reconstructed from the message rows instead of an empty bubble.

Unit tests (both added, RED→GREEN):

```bash
cd packages/cli
pnpm test src/modules/instance-ai/__tests__/message-parser.test.ts
```

- `should reconstruct tool calls when an empty snapshot is consumed as a leading orphan`
- `should not surface an empty paired snapshot tree on a content-less assistant row`

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

