### PR TITLE
fix(AWS Bedrock Chat Model Node): Validate regions from ARNs and IAM credentials

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/EmbeddingsAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/EmbeddingsAwsBedrock.node.ts
@@ -3,6 +3,7 @@ import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { BedrockEmbeddings } from '@langchain/aws';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { getNodeProxyAgent, logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
+import { getAwsDomain } from 'n8n-nodes-base/aws-credentials';
 import { awsNodeAuthOptions, awsNodeCredentials } from 'n8n-nodes-base/dist/nodes/Aws/utils';
 
 import {
@@ -109,7 +110,8 @@ export class EmbeddingsAwsBedrock implements INodeType {
 		const { region, credentials } = await resolveAwsCredentials(this, itemIndex);
 		const modelName = this.getNodeParameter('model', itemIndex) as string;
 
-		const bedrockEndpoint = `https://bedrock-runtime.${region}.amazonaws.com`;
+		// getAwsDomain keeps China (amazonaws.com.cn) / GovCloud endpoints correct.
+		const bedrockEndpoint = `https://bedrock-runtime.${region}.${getAwsDomain(region)}`;
 		const proxyAgent = getNodeProxyAgent(bedrockEndpoint);
 
 		const clientConfig: BedrockRuntimeClientConfig = {

--- a/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/test/EmbeddingsAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/embeddings/EmbeddingsAwsBedrock/test/EmbeddingsAwsBedrock.test.ts
@@ -106,6 +106,18 @@ describe('EmbeddingsAwsBedrock', () => {
 		);
 	});
 
+	it('uses the region-specific domain for the China partition endpoint', async () => {
+		mockedResolveAwsCredentials.mockResolvedValue({
+			region: 'cn-north-1',
+			credentials: { accessKeyId: 'a', secretAccessKey: 'b' },
+		});
+		const node = new EmbeddingsAwsBedrock();
+		await node.supplyData.call(mockContext('amazon.titan-embed-text-v1'), 0);
+		expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
+			'https://bedrock-runtime.cn-north-1.amazonaws.com.cn',
+		);
+	});
+
 	it('accepts arbitrary model values that are not in the loadOptions response', async () => {
 		mockedResolveAwsCredentials.mockResolvedValue({
 			region: 'us-east-1',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -8,6 +8,7 @@ import {
 	getConnectionHintNoticeField,
 } from '@n8n/ai-utilities';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { assertSupportedAwsRegion, getAwsDomain } from 'n8n-nodes-base/aws-credentials';
 import { awsNodeAuthOptions, awsNodeCredentials } from 'n8n-nodes-base/dist/nodes/Aws/utils';
 
 import {
@@ -241,15 +242,20 @@ export class LmChatAwsBedrock implements INodeType {
 		};
 
 		// If the model is specified as a full ARN, extract the region from it
-		// ARN format: arn:aws:bedrock:<region>:<account-id>:inference-profile/<profile-id>
+		// ARN format: arn:<partition>:bedrock:<region>:<account-id>:inference-profile/<profile-id>
+		// Partition covers commercial (aws), China (aws-cn) and GovCloud (aws-us-gov).
 		let region = credentialRegion;
-		const arnMatch = modelName.match(/^arn:aws:bedrock:([a-z0-9-]+):/);
+		const arnMatch = modelName.match(/^arn:(?:aws|aws-cn|aws-us-gov):bedrock:([a-z0-9-]+):/);
 		if (arnMatch) {
-			region = arnMatch[1];
+			const arnRegion = arnMatch[1];
+			// Validate before the region is interpolated into the bedrock-runtime endpoint URL below.
+			assertSupportedAwsRegion(arnRegion);
+			region = arnRegion;
 		}
 
-		// We set-up client manually to pass httpAgent and httpsAgent
-		const bedrockEndpoint = `https://bedrock-runtime.${region}.amazonaws.com`;
+		// We set-up client manually to pass httpAgent and httpsAgent.
+		// getAwsDomain keeps China (amazonaws.com.cn) / GovCloud endpoints correct.
+		const bedrockEndpoint = `https://bedrock-runtime.${region}.${getAwsDomain(region)}`;
 		const proxyAgent = getNodeProxyAgent(bedrockEndpoint);
 		const clientConfig: BedrockRuntimeClientConfig = {
 			region,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -2,7 +2,7 @@ import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { ChatBedrockConverse } from '@langchain/aws';
 import { makeN8nLlmFailedAttemptHandler, getNodeProxyAgent } from '@n8n/ai-utilities';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
-import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+import { UserError, type INode, type ISupplyDataFunctions } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
 
 import { resolveAwsCredentials } from '@utils/aws/resolveAwsCredentials';
@@ -162,6 +162,65 @@ describe('LmChatAwsBedrock', () => {
 			);
 			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
 				expect.objectContaining({ region: 'ap-southeast-1' }),
+			);
+		});
+
+		it('throws when the ARN-extracted region is not supported', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model')
+					return 'arn:aws:bedrock:not-a-region:123456789012:inference-profile/eu.amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			const call = node.supplyData.call(ctx, 0);
+			await expect(call).rejects.toThrow(UserError);
+			await expect(call).rejects.toThrow('Unsupported AWS region');
+			// Must reject before any client is constructed.
+			expect(mockedGetNodeProxyAgent).not.toHaveBeenCalled();
+			expect(MockedBedrockRuntimeClient).not.toHaveBeenCalled();
+			expect(MockedChatBedrockConverse).not.toHaveBeenCalled();
+		});
+
+		it('extracts the region from a China (aws-cn) partition ARN and targets the .com.cn endpoint', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model')
+					return 'arn:aws-cn:bedrock:cn-north-1:123456789012:inference-profile/cn.amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
+				'https://bedrock-runtime.cn-north-1.amazonaws.com.cn',
+			);
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'cn-north-1' }),
+			);
+			expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'cn-north-1' }),
+			);
+		});
+
+		it('extracts the region from a GovCloud (aws-us-gov) partition ARN', async () => {
+			const ctx = setupMockContext();
+			ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model')
+					return 'arn:aws-us-gov:bedrock:us-gov-west-1:123456789012:inference-profile/us-gov.amazon.nova-pro-v1:0';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
+				'https://bedrock-runtime.us-gov-west-1.amazonaws.com',
+			);
+			expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+				expect.objectContaining({ region: 'us-gov-west-1' }),
 			);
 		});
 

--- a/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/resolveAwsCredentials.ts
@@ -26,6 +26,10 @@ export async function resolveAwsCredentials(
 
 	if (authentication !== 'assumeRole') {
 		const creds = (await context.getCredentials('aws')) as AwsIamCredentialsType;
+
+		// Validate before the region is interpolated into service endpoint URLs downstream.
+		assertSupportedAwsRegion(creds.region);
+
 		const identity: AwsCredentialIdentity = {
 			accessKeyId: creds.accessKeyId,
 			secretAccessKey: creds.secretAccessKey,

--- a/packages/@n8n/nodes-langchain/utils/aws/test/resolveAwsCredentials.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/test/resolveAwsCredentials.test.ts
@@ -127,6 +127,48 @@ describe('resolveAwsCredentials — IAM path', () => {
 		await resolveAwsCredentials(context, 3);
 		expect(context.getNodeParameter).toHaveBeenCalledWith('authentication', 3, 'iam');
 	});
+
+	it('throws when region is not a supported AWS region', async () => {
+		const context = makeContext({
+			authentication: 'iam',
+			awsCredential: {
+				region: 'not-a-region',
+				accessKeyId: 'AKIATEST',
+				secretAccessKey: 'SECRET',
+				temporaryCredentials: false,
+			},
+		});
+		await expect(resolveAwsCredentials(context)).rejects.toThrow(UserError);
+		await expect(resolveAwsCredentials(context)).rejects.toThrow('Unsupported AWS region');
+	});
+
+	it('accepts the China partition region', async () => {
+		const context = makeContext({
+			authentication: 'iam',
+			awsCredential: {
+				region: 'cn-north-1',
+				accessKeyId: 'AKIATEST',
+				secretAccessKey: 'SECRET',
+				temporaryCredentials: false,
+			},
+		});
+		const result = await resolveAwsCredentials(context);
+		expect(result.region).toBe('cn-north-1');
+	});
+
+	it('accepts the GovCloud partition region', async () => {
+		const context = makeContext({
+			authentication: 'iam',
+			awsCredential: {
+				region: 'us-gov-west-1',
+				accessKeyId: 'AKIATEST',
+				secretAccessKey: 'SECRET',
+				temporaryCredentials: false,
+			},
+		});
+		const result = await resolveAwsCredentials(context);
+		expect(result.region).toBe('us-gov-west-1');
+	});
 });
 
 describe('resolveAwsCredentials — AssumeRole path', () => {


### PR DESCRIPTION
## Summary

The AWS credential signing path already runs every region through `assertSupportedAwsRegion` before it is interpolated into a request URL. Two AWS Bedrock paths skipped that step and accepted arbitrary strings:

- the region **extracted from a model ARN** in the Bedrock Chat Model node, and
- the region on plain **IAM credentials** in `resolveAwsCredentials` (used by both the Bedrock Chat Model and Embeddings nodes).

This PR applies the same validation in both places, so behaviour is consistent with the credential path — any unsupported region throws `UserError('Unsupported AWS region')`.

While working in the region path it also adds **China (`aws-cn`) and GovCloud (`aws-us-gov`) partition support**: the ARN partition prefix is widened to `aws | aws-cn | aws-us-gov`, and the `bedrock-runtime` endpoint domain is now derived via `getAwsDomain(region)` in both nodes so China (`amazonaws.com.cn`) / GovCloud endpoints resolve correctly (previously hardcoded `amazonaws.com`).

**Deliberately out of scope (not skipped):** the declarative `requestDefaults.baseURL` used for the model-list *dropdown* (control-plane `bedrock` service) still targets `amazonaws.com`; making it partition-aware is endpoint-construction work that belongs with ENT-141 (custom endpoints). `allowArbitraryValues` already lets users on other partitions enter the model/ARN directly.

## How to test

No special modules, license, or feature flags required.

**Automated** — from `packages/@n8n/nodes-langchain`:
```
pnpm test resolveAwsCredentials LmChatAwsBedrock EmbeddingsAwsBedrock
```
32 passing (7 new cases covering invalid IAM/ARN regions and aws-cn/aws-us-gov partitions).

**Manual:**
1. Create an AWS credential (IAM auth) + an **AWS Bedrock Chat Model** node; run with a supported region → works as before.
2. Via the API, set the credential `region` to a bogus value (e.g. `not-a-region`) → running the node surfaces a user-facing **"Unsupported AWS region"** error.
3. Set the Model to an ARN with a bogus region (e.g. `arn:aws:bedrock:not-a-region:123:inference-profile/...`) → same error, raised before any Bedrock client is constructed.
4. A China ARN (e.g. `arn:aws-cn:bedrock:cn-north-1:...`) → region is extracted and the endpoint targets `bedrock-runtime.cn-north-1.amazonaws.com.cn`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-143

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33638">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

