### PR TITLE
fix(ai-builder): Track consolidated-tool data table creations for eval cleanup (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/event-parser.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/event-parser.test.ts
@@ -160,6 +160,128 @@ describe('extractOutcomeFromEvents', () => {
 		expect(result.dataTableIds).toContain('dt-001');
 	});
 
+	const dataTablesToolEvents = (
+		args: Record<string, unknown>,
+		result: unknown,
+	): CapturedEvent[] => [
+		{
+			timestamp: 1000,
+			type: 'tool-call',
+			data: {
+				type: 'tool-call',
+				payload: { toolCallId: 'tc-1', toolName: 'data-tables', args },
+			},
+		},
+		{
+			timestamp: 1100,
+			type: 'tool-result',
+			data: {
+				type: 'tool-result',
+				payload: { toolCallId: 'tc-1', toolName: 'data-tables', result },
+			},
+		},
+	];
+
+	it('extracts the nested table id from consolidated data-tables create results', () => {
+		const events = dataTablesToolEvents(
+			{ action: 'create', name: 'posted_leads' },
+			{ table: { id: 'dt-777', name: 'posted_leads' } },
+		);
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.dataTableIds).toEqual(['dt-777']);
+	});
+
+	it('extracts the table id from stringified data-tables create results', () => {
+		const events = dataTablesToolEvents(
+			{ action: 'create', name: 'posted_leads' },
+			JSON.stringify({ table: { id: 'dt-999' } }),
+		);
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.dataTableIds).toEqual(['dt-999']);
+	});
+
+	it('does not track data-tables schema results even though they carry a top-level id', () => {
+		const events = dataTablesToolEvents(
+			{ action: 'schema', tableName: 'posted_leads' },
+			{ id: 'dt-888', name: 'posted_leads', columns: [] },
+		);
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.dataTableIds).toEqual([]);
+	});
+
+	it('does not track denied data-tables create results', () => {
+		const events = dataTablesToolEvents(
+			{ action: 'create', name: 'posted_leads' },
+			{ denied: true, reason: 'User denied the action' },
+		);
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.dataTableIds).toEqual([]);
+	});
+
+	it('extracts execution IDs from consolidated executions run results', () => {
+		const events: CapturedEvent[] = [
+			{
+				timestamp: 1000,
+				type: 'tool-call',
+				data: {
+					type: 'tool-call',
+					payload: { toolCallId: 'tc-1', toolName: 'executions', args: { action: 'run' } },
+				},
+			},
+			{
+				timestamp: 1100,
+				type: 'tool-result',
+				data: {
+					type: 'tool-result',
+					payload: {
+						toolCallId: 'tc-1',
+						toolName: 'executions',
+						result: { executionId: 'exec-321', status: 'success' },
+					},
+				},
+			},
+		];
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.executionIds).toContain('exec-321');
+	});
+
+	it('does not track executions get results', () => {
+		const events: CapturedEvent[] = [
+			{
+				timestamp: 1000,
+				type: 'tool-call',
+				data: {
+					type: 'tool-call',
+					payload: {
+						toolCallId: 'tc-1',
+						toolName: 'executions',
+						args: { action: 'get', executionId: 'exec-555' },
+					},
+				},
+			},
+			{
+				timestamp: 1100,
+				type: 'tool-result',
+				data: {
+					type: 'tool-result',
+					payload: {
+						toolCallId: 'tc-1',
+						toolName: 'executions',
+						result: { executionId: 'exec-555', status: 'running' },
+					},
+				},
+			},
+		];
+
+		const result = extractOutcomeFromEvents(events);
+		expect(result.executionIds).toEqual([]);
+	});
+
 	it('captures tool errors', () => {
 		const events: CapturedEvent[] = [
 			{

--- a/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
@@ -4,6 +4,7 @@
 
 import { isRecord } from '@n8n/utils/is-record';
 
+import { DATA_TABLES_TOOL_ID, DOMAIN_TOOL_IDS } from '../../src/tools/tool-ids';
 import type {
 	AgentActivity,
 	CapturedEvent,
@@ -22,8 +23,9 @@ import { getNestedRecord as getRecord, getString } from '../utils/safe-extract';
 
 const WORKFLOW_TOOLS = new Set(['build-workflow', 'submit-workflow', 'patch-workflow']);
 
-const EXECUTION_TOOL = 'run-workflow';
-const DATA_TABLE_TOOL = 'create-data-table';
+// Retired standalone tool names, kept so captures from older backends still parse.
+const EXECUTION_TOOL_LEGACY = 'run-workflow';
+const DATA_TABLE_TOOL_LEGACY = 'create-data-table';
 
 // ---------------------------------------------------------------------------
 // extractOutcomeFromEvents
@@ -95,7 +97,7 @@ export function extractOutcomeFromEvents(events: CapturedEvent[]): EventOutcome 
 				toolCalls.push(toolCall);
 
 				// Extract resource IDs from tool results
-				extractResourceIds(toolName, result, workflowIds, executionIds, dataTableIds);
+				extractResourceIds(toolName, args, result, workflowIds, executionIds, dataTableIds);
 				break;
 			}
 
@@ -509,6 +511,7 @@ function countEvents(events: CapturedEvent[], type: string): number {
 
 function extractResourceIds(
 	toolName: string,
+	args: Record<string, unknown>,
 	result: unknown,
 	workflowIds: string[],
 	executionIds: string[],
@@ -519,33 +522,48 @@ function extractResourceIds(
 		if (id) workflowIds.push(id);
 	}
 
-	if (toolName === EXECUTION_TOOL) {
+	const action = getString(args, 'action');
+
+	if (
+		toolName === EXECUTION_TOOL_LEGACY ||
+		(toolName === DOMAIN_TOOL_IDS.EXECUTIONS && action === 'run')
+	) {
 		const id = extractIdFromResult(result, 'executionId', 'id');
 		if (id) executionIds.push(id);
 	}
 
-	if (toolName === DATA_TABLE_TOOL) {
+	if (toolName === DATA_TABLE_TOOL_LEGACY) {
 		const id = extractIdFromResult(result, 'dataTableId', 'id');
+		if (id) dataTableIds.push(id);
+	}
+
+	// create-only: other actions (e.g. schema) return ids of EXISTING tables,
+	// and tracking those would let cleanup delete tables the agent only inspected.
+	if (toolName === DATA_TABLES_TOOL_ID && action === 'create') {
+		const record = toResultRecord(result);
+		const table = record ? getRecord(record, 'table') : undefined;
+		const id = table ? extractIdFromRecord(table, ['id']) : undefined;
 		if (id) dataTableIds.push(id);
 	}
 }
 
-function extractIdFromResult(result: unknown, ...keys: string[]): string | undefined {
-	if (!isRecord(result)) {
-		// Result might be a stringified JSON
-		if (typeof result === 'string') {
-			try {
-				const parsed: unknown = JSON.parse(result);
-				if (isRecord(parsed)) {
-					return extractIdFromRecord(parsed, keys);
-				}
-			} catch {
-				return undefined;
-			}
+/** Normalize a tool result (object or stringified JSON) to a record. */
+function toResultRecord(result: unknown): Record<string, unknown> | undefined {
+	if (isRecord(result)) return result;
+	if (typeof result === 'string') {
+		try {
+			const parsed: unknown = JSON.parse(result);
+			if (isRecord(parsed)) return parsed;
+		} catch {
+			return undefined;
 		}
-		return undefined;
 	}
-	return extractIdFromRecord(result, keys);
+	return undefined;
+}
+
+function extractIdFromResult(result: unknown, ...keys: string[]): string | undefined {
+	const record = toResultRecord(result);
+	return record ? extractIdFromRecord(record, keys) : undefined;
 }
 
 function extractIdFromRecord(record: Record<string, unknown>, keys: string[]): string | undefined {

--- a/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
@@ -105,11 +105,16 @@ export async function buildAgentOutcome(
 		}
 	}
 
-	// Fetch execution details
-	for (const execId of eventOutcome.executionIds) {
+	// Fetch execution details (one listing for all ids)
+	if (eventOutcome.executionIds.length > 0) {
+		let executions: Awaited<ReturnType<typeof client.listExecutions>> | undefined;
 		try {
-			const executions = await client.listExecutions();
-			const match = executions.find((e) => e.id === execId);
+			executions = await client.listExecutions();
+		} catch {
+			executions = undefined;
+		}
+		for (const execId of eventOutcome.executionIds) {
+			const match = executions?.find((e) => e.id === execId);
 			if (match) {
 				executionsRun.push({
 					id: match.id,
@@ -120,15 +125,9 @@ export async function buildAgentOutcome(
 				executionsRun.push({
 					id: execId,
 					workflowId: 'unknown',
-					status: 'not-found',
+					status: executions ? 'not-found' : 'fetch-failed',
 				});
 			}
-		} catch {
-			executionsRun.push({
-				id: execId,
-				workflowId: 'unknown',
-				status: 'fetch-failed',
-			});
 		}
 	}
 


### PR DESCRIPTION
## Summary

The Instance AI eval harness never deletes the data tables its builds create: the event parser (`evaluations/outcome/event-parser.ts`) still matches the retired standalone tool names (`create-data-table`, `run-workflow`), while the live consolidated tools are `data-tables` and `executions`. The consolidated create also returns the table **nested** (`{ table: { id } }`), which the top-level-only id extraction misses. Result: `createdDataTableIds` is always empty, `cleanupBuild` deletes workflows but never tables, tables accumulate for the whole run, and name conflicts push later builds of the same (or a similarly-named) case into **reusing earlier builds' tables** — the state-contamination class behind the `revises-plan-after-rejection` execution-scenario flake.

This PR re-syncs the parser with the consolidated tools:

- `data-tables` results are tracked **only for `action: 'create'`** (from the captured tool-call args) and the id is read from the nested `table.id`. The action gate matters: `schema` spreads an **existing** table's id at the top level, and tracking it would make cleanup delete tables the agent merely inspected.
- `executions` results with `action: 'run'` are tracked as executions (same drift: `run-workflow` no longer exists).
- Tool ids are imported from `src/tools/tool-ids.ts` instead of duplicated strings, so the next rename breaks the type-check instead of silently breaking cleanup.
- Legacy names remain as fallbacks for captures from older backends.

Known consideration: with cleanup actually working again, two *concurrent* same-named-table builds in direct mode could observe a table deleted mid-flight by a sibling iteration's cleanup (loud failure, previously masked by the leak). That race is the pre-existing shared-tenant design gap; per-execution isolation is tracked separately.

## How to test

- `cd packages/@n8n/instance-ai && pnpm vitest run evaluations/__tests__/event-parser.test.ts` (6 new cases: nested create extraction, stringified results, schema/denied not tracked, consolidated executions run tracked, get not tracked).
- Live: run any data-table-building eval case against a local instance and compare `GET /rest/projects/:id/data-tables` before/after — validated with `workflow-data-table` (scenario PASS, build upserted into its created table, zero net-new tables after cleanup; before the fix, every run leaked its tables).

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge order

Independent of #33584, but ideally lands before #33433 so CI runs stop accumulating leaked tables under the restored execution scenario.
