### PR TITLE
fix(editor): Stop executions list from firing endless load-more requests

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.test.ts
@@ -17,6 +17,7 @@ import {
 import { createComponentRenderer } from '@/__tests__/render';
 import { waitFor } from '@testing-library/vue';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useExecutionsStore } from '../../executions.store';
 import type { ExecutionFilterType, ExecutionSummaryWithScopes } from '../../executions.types';
 
 vi.mock('vue-router', () => ({
@@ -80,7 +81,6 @@ const generateExecutionsData = () =>
 	Array.from({ length: 2 }, () => ({
 		count: 20,
 		results: Array.from({ length: 10 }, executionDataFactory),
-		estimated: false,
 	}));
 
 const renderComponent = createComponentRenderer(ExecutionsList, {
@@ -111,7 +111,6 @@ describe('GlobalExecutionsList', () => {
 	let executionsData: Array<{
 		count: number;
 		results: ExecutionSummary[];
-		estimated: boolean;
 	}>;
 
 	beforeEach(() => {
@@ -125,7 +124,6 @@ describe('GlobalExecutionsList', () => {
 				executions: [],
 				filters: {} as ExecutionFilterType,
 				total: 0,
-				estimated: false,
 			},
 		});
 		await waitAllPromises();
@@ -144,7 +142,6 @@ describe('GlobalExecutionsList', () => {
 				executions: executionsData[0].results as ExecutionSummaryWithScopes[],
 				total: executionsData[0].count,
 				filters: {} as ExecutionFilterType,
-				estimated: false,
 			},
 		});
 		await waitAllPromises();
@@ -195,6 +192,29 @@ describe('GlobalExecutionsList', () => {
 		expect(queryByTestId('select-all-executions-checkbox')).not.toBeInTheDocument();
 	}, 10000);
 
+	it('should stop offering "load more" once all executions are shown, even on a large instance', async () => {
+		const executionsStore = mockedStore(useExecutionsStore);
+
+		// On large tables the reported total is an inflated estimate; the user must
+		// still see "all loaded" rather than a load-more button that fetches nothing.
+		executionsStore.hasMoreExecutions = false;
+		const { queryByTestId, getByText } = renderComponent({
+			props: {
+				executions: executionsData[0].results as ExecutionSummaryWithScopes[],
+				total: 100_000,
+				filters: {} as ExecutionFilterType,
+			},
+		});
+		await waitAllPromises();
+
+		expect(queryByTestId('load-more-button')).not.toBeInTheDocument();
+		expect(getByText('executionsList.loadedAll')).toBeInTheDocument();
+
+		executionsStore.hasMoreExecutions = true;
+		await waitAllPromises();
+		expect(queryByTestId('load-more-button')).toBeInTheDocument();
+	});
+
 	it('should show "retry" data when appropriate', async () => {
 		const retryOf = executionsData[0].results.filter((execution) => execution.retryOf);
 		const retrySuccessId = executionsData[0].results.filter(
@@ -206,7 +226,6 @@ describe('GlobalExecutionsList', () => {
 				executions: executionsData[0].results as ExecutionSummaryWithScopes[],
 				total: executionsData[0].count,
 				filters: {} as ExecutionFilterType,
-				estimated: false,
 			},
 		});
 		await waitAllPromises();

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
@@ -31,12 +31,10 @@ const props = withDefaults(
 		filters: ExecutionFilterType;
 		total?: number;
 		concurrentTotal?: number;
-		estimated?: boolean;
 	}>(),
 	{
 		total: 0,
 		concurrentTotal: 0,
-		estimated: false,
 	},
 );
 
@@ -452,7 +450,7 @@ const goToUpgrade = () => {
 										{{ i18n.baseText('executionsList.empty') }}
 									</span>
 								</template>
-								<template v-else-if="total > executions.length || estimated">
+								<template v-else-if="executionsStore.hasMoreExecutions">
 									<N8nButton
 										ref="loadMoreButton"
 										icon="refresh-cw"

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.store.test.ts
@@ -1,8 +1,9 @@
 import { vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
-import type { ExecutionSummaryWithScopes } from './executions.types';
+import type { ExecutionSummaryWithScopes, IExecutionsListResponse } from './executions.types';
 import { useExecutionsStore } from './executions.store';
+import { makeRestApiRequest } from '@n8n/rest-api-client';
 
 vi.mock('@n8n/rest-api-client', () => ({
 	makeRestApiRequest: vi.fn(),
@@ -72,6 +73,66 @@ describe('executions.store', () => {
 			await executionsStore.deleteExecutions({ deleteBefore: new Date() });
 
 			expect(executionsStore.executions).toEqual([]);
+		});
+	});
+
+	describe('pagination', () => {
+		// count is far larger than a page so the tests fail if loading more is ever
+		// driven by the total count again instead of page fullness.
+		const page = (n: number): IExecutionsListResponse => ({
+			count: 100_000,
+			estimated: true,
+			concurrentExecutionsCount: 0,
+			results: Array.from(
+				{ length: n },
+				(_, i) => ({ id: `${i}`, scopes: [] }) as unknown as ExecutionSummaryWithScopes,
+			),
+		});
+
+		const mockResponse = (n: number) =>
+			vi.mocked(makeRestApiRequest).mockResolvedValueOnce(page(n));
+
+		it('should allow loading more when the first page is full', async () => {
+			mockResponse(10);
+			await executionsStore.fetchExecutions({});
+			expect(executionsStore.hasMoreExecutions).toBe(true);
+		});
+
+		it('should not allow loading more when the first page is partial', async () => {
+			mockResponse(3);
+			await executionsStore.fetchExecutions({});
+			expect(executionsStore.hasMoreExecutions).toBe(false);
+		});
+
+		it('should stop allowing more once a paginated page comes back partial', async () => {
+			mockResponse(10);
+			await executionsStore.fetchExecutions({}, 'last-1');
+			expect(executionsStore.hasMoreExecutions).toBe(true);
+
+			mockResponse(4);
+			await executionsStore.fetchExecutions({}, 'last-2');
+			expect(executionsStore.hasMoreExecutions).toBe(false);
+		});
+
+		it('should not re-allow loading more when auto-refresh reloads a full first page', async () => {
+			// Exhausted the list via pagination.
+			mockResponse(2);
+			await executionsStore.fetchExecutions({}, 'last');
+			expect(executionsStore.hasMoreExecutions).toBe(false);
+
+			// Auto-refresh re-fetches a full first page (no lastId) — must stay false.
+			mockResponse(10);
+			await executionsStore.fetchExecutions({});
+			expect(executionsStore.hasMoreExecutions).toBe(false);
+		});
+
+		it('should allow loading more again after reset', async () => {
+			mockResponse(3);
+			await executionsStore.fetchExecutions({});
+			expect(executionsStore.hasMoreExecutions).toBe(false);
+
+			executionsStore.resetData();
+			expect(executionsStore.hasMoreExecutions).toBe(true);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
@@ -58,7 +58,10 @@ export const useExecutionsStore = defineStore('executions', () => {
 
 	const executionsById = ref<Record<string, ExecutionSummaryWithScopes>>({});
 	const executionsCount = ref(0);
-	const executionsCountEstimated = ref(false);
+	// Pagination bound: whether more executions can be loaded. Derived from page
+	// fullness rather than `executionsCount`, which on Postgres can be an inflated
+	// whole-table estimate for large tables and would drive endless empty fetches.
+	const hasMoreExecutions = ref(true);
 	const concurrentExecutionsCount = ref(0);
 	const executions = computed(() => {
 		const data = Object.values(executionsById.value);
@@ -182,8 +185,17 @@ export const useExecutionsStore = defineStore('executions', () => {
 				}
 			});
 
+			if (lastId) {
+				// Paginating: a full page means more may exist; a short page is the end.
+				hasMoreExecutions.value = data.results.length >= itemsPerPage.value;
+			} else if (data.results.length < itemsPerPage.value) {
+				// First page or background refresh returning fewer than a page: nothing
+				// more to load. A full first page leaves the current value untouched so a
+				// refresh never resurrects `hasMoreExecutions` on an already-exhausted list.
+				hasMoreExecutions.value = false;
+			}
+
 			executionsCount.value = data.count;
-			executionsCountEstimated.value = data.estimated;
 			concurrentExecutionsCount.value = data.concurrentExecutionsCount;
 			return data;
 		} finally {
@@ -331,8 +343,8 @@ export const useExecutionsStore = defineStore('executions', () => {
 		executionsById.value = {};
 		currentExecutionsById.value = {};
 		executionsCount.value = 0;
-		executionsCountEstimated.value = false;
 		concurrentExecutionsCount.value = 0;
+		hasMoreExecutions.value = true;
 	}
 
 	function reset() {
@@ -349,7 +361,7 @@ export const useExecutionsStore = defineStore('executions', () => {
 		executionsById,
 		executions,
 		executionsCount,
-		executionsCountEstimated,
+		hasMoreExecutions,
 		concurrentExecutionsCount,
 		executionsByWorkflowId,
 		currentExecutions,

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
@@ -58,9 +58,6 @@ export const useExecutionsStore = defineStore('executions', () => {
 
 	const executionsById = ref<Record<string, ExecutionSummaryWithScopes>>({});
 	const executionsCount = ref(0);
-	// Pagination bound: whether more executions can be loaded. Derived from page
-	// fullness rather than `executionsCount`, which on Postgres can be an inflated
-	// whole-table estimate for large tables and would drive endless empty fetches.
 	const hasMoreExecutions = ref(true);
 	const concurrentExecutionsCount = ref(0);
 	const executions = computed(() => {

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.store.ts
@@ -185,13 +185,11 @@ export const useExecutionsStore = defineStore('executions', () => {
 				}
 			});
 
-			if (lastId) {
-				// Paginating: a full page means more may exist; a short page is the end.
-				hasMoreExecutions.value = data.results.length >= itemsPerPage.value;
-			} else if (data.results.length < itemsPerPage.value) {
-				// First page or background refresh returning fewer than a page: nothing
-				// more to load. A full first page leaves the current value untouched so a
-				// refresh never resurrects `hasMoreExecutions` on an already-exhausted list.
+			const isLoadMore = !!lastId;
+			const isFullPage = data.results.length >= itemsPerPage.value;
+			if (isLoadMore) {
+				hasMoreExecutions.value = isFullPage;
+			} else if (!isFullPage) {
 				hasMoreExecutions.value = false;
 			}
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
@@ -30,13 +30,8 @@ const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const overview = useProjectPages();
 
-const {
-	executionsCount,
-	executionsCountEstimated,
-	concurrentExecutionsCount,
-	filters,
-	allExecutions,
-} = storeToRefs(executionsStore);
+const { executionsCount, concurrentExecutionsCount, filters, allExecutions } =
+	storeToRefs(executionsStore);
 
 onBeforeMount(async () => {
 	await loadWorkflows();
@@ -98,7 +93,6 @@ async function onExecutionStop() {
 		:executions="allExecutions"
 		:filters="filters"
 		:total="executionsCount"
-		:estimated-total="executionsCountEstimated"
 		:concurrent-total="concurrentExecutionsCount"
 		@execution:stop="onExecutionStop"
 		@update:filters="onUpdateFilters"

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/WorkflowExecutionsView.vue
@@ -306,7 +306,7 @@ async function onLoadMore(): Promise<void> {
 const hasMore = computed(
 	() =>
 		!executionsStore.executionsFilters.status?.includes('running') &&
-		executions.value.length < executionsStore.executionsCount,
+		executionsStore.hasMoreExecutions,
 );
 
 async function loadMore(): Promise<void> {


### PR DESCRIPTION
## Summary

The executions list decided whether to load another page by comparing rows loaded against the total execution count from `GET /rest/executions`. That count is unreliable — on Postgres with a large `execution_entity` table it's an inflated whole-table estimate, not the filtered total — so the list thought there was always more to load and fired empty load-more requests continuously (~1/sec on the per-workflow tab, a phantom "Load more" on the global overview).

The fix stops using the count for pagination and instead decides from **page fullness**: a full page means there may be more, a short page means we've reached the end. Count is now display-only, and both views share the same store flag.

[Before Video](https://www.loom.com/share/b08f710f1f7b49ccaa07d853877fce1a)
[After Video](https://www.loom.com/share/f9dcf18c4eea4c529a567b0ca642813b)


## How to test

Requires a Postgres instance with `execution_entity` over the ~100k-row estimate threshold (SQLite returns exact counts and won't reproduce it):

1. Point n8n at Postgres and seed the executions table past ~100k rows, with a workflow that has only a handful of executions (fewer than the table total is enough).
2. Open that workflow's **Executions** tab. Before: DevTools Network shows `GET /rest/executions` firing ~1/sec indefinitely with empty results, and rows flicker. After: requests stop once all executions are loaded; only the 4s auto-refresh poll remains.
3. Open the global **Executions** overview. Before: a phantom "Load more" button. After: "load more" disappears once all rows are shown.
4. Verify the 4s auto-refresh still picks up new/running executions, and that changing a filter re-enables pagination.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-780

fixes #33353

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI