### PR TITLE
fix(ai-builder): Make eval verifier resilient to stalls and exclude no-verdict runs from scoring (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/aggregator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/aggregator.test.ts
@@ -1,0 +1,98 @@
+import { aggregateResults } from '../cli/aggregator';
+import type { ExecutionScenario, WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+
+const scenario: ExecutionScenario = {
+	name: 'happy-path',
+	description: 'baseline',
+	dataSetup: 'plain',
+	successCriteria: 'works',
+};
+
+const testCase: WorkflowTestCase = {
+	conversation: [{ role: 'user', text: 'build it' }],
+	complexity: 'simple',
+	tags: [],
+	executionScenarios: [scenario],
+	datasets: ['full'],
+};
+
+function makeRunResult(run: {
+	success: boolean;
+	incomplete?: boolean;
+	failureCategory?: string;
+}): WorkflowTestCaseResult {
+	return {
+		testCase,
+		workflowBuildSuccess: true,
+		executionScenarioResults: [
+			{
+				scenario,
+				success: run.success,
+				score: run.success ? 1 : 0,
+				reasoning: run.success ? 'ok' : 'nope',
+				failureCategory: run.failureCategory,
+				...(run.incomplete ? { incomplete: true } : {}),
+			},
+		],
+	};
+}
+
+describe('aggregateResults — verifier-incomplete scenario runs', () => {
+	it('keeps incomplete runs out of the denominator but visible in runs', () => {
+		const allRuns = [
+			[makeRunResult({ success: true })],
+			[makeRunResult({ success: false, failureCategory: 'builder_issue' })],
+			[
+				makeRunResult({
+					success: false,
+					incomplete: true,
+					failureCategory: 'verification_failure',
+				}),
+			],
+		];
+
+		const evaluation = aggregateResults(allRuns, 3);
+		const sa = evaluation.testCases[0].executionScenarios[0];
+
+		expect(sa.runs).toHaveLength(3);
+		expect(sa.evaluatedCount).toBe(2);
+		expect(sa.passCount).toBe(1);
+		expect(sa.passRate).toBe(0.5);
+		// pass metrics computed over evaluated runs only (n=2)
+		expect(sa.passAtK).toHaveLength(2);
+		expect(sa.passAtK[0]).toBeCloseTo(0.5);
+		expect(sa.passAtK[1]).toBeCloseTo(1);
+	});
+
+	it('reports evaluatedCount 0 when every run is incomplete', () => {
+		const allRuns = [
+			[makeRunResult({ success: false, incomplete: true })],
+			[makeRunResult({ success: false, incomplete: true })],
+		];
+
+		const evaluation = aggregateResults(allRuns, 2);
+		const sa = evaluation.testCases[0].executionScenarios[0];
+
+		expect(sa.evaluatedCount).toBe(0);
+		expect(sa.passCount).toBe(0);
+		expect(sa.passRate).toBe(0);
+		expect(sa.passAtK).toEqual([]);
+		expect(sa.runs).toHaveLength(2);
+	});
+
+	it('leaves fully-evaluated scenarios unchanged', () => {
+		const allRuns = [
+			[makeRunResult({ success: true })],
+			[makeRunResult({ success: true })],
+			[makeRunResult({ success: false, failureCategory: 'mock_issue' })],
+		];
+
+		const evaluation = aggregateResults(allRuns, 3);
+		const sa = evaluation.testCases[0].executionScenarios[0];
+
+		expect(sa.evaluatedCount).toBe(3);
+		expect(sa.passCount).toBe(2);
+		expect(sa.passRate).toBeCloseTo(2 / 3);
+		expect(sa.passAtK).toHaveLength(3);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/checklist-verifier.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/checklist-verifier.test.ts
@@ -1,0 +1,343 @@
+import type { Mock } from 'vitest';
+import { vi } from 'vitest';
+
+vi.mock('../../src/utils/eval-agents', () => ({
+	createEvalAgent: vi.fn(),
+	resolveEvalModelConfig: vi.fn(() => ({
+		modelId: 'anthropic/test-model',
+		provider: 'anthropic',
+		providerModelId: 'test-model',
+		apiKey: 'test-key',
+	})),
+	EPHEMERAL_CACHE: {},
+}));
+
+import { createEvalAgent, resolveEvalModelConfig } from '../../src/utils/eval-agents';
+import {
+	VERIFY_ATTEMPT_TIMEOUTS_MS,
+	VERIFY_INACTIVITY_TIMEOUT_MS,
+	verifyChecklist,
+} from '../checklist/verifier';
+import type { VerificationArtifact } from '../harness/runner';
+import type { ChecklistItem } from '../types';
+
+const mockCreateEvalAgent = vi.mocked(createEvalAgent);
+const mockResolveEvalModelConfig = vi.mocked(resolveEvalModelConfig);
+
+const CHECKLIST: ChecklistItem[] = [
+	{ id: 1, description: 'two posts forwarded', category: 'execution', strategy: 'llm' },
+];
+
+const ARTIFACT: VerificationArtifact = {
+	workflowContext: '## Workflow structure',
+	scenarioContext: '## Scenario',
+};
+
+const GOOD_OUTPUT = {
+	results: [
+		{ id: 1, pass: true, reasoning: 'looks right', failureCategory: null, rootCause: null },
+	],
+};
+
+type StreamFn = Mock<(messages: unknown, opts: { abortSignal: AbortSignal }) => Promise<unknown>>;
+
+/** Wire createEvalAgent().structuredOutput().stream() to the given stream mock. */
+function mockVerifierAgent(stream: StreamFn): void {
+	const agent = { stream };
+	const structuredOutput = vi.fn().mockReturnValue(agent);
+	mockCreateEvalAgent.mockReturnValue({ structuredOutput } as unknown as ReturnType<
+		typeof createEvalAgent
+	>);
+}
+
+/** A stream that emits the given chunks immediately, then closes. */
+function chunkStream(chunks: unknown[]): ReadableStream<unknown> {
+	return new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
+/** A stream that never emits anything (stuck transport). */
+function stuckStream(): ReadableStream<unknown> {
+	return new ReadableStream({ start: () => {} });
+}
+
+/** A stream that emits a delta every `intervalMs` forever (alive but never finishing). */
+function heartbeatStream(intervalMs: number): ReadableStream<unknown> {
+	let cancelled = false;
+	return new ReadableStream({
+		start(controller) {
+			const tick = (): void => {
+				if (cancelled) return;
+				try {
+					controller.enqueue({ type: 'text-delta', id: 't', delta: '.' });
+				} catch {
+					return;
+				}
+				setTimeout(tick, intervalMs);
+			};
+			setTimeout(tick, intervalMs);
+		},
+		cancel() {
+			cancelled = true;
+		},
+	});
+}
+
+/** A stream that emits chunks at the given fake-clock offsets, then closes. */
+function timedStream(events: Array<{ at: number; chunk?: unknown; close?: true }>) {
+	return new ReadableStream({
+		start(controller) {
+			for (const event of events) {
+				setTimeout(() => {
+					if (event.chunk !== undefined) controller.enqueue(event.chunk);
+					if (event.close) controller.close();
+				}, event.at);
+			}
+		},
+	});
+}
+
+async function runWithTimers(promise: Promise<unknown>): Promise<unknown> {
+	await vi.runAllTimersAsync();
+	return await promise;
+}
+
+describe('verifyChecklist (agents stream path)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.spyOn(Math, 'random').mockReturnValue(0.5);
+		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		mockResolveEvalModelConfig.mockReturnValue({
+			modelId: 'anthropic/test-model',
+			provider: 'anthropic',
+			providerModelId: 'test-model',
+			apiKey: 'test-key',
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('parses structured output from the finish chunk', async () => {
+		const stream: StreamFn = vi.fn().mockResolvedValue({
+			stream: chunkStream([
+				{ type: 'text-delta', id: 't', delta: 'thinking…' },
+				{
+					type: 'finish',
+					finishReason: 'stop',
+					usage: { totalTokens: 10 },
+					structuredOutput: GOOD_OUTPUT,
+				},
+			]),
+		});
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toEqual([
+			{
+				id: 1,
+				pass: true,
+				reasoning: 'looks right',
+				strategy: 'llm',
+				failureCategory: undefined,
+				rootCause: undefined,
+			},
+		]);
+		expect(attempts).toHaveLength(1);
+		expect(attempts[0].status).toBe('success');
+		expect(stream).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to parsing the streamed text when no structured output arrives', async () => {
+		const json = JSON.stringify(GOOD_OUTPUT);
+		const stream: StreamFn = vi.fn().mockResolvedValue({
+			stream: chunkStream([
+				{ type: 'text-delta', id: 't', delta: json.slice(0, 20) },
+				{ type: 'text-delta', id: 't', delta: json.slice(20) },
+				{ type: 'finish', finishReason: 'stop' },
+			]),
+		});
+		mockVerifierAgent(stream);
+
+		const { results } = (await runWithTimers(verifyChecklist(CHECKLIST, ARTIFACT))) as Awaited<
+			ReturnType<typeof verifyChecklist>
+		>;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].pass).toBe(true);
+	});
+
+	it('aborts a stuck stream on inactivity and exhausts all ladder attempts', async () => {
+		const stream: StreamFn = vi
+			.fn()
+			.mockImplementation(async () => await Promise.resolve({ stream: stuckStream() }));
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toEqual([]);
+		expect(attempts).toHaveLength(VERIFY_ATTEMPT_TIMEOUTS_MS.length);
+		for (const attempt of attempts) {
+			expect(attempt.status).toBe('threw');
+			expect(attempt.error).toContain(
+				`verifier stalled: no stream activity for ${VERIFY_INACTIVITY_TIMEOUT_MS}ms`,
+			);
+		}
+		expect(stream).toHaveBeenCalledTimes(VERIFY_ATTEMPT_TIMEOUTS_MS.length);
+	});
+
+	it('keeps an alive-but-slow stream open past the inactivity window and succeeds', async () => {
+		// Deltas at 30s/55s and finish at 58s: gaps stay under the 45s inactivity
+		// window, and the total stays under the 60s first-attempt cap.
+		const stream: StreamFn = vi.fn().mockResolvedValue({
+			stream: timedStream([
+				{ at: 30_000, chunk: { type: 'text-delta', id: 't', delta: '…' } },
+				{ at: 55_000, chunk: { type: 'text-delta', id: 't', delta: '…' } },
+				{
+					at: 58_000,
+					chunk: { type: 'finish', finishReason: 'stop', structuredOutput: GOOD_OUTPUT },
+					close: true,
+				},
+			]),
+		});
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toHaveLength(1);
+		expect(attempts[0].status).toBe('success');
+		expect(stream).toHaveBeenCalledTimes(1);
+	});
+
+	it('escalates the per-attempt cap 60s/120s/240s when the stream stays alive but never finishes', async () => {
+		const stream: StreamFn = vi
+			.fn()
+			.mockImplementation(async () => await Promise.resolve({ stream: heartbeatStream(30_000) }));
+		mockVerifierAgent(stream);
+
+		const promise = verifyChecklist(CHECKLIST, ARTIFACT);
+		// Bounded advance (not runAllTimers — the heartbeat reschedules forever):
+		// caps 60s+120s+240s, two jittered pauses ≤ 3.5s, plus slack.
+		await vi.advanceTimersByTimeAsync(430_000);
+		const { results, attempts } = await promise;
+
+		expect(results).toEqual([]);
+		expect(attempts.map((a) => a.error)).toEqual([
+			expect.stringContaining('verifier timed out after 60000ms'),
+			expect.stringContaining('verifier timed out after 120000ms'),
+			expect.stringContaining('verifier timed out after 240000ms'),
+		]);
+	});
+
+	it('retries after an error chunk and succeeds on the next attempt', async () => {
+		const stream: StreamFn = vi
+			.fn()
+			.mockResolvedValueOnce({
+				stream: chunkStream([
+					{ type: 'error', error: new Error('overloaded') },
+					{ type: 'finish', finishReason: 'error' },
+				]),
+			})
+			.mockResolvedValueOnce({
+				stream: chunkStream([
+					{ type: 'finish', finishReason: 'stop', structuredOutput: GOOD_OUTPUT },
+				]),
+			});
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toHaveLength(1);
+		expect(attempts.map((a) => a.status)).toEqual(['model_error', 'success']);
+		expect(attempts[0].error).toContain('overloaded');
+		expect(stream).toHaveBeenCalledTimes(2);
+	});
+
+	it('returns empty when the model keeps answering unparseably', async () => {
+		const stream: StreamFn = vi.fn().mockImplementation(
+			async () =>
+				await Promise.resolve({
+					stream: chunkStream([
+						{ type: 'text-delta', id: 't', delta: 'not json' },
+						{ type: 'finish', finishReason: 'stop' },
+					]),
+				}),
+		);
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toEqual([]);
+		expect(attempts.map((a) => a.status)).toEqual([
+			'no_parseable_results',
+			'no_parseable_results',
+			'no_parseable_results',
+		]);
+	});
+});
+
+describe('verifyChecklist (native OpenAI path)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.spyOn(Math, 'random').mockReturnValue(0.5);
+		vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		mockResolveEvalModelConfig.mockReturnValue({
+			modelId: 'openai/gpt-test',
+			provider: 'openai',
+			providerModelId: 'gpt-test',
+			apiKey: 'test-key',
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('uses the attempt-cap ladder as the only watchdog for the non-streaming fetch', async () => {
+		const fetchMock = vi.fn(
+			async (_url: unknown, init: { signal: AbortSignal }) =>
+				await new Promise((_resolve, reject) => {
+					init.signal.addEventListener(
+						'abort',
+						() => {
+							const reason: unknown = init.signal.reason;
+							reject(reason instanceof Error ? reason : new Error(String(reason)));
+						},
+						{ once: true },
+					);
+				}),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const promise = verifyChecklist(CHECKLIST, ARTIFACT);
+		await vi.runAllTimersAsync();
+		const { results, attempts } = await promise;
+
+		expect(results).toEqual([]);
+		expect(attempts.map((a) => a.error)).toEqual([
+			expect.stringContaining('verifier timed out after 60000ms'),
+			expect.stringContaining('verifier timed out after 120000ms'),
+			expect.stringContaining('verifier timed out after 240000ms'),
+		]);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/checklist-verifier.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/checklist-verifier.test.ts
@@ -176,10 +176,34 @@ describe('verifyChecklist (agents stream path)', () => {
 		expect(results[0].pass).toBe(true);
 	});
 
-	it('aborts a stuck stream on inactivity and exhausts all ladder attempts', async () => {
+	it('bounds a never-emitting stream by the attempt cap (inactivity not yet armed)', async () => {
 		const stream: StreamFn = vi
 			.fn()
 			.mockImplementation(async () => await Promise.resolve({ stream: stuckStream() }));
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toEqual([]);
+		expect(attempts.map((a) => a.error)).toEqual([
+			expect.stringContaining('verifier timed out after 60000ms'),
+			expect.stringContaining('verifier timed out after 120000ms'),
+			expect.stringContaining('verifier timed out after 240000ms'),
+		]);
+		expect(stream).toHaveBeenCalledTimes(VERIFY_ATTEMPT_TIMEOUTS_MS.length);
+	});
+
+	it('aborts a mid-stream stall on inactivity and exhausts all ladder attempts', async () => {
+		// One chunk arrives, then silence: the watchdog (armed by the first chunk)
+		// fires at chunk+45s, well before each attempt cap.
+		const stream: StreamFn = vi.fn().mockImplementation(
+			async () =>
+				await Promise.resolve({
+					stream: timedStream([{ at: 1_000, chunk: { type: 'text-delta', id: 't', delta: '…' } }]),
+				}),
+		);
 		mockVerifierAgent(stream);
 
 		const { results, attempts } = (await runWithTimers(
@@ -194,7 +218,29 @@ describe('verifyChecklist (agents stream path)', () => {
 				`verifier stalled: no stream activity for ${VERIFY_INACTIVITY_TIMEOUT_MS}ms`,
 			);
 		}
-		expect(stream).toHaveBeenCalledTimes(VERIFY_ATTEMPT_TIMEOUTS_MS.length);
+	});
+
+	it('tolerates slow time-to-first-chunk beyond the inactivity window', async () => {
+		// First chunk at 50s (> 45s window, < 60s cap): must NOT be treated as a stall.
+		const stream: StreamFn = vi.fn().mockResolvedValue({
+			stream: timedStream([
+				{ at: 50_000, chunk: { type: 'text-delta', id: 't', delta: '…' } },
+				{
+					at: 52_000,
+					chunk: { type: 'finish', finishReason: 'stop', structuredOutput: GOOD_OUTPUT },
+					close: true,
+				},
+			]),
+		});
+		mockVerifierAgent(stream);
+
+		const { results, attempts } = (await runWithTimers(
+			verifyChecklist(CHECKLIST, ARTIFACT),
+		)) as Awaited<ReturnType<typeof verifyChecklist>>;
+
+		expect(results).toHaveLength(1);
+		expect(attempts[0].status).toBe('success');
+		expect(stream).toHaveBeenCalledTimes(1);
 	});
 
 	it('keeps an alive-but-slow stream open past the inactivity window and succeeds', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
@@ -71,6 +71,7 @@ function evaluation(
 			const buildSuccessCount = tc.buildSuccessCount ?? totalRuns;
 			const scenarios = (tc.scenarios ?? []).map((sa) => ({
 				scenario: testCase.executionScenarios.find((sc) => sc.name === sa.name)!,
+				evaluatedCount: sa.passes.length,
 				passCount: sa.passCount,
 				passRate: totalRuns > 0 ? sa.passCount / totalRuns : 0,
 				passAtK: new Array(totalRuns).fill(sa.passCount > 0 ? 1 : 0) as number[],

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
@@ -12,7 +12,8 @@ interface CaseSpec {
 	slug: string;
 	scenarios?: Array<{
 		name: string;
-		passes: boolean[];
+		/** `'incomplete'` = verifier returned no verdict for that run. */
+		passes: Array<boolean | 'incomplete'>;
 		failureCategory?: string;
 		reasoning?: string;
 	}>;
@@ -39,21 +40,25 @@ function makeEval(totalRuns: number, cases: CaseSpec[]) {
 		slugByTestCase.set(testCase, c.slug);
 
 		const scenarioAggs = (c.scenarios ?? []).map((sa) => {
-			const passCount = sa.passes.filter(Boolean).length;
+			const evaluated = sa.passes.filter((p) => p !== 'incomplete');
+			const passCount = evaluated.filter((p) => p).length;
 			const scenario = testCase.executionScenarios.find((x) => x.name === sa.name)!;
 			return {
 				scenario,
+				evaluatedCount: evaluated.length,
 				passCount,
-				passRate: totalRuns > 0 ? passCount / totalRuns : 0,
+				passRate: evaluated.length > 0 ? passCount / evaluated.length : 0,
 				passAtK: [] as number[],
 				passHatK: [] as number[],
 				runs: sa.passes.map(
 					(p): ExecutionScenarioResult => ({
 						scenario,
-						success: p,
-						score: p ? 1 : 0,
-						reasoning: p ? '' : (sa.reasoning ?? `judge: ${sa.name} failed`),
-						failureCategory: !p ? sa.failureCategory : undefined,
+						success: p === true,
+						score: p === true ? 1 : 0,
+						reasoning: p === true ? '' : (sa.reasoning ?? `judge: ${sa.name} failed`),
+						failureCategory:
+							p === 'incomplete' ? 'verification_failure' : !p ? sa.failureCategory : undefined,
+						...(p === 'incomplete' ? { incomplete: true } : {}),
 					}),
 				),
 			};
@@ -194,6 +199,49 @@ describe('evaluateGate', () => {
 		expect(gate.units).toHaveLength(1); // only the scenario
 		expect(gate.excluded).toHaveLength(1);
 		expect(gate.excluded[0].kind).toBe('buildExpectation');
+	});
+
+	it('keeps verifier-incomplete scenario runs out of the denominator and the category tally', () => {
+		const { evaluation, slugByTestCase } = makeEval(3, [
+			{
+				slug: 'a',
+				scenarios: [
+					{
+						name: 'happy',
+						passes: [true, 'incomplete', false],
+						failureCategory: 'builder_issue',
+					},
+				],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+
+		expect(gate.green).toBe(true); // pass@k over evaluated runs
+		expect(gate.units).toHaveLength(1);
+		expect(gate.units[0].total).toBe(2);
+		expect(gate.units[0].passCount).toBe(1);
+		// The incomplete run's verification_failure label stays out of the tally.
+		expect(gate.units[0].failureCategories).toEqual({ builder_issue: 1 });
+		expect(gate.aggregate).toEqual({ passed: 1, total: 2, rate: 0.5 });
+	});
+
+	it('excludes a scenario whose every run is verifier-incomplete instead of failing on it', () => {
+		const { evaluation, slugByTestCase } = makeEval(2, [
+			{
+				slug: 'a',
+				scenarios: [
+					{ name: 'happy', passes: [true, true] },
+					{ name: 'edge', passes: ['incomplete', 'incomplete'] },
+				],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+
+		expect(gate.green).toBe(true);
+		expect(gate.units).toHaveLength(1); // only the evaluated scenario
+		expect(gate.excluded).toHaveLength(1);
+		expect(gate.excluded[0].kind).toBe('scenario');
+		expect(gate.excluded[0].slug).toBe('a/edge');
 	});
 
 	it('minAggregatePassRate verdict tracks the pooled rate, not per-unit greenness', () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-gate.test.ts
@@ -225,6 +225,21 @@ describe('evaluateGate', () => {
 		expect(gate.aggregate).toEqual({ passed: 1, total: 2, rate: 0.5 });
 	});
 
+	it('is NOT green when every unit is excluded (nothing was measured)', () => {
+		const { evaluation, slugByTestCase } = makeEval(2, [
+			{
+				slug: 'a',
+				scenarios: [{ name: 'happy', passes: ['incomplete', 'incomplete'] }],
+			},
+		]);
+		const gate = evaluateGate(evaluation, { slugByTestCase });
+
+		expect(gate.green).toBe(false);
+		expect(gate.units).toHaveLength(0);
+		expect(gate.failing).toHaveLength(0);
+		expect(gate.excluded).toHaveLength(1);
+	});
+
 	it('excludes a scenario whose every run is verifier-incomplete instead of failing on it', () => {
 		const { evaluation, slugByTestCase } = makeEval(2, [
 			{

--- a/packages/@n8n/instance-ai/evaluations/__tests__/verification-artifact.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/verification-artifact.test.ts
@@ -427,6 +427,115 @@ describe('buildVerificationArtifact', () => {
 		expect(artifact.scenarioContext).toContain('**Did not run** (no execution data): none');
 	});
 
+	it('head/tail-truncates oversized JSON output blocks and reports chars saved', () => {
+		const wf: WorkflowResponse = {
+			id: 'w1',
+			name: 'big-output',
+			active: false,
+			versionId: 'v1',
+			nodes: [
+				{
+					id: 'a',
+					name: 'HTTP',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: { HTTP: { main: [[]] } },
+		};
+		const bigItems = Array.from({ length: 200 }, (_, i) => ({
+			json: { i, blob: 'x'.repeat(200) },
+		}));
+		const evalResult = makeEvalResult({
+			HTTP: makeNodeResult({
+				outputs: { main: [bigItems] },
+				outputCount: 200,
+				iterationCount: 1,
+			}),
+		});
+
+		const artifact = buildVerificationArtifact(scenario, evalResult, [wf]);
+
+		expect(artifact.scenarioContext).toContain('chars truncated]');
+		// Head and tail survive the cut.
+		expect(artifact.scenarioContext).toContain('"i": 0');
+		expect(artifact.scenarioContext).toContain('"i": 199');
+		expect(artifact.truncationSavedChars ?? 0).toBeGreaterThan(0);
+	});
+
+	it('elides the middle of an oversized intercepted-request list', () => {
+		const wf: WorkflowResponse = {
+			id: 'w1',
+			name: 'paginated',
+			active: false,
+			versionId: 'v1',
+			nodes: [
+				{
+					id: 'a',
+					name: 'HTTP',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: { HTTP: { main: [[]] } },
+		};
+		const evalResult = makeEvalResult({
+			HTTP: makeNodeResult({
+				interceptedRequests: Array.from({ length: 30 }, (_, i) => ({
+					method: 'GET',
+					url: `https://api.example.com/page/${i}`,
+					mockResponse: { page: i },
+				})),
+				iterationCount: 1,
+			}),
+		});
+
+		const artifact = buildVerificationArtifact(scenario, evalResult, [wf]);
+
+		// First and last pages render; the middle is elided with a marker.
+		expect(artifact.scenarioContext).toContain('https://api.example.com/page/0');
+		expect(artifact.scenarioContext).toContain('https://api.example.com/page/29');
+		expect(artifact.scenarioContext).toContain('18 further requests omitted for size');
+		expect(artifact.scenarioContext).not.toContain('https://api.example.com/page/15');
+		expect(artifact.truncationSavedChars ?? 0).toBeGreaterThan(0);
+	});
+
+	it('reports zero truncation savings for small traces', () => {
+		const wf: WorkflowResponse = {
+			id: 'w1',
+			name: 'small',
+			active: false,
+			versionId: 'v1',
+			nodes: [
+				{
+					id: 'a',
+					name: 'HTTP',
+					type: 'n8n-nodes-base.httpRequest',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: { HTTP: { main: [[]] } },
+		};
+		const evalResult = makeEvalResult({
+			HTTP: makeNodeResult({
+				outputs: { main: [[{ json: { ok: true } }]] },
+				outputCount: 1,
+				iterationCount: 1,
+			}),
+		});
+
+		const artifact = buildVerificationArtifact(scenario, evalResult, [wf]);
+
+		expect(artifact.truncationSavedChars).toBe(0);
+		expect(artifact.scenarioContext).not.toContain('chars truncated]');
+	});
+
 	it('tags loop iterations and first-error iteration in the trace header', () => {
 		const wf: WorkflowResponse = {
 			id: 'w1',

--- a/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
@@ -32,7 +32,8 @@ const checklistResultSchema = z.object({
 
 /** Escalating per-attempt caps: stalls fail fast and retry, genuinely slow verifies get room. */
 export const VERIFY_ATTEMPT_TIMEOUTS_MS = [60_000, 120_000, 240_000];
-/** Abort an attempt when the stream emits no chunk for this long (agents path only). */
+/** Abort when the stream goes silent for this long AFTER its first chunk (agents path only).
+ *  Pre-first-chunk time is bounded by the attempt cap, not this window. */
 export const VERIFY_INACTIVITY_TIMEOUT_MS = 45_000;
 const VERIFIER_DEBUG = process.env.N8N_EVAL_VERIFIER_DEBUG === '1';
 
@@ -449,7 +450,9 @@ export async function verifyChecklist(
 					cache: true,
 				}).structuredOutput(checklistResultSchema);
 
-				resetInactivity();
+				// The inactivity watchdog arms on the FIRST chunk (inside the consume
+				// loop): time-to-first-token on a cache-cold large artifact can exceed
+				// the window, and the attempt cap already bounds the pre-stream phase.
 				const streamResult = await agent.stream(messages, {
 					abortSignal: abortController.signal,
 					smoothStream: false,

--- a/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
+++ b/packages/@n8n/instance-ai/evaluations/checklist/verifier.ts
@@ -1,10 +1,9 @@
-import type { Message } from '@n8n/agents';
+import type { Message, StreamChunk } from '@n8n/agents';
 import { z } from 'zod';
 
 import {
 	EPHEMERAL_CACHE,
 	createEvalAgent,
-	extractText,
 	resolveEvalModelConfig,
 } from '../../src/utils/eval-agents';
 import type { VerificationArtifact } from '../harness/runner';
@@ -31,14 +30,19 @@ const checklistResultSchema = z.object({
 // Public API
 // ---------------------------------------------------------------------------
 
-// 3 attempts, longer timeout on the last: "verifier returned empty" scenarios
-// in CI cluster on large artifacts + provider contention, where one more
-// attempt with extra headroom recovers a verdict instead of recording a
-// verification_failure for an already-executed scenario.
-const MAX_VERIFY_ATTEMPTS = 3;
-const VERIFY_ATTEMPT_TIMEOUT_MS = 120_000;
-const VERIFY_FINAL_ATTEMPT_TIMEOUT_MS = 180_000;
+/** Escalating per-attempt caps: stalls fail fast and retry, genuinely slow verifies get room. */
+export const VERIFY_ATTEMPT_TIMEOUTS_MS = [60_000, 120_000, 240_000];
+/** Abort an attempt when the stream emits no chunk for this long (agents path only). */
+export const VERIFY_INACTIVITY_TIMEOUT_MS = 45_000;
 const VERIFIER_DEBUG = process.env.N8N_EVAL_VERIFIER_DEBUG === '1';
+
+function jitteredPauseMs(attempt: number): number {
+	return 1_000 * attempt + Math.random() * 1_000;
+}
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export interface VerifierAttemptDebug {
 	attempt: number;
@@ -304,6 +308,74 @@ function buildVerifierMessages(
 	];
 }
 
+interface StreamedVerifierResult {
+	assistantText: string;
+	structuredOutput: unknown;
+	finishReason: unknown;
+	usage: unknown;
+	streamError: unknown;
+}
+
+/**
+ * Drain the agent stream, resetting the inactivity watchdog on every chunk.
+ * Each read is raced against the abort signal so a transport that stops
+ * emitting (the observed 120s+ hangs) can't pin the attempt to its full cap.
+ */
+async function consumeVerifierStream(
+	stream: ReadableStream<StreamChunk>,
+	abortSignal: AbortSignal,
+	onActivity: () => void,
+): Promise<StreamedVerifierResult> {
+	const result: StreamedVerifierResult = {
+		assistantText: '',
+		structuredOutput: undefined,
+		finishReason: null,
+		usage: null,
+		streamError: undefined,
+	};
+
+	const aborted = new Promise<never>((_, reject) => {
+		const rejectWithReason = (): void => {
+			reject(abortSignal.reason instanceof Error ? abortSignal.reason : new Error('aborted'));
+		};
+		if (abortSignal.aborted) rejectWithReason();
+		else abortSignal.addEventListener('abort', rejectWithReason, { once: true });
+	});
+
+	const reader = stream.getReader();
+	try {
+		while (true) {
+			const { done, value } = await Promise.race([reader.read(), aborted]);
+			if (done) break;
+			onActivity();
+			switch (value.type) {
+				case 'text-delta':
+					result.assistantText += value.delta;
+					break;
+				case 'finish':
+					result.finishReason = value.finishReason;
+					result.usage = value.usage ?? null;
+					result.structuredOutput = value.structuredOutput;
+					break;
+				case 'error':
+					result.streamError = value.error;
+					break;
+				default:
+					break;
+			}
+		}
+	} finally {
+		void reader.cancel().catch(() => {});
+		try {
+			reader.releaseLock();
+		} catch {
+			// already released
+		}
+	}
+
+	return result;
+}
+
 export async function verifyChecklist(
 	checklist: ChecklistItem[],
 	artifact: VerificationArtifact,
@@ -325,14 +397,32 @@ export async function verifyChecklist(
 		path: useNativeOpenAiVerifier ? 'native-openai' : 'agents-wrapper',
 	});
 
-	for (let attempt = 1; attempt <= MAX_VERIFY_ATTEMPTS; attempt++) {
-		const attemptTimeoutMs =
-			attempt === MAX_VERIFY_ATTEMPTS ? VERIFY_FINAL_ATTEMPT_TIMEOUT_MS : VERIFY_ATTEMPT_TIMEOUT_MS;
+	const maxAttempts = VERIFY_ATTEMPT_TIMEOUTS_MS.length;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		// Pause before every retry (`continue` paths included), decorrelating
+		// concurrent lanes hitting the provider at the same moment.
+		if (attempt > 1) await sleep(jitteredPauseMs(attempt - 1));
+		const attemptCapMs = VERIFY_ATTEMPT_TIMEOUTS_MS[attempt - 1];
 		const abortController = new AbortController();
-		const timer = setTimeout(
-			() => abortController.abort(new Error(`verifier timed out after ${attemptTimeoutMs}ms`)),
-			attemptTimeoutMs,
+		// The runtime's abort chunk carries a generic message — remember why WE aborted.
+		let abortReason: string | null = null;
+		const abortWith = (reason: string): void => {
+			abortReason = reason;
+			abortController.abort(new Error(reason));
+		};
+		const capTimer = setTimeout(
+			() => abortWith(`verifier timed out after ${attemptCapMs}ms`),
+			attemptCapMs,
 		);
+		let inactivityTimer: NodeJS.Timeout | undefined;
+		const resetInactivity = (): void => {
+			if (inactivityTimer) clearTimeout(inactivityTimer);
+			inactivityTimer = setTimeout(
+				() =>
+					abortWith(`verifier stalled: no stream activity for ${VERIFY_INACTIVITY_TIMEOUT_MS}ms`),
+				VERIFY_INACTIVITY_TIMEOUT_MS,
+			);
+		};
 
 		try {
 			let assistantText = '';
@@ -343,6 +433,7 @@ export async function verifyChecklist(
 			let hasStructuredOutput = false;
 
 			if (useNativeOpenAiVerifier) {
+				// Single non-streaming fetch: the attempt cap is the only watchdog here.
 				const nativeResult = await runNativeOpenAiVerifier(
 					nativeUserMessage,
 					abortController.signal,
@@ -358,30 +449,39 @@ export async function verifyChecklist(
 					cache: true,
 				}).structuredOutput(checklistResultSchema);
 
-				const result = await agent.generate(messages, { abortSignal: abortController.signal });
-				assistantText = extractText(result);
-				const parsedStructuredOutput = checklistResultSchema.safeParse(result.structuredOutput);
+				resetInactivity();
+				const streamResult = await agent.stream(messages, {
+					abortSignal: abortController.signal,
+					smoothStream: false,
+				});
+				const streamed = await consumeVerifierStream(
+					streamResult.stream,
+					abortController.signal,
+					resetInactivity,
+				);
+				assistantText = streamed.assistantText;
+				const parsedStructuredOutput = checklistResultSchema.safeParse(streamed.structuredOutput);
 				parsed = parsedStructuredOutput.success
 					? parsedStructuredOutput.data
 					: parseStructuredOutputFromText(assistantText);
-				finishReason = 'finishReason' in result ? result.finishReason : null;
-				usage = 'usage' in result ? result.usage : null;
-				hasStructuredOutput = result.structuredOutput !== undefined;
+				finishReason = streamed.finishReason;
+				usage = streamed.usage;
+				hasStructuredOutput = streamed.structuredOutput !== undefined;
 
-				if (result.error) {
+				if (streamed.streamError !== undefined) {
 					modelError =
-						result.error instanceof Error ? result.error.message : JSON.stringify(result.error);
+						abortReason ??
+						(streamed.streamError instanceof Error
+							? streamed.streamError.message
+							: JSON.stringify(streamed.streamError));
 				}
 
 				logVerifierDebug(`attempt ${attempt} raw result`, {
-					resultKeys: Object.keys(result as Record<string, unknown>),
 					finishReason,
-					error: 'error' in result ? result.error : null,
-					model: 'model' in result ? result.model : null,
+					error: streamed.streamError ?? null,
 					usage,
-					messages: 'messages' in result ? result.messages : null,
 					hasStructuredOutput,
-					structuredOutput: result.structuredOutput ?? null,
+					structuredOutput: streamed.structuredOutput ?? null,
 					assistantTextChars: assistantText.length,
 					assistantTextPreview: assistantText.slice(0, 2_000),
 				});
@@ -411,7 +511,7 @@ export async function verifyChecklist(
 					}),
 				);
 				console.warn(
-					`[verifier] attempt ${attempt}/${MAX_VERIFY_ATTEMPTS} returned model error: ${modelError}`,
+					`[verifier] attempt ${attempt}/${maxAttempts} returned model error: ${modelError}`,
 				);
 				continue;
 			}
@@ -443,11 +543,9 @@ export async function verifyChecklist(
 					acceptedResultsCount: results.length,
 				}),
 			);
-			console.warn(
-				`[verifier] attempt ${attempt}/${MAX_VERIFY_ATTEMPTS} produced no parseable results`,
-			);
+			console.warn(`[verifier] attempt ${attempt}/${maxAttempts} produced no parseable results`);
 		} catch (error: unknown) {
-			const msg = error instanceof Error ? error.message : String(error);
+			const msg = abortReason ?? (error instanceof Error ? error.message : String(error));
 			attempts.push(
 				createAttemptDebug({
 					attempt,
@@ -455,12 +553,13 @@ export async function verifyChecklist(
 					error: msg,
 				}),
 			);
-			console.warn(`[verifier] attempt ${attempt}/${MAX_VERIFY_ATTEMPTS} failed: ${msg}`);
+			console.warn(`[verifier] attempt ${attempt}/${maxAttempts} failed: ${msg}`);
 		} finally {
-			clearTimeout(timer);
+			clearTimeout(capTimer);
+			if (inactivityTimer) clearTimeout(inactivityTimer);
 		}
 	}
 
-	console.warn(`[verifier] exhausted ${MAX_VERIFY_ATTEMPTS} attempts, returning empty result`);
+	console.warn(`[verifier] exhausted ${maxAttempts} attempts, returning empty result`);
 	return { results: [], attempts };
 }

--- a/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/aggregator.ts
@@ -82,14 +82,19 @@ export function aggregateResults(
 						reasoning: 'Build failed — scenario not executed',
 					},
 			);
-			const passCount = scenarioRuns.filter((sr) => sr.success).length;
-			const { passAtKValues, passHatKValues } = computePassMetrics(totalRuns, passCount);
+			// Verifier-incomplete runs carry no verdict — excluded from the count,
+			// mirroring build expectations (denominator = evaluated runs).
+			const evaluated = scenarioRuns.filter((sr) => !sr.incomplete);
+			const passCount = evaluated.filter((sr) => sr.success).length;
+			const n = evaluated.length;
+			const { passAtKValues, passHatKValues } = computePassMetrics(n, passCount);
 
 			executionScenarios.push({
 				scenario,
 				runs: scenarioRuns,
+				evaluatedCount: n,
 				passCount,
-				passRate: totalRuns > 0 ? passCount / totalRuns : 0,
+				passRate: n > 0 ? passCount / n : 0,
 				passAtK: passAtKValues,
 				passHatK: passHatKValues,
 			});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -1462,7 +1462,7 @@ function computePassRatePerIter(evaluation: MultiRunEvaluation): string {
 				if (verdict.pass) passed++;
 			}
 		}
-		rates.push(`${String(total > 0 ? Math.round((passed / total) * 100) : 0)}%`);
+		rates.push(total > 0 ? `${String(Math.round((passed / total) * 100))}%` : 'n/a');
 	}
 	return rates.join(' / ');
 }

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -909,6 +909,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			reasoning: result.reasoning,
 			failureCategory,
 			rootCause,
+			...(result.incomplete ? { incomplete: true } : {}),
 			execErrors: result.evalResult?.errors ?? [],
 			evalResult: result.evalResult,
 			buildDurationMs,
@@ -927,12 +928,18 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		// 'none' for passed scenarios so the column shows a full categorical
 		// breakdown instead of blank cells.
 		const failureCategory = output.passed ? 'none' : (output.failureCategory ?? 'unknown');
+		// Verifier-incomplete runs get no scenario_pass score so LangSmith
+		// experiment averages match the local evaluated-only pass rate.
 		const feedback: EvaluationResult[] = [
-			{
-				key: 'scenario_pass',
-				score: output.score,
-				comment: output.reasoning || undefined,
-			},
+			...(output.incomplete
+				? []
+				: [
+						{
+							key: 'scenario_pass',
+							score: output.score,
+							comment: output.reasoning || undefined,
+						},
+					]),
 			{
 				key: 'failure_category',
 				value: failureCategory,
@@ -1409,7 +1416,7 @@ function computeAggregateMetrics(evaluation: MultiRunEvaluation): AggregateMetri
 	// Units = scenarios + evaluated build-expectations — mirrors the per-card badge
 	// and the terminal per-case table so the headline rate can't disagree with them.
 	const units = testCases.flatMap((tc) => [
-		...tc.executionScenarios,
+		...tc.executionScenarios.filter((sa) => sa.evaluatedCount > 0),
 		...tc.buildExpectations.filter((ea) => ea.evaluatedCount > 0),
 	]);
 	const total = units.length;
@@ -1442,8 +1449,10 @@ function computePassRatePerIter(evaluation: MultiRunEvaluation): string {
 		let total = 0;
 		for (const tc of testCases) {
 			for (const sa of tc.executionScenarios) {
+				const runResult = sa.runs[i];
+				if (runResult?.incomplete) continue;
 				total++;
-				if (sa.runs[i]?.success) passed++;
+				if (runResult?.success) passed++;
 			}
 			// Count each scored verdict in this iteration directly — skips incomplete
 			// (build-failed) verdicts and is robust to duplicate expectation strings.
@@ -1543,12 +1552,14 @@ function writeEvalResults(
 			scenarios: tc.executionScenarios.map((sa) => ({
 				name: sa.scenario.name,
 				passCount: sa.passCount,
+				evaluatedCount: sa.evaluatedCount,
 				totalRuns,
 				passAtK: terminalRate(sa.passAtK),
 				passHatK: terminalRate(sa.passHatK),
 				runs: sa.runs.map((sr, runIndex) => ({
 					workflowId: sr.workflowId ?? tc.runs[runIndex]?.workflowId ?? null,
 					passed: sr.success,
+					...(sr.incomplete ? { incomplete: true } : {}),
 					score: sr.score,
 					reasoning: sr.reasoning,
 					failureCategory: sr.failureCategory,
@@ -1682,11 +1693,12 @@ function bucketFromEvaluation(
 				`bucketFromEvaluation: no fileSlug for test case "${caseDisplayPrompt(tc.testCase, tc.runs[0]?.transcript).slice(0, 60)}"`,
 			);
 		}
-		const total = tc.runs.length;
 		for (const sa of tc.executionScenarios) {
 			const key = `${fileSlug}/${sa.scenario.name}`;
 			const failureCategories: Record<string, number> = {};
 			for (const sr of sa.runs) {
+				// Verifier-incomplete runs carry no verdict — not a trial.
+				if (sr.incomplete) continue;
 				trialTotal++;
 				if (!sr.success && sr.failureCategory) {
 					failureCategories[sr.failureCategory] = (failureCategories[sr.failureCategory] ?? 0) + 1;
@@ -1698,7 +1710,7 @@ function bucketFromEvaluation(
 				testCaseFile: fileSlug,
 				scenarioName: sa.scenario.name,
 				passed: sa.passCount,
-				total,
+				total: sa.evaluatedCount,
 				failureCategories,
 			});
 		}

--- a/packages/@n8n/instance-ai/evaluations/cli/reshape.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/reshape.ts
@@ -41,6 +41,8 @@ const targetOutputSchema = z.object({
 	scenarioWorkflowId: z.string().optional(),
 	failureCategory: z.string().optional(),
 	rootCause: z.string().optional(),
+	/** Verifier returned no verdict — run is excluded from scoring but stays visible. */
+	incomplete: z.boolean().optional(),
 	execErrors: z.array(z.string()).default([]),
 	evalResult: z.unknown().optional(),
 	/** Only set on the scenario that initiated the build. */
@@ -196,6 +198,7 @@ export function reshapeLangSmithRuns(
 					reasoning: output.reasoning,
 					failureCategory: output.failureCategory,
 					rootCause: output.rootCause,
+					...(output.incomplete ? { incomplete: true } : {}),
 				});
 			}
 

--- a/packages/@n8n/instance-ai/evaluations/comparison/fetch-baseline.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/fetch-baseline.ts
@@ -44,6 +44,7 @@ const outputsSchema = z
 	.object({
 		passed: z.boolean().default(false),
 		failureCategory: z.string().optional(),
+		incomplete: z.boolean().optional(),
 	})
 	.passthrough();
 
@@ -104,6 +105,8 @@ export async function fetchBaselineBucket(
 		}
 		const outputs = outputsSchema.safeParse(rawOutputs);
 		if (!outputs.success) continue;
+		// Verifier-incomplete rows carry no verdict — skip so they don't count as failed trials.
+		if (outputs.data.incomplete) continue;
 
 		const key = `${inputs.data.testCaseFile}/${inputs.data.scenarioName}`;
 		const existing: ScenarioCounts = scenarios.get(key) ?? {

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -280,6 +280,13 @@ function formatGateAlertMarkdown(gate: GateResult): string {
 			`> 🔴 ${gate.failing.length} of ${pluralUnits(n)} not green ${over}.`,
 		].join('\n');
 	}
+	// Zero measured units (e.g. verifier outage excluded everything): red, not clean.
+	if (!gate.green) {
+		return [
+			'> [!CAUTION]',
+			`> 🔴 Gate has no measured units — ${gate.excluded.length} excluded with no verdict. Nothing was actually gated.`,
+		].join('\n');
+	}
 	// All units pass@k. Only warn when a unit *barely* passed (failed most of its runs);
 	// a single flaky miss stays green but is still listed in Failures below.
 	const barely = barelyPassedUnits(gate).length;
@@ -320,6 +327,9 @@ function formatTerminalGateLine(gate: GateResult): string {
 	const over = `over ${gate.totalRuns} run${gate.totalRuns === 1 ? '' : 's'}`;
 	if (gate.failing.length > 0) {
 		return `▶ GATE: ${gate.failing.length} of ${pluralUnits(n)} NOT green ${over}`;
+	}
+	if (!gate.green) {
+		return `▶ GATE: NO measured units (${gate.excluded.length} excluded, no verdicts) — not green`;
 	}
 	const barely = barelyPassedUnits(gate).length;
 	if (barely > 0) {

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -89,10 +89,12 @@ function aggregateMeasuredUnits(testCases: TestCaseAggregation[]) {
 	let expectations = 0;
 
 	for (const tc of testCases) {
-		scenarios += tc.executionScenarios.length;
-		for (const sa of tc.executionScenarios) {
+		// Only evaluated runs count — verifier-incomplete runs carry no verdict.
+		const evaluatedScenarios = tc.executionScenarios.filter((sa) => sa.evaluatedCount > 0);
+		scenarios += evaluatedScenarios.length;
+		for (const sa of evaluatedScenarios) {
 			passed += sa.passCount;
-			total += sa.runs.length;
+			total += sa.evaluatedCount;
 		}
 
 		const buildExpectations = evaluatedBuildExpectations(tc);
@@ -668,7 +670,10 @@ function renderPerTestCaseDetails(
 		lines.push(`| Workflow | Built | pass@${totalRuns} | pass^${totalRuns} |`);
 		lines.push('|---|---|---|---|');
 		for (const tc of testCases) {
-			const units = [...tc.executionScenarios, ...evaluatedBuildExpectations(tc)];
+			const units = [
+				...tc.executionScenarios.filter((sa) => sa.evaluatedCount > 0),
+				...evaluatedBuildExpectations(tc),
+			];
 			const meanPassAtK = units.length
 				? Math.round(
 						(units.reduce((sum, unit) => sum + (unit.passAtK[unit.passAtK.length - 1] ?? 0), 0) /
@@ -692,11 +697,12 @@ function renderPerTestCaseDetails(
 		lines.push('|---|---|---|');
 		for (const tc of testCases) {
 			const built = tc.runs[0]?.workflowBuildSuccess ? '✓' : '✗';
-			const scenariosPassed = tc.executionScenarios.filter((sa) => sa.runs[0]?.success).length;
+			const scoredScenarios = tc.executionScenarios.filter((sa) => !sa.runs[0]?.incomplete);
+			const scenariosPassed = scoredScenarios.filter((sa) => sa.runs[0]?.success).length;
 			const buildExpectations = evaluatedBuildExpectations(tc);
 			const expectationsPassed = buildExpectations.filter((ea) => ea.runs[0]?.pass).length;
 			const passed = scenariosPassed + expectationsPassed;
-			const total = tc.executionScenarios.length + buildExpectations.length;
+			const total = scoredScenarios.length + buildExpectations.length;
 			lines.push(`| ${renderName(tc)} | ${built} | ${passed}/${total} |`);
 		}
 	}
@@ -774,13 +780,22 @@ function renderFailureDetails(
 		const prefix =
 			slugByTestCase?.get(tc.testCase) ?? caseDisplayPrompt(tc.testCase).slice(0, 50).trim();
 		for (const sa of tc.executionScenarios) {
-			const failedRuns = sa.runs.filter((r) => !r.success);
-			if (failedRuns.length > 0) {
+			// Verifier-incomplete runs are shown for visibility but tagged as
+			// excluded — they're outside the passCount/total denominator.
+			const failedRuns = sa.runs.filter((r) => !r.success && !r.incomplete);
+			const excludedRuns = sa.runs.filter((r) => r.incomplete);
+			if (failedRuns.length > 0 || excludedRuns.length > 0) {
 				units.push({
 					slug: `${prefix}/${sa.scenario.name}`,
 					passCount: sa.passCount,
-					total: sa.runs.length,
-					runs: failedRuns.map((r) => ({ category: r.failureCategory, text: r.reasoning })),
+					total: sa.evaluatedCount,
+					runs: [
+						...failedRuns.map((r) => ({ category: r.failureCategory, text: r.reasoning })),
+						...excludedRuns.map((r) => ({
+							category: 'excluded from scoring — verifier returned no verdict',
+							text: r.reasoning,
+						})),
+					],
 				});
 			}
 		}
@@ -854,7 +869,8 @@ function buildFailedRunsIndex(
 		for (const sa of tc.executionScenarios) {
 			const failedRuns: FailedRunDetail[] = [];
 			sa.runs.forEach((r, i) => {
-				if (!r.success) {
+				// Incomplete runs are outside the comparison denominators — skip.
+				if (!r.success && !r.incomplete) {
 					failedRuns.push({
 						category: r.failureCategory,
 						reasoning: r.reasoning,
@@ -1196,7 +1212,7 @@ function formatTerminalPerTestCase(
 			if (r.buildError) lines.push(TERMINAL_INDENT + `  error: ${r.buildError.slice(0, 200)}`);
 			for (const sa of tc.executionScenarios) {
 				const sr = sa.runs[0];
-				const status = sr.success ? 'PASS' : 'FAIL';
+				const status = sr.incomplete ? 'SKIP (no verdict)' : sr.success ? 'PASS' : 'FAIL';
 				const category = sr.failureCategory ? ` [${sr.failureCategory}]` : '';
 				lines.push(TERMINAL_INDENT + `  ${status}  ${sr.scenario.name}${category}`);
 				if (!sr.success) {

--- a/packages/@n8n/instance-ai/evaluations/comparison/gate.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/gate.ts
@@ -9,9 +9,10 @@
 //
 // A "unit" is an execution scenario or an evaluated build expectation (the
 // same units the pass rate is computed over). Always-failing scenarios are
-// deleted from the curated tier rather than flagged; build expectations with
-// no verdict (evaluatedCount 0) are excluded automatically since there's
-// nothing to judge.
+// deleted from the curated tier rather than flagged; units with no verdict
+// (evaluatedCount 0 — judge never returned for expectations, verifier
+// exhausted for scenarios) are excluded automatically since there's nothing
+// to judge.
 // ---------------------------------------------------------------------------
 
 import type { MultiRunEvaluation, WorkflowTestCase } from '../types';
@@ -98,9 +99,12 @@ export function evaluateGate(
 		const prefix = fileSlug ?? 'unknown';
 
 		for (const sa of tc.executionScenarios) {
-			const total = sa.runs.length;
+			// Verifier-incomplete runs carry no verdict — out of the denominator and
+			// the failure tally, mirroring build expectations.
+			const evaluated = sa.runs.filter((r) => !r.incomplete);
+			const total = evaluated.length;
 			const failureCategories: Record<string, number> = {};
-			for (const r of sa.runs) {
+			for (const r of evaluated) {
 				if (!r.success) {
 					const cat = r.failureCategory ?? 'uncategorized';
 					failureCategories[cat] = (failureCategories[cat] ?? 0) + 1;
@@ -115,7 +119,9 @@ export function evaluateGate(
 				green: unitGreen(sa.passCount, total, criterion),
 				...(Object.keys(failureCategories).length > 0 ? { failureCategories } : {}),
 			};
-			gated.push(unit);
+			// No verdict in any run → nothing to gate on; surface for visibility.
+			if (total === 0) excluded.push(unit);
+			else gated.push(unit);
 		}
 
 		for (const ea of tc.buildExpectations) {

--- a/packages/@n8n/instance-ai/evaluations/comparison/gate.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/gate.ts
@@ -145,10 +145,12 @@ export function evaluateGate(
 	const aggregate = { passed, total, rate: total > 0 ? passed / total : 0 };
 
 	const failing = gated.filter((u) => !u.green);
+	// A gate with zero measured units (e.g. verifier outage excluded everything)
+	// must not read as green — there is nothing the verdict could stand on.
 	const green =
 		criterion.kind === 'minAggregatePassRate'
 			? gated.length > 0 && aggregate.rate >= criterion.minRate
-			: failing.length === 0;
+			: gated.length > 0 && failing.length === 0;
 
 	return {
 		criterion,

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -1008,6 +1008,12 @@ async function runScenario(
 
 	const verifyStart = Date.now();
 	const artifact = buildVerificationArtifact(scenario, evalResult, workflowJsons, targetWorkflowId);
+	const savedChars = artifact.truncationSavedChars ?? 0;
+	if (savedChars > 0) {
+		logger.info(
+			`    [${scenario.name}] scenario context capped: saved ${String(savedChars)} chars (~${String(Math.round(savedChars / 4))} tokens)`,
+		);
+	}
 
 	const scenarioChecklist: ChecklistItem[] = [
 		{
@@ -1035,13 +1041,23 @@ async function runScenario(
 		buildTrace,
 		logger,
 	});
-	const reasoning = result?.reasoning ?? 'No verification result — LLM verifier returned empty';
+	// Empty verification = the verifier itself failed after all attempts. The run
+	// is excluded from scoring (mirrors incomplete build expectations) but stays
+	// visible in console/report/artifact under `verification_failure`.
+	const incomplete = verificationResults.length === 0;
+	const attemptErrors = verification.attempts
+		.map((a) => a.error)
+		.filter((e): e is string => e !== null);
+	const reasoning =
+		result?.reasoning ??
+		`No verification result — verifier exhausted all attempts${attemptErrors.length > 0 ? ` (${attemptErrors.join('; ')})` : ''}`;
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
 
 	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
+	const statusLabel = incomplete ? 'INCOMPLETE (excluded from scoring)' : passed ? 'PASS' : 'FAIL';
 	logger.info(
-		`    [${scenario.name}] ${passed ? 'PASS' : 'FAIL'}${categoryLabel} verify=${String(Math.round(verifyMs / 1000))}s`,
+		`    [${scenario.name}] ${statusLabel}${categoryLabel} verify=${String(Math.round(verifyMs / 1000))}s`,
 	);
 	if (!passed) {
 		logger.info(`    [${scenario.name}] ${reasoning}`);
@@ -1056,6 +1072,7 @@ async function runScenario(
 		reasoning,
 		failureCategory,
 		rootCause,
+		...(incomplete ? { incomplete: true } : {}),
 	};
 }
 
@@ -1068,6 +1085,33 @@ export interface VerificationArtifact {
 	workflowContext: string;
 	/** Scenario + execution trace + errors. Fresh per scenario. */
 	scenarioContext: string;
+	/** Chars dropped from oversized JSON blocks / request lists (head/tail truncation). */
+	truncationSavedChars?: number;
+}
+
+/** Per-JSON-block char cap in the scenario context (~1.5k tokens). */
+const SCENARIO_JSON_BLOCK_CAP = 6_000;
+/** Max intercepted requests rendered per node — first/last half beyond this. */
+const MAX_RENDERED_REQUESTS_PER_NODE = 12;
+
+/** Head/tail-truncate an oversized JSON block, keeping shape + boundaries. */
+function capJsonBlock(json: string, saved: { chars: number }): string {
+	if (json.length <= SCENARIO_JSON_BLOCK_CAP) return json;
+	const half = Math.floor(SCENARIO_JSON_BLOCK_CAP / 2);
+	const omitted = json.length - 2 * half;
+	saved.chars += omitted;
+	return `${json.slice(0, half)}\n… [${String(omitted)} chars truncated] …\n${json.slice(json.length - half)}`;
+}
+
+/** Keep the first/last half of an oversized list, dropping the middle. */
+function elideMiddle<T>(items: T[], max: number): { head: T[]; tail: T[]; omitted: T[] } {
+	if (items.length <= max) return { head: items, tail: [], omitted: [] };
+	const half = Math.floor(max / 2);
+	return {
+		head: items.slice(0, half),
+		tail: items.slice(items.length - half),
+		omitted: items.slice(half, items.length - half),
+	};
 }
 
 function isObjectRecord(v: unknown): v is Record<string, unknown> {
@@ -1121,6 +1165,7 @@ function renderNodeOutputs(
 	outputCount: number,
 	truncated: boolean | undefined,
 	connections: Record<string, unknown> | undefined,
+	saved: { chars: number },
 ): string[] {
 	const lines: string[] = [];
 	const connTypes = Object.keys(outputs);
@@ -1137,7 +1182,7 @@ function renderNodeOutputs(
 		const isMultiBranch = branches.length > 1 || connType !== 'main';
 		if (!isMultiBranch) {
 			lines.push(`**Output [${connType}]:** ${String(branches[0].length)} items`);
-			lines.push('```json', JSON.stringify(branches[0], null, 2), '```');
+			lines.push('```json', capJsonBlock(JSON.stringify(branches[0], null, 2), saved), '```');
 			continue;
 		}
 		for (let i = 0; i < branches.length; i++) {
@@ -1149,7 +1194,7 @@ function renderNodeOutputs(
 				`**Output [${connType} branch ${String(i)}] ${targetLabel}:** ${String(branch.length)} items`,
 			);
 			if (branch.length > 0) {
-				lines.push('```json', JSON.stringify(branch, null, 2), '```');
+				lines.push('```json', capJsonBlock(JSON.stringify(branch, null, 2), saved), '```');
 			}
 		}
 	}
@@ -1166,6 +1211,7 @@ function buildScenarioContextBlock(
 	scenario: ExecutionScenario,
 	evalResult: InstanceAiEvalExecutionResult,
 	wf: WorkflowResponse | undefined,
+	saved: { chars: number },
 ): string {
 	const sections: string[] = [];
 
@@ -1262,22 +1308,37 @@ function buildScenarioContextBlock(
 			sections.push(`**Config issues:** ${Object.values(nr.configIssues).flat().join('; ')}`);
 		}
 
-		for (const req of nr.interceptedRequests) {
+		const renderRequest = (req: (typeof nr.interceptedRequests)[number]): void => {
 			sections.push(`**Request:** ${req.method} ${req.url}`);
 			if (req.requestBody) {
-				sections.push('```json', JSON.stringify(req.requestBody, null, 2), '```');
+				sections.push(
+					'```json',
+					capJsonBlock(JSON.stringify(req.requestBody, null, 2), saved),
+					'```',
+				);
 			}
 			if (req.mockResponse !== undefined) {
 				sections.push('**Mock response:**');
-				sections.push('```json', JSON.stringify(req.mockResponse, null, 2), '```');
+				sections.push(
+					'```json',
+					capJsonBlock(JSON.stringify(req.mockResponse, null, 2), saved),
+					'```',
+				);
 			}
+		};
+		const reqs = elideMiddle(nr.interceptedRequests, MAX_RENDERED_REQUESTS_PER_NODE);
+		for (const req of reqs.head) renderRequest(req);
+		if (reqs.omitted.length > 0) {
+			saved.chars += reqs.omitted.reduce((n, r) => n + JSON.stringify(r).length, 0);
+			sections.push(`_… ${String(reqs.omitted.length)} further requests omitted for size …_`);
 		}
+		for (const req of reqs.tail) renderRequest(req);
 
 		const nodeOutputs = getNodeOutputs(nr.outputs);
 		const outputCount = getNumber(nr.outputCount);
 		const truncated = getOptionalBoolean(nr.truncated);
 		sections.push(
-			...renderNodeOutputs(nodeName, nodeOutputs, outputCount, truncated, wf?.connections),
+			...renderNodeOutputs(nodeName, nodeOutputs, outputCount, truncated, wf?.connections, saved),
 		);
 
 		sections.push('');
@@ -1294,9 +1355,11 @@ export function buildVerificationArtifact(
 	workflowId?: string,
 ): VerificationArtifact {
 	const wf = workflowJsons.find((w) => w.id === workflowId) ?? workflowJsons[0];
+	const saved = { chars: 0 };
 	return {
 		workflowContext: buildWorkflowContextBlock(wf),
-		scenarioContext: buildScenarioContextBlock(scenario, evalResult, wf),
+		scenarioContext: buildScenarioContextBlock(scenario, evalResult, wf, saved),
+		truncationSavedChars: saved.chars,
 	};
 }
 

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -451,7 +451,9 @@ function verifierReview(sr: ExecutionScenarioResult): StageReview {
 		status: sr.success ? 'pass' : 'fail',
 		reason: sr.success
 			? 'The verifier accepted this scenario.'
-			: `The verifier rejected this scenario${sr.failureCategory ? ` as ${sr.failureCategory}` : ''}.`,
+			: sr.incomplete
+				? 'The verifier returned no verdict after all attempts — this run is excluded from scoring.'
+				: `The verifier rejected this scenario${sr.failureCategory ? ` as ${sr.failureCategory}` : ''}.`,
 		body: bodyParts.join(''),
 	};
 }
@@ -536,6 +538,22 @@ function renderScenario(
 	const icon = sr.success ? '&#10003;' : '&#10007;';
 	const statusClass = sr.success ? 'pass' : 'fail';
 	const execLink = renderExecutionLink(sr, result.n8nBaseUrl, result.workflowId);
+
+	// Verifier-incomplete: neutral one-liner, excluded from scoring.
+	if (sr.incomplete) {
+		return `<div class="scenario na">
+			<div class="scenario-header" onclick="this.parentElement.classList.toggle('expanded')">
+				<span class="scenario-icon na">⌀</span>
+				<span class="scenario-name">${escapeHtml(sr.scenario.name)}</span>
+				<span class="scenario-summary-inline">verifier returned no verdict — excluded from scoring</span>
+				${execLink}
+			</div>
+			<div class="scenario-detail" id="scenario-${String(index)}">
+				${renderScenarioReview(result, sr)}
+				${renderScenarioDetail(sr)}
+			</div>
+		</div>`;
+	}
 
 	// Passing scenarios: compact one-liner with collapsible detail
 	if (sr.success) {
@@ -1175,12 +1193,13 @@ function renderWorkflowSummary(result: WorkflowTestCaseResult): string {
 // ---------------------------------------------------------------------------
 
 function renderTestCase(result: WorkflowTestCaseResult, tcIndex: number): string {
-	// Pass rate counts scenarios AND build expectations as units (incomplete expectations excluded).
+	// Pass rate counts scenarios AND build expectations as units (incomplete units excluded).
 	const scoredExpectations = (result.buildExpectationResults ?? []).filter((e) => !e.incomplete);
+	const scoredScenarios = result.executionScenarioResults.filter((sr) => !sr.incomplete);
 	const passCount =
-		result.executionScenarioResults.filter((sr) => sr.success).length +
+		scoredScenarios.filter((sr) => sr.success).length +
 		scoredExpectations.filter((e) => e.pass).length;
-	const totalCount = result.executionScenarioResults.length + scoredExpectations.length;
+	const totalCount = scoredScenarios.length + scoredExpectations.length;
 	const allPass = passCount === totalCount && totalCount > 0;
 	const statusClass = result.workflowBuildSuccess ? (allPass ? 'pass' : 'mixed') : 'fail';
 
@@ -1206,10 +1225,11 @@ function renderTestCase(result: WorkflowTestCaseResult, tcIndex: number): string
 
 	// Inline indicators for quick triage without expanding — scenarios and expectations as units.
 	const scenarioIndicators = [
-		...result.executionScenarioResults.map(
-			(sr) =>
-				`<span class="scenario-indicator ${sr.success ? 'pass' : 'fail'}" title="${escapeHtml(sr.scenario.name)}">${sr.success ? '✓' : '✗'} scenario: ${escapeHtml(sr.scenario.name)}</span>`,
-		),
+		...result.executionScenarioResults.map((sr) => {
+			const cls = sr.incomplete ? 'na' : sr.success ? 'pass' : 'fail';
+			const icon = sr.incomplete ? '⌀' : sr.success ? '✓' : '✗';
+			return `<span class="scenario-indicator ${cls}" title="${escapeHtml(sr.scenario.name)}">${icon} scenario: ${escapeHtml(sr.scenario.name)}</span>`;
+		}),
 		...(result.buildExpectationResults ?? []).map((e) => {
 			const cls = e.incomplete ? 'na' : e.pass ? 'pass' : 'fail';
 			const icon = e.incomplete ? '⌀' : e.pass ? '✓' : '✗';
@@ -1274,9 +1294,12 @@ export function generateWorkflowReport(results: WorkflowTestCaseResult[]): strin
 	const totalTestCases = results.length;
 	const builtCount = results.filter((r) => r.workflowBuildSuccess).length;
 	const allScenarios = results.flatMap((r) => r.executionScenarioResults);
-	const passCount = allScenarios.filter((sr) => sr.success).length;
-	const failCount = allScenarios.length - passCount;
-	const totalScenarios = allScenarios.length;
+	// Verifier-incomplete runs (no verdict) are visible but not scored.
+	const scoredScenarios = allScenarios.filter((sr) => !sr.incomplete);
+	const noVerdictCount = allScenarios.length - scoredScenarios.length;
+	const passCount = scoredScenarios.filter((sr) => sr.success).length;
+	const failCount = scoredScenarios.length - passCount;
+	const totalScenarios = scoredScenarios.length;
 	const passRate = totalScenarios > 0 ? Math.round((passCount / totalScenarios) * 100) : 0;
 
 	return `<!DOCTYPE html>
@@ -1364,6 +1387,7 @@ export function generateWorkflowReport(results: WorkflowTestCaseResult[]): strin
 	.scenario-icon { font-weight: bold; font-size: 14px; min-width: 16px; }
 	.scenario-icon.pass { color: var(--color-pass); }
 	.scenario-icon.fail { color: var(--color-fail); }
+	.scenario-icon.na { color: #8b949e; }
 	.scenario-name { color: var(--text-primary); font-weight: 600; }
 	.scenario-desc { color: var(--text-muted); font-size: 12px; }
 	.scenario-summary-inline { color: var(--text-muted); font-size: 12px; flex: 1; }
@@ -1562,7 +1586,15 @@ export function generateWorkflowReport(results: WorkflowTestCaseResult[]): strin
 	<div class="stat-card">
 		<div class="label">Failed</div>
 		<div class="value${failCount > 0 ? ' fail' : ''}">${String(failCount)}</div>
-	</div>
+	</div>${
+		noVerdictCount > 0
+			? `
+	<div class="stat-card">
+		<div class="label">No verdict</div>
+		<div class="value">${String(noVerdictCount)}</div>
+	</div>`
+			: ''
+	}
 	<div class="stat-card">
 		<div class="label">Built</div>
 		<div class="value${builtCount === totalTestCases ? ' pass' : ' mixed'}">${String(builtCount)}/${String(totalTestCases)}</div>

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -38,7 +38,7 @@ function escapeHtml(str: string): string {
 		.replace(/'/g, '&#39;');
 }
 
-type StageStatus = 'pass' | 'fail';
+type StageStatus = 'pass' | 'fail' | 'na';
 
 interface StageReview {
 	label: string;
@@ -280,7 +280,7 @@ function renderStageReview(stage: StageReview): string {
 				<span class="review-status-dot ${stage.status}"></span>
 				<span class="review-stage-label">${escapeHtml(stage.label)}</span>
 			</div>
-			<span class="review-status-pill ${stage.status}">${stage.status === 'pass' ? 'green' : 'red'}</span>
+			<span class="review-status-pill ${stage.status}">${stage.status === 'pass' ? 'green' : stage.status === 'na' ? 'no verdict' : 'red'}</span>
 		</div>
 		<div class="review-stage-reason">${escapeHtml(stage.reason)}</div>
 		<div class="review-stage-body">${stage.body}</div>
@@ -448,7 +448,7 @@ function verifierReview(sr: ExecutionScenarioResult): StageReview {
 
 	return {
 		label: '4. Verifier judgment',
-		status: sr.success ? 'pass' : 'fail',
+		status: sr.success ? 'pass' : sr.incomplete ? 'na' : 'fail',
 		reason: sr.success
 			? 'The verifier accepted this scenario.'
 			: sr.incomplete
@@ -537,7 +537,7 @@ function renderScenario(
 ): string {
 	const icon = sr.success ? '&#10003;' : '&#10007;';
 	const statusClass = sr.success ? 'pass' : 'fail';
-	const execLink = renderExecutionLink(sr, result.n8nBaseUrl, result.workflowId);
+	const execLink = renderExecutionLink(sr, result.n8nBaseUrl, sr.workflowId ?? result.workflowId);
 
 	// Verifier-incomplete: neutral one-liner, excluded from scoring.
 	if (sr.incomplete) {
@@ -1435,20 +1435,24 @@ export function generateWorkflowReport(results: WorkflowTestCaseResult[]): strin
 	.review-overview-chip { display: inline-flex; align-items: center; min-height: 24px; padding: 0 10px; border: 1px solid var(--border); border-radius: 999px; color: var(--text-secondary); font-size: 11px; font-weight: 600; }
 	.review-overview-chip.pass { border-color: #238636; color: var(--color-pass); background: var(--color-pass-bg); }
 	.review-overview-chip.fail { border-color: #da3633; color: var(--color-fail); background: var(--color-fail-bg); }
+	.review-overview-chip.na { border-color: #8b949e; color: #8b949e; }
 	.review-grid { display: grid; grid-template-columns: 1fr; }
 	.review-stage { padding: 12px; border-top: 1px solid var(--border-light); border-left: 4px solid var(--border); background: var(--bg-secondary); }
 	.review-stage:first-child { border-top: 0; }
 	.review-stage.pass { border-left-color: var(--color-pass); }
 	.review-stage.fail { border-left-color: var(--color-fail); }
+	.review-stage.na { border-left-color: #8b949e; }
 	.review-stage-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 6px; }
 	.review-stage-heading { display: flex; align-items: center; gap: 8px; min-width: 0; }
 	.review-stage-label { color: var(--text-primary); font-size: 12px; font-weight: 700; }
 	.review-status-dot { width: 10px; height: 10px; border-radius: 50%; flex: 0 0 auto; }
 	.review-status-dot.pass { background: var(--color-pass); box-shadow: 0 0 0 3px var(--color-pass-bg); }
 	.review-status-dot.fail { background: var(--color-fail); box-shadow: 0 0 0 3px var(--color-fail-bg); }
+	.review-status-dot.na { background: #8b949e; box-shadow: 0 0 0 3px rgba(139,148,158,0.2); }
 	.review-status-pill { display: inline-flex; align-items: center; min-height: 22px; padding: 0 8px; border-radius: 999px; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0; }
 	.review-status-pill.pass { background: var(--color-pass-bg); color: var(--color-pass); }
 	.review-status-pill.fail { background: var(--color-fail-bg); color: var(--color-fail); }
+	.review-status-pill.na { background: rgba(139,148,158,0.15); color: #8b949e; }
 	.review-stage-reason { color: var(--text-secondary); font-size: 12px; line-height: 1.6; margin-bottom: 4px; }
 	.review-stage-body { margin-top: 6px; }
 	.review-subsection { padding-top: 4px; }

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -243,6 +243,10 @@ export interface ExecutionScenarioResult {
 	failureCategory?: string;
 	/** Detailed root cause explanation */
 	rootCause?: string;
+	/** Verifier returned no verdict after all attempts (infra failure, not a
+	 *  workflow failure). Rendered visibly but kept out of the pass-rate count,
+	 *  mirroring `BuildExpectationResult.incomplete`. */
+	incomplete?: boolean;
 }
 
 /** Verdict for one author-written build expectation. Informational only. */
@@ -380,6 +384,8 @@ export interface SetupCardRequest {
 export interface ExecutionScenarioAggregation {
 	scenario: ExecutionScenario;
 	runs: ExecutionScenarioResult[];
+	/** Runs where the verifier returned a verdict (excludes `incomplete`). */
+	evaluatedCount: number;
 	passCount: number;
 	passRate: number;
 	/** probability at least 1 of k attempts passes */


### PR DESCRIPTION
## Summary

Eliminates `verification_failure` noise in the workflow-eval harness: verifier infra timeouts were failing eval units as if the builder had failed. Three changes:

1. **Verifier resilience — escalating retry ladder + inactivity abort** (`evaluations/checklist/verifier.ts`)
   - 2 attempts × flat 120s → 3 attempts with escalating caps **60s / 120s / 240s** and jittered pauses between attempts (decorrelates concurrent lanes).
   - The agents-path verifier now consumes `agent.stream()` instead of `generate()`: a **45s no-chunk inactivity watchdog** aborts stalled transports early (the observed failure mode was a silent 120s+ hang), while the per-attempt cap stays as backstop. A genuinely slow-but-streaming verify is no longer killed; a stalled one fails fast and retries.
   - The native OpenAI path (non-streaming fetch) keeps the cap-only ladder.

2. **Attribution — exhausted verifies no longer score as builder failures**
   - When the verifier returns no verdict after all attempts, the scenario run is marked `incomplete` and **excluded from scoring**, mirroring the existing `BuildExpectationResult.incomplete` precedent (`evaluatedCount` denominators).
   - Wired through: aggregator, gate (all-incomplete units move to the `excluded` list like no-verdict expectations), local + LangSmith comparison buckets (`fetch-baseline` skips `incomplete` outputs; `scenario_pass` feedback is not emitted for them), PR-comment/terminal formatters, HTML report, and `eval-results.json`.
   - Still **visible everywhere**: console logs `INCOMPLETE (excluded from scoring) [verification_failure]`, the HTML report renders a neutral `⌀ no verdict` state (+ "No verdict" dashboard tile), the PR-comment failure details tag them `excluded from scoring — verifier returned no verdict`, and `eval-results.json` carries `incomplete: true` + `evaluatedCount`.

3. **Verifier context caps** (`evaluations/harness/runner.ts`)
   - Per-JSON-block head/tail truncation (6k chars/block) for node outputs, request bodies, and mock responses in the scenario context, plus first/last-half elision of oversized intercepted-request lists (>12/node).
   - Chars saved are logged per scenario (`scenario context capped: saved Nk chars (~M tokens)`) and reported on the artifact (`truncationSavedChars`).

## Evidence

This week's 10-case N=5 lanes run had 2 unit-failing verifier timeouts (`verifier timed out after 120000ms` ×2 attempts each — `no-change-no-alert`, `daily-no-qualifying-deal` snapshots), i.e. harness noise scored as builder failures (verification_failure +1.7pp vs baseline).

## Validation

- `pnpm vitest run evaluations/` — 835 tests green (new: stream consumption, stuck-stream inactivity abort, cap-ladder escalation incl. native path, retry-after-error-chunk, aggregation/gate exclusion semantics, context-cap truncation).
- Scoped `pnpm typecheck` + `pnpm lint` green.
- Lanes validation on the two flight cases, N=5 × 5 scenario units (same docker image as this week's run — backend constant, harness-only diff):
  - **0 `verification_failure`s** (baseline run had 2 on these cases) and 0 excluded runs — every one of the 25 verifies returned a verdict.
  - The ladder demonstrably rescued verifies the old 2×120s code could not have completed: `verify=248s` (60s timeout → 120s timeout → success, unit PASS) and `verify=281s` (verdict = correctly-attributed `framework_issue` FAIL). Both exceed the old code's 240s total wall — they were guaranteed exhaustion noise before.
  - Context caps fired 11×, saving up to ~1.3k tokens per scenario, logged as `scenario context capped: saved N chars (~M tokens)`.
  - Aggregate 16/25 vs Tuesday's 21/25 on these units — the delta is a single bad build whose workflow the harness couldn't execute (`Workflow flight-price-watcher not found or not accessible`, 4 framework_issue verdicts + 1 more exec-side) plus one extra mock flake. All carry full verifier verdicts with correct categories; none are verifier-attributable, and the failure-category drift table shows `verification_failure 0 (0.0%) vs 1 (0.2%)`. The multi-workflow execution-accessibility class is the one already flagged in the PR #33530 review (routing/artifact[0]) — pre-existing and out of scope here.

## Review notes

- `ExecutionScenarioAggregation.evaluatedCount` is a new required field — only the aggregator constructs it in prod code.
- Scoring semantics for fully-evaluated runs are unchanged (denominator only shrinks when the verifier itself gave up, which previously counted as a unit failure).

## How to test

- `pnpm --filter @n8n/instance-ai vitest run evaluations/` (835 tests; new suites: `checklist-verifier.test.ts`, `aggregator.test.ts`, extended `comparison-gate` / `verification-artifact` / `comparison-format`).
- Live: any lanes run — per-scenario lines now log `verify=Ns` outcomes with `INCOMPLETE (excluded from scoring)` when the verifier exhausts, and `scenario context capped: saved N chars (~M tokens)` when caps fire. Validation evidence above from `run-eval-lanes.sh --instance-count 3 --iterations 5 -- --filter flight-deal-monitor-ber-lax,flight-status-change-alert`.

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to the reliability review of #33530 (verifier `verification_failure` noise was the remaining new harness-noise source: 2×"verifier timed out after 120000ms" unit failures in this week's 10-case N=5 run).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Tests included.
