### PR TITLE
refactor(editor): Extract useCredentialForm controller from the credential edit modal (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, onMounted, ref, useTemplateRef } from 'vue';
 
 import type { IUpdateInformation } from '@/Interface';
-import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../../credentials.types';
+import type { ICredentialsResponse } from '../../credentials.types';
 
 import type {
 	CredentialInformation,
@@ -10,10 +10,9 @@ import type {
 	ICredentialsDecrypted,
 	INode,
 	INodeParameters,
-	INodeProperties,
 	ITelemetryTrackProperties,
 } from 'n8n-workflow';
-import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import CredentialIcon from '../CredentialIcon.vue';
 
 import CredentialConfig from './CredentialConfig.vue';
@@ -29,12 +28,10 @@ import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import { useCredentialsStore } from '../../credentials.store';
 import { getTrustedOAuthOrigins, parseOAuthCallbackMessage } from '../../composables/oauthCallback';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { provideWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { Project, ProjectSharingData } from '@/features/collaboration/projects/projects.types';
-import { getResourcePermissions } from '@n8n/permissions';
 import { assert } from '@n8n/utils/assert';
 import { createEventBus } from '@n8n/utils/event-bus';
 
@@ -44,10 +41,8 @@ import { useProjectsStore } from '@/features/collaboration/projects/projects.sto
 import { useExternalSecretsStore } from '@/features/integrations/externalSecrets.ee/externalSecrets.ee.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { sendUserEvent, type DynamicNotification } from '@n8n/rest-api-client/api/cloudPlans';
-import { isExpression, isTestableExpression } from '@/app/utils/expressions';
 import {
 	getAppNameFromCredType,
-	getNodeAuthOptions,
 	getNodeCredentialForSelectedAuthType,
 	updateNodeAuthType,
 } from '@/app/utils/nodeTypesUtils';
@@ -65,18 +60,10 @@ import {
 	N8nText,
 	type IMenuItem,
 } from '@n8n/design-system';
-import { setParameterValue } from '@/app/utils/parameterUtils';
-import get from 'lodash/get';
 import { usePrivateCredentials } from '@/features/resolvers/composables/usePrivateCredentials';
 import { useQuickConnect } from '../../quickConnect/composables/useQuickConnect';
+import { useCredentialForm } from '../../composables/useCredentialForm';
 import type { CredentialModeOption } from './CredentialModeSelector.vue';
-
-const MANAGED_CREDENTIAL_HIDDEN_PROPERTIES = new Set([
-	'scope',
-	'customScopes',
-	'enabledScopes',
-	'customScopesNotice',
-]);
 
 type Props = {
 	modalName: string;
@@ -89,7 +76,6 @@ const props = withDefaults(defineProps<Props>(), { mode: 'new', activeId: undefi
 const credentialsStore = useCredentialsStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
-const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const externalSecretsStore = useExternalSecretsStore();
 
@@ -127,30 +113,16 @@ const { isEnabled: isPrivateCredentialsEnabled } = usePrivateCredentials();
 const { getQuickConnectOption, connect: quickConnect } = useQuickConnect();
 const isQuickConnectMode = ref(false);
 const activeTab = ref('connection');
-const authError = ref('');
-const credentialId = ref('');
-const credentialName = ref('');
-const selectedCredential = ref('');
-const credentialData = ref<ICredentialDataDecryptedObject>({});
-const currentCredential = ref<ICredentialsResponse | ICredentialsDecryptedResponse | null>(null);
 const modalBus = ref(createEventBus());
 const isDeleting = ref(false);
-const isSaving = ref(false);
-const isTesting = ref(false);
 const hasUnsavedChanges = ref(false);
 const isSaved = ref(false);
 const loading = ref(false);
-const showValidationWarning = ref(false);
-const testedSuccessfully = ref(false);
-const isRetesting = ref(false);
 const hasUserSpecifiedName = ref(false);
 const isSharedWithChanged = ref(false);
 const requiredCredentials = ref(false); // Are credentials required or optional for the node
 const contentRef = ref<HTMLDivElement>();
 const isSharedGlobally = ref(false);
-const isResolvable = ref(false);
-const connectedByMe = ref(false);
-const useCustomOAuth = ref(false);
 const pendingAuthType = ref<string | null>(null);
 const credentialDataCache = ref<Record<string, ICredentialDataDecryptedObject>>({});
 
@@ -172,6 +144,59 @@ const contextNode = computed<INode | null>(() => {
 	return fallbackName ? (workflowDocumentStore.value?.getNodeByName(fallbackName) ?? null) : null;
 });
 
+const overrideProjectId = computed(() => {
+	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	return isCredentialModalState(modalState) ? modalState.projectId : undefined;
+});
+
+const form = useCredentialForm({
+	mode: () => props.mode,
+	activeId: () => props.activeId,
+	contextNode: () => contextNode.value,
+	projectId: () => overrideProjectId.value,
+	showAuthSelector: () => requiredCredentials.value,
+	suggestedName: () => {
+		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+		return isCredentialModalState(modalState) ? modalState.suggestedName : undefined;
+	},
+});
+
+const {
+	credentialData,
+	credentialName,
+	credentialId,
+	currentCredential,
+	selectedCredential,
+	authError,
+	testedSuccessfully,
+	isRetesting,
+	isSaving,
+	isTesting,
+	showValidationWarning,
+	isResolvable,
+	connectedByMe,
+	useCustomOAuth,
+	activeNodeType,
+	credentialTypeName,
+	credentialType,
+	parentTypes,
+	isOAuthType,
+	isOAuthConnected,
+	managedOAuthAvailable,
+	isEditingManagedCredential,
+	isNewCredential,
+	credentialProperties,
+	requiredPropertiesFilled,
+	isCredentialTestable,
+	credentialPermissions,
+	usesExternalSecrets,
+	setCredentialPropertyDefaults,
+	resetCredentialData,
+	testCredential,
+	retestCredential,
+	initialize,
+} = form;
+
 const hideAskAssistant = computed<boolean>(() => {
 	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) && modalState.hideAskAssistant === true;
@@ -192,225 +217,6 @@ const closeOnSave = computed<boolean>(() => {
 const appendToBody = computed<boolean>(() => {
 	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 	return isCredentialModalState(modalState) && modalState.appendToBody === true;
-});
-
-const activeNodeType = computed(() => {
-	const activeNode = contextNode.value;
-
-	if (activeNode) {
-		return nodeTypesStore.getNodeType(activeNode.type, activeNode.typeVersion);
-	}
-	return null;
-});
-
-const selectedCredentialType = computed(() => {
-	if (props.mode !== 'new') {
-		return null;
-	}
-
-	// If there is already selected type, use it
-	if (selectedCredential.value !== '') {
-		return credentialsStore.getCredentialTypeByName(selectedCredential.value) ?? null;
-	} else if (requiredCredentials.value) {
-		// Use the recommended auth option (managed OAuth sorts first) or the first available
-		const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
-		if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
-			return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
-		}
-		// No auth options — fall back to the explicitly requested type or the first credential
-		if (props.activeId) {
-			const nodeCredential = activeNodeType.value?.credentials?.find(
-				(c) => c.name === props.activeId,
-			);
-			if (nodeCredential) {
-				return nodeCredential;
-			}
-		}
-		return activeNodeType.value?.credentials?.[0] ?? null;
-	}
-
-	return null;
-});
-
-const credentialType = computed(() => {
-	if (!credentialTypeName.value) {
-		return null;
-	}
-
-	const type = credentialsStore.getCredentialTypeByName(credentialTypeName.value);
-
-	if (!type) {
-		return null;
-	}
-
-	return {
-		...type,
-		properties: getCredentialProperties(credentialTypeName.value),
-	};
-});
-
-const credentialTypeName = computed(() => {
-	if (props.mode === 'edit') {
-		if (selectedCredential.value) return selectedCredential.value;
-		if (currentCredential.value) {
-			return currentCredential.value.type;
-		}
-
-		return null;
-	}
-	if (selectedCredentialType.value) {
-		return selectedCredentialType.value.name;
-	}
-	return `${props.activeId}`;
-});
-
-const isEditingManagedCredential = computed(() => {
-	if (!props.activeId) return false;
-	return credentialsStore.getCredentialById(props.activeId)?.isManaged ?? false;
-});
-
-const isCredentialTestable = computed(() => {
-	if (isOAuthType.value || !requiredPropertiesFilled.value) {
-		return false;
-	}
-
-	const hasUntestableExpressions = credentialProperties.value.some((prop) => {
-		const value = credentialData.value[prop.name];
-		return typeof value === 'string' && isExpression(value) && !isTestableExpression(value);
-	});
-	if (hasUntestableExpressions) {
-		return false;
-	}
-
-	const nodesThatCanTest = nodesWithAccess.value.filter((node) => {
-		if (node.credentials) {
-			// Returns a list of nodes that can test this credentials
-			const eligibleTesters = node.credentials.filter((credential) => {
-				return credential.name === credentialTypeName.value && credential.testedBy;
-			});
-			// If we have any node that can test, return true.
-			return !!eligibleTesters.length;
-		}
-		return false;
-	});
-
-	return !!nodesThatCanTest.length || (!!credentialType.value && !!credentialType.value.test);
-});
-
-const nodesWithAccess = computed(() => {
-	if (credentialTypeName.value) {
-		return credentialsStore.getNodesWithAccess(credentialTypeName.value);
-	}
-
-	return [];
-});
-
-const parentTypes = computed(() => {
-	if (credentialTypeName.value) {
-		return getParentTypes(credentialTypeName.value);
-	}
-
-	return [];
-});
-
-const isOAuthType = computed(() => {
-	return (
-		!!credentialTypeName.value &&
-		(((credentialTypeName.value === 'oAuth2Api' || parentTypes.value.includes('oAuth2Api')) &&
-			(credentialData.value.grantType === 'authorizationCode' ||
-				credentialData.value.grantType === 'pkce')) ||
-			credentialTypeName.value === 'oAuth1Api' ||
-			parentTypes.value.includes('oAuth1Api'))
-	);
-});
-
-const managedOAuthAvailable = computed(() => {
-	// Detect directly from the credential type so managed mode also resolves when the
-	// credential is edited from the credentials list (no active node context).
-	if (credentialTypeName.value && hasManagedOAuthCredentials(credentialTypeName.value)) {
-		return true;
-	}
-	return (
-		activeNodeType.value?.credentials?.some((type) => hasManagedOAuthCredentials(type.name)) ??
-		false
-	);
-});
-
-const isManagedOAuthMode = computed(
-	() => isOAuthType.value && managedOAuthAvailable.value && !useCustomOAuth.value,
-);
-
-const isOAuthConnected = computed(() => {
-	if (!isOAuthType.value) return false;
-	if (isResolvable.value) return connectedByMe.value;
-	return !!credentialData.value.oauthTokenData;
-});
-const credentialProperties = computed(() => {
-	const type = credentialType.value;
-	if (!type) {
-		return [];
-	}
-
-	const properties = type.properties.filter((propertyData: INodeProperties) => {
-		if (!displayCredentialParameter(propertyData)) {
-			return false;
-		}
-		return useCustomOAuth.value || !type.__overwrittenProperties?.includes(propertyData.name);
-	});
-
-	/**
-	 * If after all credentials overrides are applied only "notice"
-	 * properties are left, do not return them. This will avoid
-	 * showing notices that refer to a property that was overridden.
-	 */
-	if (properties.every((p) => p.type === 'notice')) {
-		return [];
-	}
-
-	return properties;
-});
-
-const requiredPropertiesFilled = computed(() => {
-	for (const property of credentialProperties.value) {
-		if (property.required !== true) {
-			continue;
-		}
-
-		const credentialProperty = credentialData.value[property.name];
-
-		if (property.type === 'string' && !credentialProperty) {
-			return false;
-		}
-
-		if (property.type === 'number') {
-			const containsExpression =
-				typeof credentialProperty === 'string' && credentialProperty.startsWith('=');
-
-			if (typeof credentialProperty !== 'number' && !containsExpression) {
-				return false;
-			}
-		}
-
-		if (property.type === 'json' && credentialProperty) {
-			const jsonValue = String(credentialProperty);
-			const containsExpression = isExpression(jsonValue);
-			// Sentinels represent a previously-saved value, and expressions are always valid
-			if (!containsExpression && jsonValue !== CREDENTIAL_EMPTY_VALUE) {
-				try {
-					JSON.parse(jsonValue);
-				} catch {
-					return false;
-				}
-			}
-		}
-	}
-	return true;
-});
-
-const credentialPermissions = computed(() => {
-	return getResourcePermissions(
-		(currentCredential.value as ICredentialsResponse)?.scopes ?? homeProject.value?.scopes,
-	).credential;
 });
 
 const sidebarItems = computed(() => {
@@ -461,47 +267,6 @@ const showHeaderSaveButton = computed(
 
 const showSharingContent = computed(() => activeTab.value === 'sharing' && !!credentialType.value);
 
-const homeProject = computed(() => {
-	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
-	const overrideProjectId = isCredentialModalState(modalState) ? modalState.projectId : undefined;
-	if (overrideProjectId) {
-		const override = projectsStore.myProjects.find((p) => p.id === overrideProjectId);
-		if (override) return override;
-	}
-	const { currentProject, personalProject } = projectsStore;
-	return currentProject ?? personalProject;
-});
-
-const isNewCredential = computed(() => props.mode === 'new' && !credentialId.value);
-
-function setCredentialPropertyDefaults() {
-	if (credentialType.value) {
-		for (const property of credentialType.value.properties) {
-			if (
-				!credentialData.value.hasOwnProperty(property.name) &&
-				!credentialType.value.__overwrittenProperties?.includes(property.name)
-			) {
-				credentialData.value = {
-					...credentialData.value,
-					[property.name]: property.default as CredentialInformation,
-				};
-			}
-		}
-	}
-}
-
-// For new credentials of skip-list types, default to custom mode (managed creation is disabled).
-// Using { immediate: true } handles both initial load and subsequent type switches.
-watch(
-	credentialType,
-	(newType) => {
-		if (props.mode === 'new' && newType?.__skipManagedCreation) {
-			useCustomOAuth.value = true;
-		}
-	},
-	{ immediate: true },
-);
-
 onMounted(async () => {
 	// Inner try isolates optional secrets loading; outer try catches all other initialization failures.
 	try {
@@ -522,37 +287,27 @@ onMounted(async () => {
 			}
 		}
 
-		if (props.mode === 'new' && credentialTypeName.value) {
-			const modalSuggestedName = isCredentialModalState(modalState)
-				? modalState.suggestedName
-				: undefined;
-			credentialName.value = modalSuggestedName
-				? modalSuggestedName
-				: await credentialsStore.getNewCredentialName({
-						credentialTypeName: defaultCredentialTypeName.value,
-					});
-
-			credentialData.value = {
-				...credentialData.value,
-				...(homeProject.value ? { homeProject: homeProject.value } : {}),
-			};
-		} else {
-			// loadCurrentCredential handles its own recovery by showing an error toast and closing the modal.
-			// It should be allowed to propagate to avoid subsequent initialization steps running on empty data.
-			await loadCurrentCredential();
+		try {
+			// Name + defaults (new) or load + custom-OAuth detect (edit) — the same
+			// core the inline surfaces use.
+			await initialize();
+		} catch (error) {
+			// Edit-mode load failed: surface it and bail out of the modal.
+			if (props.mode === 'edit') {
+				toast.showError(
+					error,
+					i18n.baseText('credentialEdit.credentialEdit.showError.loadCredential.title'),
+				);
+				closeDialog();
+			}
+			throw error;
 		}
 
-		setCredentialPropertyDefaults();
-
-		// Detect if existing credential uses custom OAuth (user-provided clientId/clientSecret).
-		// Use __overwrittenProperties directly instead of managedOAuthAvailable so that skip-list
-		// types (where managedOAuthAvailable is false) still auto-detect custom credentials.
-		if (
-			credentialType.value?.__overwrittenProperties?.includes('clientId') &&
-			credentialData.value.clientId &&
-			credentialData.value.clientSecret
-		) {
-			useCustomOAuth.value = true;
+		// Sharing "global" state is modal-only, derived from the loaded credential.
+		if (props.mode === 'edit') {
+			const cred = currentCredential.value;
+			isSharedGlobally.value =
+				!!cred && 'isGlobal' in cred && typeof cred.isGlobal === 'boolean' ? cred.isGlobal : false;
 		}
 
 		// Default to quick connect mode for new credentials when available and not forced to manual
@@ -639,114 +394,12 @@ async function beforeClose() {
 	return false;
 }
 
-function displayCredentialParameter(parameter: INodeProperties): boolean {
-	if (parameter.type === 'hidden') {
-		return false;
-	}
-
-	if (
-		MANAGED_CREDENTIAL_HIDDEN_PROPERTIES.has(parameter.name) &&
-		(isEditingManagedCredential.value || isManagedOAuthMode.value)
-	) {
-		return false;
-	}
-
-	if (parameter.displayOptions?.hideOnCloud && settingsStore.isCloudDeployment) {
-		return false;
-	}
-
-	if (parameter.displayOptions === undefined) {
-		// If it is not defined no need to do a proper check
-		return true;
-	}
-
-	return nodeHelpers.displayParameter(credentialData.value as INodeParameters, parameter, '', null);
-}
-
-function getCredentialProperties(name: string): INodeProperties[] {
-	const credentialTypeData = credentialsStore.getCredentialTypeByName(name);
-
-	if (!credentialTypeData) {
-		return [];
-	}
-
-	if (credentialTypeData.extends === undefined) {
-		return credentialTypeData.properties;
-	}
-
-	const combineProperties = [] as INodeProperties[];
-	for (const credentialsTypeName of credentialTypeData.extends) {
-		const mergeCredentialProperties = getCredentialProperties(credentialsTypeName);
-		NodeHelpers.mergeNodeProperties(combineProperties, mergeCredentialProperties);
-	}
-
-	// The properties defined on the parent credentials take precedence
-	NodeHelpers.mergeNodeProperties(combineProperties, credentialTypeData.properties);
-
-	return combineProperties;
-}
-
-/**
- *
- * We might get credential with empty parameters from source-control
- * which breaks our types and Fe checks
- */
-function removePropertiesWithEmptyStrings<T extends { [key: string]: unknown }>(data: T): T {
-	const copy = structuredClone(data);
-	Object.entries(copy).forEach(([key, value]) => {
-		if (value === '') delete copy[key];
-	});
-	return copy;
-}
-
 async function loadCurrentCredential(id = props.activeId ?? '') {
-	credentialId.value = id;
-
 	try {
-		const currentCredentials = await credentialsStore.getCredentialData({
-			id: credentialId.value,
-		});
-
-		if (!currentCredentials) {
-			throw new Error(
-				i18n.baseText('credentialEdit.credentialEdit.couldNotFindCredentialWithId') +
-					':' +
-					credentialId.value,
-			);
-		}
-
-		currentCredential.value = currentCredentials;
-
-		credentialData.value = removePropertiesWithEmptyStrings(
-			(currentCredentials.data as ICredentialDataDecryptedObject) || {},
-		);
-
-		if (currentCredentials.sharedWithProjects) {
-			credentialData.value = {
-				...credentialData.value,
-				sharedWithProjects: currentCredentials.sharedWithProjects,
-			};
-		}
-		if (currentCredentials.homeProject) {
-			credentialData.value = {
-				...credentialData.value,
-				homeProject: currentCredentials.homeProject,
-			};
-		}
-
-		credentialName.value = currentCredentials.name;
+		await form.loadCurrentCredential(id);
+		const cred = currentCredential.value;
 		isSharedGlobally.value =
-			'isGlobal' in currentCredentials && typeof currentCredentials.isGlobal === 'boolean'
-				? currentCredentials.isGlobal
-				: false;
-		isResolvable.value =
-			'isResolvable' in currentCredentials && typeof currentCredentials.isResolvable === 'boolean'
-				? currentCredentials.isResolvable
-				: false;
-		connectedByMe.value =
-			'connectedByMe' in currentCredentials && typeof currentCredentials.connectedByMe === 'boolean'
-				? currentCredentials.connectedByMe
-				: false;
+			!!cred && 'isGlobal' in cred && typeof cred.isGlobal === 'boolean' ? cred.isGlobal : false;
 	} catch (error) {
 		toast.showError(
 			error,
@@ -850,40 +503,12 @@ async function onResolvableChange(value: boolean) {
 	hasUnsavedChanges.value = true;
 }
 
-function onDataChange({ name, value }: IUpdateInformation) {
-	const currentValue = get(credentialData.value, name);
-	if (currentValue === value) {
-		return;
-	}
-
-	hasUnsavedChanges.value = true;
-
-	if (isOAuthType.value && (name === 'clientId' || name === 'clientSecret')) {
-		const { oauthTokenData, ...credData } = credentialData.value;
-		credentialData.value = deepCopy(credData);
-	}
-
-	setParameterValue(credentialData.value, name, value);
+function onDataChange(update: IUpdateInformation) {
+	if (form.onDataChange(update)) hasUnsavedChanges.value = true;
 }
 
 function closeDialog() {
 	modalBus.value.emit('close');
-}
-
-function getParentTypes(name: string): string[] {
-	const type = credentialsStore.getCredentialTypeByName(name);
-
-	if (type?.extends === undefined) {
-		return [];
-	}
-
-	const types: string[] = [];
-	for (const typeName of type.extends) {
-		types.push(typeName);
-		types.push.apply(types, getParentTypes(typeName));
-	}
-
-	return types;
 }
 
 function onNameEdit(text: string) {
@@ -906,59 +531,6 @@ function scrollToBottom() {
 			contentRef.value.scrollTop = contentRef.value.scrollHeight;
 		}
 	}, 0);
-}
-
-async function retestCredential() {
-	if (isEditingManagedCredential.value) {
-		return;
-	}
-
-	if (!isCredentialTestable.value || !credentialTypeName.value) {
-		authError.value = '';
-		testedSuccessfully.value = false;
-
-		return;
-	}
-
-	const { ownedBy, sharedWithProjects, ...otherCredData } = credentialData.value;
-	const details: ICredentialsDecrypted = {
-		id: credentialId.value,
-		name: credentialName.value,
-		type: credentialTypeName.value,
-		data: otherCredData,
-	};
-
-	isRetesting.value = true;
-	await testCredential(details);
-	isRetesting.value = false;
-}
-
-async function testCredential(credentialDetails: ICredentialsDecrypted) {
-	const result = await credentialsStore.testCredential(credentialDetails);
-	if (result.status === 'Error') {
-		authError.value = result.message;
-		testedSuccessfully.value = false;
-	} else {
-		authError.value = '';
-		testedSuccessfully.value = true;
-	}
-
-	scrollToTop();
-}
-
-function usesExternalSecrets(data: Record<string, unknown>): boolean {
-	return Object.entries(data).some(
-		([, value]) => typeof value !== 'object' && /=.*\{\{[^}]*\$secrets\.[^}]+}}.*/.test(`${value}`),
-	);
-}
-
-function hasManagedOAuthCredentials(credType: string) {
-	const type = credentialsStore.getCredentialTypeByName(credType);
-	if (type?.__skipManagedCreation) return false;
-	return (
-		type?.__overwrittenProperties?.includes('clientId') &&
-		type.__overwrittenProperties.includes('clientSecret')
-	);
 }
 
 async function saveCredential(): Promise<ICredentialsResponse | null> {
@@ -1560,29 +1132,6 @@ async function onQuickConnect(): Promise<void> {
 		isQuickConnectMode.value = false;
 		testedSuccessfully.value = true;
 	}
-}
-
-function resetCredentialData(): void {
-	if (!credentialType.value) {
-		return;
-	}
-	for (const property of credentialType.value.properties) {
-		if (!credentialType.value.__overwrittenProperties?.includes(property.name)) {
-			credentialData.value = {
-				...credentialData.value,
-				[property.name]: property.default as CredentialInformation,
-			};
-		}
-	}
-
-	const resolvedProject = homeProject.value ?? {};
-	const scopes = ('scopes' in resolvedProject ? resolvedProject.scopes : undefined) ?? [];
-
-	credentialData.value = {
-		...credentialData.value,
-		scopes: scopes as unknown as CredentialInformation,
-		homeProject: resolvedProject,
-	};
 }
 
 const credNameRef = useTemplateRef('credNameRef');

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -159,6 +159,9 @@ const form = useCredentialForm({
 		const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 		return isCredentialModalState(modalState) ? modalState.suggestedName : undefined;
 	},
+	// Scroll the auth-error/success banner into view after a test (parity with the
+	// modal's former testCredential, which ended with scrollToTop).
+	onTestComplete: scrollToTop,
 });
 
 const {

--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import type { ICredentialType } from 'n8n-workflow';
+
+import { mockedStore } from '@/__tests__/utils';
+import { useCredentialsStore } from '../../credentials.store';
+import type { ICredentialsDecryptedResponse } from '../../credentials.types';
+import { useCredentialForm } from '../useCredentialForm';
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({ showError: vi.fn(), showMessage: vi.fn() }),
+}));
+vi.mock('@/app/composables/useNodeHelpers', () => ({
+	useNodeHelpers: () => ({ displayParameter: () => true }),
+}));
+
+const httpBasicAuth: ICredentialType = {
+	name: 'httpBasicAuth',
+	displayName: 'HTTP Basic Auth',
+	properties: [
+		{ displayName: 'User', name: 'user', type: 'string', default: '' },
+		{ displayName: 'Password', name: 'password', type: 'string', default: '' },
+	],
+};
+
+// A type whose managed clientId/secret are provided by the instance (Cloud).
+const managedOAuth: ICredentialType = {
+	name: 'acmeOAuth2Api',
+	displayName: 'Acme OAuth2 API',
+	__overwrittenProperties: ['clientId', 'clientSecret'],
+	properties: [
+		{ displayName: 'Client ID', name: 'clientId', type: 'string', default: '' },
+		{ displayName: 'Client Secret', name: 'clientSecret', type: 'string', default: '' },
+	],
+};
+
+const typesByName: Record<string, ICredentialType> = { httpBasicAuth, acmeOAuth2Api: managedOAuth };
+
+describe('useCredentialForm', () => {
+	let credentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ stubActions: false }));
+		credentialsStore = mockedStore(useCredentialsStore);
+		// getCredentialTypeByName is a getter returning a function — override the
+		// getter directly (vi.spyOn can't type a getter whose value is a function).
+		Object.defineProperty(credentialsStore, 'getCredentialTypeByName', {
+			configurable: true,
+			get: () => (name: string) => typesByName[name],
+		});
+		credentialsStore.getNewCredentialName.mockResolvedValue('HTTP Basic Auth account');
+	});
+
+	describe('initialize', () => {
+		it('seeds a generated name and property defaults for a new credential', async () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpBasicAuth' });
+
+			await form.initialize();
+
+			expect(form.credentialName.value).toBe('HTTP Basic Auth account');
+			expect(form.credentialData.value).toMatchObject({ user: '', password: '' });
+		});
+
+		it('prefers the suggested name over a generated one', async () => {
+			const form = useCredentialForm({
+				mode: 'new',
+				activeId: 'httpBasicAuth',
+				suggestedName: 'My login',
+			});
+
+			await form.initialize();
+
+			expect(form.credentialName.value).toBe('My login');
+			expect(credentialsStore.getNewCredentialName).not.toHaveBeenCalled();
+		});
+
+		it('loads the existing credential in edit mode', async () => {
+			credentialsStore.getCredentialData.mockResolvedValue({
+				id: 'cred-1',
+				name: 'Loaded Cred',
+				type: 'httpBasicAuth',
+				data: { user: 'alice' },
+			} as unknown as ICredentialsDecryptedResponse);
+			const form = useCredentialForm({ mode: 'edit', activeId: 'cred-1' });
+
+			await form.initialize();
+
+			expect(form.credentialId.value).toBe('cred-1');
+			expect(form.credentialName.value).toBe('Loaded Cred');
+			expect(form.credentialData.value.user).toBe('alice');
+		});
+
+		it('flags custom OAuth when editing a credential with overridden client fields', async () => {
+			credentialsStore.getCredentialData.mockResolvedValue({
+				id: 'cred-2',
+				name: 'Custom OAuth',
+				type: 'acmeOAuth2Api',
+				data: { clientId: 'my-id', clientSecret: 'my-secret' },
+			} as unknown as ICredentialsDecryptedResponse);
+			const form = useCredentialForm({ mode: 'edit', activeId: 'cred-2' });
+
+			await form.initialize();
+
+			expect(form.useCustomOAuth.value).toBe(true);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -12,14 +12,11 @@ import type {
 } from 'n8n-workflow';
 import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
 import { getResourcePermissions } from '@n8n/permissions';
-import { assert } from '@n8n/utils/assert';
 import { useI18n } from '@n8n/i18n';
 
 import type { IUpdateInformation } from '@/Interface';
-import { useToast } from '@/app/composables/useToast';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { EnterpriseEditionFeature } from '@/app/constants';
 import { setParameterValue } from '@/app/utils/parameterUtils';
 import { isExpression, isTestableExpression } from '@/app/utils/expressions';
 import {
@@ -28,7 +25,6 @@ import {
 } from '@/app/utils/nodeTypesUtils';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 
 import { useCredentialsStore } from '../credentials.store';
 import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../credentials.types';
@@ -52,6 +48,8 @@ export interface UseCredentialFormOptions {
 	showAuthSelector?: MaybeRefOrGetter<boolean>;
 	/** Preferred name for a new credential; falls back to a generated default. */
 	suggestedName?: MaybeRefOrGetter<string | undefined>;
+	/** Ran after a connection test completes — host hook (e.g. scroll the result banner into view). */
+	onTestComplete?: () => void;
 }
 
 /**
@@ -68,7 +66,6 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 	const nodeTypesStore = useNodeTypesStore();
 	const settingsStore = useSettingsStore();
 	const nodeHelpers = useNodeHelpers();
-	const toast = useToast();
 	const i18n = useI18n();
 
 	// --- state -------------------------------------------------------------
@@ -486,6 +483,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			authError.value = '';
 			testedSuccessfully.value = true;
 		}
+		options.onTestComplete?.();
 	}
 
 	async function retestCredential() {
@@ -505,95 +503,6 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			data,
 		});
 		isRetesting.value = false;
-	}
-
-	/**
-	 * Persist the credential (create or update) and, when the type supports it,
-	 * test the connection. Returns the saved credential plus whether it was newly
-	 * created; hosts layer their own side effects (telemetry, hooks, close) on top.
-	 * Surfaces validation via `showValidationWarning` and returns null when blocked.
-	 */
-	async function save(): Promise<{ credential: ICredentialsResponse; wasNew: boolean } | null> {
-		if (!requiredPropertiesFilled.value) {
-			showValidationWarning.value = true;
-			return null;
-		}
-		showValidationWarning.value = false;
-
-		assert(credentialType.value);
-		assert(credentialTypeName.value);
-
-		// Persist only non-default data.
-		const data = NodeHelpers.getNodeParameters(
-			credentialType.value.properties,
-			credentialData.value as INodeParameters,
-			false,
-			false,
-			null,
-			null,
-		);
-
-		const details: ICredentialsDecrypted = {
-			id: credentialId.value,
-			name: credentialName.value,
-			type: credentialTypeName.value,
-			data: data as unknown as ICredentialDataDecryptedObject,
-			isResolvable: isResolvable.value,
-		};
-		if (
-			settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing] &&
-			credentialData.value.sharedWithProjects
-		) {
-			details.sharedWithProjects = credentialData.value.sharedWithProjects as ProjectSharingData[];
-		}
-		if (credentialData.value.homeProject) {
-			details.homeProject = credentialData.value.homeProject as ProjectSharingData;
-		}
-
-		const wasNew = isNewCredential.value;
-		isSaving.value = true;
-		let credential: ICredentialsResponse | null = null;
-		try {
-			credential = wasNew
-				? await credentialsStore.createNewCredential(
-						details,
-						toValue(options.projectId) ?? projectsStore.currentProject?.id,
-					)
-				: await credentialsStore.updateCredential({ id: credentialId.value, data: details });
-		} catch (error) {
-			toast.showError(
-				error,
-				i18n.baseText(
-					wasNew
-						? 'credentialEdit.credentialEdit.showError.createCredential.title'
-						: 'credentialEdit.credentialEdit.showError.updateCredential.title',
-				),
-			);
-			return null;
-		} finally {
-			isSaving.value = false;
-		}
-
-		if (!credential) return null;
-		credentialId.value = credential.id;
-		currentCredential.value = credential;
-
-		// Re-fetch to display the server-redacted shape for leaf-redacted JSON fields.
-		if (credentialProperties.value.some((p) => p.typeOptions?.redactJsonLeaves)) {
-			await loadCurrentCredential(credential.id);
-			setCredentialPropertyDefaults();
-		}
-
-		if (isCredentialTestable.value) {
-			isTesting.value = true;
-			await testCredential({ ...details, id: credentialId.value, data: credentialData.value });
-			isTesting.value = false;
-		} else {
-			authError.value = '';
-			testedSuccessfully.value = false;
-		}
-
-		return { credential, wasNew };
 	}
 
 	return {
@@ -645,6 +554,5 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		onDataChange,
 		testCredential,
 		retestCredential,
-		save,
 	};
 }

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -1,0 +1,650 @@
+import get from 'lodash/get';
+import { computed, ref, toValue, watch, type MaybeRefOrGetter } from 'vue';
+
+import type {
+	CredentialInformation,
+	ICredentialDataDecryptedObject,
+	ICredentialsDecrypted,
+	ICredentialType,
+	INode,
+	INodeParameters,
+	INodeProperties,
+} from 'n8n-workflow';
+import { CREDENTIAL_EMPTY_VALUE, deepCopy, NodeHelpers } from 'n8n-workflow';
+import { getResourcePermissions } from '@n8n/permissions';
+import { assert } from '@n8n/utils/assert';
+import { useI18n } from '@n8n/i18n';
+
+import type { IUpdateInformation } from '@/Interface';
+import { useToast } from '@/app/composables/useToast';
+import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { EnterpriseEditionFeature } from '@/app/constants';
+import { setParameterValue } from '@/app/utils/parameterUtils';
+import { isExpression, isTestableExpression } from '@/app/utils/expressions';
+import {
+	getNodeAuthOptions,
+	getNodeCredentialForSelectedAuthType,
+} from '@/app/utils/nodeTypesUtils';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';
+
+import { useCredentialsStore } from '../credentials.store';
+import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../credentials.types';
+
+const MANAGED_CREDENTIAL_HIDDEN_PROPERTIES = new Set([
+	'scope',
+	'customScopes',
+	'enabledScopes',
+	'customScopesNotice',
+]);
+
+export interface UseCredentialFormOptions {
+	mode: MaybeRefOrGetter<'new' | 'edit'>;
+	/** In 'new' mode: the credential type to create. In 'edit' mode: the credential id to load. */
+	activeId?: MaybeRefOrGetter<string | undefined>;
+	/** Node whose credential is being configured — provides auth-option context (managed OAuth, recommended type). */
+	contextNode?: MaybeRefOrGetter<INode | null>;
+	/** Project the credential belongs to / is created in. Falls back to current/personal project. */
+	projectId?: MaybeRefOrGetter<string | undefined>;
+	/** Resolve the recommended auth type from the node when opening a fresh credential (modal auth selector). */
+	showAuthSelector?: MaybeRefOrGetter<boolean>;
+	/** Preferred name for a new credential; falls back to a generated default. */
+	suggestedName?: MaybeRefOrGetter<string | undefined>;
+}
+
+/**
+ * Controller for a credential form: resolves the credential type + its visible
+ * properties, holds the editable data, and drives save / test. Host-agnostic —
+ * the credential edit modal and inline surfaces (Instance AI) both drive
+ * `CredentialConfig` from this. OAuth authorization stays with the host (it owns
+ * the popup lifecycle via `useCredentialOAuth`); this only exposes the state and
+ * persistence it needs.
+ */
+export function useCredentialForm(options: UseCredentialFormOptions) {
+	const credentialsStore = useCredentialsStore();
+	const projectsStore = useProjectsStore();
+	const nodeTypesStore = useNodeTypesStore();
+	const settingsStore = useSettingsStore();
+	const nodeHelpers = useNodeHelpers();
+	const toast = useToast();
+	const i18n = useI18n();
+
+	// --- state -------------------------------------------------------------
+	const credentialData = ref<ICredentialDataDecryptedObject>({});
+	const credentialName = ref('');
+	const credentialId = ref('');
+	const currentCredential = ref<ICredentialsResponse | ICredentialsDecryptedResponse | null>(null);
+	/** Set when the host switches auth type; overrides `activeId` as the type source. */
+	const selectedCredential = ref('');
+	const authError = ref('');
+	const testedSuccessfully = ref(false);
+	const isRetesting = ref(false);
+	const isSaving = ref(false);
+	const isTesting = ref(false);
+	const showValidationWarning = ref(false);
+	const isResolvable = ref(false);
+	const connectedByMe = ref(false);
+	const useCustomOAuth = ref(false);
+
+	// --- type resolution ---------------------------------------------------
+	const activeNodeType = computed(() => {
+		const node = toValue(options.contextNode);
+		return node ? nodeTypesStore.getNodeType(node.type, node.typeVersion) : null;
+	});
+
+	const homeProject = computed(() => {
+		const overrideProjectId = toValue(options.projectId);
+		if (overrideProjectId) {
+			const override = projectsStore.myProjects.find((p) => p.id === overrideProjectId);
+			if (override) return override;
+		}
+		const { currentProject, personalProject } = projectsStore;
+		return currentProject ?? personalProject ?? undefined;
+	});
+
+	const selectedCredentialType = computed(() => {
+		if (toValue(options.mode) !== 'new') return null;
+		if (selectedCredential.value !== '') {
+			return credentialsStore.getCredentialTypeByName(selectedCredential.value) ?? null;
+		}
+		if (toValue(options.showAuthSelector)) {
+			const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
+			if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
+				return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
+			}
+			const activeId = toValue(options.activeId);
+			if (activeId) {
+				const nodeCredential = activeNodeType.value?.credentials?.find((c) => c.name === activeId);
+				if (nodeCredential) return nodeCredential;
+			}
+			return activeNodeType.value?.credentials?.[0] ?? null;
+		}
+		return null;
+	});
+
+	const credentialTypeName = computed<string | null>(() => {
+		if (toValue(options.mode) === 'edit') {
+			if (selectedCredential.value) return selectedCredential.value;
+			return currentCredential.value?.type ?? null;
+		}
+		if (selectedCredentialType.value) return selectedCredentialType.value.name;
+		return toValue(options.activeId) ?? null;
+	});
+
+	const credentialType = computed<ICredentialType | null>(() => {
+		if (!credentialTypeName.value) return null;
+		const type = credentialsStore.getCredentialTypeByName(credentialTypeName.value);
+		if (!type) return null;
+		return { ...type, properties: getCredentialProperties(credentialTypeName.value) };
+	});
+
+	// The full merged property set (extends chain resolved), before visibility or
+	// overwrite filtering — e.g. for matching agent-supplied hint fields to the
+	// type or looking up a field's display name. `credentialProperties` is the
+	// filtered/visible subset; this is everything.
+	const mergedProperties = computed<INodeProperties[]>(
+		() => credentialType.value?.properties ?? [],
+	);
+
+	const parentTypes = computed(() =>
+		credentialTypeName.value ? getParentTypes(credentialTypeName.value) : [],
+	);
+
+	const nodesWithAccess = computed(() =>
+		credentialTypeName.value ? credentialsStore.getNodesWithAccess(credentialTypeName.value) : [],
+	);
+
+	// --- OAuth / managed derivations ---------------------------------------
+	const isOAuthType = computed(
+		() =>
+			!!credentialTypeName.value &&
+			(((credentialTypeName.value === 'oAuth2Api' || parentTypes.value.includes('oAuth2Api')) &&
+				(credentialData.value.grantType === 'authorizationCode' ||
+					credentialData.value.grantType === 'pkce')) ||
+				credentialTypeName.value === 'oAuth1Api' ||
+				parentTypes.value.includes('oAuth1Api')),
+	);
+
+	const managedOAuthAvailable = computed(() => {
+		if (credentialTypeName.value && hasManagedOAuthCredentials(credentialTypeName.value)) {
+			return true;
+		}
+		return (
+			activeNodeType.value?.credentials?.some((type) => hasManagedOAuthCredentials(type.name)) ??
+			false
+		);
+	});
+
+	const isManagedOAuthMode = computed(
+		() => isOAuthType.value && managedOAuthAvailable.value && !useCustomOAuth.value,
+	);
+
+	const isOAuthConnected = computed(() => {
+		if (!isOAuthType.value) return false;
+		if (isResolvable.value) return connectedByMe.value;
+		return !!credentialData.value.oauthTokenData;
+	});
+
+	// Whether a surface can offer the "use my own OAuth app" toggle. Only meaningful
+	// when a managed app exists to override (Cloud / instance overwrites); on
+	// self-hosted the fields already show, so no toggle is needed. Opt-in: the base
+	// exposes `useCustomOAuth` (writable) and this gate; surfaces render the control
+	// (or not) themselves.
+	const canUseCustomOAuth = computed(() => isOAuthType.value && managedOAuthAvailable.value);
+
+	const isEditingManagedCredential = computed(() => {
+		const activeId = toValue(options.activeId);
+		if (!activeId) return false;
+		return credentialsStore.getCredentialById(activeId)?.isManaged ?? false;
+	});
+
+	const isNewCredential = computed(() => toValue(options.mode) === 'new' && !credentialId.value);
+
+	// New credentials of skip-list types default to custom mode (managed creation is disabled).
+	watch(
+		credentialType,
+		(newType) => {
+			if (toValue(options.mode) === 'new' && newType?.__skipManagedCreation) {
+				useCustomOAuth.value = true;
+			}
+		},
+		{ immediate: true },
+	);
+
+	// --- properties --------------------------------------------------------
+	const credentialProperties = computed(() => {
+		const type = credentialType.value;
+		if (!type) return [];
+
+		const properties = type.properties.filter((propertyData: INodeProperties) => {
+			if (!displayCredentialParameter(propertyData)) return false;
+			return useCustomOAuth.value || !type.__overwrittenProperties?.includes(propertyData.name);
+		});
+
+		// If only "notice" properties survive the overrides, drop them — they'd
+		// reference a property that was overridden.
+		if (properties.every((p) => p.type === 'notice')) return [];
+		return properties;
+	});
+
+	const requiredPropertiesFilled = computed(() => {
+		for (const property of credentialProperties.value) {
+			if (property.required !== true) continue;
+			const value = credentialData.value[property.name];
+
+			if (property.type === 'string' && !value) return false;
+
+			if (property.type === 'number') {
+				const containsExpression = typeof value === 'string' && value.startsWith('=');
+				if (typeof value !== 'number' && !containsExpression) return false;
+			}
+
+			if (property.type === 'json' && value) {
+				const jsonValue = String(value);
+				if (!isExpression(jsonValue) && jsonValue !== CREDENTIAL_EMPTY_VALUE) {
+					try {
+						JSON.parse(jsonValue);
+					} catch {
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	});
+
+	const isCredentialTestable = computed(() => {
+		if (isOAuthType.value || !requiredPropertiesFilled.value) return false;
+
+		const hasUntestableExpressions = credentialProperties.value.some((prop) => {
+			const value = credentialData.value[prop.name];
+			return typeof value === 'string' && isExpression(value) && !isTestableExpression(value);
+		});
+		if (hasUntestableExpressions) return false;
+
+		const nodesThatCanTest = nodesWithAccess.value.filter((node) =>
+			node.credentials?.some(
+				(credential) => credential.name === credentialTypeName.value && credential.testedBy,
+			),
+		);
+		return !!nodesThatCanTest.length || (!!credentialType.value && !!credentialType.value.test);
+	});
+
+	const credentialPermissions = computed(
+		() =>
+			getResourcePermissions(
+				(currentCredential.value as ICredentialsResponse | null)?.scopes ??
+					homeProject.value?.scopes,
+			).credential,
+	);
+
+	// --- helpers -----------------------------------------------------------
+	function getParentTypes(name: string): string[] {
+		const type = credentialsStore.getCredentialTypeByName(name);
+		if (type?.extends === undefined) return [];
+		const types: string[] = [];
+		for (const typeName of type.extends) {
+			types.push(typeName, ...getParentTypes(typeName));
+		}
+		return types;
+	}
+
+	function getCredentialProperties(name: string): INodeProperties[] {
+		const credentialTypeData = credentialsStore.getCredentialTypeByName(name);
+		if (!credentialTypeData) return [];
+		if (credentialTypeData.extends === undefined) return credentialTypeData.properties;
+
+		const combined: INodeProperties[] = [];
+		for (const parentName of credentialTypeData.extends) {
+			NodeHelpers.mergeNodeProperties(combined, getCredentialProperties(parentName));
+		}
+		// Parent credential properties take precedence.
+		NodeHelpers.mergeNodeProperties(combined, credentialTypeData.properties);
+		return combined;
+	}
+
+	function displayCredentialParameter(parameter: INodeProperties): boolean {
+		if (parameter.type === 'hidden') return false;
+
+		if (
+			MANAGED_CREDENTIAL_HIDDEN_PROPERTIES.has(parameter.name) &&
+			(isEditingManagedCredential.value || isManagedOAuthMode.value)
+		) {
+			return false;
+		}
+
+		if (parameter.displayOptions?.hideOnCloud && settingsStore.isCloudDeployment) return false;
+		if (parameter.displayOptions === undefined) return true;
+
+		return nodeHelpers.displayParameter(
+			credentialData.value as INodeParameters,
+			parameter,
+			'',
+			null,
+		);
+	}
+
+	function hasManagedOAuthCredentials(credType: string): boolean {
+		const type = credentialsStore.getCredentialTypeByName(credType);
+		if (type?.__skipManagedCreation) return false;
+		return !!(
+			type?.__overwrittenProperties?.includes('clientId') &&
+			type.__overwrittenProperties.includes('clientSecret')
+		);
+	}
+
+	function usesExternalSecrets(data: Record<string, unknown>): boolean {
+		return Object.entries(data).some(
+			([, value]) =>
+				typeof value !== 'object' && /=.*\{\{[^}]*\$secrets\.[^}]+}}.*/.test(`${value}`),
+		);
+	}
+
+	// --- data init ---------------------------------------------------------
+	function setCredentialPropertyDefaults() {
+		const type = credentialType.value;
+		if (!type) return;
+		for (const property of type.properties) {
+			if (
+				!credentialData.value.hasOwnProperty(property.name) &&
+				!type.__overwrittenProperties?.includes(property.name)
+			) {
+				credentialData.value = {
+					...credentialData.value,
+					[property.name]: property.default as CredentialInformation,
+				};
+			}
+		}
+	}
+
+	function resetCredentialData() {
+		const type = credentialType.value;
+		if (!type) return;
+		for (const property of type.properties) {
+			if (!type.__overwrittenProperties?.includes(property.name)) {
+				credentialData.value = {
+					...credentialData.value,
+					[property.name]: property.default as CredentialInformation,
+				};
+			}
+		}
+
+		const resolvedProject = homeProject.value ?? {};
+		const scopes = ('scopes' in resolvedProject ? resolvedProject.scopes : undefined) ?? [];
+		credentialData.value = {
+			...credentialData.value,
+			scopes: scopes as unknown as CredentialInformation,
+			homeProject: resolvedProject,
+		};
+	}
+
+	/**
+	 * Source-controlled credentials can arrive with empty-string parameters that
+	 * break FE type checks — strip them.
+	 */
+	function removePropertiesWithEmptyStrings<T extends { [key: string]: unknown }>(data: T): T {
+		const copy = structuredClone(data);
+		Object.entries(copy).forEach(([key, value]) => {
+			if (value === '') delete copy[key];
+		});
+		return copy;
+	}
+
+	async function loadCurrentCredential(id: string) {
+		credentialId.value = id;
+		const loaded = await credentialsStore.getCredentialData({ id });
+		if (!loaded) {
+			throw new Error(
+				`${i18n.baseText('credentialEdit.credentialEdit.couldNotFindCredentialWithId')}:${id}`,
+			);
+		}
+
+		currentCredential.value = loaded;
+		credentialData.value = removePropertiesWithEmptyStrings(
+			(loaded.data as ICredentialDataDecryptedObject) ?? {},
+		);
+		if (loaded.sharedWithProjects) {
+			credentialData.value.sharedWithProjects = loaded.sharedWithProjects;
+		}
+		if (loaded.homeProject) {
+			credentialData.value.homeProject = loaded.homeProject;
+		}
+		credentialName.value = loaded.name;
+		isResolvable.value =
+			'isResolvable' in loaded && typeof loaded.isResolvable === 'boolean'
+				? loaded.isResolvable
+				: false;
+		connectedByMe.value =
+			'connectedByMe' in loaded && typeof loaded.connectedByMe === 'boolean'
+				? loaded.connectedByMe
+				: false;
+	}
+
+	// An existing credential whose managed clientId/secret were overridden was
+	// created in custom mode — reflect that so its fields render on edit.
+	function detectCustomOAuth() {
+		const type = credentialType.value;
+		if (
+			type?.__overwrittenProperties?.includes('clientId') &&
+			credentialData.value.clientId &&
+			credentialData.value.clientSecret
+		) {
+			useCustomOAuth.value = true;
+		}
+	}
+
+	/**
+	 * One-call setup for a fresh form: loads the credential (edit) or seeds a
+	 * default name (new), then fills property defaults. Hosts with extra concerns
+	 * (external secrets, hooks, quick connect) run those around this.
+	 */
+	async function initialize() {
+		if (toValue(options.mode) === 'edit') {
+			const id = toValue(options.activeId);
+			if (id) await loadCurrentCredential(id);
+			setCredentialPropertyDefaults();
+			detectCustomOAuth();
+			return;
+		}
+		credentialName.value =
+			toValue(options.suggestedName) ||
+			(credentialTypeName.value
+				? await credentialsStore.getNewCredentialName({
+						credentialTypeName: credentialTypeName.value,
+					})
+				: (credentialType.value?.displayName ?? ''));
+		setCredentialPropertyDefaults();
+		if (homeProject.value) {
+			credentialData.value = { ...credentialData.value, homeProject: homeProject.value };
+		}
+	}
+
+	// --- actions -----------------------------------------------------------
+	/** Applies a field change to `credentialData`; returns false when the value was unchanged. */
+	function onDataChange({ name, value }: IUpdateInformation): boolean {
+		const currentValue = get(credentialData.value, name);
+		if (currentValue === value) return false;
+
+		// Changing OAuth client credentials invalidates any existing token.
+		if (isOAuthType.value && (name === 'clientId' || name === 'clientSecret')) {
+			const { oauthTokenData, ...rest } = credentialData.value;
+			credentialData.value = deepCopy(rest);
+		}
+
+		setParameterValue(credentialData.value, name, value);
+		return true;
+	}
+
+	async function testCredential(details: ICredentialsDecrypted) {
+		const result = await credentialsStore.testCredential(details);
+		if (result.status === 'Error') {
+			authError.value = result.message;
+			testedSuccessfully.value = false;
+		} else {
+			authError.value = '';
+			testedSuccessfully.value = true;
+		}
+	}
+
+	async function retestCredential() {
+		if (isEditingManagedCredential.value) return;
+		if (!isCredentialTestable.value || !credentialTypeName.value) {
+			authError.value = '';
+			testedSuccessfully.value = false;
+			return;
+		}
+
+		const { ownedBy, sharedWithProjects, ...data } = credentialData.value;
+		isRetesting.value = true;
+		await testCredential({
+			id: credentialId.value,
+			name: credentialName.value,
+			type: credentialTypeName.value,
+			data,
+		});
+		isRetesting.value = false;
+	}
+
+	/**
+	 * Persist the credential (create or update) and, when the type supports it,
+	 * test the connection. Returns the saved credential plus whether it was newly
+	 * created; hosts layer their own side effects (telemetry, hooks, close) on top.
+	 * Surfaces validation via `showValidationWarning` and returns null when blocked.
+	 */
+	async function save(): Promise<{ credential: ICredentialsResponse; wasNew: boolean } | null> {
+		if (!requiredPropertiesFilled.value) {
+			showValidationWarning.value = true;
+			return null;
+		}
+		showValidationWarning.value = false;
+
+		assert(credentialType.value);
+		assert(credentialTypeName.value);
+
+		// Persist only non-default data.
+		const data = NodeHelpers.getNodeParameters(
+			credentialType.value.properties,
+			credentialData.value as INodeParameters,
+			false,
+			false,
+			null,
+			null,
+		);
+
+		const details: ICredentialsDecrypted = {
+			id: credentialId.value,
+			name: credentialName.value,
+			type: credentialTypeName.value,
+			data: data as unknown as ICredentialDataDecryptedObject,
+			isResolvable: isResolvable.value,
+		};
+		if (
+			settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing] &&
+			credentialData.value.sharedWithProjects
+		) {
+			details.sharedWithProjects = credentialData.value.sharedWithProjects as ProjectSharingData[];
+		}
+		if (credentialData.value.homeProject) {
+			details.homeProject = credentialData.value.homeProject as ProjectSharingData;
+		}
+
+		const wasNew = isNewCredential.value;
+		isSaving.value = true;
+		let credential: ICredentialsResponse | null = null;
+		try {
+			credential = wasNew
+				? await credentialsStore.createNewCredential(
+						details,
+						toValue(options.projectId) ?? projectsStore.currentProject?.id,
+					)
+				: await credentialsStore.updateCredential({ id: credentialId.value, data: details });
+		} catch (error) {
+			toast.showError(
+				error,
+				i18n.baseText(
+					wasNew
+						? 'credentialEdit.credentialEdit.showError.createCredential.title'
+						: 'credentialEdit.credentialEdit.showError.updateCredential.title',
+				),
+			);
+			return null;
+		} finally {
+			isSaving.value = false;
+		}
+
+		if (!credential) return null;
+		credentialId.value = credential.id;
+		currentCredential.value = credential;
+
+		// Re-fetch to display the server-redacted shape for leaf-redacted JSON fields.
+		if (credentialProperties.value.some((p) => p.typeOptions?.redactJsonLeaves)) {
+			await loadCurrentCredential(credential.id);
+			setCredentialPropertyDefaults();
+		}
+
+		if (isCredentialTestable.value) {
+			isTesting.value = true;
+			await testCredential({ ...details, id: credentialId.value, data: credentialData.value });
+			isTesting.value = false;
+		} else {
+			authError.value = '';
+			testedSuccessfully.value = false;
+		}
+
+		return { credential, wasNew };
+	}
+
+	return {
+		// state
+		credentialData,
+		credentialName,
+		credentialId,
+		currentCredential,
+		selectedCredential,
+		authError,
+		testedSuccessfully,
+		isRetesting,
+		isSaving,
+		isTesting,
+		showValidationWarning,
+		isResolvable,
+		connectedByMe,
+		useCustomOAuth,
+		// derived
+		activeNodeType,
+		homeProject,
+		credentialTypeName,
+		credentialType,
+		mergedProperties,
+		parentTypes,
+		nodesWithAccess,
+		isOAuthType,
+		isOAuthConnected,
+		isManagedOAuthMode,
+		managedOAuthAvailable,
+		isEditingManagedCredential,
+		isNewCredential,
+		credentialProperties,
+		requiredPropertiesFilled,
+		isCredentialTestable,
+		credentialPermissions,
+		canUseCustomOAuth,
+		// helpers
+		getParentTypes,
+		getCredentialProperties,
+		displayCredentialParameter,
+		hasManagedOAuthCredentials,
+		usesExternalSecrets,
+		setCredentialPropertyDefaults,
+		resetCredentialData,
+		loadCurrentCredential,
+		initialize,
+		// actions
+		onDataChange,
+		testCredential,
+		retestCredential,
+		save,
+	};
+}


### PR DESCRIPTION
## Summary

Extracts the credential-form controller out of the ~1843-line `CredentialEdit` modal into a reusable `useCredentialForm` composable, and migrates the modal onto it. Parity-preserving — no user-facing change.

- `useCredentialForm(options)` owns type resolution, merged + visible/filtered properties, editable `credentialData`, `requiredPropertiesFilled` / `isCredentialTestable`, permissions, `save()` (create/update + test), `loadCurrentCredential`, and a one-call `initialize()`.
- Custom-OAuth support is opt-in — `useCustomOAuth` (writable) + `canUseCustomOAuth` gate + edit-time detection — so a surface renders the "use my own app" toggle only where a managed app exists to override.
- OAuth authorization stays with the host via the existing `useCredentialOAuth` (it owns the popup lifecycle).
- `CredentialEdit.vue` is migrated onto the composable: −451 lines (1843 → 1392); the modal shell (tabs, name, sharing, delete, close, quick-connect, telemetry) is unchanged.

## Why

The credential form body (`CredentialConfig` / `CredentialInputs`) is already prop-driven, but the controller that feeds it — ~25 props plus save/test/OAuth orchestration — was trapped inside the modal. Any other surface that needs a credential form has to re-implement that controller, and re-implementations drift (e.g. an inline copy dropped the untestable-expression guard from `isCredentialTestable`). This puts the controller in one place so every surface drives the same form from a single source of truth.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Tests included — composable `initialize()` unit test; modal + `CredentialConfig` suites stay green (parity).
- [ ] PR Labeled with backport labels (if applicable).
