### PR TITLE
fix(ai-builder): Make eval scenario state deterministic — keep empty pins, blank static data (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -18,6 +18,7 @@ import type { NodeTypes } from '@/node-types';
 import type { PostHogClient } from '@/posthog';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before the import of the class under test
@@ -205,6 +206,7 @@ describe('EvalExecutionService', () => {
 	const activeExecutions = mock<ActiveExecutions>();
 	const executionsConfig = mock<ExecutionsConfig>({ mode: 'regular' });
 	const binaryDataService = mock<BinaryDataService>();
+	const workflowStaticDataService = mock<WorkflowStaticDataService>();
 
 	// Captured configureAdditionalData closure so tests can re-invoke it on a
 	// stub additionalData without booting the real runner.
@@ -237,6 +239,7 @@ describe('EvalExecutionService', () => {
 			activeExecutions,
 			executionsConfig,
 			binaryDataService,
+			workflowStaticDataService,
 		);
 		// Reset to safe default — tests that flip queue mode reassign in-test.
 		Object.assign(executionsConfig, { mode: 'regular' });
@@ -427,6 +430,33 @@ describe('EvalExecutionService', () => {
 					workflowData: expect.objectContaining({ id: 'wf-1', staticData: undefined }),
 				}),
 			);
+		});
+
+		it('blanks the persisted workflow staticData after the run', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(
+				makeWorkflowEntity({
+					staticData: { global: { lastLeadsRow: 4 } },
+				} as never) as never,
+			);
+
+			await service.executeWithLlmMock('wf-1', makeUser());
+
+			expect(workflowStaticDataService.saveStaticDataById).toHaveBeenCalledWith('wf-1', {});
+			// The blank must land after the run — it undoes what the execution's
+			// lifecycle hooks persisted.
+			expect(workflowRunner.run.mock.invocationCallOrder[0]).toBeLessThan(
+				workflowStaticDataService.saveStaticDataById.mock.invocationCallOrder[0],
+			);
+		});
+
+		it('blanks the persisted workflow staticData even when the execution fails', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(makeWorkflowEntity() as never);
+			activeExecutions.getPostExecutePromise.mockRejectedValue(new Error('execution crashed'));
+
+			const result = await service.executeWithLlmMock('wf-1', makeUser());
+
+			expect(result.success).toBe(false);
+			expect(workflowStaticDataService.saveStaticDataById).toHaveBeenCalledWith('wf-1', {});
 		});
 
 		it('returns a framework failure when bypass pin data generation fails', async () => {

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -413,6 +413,22 @@ describe('EvalExecutionService', () => {
 			);
 		});
 
+		it('runs with blank workflow staticData even when the entity carries some', async () => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(
+				makeWorkflowEntity({
+					staticData: { global: { lastLeadsRow: 4 } },
+				} as never) as never,
+			);
+
+			await service.executeWithLlmMock('wf-1', makeUser());
+
+			expect(workflowRunner.run).toHaveBeenCalledWith(
+				expect.objectContaining({
+					workflowData: expect.objectContaining({ id: 'wf-1', staticData: undefined }),
+				}),
+			);
+		});
+
 		it('returns a framework failure when bypass pin data generation fails', async () => {
 			const bypassNode = {
 				id: 'node-3',

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/pin-data-generator.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/pin-data-generator.test.ts
@@ -1,0 +1,109 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+vi.mock('@n8n/instance-ai', () => ({
+	createEvalAgent: vi.fn(),
+	extractText: vi.fn(),
+}));
+
+import { createEvalAgent, extractText } from '@n8n/instance-ai';
+
+import { generatePinData } from '../pin-data-generator';
+
+const createEvalAgentMock = vi.mocked(createEvalAgent);
+const extractTextMock = vi.mocked(extractText);
+
+const workflow = {
+	nodes: [
+		{
+			name: 'Get Posted Keys',
+			type: 'n8n-nodes-base.dataTable',
+			typeVersion: 1,
+			parameters: { resource: 'row', operation: 'get' },
+		},
+		{
+			name: 'AI Root',
+			type: '@n8n/n8n-nodes-langchain.agent',
+			typeVersion: 1,
+			parameters: {},
+		},
+	],
+	connections: {},
+} as unknown as WorkflowJSON;
+
+const generateMock = vi.fn();
+
+function respondWith(text: string) {
+	generateMock.mockResolvedValue({});
+	extractTextMock.mockReturnValue(text);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	createEvalAgentMock.mockReturnValue({ generate: generateMock } as unknown as ReturnType<
+		typeof createEvalAgent
+	>);
+});
+
+describe('generatePinData', () => {
+	it('keeps empty-array pins for "no stored data" states', async () => {
+		respondWith(JSON.stringify({ 'Get Posted Keys': [] }));
+
+		const result = await generatePinData({ workflow, nodeNames: ['Get Posted Keys'] });
+
+		expect(result).toEqual({ 'Get Posted Keys': [] });
+	});
+
+	it('keeps empty-array pins inside code fences', async () => {
+		respondWith('```json\n{ "Get Posted Keys": [] }\n```');
+
+		const result = await generatePinData({ workflow, nodeNames: ['Get Posted Keys'] });
+
+		expect(result).toEqual({ 'Get Posted Keys': [] });
+	});
+
+	it('wraps raw items and passes json-wrapped items through', async () => {
+		respondWith(
+			JSON.stringify({
+				'Get Posted Keys': [{ lead_key: 'a@b.c' }, { json: { lead_key: 'd@e.f' } }],
+			}),
+		);
+
+		const result = await generatePinData({ workflow, nodeNames: ['Get Posted Keys'] });
+
+		expect(result['Get Posted Keys']).toEqual([
+			{ json: { lead_key: 'a@b.c' } },
+			{ json: { lead_key: 'd@e.f' } },
+		]);
+	});
+
+	it('throws when the response misses a requested node', async () => {
+		respondWith(JSON.stringify({ 'Get Posted Keys': [] }));
+
+		await expect(
+			generatePinData({ workflow, nodeNames: ['Get Posted Keys', 'AI Root'] }),
+		).rejects.toThrow('Pin data generation returned no data for node(s): AI Root');
+	});
+
+	it('throws with all requested nodes when the response is not valid JSON', async () => {
+		respondWith('sorry, I cannot help with that');
+
+		await expect(
+			generatePinData({ workflow, nodeNames: ['Get Posted Keys', 'AI Root'] }),
+		).rejects.toThrow('Get Posted Keys, AI Root');
+	});
+
+	it('propagates agent errors instead of swallowing them', async () => {
+		generateMock.mockRejectedValue(new Error('model overloaded'));
+
+		await expect(generatePinData({ workflow, nodeNames: ['Get Posted Keys'] })).rejects.toThrow(
+			'model overloaded',
+		);
+	});
+
+	it('returns {} without calling the LLM when no nodes are requested', async () => {
+		const result = await generatePinData({ workflow, nodeNames: [] });
+
+		expect(result).toEqual({});
+		expect(createEvalAgentMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -44,6 +44,7 @@ import { NodeTypes } from '@/node-types';
 import { PostHogClient } from '@/posthog';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 
 import { createLlmCompletionMockHandler } from './llm-completion-mock';
 import { EvalMockedCredentialsHelper } from './eval-mocked-credentials-helper';
@@ -88,6 +89,7 @@ export class EvalExecutionService {
 		private readonly activeExecutions: ActiveExecutions,
 		private readonly executionsConfig: ExecutionsConfig,
 		private readonly binaryDataService: BinaryDataService,
+		private readonly workflowStaticDataService: WorkflowStaticDataService,
 	) {}
 
 	async executeWithLlmMock(
@@ -483,7 +485,23 @@ export class EvalExecutionService {
 					});
 				}
 			}
+			await this.blankPersistedStaticData(workflowEntity.id);
 			timings.summary(this.logger);
+		}
+	}
+
+	/**
+	 * 'evaluation'-mode runs persist getWorkflowStaticData() writes back to the
+	 * workflow row — blank it after the run so scenarios leave no state behind.
+	 */
+	private async blankPersistedStaticData(workflowId: string): Promise<void> {
+		try {
+			await this.workflowStaticDataService.saveStaticDataById(workflowId, {});
+		} catch (error) {
+			this.logger.warn('[EvalMock] Failed to blank workflow staticData after run', {
+				workflowId,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -423,7 +423,8 @@ export class EvalExecutionService {
 
 			const runData: IWorkflowExecutionDataProcess = {
 				executionMode: 'evaluation',
-				workflowData: workflowEntity,
+				// Builder-verify runs persist staticData (e.g. dedup cursors); scenarios assume it starts empty.
+				workflowData: { ...workflowEntity, staticData: undefined },
 				userId: user.id,
 				executionData,
 				pinData,

--- a/packages/cli/src/modules/instance-ai/eval/pin-data-generator.ts
+++ b/packages/cli/src/modules/instance-ai/eval/pin-data-generator.ts
@@ -13,6 +13,7 @@
 import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import type { WorkflowJSON, NodeJSON } from '@n8n/workflow-sdk';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { OperationalError } from 'n8n-workflow';
 import { join } from 'path';
 
 import { buildDateAnchors } from './date-anchors';
@@ -598,7 +599,8 @@ function parsePinDataResponse(responseText: string, expectedNodes: string[]): Pi
 
 	for (const nodeName of expectedNodes) {
 		const nodeData = parsed[nodeName];
-		if (!Array.isArray(nodeData) || nodeData.length === 0) continue;
+		// Keep empty arrays — a valid "no stored data" pin; dropping one falls back to real execution.
+		if (!Array.isArray(nodeData)) continue;
 
 		pinData[nodeName] = nodeData.map((item: unknown) => {
 			// The execution engine expects { json: IDataObject } format.
@@ -686,7 +688,8 @@ export function repairStructuredAgentOutput(
  * The caller decides which nodes need pin data (via nodeNames).
  * This function only generates it.
  *
- * @returns PinData map (node name → data items). Returns {} on failure.
+ * @returns PinData covering every requested node (empty array = valid "no stored data" pin).
+ * @throws when generation fails or a node is missing — a silently unpinned node runs for real.
  */
 export async function generatePinData(options: GeneratePinDataOptions): Promise<PinData> {
 	const { workflow, nodeNames, instructions } = options;
@@ -707,28 +710,32 @@ export async function generatePinData(options: GeneratePinDataOptions): Promise<
 	const userPrompt = buildUserPrompt(workflow, contexts, instructions);
 	const expectedNodeNames = contexts.map((c) => c.nodeName);
 
-	try {
-		const agent = createEvalAgent('eval-pin-data-generator', {
-			instructions: SYSTEM_PROMPT,
-			cache: true,
-		});
+	const agent = createEvalAgent('eval-pin-data-generator', {
+		instructions: SYSTEM_PROMPT,
+		cache: true,
+	});
 
-		const result = await agent.generate(userPrompt, {
-			providerOptions: { anthropic: { maxTokens: 16_384 } },
-			abortSignal: AbortSignal.timeout(PIN_DATA_LLM_TIMEOUT_MS),
-		});
+	const result = await agent.generate(userPrompt, {
+		providerOptions: { anthropic: { maxTokens: 16_384 } },
+		abortSignal: AbortSignal.timeout(PIN_DATA_LLM_TIMEOUT_MS),
+	});
 
-		const responseText = extractText(result);
-		const pinData = parsePinDataResponse(responseText, expectedNodeNames);
-		// The `{ output: ... }` envelope repair only holds for Agent roots —
-		// chainLlm unwraps parser output flat, so wrapping it would break
-		// downstream references.
-		const agentParserTargets = [...outputParserTargets.keys()].filter(
-			(name) =>
-				name in pinData && targetNodes.some((n) => n.name === name && n.type === AGENT_NODE_TYPE),
+	const responseText = extractText(result);
+	const pinData = parsePinDataResponse(responseText, expectedNodeNames);
+
+	const missing = expectedNodeNames.filter((name) => !(name in pinData));
+	if (missing.length > 0) {
+		throw new OperationalError(
+			`Pin data generation returned no data for node(s): ${missing.join(', ')}`,
 		);
-		return repairStructuredAgentOutput(pinData, agentParserTargets);
-	} catch {
-		return {};
 	}
+
+	// The `{ output: ... }` envelope repair only holds for Agent roots —
+	// chainLlm unwraps parser output flat, so wrapping it would break
+	// downstream references.
+	const agentParserTargets = [...outputParserTargets.keys()].filter(
+		(name) =>
+			name in pinData && targetNodes.some((n) => n.name === name && n.type === AGENT_NODE_TYPE),
+	);
+	return repairStructuredAgentOutput(pinData, agentParserTargets);
 }


### PR DESCRIPTION
## Summary

Two eval-seam fixes that make scenario executions start from the state their `dataSetup` promises, instead of inheriting shared/persisted state. Both were found while validating the `revises-plan-after-rejection` scenario restoration, each caught red-handed with a reproduction.

**1. Empty pin data was silently dropped → data-table reads ran REAL (`pin-data-generator.ts`).**
#33530 pins Data Table row-reads with LLM-generated stored state, and its own prompt rule 8 tells the generator that a boring/empty case is usually the point — so for "no stored data" scenarios the generator correctly returns `{"Node": []}`. The parser then threw that away (`length === 0 → continue`), the node was never pinned, and it executed for real against the shared eval project. Observed: 3/4 builds ran their dedup `get` for real; one deterministic repro read **4 leaked rows** from a previous run's table. The engine honors empty pins and applies `alwaysOutputData` *after* the pin branch, so a kept empty pin reproduces real empty-table semantics for both flag states — no substitution logic needed. `generatePinData` also swallowed every error to `{}`, making the execution service's FRAMEWORK ISSUE wrapping dead code; it now propagates errors and throws when the response misses a requested node (silently-unpinned bypass nodes were the failure mode this whole class hides).

**2. Workflow static data leaked from builder-verify into scenarios (`execution.service.ts`).**
A build that implements dedup via `getWorkflowStaticData()` gets its cursor persisted by the builder's own verification run; the eval scenario then starts with the cursor advanced, filters out every mocked row, and fails (judge-attributed as framework noise, observed live). Eval executions now run with `staticData` blanked.

## Validation

- Unit: new `pin-data-generator.test.ts` (empty pins kept incl. code-fenced, wrapping, missing-node throw, non-JSON throw, error propagation) + a `staticData`-blanking assertion in `execution.service.test.ts`. Full eval module suite green (478 tests → 497 incl. new).
- Deterministic repro flip: same imported workflow + request went from `Get Posted Keys: real, outputs=4` (leaked rows) before, to `pinned, outputs=1` (empty pin + alwaysOutputData phantom) after.
- Case sweep against a local instance on this branch's dist: `datatable-exact-spec-schema` 5/5, `workflow-data-table` PASS, `revises-plan-after-rejection` ×3 → 15/15 trials (during the pre-static-data-fix sweep, the one failure was exactly the static-data leak, judge-attributed — fixed by commit 2). Data-table reads now show `pinned` in nodeResults across differently-shaped builds.

## How to test

- `cd packages/cli && pnpm vitest run src/modules/instance-ai/eval/`
- Live: run `pnpm eval:instance-ai --filter workflow-data-table --base-url <local>` and check the scenario's nodeResults — Data Table `get`/`rowExists`/`rowNotExists` nodes report `executionMode: pinned` even when the scenario describes empty stored state.

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

## Merge order

Merge this before #33433: the restored `revises-plan-after-rejection` execution scenario relies on data-table read pins that, without this fix, get silently dropped whenever the generator correctly answers "empty stored state".
