### PR TITLE
fix(editor): Preserve chat input scroll position when editing text mid-content

### DIFF
--- a/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.test.ts
+++ b/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.test.ts
@@ -138,16 +138,30 @@ describe('useAutosizeTextarea', () => {
 			expect(textarea.style.overflowY).toBe('');
 		});
 
-		it('keeps the focused textarea scrolled to the bottom after recalculation', async () => {
+		it('keeps the focused textarea scrolled to the bottom when the caret is at the end', async () => {
 			const wrapper = mount(TestComponent, { attachTo: document.body });
 			const textarea = wrapper.vm.textarea as HTMLTextAreaElement;
 			textarea.focus();
+			textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
 			textarea.scrollTop = 0;
 
 			wrapper.vm.calculateTextareaHeight();
 			await nextTick();
 
 			expect(textarea.scrollTop).toBe(textarea.scrollHeight);
+		});
+
+		it('preserves the scroll position when the caret is mid-content', async () => {
+			const wrapper = mount(TestComponent, { attachTo: document.body });
+			const textarea = wrapper.vm.textarea as HTMLTextAreaElement;
+			textarea.focus();
+			textarea.selectionStart = textarea.selectionEnd = 4;
+			textarea.scrollTop = 5;
+
+			wrapper.vm.calculateTextareaHeight();
+			await nextTick();
+
+			expect(textarea.scrollTop).toBe(5);
 		});
 
 		it('does not calculate styles when disabled', () => {

--- a/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.ts
+++ b/packages/frontend/@n8n/design-system/src/composables/useAutosizeTextarea.ts
@@ -129,8 +129,13 @@ export function useAutosizeTextarea({
 		const textareaElement = toValue(textarea);
 		if (!textareaElement || document.activeElement !== textareaElement) return;
 
-		textareaElement.scrollTop =
-			textareaElement.selectionStart === 0 ? 0 : textareaElement.scrollHeight;
+		// Only force-scroll at the content boundaries; when editing mid-content
+		// the browser keeps the caret visible and we must preserve the user's scroll position
+		if (textareaElement.selectionStart === 0) {
+			textareaElement.scrollTop = 0;
+		} else if (textareaElement.selectionStart === textareaElement.value.length) {
+			textareaElement.scrollTop = textareaElement.scrollHeight;
+		}
 	}
 
 	const calculateTextareaHeight = () => {


### PR DESCRIPTION
## Summary

When editing text in a multi-line chat input (e.g. the agents preview chat) after scrolling
up, the textarea would immediately jump back to the bottom on every keystroke, even though
the caret stayed at the same position higher up in the text.

This was caused by `scrollCaretIntoView()` in `useAutosizeTextarea`, which ran on every
height recalculation and force-set `scrollTop` to `scrollHeight` (bottom) for any caret
position other than 0. It now only force-scrolls at the content boundaries: caret at the
very start scrolls to the top, caret at the very end scrolls to the bottom, and mid-content
edits leave the current scroll position untouched (the browser already keeps the caret
visible natively in that case).

This affects any input built on `N8nChatInput` (agent preview/build chat, Chat Hub, AI
Assistant builder, Instance AI) as well as `N8nInput`'s autosize textarea, since both share
the `useAutosizeTextarea` composable.

## How to test

1. Open an agent's preview chat.
2. Paste or type a prompt long enough to exceed the input's max visible rows (6 rows) so it
   becomes scrollable.
3. Scroll the input up so earlier lines are visible.
4. Click into the middle of the visible text and add/remove a character.
5. Before: the view jumps to the bottom on every edit. After: the view stays put and only
   the edited line changes.
6. Confirm typing at the very end of the text still keeps the bottom (and caret) visible.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-329/bug-long-text-editing-in-preview-chat-ui-issue

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33619">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->