### PR TITLE
feat(editor): Add hover state to N8nSwitch

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nSwitch/Switch.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSwitch/Switch.stories.ts
@@ -93,6 +93,14 @@ export const States = {
 		</div>
 		`,
 	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'All visual states. Hovering a non-disabled switch stretches the thumb slightly along the track, anchored to its side. Disabled switches do not react to hover.',
+			},
+		},
+	},
 } satisfies Story;
 
 export const WithCustomLabel = {

--- a/packages/frontend/@n8n/design-system/src/components/N8nSwitch/Switch.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSwitch/Switch.vue
@@ -99,11 +99,18 @@ const rootAttrs = computed(() => reactiveOmit(attrs, ['class']));
 	transform: translateY(-50%);
 	display: block;
 	background-color: var(--switch--toggle--color);
-	border-radius: 50%;
-	transition: left 0.15s ease;
-	will-change: left;
+	transition:
+		left var(--duration--snappy) var(--easing--ease-out),
+		width var(--duration--snappy) var(--easing--ease-out);
+	will-change: left, width;
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
+
+/*
+ * Hover/press stretch: the thumb elongates by 2px along the track. Unchecked is anchored
+ * left (grows inward to the right), checked is anchored right (left shifts in sync so it
+ * grows inward to the left). Disabled switches don't stretch.
+ */
 
 .label {
 	flex: 1;
@@ -130,10 +137,23 @@ const rootAttrs = computed(() => reactiveOmit(attrs, ['class']));
 .small .switchThumb {
 	width: 12px;
 	height: 12px;
+
+	/* Fixed half-height radius (not 50%) so the thumb reads as a pill while stretched. */
+	border-radius: var(--radius--2xs);
 }
 
 .small .switchRoot[data-state='checked'] .switchThumb {
 	left: calc(100% - 14px);
+}
+
+.small .switchRoot:not([data-disabled]):hover .switchThumb,
+.small .switchRoot:not([data-disabled]):active .switchThumb {
+	width: 14px;
+}
+
+.small .switchRoot[data-state='checked']:not([data-disabled]):hover .switchThumb,
+.small .switchRoot[data-state='checked']:not([data-disabled]):active .switchThumb {
+	left: calc(100% - 16px);
 }
 
 .small .label {
@@ -150,9 +170,22 @@ const rootAttrs = computed(() => reactiveOmit(attrs, ['class']));
 .large .switchThumb {
 	width: 16px;
 	height: 16px;
+
+	/* Fixed half-height radius (not 50%) so the thumb reads as a pill while stretched. */
+	border-radius: var(--radius--xs);
 }
 
 .large .switchRoot[data-state='checked'] .switchThumb {
 	left: calc(100% - 18px);
+}
+
+.large .switchRoot:not([data-disabled]):hover .switchThumb,
+.large .switchRoot:not([data-disabled]):active .switchThumb {
+	width: 18px;
+}
+
+.large .switchRoot[data-state='checked']:not([data-disabled]):hover .switchThumb,
+.large .switchRoot[data-state='checked']:not([data-disabled]):active .switchThumb {
+	left: calc(100% - 20px);
 }
 </style>


### PR DESCRIPTION
## Summary

Adds a subtle hover interaction to the design system's `N8nSwitch` component: hovering or pressing a non-disabled switch stretches the thumb by 2px along the track, anchored to its side (unchecked grows inward from the left, checked grows inward from the right). This gives the switch a tactile, responsive feel consistent with modern toggle interactions.

Implementation notes:

- Pure CSS, no API changes and no new props.
- Uses the design system's motion tokens (`--duration--snappy`, `--easing--ease-out`) for the transition, per review feedback.
- The thumb's `border-radius: 50%` is replaced with fixed half-height radius tokens (`--radius--2xs` small, `--radius--xs` large) so the thumb reads as a pill while stretched. Resolved pixel values are unchanged.
- Disabled switches do not react to hover.
- The `States` Storybook story documents the hover behavior.

## Related Linear tickets, Github issues, and Community forum posts

None. Design system contribution developed while building an internal prototype.

## Review / Merge checklist

- [x] PR title and summary are descriptive. **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.