### PR TITLE
test: Centralize the zod CJS-pin alias in shared Vitest config

### DIFF
--- a/packages/@n8n/ai-utilities/vite.config.ts
+++ b/packages/@n8n/ai-utilities/vite.config.ts
@@ -2,21 +2,11 @@ import { createVitestConfig } from '@n8n/vitest-config/node';
 import path from 'node:path';
 import { mergeConfig } from 'vite';
 
-export default mergeConfig(createVitestConfig({}), {
+// `zod` is pinned to its CJS build (via `pinCjs`) so `schema instanceof ZodSchema` in
+// src/converters/tool.ts holds against zod objects created in externalized CJS workspace
+// deps. See `cjsPinAliases` in @n8n/vitest-config/node for the rationale.
+export default mergeConfig(createVitestConfig({}, { pinCjs: ['zod'] }), {
 	resolve: {
-		alias: [
-			{ find: 'src', replacement: path.resolve(__dirname, './src') },
-			// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
-			// Workspace deps CJS-require zod while tests ESM-import it, so
-			// `schema instanceof ZodSchema` in src/converters/tool.ts fails across the
-			// two. Pin the top-level `zod` import to the CJS file so both share one
-			// module instance. `require.resolve` follows zod's `require` export condition,
-			// so it tracks the installed (catalog) version automatically. Subpaths like
-			// `zod/v4` keep their normal resolution.
-			{
-				find: /^zod$/,
-				replacement: require.resolve('zod'),
-			},
-		],
+		alias: [{ find: 'src', replacement: path.resolve(__dirname, './src') }],
 	},
 });

--- a/packages/@n8n/ai-workflow-builder.ee/vitest.config.base.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/vitest.config.base.ts
@@ -5,22 +5,13 @@ import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decora
 // Shared base config for both the unit (vite.config.ts) and integration
 // (vitest.config.integration.ts) runs. Test include/exclude is intentionally
 // left to the extending configs so they don't merge-concatenate each other's globs.
-export const baseConfig = mergeConfig(createVitestConfigWithDecorators({}), {
-	resolve: {
-		alias: [
-			{ find: '@', replacement: path.resolve(__dirname, './src') },
-			// zod has dual ESM/CJS exports (`./dist/esm/index.js` for `import`,
-			// `./dist/cjs/index.js` for `require`) — two separate files with two separate
-			// `ZodType` classes. Workspace deps CJS-require zod, test files ESM-import it, and
-			// `instanceof z.ZodX` checks in source fail between them. Pin the top-level `zod`
-			// import to the CJS file so both code paths share a single module instance.
-			{
-				find: /^zod$/,
-				replacement: path.resolve(
-					__dirname,
-					'../../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
-				),
-			},
-		],
+export const baseConfig = mergeConfig(
+	// Pin `zod` to its CJS build so `instanceof z.ZodError` holds against the externalized
+	// CJS dist. See `cjsPinAliases` in @n8n/vitest-config/node for the rationale.
+	createVitestConfigWithDecorators({}, { pinCjs: ['zod'] }),
+	{
+		resolve: {
+			alias: [{ find: '@', replacement: path.resolve(__dirname, './src') }],
+		},
 	},
-});
+);

--- a/packages/@n8n/instance-ai/vite.config.ts
+++ b/packages/@n8n/instance-ai/vite.config.ts
@@ -84,22 +84,12 @@ function rewriteLazyRequireForTests(): Plugin {
 	};
 }
 
-export default mergeConfig(createVitestConfig({}), {
+// `zod` is pinned to its CJS build (via `pinCjs`) so `instanceof` checks (e.g. in
+// sanitize-mcp-schemas) hold against zod objects created in externalized CJS workspace
+// deps. See `cjsPinAliases` in @n8n/vitest-config/node for the rationale.
+export default mergeConfig(createVitestConfig({}, { pinCjs: ['zod'] }), {
 	plugins: [rewriteLazyRequireForTests()],
 	resolve: {
-		alias: [
-			{ find: '@', replacement: path.resolve(__dirname, './src') },
-			// zod has dual ESM/CJS exports (two separate `ZodType` class identities).
-			// Workspace deps CJS-require zod while test files ESM-import it, so
-			// `instanceof` checks (e.g. in sanitize-mcp-schemas) fail across the two
-			// module instances. Pin the top-level `zod` import to the CJS file so all
-			// code paths share one instance. `require.resolve` follows zod's `require`
-			// export condition, so it tracks the installed (catalog) version
-			// automatically. Subpaths like `zod/v4` resolve normally.
-			{
-				find: /^zod$/,
-				replacement: require.resolve('zod'),
-			},
-		],
+		alias: [{ find: '@', replacement: path.resolve(__dirname, './src') }],
 	},
 });

--- a/packages/@n8n/vitest-config/node-decorators.ts
+++ b/packages/@n8n/vitest-config/node-decorators.ts
@@ -2,8 +2,16 @@ import { mergeConfig } from 'vitest/config';
 import type { InlineConfig } from 'vitest/node';
 import { createVitestConfig } from './node.js';
 
-export const createVitestConfigWithDecorators = (options: InlineConfig = {}) => {
-	const baseConfig = createVitestConfig(options);
+export const createVitestConfigWithDecorators = (
+	options: InlineConfig = {},
+	// `pinCjs` is opt-in per package (default none): pinning a dep to CJS also forces its
+	// transitive dual-build deps to CJS (e.g. `n8n-workflow` drags luxon's `DateTime`
+	// identity along), which can break unrelated `instanceof`/`expect.any` checks. Only
+	// packages whose own tests need a specific dep unified should pass it. See
+	// `cjsPinAliases` for the full rationale.
+	{ pinCjs = [] }: { pinCjs?: string[] } = {},
+) => {
+	const baseConfig = createVitestConfig(options, { pinCjs });
 	return mergeConfig(baseConfig, {
 		test: {
 			server: {

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -1,7 +1,31 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import type { Alias } from 'vite';
 import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 import type { InlineConfig } from 'vitest/node';
 
 import { coverageExcludes } from './coverage-excludes.js';
+
+/**
+ * Pin dual-build (ESM+CJS) deps to their CJS entry so a single class identity is shared
+ * across test/source (which ESM-import the dep) and externalized workspace dist (which
+ * `require()`s the CJS build) — otherwise cross-boundary `instanceof` checks fail. Vite's
+ * externalizer always prefers a dep's `import` export condition, so the two sides land on
+ * different files; rewriting the bare specifier to a concrete CJS path is the only way to
+ * unify them. Resolved from the consuming package (cwd) so it tracks the catalog version.
+ * The exact-match regex leaves subpaths (e.g. `zod/v4`) on their normal resolution. Deps
+ * not resolvable from the package are skipped (harmless — they can't be imported there).
+ */
+export const cjsPinAliases = (deps: string[], from: string = process.cwd()): Alias[] => {
+	const req = createRequire(join(from, 'noop.js'));
+	return deps.flatMap((dep) => {
+		try {
+			return [{ find: new RegExp(`^${dep}$`), replacement: req.resolve(dep) }];
+		} catch {
+			return [];
+		}
+	});
+};
 
 /**
  * Per-suite fork-pool cap, applied only in CI.
@@ -50,7 +74,13 @@ export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig
 	...options,
 });
 
-export const createVitestConfig = (options: InlineConfig = {}) =>
-	defineConfig({ test: createBaseInlineConfig(options) });
+export const createVitestConfig = (
+	options: InlineConfig = {},
+	{ pinCjs = [] }: { pinCjs?: string[] } = {},
+) =>
+	defineConfig({
+		test: createBaseInlineConfig(options),
+		...(pinCjs.length ? { resolve: { alias: cjsPinAliases(pinCjs) } } : {}),
+	});
 
 export const vitestConfig = createVitestConfig();

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -3,37 +3,21 @@ import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decora
 import path from 'node:path';
 
 export default mergeConfig(
-	createVitestConfigWithDecorators({
-		globalSetup: ['./test/setup.ts'],
-		setupFiles: ['./test/setup-mocks.ts'],
-	}),
+	createVitestConfigWithDecorators(
+		{
+			globalSetup: ['./test/setup.ts'],
+			setupFiles: ['./test/setup-mocks.ts'],
+		},
+		// Pin `zod` and `n8n-workflow` to their CJS build so cross-boundary `instanceof`
+		// (`ZodType`, `UserError`) holds against the externalized CJS dist. See
+		// `cjsPinAliases` in @n8n/vitest-config/node for the rationale.
+		{ pinCjs: ['zod', 'n8n-workflow'] },
+	),
 	{
 		resolve: {
 			alias: [
 				{ find: '@', replacement: path.resolve(__dirname, './src') },
 				{ find: '@test', replacement: path.resolve(__dirname, './test') },
-				// zod has dual ESM/CJS exports (`./dist/esm/index.js` for `import`,
-				// `./dist/cjs/index.js` for `require`) — two separate files with two separate
-				// `ZodType` classes. @n8n/config dist CJS-requires zod, test files ESM-import
-				// it, and `instanceof` fails between them. Pin the top-level `zod` import to the
-				// CJS file so both code paths share a single module instance. `require.resolve`
-				// follows zod's `require` export condition, so it tracks the installed (catalog)
-				// version automatically. Subpaths like `zod/v4` keep their normal resolution.
-				{
-					find: /^zod$/,
-					replacement: require.resolve('zod'),
-				},
-				// `n8n-workflow` has dual ESM/CJS builds (`./dist/esm/index.js` for `import`,
-				// `./dist/cjs/index.js` for `require`), each with its own `UserError` class.
-				// `@n8n/backend-network` is loaded from its CJS dist and `require`s the CJS copy,
-				// so `SsrfBlockedIpError extends UserError` (CJS), while test files ESM-import
-				// `UserError` (ESM) — and `instanceof` fails between them. Pin the top-level
-				// `n8n-workflow` import to the CJS file so both code paths share one module
-				// instance. `require.resolve` follows the `require` export condition.
-				{
-					find: /^n8n-workflow$/,
-					replacement: require.resolve('n8n-workflow'),
-				},
 			],
 		},
 		oxc: {


### PR DESCRIPTION
## Summary

Four Vitest configs each carried a duplicated workaround pinning the top-level `zod` import to zod's CJS build:

```ts
{ find: /^zod$/, replacement: require.resolve('zod') }
```

This PR hoists that into a shared, documented `cjsPinAliases` helper in `@n8n/vitest-config`, exposed via an opt-in `pinCjs` option on `createVitestConfig` / `createVitestConfigWithDecorators`, and deletes the four leaf copies.

**Why the alias is needed (a real dual-package hazard, not migration cruft):** `zod@3.25.67` ships dual builds — `dist/esm/index.js` (`import` condition) and `dist/cjs/index.js` (`require` condition) — each with its own `ZodType`/`ZodError` classes. Under Vitest, test/source files ESM-import zod while the DI-externalized workspace deps `require('zod')` (CJS), so cross-boundary `instanceof` returns `false` and tests fail. Pinning to the concrete CJS path is the **only** mechanism that unifies identity: Vite's externalizer always prefers a dep's `import` export condition, so no `resolve.conditions` / `deps.inline` / `optimizer` knob can eliminate the need for it.

**Design notes:**
- `pinCjs` is **opt-in per package** (default none). Pinning a dep to CJS also forces its transitive dual-build deps to CJS — e.g. pinning `n8n-workflow` drags luxon's `DateTime` identity along, which breaks unrelated `expect.any(DateTime)` checks (verified against `@n8n/task-runner`). Only the four packages that need it opt in, so the affected set is unchanged.
- The helper resolves from the consuming package (cwd), tracking the catalog version; the exact-match regex leaves subpaths like `zod/v4` untouched; unresolvable deps are skipped.
- De-fragilizes `ai-workflow-builder.ee`, which previously **hardcoded** `zod@3.25.67/.../dist/cjs/index.js`. It now resolves dynamically.

Behavior is identical for every package — this is de-duplication + de-fragilization only. Builds on the recently-landed `restoreMocks` default in the same shared configs.

## How to test

Pure test-config change; no runtime/app surface. Rebuild the shared config (it's consumed from dist) and confirm the cross-boundary `instanceof` suites stay green:

```bash
pnpm --filter @n8n/vitest-config build
pnpm --filter n8n-core test run src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
pnpm --filter @n8n/instance-ai test src/agent/__tests__/sanitize-mcp-schemas.test.ts
pnpm --filter @n8n/ai-utilities test src/__tests__/converters/tool.test.ts
pnpm --filter @n8n/ai-workflow-builder test src/tools
# regression guard — a decorator consumer that must NOT get the pin:
pnpm --filter @n8n/task-runner test
```

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to the shared-vitest-config `restoreMocks` change.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33627">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

