### PR TITLE
fix(ai-builder): Validate OpenAI structured-output schemas and normalize Responses mock envelopes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/daily-gmail-action-digest.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/daily-gmail-action-digest.json
@@ -21,7 +21,7 @@
 			"name": "no-recent-emails",
 			"description": "No Gmail messages arrived in the last 24 hours",
 			"dataSetup": "The Gmail search node returns no emails. The workflow should handle the empty inbox and either send a concise no-action-needed digest email or complete cleanly through an explicit empty/fallback path.",
-			"successCriteria": "The workflow executes without errors and handles the empty inbox gracefully: it either sends a concise no-action-needed digest email or completes cleanly end-to-end on the empty case. Branching on the empty case is optional — a single-path design that degrades gracefully is equally acceptable — but if the workflow does branch, the empty branch must be wired to a downstream node, not left terminal."
+			"successCriteria": "The workflow executes without errors and handles the empty inbox OBSERVABLY: either a concise no-action-needed digest email is sent, or an explicitly-designed fallback/no-op step executes as the final node on the empty path. A run where every node after the Gmail fetch is silently skipped on empty input does NOT count as handling the case. Branching is optional — a single-path design is fine if its final node still executes on empty input — but if the workflow does branch, the empty branch must be wired to a downstream node, not left terminal."
 		}
 	]
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/daily-gmail-action-digest.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/daily-gmail-action-digest.json
@@ -20,8 +20,8 @@
 		{
 			"name": "no-recent-emails",
 			"description": "No Gmail messages arrived in the last 24 hours",
-			"dataSetup": "The Gmail search node returns no emails. The workflow should take the empty-inbox branch and either send a concise no-action-needed digest email or complete through a clearly named no-op/fallback node.",
-			"successCriteria": "The workflow executes without errors. The empty-inbox branch is wired downstream from the IF/Switch node. The workflow does not leave the branch node terminal and incomplete."
+			"dataSetup": "The Gmail search node returns no emails. The workflow should handle the empty inbox and either send a concise no-action-needed digest email or complete cleanly through an explicit empty/fallback path.",
+			"successCriteria": "The workflow executes without errors and handles the empty inbox gracefully: it either sends a concise no-action-needed digest email or completes cleanly end-to-end on the empty case. Branching on the empty case is optional — a single-path design that degrades gracefully is equally acceptable — but if the workflow does branch, the empty branch must be wired to a downstream node, not left terminal."
 		}
 	]
 }

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
@@ -1,0 +1,89 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import type { IDataObject } from 'n8n-workflow';
+
+import { detectUnparseableOpenAiSchema } from '../detect-unparseable-openai-schema';
+
+function workflow(
+	parameters: Record<string, unknown>,
+	type = '@n8n/n8n-nodes-langchain.openAi',
+): WorkflowJSON {
+	return {
+		id: 'wf-test',
+		name: 'Test',
+		nodes: [
+			{
+				id: '1',
+				name: 'Extract Action Items',
+				type,
+				typeVersion: 2.3,
+				position: [0, 0],
+				parameters: parameters as IDataObject,
+			},
+		],
+		connections: {},
+	};
+}
+
+function jsonSchemaParams(schema: unknown, textOptionsShape: 'object' | 'array' = 'object') {
+	const textOptions = { type: 'json_schema', name: 'my_schema', schema };
+	return {
+		resource: 'text',
+		operation: 'response',
+		textFormat: {
+			textOptions: textOptionsShape === 'object' ? textOptions : [textOptions],
+		},
+	};
+}
+
+const VALID_SCHEMA = JSON.stringify({
+	type: 'object',
+	properties: { items: { type: 'array', items: { type: 'string' } } },
+	required: ['items'],
+	additionalProperties: false,
+});
+
+describe('detectUnparseableOpenAiSchema', () => {
+	const codes = (w: WorkflowJSON) => detectUnparseableOpenAiSchema(w).map((x) => x.code);
+
+	it('flags a schema string that is not valid JSON', () => {
+		const w = workflow(jsonSchemaParams('{ "type": "object", '));
+		const warnings = detectUnparseableOpenAiSchema(w);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].code).toBe('OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID');
+		expect(warnings[0].nodeName).toBe('Extract Action Items');
+		expect(warnings[0].message).toContain('Failed to parse schema');
+	});
+
+	it('flags a schema whose root is not an object schema', () => {
+		expect(codes(workflow(jsonSchemaParams(JSON.stringify({ type: 'array' }))))).toEqual([
+			'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+		]);
+		expect(codes(workflow(jsonSchemaParams(JSON.stringify(['not', 'an', 'object']))))).toEqual([
+			'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+		]);
+	});
+
+	it('accepts a valid object schema', () => {
+		expect(codes(workflow(jsonSchemaParams(VALID_SCHEMA)))).toEqual([]);
+	});
+
+	it('handles textOptions stored as an array of one (fixedCollection default shape)', () => {
+		expect(codes(workflow(jsonSchemaParams('{ broken', 'array')))).toEqual([
+			'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+		]);
+		expect(codes(workflow(jsonSchemaParams(VALID_SCHEMA, 'array')))).toEqual([]);
+	});
+
+	it('ignores non-json_schema output formats, expressions, and other node types', () => {
+		const textFormat = { textOptions: { type: 'text' } };
+		expect(codes(workflow({ textFormat }))).toEqual([]);
+		expect(codes(workflow(jsonSchemaParams('={{ $json.schema }}')))).toEqual([]);
+		expect(codes(workflow(jsonSchemaParams('{ broken'), 'n8n-nodes-base.httpRequest'))).toEqual([]);
+		expect(codes(workflow({}))).toEqual([]);
+	});
+
+	it('ignores a non-string or empty schema value', () => {
+		expect(codes(workflow(jsonSchemaParams({ type: 'object' })))).toEqual([]);
+		expect(codes(workflow(jsonSchemaParams('   ')))).toEqual([]);
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
@@ -24,13 +24,16 @@ function workflow(
 	};
 }
 
+/** Real built-workflow shape: the Response operation nests textFormat under `options`. */
 function jsonSchemaParams(schema: unknown, textOptionsShape: 'object' | 'array' = 'object') {
 	const textOptions = { type: 'json_schema', name: 'my_schema', schema };
 	return {
 		resource: 'text',
 		operation: 'response',
-		textFormat: {
-			textOptions: textOptionsShape === 'object' ? textOptions : [textOptions],
+		options: {
+			textFormat: {
+				textOptions: textOptionsShape === 'object' ? textOptions : [textOptions],
+			},
 		},
 	};
 }
@@ -104,5 +107,23 @@ describe('detectUnparseableOpenAiSchema', () => {
 	it('ignores an empty or absent schema value', () => {
 		expect(codes(workflow(jsonSchemaParams('   ')))).toEqual([]);
 		expect(codes(workflow(jsonSchemaParams(undefined)))).toEqual([]);
+	});
+
+	it('also inspects a top-level textFormat (defensive fallback)', () => {
+		const topLevel = {
+			resource: 'text',
+			operation: 'response',
+			textFormat: { textOptions: { type: 'json_schema', name: 's', schema: '{ broken' } },
+		};
+		expect(codes(workflow(topLevel))).toEqual(['OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID']);
+	});
+
+	it('ignores non-json_schema formats under options.textFormat too', () => {
+		const textParams = {
+			resource: 'text',
+			operation: 'response',
+			options: { textFormat: { textOptions: { type: 'text' } } },
+		};
+		expect(codes(workflow(textParams))).toEqual([]);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts
@@ -67,11 +67,22 @@ describe('detectUnparseableOpenAiSchema', () => {
 		expect(codes(workflow(jsonSchemaParams(VALID_SCHEMA)))).toEqual([]);
 	});
 
-	it('handles textOptions stored as an array of one (fixedCollection default shape)', () => {
+	it('flags array-stored textOptions as silently-ignored structured output (regardless of schema)', () => {
+		// The node reads textFormat.textOptions as an object; an array-stored
+		// config never reaches the json_schema branch at runtime.
 		expect(codes(workflow(jsonSchemaParams('{ broken', 'array')))).toEqual([
-			'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+			'OPENAI_STRUCTURED_OUTPUT_IGNORED',
 		]);
-		expect(codes(workflow(jsonSchemaParams(VALID_SCHEMA, 'array')))).toEqual([]);
+		expect(codes(workflow(jsonSchemaParams(VALID_SCHEMA, 'array')))).toEqual([
+			'OPENAI_STRUCTURED_OUTPUT_IGNORED',
+		]);
+	});
+
+	it('flags an object-valued schema (JSON.parse of a non-string throws at runtime)', () => {
+		const warnings = detectUnparseableOpenAiSchema(workflow(jsonSchemaParams({ type: 'object' })));
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0].code).toBe('OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID');
+		expect(warnings[0].message).toContain('not a string');
 	});
 
 	it('ignores non-json_schema output formats, expressions, and other node types', () => {
@@ -82,8 +93,16 @@ describe('detectUnparseableOpenAiSchema', () => {
 		expect(codes(workflow({}))).toEqual([]);
 	});
 
-	it('ignores a non-string or empty schema value', () => {
-		expect(codes(workflow(jsonSchemaParams({ type: 'object' })))).toEqual([]);
+	it('treats a leading-space "=" as a literal string, not an expression (n8n semantics)', () => {
+		// n8n only treats charAt(0)==='=' as an expression; ' ={{...}}' is a
+		// literal that will crash JSON.parse at runtime.
+		expect(codes(workflow(jsonSchemaParams(' ={{ $json.schema }}')))).toEqual([
+			'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+		]);
+	});
+
+	it('ignores an empty or absent schema value', () => {
 		expect(codes(workflow(jsonSchemaParams('   ')))).toEqual([]);
+		expect(codes(workflow(jsonSchemaParams(undefined)))).toEqual([]);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
@@ -12,7 +12,12 @@ interface ResolvedTextOptions {
 }
 
 function getTextOptions(parameters: Record<string, unknown>): ResolvedTextOptions | undefined {
-	const textFormat = parameters.textFormat;
+	// The Response operation nests its format config under the `options`
+	// collection (`parameters.options.textFormat` — this is where built
+	// workflows carry it); the top level is checked too as a defensive
+	// fallback for future param layouts.
+	const optionsParam = isRecord(parameters.options) ? parameters.options : undefined;
+	const textFormat = optionsParam?.textFormat ?? parameters.textFormat;
 	if (!isRecord(textFormat)) return undefined;
 	const raw = textFormat.textOptions;
 	if (isRecord(raw)) return { options: raw, storedAsArray: false };

--- a/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
@@ -5,36 +5,30 @@ import type { ValidationWarning } from './workflow-validation-warnings';
 
 const OPENAI_NODE_TYPE = '@n8n/n8n-nodes-langchain.openAi';
 
-/** fixedCollection storage: `textOptions` is an object, or an array of one. */
-function getTextOptions(parameters: Record<string, unknown>): Record<string, unknown> | undefined {
+interface ResolvedTextOptions {
+	options: Record<string, unknown>;
+	/** fixedCollection can persist the values as an array of one entry. */
+	storedAsArray: boolean;
+}
+
+function getTextOptions(parameters: Record<string, unknown>): ResolvedTextOptions | undefined {
 	const textFormat = parameters.textFormat;
 	if (!isRecord(textFormat)) return undefined;
 	const raw = textFormat.textOptions;
-	if (isRecord(raw)) return raw;
-	if (Array.isArray(raw) && isRecord(raw[0])) return raw[0];
-	return undefined;
-}
-
-/** Why the schema string won't survive the node's runtime parse, or undefined when fine. */
-function schemaProblem(schema: string): string | undefined {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(schema);
-	} catch (error) {
-		return `is not valid JSON (${error instanceof Error ? error.message : 'parse error'})`;
-	}
-	if (!isRecord(parsed)) return 'must be a JSON object, not a bare value or array';
-	if (parsed.type !== 'object') {
-		return `must declare "type": "object" at the root (got ${JSON.stringify(parsed.type)})`;
-	}
+	if (isRecord(raw)) return { options: raw, storedAsArray: false };
+	if (Array.isArray(raw) && isRecord(raw[0])) return { options: raw[0], storedAsArray: true };
 	return undefined;
 }
 
 /**
- * Flags OpenAI nodes whose structured-output schema string cannot be parsed.
- * The node calls `jsonParse(textOptions.schema)` at execute time and throws
- * "Failed to parse schema" before making any request, so a bad schema written
- * at build time is a guaranteed runtime crash the builder never sees.
+ * Flags OpenAI nodes whose structured-output ("JSON Schema") config cannot work
+ * at runtime:
+ * - array-stored `textOptions`: the node reads the path as an object, so the
+ *   whole format block is silently ignored and plain text comes back;
+ * - non-string schema values and unparseable JSON: the node passes the raw
+ *   value through `jsonParse` per item and throws "Failed to parse schema";
+ * - non-object schema roots: the OpenAI API rejects them for structured output.
+ * All three are defects the builder never sees at build time otherwise.
  */
 export function detectUnparseableOpenAiSchema(json: WorkflowJSON): ValidationWarning[] {
 	const warnings: ValidationWarning[] = [];
@@ -43,25 +37,67 @@ export function detectUnparseableOpenAiSchema(json: WorkflowJSON): ValidationWar
 		if (node.type !== OPENAI_NODE_TYPE) continue;
 		const params = node.parameters;
 		if (!isRecord(params)) continue;
-		const textOptions = getTextOptions(params);
-		if (!textOptions || textOptions.type !== 'json_schema') continue;
+		const resolved = getTextOptions(params);
+		if (!resolved || resolved.options.type !== 'json_schema') continue;
+		const nodeName = typeof node.name === 'string' ? node.name : undefined;
 
-		const schema = textOptions.schema;
-		if (typeof schema !== 'string' || schema.trim().length === 0) continue;
-		// Expressions resolve at runtime — not statically checkable.
-		if (schema.trimStart().startsWith('=')) continue;
+		if (resolved.storedAsArray) {
+			warnings.push({
+				code: 'OPENAI_STRUCTURED_OUTPUT_IGNORED',
+				nodeName,
+				message:
+					'OpenAI node stores textFormat.textOptions as an ARRAY. At runtime the node reads that path as an object, ' +
+					'so the JSON Schema output format is silently ignored and the node returns plain text. ' +
+					'Store textOptions as a single object: textFormat: { textOptions: { type: "json_schema", name, schema } }.',
+			});
+			continue;
+		}
 
-		const problem = schemaProblem(schema);
-		if (!problem) continue;
+		const schema = resolved.options.schema;
+		if (schema === undefined || schema === null) continue;
+		// n8n treats a value as an expression only when its FIRST character is '='.
+		if (typeof schema === 'string' && schema.startsWith('=')) continue;
+		if (typeof schema === 'string' && schema.trim().length === 0) continue;
 
-		warnings.push({
-			code: 'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
-			nodeName: typeof node.name === 'string' ? node.name : undefined,
-			message:
-				`OpenAI node output format is "JSON Schema", but the schema string ${problem}. ` +
-				'At runtime the node throws "Failed to parse schema" before making any request. ' +
-				'Set textFormat.textOptions.schema to a valid JSON Schema object with "type": "object" at the root.',
-		});
+		if (typeof schema !== 'string') {
+			warnings.push({
+				code: 'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+				nodeName,
+				message:
+					'OpenAI node output format is "JSON Schema", but the schema value is not a string. ' +
+					'The node passes the raw value through JSON.parse and throws "Failed to parse schema" at runtime. ' +
+					'Serialize the schema to a JSON string in textFormat.textOptions.schema.',
+			});
+			continue;
+		}
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(schema);
+		} catch (error) {
+			warnings.push({
+				code: 'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+				nodeName,
+				message:
+					'OpenAI node output format is "JSON Schema", but the schema string is not valid JSON ' +
+					`(${error instanceof Error ? error.message : 'parse error'}). ` +
+					'At runtime the node throws "Failed to parse schema" before making any request. ' +
+					'Set textFormat.textOptions.schema to valid JSON.',
+			});
+			continue;
+		}
+
+		if (!isRecord(parsed) || parsed.type !== 'object') {
+			warnings.push({
+				code: 'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+				nodeName,
+				message:
+					'OpenAI node output format is "JSON Schema", but the schema root is not an object schema ' +
+					`(got ${JSON.stringify(isRecord(parsed) ? parsed.type : parsed)}). ` +
+					'The OpenAI API rejects non-object roots for structured output. ' +
+					'Use a root of the form {"type": "object", "properties": {...}}.',
+			});
+		}
 	}
 
 	return warnings;

--- a/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/detect-unparseable-openai-schema.ts
@@ -1,0 +1,68 @@
+import { isRecord } from '@n8n/utils/is-record';
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import type { ValidationWarning } from './workflow-validation-warnings';
+
+const OPENAI_NODE_TYPE = '@n8n/n8n-nodes-langchain.openAi';
+
+/** fixedCollection storage: `textOptions` is an object, or an array of one. */
+function getTextOptions(parameters: Record<string, unknown>): Record<string, unknown> | undefined {
+	const textFormat = parameters.textFormat;
+	if (!isRecord(textFormat)) return undefined;
+	const raw = textFormat.textOptions;
+	if (isRecord(raw)) return raw;
+	if (Array.isArray(raw) && isRecord(raw[0])) return raw[0];
+	return undefined;
+}
+
+/** Why the schema string won't survive the node's runtime parse, or undefined when fine. */
+function schemaProblem(schema: string): string | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(schema);
+	} catch (error) {
+		return `is not valid JSON (${error instanceof Error ? error.message : 'parse error'})`;
+	}
+	if (!isRecord(parsed)) return 'must be a JSON object, not a bare value or array';
+	if (parsed.type !== 'object') {
+		return `must declare "type": "object" at the root (got ${JSON.stringify(parsed.type)})`;
+	}
+	return undefined;
+}
+
+/**
+ * Flags OpenAI nodes whose structured-output schema string cannot be parsed.
+ * The node calls `jsonParse(textOptions.schema)` at execute time and throws
+ * "Failed to parse schema" before making any request, so a bad schema written
+ * at build time is a guaranteed runtime crash the builder never sees.
+ */
+export function detectUnparseableOpenAiSchema(json: WorkflowJSON): ValidationWarning[] {
+	const warnings: ValidationWarning[] = [];
+
+	for (const node of json.nodes ?? []) {
+		if (node.type !== OPENAI_NODE_TYPE) continue;
+		const params = node.parameters;
+		if (!isRecord(params)) continue;
+		const textOptions = getTextOptions(params);
+		if (!textOptions || textOptions.type !== 'json_schema') continue;
+
+		const schema = textOptions.schema;
+		if (typeof schema !== 'string' || schema.trim().length === 0) continue;
+		// Expressions resolve at runtime — not statically checkable.
+		if (schema.trimStart().startsWith('=')) continue;
+
+		const problem = schemaProblem(schema);
+		if (!problem) continue;
+
+		warnings.push({
+			code: 'OPENAI_STRUCTURED_OUTPUT_SCHEMA_INVALID',
+			nodeName: typeof node.name === 'string' ? node.name : undefined,
+			message:
+				`OpenAI node output format is "JSON Schema", but the schema string ${problem}. ` +
+				'At runtime the node throws "Failed to parse schema" before making any request. ' +
+				'Set textFormat.textOptions.schema to a valid JSON Schema object with "type": "object" at the root.',
+		});
+	}
+
+	return warnings;
+}

--- a/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/workflow-source-compiler.ts
@@ -4,6 +4,7 @@ import { validateWorkflow, type WorkflowJSON } from '@n8n/workflow-sdk';
 
 import { buildCredentialHostIndex, resolveCredentialByUrl } from './credential-url-resolver';
 import { detectArrayInputCollapse } from './detect-array-input-collapse';
+import { detectUnparseableOpenAiSchema } from './detect-unparseable-openai-schema';
 import { detectWrongKindLocatorValues } from './detect-wrong-kind-locator';
 import { collectValidationIssues, type ValidationWarning } from './workflow-validation-warnings';
 import type { InstanceAiContext } from '../../types';
@@ -87,6 +88,7 @@ function validateCompiledWorkflow(
 	collectValidationIssues(schemaValidation.warnings, warnings);
 	warnings.push(...detectArrayInputCollapse(json));
 	warnings.push(...detectWrongKindLocatorValues(json, context.nodeTypesProvider));
+	warnings.push(...detectUnparseableOpenAiSchema(json));
 	return warnings;
 }
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/openai-responses-envelope.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/openai-responses-envelope.test.ts
@@ -5,7 +5,9 @@ import {
 	extractResponsesRequestModel,
 	forwardTranslateToResponsesEnvelope,
 	forwardTranslateToResponsesSseEvents,
+	isOpenAiResponsesUrl,
 	isResponsesStreamRequested,
+	normalizeOpenAiResponsesMockResponse,
 	reverseTranslateOpenAiResponsesRequest,
 } from '../openai-responses-envelope';
 
@@ -363,5 +365,82 @@ describe('buildResponsesErrorEnvelope', () => {
 				param: null,
 			},
 		});
+	});
+});
+
+describe('isOpenAiResponsesUrl', () => {
+	it('matches the Responses endpoint and rejects everything else', () => {
+		expect(isOpenAiResponsesUrl('https://api.openai.com/v1/responses')).toBe(true);
+		expect(isOpenAiResponsesUrl('https://api.openai.com/v1/responses/')).toBe(true);
+		expect(isOpenAiResponsesUrl('https://api.openai.com/v1/chat/completions')).toBe(false);
+		expect(isOpenAiResponsesUrl('https://api.openai.com/v1/responses/resp_123')).toBe(false);
+		expect(isOpenAiResponsesUrl('https://evil.example.com/v1/responses')).toBe(false);
+		expect(isOpenAiResponsesUrl('not a url')).toBe(false);
+	});
+});
+
+describe('normalizeOpenAiResponsesMockResponse', () => {
+	const asResponse = (body: unknown): EvalMockHttpResponse => ({
+		body,
+		headers: { 'content-type': 'application/json' },
+		statusCode: 200,
+	});
+
+	it('coerces the observed malformed body (no item type, content type "text") to the canonical envelope', () => {
+		// Verbatim shape served in the failing daily-gmail-action-digest run:
+		// the node's parser found no `message` item / `output_text` part and
+		// collapsed `output` to [].
+		const failingBody = {
+			output: [
+				{
+					index: 0,
+					content: [{ type: 'text', text: '<p>4 of your 5 emails today require action.</p>' }],
+				},
+			],
+		};
+
+		const normalized = normalizeOpenAiResponsesMockResponse(asResponse(failingBody), 'gpt-4o-mini');
+
+		const body = normalized.body as {
+			object: string;
+			status: string;
+			output: Array<{
+				type: string;
+				role: string;
+				content: Array<{ type: string; text: string; annotations: unknown[] }>;
+			}>;
+		};
+		expect(body.object).toBe('response');
+		expect(body.status).toBe('completed');
+		expect(body.output).toHaveLength(1);
+		expect(body.output[0].type).toBe('message');
+		expect(body.output[0].role).toBe('assistant');
+		expect(body.output[0].content[0].type).toBe('output_text');
+		expect(body.output[0].content[0].text).toBe('<p>4 of your 5 emails today require action.</p>');
+		expect(body.output[0].content[0].annotations).toEqual([]);
+	});
+
+	it('keeps the text of an already-canonical body intact', () => {
+		const canonical = forwardTranslateToResponsesEnvelope(
+			asResponse({ output_text: '{"items":[]}' }),
+			'gpt-4o-mini',
+		);
+
+		const normalized = normalizeOpenAiResponsesMockResponse(asResponse(canonical), 'gpt-4o-mini');
+
+		const body = normalized.body as {
+			output: Array<{ type: string; content: Array<{ type: string; text: string }> }>;
+		};
+		expect(body.output[0].type).toBe('message');
+		expect(body.output[0].content[0].type).toBe('output_text');
+		expect(body.output[0].content[0].text).toBe('{"items":[]}');
+	});
+
+	it('passes error bodies through untouched so mock failures stay visible', () => {
+		const evalError = asResponse({ _evalMockError: true, message: 'generation failed' });
+		expect(normalizeOpenAiResponsesMockResponse(evalError, 'gpt-4o-mini')).toBe(evalError);
+
+		const apiError = asResponse({ error: { message: 'rate limited', type: 'rate_limit' } });
+		expect(normalizeOpenAiResponsesMockResponse(apiError, 'gpt-4o-mini')).toBe(apiError);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/openai-responses-envelope.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/openai-responses-envelope.test.ts
@@ -444,3 +444,88 @@ describe('normalizeOpenAiResponsesMockResponse', () => {
 		expect(normalizeOpenAiResponsesMockResponse(apiError, 'gpt-4o-mini')).toBe(apiError);
 	});
 });
+
+describe('normalizeOpenAiResponsesMockResponse — structure preservation', () => {
+	const asResponse = (body: unknown): EvalMockHttpResponse => ({
+		body,
+		headers: { 'content-type': 'application/json' },
+		statusCode: 200,
+	});
+
+	it('normalizes a malformed body even when it carries the realistic error:null field', () => {
+		const failingBody = {
+			error: null,
+			output: [{ index: 0, content: [{ type: 'text', text: 'digest ready' }] }],
+		};
+
+		const normalized = normalizeOpenAiResponsesMockResponse(asResponse(failingBody), 'gpt-4o-mini');
+
+		const body = normalized.body as {
+			output: Array<{ type: string; content: Array<{ type: string; text: string }> }>;
+		};
+		expect(body.output[0].type).toBe('message');
+		expect(body.output[0].content[0].type).toBe('output_text');
+		expect(body.output[0].content[0].text).toBe('digest ready');
+	});
+
+	it('preserves Responses-native function_call items instead of flattening them to text', () => {
+		const toolCallBody = {
+			output: [
+				{
+					type: 'function_call',
+					name: 'lookup_flight',
+					arguments: '{"flight":"FR485"}',
+					call_id: 'call_abc',
+					id: 'fc_abc',
+				},
+			],
+		};
+
+		const normalized = normalizeOpenAiResponsesMockResponse(
+			asResponse(toolCallBody),
+			'gpt-4o-mini',
+		);
+
+		const body = normalized.body as {
+			object: string;
+			output: Array<{ type: string; name: string; arguments: string; call_id: string }>;
+		};
+		expect(body.object).toBe('response');
+		expect(body.output).toHaveLength(1);
+		expect(body.output[0].type).toBe('function_call');
+		expect(body.output[0].name).toBe('lookup_flight');
+		expect(body.output[0].arguments).toBe('{"flight":"FR485"}');
+		expect(body.output[0].call_id).toBe('call_abc');
+	});
+
+	it('preserves a mixed message + function_call output and fills missing tool-call ids', () => {
+		const mixedBody = {
+			output: [
+				{ content: [{ type: 'text', text: 'calling the tool' }] },
+				{ type: 'function_call', name: 'save_lead', arguments: '{}' },
+			],
+		};
+
+		const normalized = normalizeOpenAiResponsesMockResponse(asResponse(mixedBody), 'gpt-4o-mini');
+
+		const body = normalized.body as { output: Array<Record<string, unknown>> };
+		expect(body.output).toHaveLength(2);
+		expect(body.output[0].type).toBe('message');
+		expect(body.output[1].type).toBe('function_call');
+		expect(typeof body.output[1].call_id).toBe('string');
+		expect((body.output[1].call_id as string).length).toBeGreaterThan(0);
+	});
+
+	it('rebuilds shapeless bodies (bare string) into a message envelope', () => {
+		const normalized = normalizeOpenAiResponsesMockResponse(
+			asResponse('just some text'),
+			'gpt-4o-mini',
+		);
+
+		const body = normalized.body as {
+			output: Array<{ type: string; content: Array<{ type: string; text: string }> }>;
+		};
+		expect(body.output[0].type).toBe('message');
+		expect(body.output[0].content[0].text).toBe('just some text');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -50,6 +50,11 @@ import { EvalMockedCredentialsHelper } from './eval-mocked-credentials-helper';
 import { EvalTimings } from './eval-timings';
 import { type InterceptedTurn, LlmWireServer } from './llm-wire-server';
 import { createLlmMockHandler } from './mock-handler';
+import {
+	extractResponsesRequestModel,
+	isOpenAiResponsesUrl,
+	normalizeOpenAiResponsesMockResponse,
+} from './openai-responses-envelope';
 import { generatePinData } from './pin-data-generator';
 import {
 	buildVendorLlmRouting,
@@ -739,11 +744,21 @@ export class EvalExecutionService {
 				executionMode: 'mocked',
 			});
 			entry.executionMode = 'mocked';
-			const response = await timings.time(
+			let response = await timings.time(
 				'http-mock',
 				node.name,
 				async () => await mockHandler(requestOptions, node),
 			);
+
+			// Responses-API calls from the openAi node bypass the wire-server
+			// protocol adapters — coerce the generated body to the canonical
+			// envelope so the node's real parser accepts it.
+			if (response && response.statusCode < 400 && isOpenAiResponsesUrl(requestOptions.url)) {
+				response = normalizeOpenAiResponsesMockResponse(
+					response,
+					extractResponsesRequestModel(requestOptions.body),
+				);
+			}
 
 			entry.interceptedRequests.push({
 				// Broken routing (resource/operation missing on the node type) emits a

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -754,10 +754,18 @@ export class EvalExecutionService {
 			// protocol adapters — coerce the generated body to the canonical
 			// envelope so the node's real parser accepts it.
 			if (response && response.statusCode < 400 && isOpenAiResponsesUrl(requestOptions.url)) {
-				response = normalizeOpenAiResponsesMockResponse(
+				const normalized = normalizeOpenAiResponsesMockResponse(
 					response,
 					extractResponsesRequestModel(requestOptions.body),
 				);
+				if (normalized !== response) {
+					// Triage breadcrumb: the recorded mockResponse below is the coerced
+					// body, not the generator's raw output.
+					this.logger.debug(
+						`[EvalMock] Applied Responses-envelope normalization for "${node.name}"`,
+					);
+				}
+				response = normalized;
 			}
 
 			entry.interceptedRequests.push({

--- a/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
+++ b/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
@@ -301,7 +301,12 @@ export function normalizeOpenAiResponsesMockResponse(
 	model: string,
 ): EvalMockHttpResponse {
 	const body = mockResponse.body;
-	if (isPlainRecord(body) && ('_evalMockError' in body || body.error != null)) return mockResponse;
+	if (
+		isPlainRecord(body) &&
+		('_evalMockError' in body || (body.error !== null && body.error !== undefined))
+	) {
+		return mockResponse;
+	}
 
 	if (isPlainRecord(body) && Array.isArray(body.output)) {
 		const output = body.output

--- a/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
+++ b/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
@@ -235,20 +235,101 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/** Coerce one content part to `{ type: 'output_text', text, annotations }`. */
+function normalizeContentPart(part: unknown): Record<string, unknown> | undefined {
+	if (typeof part === 'string') return { type: 'output_text', text: part, annotations: [] };
+	if (!isPlainRecord(part)) return undefined;
+	const text = part.text;
+	if (typeof text !== 'string') return undefined;
+	return {
+		...part,
+		type: 'output_text',
+		text,
+		annotations: Array.isArray(part.annotations) ? part.annotations : [],
+	};
+}
+
+/**
+ * Canonicalize one output item. Responses-native `function_call` items are
+ * preserved (only missing ids filled); content-bearing items are coerced to a
+ * canonical assistant message; other typed items pass through untouched.
+ * Returns undefined for unsalvageable entries.
+ */
+function normalizeOutputItem(item: unknown, index: number): Record<string, unknown> | undefined {
+	if (!isPlainRecord(item)) return undefined;
+	if (item.type === 'function_call') {
+		if (typeof item.name !== 'string' || typeof item.arguments !== 'string') return undefined;
+		return {
+			...item,
+			id: typeof item.id === 'string' ? item.id : `fc_norm_${String(index)}`,
+			call_id: typeof item.call_id === 'string' ? item.call_id : `call_norm_${String(index)}`,
+		};
+	}
+	const content = item.content;
+	if (Array.isArray(content)) {
+		const parts = content
+			.map(normalizeContentPart)
+			.filter((part): part is Record<string, unknown> => part !== undefined);
+		if (parts.length === 0) return undefined;
+		return {
+			id: typeof item.id === 'string' ? item.id : `msg_norm_${String(index)}`,
+			type: 'message',
+			role: 'assistant',
+			status: 'completed',
+			content: parts,
+		};
+	}
+	// Unknown-but-typed items (e.g. reasoning): keep verbatim — the node ignores them.
+	if (typeof item.type === 'string') return { ...item };
+	return undefined;
+}
+
 /**
  * Coerce a freeform LLM-generated mock body into the canonical Responses
  * envelope. The openAi node's `response` operation is wire-intercepted (no
  * protocol adapter runs), and generated bodies routinely miss the strict item
  * shape (`type: 'message'`, `content[].type: 'output_text'`) the node's parser
- * filters on — collapsing `output` to `[]`. Error bodies pass through
- * untouched so mock-generation failures and injected API errors stay visible.
+ * filters on — collapsing `output` to `[]`.
+ *
+ * Structure-preserving: bodies with an `output` array are fixed item-by-item so
+ * Responses-native tool calls survive; only shapeless bodies go through the
+ * full text-extraction rebuild. Error bodies pass through untouched (the real
+ * envelope carries `error: null`, so only a NON-null error marks a failure).
  */
 export function normalizeOpenAiResponsesMockResponse(
 	mockResponse: EvalMockHttpResponse,
 	model: string,
 ): EvalMockHttpResponse {
 	const body = mockResponse.body;
-	if (isPlainRecord(body) && ('_evalMockError' in body || 'error' in body)) return mockResponse;
+	if (isPlainRecord(body) && ('_evalMockError' in body || body.error != null)) return mockResponse;
+
+	if (isPlainRecord(body) && Array.isArray(body.output)) {
+		const output = body.output
+			.map(normalizeOutputItem)
+			.filter((item): item is Record<string, unknown> => item !== undefined);
+		if (output.length > 0) {
+			return {
+				...mockResponse,
+				body: {
+					...body,
+					id:
+						typeof body.id === 'string'
+							? body.id
+							: `resp_${randomUUID().replace(/-/g, '').slice(0, 32)}`,
+					object: 'response',
+					status: 'completed',
+					model: typeof body.model === 'string' && body.model.length > 0 ? body.model : model,
+					created_at:
+						typeof body.created_at === 'number' ? body.created_at : Math.floor(Date.now() / 1000),
+					output,
+					usage: isPlainRecord(body.usage)
+						? body.usage
+						: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+				},
+			};
+		}
+	}
+
 	return { ...mockResponse, body: forwardTranslateToResponsesEnvelope(mockResponse, model) };
 }
 

--- a/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
+++ b/packages/cli/src/modules/instance-ai/eval/openai-responses-envelope.ts
@@ -221,6 +221,37 @@ export function forwardTranslateToResponsesSseEvents(
 	return events;
 }
 
+/** True for the OpenAI Responses endpoint the openAi node calls directly over the wire. */
+export function isOpenAiResponsesUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		return parsed.hostname === 'api.openai.com' && /^\/v\d+\/responses\/?$/.test(parsed.pathname);
+	} catch {
+		return false;
+	}
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Coerce a freeform LLM-generated mock body into the canonical Responses
+ * envelope. The openAi node's `response` operation is wire-intercepted (no
+ * protocol adapter runs), and generated bodies routinely miss the strict item
+ * shape (`type: 'message'`, `content[].type: 'output_text'`) the node's parser
+ * filters on — collapsing `output` to `[]`. Error bodies pass through
+ * untouched so mock-generation failures and injected API errors stay visible.
+ */
+export function normalizeOpenAiResponsesMockResponse(
+	mockResponse: EvalMockHttpResponse,
+	model: string,
+): EvalMockHttpResponse {
+	const body = mockResponse.body;
+	if (isPlainRecord(body) && ('_evalMockError' in body || 'error' in body)) return mockResponse;
+	return { ...mockResponse, body: forwardTranslateToResponsesEnvelope(mockResponse, model) };
+}
+
 /** Responses API uses the same error envelope as chat-completions, with `error.type` describing the failure. */
 export function buildResponsesErrorEnvelope(message: string): Record<string, unknown> {
 	return {


### PR DESCRIPTION
## Summary

Makes `daily-gmail-action-digest` stable by fixing the two real bug classes behind its flakiness (2/5 + 4/5 at N=5 in this week's reliability run). The Gmail mock shape is untouched — it had 0 shape failures in 105 runs.

**Commit 1 — deterministic validator for OpenAI structured-output schemas** (`@n8n/instance-ai`)
- New `detectUnparseableOpenAiSchema` compile-path check (pattern: `detect-array-input-collapse`), wired into `workflow-source-compiler`.
- Targets `@n8n/n8n-nodes-langchain.openAi` nodes with `textFormat.textOptions.type: 'json_schema'` (v2.x `response` operation; handles both object and array-of-one fixedCollection storage; skips `=` expressions).
- Flags schema strings that are invalid JSON or whose root isn't `"type": "object"` — both are guaranteed runtime failures: the node calls `jsonParse(schema)` per item and throws `Failed to parse schema` before any request (`v2/actions/text/helpers/responses.ts:178`), which the builder otherwise never sees at build time.
- **Note for review:** the brief suggested warning-only, but on master non-informational `ValidationWarning`s fail the build with fix-and-rebuild remediation (same as `ARRAY_INPUT_COLLAPSED_TO_FIRST_ITEM`). Both checks here are zero-false-positive hard guarantees, so blocking is intentional — the builder must fix the schema for the build to land, which is what actually kills this failure class.

**Commit 2 — Responses-API mock envelope normalization** (`packages/cli` eval module)
- Root cause found: the openAi node's `response` operation calls `https://api.openai.com/v1/responses` directly over the wire, so its mock is generated by the generic LLM mock handler and served **verbatim** — `forwardTranslateToResponsesEnvelope` only runs on the LLM wire-server route (LangChain models). The observed failing body `{"output":[{"index":0,"content":[{"type":"text",...}]}]}` was missing `type:'message'` on the item and used `text` instead of `output_text`, so the node's parser collapsed `output` to `[]` and the downstream `$json.output[0]` expression crashed.
- Fix: `normalizeOpenAiResponsesMockResponse` coerces generated bodies to the canonical envelope at the node-interception point (`createInterceptingHandler`) — the wire-server path is untouched, so no double translation. Error bodies (`_evalMockError`, API `error`) pass through so mock failures and injected errors stay visible. Unit-tested with the exact failing body from the run.

**Commit 3 — `no-recent-emails` expectation reworded to intent**
- The old successCriteria hard-required "the empty-inbox branch wired downstream from the IF/Switch node" — implementation-over-intent: 4/5 runs passed with a legitimate linear design (empty case handled inline), 1/5 the verifier enforced the letter. Reworded to require graceful empty-inbox handling (no-action digest or clean completion; branching optional but must be wired if present). Flagging per the brief.
- The run-4 `framework_issue` ("operation was aborted due to timeout") is the known AI-node mock-generation timeout class (undici 300s cap under contention) — correctly attributed, unrelated to this PR.

## Validation

- Unit: 6 validator tests, 26 envelope tests (incl. the exact failing mock body from the run), 9 compiler tests — green; typecheck + lint green in both packages.
- Lanes pre/post at **N=10** on `daily-gmail-action-digest`, dedicated docker images built from clean master (`p2-pre-master`) vs master+this diff (`p2-post-fixes`), 5 lanes each:

| Scenario | PRE (master) | POST (this PR) |
|---|---|---|
| emails-with-action-items | 5/10 — 4× mock_issue, 1× framework | **8/10** — 0× mock, 0× builder, 2× framework (exec timeouts) |
| no-recent-emails | 8/10 — 2× builder_issue | **10/10** |

  Both targeted failure classes went to **zero** (schema-parse crashes and Responses-envelope shape misses). The two residual fails are the known AI-node exec-timeout infra class (client aborts at the 900s budget — same class as the pre-run's framework fail; addressed separately by exec-timeout retry in #33565 and attribution in #33562).
- Guardrail N=3 on `voice-agent-crm-backend` + `flight-status-change-alert`: no regression signature. Flight 2/3 + 2/3 with its historical mock-nondeterminism flakes (stored-record content mismatch). Voice-agent runs weak on master-based images (Sheets `__rl` empty-locator, `toolCall.arguments` path bug, multi-workflow routing pinning the wrong webhook — all pre-existing classes that #33530's unmerged fixes target; zero mentions of schemas, `textFormat`, or Responses shapes in any failure).
- Ops note: an earlier post-run produced mass 900s build hangs — reproduced on the *pre* image too under host load; caused by running turbo builds concurrently with the lanes, not by this diff (clean rerun above).

## How to test

- `pnpm --filter @n8n/instance-ai vitest run src/tools/workflows/__tests__/detect-unparseable-openai-schema.test.ts` and `cd packages/cli && pnpm vitest run src/modules/instance-ai/eval/__tests__/openai-responses-envelope.test.ts`.
- Lanes: `./scripts/run-eval-lanes.sh --instance-count 5 --iterations 10 --build -- --filter daily-gmail-action-digest` (requires rebuilding the docker image — both fixes are backend-side).

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to the PR #33530 reliability review (the "Failed to parse schema" ×3 and Responses `type:'text'` mock-shape classes). Complements #33565's prompt-side Responses quirk with a deterministic guarantee.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->