### PR TITLE
fix(core): Return empty form values when capturing browser secrets (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-browser/src/adapters/playwright.get-element-value.test.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.get-element-value.test.ts
@@ -55,9 +55,10 @@ describe('PlaywrightAdapter.getElementValue', () => {
 		const value = await adapter.getElementValue('p1', { ref: 'e5' });
 
 		expect(value).toBe('secret-in-code-block');
+		expect(locator.innerText).toHaveBeenCalled();
 	});
 
-	it('falls back to inner text when the input value is empty', async () => {
+	it('returns an empty form value without falling back to text', async () => {
 		const locator: FakeLocator = {
 			count: vi.fn().mockResolvedValue(1),
 			inputValue: vi.fn().mockResolvedValue(''),
@@ -67,7 +68,8 @@ describe('PlaywrightAdapter.getElementValue', () => {
 
 		const value = await adapter.getElementValue('p1', { ref: 'e5' });
 
-		expect(value).toBe('text-content');
+		expect(value).toBe('');
+		expect(locator.innerText).not.toHaveBeenCalled();
 	});
 
 	it('reads the value for a selector target', async () => {

--- a/packages/@n8n/mcp-browser/src/adapters/playwright.ts
+++ b/packages/@n8n/mcp-browser/src/adapters/playwright.ts
@@ -1041,14 +1041,12 @@ export class PlaywrightAdapter {
 
 	async getElementValue(pageId: string, target: ElementTarget): Promise<string> {
 		const locator = await this.resolveLocator(pageId, target);
-		let value = '';
 		try {
-			value = await locator.inputValue();
+			return await locator.inputValue();
 		} catch {
-			// Not an <input>/<textarea>/<select>.
+			// Not an <input>/<textarea>/<select> — read its text instead.
+			return await locator.innerText();
 		}
-		if (value !== '') return value;
-		return await locator.innerText();
 	}
 
 	private async resolveLocator(pageId: string, target: ElementTarget): Promise<Locator> {


### PR DESCRIPTION
## Summary

Follow-up to #33518. Addresses [Dimitri's review comment](https://github.com/n8n-io/n8n/pull/33518#discussion_r3520220171) on the merged code.

`PlaywrightAdapter.getElementValue` treated a **present-but-empty** form value as "no value" and fell back to `innerText()`:

```ts
if (value !== '') return value;
return await locator.innerText();
```

For a `<select>` whose selected option has an empty value, `inputValue()` correctly returns `''`, but `innerText()` returns the concatenated option **labels**. So `browser_capture_secret` would store that label text instead of the real empty value:

```html
<select>
  <option value="">empty</option>
  <option value="non-empty">non-empty</option>
</select>
```
→ old code captured `"empty\nnon-empty"` instead of `""`. Same class of bug for any empty `<input>`/`<textarea>`.

### Fix

`inputValue()` already supports `<input>`, `<textarea>` and `<select>` and throws only for non-form elements, so the fallback belongs in the `catch` — return whatever `inputValue()` yields (including `''`), and fall back to `innerText()` only when it throws:

```ts
try {
    return await locator.inputValue();
} catch {
    // Not an <input>/<textarea>/<select> — read its text instead.
    return await locator.innerText();
}
```
## How to test

Use below html file and then instruct instance AI to create a http basic auth credential with username based on the Environment value, then check the credential afterwards: should be empty

[test.html](https://github.com/user-attachments/files/29691320/test.html)


## Related Linear tickets, Github issues, and Community forum posts

Previous PR https://github.com/n8n-io/n8n/pull/33518
https://linear.app/n8n/issue/NODE-5361

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33612">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->