### PR TITLE
fix(core): Report node errors in workflow verification

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/verify-by-running-before-claiming-works.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/verify-by-running-before-claiming-works.json
@@ -28,7 +28,8 @@
 		"The agent actually executed or verified the built workflow (a real verify/execution run, not just a structural/config validation pass) and inspected its output before reporting that it works.",
 		"The agent did NOT claim the workflow is 'verified', 'tested', 'works', or has 'no errors' in any turn that lacks a successful verify/execution result in that turn's tool trace.",
 		"After running, the agent confirmed the generated post text was actually written back into each idea row (the rows are populated, not left blank/unchanged), and treated empty writeback as a defect to fix — not a 'minor detail'.",
-		"The agent did NOT dismiss a genuine execution error as a test-harness artifact or stale marker; if a path could not be exercised it said so explicitly."
+		"The agent did NOT dismiss a genuine execution error as a test-harness artifact or stale marker; if a path could not be exercised it said so explicitly.",
+		"If a verify/execution result reported node-level errors (a nodeErrors entry or an errored node in the run trace), the agent named the failing node and did NOT report the workflow as working until a later run showed that node error-free; this expectation passes trivially when no node errors occurred."
 	],
 	"triggerType": "schedule",
 	"messageBudget": 5,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
@@ -1221,6 +1221,25 @@ describe('verify-built-workflow tool — node simulation plan', () => {
 		expect(verification?.evidence?.errorMessage).toContain('geocode_city');
 	});
 
+	it('keeps needs_setup routing when a waiting execution also has node errors', async () => {
+		const { ctx } = makeContext(makeBuildOutcome({ nodeSimulationPlan: [] }), {
+			executionId: 'exec-waiting-node-error',
+			status: 'waiting',
+			data: {},
+			executedNodeNames: ['Lookup', 'Community Pause'],
+			nodeErrors: [{ nodeName: 'Lookup', message: 'lookup failed' }],
+		});
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.success).toBe(false);
+		expect(result.remediation).toMatchObject({
+			category: 'needs_setup',
+			shouldEdit: false,
+			reason: 'execution_waiting',
+		});
+	});
+
 	it('reports planned simulations the execution never reached as unverified (empty-read dead-end)', async () => {
 		// Reproduces the order-fulfillment scenario: a data-table lookup on an
 		// empty table returns zero items mid-chain, so everything downstream —

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
@@ -31,6 +31,7 @@ type VerifyBuiltWorkflowOutput = {
 	simulationNote?: string;
 	lastNodeExecuted?: string;
 	nodesNotReached?: string[];
+	nodeErrors?: Array<{ nodeName: string; message?: string }>;
 	coverageNote?: string;
 	data?: Record<string, unknown>;
 	remediation?: { category: string; shouldEdit: boolean; reason?: string };
@@ -435,6 +436,7 @@ type ExecutionRunResult = {
 	data?: Record<string, unknown>;
 	executedNodeNames?: string[];
 	lastNodeExecuted?: string;
+	nodeErrors?: Array<{ nodeName: string; message?: string }>;
 	error?: string;
 };
 
@@ -1174,6 +1176,49 @@ describe('verify-built-workflow tool — node simulation plan', () => {
 		expect(result.success).toBe(true);
 		expect(result.simulationNote).toBeUndefined();
 		expect(ctx.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('downgrades workflow success when an executed AI tool errored', async () => {
+		const { ctx, updateBuildOutcome } = makeContext(makeBuildOutcome({ nodeSimulationPlan: [] }), {
+			executionId: 'exec-ai-tool-error',
+			status: 'success',
+			data: {
+				'API Request': [{ body: { city: 'Lisbon' } }],
+				'Destination Analyst': [{ output: '{"city":"Lisbon"}' }],
+				'Return Brief': [{ output: '{"city":"Lisbon"}' }],
+			},
+			executedNodeNames: [
+				'API Request',
+				'GPT Model',
+				'geocode_city',
+				'Destination Analyst',
+				'Return Brief',
+			],
+			nodeErrors: [
+				{
+					nodeName: 'geocode_city',
+					message:
+						'The node "@n8n/n8n-nodes-langchain.toolHttpRequest" has a "supplyData" method but no "execute" method.',
+				},
+			],
+			lastNodeExecuted: 'Return Brief',
+		});
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.success).toBe(false);
+		expect(result.nodeErrors).toHaveLength(1);
+		expect(result.nodeErrors?.[0]?.nodeName).toBe('geocode_city');
+		expect(result.nodeErrors?.[0]?.message).toContain('supplyData');
+		expect(result.error).toContain('geocode_city');
+		const verification = updateBuildOutcome.mock.calls[0][1].verification;
+		expect(verification?.success).toBe(false);
+		expect(verification?.status).toBe('success');
+		expect(verification?.failureSignature).toContain('geocode_city');
+		expect(verification?.evidence?.nodeErrors).toHaveLength(1);
+		expect(verification?.evidence?.nodeErrors?.[0]?.nodeName).toBe('geocode_city');
+		expect(verification?.evidence?.nodeErrors?.[0]?.message).toContain('supplyData');
+		expect(verification?.evidence?.errorMessage).toContain('geocode_city');
 	});
 
 	it('reports planned simulations the execution never reached as unverified (empty-read dead-end)', async () => {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
@@ -12,6 +12,8 @@ import type {
 	WorkflowLoopState,
 } from '../../../workflow-loop/workflow-loop-state';
 
+type ExecutionNodeError = NonNullable<ExecutionRunResult['nodeErrors']>[number];
+
 const CREDENTIAL_FAILURE_KEYWORDS = [
 	'credential',
 	'unauthorized',
@@ -241,6 +243,18 @@ function buildCoverageNote(
 	);
 }
 
+function buildNodeErrorMessage(nodeErrors: ExecutionNodeError[]): string | undefined {
+	if (nodeErrors.length === 0) return undefined;
+
+	return nodeErrors
+		.map((nodeError) =>
+			nodeError.message
+				? `${nodeError.nodeName}: ${nodeError.message}`
+				: `${nodeError.nodeName}: node execution failed`,
+		)
+		.join('; ');
+}
+
 export function namesOrDataKeys(
 	reachedNames: Set<string>,
 	data: Record<string, unknown> | undefined,
@@ -258,6 +272,8 @@ export interface VerificationAnalysis {
 	nodesExecuted?: string[];
 	simulationNote?: string;
 	coverageNote?: string;
+	errorMessage?: string;
+	nodeErrors: ExecutionNodeError[];
 }
 
 export function analyzeVerificationResult(args: {
@@ -268,21 +284,31 @@ export function analyzeVerificationResult(args: {
 	runId: string;
 }): VerificationAnalysis {
 	const { result, buildOutcome, simulatedNodes, stateBefore, runId } = args;
+	const nodeErrors = result.nodeErrors ?? [];
 	const reachedNames = new Set(
 		result.executedNodeNames ?? (result.data ? Object.keys(result.data) : []),
 	);
+	for (const nodeError of nodeErrors) {
+		reachedNames.add(nodeError.nodeName);
+	}
 	const reachedSimulatedNodes = simulatedNodes.filter((n) => reachedNames.has(n.nodeName));
 	const nodesNotReached = (buildOutcome.nodeSimulationPlan ?? [])
 		.map((verdict) => verdict.nodeName)
 		.filter((name) => !reachedNames.has(name));
 	const hasSimulationPlan = (buildOutcome.nodeSimulationPlan?.length ?? 0) > 0;
 	const hasOutput = result.data ? Object.keys(result.data).length > 0 : false;
+	const errorMessage = result.error ?? buildNodeErrorMessage(nodeErrors);
 	const success =
-		result.status === 'success' ||
-		(!hasSimulationPlan && result.status === 'waiting' && !result.error && hasOutput);
+		nodeErrors.length === 0 &&
+		(result.status === 'success' ||
+			(!hasSimulationPlan && result.status === 'waiting' && !errorMessage && hasOutput));
 	const failureRemediation = success
 		? undefined
-		: classifyVerificationFailure(result.error, result.status, buildOutcome);
+		: classifyVerificationFailure(
+				errorMessage,
+				nodeErrors.length > 0 ? 'error' : result.status,
+				buildOutcome,
+			);
 	const budgetRemediation =
 		failureRemediation?.shouldEdit === true
 			? terminalRemediationFromState(stateBefore, runId)
@@ -298,5 +324,7 @@ export function analyzeVerificationResult(args: {
 		nodesExecuted: namesOrDataKeys(reachedNames, result.data),
 		simulationNote: buildSimulationNote(reachedSimulatedNodes, false),
 		coverageNote: buildCoverageNote(nodesNotReached, result, success),
+		errorMessage,
+		nodeErrors,
 	};
 }

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/analyze-result.ts
@@ -288,9 +288,6 @@ export function analyzeVerificationResult(args: {
 	const reachedNames = new Set(
 		result.executedNodeNames ?? (result.data ? Object.keys(result.data) : []),
 	);
-	for (const nodeError of nodeErrors) {
-		reachedNames.add(nodeError.nodeName);
-	}
 	const reachedSimulatedNodes = simulatedNodes.filter((n) => reachedNames.has(n.nodeName));
 	const nodesNotReached = (buildOutcome.nodeSimulationPlan ?? [])
 		.map((verdict) => verdict.nodeName)
@@ -306,7 +303,8 @@ export function analyzeVerificationResult(args: {
 		? undefined
 		: classifyVerificationFailure(
 				errorMessage,
-				nodeErrors.length > 0 ? 'error' : result.status,
+				// Only escalate a clean status; 'waiting' must keep its needs_setup routing.
+				nodeErrors.length > 0 && result.status === 'success' ? 'error' : result.status,
 				buildOutcome,
 			);
 	const budgetRemediation =

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/finalize-result.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/finalize-result.ts
@@ -102,14 +102,16 @@ export async function persistVerificationOutcome(args: {
 				success: analysis.success,
 				executionId: result.executionId || undefined,
 				status: result.status,
-				failureSignature: analysis.success ? undefined : result.error,
+				failureSignature: analysis.success ? undefined : analysis.errorMessage,
 				evidence: {
 					nodesExecuted:
 						executedForEvidence && executedForEvidence.length > 0 ? executedForEvidence : undefined,
 					nodesNotReached:
 						analysis.nodesNotReached.length > 0 ? analysis.nodesNotReached : undefined,
 					producedOutputRows: countProducedOutputRows(result.data),
-					errorMessage: analysis.success ? undefined : result.error,
+					errorNodeName: analysis.success ? undefined : analysis.nodeErrors[0]?.nodeName,
+					errorMessage: analysis.success ? undefined : analysis.errorMessage,
+					nodeErrors: analysis.nodeErrors.length > 0 ? analysis.nodeErrors : undefined,
 				},
 				verifiedAt: new Date().toISOString(),
 			},

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/types.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/types.ts
@@ -1,4 +1,4 @@
-import type { OrchestrationContext } from '../../../types';
+import type { ExecutionNodeError, OrchestrationContext } from '../../../types';
 import type { RemediationMetadata } from '../../../workflow-loop/workflow-loop-state';
 
 export interface VerifyToolInput {
@@ -40,6 +40,7 @@ export interface VerifyBuiltWorkflowOutput {
 	simulatedNodes?: Array<{ nodeName: string; reason: string }>;
 	simulationNote?: string;
 	lastNodeExecuted?: string;
+	nodeErrors?: ExecutionNodeError[];
 	nodesNotReached?: string[];
 	coverageNote?: string;
 	data?: Record<string, unknown>;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -17,6 +17,7 @@ import {
 } from './verification/finalize-result';
 import { prepareVerificationRun } from './verification/prepare-run';
 import { resolveVerificationTarget } from './verification/resolve-target';
+import { executionNodeErrorSchema } from '../../workflow-loop/workflow-loop-state';
 
 const DEFAULT_NODE_PREVIEW_CHARS = 600;
 
@@ -98,9 +99,7 @@ const verifyBuiltWorkflowOutputSchema = z.object({
 	simulatedNodes: z.array(z.object({ nodeName: z.string(), reason: z.string() })).optional(),
 	simulationNote: z.string().optional(),
 	lastNodeExecuted: z.string().optional(),
-	nodeErrors: z
-		.array(z.object({ nodeName: z.string(), message: z.string().optional() }))
-		.optional(),
+	nodeErrors: z.array(executionNodeErrorSchema).optional(),
 	nodesNotReached: z.array(z.string()).optional(),
 	coverageNote: z.string().optional(),
 	data: z.record(z.unknown()).optional(),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -98,6 +98,9 @@ const verifyBuiltWorkflowOutputSchema = z.object({
 	simulatedNodes: z.array(z.object({ nodeName: z.string(), reason: z.string() })).optional(),
 	simulationNote: z.string().optional(),
 	lastNodeExecuted: z.string().optional(),
+	nodeErrors: z
+		.array(z.object({ nodeName: z.string(), message: z.string().optional() }))
+		.optional(),
 	nodesNotReached: z.array(z.string()).optional(),
 	coverageNote: z.string().optional(),
 	data: z.record(z.unknown()).optional(),
@@ -185,10 +188,11 @@ export function createVerifyBuiltWorkflowTool(context: OrchestrationContext) {
 				simulatedNodes:
 					analysis.reachedSimulatedNodes.length > 0 ? analysis.reachedSimulatedNodes : undefined,
 				simulationNote: analysis.simulationNote,
+				nodeErrors: analysis.nodeErrors.length > 0 ? analysis.nodeErrors : undefined,
 				nodesNotReached: analysis.nodesNotReached.length > 0 ? analysis.nodesNotReached : undefined,
 				coverageNote: analysis.coverageNote,
 				...(resolvedInput.includeData ? { data: result.data } : {}),
-				error: result.error,
+				error: analysis.errorMessage,
 				remediation: analysis.remediation,
 				guidance: analysis.remediation?.guidance,
 			};

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -78,6 +78,11 @@ export interface WorkflowNode {
 	webhookId?: string;
 }
 
+export interface ExecutionNodeError {
+	nodeName: string;
+	message?: string;
+}
+
 export interface ExecutionResult {
 	executionId: string;
 	status: 'running' | 'success' | 'error' | 'waiting' | 'unknown';
@@ -88,6 +93,8 @@ export interface ExecutionResult {
 	 * nothing" apart from "never reached".
 	 */
 	executedNodeNames?: string[];
+	/** Node-level errors from run data, including continue-on-fail errors. */
+	nodeErrors?: ExecutionNodeError[];
 	/** Name of the last node the execution processed, when available. */
 	lastNodeExecuted?: string;
 	error?: string;

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -140,7 +140,7 @@ export type AttemptRecord = z.infer<typeof attemptRecordSchema>;
 
 export const triggerTypeSchema = z.enum(['manual_or_testable', 'trigger_only']);
 
-const executionNodeErrorSchema = z.object({
+export const executionNodeErrorSchema = z.object({
 	nodeName: z.string(),
 	message: z.string().optional(),
 });

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -140,6 +140,11 @@ export type AttemptRecord = z.infer<typeof attemptRecordSchema>;
 
 export const triggerTypeSchema = z.enum(['manual_or_testable', 'trigger_only']);
 
+const executionNodeErrorSchema = z.object({
+	nodeName: z.string(),
+	message: z.string().optional(),
+});
+
 /**
  * Structured verification evidence the builder captures when it runs
  * `verify-built-workflow`. Downstream checkpoint runs read this and skip
@@ -163,6 +168,7 @@ export const workflowVerificationEvidenceSchema = z.object({
 			producedOutputRows: z.number().optional(),
 			errorNodeName: z.string().optional(),
 			errorMessage: z.string().optional(),
+			nodeErrors: z.array(executionNodeErrorSchema).optional(),
 		})
 		.optional(),
 	verifiedAt: z.string().datetime().optional(),

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -104,6 +104,7 @@ function makeTaskData(
 	outputItems: Array<Record<string, unknown>>,
 	opts?: {
 		error?: Error | Partial<ExecutionError>;
+		executionStatus?: ITaskData['executionStatus'];
 		startTime?: number;
 		executionTime?: number;
 	},
@@ -117,6 +118,7 @@ function makeTaskData(
 			main: [outputItems.map((json) => ({ json }))],
 		},
 		...(opts?.error ? { error: opts.error } : {}),
+		...(opts?.executionStatus ? { executionStatus: opts.executionStatus } : {}),
 	} as unknown as ITaskData;
 }
 
@@ -289,6 +291,36 @@ describe('extractExecutionResult', () => {
 		const result = await extractExecutionResult('exec-1', true);
 
 		expect(result.data).toBeUndefined();
+	});
+
+	it('includes node-level errors even when the execution completed successfully', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: {
+					geocode_city: [
+						makeTaskData([], {
+							executionStatus: 'error',
+							error: {
+								name: 'UnexpectedError',
+								message: 'The node has a supplyData method but no execute method.',
+							},
+						}),
+					],
+				},
+			}),
+		);
+
+		const result = await extractExecutionResult('exec-1', false);
+
+		expect(result.status).toBe('success');
+		expect(result.error).toBeUndefined();
+		expect(result.nodeErrors).toEqual([
+			{
+				nodeName: 'geocode_city',
+				message: 'The node has a supplyData method but no execute method.',
+			},
+		]);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -77,7 +77,7 @@ function makeExecution(
 		runData?: Record<string, ITaskData[]>;
 		pinData?: IPinData;
 		error?: Partial<ExecutionError>;
-		workflowNodes?: Array<{ name: string; type: string }>;
+		workflowNodes?: Array<{ name: string; type: string; onError?: string }>;
 	} = {},
 ) {
 	const runData = overrides.runData ?? {};
@@ -321,6 +321,57 @@ describe('extractExecutionResult', () => {
 				message: 'The node has a supplyData method but no execute method.',
 			},
 		]);
+	});
+
+	it('omits errors on nodes configured to continue on error', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				workflowNodes: [
+					{
+						name: 'Fallback Lookup',
+						type: 'n8n-nodes-base.httpRequest',
+						onError: 'continueErrorOutput',
+					},
+				],
+				runData: {
+					'Fallback Lookup': [
+						makeTaskData([], {
+							executionStatus: 'error',
+							error: { name: 'NodeApiError', message: 'Not found' },
+						}),
+					],
+				},
+			}),
+		);
+
+		const result = await extractExecutionResult('exec-1', false);
+
+		expect(result.nodeErrors).toBeUndefined();
+	});
+
+	it('reports a single entry for a node that errored on multiple runs', async () => {
+		createMockExecutionRepository(
+			makeExecution({
+				status: 'success',
+				runData: {
+					geocode_city: [
+						makeTaskData([], {
+							executionStatus: 'error',
+							error: { name: 'UnexpectedError', message: 'boom 1' },
+						}),
+						makeTaskData([], {
+							executionStatus: 'error',
+							error: { name: 'UnexpectedError', message: 'boom 2' },
+						}),
+					],
+				},
+			}),
+		);
+
+		const result = await extractExecutionResult('exec-1', false);
+
+		expect(result.nodeErrors).toEqual([{ nodeName: 'geocode_city', message: 'boom 1' }]);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -89,6 +89,7 @@ import {
 	type WorkflowExecuteMode,
 	type ExecutionError,
 	type IRunData,
+	type ITaskData,
 	NodeHelpers,
 	Workflow,
 	CHAT_TRIGGER_NODE_TYPE,
@@ -2695,33 +2696,51 @@ function wrapResultDataEntries(data: Record<string, unknown>): Record<string, un
 	return wrapped;
 }
 
+const MAX_NODE_ERRORS = 10;
+
+function isFailedNodeRun(nodeRun: ITaskData): boolean {
+	return (
+		nodeRun.executionStatus === 'error' ||
+		nodeRun.error !== undefined ||
+		nodeRun.redactedError !== undefined
+	);
+}
+
+function nodeContinuesOnError(node: INode | undefined): boolean {
+	return (
+		node?.continueOnFail === true ||
+		node?.onError === 'continueRegularOutput' ||
+		node?.onError === 'continueErrorOutput'
+	);
+}
+
 function extractNodeErrors(
 	runData: IRunData | undefined,
 	includeUpstreamDetails: boolean,
+	workflowNodes: INode[] = [],
 ): NonNullable<ExecutionResult['nodeErrors']> {
 	if (!runData) return [];
 
+	const nodesByName = new Map(workflowNodes.map((node) => [node.name, node]));
 	const nodeErrors: NonNullable<ExecutionResult['nodeErrors']> = [];
 	for (const [nodeName, nodeRuns] of Object.entries(runData)) {
-		for (const nodeRun of nodeRuns) {
-			const failed =
-				nodeRun.executionStatus === 'error' ||
-				nodeRun.error !== undefined ||
-				nodeRun.redactedError !== undefined;
-			if (!failed) continue;
+		if (nodeErrors.length >= MAX_NODE_ERRORS) break;
+		if (nodeContinuesOnError(nodesByName.get(nodeName))) continue;
 
-			const message = nodeRun.error
-				? formatExecutionError(nodeRun.error, includeUpstreamDetails)
-				: nodeRun.redactedError
-					? `${nodeRun.redactedError.type} error${
-							nodeRun.redactedError.httpCode ? ` (${nodeRun.redactedError.httpCode})` : ''
-						}`
-					: undefined;
-			nodeErrors.push({
-				nodeName,
-				...(message ? { message } : {}),
-			});
-		}
+		const failedRun = nodeRuns.find(isFailedNodeRun);
+		if (!failedRun) continue;
+
+		const message = failedRun.error
+			? formatExecutionError(failedRun.error, includeUpstreamDetails)
+			: failedRun.redactedError
+				? `${failedRun.redactedError.type} error${
+						failedRun.redactedError.httpCode ? ` (${failedRun.redactedError.httpCode})` : ''
+					}`
+				: undefined;
+		nodeErrors.push({
+			nodeName,
+			...(message ? { message } : {}),
+		});
 	}
 
 	return nodeErrors;
@@ -2778,7 +2797,7 @@ export async function extractExecutionResult(
 	// Extract error if present
 	const error = execution.data?.resultData?.error;
 	const errorMessage = error ? formatExecutionError(error, includeOutputData) : undefined;
-	const nodeErrors = extractNodeErrors(runData, includeOutputData);
+	const nodeErrors = extractNodeErrors(runData, includeOutputData, execution.workflowData?.nodes);
 
 	return {
 		executionId,
@@ -3020,7 +3039,7 @@ export async function extractExecutionDebugInfo(
 			nodeTrace.push({
 				name: nodeName,
 				type: nodeType,
-				status: lastRun.error !== undefined ? 'error' : 'success',
+				status: isFailedNodeRun(lastRun) ? 'error' : 'success',
 				startedAt:
 					lastRun.startTime !== undefined ? new Date(lastRun.startTime).toISOString() : undefined,
 				finishedAt:

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -88,6 +88,7 @@ import {
 	type DataTableRows,
 	type WorkflowExecuteMode,
 	type ExecutionError,
+	type IRunData,
 	NodeHelpers,
 	Workflow,
 	CHAT_TRIGGER_NODE_TYPE,
@@ -2694,6 +2695,38 @@ function wrapResultDataEntries(data: Record<string, unknown>): Record<string, un
 	return wrapped;
 }
 
+function extractNodeErrors(
+	runData: IRunData | undefined,
+	includeUpstreamDetails: boolean,
+): NonNullable<ExecutionResult['nodeErrors']> {
+	if (!runData) return [];
+
+	const nodeErrors: NonNullable<ExecutionResult['nodeErrors']> = [];
+	for (const [nodeName, nodeRuns] of Object.entries(runData)) {
+		for (const nodeRun of nodeRuns) {
+			const failed =
+				nodeRun.executionStatus === 'error' ||
+				nodeRun.error !== undefined ||
+				nodeRun.redactedError !== undefined;
+			if (!failed) continue;
+
+			const message = nodeRun.error
+				? formatExecutionError(nodeRun.error, includeUpstreamDetails)
+				: nodeRun.redactedError
+					? `${nodeRun.redactedError.type} error${
+							nodeRun.redactedError.httpCode ? ` (${nodeRun.redactedError.httpCode})` : ''
+						}`
+					: undefined;
+			nodeErrors.push({
+				nodeName,
+				...(message ? { message } : {}),
+			});
+		}
+	}
+
+	return nodeErrors;
+}
+
 export async function extractExecutionResult(
 	executionId: string,
 	includeOutputData = true,
@@ -2723,9 +2756,9 @@ export async function extractExecutionResult(
 	// omits. Verification uses this to tell "ran and returned nothing" apart
 	// from "never reached". Node names only, so it is safe regardless of the
 	// parameter-values privacy setting.
-	const executedNodeNames = Object.keys(execution.data?.resultData?.runData ?? {});
+	const runData = execution.data?.resultData?.runData;
+	const executedNodeNames = Object.keys(runData ?? {});
 	if (includeOutputData) {
-		const runData = execution.data?.resultData?.runData;
 		if (runData) {
 			for (const [nodeName, nodeRuns] of Object.entries(runData)) {
 				const lastRun = nodeRuns[nodeRuns.length - 1];
@@ -2745,6 +2778,7 @@ export async function extractExecutionResult(
 	// Extract error if present
 	const error = execution.data?.resultData?.error;
 	const errorMessage = error ? formatExecutionError(error, includeOutputData) : undefined;
+	const nodeErrors = extractNodeErrors(runData, includeOutputData);
 
 	return {
 		executionId,
@@ -2754,6 +2788,7 @@ export async function extractExecutionResult(
 				? wrapResultDataEntries(truncateResultData(resultData))
 				: undefined,
 		executedNodeNames: executedNodeNames.length > 0 ? executedNodeNames : undefined,
+		nodeErrors: nodeErrors.length > 0 ? nodeErrors : undefined,
 		lastNodeExecuted: execution.data?.resultData?.lastNodeExecuted,
 		error: errorMessage,
 		startedAt: execution.startedAt?.toISOString(),


### PR DESCRIPTION
## Summary

Report node-level run errors in Instance AI workflow verification, even when the overall execution status is `success`. This prevents the verifier from treating a workflow as fully verified when a continue-on-fail/AI tool node errored during execution.

This change:
- carries node-level errors from execution run data into `ExecutionResult`
- downgrades verification success when any executed node has an error
- persists node error evidence on the workflow verification record
- adds focused regression coverage for the verifier and adapter plumbing

## How to test

```bash
pushd packages/@n8n/instance-ai >/dev/null && corepack pnpm test src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts; rc=$?; popd >/dev/null; exit $rc
```

```bash
pushd packages/cli >/dev/null && corepack pnpm exec vitest run src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts; rc=$?; popd >/dev/null; exit $rc
```

Also ran file-scoped Biome formatting and file-scoped ESLint for the touched Instance AI files and CLI adapter test file. File-scoped ESLint on the large CLI adapter implementation file is currently blocked by pre-existing `no-unsafe-*` errors outside this change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-783

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33576">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->