### PR TITLE
fix(editor): Generate actions for nodes using a flat Action field across versions

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.test.ts
@@ -408,6 +408,110 @@ describe('useActionsGenerator', () => {
 		});
 	});
 
+	describe('App actions for resource/operation collapsed into a single Action across versions', () => {
+		// Mirrors a node (e.g. Browserbase) that collapsed resource+operation into a
+		// flat "Action" field for its latest version, while keeping the legacy
+		// resource shape for older versions. Both are version-gated with `_cnd`.
+		const collapsedActionNode: INodeTypeDescription = {
+			...baseV2NodeWoProps,
+			version: [2, 2.1, 3],
+			defaultVersion: undefined,
+			properties: [
+				{
+					displayName: 'Action',
+					name: 'operation',
+					type: 'options',
+					noDataExpression: true,
+					displayOptions: { show: { '@version': [{ _cnd: { gte: 3 } }] } },
+					options: [
+						{
+							name: 'Run an Agent',
+							value: 'execute',
+							description: 'Run an agent',
+							action: 'Run an agent',
+						},
+						{
+							name: 'Fetch a Webpage',
+							value: 'fetch',
+							description: 'Fetch a page',
+							action: 'Fetch a webpage',
+						},
+						{
+							name: 'Search the Web',
+							value: 'search',
+							description: 'Search the web',
+							action: 'Search the web',
+						},
+					],
+					default: 'execute',
+				},
+				{
+					displayName: 'Resource',
+					name: 'resource',
+					type: 'options',
+					noDataExpression: true,
+					displayOptions: { show: { '@version': [{ _cnd: { lt: 3 } }] } },
+					options: [
+						{ name: 'Agent', value: 'agent' },
+						{ name: 'Fetch', value: 'fetch' },
+						{ name: 'Search', value: 'search' },
+					],
+					default: 'agent',
+				},
+				{
+					displayName: 'Operation',
+					name: 'operation',
+					type: 'options',
+					noDataExpression: true,
+					displayOptions: { show: { '@version': [{ _cnd: { lt: 3 } }], resource: ['agent'] } },
+					options: [{ name: 'Run an Agent', value: 'execute', action: 'Run an agent' }],
+					default: 'execute',
+				},
+				{
+					displayName: 'Operation',
+					name: 'operation',
+					type: 'options',
+					noDataExpression: true,
+					displayOptions: { show: { '@version': [{ _cnd: { lt: 3 } }], resource: ['fetch'] } },
+					options: [{ name: 'Fetch', value: 'fetch', action: 'Fetch a page' }],
+					default: 'fetch',
+				},
+				{
+					displayName: 'Operation',
+					name: 'operation',
+					type: 'options',
+					noDataExpression: true,
+					displayOptions: { show: { '@version': [{ _cnd: { lt: 3 } }], resource: ['search'] } },
+					options: [{ name: 'Search', value: 'search', action: 'Search the web' }],
+					default: 'search',
+				},
+			],
+		};
+
+		it('generates the flat operation actions for the default (latest) version without duplicates', () => {
+			const { actions } = generateMergedNodesAndActions([collapsedActionNode], []);
+
+			expect(actions[NODE_NAME]).toEqual([
+				expect.objectContaining({ actionKey: 'execute', displayName: 'Run an agent' }),
+				expect.objectContaining({ actionKey: 'fetch', displayName: 'Fetch a webpage' }),
+				expect.objectContaining({ actionKey: 'search', displayName: 'Search the web' }),
+			]);
+		});
+
+		it('falls back to the resource-based actions when the default version is a legacy one', () => {
+			const { actions } = generateMergedNodesAndActions(
+				[{ ...collapsedActionNode, defaultVersion: 2 }],
+				[],
+			);
+
+			expect(actions[NODE_NAME]).toEqual([
+				expect.objectContaining({ actionKey: 'execute', displayName: 'Run an agent' }),
+				expect.objectContaining({ actionKey: 'fetch', displayName: 'Fetch a page' }),
+				expect.objectContaining({ actionKey: 'search', displayName: 'Search the web' }),
+			]);
+		});
+	});
+
 	describe('Simple Memory node filtering', () => {
 		const simpleMemoryNode: INodeTypeDescription = {
 			name: SIMPLE_MEMORY_NODE_TYPE,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.test.ts
@@ -510,6 +510,64 @@ describe('useActionsGenerator', () => {
 				expect.objectContaining({ actionKey: 'search', displayName: 'Search the web' }),
 			]);
 		});
+
+		it('resolves the default version from a single numeric `version` when defaultVersion is unset', () => {
+			const node: INodeTypeDescription = {
+				...baseV2NodeWoProps,
+				version: 2,
+				defaultVersion: undefined,
+				properties: [
+					{
+						displayName: 'Operation',
+						name: 'operation',
+						type: 'options',
+						noDataExpression: true,
+						displayOptions: { show: { '@version': [{ _cnd: { gte: 2 } }] } },
+						options: [
+							{ name: 'Get', value: 'get', action: 'Get a thing' },
+							{ name: 'Create', value: 'create', action: 'Create a thing' },
+						],
+						default: 'get',
+					},
+				],
+			};
+
+			const { actions } = generateMergedNodesAndActions([node], []);
+
+			expect(actions[NODE_NAME]).toEqual([
+				expect.objectContaining({ actionKey: 'get', displayName: 'Get a thing' }),
+				expect.objectContaining({ actionKey: 'create', displayName: 'Create a thing' }),
+			]);
+		});
+
+		it('falls back to the first operation when none matches the default version', () => {
+			const node: INodeTypeDescription = {
+				...baseV2NodeWoProps,
+				version: [1, 2],
+				defaultVersion: 2,
+				properties: [
+					{
+						displayName: 'Operation',
+						name: 'operation',
+						type: 'options',
+						noDataExpression: true,
+						displayOptions: { show: { '@version': [1] } },
+						options: [
+							{ name: 'Get', value: 'get', action: 'Get a thing' },
+							{ name: 'Create', value: 'create', action: 'Create a thing' },
+						],
+						default: 'get',
+					},
+				],
+			};
+
+			const { actions } = generateMergedNodesAndActions([node], []);
+
+			expect(actions[NODE_NAME]).toEqual([
+				expect.objectContaining({ actionKey: 'get', displayName: 'Get a thing' }),
+				expect.objectContaining({ actionKey: 'create', displayName: 'Create a thing' }),
+			]);
+		});
 	});
 
 	describe('Simple Memory node filtering', () => {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useActionsGeneration.ts
@@ -10,6 +10,7 @@ import {
 import memoize from 'lodash/memoize';
 import startCase from 'lodash/startCase';
 import {
+	checkConditions,
 	EVALUATION_NODE_TYPE,
 	EVALUATION_TRIGGER_NODE_TYPE,
 	type ICredentialType,
@@ -99,8 +100,34 @@ function getNodeTypeBase(nodeTypeDescription: INodeTypeDescription, label?: stri
 	};
 }
 
+// Actions represent adding a new node, which uses the default (latest) version.
+function getDefaultNodeVersion(nodeTypeDescription: INodeTypeDescription): number {
+	if (typeof nodeTypeDescription.defaultVersion === 'number') {
+		return nodeTypeDescription.defaultVersion;
+	}
+	return Array.isArray(nodeTypeDescription.version)
+		? Math.max(...nodeTypeDescription.version)
+		: nodeTypeDescription.version;
+}
+
+// Whether a property shows for a version, honoring `_cnd` `@version` conditions.
+function isPropertyForVersion(property: INodeProperties, version: number): boolean {
+	const versionConditions = property.displayOptions?.show?.['@version'];
+	if (!versionConditions) return true;
+	return checkConditions(versionConditions, [version]);
+}
+
 function operationsCategory(nodeTypeDescription: INodeTypeDescription): ActionTypeDescription[] {
-	if (nodeTypeDescription.properties.find((property) => property.name === 'resource')) return [];
+	const defaultVersion = getDefaultNodeVersion(nodeTypeDescription);
+
+	// Defer to resourceCategories only if the default version is resource-based;
+	// a node may keep a legacy `resource` for old versions and a flat `operation` now.
+	if (
+		nodeTypeDescription.properties.some(
+			(property) => property.name === 'resource' && isPropertyForVersion(property, defaultVersion),
+		)
+	)
+		return [];
 
 	if (nodeTypeDescription.name === 'n8n-nodes-base.code') {
 		const languageProperty = nodeTypeDescription.properties.find(
@@ -117,9 +144,13 @@ function operationsCategory(nodeTypeDescription: INodeTypeDescription): ActionTy
 		}
 	}
 
-	const matchedProperty = nodeTypeDescription.properties.find(
-		(property) => property.name?.toLowerCase() === 'operation',
-	);
+	const matchedProperty =
+		nodeTypeDescription.properties.find(
+			(property) =>
+				property.name?.toLowerCase() === 'operation' &&
+				isPropertyForVersion(property, defaultVersion),
+		) ??
+		nodeTypeDescription.properties.find((property) => property.name?.toLowerCase() === 'operation');
 
 	if (!matchedProperty?.options) return [];
 
@@ -232,8 +263,9 @@ function triggersCategory(nodeTypeDescription: INodeTypeDescription): ActionType
 
 function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTypeDescription[] {
 	const transformedNodes: ActionTypeDescription[] = [];
+	const defaultVersion = getDefaultNodeVersion(nodeTypeDescription);
 	const matchedProperties = nodeTypeDescription.properties.filter(
-		(property) => property.name === 'resource',
+		(property) => property.name === 'resource' && isPropertyForVersion(property, defaultVersion),
 	);
 
 	matchedProperties.forEach((property) => {
@@ -249,19 +281,7 @@ function resourceCategories(nodeTypeDescription: INodeTypeDescription): ActionTy
 						operation.displayOptions?.show?.resource?.includes(resourceOption.value) ??
 						isSingleResource;
 
-					// If the operation doesn't have a version defined, it should be
-					// available for all versions. Otherwise, make sure the node type
-					// version matches the operation version
-					const operationVersions = operation.displayOptions?.show?.['@version'];
-					const nodeTypeVersions = Array.isArray(nodeTypeDescription.version)
-						? nodeTypeDescription.version
-						: [nodeTypeDescription.version];
-
-					const isMatchingVersion = operationVersions
-						? operationVersions.some(
-								(version) => typeof version === 'number' && nodeTypeVersions.includes(version),
-							)
-						: true;
+					const isMatchingVersion = isPropertyForVersion(operation, defaultVersion);
 
 					return isOperation && isMatchingResource && isMatchingVersion;
 				});


### PR DESCRIPTION
## Summary

Standalone nodes that use a single flat `operation` ("Action") field for their latest version while keeping a legacy `resource` shape for older versions (e.g. Browserbase v2 vs v3) showed **no actions** in the node creator — only the bare "Add to workflow" preview.

The empty panel came from n8n's node-creator action generation (`useActionsGeneration.ts`), which builds a single flat action list from the merged property list across all versions and made two version-blind assumptions:

1. `operationsCategory` bailed on *any* `resource` property (`if (properties.find(p => p.name === 'resource')) return []`), even one gated to old versions only — so the flat operations were never turned into actions.
2. `resourceCategories` matched `@version` with `typeof version === 'number'`, silently ignoring conditional `{ _cnd: { lt: 3 } }` / `{ _cnd: { gte: 3 } }` versions.

Net result: both generators returned `[]` → zero actions.

### Fix

Action generation is now **version-aware**, keyed off the node's default (latest) version — the version used when adding a new node:

- Added `getDefaultNodeVersion()` and `isPropertyForVersion()` (the latter reuses `checkConditions` from `n8n-workflow`, so `_cnd` operators are evaluated exactly as elsewhere).
- `operationsCategory` defers to `resourceCategories` only when a `resource` property is shown for the default version, and selects the `operation` property applicable to that version.
- `resourceCategories` filters resources to the default version and uses `_cnd`-aware version matching.

For a Browserbase-shaped node (default v3): the v2 `resource` is excluded → the flat actions (Run an Agent / Fetch a Webpage / Search the Web) are emitted with no duplicates. Operation-only nodes (Chat, PDF.co) and pure resource/operation nodes are unaffected.

## How to test

1. In the node creator, open a node whose latest version uses a flat `operation` field named "Action" while an older version used `resource` + `operation`, both gated with `_cnd` `@version` conditions (e.g. Browserbase v3).
2. Confirm the node now lists its actions (e.g. Run an Agent / Fetch a Webpage / Search the Web) instead of only the "Add to workflow" preview.
3. Sanity check unaffected nodes: PDF.co (flat operation, no resource) and any standard resource/operation node still show their usual actions.

Automated: `pnpm --filter n8n-editor-ui test src/features/shared/nodeCreator/composables/useActionsGeneration.test.ts` — includes new regression cases (default v3 shows flat actions; `defaultVersion: 2` falls back to legacy resource-based actions).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-161

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33568">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->