### PR TITLE
fix(workflow-sdk): point generate-types export at dist files

### DIFF
--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -9,8 +9,8 @@
     },
     "./package.json": "./package.json",
     "./scripts/generate-types": {
-      "types": "./src/generate-types/generate-types.ts",
-      "default": "./src/generate-types/generate-types.ts"
+      "types": "./dist/generate-types/generate-types.d.ts",
+      "default": "./dist/generate-types/generate-types.js"
     },
     "./dist/generate-types/generate-types": {
       "default": "./dist/generate-types/generate-types.js"


### PR DESCRIPTION
## Summary
- point the `@n8n/workflow-sdk` `./scripts/generate-types` export at the built `dist` files included in the published package
- keep the existing `./dist/generate-types/generate-types` export untouched

## Why
`package.json` currently points `./scripts/generate-types` to `./src/generate-types/generate-types.ts`, but the package publishes `dist/**/*`. The issue reproduction shows the subpath import failing because the referenced source file is not present in the package, while `dist/generate-types/generate-types.js` is present.

## Verification
- Checked the package metadata against the reproduction in #31980
- Verified the PR diff only changes `packages/@n8n/workflow-sdk/package.json`

Fixes #31980

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33598">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

