### PR TITLE
feat(core): Add role:manageProject scope for project-role-only management

### DIFF
--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -141,6 +141,7 @@ exports[`Scope Information > ensure scopes are defined correctly 1`] = `
   "workflowTags:list",
   "role:manage",
   "role:read",
+  "role:manageProject",
   "mcp:manage",
   "mcp:oauth",
   "mcpApiKey:create",

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -70,7 +70,7 @@ export const RESOURCES = {
 	execution: ['delete', 'read', 'retry', 'list', 'get', 'reveal'] as const,
 	testRun: ['read', 'list'] as const,
 	workflowTags: ['update', 'list'] as const,
-	role: ['manage', 'read'] as const,
+	role: ['manage', 'read', 'manageProject'] as const,
 	mcp: ['manage', 'oauth'] as const,
 	mcpApiKey: ['create', 'rotate'] as const,
 	chatHub: ['manage', 'message'] as const,

--- a/packages/@n8n/permissions/src/roles/custom-role-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/custom-role-scopes.ee.ts
@@ -104,6 +104,7 @@ export const GLOBAL_CUSTOM_ROLE_SCOPE_GROUPS = {
 		],
 	},
 	role: {
+		'Manage project roles': ['role:read', 'role:manageProject'],
 		Manage: ['role:read', 'role:manage'],
 	},
 	apiKey: {

--- a/packages/@n8n/permissions/src/scope-information.ts
+++ b/packages/@n8n/permissions/src/scope-information.ts
@@ -114,4 +114,8 @@ export const scopeInformation: Partial<Record<Scope, ScopeInformation>> = {
 		displayName: 'Execute Workflow in Chat',
 		description: 'Allows executing workflows in chat.',
 	},
+	'role:manageProject': {
+		displayName: 'Manage project roles',
+		description: 'Allows creating, editing, and deleting project role definitions.',
+	},
 };

--- a/packages/cli/src/controllers/__tests__/role.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/role.controller.test.ts
@@ -12,6 +12,13 @@ describe('RoleController', () => {
 	const roleService = mock<RoleService>();
 	const controller = new RoleController(roleService, eventService);
 
+	// A user whose global role grants role:manage, so the controller's
+	// authorization guard short-circuits and these tests can focus on events.
+	const managerRequest = () =>
+		mock<AuthenticatedRequest>({
+			user: { id: '123', role: { scopes: [{ slug: 'role:manage' }] } },
+		});
+
 	beforeEach(() => {
 		vi.restoreAllMocks();
 	});
@@ -19,7 +26,7 @@ describe('RoleController', () => {
 	describe('emits action events', () => {
 		describe('createRole', () => {
 			it('should emit custom-role-created', async () => {
-				const request = mock<AuthenticatedRequest>({ user: { id: '123' } });
+				const request = managerRequest();
 				roleService.createCustomRole.mockResolvedValue({
 					slug: 'custom-editor',
 					scopes: ['workflow:read', 'workflow:update'],
@@ -37,7 +44,8 @@ describe('RoleController', () => {
 
 		describe('updateRole', () => {
 			it('should emit custom-role-updated', async () => {
-				const request = mock<AuthenticatedRequest>({ user: { id: '123' } });
+				const request = managerRequest();
+				roleService.getRole.mockResolvedValue({ roleType: 'project' } as Role);
 				roleService.updateCustomRole.mockResolvedValue({
 					slug: 'custom-editor',
 					scopes: ['workflow:read', 'workflow:update', 'workflow:delete'],
@@ -55,7 +63,8 @@ describe('RoleController', () => {
 
 		describe('deleteRole', () => {
 			it('should emit custom-role-deleted', async () => {
-				const request = mock<AuthenticatedRequest>({ user: { id: '123' } });
+				const request = managerRequest();
+				roleService.getRole.mockResolvedValue({ roleType: 'project' } as Role);
 				roleService.removeCustomRole.mockResolvedValue({
 					slug: 'custom-editor',
 				} as Role);

--- a/packages/cli/src/controllers/role.controller.ts
+++ b/packages/cli/src/controllers/role.controller.ts
@@ -13,7 +13,7 @@ import type {
 	RoleProjectMembersResponse,
 } from '@n8n/api-types';
 import { LICENSE_FEATURES } from '@n8n/constants';
-import { AuthenticatedRequest } from '@n8n/db';
+import { AuthenticatedRequest, User } from '@n8n/db';
 import {
 	Body,
 	Delete,
@@ -26,10 +26,12 @@ import {
 	Query,
 	RestController,
 } from '@n8n/decorators';
-import { Role as RoleDTO } from '@n8n/permissions';
+import { hasGlobalScope, Role as RoleDTO, RoleNamespace } from '@n8n/permissions';
 
 import { EventService } from '@/events/event.service';
 import { RoleService } from '@/services/role.service';
+import { RESPONSE_ERROR_MESSAGES } from '@/constants';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 @RestController('/roles')
 export class RoleController {
@@ -37,6 +39,12 @@ export class RoleController {
 		private readonly roleService: RoleService,
 		private readonly eventService: EventService,
 	) {}
+
+	private assertCanManageRoleType(user: User, roleType: RoleNamespace): void {
+		if (hasGlobalScope(user, 'role:manage')) return;
+		if (roleType === 'project' && hasGlobalScope(user, 'role:manageProject')) return;
+		throw new ForbiddenError(RESPONSE_ERROR_MESSAGES.MISSING_SCOPE);
+	}
 
 	@Get('/')
 	async getAllRoles(
@@ -54,24 +62,26 @@ export class RoleController {
 	}
 
 	@Get('/:slug/assignments/:projectId/members')
-	@GlobalScope('role:manage')
 	async getRoleProjectMembers(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('slug') slug: string,
 		@Param('projectId') projectId: string,
 	): Promise<RoleProjectMembersResponse> {
+		const role = await this.roleService.getRole(slug);
+		this.assertCanManageRoleType(req.user, role.roleType);
 		const result = await this.roleService.getRoleProjectMembers(slug, projectId);
 		return RoleProjectMembersResponseDto.parse(result);
 	}
 
 	@Get('/:slug/assignments')
-	@GlobalScope('role:manage')
 	async getRoleAssignments(
-		_req: AuthenticatedRequest,
+		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('slug') slug: string,
 	): Promise<RoleAssignmentsResponse> {
+		const role = await this.roleService.getRole(slug);
+		this.assertCanManageRoleType(req.user, role.roleType);
 		const result = await this.roleService.getRoleAssignments(slug);
 		return RoleAssignmentsResponseDto.parse(result);
 	}
@@ -98,7 +108,6 @@ export class RoleController {
 	}
 
 	@Patch('/:slug')
-	@GlobalScope('role:manage')
 	@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)
 	async updateRole(
 		req: AuthenticatedRequest,
@@ -106,6 +115,8 @@ export class RoleController {
 		@Param('slug') slug: string,
 		@Body updateRole: UpdateRoleDto,
 	): Promise<RoleDTO> {
+		const role = await this.roleService.getRole(slug);
+		this.assertCanManageRoleType(req.user, role.roleType);
 		const result = await this.roleService.updateCustomRole(slug, updateRole);
 		this.eventService.emit('custom-role-updated', {
 			userId: req.user.id,
@@ -116,13 +127,14 @@ export class RoleController {
 	}
 
 	@Delete('/:slug')
-	@GlobalScope('role:manage')
 	@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)
 	async deleteRole(
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Param('slug') slug: string,
 	): Promise<RoleDTO> {
+		const role = await this.roleService.getRole(slug);
+		this.assertCanManageRoleType(req.user, role.roleType);
 		const result = await this.roleService.removeCustomRole(slug);
 		this.eventService.emit('custom-role-deleted', {
 			userId: req.user.id,
@@ -132,13 +144,13 @@ export class RoleController {
 	}
 
 	@Post('/')
-	@GlobalScope('role:manage')
 	@Licensed(LICENSE_FEATURES.CUSTOM_ROLES)
 	async createRole(
 		req: AuthenticatedRequest,
 		_res: Response,
 		@Body createRole: CreateRoleDto,
 	): Promise<RoleDTO> {
+		this.assertCanManageRoleType(req.user, createRole.roleType);
 		const result = await this.roleService.createCustomRole(createRole);
 		this.eventService.emit('custom-role-created', {
 			userId: req.user.id,

--- a/packages/cli/test/integration/access-control/instance-roles.test.ts
+++ b/packages/cli/test/integration/access-control/instance-roles.test.ts
@@ -277,7 +277,7 @@ describe('Instance (global) custom role authorization', () => {
 				.expect(200);
 			const global = await agent
 				.post('/roles')
-				.send({ displayName: 'Manage Global Role', roleType: 'global', scopes: ['workflow:read'] })
+				.send({ displayName: 'Manage Global Role', roleType: 'global', scopes: ['role:read'] })
 				.expect(200);
 
 			await agent.delete(`/roles/${project.body.data.slug}`).expect(200);

--- a/packages/cli/test/integration/access-control/instance-roles.test.ts
+++ b/packages/cli/test/integration/access-control/instance-roles.test.ts
@@ -1,7 +1,13 @@
-import { mockInstance, randomCredentialPayload, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	mockInstance,
+	randomCredentialPayload,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
-import { GLOBAL_MEMBER_ROLE } from '@n8n/db';
+import { GLOBAL_MEMBER_ROLE, ScopeRepository } from '@n8n/db';
 import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
 
 import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
@@ -153,6 +159,134 @@ describe('Instance (global) custom role authorization', () => {
 			);
 
 			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/members`).expect(403);
+		});
+	});
+
+	describe('project-role administration (role:manageProject)', () => {
+		// A custom global role granted ONLY role:manageProject — the least-privilege
+		// "project role administrator". It must manage project roles yet be barred
+		// from every other roleType, and never gain role:manage's global reach.
+		const MANAGE_PROJECT = ['role:manageProject'];
+
+		test('role:manageProject can create a project role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+
+			await agent
+				.post('/roles')
+				.send({
+					displayName: 'Created Project Role',
+					roleType: 'project',
+					scopes: ['workflow:read'],
+				})
+				.expect(200);
+		});
+
+		test('role:manageProject cannot create a global role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+
+			await agent
+				.post('/roles')
+				.send({ displayName: 'Blocked Global Role', roleType: 'global', scopes: ['workflow:read'] })
+				.expect(403);
+		});
+
+		test('role:manageProject can update and delete a project role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+			const projectRole = await createCustomRoleWithScopeSlugs(['workflow:read'], {
+				roleType: 'project',
+				displayName: 'Editable Project Role',
+			});
+
+			await agent.patch(`/roles/${projectRole.slug}`).send({ displayName: 'Renamed' }).expect(200);
+			await agent.delete(`/roles/${projectRole.slug}`).expect(200);
+		});
+
+		test('role:manageProject cannot update or delete a global role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+			const globalRole = await createCustomRoleWithScopeSlugs(['workflow:read'], {
+				roleType: 'global',
+				displayName: 'Off-Limits Global Role',
+			});
+
+			await agent.patch(`/roles/${globalRole.slug}`).send({ displayName: 'Nope' }).expect(403);
+			await agent.delete(`/roles/${globalRole.slug}`).expect(403);
+		});
+
+		test('role:manageProject can read assignments and project members for a project role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+			const owner = await createOwner();
+			const project = await createTeamProject('Project Role Members', owner);
+			const projectRole = await createCustomRoleWithScopeSlugs(['workflow:read'], {
+				roleType: 'project',
+				displayName: 'Assignable Project Role',
+			});
+
+			await agent.get(`/roles/${projectRole.slug}/assignments`).expect(200);
+			await agent.get(`/roles/${projectRole.slug}/assignments/${project.id}/members`).expect(200);
+		});
+
+		test('role:manageProject cannot read assignments or project members for a global role', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				MANAGE_PROJECT,
+				'Project Role Manager',
+			);
+			const owner = await createOwner();
+			const project = await createTeamProject('Global Role Members', owner);
+
+			await agent.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/assignments`).expect(403);
+			await agent
+				.get(`/roles/${GLOBAL_MEMBER_ROLE.slug}/assignments/${project.id}/members`)
+				.expect(403);
+		});
+
+		test('role:manage still manages roles of every roleType (backwards compatible)', async () => {
+			const { agent } = await createGlobalRoleUser(
+				testServer,
+				['role:manage'],
+				'Full Role Manager',
+			);
+
+			const project = await agent
+				.post('/roles')
+				.send({
+					displayName: 'Manage Project Role',
+					roleType: 'project',
+					scopes: ['workflow:read'],
+				})
+				.expect(200);
+			const global = await agent
+				.post('/roles')
+				.send({ displayName: 'Manage Global Role', roleType: 'global', scopes: ['workflow:read'] })
+				.expect(200);
+
+			await agent.delete(`/roles/${project.body.data.slug}`).expect(200);
+			await agent.delete(`/roles/${global.body.data.slug}`).expect(200);
+		});
+
+		test('role:manageProject is present in the scope catalog after startup sync', async () => {
+			const scopes = await Container.get(ScopeRepository).findByList(['role:manageProject']);
+			expect(scopes).toHaveLength(1);
 		});
 	});
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2835,6 +2835,7 @@
 	"instanceRoles.option.manage": "Manage",
 	"instanceRoles.option.manageOwn": "Manage own",
 	"instanceRoles.option.manageAll": "Manage others",
+	"instanceRoles.option.manageProjectRoles": "Manage project roles",
 	"instanceRoles.option.includedIn": "Included in {option}",
 	"roles.instance.newRole": "New instance role",
 	"roles.instance.editRole": "Custom instance role",

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -835,7 +835,7 @@ export const routes: RouteRecordRaw[] = [
 					middleware: ['authenticated', 'rbac'],
 					middlewareOptions: {
 						rbac: {
-							scope: ['role:manage'],
+							scope: ['role:manage', 'role:manageProject'],
 						},
 					},
 					telemetry: {
@@ -933,7 +933,7 @@ export const routes: RouteRecordRaw[] = [
 					middleware: ['authenticated', 'rbac'],
 					middlewareOptions: {
 						rbac: {
-							scope: ['role:manage'],
+							scope: ['role:manage', 'role:manageProject'],
 						},
 					},
 					telemetry: {

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.test.ts
@@ -1,4 +1,6 @@
 import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore, type MockedStore } from '@/__tests__/utils';
+import { useRBACStore } from '@/app/stores/rbac.store';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import RolesView from './RolesView.vue';
@@ -24,11 +26,17 @@ const renderComponent = createComponentRenderer(RolesView, {
 	},
 });
 
+let rbacStore: MockedStore<typeof useRBACStore>;
+
 describe('RolesView', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockQuery = {};
 		createTestingPinia();
+		rbacStore = mockedStore(useRBACStore);
+		// Default to a fully-privileged (role:manage) user; the manageProject-only
+		// case overrides this per test.
+		rbacStore.hasScope = vi.fn().mockReturnValue(true);
 	});
 
 	it('defaults to the instance tab', () => {
@@ -53,5 +61,37 @@ describe('RolesView', () => {
 		await userEvent.click(getByText('Project roles'));
 
 		expect(mockReplace).toHaveBeenCalledWith({ query: { tab: 'project' } });
+	});
+
+	describe('scope-based tab filtering', () => {
+		it('shows both tabs to a user with role:manage', () => {
+			rbacStore.hasScope = vi.fn().mockReturnValue(true);
+
+			const { getByText } = renderComponent();
+
+			expect(getByText('Instance roles')).toBeInTheDocument();
+			expect(getByText('Project roles')).toBeInTheDocument();
+		});
+
+		it('hides the instance tab from a role:manageProject-only user', () => {
+			rbacStore.hasScope = vi.fn().mockReturnValue(false);
+
+			const { getByText, queryByText, getByTestId, queryByTestId } = renderComponent();
+
+			expect(queryByText('Instance roles')).not.toBeInTheDocument();
+			expect(getByText('Project roles')).toBeInTheDocument();
+			expect(getByTestId('project-roles-view')).toBeInTheDocument();
+			expect(queryByTestId('instance-roles-view')).not.toBeInTheDocument();
+		});
+
+		it('coerces ?tab=instance to the project tab for a role:manageProject-only user', () => {
+			rbacStore.hasScope = vi.fn().mockReturnValue(false);
+			mockQuery = { tab: 'instance' };
+
+			const { getByTestId, queryByTestId } = renderComponent();
+
+			expect(getByTestId('project-roles-view')).toBeInTheDocument();
+			expect(queryByTestId('instance-roles-view')).not.toBeInTheDocument();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.vue
@@ -12,7 +12,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import InstanceRolesView from './instance/InstanceRolesView.vue';
 import ProjectRolesView from './project/ProjectRolesView.vue';
-import { useRBACStore } from '@/app/stores/rbac.store.js';
+import { useRBACStore } from '@/app/stores/rbac.store';
 
 type RolesTab = 'instance' | 'project';
 const DEFAULT_TAB: RolesTab = 'instance';

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.vue
@@ -12,6 +12,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import InstanceRolesView from './instance/InstanceRolesView.vue';
 import ProjectRolesView from './project/ProjectRolesView.vue';
+import { useRBACStore } from '@/app/stores/rbac.store.js';
 
 type RolesTab = 'instance' | 'project';
 const DEFAULT_TAB: RolesTab = 'instance';
@@ -22,6 +23,7 @@ const i18n = useI18n();
 const rolesStore = useRolesStore();
 const settingsStore = useSettingsStore();
 const { showError } = useToast();
+const rbacStore = useRBACStore();
 
 function normalizeTab(value: unknown): RolesTab {
 	return value === 'project' ? 'project' : DEFAULT_TAB;
@@ -35,10 +37,16 @@ function addRole() {
 	});
 }
 
-const tabOptions = computed<Array<TabOptions<RolesTab>>>(() => [
-	{ label: i18n.baseText('roles.tab.instance'), value: 'instance' },
-	{ label: i18n.baseText('roles.tab.project'), value: 'project' },
-]);
+const canManageInstanceRoles = computed(() => rbacStore.hasScope('role:manage'));
+
+const tabOptions = computed<Array<TabOptions<RolesTab>>>(() =>
+	canManageInstanceRoles.value
+		? [
+				{ label: i18n.baseText('roles.tab.instance'), value: 'instance' },
+				{ label: i18n.baseText('roles.tab.project'), value: 'project' },
+			]
+		: [{ label: i18n.baseText('roles.tab.project'), value: 'project' }],
+);
 
 // Reflect tab selection in the URL (replace keeps history clean / back-button safe).
 watch(activeTab, (tab) => {
@@ -93,7 +101,7 @@ onMounted(async () => {
 			</N8nButton>
 		</div>
 
-		<InstanceRolesView v-if="activeTab === 'instance'" />
+		<InstanceRolesView v-if="activeTab === 'instance' && canManageInstanceRoles" />
 		<ProjectRolesView v-else embedded />
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.vue
@@ -26,8 +26,10 @@ const { showError } = useToast();
 const rbacStore = useRBACStore();
 
 function normalizeTab(value: unknown): RolesTab {
-	return value === 'project' ? 'project' : DEFAULT_TAB;
+	return value === 'project' || !rbacStore.hasScope('role:manage') ? 'project' : DEFAULT_TAB;
 }
+
+const canManageInstanceRoles = computed(() => rbacStore.hasScope('role:manage'));
 
 const activeTab = ref<RolesTab>(normalizeTab(route.query.tab));
 
@@ -36,8 +38,6 @@ function addRole() {
 		name: activeTab.value === 'project' ? VIEWS.PROJECT_NEW_ROLE : VIEWS.INSTANCE_NEW_ROLE,
 	});
 }
-
-const canManageInstanceRoles = computed(() => rbacStore.hasScope('role:manage'));
 
 const tabOptions = computed<Array<TabOptions<RolesTab>>>(() =>
 	canManageInstanceRoles.value

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.test.ts
@@ -70,7 +70,7 @@ describe('instanceRoleScopes config', () => {
 		it('exposes the configured option labels per resource', () => {
 			expect(Object.keys(INSTANCE_SCOPE_GROUPS.apiKey)).toEqual(['Manage own', 'Manage all']);
 			expect(Object.keys(INSTANCE_SCOPE_GROUPS.tag)).toEqual(['Manage']);
-			expect(Object.keys(INSTANCE_SCOPE_GROUPS.role)).toEqual(['Manage']);
+			expect(Object.keys(INSTANCE_SCOPE_GROUPS.role)).toEqual(['Manage project roles', 'Manage']);
 			expect(Object.keys(INSTANCE_SCOPE_GROUPS.project)).toEqual(['Create']);
 			expect(Object.keys(INSTANCE_SCOPE_GROUPS.settings)).toEqual(['Manage']);
 		});

--- a/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/instanceRoleScopes.ts
@@ -45,12 +45,14 @@ export const INSTANCE_OPTION_LABEL_KEYS: Record<string, BaseTextKey> = {
 	Manage: 'instanceRoles.option.manage',
 	'Manage own': 'instanceRoles.option.manageOwn',
 	'Manage all': 'instanceRoles.option.manageAll',
+	'Manage project roles': 'instanceRoles.option.manageProjectRoles',
 };
 
 /** Display order of options within a resource group. */
 export const INSTANCE_OPTION_ORDER: string[] = [
 	'View',
 	'Create',
+	'Manage project roles',
 	'Manage',
 	'Manage own',
 	'Manage all',
@@ -107,6 +109,7 @@ export type OptionState = 'checked' | 'indeterminate' | 'unchecked';
  */
 export const SUPERSEDED_BY: Partial<Record<string, string>> = {
 	'Manage own': 'Manage all',
+	'Manage project roles': 'Manage',
 };
 
 /**


### PR DESCRIPTION
## Summary

Splits the `role:manage` permission scope by adding a narrower, opt-in scope `role:manageProject`. `role:manage` is unchanged and still governs **all** role types (the full superset). `role:manageProject` allows managing **only** role definitions where `roleType === 'project'`, and can be granted to custom instance roles.

**Why:** Today `role:manage` gates CRUD of *every* custom role definition in `role.controller.ts` regardless of `roleType`. Delegating project-role administration therefore forces granting `role:manage`, which also permits creating/editing/deleting **global** roles — an instance-wide privilege escalation. There was no least-privilege "project role administrator" option. This change enables safe delegation with zero change to existing `global:owner` / `global:admin` behaviour.

Mental model: `role:manageProject` == `role:manage`, restricted to `roleType === 'project'`.

The change is purely additive — no data migration. `role:manage` is not narrowed, so existing custom roles keep full capability; the new scope's DB row is auto-created on startup by `AuthRolesService.syncScopes` from `ALL_SCOPES`, and it is **not** added to any built-in role map — it is only assignable via the custom-role editor.

### How to test manually

Prerequisites: an instance with the enterprise **Custom Roles** feature enabled (the create/update/delete endpoints are `@Licensed(CUSTOM_ROLES)`), signed in as `global:owner` or `global:admin`.

1. **Create the delegated role:** Settings → Roles → **Instance roles** tab → *New instance role*. Under the **Role** resource, select the **Manage project roles** option and save.
2. **Assign it:** give that custom instance role to a member user.
3. **Sign in as that member** and open Settings → Roles. Expected: only the **Project roles** tab is shown — the **Instance roles** tab is hidden. Deep-linking to `/settings/roles?tab=instance` still lands on the Project roles tab.
4. **Project roles succeed:** as the member, create, edit, and delete a project role → all succeed.
5. **Everything else is blocked (403):** as the member, attempt to manage a non-project role — e.g. `PATCH`/`DELETE /roles/:globalRoleSlug`, `POST /roles` with `roleType: "global"`, or `GET /roles/:globalRoleSlug/assignments`. Each returns `403`.
6. **Backwards compatible:** confirm a user with `role:manage` still creates/updates/deletes roles of **every** `roleType`, and still sees both tabs — unchanged.

Edge cases worth checking: a `role:manageProject`-only user creating a role with `roleType: "global"` → `403`; requesting a non-existent slug → `404` (role is loaded before the authorization check).

Automated coverage: backend integration tests in `packages/cli/test/integration/access-control/instance-roles.test.ts` (positive project-role cases, negative non-project cases, `role:manage` backwards-compat, and scope-catalog presence after startup sync) and a frontend `RolesView.test.ts` block for scope-based tab filtering.

### Key implementation decisions

- **Guard moved from decorator to a shared helper.** `@GlobalScope('role:manage')` runs as pre-handler route middleware, accepts a single scope, and evaluates with `allOf` semantics — it cannot express "`role:manage` OR (`role:manageProject` AND `roleType === 'project'`)" because `roleType` is only known per-request. The five endpoints (`create`/`update`/`delete`/`getRoleAssignments`/`getRoleProjectMembers`) drop the decorator and call a single private `assertCanManageRoleType(user, roleType)` helper instead. Authentication is unaffected (separate middleware).
- **`roleType` source per endpoint.** `createRole` reads it from `CreateRoleDto.roleType`; the four slug endpoints call `roleService.getRole(slug)` up front to obtain it (and to `404` on a missing slug before the authorization check).
- **Not-found before forbidden.** Slug endpoints `404` on a missing role, then `403` on a `roleType` mismatch. Existence is not concealed because `GET /roles` already lists all roles to any authenticated user.
- **Frontend combined view stays reachable.** The `settings/roles` shell and the `project-roles` route group are gated on `role:manage` OR `role:manageProject`; `RolesView` filters out the Instance tab and coerces the default/`?tab` selection to Project when the user lacks `role:manage`. Instance-role routes remain gated on `role:manage`.

## Related

closes https://linear.app/n8n/issue/IAM-941

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33628">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

