### PR TITLE
fix(Rundeck Node): Verify TLS certificates by default

### DIFF
--- a/packages/nodes-base/credentials/RundeckApi.credentials.ts
+++ b/packages/nodes-base/credentials/RundeckApi.credentials.ts
@@ -27,6 +27,13 @@ export class RundeckApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'Allow Unauthorized Certificates',
+			name: 'allowUnauthorizedCerts',
+			type: 'boolean',
+			description: 'Whether to connect even if SSL certificate validation is not possible',
+			default: false,
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -43,6 +50,7 @@ export class RundeckApi implements ICredentialType {
 			baseURL: '={{$credentials.url}}',
 			url: '/api/14/system/info',
 			method: 'GET',
+			skipSslCertificateValidation: '={{$credentials.allowUnauthorizedCerts}}',
 		},
 	};
 }

--- a/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
+++ b/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
@@ -10,6 +10,7 @@ import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 export interface RundeckCredentials {
 	url: string;
 	token: string;
+	allowUnauthorizedCerts?: boolean;
 }
 
 export class RundeckApi {
@@ -30,7 +31,7 @@ export class RundeckApi {
 		const credentialType = 'rundeckApi';
 
 		const options: IRequestOptions = {
-			rejectUnauthorized: false,
+			rejectUnauthorized: !this.credentials?.allowUnauthorizedCerts,
 			method,
 			qs: query,
 			uri: (this.credentials?.url as string) + endpoint,

--- a/packages/nodes-base/nodes/Rundeck/test/RundeckApi.test.ts
+++ b/packages/nodes-base/nodes/Rundeck/test/RundeckApi.test.ts
@@ -1,0 +1,66 @@
+import type { IDataObject, IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+
+import { RundeckApi } from '../RundeckApi';
+
+function buildFunctions(credentials: IDataObject) {
+	const requestWithAuthentication = vi.fn(async () => ({}));
+	const getCredentials = vi.fn(async () => credentials);
+
+	const functions = {
+		getCredentials,
+		getNode: vi.fn(
+			() =>
+				({
+					id: 'rundeck-node',
+					name: 'Rundeck',
+					type: 'n8n-nodes-base.rundeck',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				}) as INode,
+		),
+		helpers: {
+			requestWithAuthentication,
+		},
+	} as unknown as IExecuteFunctions;
+
+	return { functions, requestWithAuthentication };
+}
+
+function requestOptions(requestWithAuthentication: Mock) {
+	return requestWithAuthentication.mock.calls[0][1] as IDataObject;
+}
+
+describe('RundeckApi TLS certificate verification', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('verifies the server certificate by default', async () => {
+		const { functions, requestWithAuthentication } = buildFunctions({
+			url: 'https://rundeck.example.com',
+			token: 'token',
+		});
+
+		const api = new RundeckApi(functions);
+		await api.init();
+		await api.getJobMetadata('1');
+
+		expect(requestOptions(requestWithAuthentication).rejectUnauthorized).toBe(true);
+	});
+
+	it('skips verification only when allowUnauthorizedCerts is enabled', async () => {
+		const { functions, requestWithAuthentication } = buildFunctions({
+			url: 'https://rundeck.example.com',
+			token: 'token',
+			allowUnauthorizedCerts: true,
+		});
+
+		const api = new RundeckApi(functions);
+		await api.init();
+		await api.getJobMetadata('1');
+
+		expect(requestOptions(requestWithAuthentication).rejectUnauthorized).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

`nodes/Rundeck/RundeckApi.ts` hardcodes `rejectUnauthorized: false` on every API
request, disabling TLS certificate verification for **all** traffic to the
configured Rundeck server — including the `X-Rundeck-Auth-Token` and
job-execution calls — with no user control. A network attacker between n8n and
Rundeck can present any certificate, capture the token, and trigger arbitrary
jobs. There is currently no option to re-enable verification.

In the common local setup (the credential's placeholder is `http://127.0.0.1:4440`)
requests are plain HTTP and this flag is a no-op, so those users are unaffected;
the change only takes effect for deployments that use HTTPS.

## Change

Follows the existing n8n convention for HTTP credentials (MISP, Splunk, ERPNext,
Zammad, …): an **Allow Unauthorized Certificates** toggle on the `rundeckApi`
credential, defaulting to `false`, honored in the request.

- `RundeckApi.credentials.ts` — new `allowUnauthorizedCerts` boolean (default
  `false`) + `skipSslCertificateValidation` on the credential test.
- `RundeckApi.ts` — `rejectUnauthorized: !credentials.allowUnauthorizedCerts`.

## Compatibility

This flips the effective default from "never verify" to "verify" for HTTPS
Rundeck servers. Setups that connect over HTTPS with a self-signed/invalid
certificate will need to enable **Allow Unauthorized Certificates** on their
credential — matching how the other HTTP credentials in n8n already behave.

## Testing

The change mirrors the existing MISP/Splunk/ERPNext credential pattern
(`rejectUnauthorized` derived from `allowUnauthorizedCerts`,
`skipSslCertificateValidation` on the credential test), so it is type-safe by
construction; the credential's connection test (`GET /api/14/system/info`) now
exercises the new wiring. I relied on CI for the full lint/type/test run rather
than building the whole monorepo locally.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33593">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

