### PR TITLE
fix(core): resolve evaluation queue loop from null runData in queue mode

### DIFF
--- a/packages/cli/src/__tests__/manual-execution.service.test.ts
+++ b/packages/cli/src/__tests__/manual-execution.service.test.ts
@@ -284,6 +284,42 @@ describe('ManualExecutionService', () => {
 			});
 		});
 
+		it('should call workflowExecute.run for full execution when runData is null', async () => {
+			const data = mock<IWorkflowExecutionDataProcess>({
+				executionMode: 'manual',
+				destinationNode: undefined,
+				pinData: undefined,
+				runData: null as unknown as any,
+			}) as unknown as IWorkflowExecutionDataProcess;
+
+			const workflow = mock<Workflow>({
+				getNode: vi.fn().mockReturnValue(null),
+				getTriggerNodes: vi.fn().mockReturnValue([]),
+			});
+
+			const additionalData = mock<IWorkflowExecuteAdditionalData>();
+			const executionId = 'test-execution-id-null-run-data';
+
+			const mockRun = vi.fn().mockReturnValue('mockRunReturn');
+			vi.mocked(WorkflowExecute).mockImplementationOnce(function () {
+				return {
+					run: mockRun,
+					processRunExecutionData: vi.fn(),
+				};
+			});
+
+			await manualExecutionService.runManually(data, workflow, additionalData, executionId);
+
+			expect(mockRun).toHaveBeenCalledWith({
+				workflow,
+				startNode: undefined,
+				destinationNode: undefined,
+				pinData: undefined,
+				triggerToStartFrom: data.triggerToStartFrom,
+				additionalRunFilterNodes: [],
+			});
+		});
+
 		it('should use execution start node when available for full execution', async () => {
 			const data = mock<IWorkflowExecutionDataProcess>({
 				executionMode: 'manual',

--- a/packages/cli/src/manual-execution.service.ts
+++ b/packages/cli/src/manual-execution.service.ts
@@ -103,7 +103,11 @@ export class ManualExecutionService {
 				executionData,
 			);
 			return workflowExecute.processRunExecutionData(workflow);
-		} else if (data.runData === undefined || data.executionMode === 'evaluation') {
+		} else if (
+			data.runData === undefined ||
+			data.runData === null ||
+			data.executionMode === 'evaluation'
+		) {
 			// Full Execution
 			// TODO: When the old partial execution logic is removed this block can
 			// be removed and the previous one can be merged into

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -259,7 +259,7 @@ export class JobProcessor {
 				workflowData: execution.workflowData,
 				destinationNode: startData?.destinationNode,
 				startNodes: startData?.startNodes,
-				runData: resultData.runData,
+				runData: resultData.runData ?? undefined,
 				pinData: resultData.pinData,
 				dirtyNodeNames: manualData?.dirtyNodeNames,
 				triggerToStartFrom: manualData?.triggerToStartFrom,


### PR DESCRIPTION
Fixes #31522
Linear Ticket: https://linear.app/n8n/issue/GHC-8834

## What this PR does
Fixes a serialization mismatch in n8n's queue mode where `runData` is serialized/persisted to the database as `null`, but workers expect `undefined`. This mismatch incorrectly directed manual execution reruns (like those triggered sequentially by evaluation triggers in the frontend) into the partial execution path, causing them to crash with an assertion error. 
Because the workers crashed during initialization before they could emit execution lifecycle hooks, the main process was never notified, leaving the runs stuck in a "Queued" or "Running" state forever and stalling the evaluation trigger loop.

## How to test
1. Enable queue execution mode in your n8n configuration.
2. Run an evaluation workflow manually from the editor.
3. Verify that the workflow transitions through the evaluation trigger rows sequentially without getting stuck in the queue or entering an infinite loop.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33591">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

