### PR TITLE
fix: update YouTube playlistId handling for playlistItem getAll (#33594)

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/PlaylistItemDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/PlaylistItemDescription.ts
@@ -46,14 +46,10 @@ export const playlistItemFields: INodeProperties[] = [
 	/*                                 playlistItem:add                           */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Playlist Name or ID',
+		displayName: 'Playlist ID',
 		name: 'playlistId',
-		type: 'options',
-		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-		typeOptions: {
-			loadOptionsMethod: 'getPlaylists',
-		},
+		type: 'string',
+		description: 'Enter the playlist ID, or use an expression to specify one.',
 		required: true,
 		displayOptions: {
 			show: {
@@ -253,14 +249,10 @@ export const playlistItemFields: INodeProperties[] = [
 	/*                                 playlistItem:getAll                        */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Playlist Name or ID',
+		displayName: 'Playlist ID',
 		name: 'playlistId',
-		type: 'options',
-		description:
-			'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-		typeOptions: {
-			loadOptionsMethod: 'getPlaylists',
-		},
+		type: 'string',
+		description: 'Enter the playlist ID, or use an expression to specify one.',
 		required: true,
 		displayOptions: {
 			show: {

--- a/packages/nodes-base/nodes/Google/YouTube/__test__/PlaylistItemDescription.test.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/__test__/PlaylistItemDescription.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { playlistItemFields } from '../PlaylistItemDescription';
+
+describe('YouTube Playlist Item description fields', () => {
+	it('should accept arbitrary playlist IDs for add and getAll operations', () => {
+		const addPlaylistField = playlistItemFields.find(
+			(field) =>
+				field.name === 'playlistId' && field.displayOptions?.show?.operation?.includes('add'),
+		);
+		const getAllPlaylistField = playlistItemFields.find(
+			(field) =>
+				field.name === 'playlistId' && field.displayOptions?.show?.operation?.includes('getAll'),
+		);
+
+		expect(addPlaylistField).toBeDefined();
+		expect(addPlaylistField?.type).toBe('string');
+		expect(addPlaylistField?.typeOptions).toBeUndefined();
+
+		expect(getAllPlaylistField).toBeDefined();
+		expect(getAllPlaylistField?.type).toBe('string');
+		expect(getAllPlaylistField?.typeOptions).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Fix YouTube `playlistItem` handling so **Get Many** accepts any valid public playlist ID instead of only playlists from the authenticated user's default channel. This removes the invalid *"value ... is not supported"* behavior and prevents the node from hanging when a playlist ID is supplied via an expression.

## What changed

* Updated `PlaylistItemDescription.ts`

  * Changed `playlistId` for `playlistItem:getAll` from:

    * `type: 'options'` with `loadOptionsMethod: 'getPlaylists'`
    * to `type: 'string'`
  * Changed `playlistId` for `playlistItem:add` to `type: 'string'` for consistency and full expression support.
* Added regression tests in `PlaylistItemDescription.test.ts` that verify:

  * Both `playlistId` fields are plain string inputs.
  * Neither field depends on dynamic load options.

## Root cause

Previously, `playlistId` was implemented as an `options` field populated using `GET /youtube/v3/playlists?mine=true`, which only returns playlists owned by the authenticated user's default channel.

However, the YouTube `playlistItems.list` API accepts **any valid public playlist ID**, including playlists owned by other channels (such as uploads playlists). Restricting the field to loaded options prevented valid playlist IDs from being used and caused expression validation failures or silent execution hangs.

## Why this matters

* Enables the documented, quota-efficient approach of reading a channel's uploads playlist by ID.
* Allows `playlistItem:getAll` to work with public playlists that are not owned by the authenticated user's default channel.
* Prevents the UI from rejecting valid playlist IDs simply because they are not present in the loaded dropdown.

## Tests

Added a regression test for `PlaylistItemDescription`.

Recommended local validation:

```bash
cd packages/nodes-base
pnpm exec vitest run nodes/Google/YouTube/__test__/PlaylistItemDescription.test.ts
```


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

