### PR TITLE
fix(benchmark): Replace deprecated Azure dedicated host SKU (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/infra/vars.tf
+++ b/packages/@n8n/benchmark/infra/vars.tf
@@ -10,13 +10,13 @@ variable "resource_group_name" {
 
 variable "host_size_family" {
   description = "Size Family for the Host Group"
-  default     = "DCSv2-Type1"
+  default     = "DSv5-Type1"
 }
 
 variable "vm_size" {
   description = "VM Size"
   # 8 vCPUs, 32 GiB memory
-  default = "Standard_DC8_v2"
+  default = "Standard_D8s_v5"
 }
 
 variable "number_of_vms" {


### PR DESCRIPTION
## Summary

Nightly benchmark runs fail to provision their cloud environment with `ZonalAllocationFailed` ("We do not have sufficient capacity for the requested host SKU in this zone") when creating the Azure dedicated host. Azure is retiring the DCsv2 series, so capacity for it is drying up.

This swaps the benchmark Terraform defaults to a current SKU:

- `host_size_family`: `DCSv2-Type1` → `DSv5-Type1`
- `vm_size`: `Standard_DC8_v2` → `Standard_D8s_v5` (same 8 vCPU / 32 GiB)

D8s_v5 keeps SCSI disk naming, so the hardcoded `/dev/sdc` wait in `scripts/bootstrap.sh` keeps working (NVMe-only families like v6 would break it), and Premium SSD v2 data disk support carries over.

Notes:

- There is no small dedicated-host SKU anymore, so the host cost goes from ~$0.845/hr to ~$5.28/hr (~6×). For an ephemeral per-run environment this is a few dollars per benchmark run, but it's unavoidable while dedicated-host isolation remains a requirement.
- The CPU generation changes (Coffee Lake → Ice Lake), so benchmark baselines will shift — the first runs on the new host establish a new baseline; don't compare results across the switch.

## How to test

`terraform fmt -check` and `terraform validate` pass. Real proof requires Azure credentials:

1. Run `pnpm provision-cloud-env` from `packages/@n8n/benchmark`, or trigger the nightly benchmark workflow manually.
2. Verify the dedicated host and VM provision successfully and the benchmark completes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3669

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33625">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


