### PR TITLE
fix(Redis Chat Memory Node): Fix orphaned tool-call messages causing OpenAI Responses API errors

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryBufferWindow/MemoryBufferWindow.node.ts
@@ -1,4 +1,5 @@
 import type { BufferWindowMemoryInput } from '@langchain/classic/memory';
+import { withOrphanCleanup } from '@utils/memory/withOrphanCleanup';
 import { BufferWindowMemory } from '@langchain/classic/memory';
 import {
 	NodeConnectionTypes,
@@ -48,7 +49,7 @@ class MemoryChatBufferSingleton {
 		if (memoryInstance) {
 			memoryInstance.last_accessed = new Date();
 		} else {
-			const newMemory = new BufferWindowMemory(memoryParams);
+			const newMemory = withOrphanCleanup(new BufferWindowMemory(memoryParams));
 
 			memoryInstance = {
 				buffer: newMemory,

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryMongoDbChat/MemoryMongoDbChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryMongoDbChat/MemoryMongoDbChat.node.ts
@@ -1,6 +1,7 @@
 import { MongoDBChatMessageHistory } from '@langchain/mongodb';
 import { BufferWindowMemory } from '@langchain/classic/memory';
 import { MongoClient } from 'mongodb';
+import { withOrphanCleanup } from '@utils/memory/withOrphanCleanup';
 import type {
 	ISupplyDataFunctions,
 	INodeType,
@@ -146,14 +147,16 @@ export class MemoryMongoDbChat implements INodeType {
 				sessionId,
 			});
 
-			const memory = new BufferWindowMemory({
-				memoryKey: 'chat_history',
-				chatHistory: mongoDBChatHistory,
-				returnMessages: true,
-				inputKey: 'input',
-				outputKey: 'output',
-				k: this.getNodeParameter('contextWindowLength', itemIndex, 5) as number,
-			});
+			const memory = withOrphanCleanup(
+				new BufferWindowMemory({
+					memoryKey: 'chat_history',
+					chatHistory: mongoDBChatHistory,
+					returnMessages: true,
+					inputKey: 'input',
+					outputKey: 'output',
+					k: this.getNodeParameter('contextWindowLength', itemIndex, 5) as number,
+				}),
+			);
 
 			async function closeFunction() {
 				await client.close();

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
@@ -1,5 +1,6 @@
 import { PostgresChatMessageHistory } from '@langchain/community/stores/message/postgres';
 import { BufferMemory, BufferWindowMemory } from '@langchain/classic/memory';
+import { withOrphanCleanup } from '@utils/memory/withOrphanCleanup';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
 import { postgresConnectionTest } from 'n8n-nodes-base/dist/nodes/Postgres/v2/methods/credentialTest';
@@ -107,14 +108,16 @@ export class MemoryPostgresChat implements INodeType {
 				? {}
 				: { k: this.getNodeParameter('contextWindowLength', itemIndex) };
 
-		const memory = new memClass({
-			memoryKey: 'chat_history',
-			chatHistory: pgChatHistory,
-			returnMessages: true,
-			inputKey: 'input',
-			outputKey: 'output',
-			...kOptions,
-		});
+		const memory = withOrphanCleanup(
+			new memClass({
+				memoryKey: 'chat_history',
+				chatHistory: pgChatHistory,
+				returnMessages: true,
+				inputKey: 'input',
+				outputKey: 'output',
+				...kOptions,
+			}),
+		);
 
 		return {
 			response: logWrapper(memory, this),

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryRedisChat/MemoryRedisChat.node.ts
@@ -1,5 +1,7 @@
 import type { RedisChatMessageHistoryInput } from '@langchain/redis';
+import { withOrphanCleanup } from '@utils/memory/withOrphanCleanup';
 import { RedisChatMessageHistory } from '@langchain/redis';
+
 import { BufferMemory, BufferWindowMemory } from '@langchain/classic/memory';
 import {
 	NodeOperationError,
@@ -166,14 +168,16 @@ export class MemoryRedisChat implements INodeType {
 				? {}
 				: { k: this.getNodeParameter('contextWindowLength', itemIndex) };
 
-		const memory = new memClass({
-			memoryKey: 'chat_history',
-			chatHistory: redisChatHistory,
-			returnMessages: true,
-			inputKey: 'input',
-			outputKey: 'output',
-			...kOptions,
-		});
+		const memory = withOrphanCleanup(
+			new memClass({
+				memoryKey: 'chat_history',
+				chatHistory: redisChatHistory,
+				returnMessages: true,
+				inputKey: 'input',
+				outputKey: 'output',
+				...kOptions,
+			}),
+		);
 
 		async function closeFunction() {
 			void client.disconnect();

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
@@ -1,6 +1,7 @@
 import { XataChatMessageHistory } from '@langchain/community/stores/message/xata';
 import { BaseClient } from '@xata.io/client';
 import { BufferMemory, BufferWindowMemory } from '@langchain/classic/memory';
+import { withOrphanCleanup } from '@utils/memory/withOrphanCleanup';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import type {
 	ISupplyDataFunctions,
@@ -144,14 +145,16 @@ export class MemoryXata implements INodeType {
 				? {}
 				: { k: this.getNodeParameter('contextWindowLength', itemIndex) };
 
-		const memory = new memClass({
-			chatHistory,
-			memoryKey: 'chat_history',
-			returnMessages: true,
-			inputKey: 'input',
-			outputKey: 'output',
-			...kOptions,
-		});
+		const memory = withOrphanCleanup(
+			new memClass({
+				chatHistory,
+				memoryKey: 'chat_history',
+				returnMessages: true,
+				inputKey: 'input',
+				outputKey: 'output',
+				...kOptions,
+			}),
+		);
 
 		return {
 			response: logWrapper(memory, this),

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -161,7 +161,7 @@ export function buildToolContext(steps: ToolCallData[]): string {
  * @param chatHistory - Array of messages to clean up
  * @returns Cleaned array with orphaned messages removed from the start
  */
-function cleanupOrphanedMessages(chatHistory: BaseMessage[]): BaseMessage[] {
+export function cleanupOrphanedMessages(chatHistory: BaseMessage[]): BaseMessage[] {
 	let changed = true;
 	while (changed && chatHistory.length > 0) {
 		changed = false;

--- a/packages/@n8n/nodes-langchain/utils/memory/test/withOrphanCleanup.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/memory/test/withOrphanCleanup.test.ts
@@ -1,0 +1,82 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { Mocked } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { withOrphanCleanup, type ChatMemoryWithKey } from '../withOrphanCleanup';
+
+describe('withOrphanCleanup', () => {
+	let mockMemory: Mocked<ChatMemoryWithKey>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockMemory = mock<ChatMemoryWithKey>();
+		mockMemory.memoryKey = 'chat_history';
+	});
+
+	it('strips a leading orphaned ToolMessage (window cut mid tool-call sequence)', async () => {
+		const orphanToolMessage = new ToolMessage({ content: '42', tool_call_id: 'call-1' });
+		const humanMessage = new HumanMessage('Thanks');
+		const aiMessage = new AIMessage('You are welcome');
+
+		mockMemory.loadMemoryVariables.mockResolvedValue({
+			chat_history: [orphanToolMessage, humanMessage, aiMessage],
+		});
+
+		const wrapped = withOrphanCleanup(mockMemory);
+		const result = await wrapped.loadMemoryVariables({});
+
+		expect(result.chat_history).toEqual([humanMessage, aiMessage]);
+	});
+
+	it('strips a leading orphaned AIMessage(tool_calls) with no following ToolMessage', async () => {
+		const orphanAIMessage = new AIMessage({
+			content: '',
+			tool_calls: [{ id: 'call-1', name: 'search', args: {}, type: 'tool_call' }],
+		});
+		const humanMessage = new HumanMessage('Hello again');
+
+		mockMemory.loadMemoryVariables.mockResolvedValue({
+			chat_history: [orphanAIMessage, humanMessage],
+		});
+
+		const wrapped = withOrphanCleanup(mockMemory);
+		const result = await wrapped.loadMemoryVariables({});
+
+		expect(result.chat_history).toEqual([humanMessage]);
+	});
+
+	it('leaves a valid, intact tool-call sequence untouched', async () => {
+		const aiMessage = new AIMessage({
+			content: '',
+			tool_calls: [{ id: 'call-1', name: 'search', args: {}, type: 'tool_call' }],
+		});
+		const toolMessage = new ToolMessage({ content: 'result', tool_call_id: 'call-1' });
+		const chatHistory = [aiMessage, toolMessage];
+
+		mockMemory.loadMemoryVariables.mockResolvedValue({ chat_history: chatHistory });
+
+		const wrapped = withOrphanCleanup(mockMemory);
+		const result = await wrapped.loadMemoryVariables({});
+
+		expect(result.chat_history).toEqual(chatHistory);
+	});
+
+	it('passes through non-array / missing history untouched', async () => {
+		mockMemory.loadMemoryVariables.mockResolvedValue({});
+
+		const wrapped = withOrphanCleanup(mockMemory);
+		const result = await wrapped.loadMemoryVariables({});
+
+		expect(result).toEqual({});
+	});
+
+	it('forwards the input values to the original loadMemoryVariables', async () => {
+		mockMemory.loadMemoryVariables.mockResolvedValue({ chat_history: [] });
+
+		const originalSpy = mockMemory.loadMemoryVariables;
+		const wrapped = withOrphanCleanup(mockMemory);
+		await wrapped.loadMemoryVariables({ input: 'hi' });
+
+		expect(originalSpy).toHaveBeenCalledWith({ input: 'hi' });
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/memory/withOrphanCleanup.ts
+++ b/packages/@n8n/nodes-langchain/utils/memory/withOrphanCleanup.ts
@@ -1,0 +1,49 @@
+import type { BaseChatMemory } from '@langchain/classic/memory';
+import type { InputValues, MemoryVariables } from '@langchain/core/memory';
+
+import { cleanupOrphanedMessages } from '../agent-execution/memoryManagement';
+
+/**
+ * Wraps a chat memory instance so `loadMemoryVariables()` always returns a
+ * history that is free of orphaned tool-call sequences.
+ *
+ * Windowed memories (e.g. `BufferWindowMemory` with a `k` / "Context Window
+ * Length" setting) truncate history by raw message count. That truncation
+ * has no notion of a "conversation turn", so it can easily cut a stored
+ * history in the middle of a tool-call exchange, leaving either:
+ *   - a `ToolMessage` whose originating `AIMessage(tool_calls)` fell outside
+ *     the window, or
+ *   - an `AIMessage` with `tool_calls` whose `ToolMessage` result fell
+ *     outside the window.
+ *
+ * Providers such as the OpenAI Responses API validate this pairing and
+ * reject the request (e.g. "No tool call found for function call output
+ * with call_id ...") when it is broken. This wrapper removes any such
+ * orphans from the start of the loaded history before it is handed back to
+ * the caller (agent executor, chain, etc.), regardless of which code path
+ * reads the memory.
+ *
+ * This is applied at the memory-node level (Redis, Postgres, MongoDB, Xata,
+ * Buffer Window) so it protects every consumer uniformly, rather than
+ * relying on each agent implementation to clean up after itself.
+ */
+
+export type ChatMemoryWithKey = BaseChatMemory & { memoryKey: string };
+
+export function withOrphanCleanup<T extends ChatMemoryWithKey>(memory: T): T {
+	const originalLoadMemoryVariables = memory.loadMemoryVariables.bind(memory);
+
+	memory.loadMemoryVariables = async (values: InputValues): Promise<MemoryVariables> => {
+		const result = await originalLoadMemoryVariables(values);
+		const key = memory.memoryKey;
+		const history = result[key];
+
+		if (Array.isArray(history)) {
+			result[key] = cleanupOrphanedMessages([...history]);
+		}
+
+		return result;
+	};
+
+	return memory;
+}


### PR DESCRIPTION
## Summary

Windowed chat memory nodes (Redis, Postgres, MongoDB, Xata, Buffer Window) truncate stored
history by raw message count via LangChain's `BufferWindowMemory` `k` option. That truncation
has no notion of a "conversation turn," so it can cut a stored history in the middle of a
tool-call exchange - leaving either a `ToolMessage` whose originating `AIMessage(tool_calls)`
fell outside the window, or an `AIMessage(tool_calls)` whose result fell outside the window.

The OpenAI Responses API validates this tool-call/tool-result pairing strictly and rejects the
request with `No tool call found for function call output with call_id ...` when it's broken.

A cleanup for this already existed in `ToolsAgent` V2/V3's `loadMemory()` helper
(`cleanupOrphanedMessages`), but that only protects workflows using those agent versions.
Workflows still on the older `ToolsAgent` V1 (plain LangChain `AgentExecutor`, which reads
memory directly) were never covered.

This PR moves the fix to the memory nodes themselves via a new `withOrphanCleanup()` wrapper
in `utils/memory/withOrphanCleanup.ts`, applied to the Redis, Postgres, MongoDB, Xata, and
Buffer Window chat memory nodes. Since it wraps `loadMemoryVariables()` directly on the memory
instance, it protects every consumer of that memory - any agent version, or any custom usage -
rather than relying on each agent implementation to clean up after itself.

## How to test

1. Build a workflow: **Chat Trigger → AI Agent (Tools Agent) → Redis Chat Memory** (connected
   to the Agent's memory input) + an **OpenAI Chat Model** with the **Responses API** enabled,
   plus one simple tool (e.g. Calculator or an HTTP tool).
2. Set the Redis memory node's **Context Window Length** to a low value, e.g. `2`.
3. Send a message that triggers a tool call, then send 2-3 follow-up messages in the same
   session so the low window forces the stored tool-call/tool-result pair to be split by
   truncation.
4. **Before this fix:** the OpenAI Responses API call eventually fails with
   `No tool call found for function call output with call_id ...`.
5. **After this fix:** the conversation continues normally - the orphaned message is silently
   dropped from context instead of being sent.
6. Repeat with **Postgres Chat Memory**, **MongoDB Chat Memory**, **Xata Chat Memory**, and
   **Simple Memory (buffer window)** to confirm all five affected nodes are fixed.

Unit tests: `pnpm --filter n8n-nodes-langchain test -- withOrphanCleanup`

## Related Linear tickets, Github issues, and Community forum posts

Closes #33431

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if urgent)

---

**Note for reviewers:** this PR touches 5 memory node files since they all share the same
`BufferWindowMemory`/`BufferMemory` truncation issue. If you'd prefer to keep the initial PR
scoped strictly to the reported Redis case, I'm happy to split Postgres/MongoDB/Xata/Buffer
Window into follow-up PRs — the shared `withOrphanCleanup()` utility makes that trivial, since
each node only needs the same one-import + one-wrapped-constructor change.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33590">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

