### PR TITLE
fix(core): Keep already-redacted markers intact when scrubbing secrets (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -116,6 +116,26 @@ describe('OutputRedactor', () => {
 		expect(JSON.stringify(out)).not.toContain('abcdef1234567890');
 	});
 
+	it('leaves upstream browser redaction markers intact in a tool-result', () => {
+		const redactor = createRedactor();
+		const event: InstanceAiEvent = {
+			type: 'tool-result',
+			runId: 'run-1',
+			agentId: 'agent-1',
+			payload: {
+				toolCallId: 'tc-1',
+				result: {
+					snapshot: 'Client Secret [REDACTED:secret:1] Signing Secret [REDACTED:secret:2]',
+				},
+			},
+		};
+		const [out] = redactor.processEvent(event);
+		const serialized = JSON.stringify(out);
+		expect(serialized).not.toContain('[REDACTED:[REDACTED');
+		expect(serialized).toContain('[REDACTED:secret:1]');
+		expect(serialized).toContain('[REDACTED:secret:2]');
+	});
+
 	it('redacts confirmation card display text', () => {
 		const redactor = createRedactor(createLogger(), { detect: ['email'] });
 		const event: InstanceAiEvent = {

--- a/packages/@n8n/utils/src/scrub-secrets.test.ts
+++ b/packages/@n8n/utils/src/scrub-secrets.test.ts
@@ -121,6 +121,22 @@ describe('scrubSecretsInText', () => {
 		expect(scrubSecretsInText(ownOutput)).toBe(ownOutput);
 	});
 
+	it('leaves typed redaction markers untouched instead of nesting them', () => {
+		expect(scrubSecretsInText('[REDACTED:secret:1]')).toBe('[REDACTED:secret:1]');
+		expect(scrubSecretsInText('[REDACTED:password:2]')).toBe('[REDACTED:password:2]');
+		const out = scrubSecretsInText('button "Copy [REDACTED:secret:1]" and [REDACTED:secret:2]');
+		expect(out).not.toContain('[REDACTED:[REDACTED');
+		expect(out).toContain('[REDACTED:secret:1]');
+		expect(out).toContain('[REDACTED:secret:2]');
+	});
+
+	it('leaves typed redaction markers untouched inside serialized JSON/JS fields', () => {
+		const json = '{"password":"[REDACTED:secret:1]","apiKey":"[REDACTED:anthropic_api_key:2]"}';
+		expect(scrubSecretsInText(json)).toBe(json);
+		const js = "{'password': '[REDACTED:secret:1]'}";
+		expect(scrubSecretsInText(js)).toBe(js);
+	});
+
 	it('leaves opaque strings alone to avoid false positives', () => {
 		expect(scrubSecretsInText('feedback about the workflow plan')).toBe(
 			'feedback about the workflow plan',

--- a/packages/@n8n/utils/src/scrub-secrets.ts
+++ b/packages/@n8n/utils/src/scrub-secrets.ts
@@ -46,20 +46,28 @@ export const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
 	// body uses the standard JSON-string idiom `(?:\\.|[^"\r\n])*` so an
 	// escaped quote inside the value (`"abc\"def"`) doesn't end the match
 	// early and leak the rest of the secret. The negative lookahead skips
-	// values that are already a `[redacted]` / `[REDACTED]` placeholder so
-	// this stays idempotent when chained behind upstream object-walking
-	// redaction (e.g. langsmith trace payloads).
+	// values that are already a `[redacted]` / `[REDACTED]` / typed
+	// `[REDACTED:<type>:<index>]` placeholder so this stays idempotent when
+	// chained behind upstream object-walking redaction (langsmith trace
+	// payloads, mcp-browser markers).
 	new RegExp(
-		`"(?:${SECRET_KEYS})"\\s*:\\s*"(?!\\[(?:redacted|REDACTED)\\]")(?:\\\\.|[^"\\r\\n])*"`,
+		`"(?:${SECRET_KEYS})"\\s*:\\s*"(?!\\[(?:redacted|REDACTED)(?::[^"\\]]*)?\\]")(?:\\\\.|[^"\\r\\n])*"`,
 		'gi',
 	),
 	// JS-object-shaped `'key': 'value'`
 	new RegExp(
-		`'(?:${SECRET_KEYS})'\\s*:\\s*'(?!\\[(?:redacted|REDACTED)\\]')(?:\\\\.|[^'\\r\\n])*'`,
+		`'(?:${SECRET_KEYS})'\\s*:\\s*'(?!\\[(?:redacted|REDACTED)(?::[^'\\]]*)?\\]')(?:\\\\.|[^'\\r\\n])*'`,
 		'gi',
 	),
-	// Generic `password=...` / `api_key=...` / `secret=...` style assignments
-	new RegExp(`\\b(?:${SECRET_KEYS})\\s*[:=]\\s*\\S+`, 'gi'),
+	// Generic `password=...` / `api_key=...` / `secret=...` style assignments.
+	// The negative lookbehind skips a keyword sitting at the `<type>` position of
+	// an upstream `[REDACTED:<type>:<index>]` marker (e.g. mcp-browser output), so
+	// the `secret:1]` tail isn't re-matched into a nested `[REDACTED:[REDACTED]`.
+	// Checking only the `[REDACTED:` prefix suffices: inside a marker a keyword can
+	// only start a `\b` match right after that prefix — every other keyword-shaped
+	// substring is preceded by `_` (snake_case type slug) or a digit, so no word
+	// boundary opens there.
+	new RegExp(`(?<!\\[(?:redacted|REDACTED):)\\b(?:${SECRET_KEYS})\\s*[:=]\\s*\\S+`, 'gi'),
 ];
 
 export function scrubSecretsInText(input: string): string {


### PR DESCRIPTION
## Summary

The instance-based browser use feature redacts secrets in page snapshots. Its output was sometimes double-encoded into invalid nested markers like `[REDACTED:[REDACTED]` (reliably reproducible on the Slack app settings page, where both the client secret and signing secret collapsed to the same mangled marker).

Root cause: two redaction layers run in sequence on browser tool output.

1. `@n8n/mcp-browser` redacts detected secrets into typed markers shaped `[REDACTED:<type>:<index>]` (e.g. `[REDACTED:secret:1]`).
2. The instance-ai `OutputRedactor` then re-scans that already-redacted `tool-result` using the shared `SECRET_VALUE_PATTERNS` from `@n8n/utils/scrub-secrets`. Its generic `key:value` pattern matched the `secret:1]` tail *inside* the marker and replaced it with the bare placeholder, yielding `[REDACTED:` + `[REDACTED]` = `[REDACTED:[REDACTED]`.

`scrub-secrets` was already designed to be idempotent behind upstream redaction, but only recognised the *bare* `[REDACTED]` placeholder — not the typed `[REDACTED:<type>:<index>]` shape. This fixes that in the single source of truth (`SECRET_VALUE_PATTERNS`), so both `scrubSecretsInText` and the `@n8n/agents` redactor that instance-ai uses inherit it:

- generic assignment pattern: a negative lookbehind skips a keyword sitting at the marker's `<type>` position;
- JSON and JS-object patterns: the existing idempotency lookahead is widened to also skip `[REDACTED:...]` values.

No change to the mcp-browser marker format (avoids touching its `browser_capture_secret` round-trip parsing).

## How to test

via instance-based browser use, open the Slack app settings page (`https://api.slack.com/apps/<id>/general`) or any other secrets page and confirm the snapshot shows two distinct `[REDACTED:...:1]` / `[REDACTED:...:2]` markers with no nesting.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5360

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI