### PR TITLE
test(editor): Stub node-icon svg imports in frontend vitest config

### DIFF
--- a/packages/@n8n/vitest-config/frontend.ts
+++ b/packages/@n8n/vitest-config/frontend.ts
@@ -1,11 +1,24 @@
+import { fileURLToPath } from 'node:url';
 import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 import type { InlineConfig } from 'vitest/node';
 
 import { coverageExcludes } from './coverage-excludes.js';
 
+// Resolves to the empty component that stands in for `.svg` imports (see below).
+const svgStub = fileURLToPath(new URL('./svg-stub.js', import.meta.url));
+
 export const createVitestConfig = (options: InlineConfig = {}) => {
 	const vitestConfig = defineConfig({
 		test: {
+			// Redirect the node-icon `.svg` imports (the ~80 files under
+			// `N8nIcon/nodes/`) to an inert component. `node-icons.ts` is imported
+			// lazily (on the first `node:*` icon render), so its bulk async
+			// `vite-svg-loader` transforms can kick off late and resolve after jsdom
+			// tears down — failing an otherwise-green run with `EnvironmentTeardownError`.
+			// Scoped to `nodes/` because those icons never appear in component
+			// snapshots (unlike the eagerly-imported `custom/` icons), and to
+			// `test.alias` so it never leaks into production/dev builds. See svg-stub.ts.
+			alias: [{ find: /^.*\/nodes\/[^/]+\.svg(\?.*)?$/, replacement: svgStub }],
 			silent: true,
 			globals: true,
 			// Restore `vi.spyOn` spies to their original implementation before each test, so

--- a/packages/@n8n/vitest-config/svg-stub.ts
+++ b/packages/@n8n/vitest-config/svg-stub.ts
@@ -1,0 +1,9 @@
+// Inert stand-in for `.svg` imports in the frontend vitest harness.
+//
+// `icons.ts` / `node-icons.ts` statically import ~100 `.svg` files that
+// `vite-svg-loader` transforms on demand (async). In jsdom an in-flight
+// transform can resolve *after* the environment tears down, surfacing as an
+// `EnvironmentTeardownError` that turns an otherwise-green shard red. Aliasing
+// every `.svg` import to this empty functional component removes the racy
+// transform (see frontend.ts).
+export default () => null;


### PR DESCRIPTION
## Summary

The `Unit tests / Frontend` shard intermittently exits non-zero even though every test passes. An async error escapes *after* the tests finish:

```
EnvironmentTeardownError: Cannot load '.../N8nIcon/nodes/ai-agent.svg?import' imported from node-icons.ts after the environment was torn down.
```

**Root cause:** the design-system `N8nIcon` barrel lazily imports `node-icons.ts`, which statically imports ~80 `.svg` files under `N8nIcon/nodes/`. Each is transformed on demand (async) by `vite-svg-loader`. When a test finishes and jsdom tears down, an in-flight transform can resolve *after* teardown, and Vitest promotes that post-teardown rejection to a run-level failure — so the shard goes red despite no failing test. It is non-deterministic (which svg wins the race varies).

**Fix:** add a `test.alias` in `@n8n/vitest-config/frontend.ts` that redirects node-icon `.svg` imports to an inert stub component (`svg-stub.ts`). The `.svg` id never reaches `vite-svg-loader`, so the racy transform never runs — killing the flake for the whole class (any test that transitively pulls in `node-icons.ts`).

Two deliberate scoping decisions vs. the ticket's "stub all `.svg`" suggestion:

- **`test.alias`, not top-level `resolve.alias`.** `vitestConfig` is merged into editor-ui's *default* Vite export (used by `vite build`/dev too), so a top-level alias would break production svg rendering. `test.alias` applies only under Vitest.
- **Scoped to `nodes/` only.** A blanket stub broke tests that legitimately render svgs — `N8nLogo` (reads svg `outerHTML` for the favicon) and `N8nChatInput` streaming (`custom/filled-square.svg` stop-button icon). Node icons appear in **zero** component snapshots and are the reported flake source, so `nodes/`-only kills the flake with zero snapshot churn while the eagerly-imported `custom/` icons keep rendering.

## How to test

This is a test-harness config change; no runtime/product behavior changes.

- `pnpm --filter @n8n/design-system test` — full suite green (1195 tests), no snapshot changes.
- `pnpm --filter n8n-editor-ui test src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts` (the originally-flaky trigger) plus the canvas node-icon tests — all pass.
- Node `.svg` imports now resolve to the inert stub; `custom/` svgs still resolve to real `vite-svg-loader` components.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-632

Same flake class as DEVP-209, DEVP-201, DEVP-617.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33626">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

