### PR TITLE
fix(AI Agent Node): Remove assistant tool call redundant message and simplify chat tool response

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatOllama/LmChatOllama.node.ts
@@ -14,6 +14,8 @@ import {
 	type SupplyData,
 } from 'n8n-workflow';
 
+import { wrapChatModelMessageInput } from '@utils/chatModelMessageWrapper';
+
 import { ollamaModel, ollamaOptions, ollamaDescription } from '../LMOllama/description';
 
 export class LmChatOllama implements INodeType {
@@ -81,7 +83,7 @@ export class LmChatOllama implements INodeType {
 		});
 
 		return {
-			response: model,
+			response: wrapChatModelMessageInput(model),
 		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/LmChatCohere.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatCohere/LmChatCohere.node.ts
@@ -1,5 +1,10 @@
 import { ChatCohere } from '@langchain/cohere';
 import type { LLMResult } from '@langchain/core/outputs';
+import {
+	makeN8nLlmFailedAttemptHandler,
+	N8nLlmTracing,
+	getConnectionHintNoticeField,
+} from '@n8n/ai-utilities';
 import type {
 	INodeType,
 	INodeTypeDescription,
@@ -7,11 +12,7 @@ import type {
 	SupplyData,
 } from 'n8n-workflow';
 
-import {
-	makeN8nLlmFailedAttemptHandler,
-	N8nLlmTracing,
-	getConnectionHintNoticeField,
-} from '@n8n/ai-utilities';
+import { wrapChatModelMessageInput } from '@utils/chatModelMessageWrapper';
 
 export function tokensUsageParser(result: LLMResult): {
 	completionTokens: number;
@@ -176,7 +177,7 @@ export class LmChatCohere implements INodeType {
 		});
 
 		return {
-			response: model,
+			response: wrapChatModelMessageInput(model),
 		};
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
@@ -18,6 +18,7 @@ import {
 	SEND_AND_WAIT_OPERATION,
 	getHighlightedInputKey,
 	getHighlightedResponseKey,
+	isToolType,
 } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
@@ -35,6 +36,21 @@ import {
 	getChatMessage,
 	getSendAndWaitPropertiesForChatNode,
 } from './util';
+
+function getToolFlowResponse(context: IExecuteFunctions, data: INodeExecutionData) {
+	const isToolExecution = isToolType(context.getNode().type);
+	if (!isToolExecution) return data;
+
+	const json: IDataObject = { ...data.json, sent: true };
+	if (json.chatInput === '') {
+		delete json.chatInput;
+	}
+
+	return {
+		...data,
+		json,
+	};
+}
 
 export class Chat implements INodeType {
 	description: INodeTypeDescription = {
@@ -226,7 +242,7 @@ export class Chat implements INodeType {
 
 		if (!waitForReply) {
 			// return original message instead of input data
-			if (nodeVersion >= 1.3) return [[data]];
+			if (nodeVersion >= 1.3) return [[getToolFlowResponse(context, data)]];
 
 			const inputData = context.getInputData();
 			return [inputData];

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/Chat.node.ts
@@ -38,9 +38,11 @@ import {
 } from './util';
 
 function getToolFlowResponse(context: IExecuteFunctions, data: INodeExecutionData) {
+	// context.isToolExecution() doesn't work with ExecuteFunctionContext
 	const isToolExecution = isToolType(context.getNode().type);
 	if (!isToolExecution) return data;
 
+	// strip empty field and add sent: true to clarify the result for LLMs
 	const json: IDataObject = { ...data.json, sent: true };
 	if (json.chatInput === '') {
 		delete json.chatInput;

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/Chat.node.test.ts
@@ -1,6 +1,7 @@
 import type { INode, IExecuteFunctions } from 'n8n-workflow';
 import {
 	CHAT_NODE_TYPE,
+	CHAT_TOOL_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
 	FREE_TEXT_CHAT_RESPONSE_TYPE,
 	SEND_AND_WAIT_OPERATION,
@@ -315,6 +316,32 @@ describe('Test Chat Node', () => {
 			const result = await chat.onMessage(mockExecuteFunctions, message);
 
 			expect(result).toEqual([[message]]);
+		});
+
+		it('v1.3 should return a tool-friendly response when used as a tool without waiting for reply', async () => {
+			const chatToolNode = mock<INode>({
+				name: 'Chat',
+				type: CHAT_TOOL_NODE_TYPE,
+				parameters: {},
+				typeVersion: 1.3,
+			});
+			const message = { json: { chatInput: '' } };
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: { chatInput: 'other input' } }]);
+			mockExecuteFunctions.getNode.mockReturnValue(chatToolNode);
+			mockExecuteFunctions.getNodeParameter.mockImplementation((parameterName) => {
+				switch (parameterName) {
+					case 'operation':
+						return 'send';
+					case 'options':
+						return { memoryConnection: false };
+					default:
+						return undefined;
+				}
+			});
+
+			const result = await chat.onMessage(mockExecuteFunctions, message);
+
+			expect(result).toEqual([[{ json: { sent: true } }]]);
 		});
 
 		it('v1.2 should return output data directly without nesting into `data` field (except `approved`)', async () => {

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -386,11 +386,14 @@ export function buildSteps(
 				: []
 			: [buildIndividualAIMessage(toolId, toolName, toolInput, providerMetadata)];
 
+		const logFallback = messageLog[0]?.content?.length
+			? messageLog[0]?.content
+			: `Calling ${nodeName}`;
 		steps.push({
 			action: {
 				tool: toolName,
 				toolInput: toolInputForResult,
-				log: toolInput.log || (messageLog[0]?.content ?? `Calling ${nodeName}`),
+				log: toolInput.log || logFallback,
 				messageLog,
 				toolCallId: toolInput?.id,
 				type: toolInput.type || 'tool_call',

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -134,7 +134,7 @@ function buildMessageContent(
 	toolInput: IDataObject,
 	toolId: string,
 	toolName: string,
-): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
+): null | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
 
 	// Anthropic thinking mode: build content blocks
@@ -149,8 +149,7 @@ function buildMessageContent(
 		);
 	}
 
-	// Default: simple string content
-	return `Calling ${toolName} with input: ${JSON.stringify(toolInput)}`;
+	return null;
 }
 
 function resolveToolName(tool: EngineResult<RequestResponseMetadata>): string {
@@ -231,9 +230,9 @@ function buildIndividualAIMessage(
 	const content = buildMessageContent(providerMetadata, toolInput, toolId, toolName);
 
 	return new AIMessage({
-		content,
+		content: content ?? [],
 		// When content is an array (Anthropic thinking), LangChain ignores tool_calls
-		...(typeof content === 'string' && { tool_calls: [toolCall] }),
+		...(content === null && { tool_calls: [toolCall] }),
 		...(providerMetadata.thoughtSignature && {
 			additional_kwargs: buildGeminiAdditionalKwargs(
 				[{ id: toolId, name: toolName, args: toolInput }],

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -411,6 +411,7 @@ describe('buildSteps', () => {
 
 				const message = result[0].action.messageLog![0];
 				expect(message.content).toEqual([]);
+				expect(result[0].action.log).toBe('Calling Calculator Node');
 				expect(message).toHaveProperty('tool_calls');
 				expect(message.tool_calls).toHaveLength(1);
 				expect(message.tool_calls?.[0]).toMatchObject({

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -410,6 +410,7 @@ describe('buildSteps', () => {
 				expect(result[0].action.messageLog).toHaveLength(1);
 
 				const message = result[0].action.messageLog![0];
+				expect(message.content).toEqual([]);
 				expect(message).toHaveProperty('tool_calls');
 				expect(message.tool_calls).toHaveLength(1);
 				expect(message.tool_calls?.[0]).toMatchObject({
@@ -878,7 +879,7 @@ describe('buildSteps', () => {
 			});
 		});
 
-		it('should use string content when no thinking blocks present', () => {
+		it('should use empty content and tool_calls when no thinking blocks are present', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
 					{
@@ -917,9 +918,9 @@ describe('buildSteps', () => {
 			expect(result[0].action.messageLog).toHaveLength(1);
 
 			const message = result[0].action.messageLog![0];
-			expect(typeof message.content).toBe('string');
-			expect(message.content).toContain('Calling Calculator');
+			expect(message.content).toEqual([]);
 			expect(message).toHaveProperty('tool_calls');
+			expect(message.tool_calls?.[0].name).toBe('Calculator');
 		});
 
 		it('should handle thinking content without thinkingType', () => {
@@ -961,8 +962,9 @@ describe('buildSteps', () => {
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
-			// Should fall back to string content when thinkingType is missing
-			expect(typeof message.content).toBe('string');
+			// Should fall back to default tool_calls format when thinkingType is missing
+			expect(message.content).toEqual([]);
+			expect(message.tool_calls?.[0].name).toBe('Calculator');
 		});
 
 		it('should work alongside Gemini thought_signature', () => {
@@ -1111,53 +1113,6 @@ describe('buildSteps', () => {
 			expect(result[0].action.tool).toBe('Calculator_Node');
 		});
 
-		it('should use HITL toolName in message content', () => {
-			const response: EngineResponse<RequestResponseMetadata> = {
-				actionResponses: [
-					{
-						action: {
-							actionType: 'ExecutionNodeAction',
-							nodeName: 'HITL Node',
-							input: {
-								id: 'call_123',
-								input: { query: 'test' },
-							},
-							type: NodeConnectionTypes.AiTool,
-							id: 'call_123',
-							metadata: {
-								itemIndex: 0,
-								hitl: {
-									toolName: 'custom_tool',
-									gatedToolNodeName: 'Custom Tool',
-									originalInput: { query: 'test' },
-								},
-							},
-						},
-						data: {
-							data: {
-								ai_tool: [[{ json: { result: 'success' } }]],
-							},
-							executionTime: 0,
-							startTime: 0,
-							executionIndex: 0,
-							source: [],
-						},
-					},
-				],
-				metadata: {},
-			};
-
-			const result = buildSteps(response, itemIndex);
-
-			expect(result).toHaveLength(1);
-			const message = result[0].action.messageLog![0];
-			// Message content should use the HITL toolName
-			expect(message.content).toContain('Calling custom_tool');
-			expect(message.content).not.toContain('HITL Node');
-			// Tool call should also use the HITL toolName
-			expect(message.tool_calls?.[0].name).toBe('custom_tool');
-		});
-
 		it('should use converted nodeName in message content when HITL metadata is absent', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [
@@ -1193,8 +1148,7 @@ describe('buildSteps', () => {
 
 			expect(result).toHaveLength(1);
 			const message = result[0].action.messageLog![0];
-			// Message content should use the converted tool name
-			expect(message.content).toContain('Calling My_Custom_Node');
+			expect(message.content).toEqual([]);
 			expect(message.tool_calls?.[0].name).toBe('My_Custom_Node');
 		});
 

--- a/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.test.ts
@@ -1,5 +1,10 @@
 import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import {
+	AIMessage,
+	AIMessageChunk,
+	type BaseMessage,
+	HumanMessage,
+} from '@langchain/core/messages';
 import { ChatGenerationChunk } from '@langchain/core/outputs';
 
 import {
@@ -33,6 +38,14 @@ describe('chatModelMessageWrapper', () => {
 
 			expect(normalized).toBe(message);
 		});
+
+		it('leaves AI messages without tool calls unchanged', () => {
+			const message = new AIMessage({ content: [] });
+
+			const [normalized] = normalizeEmptyToolCallContent([message]);
+
+			expect(normalized).toBe(message);
+		});
 	});
 
 	it('wraps generate and stream paths with the message transformer', async () => {
@@ -40,14 +53,16 @@ describe('chatModelMessageWrapper', () => {
 		const seenStreamMessages: unknown[] = [];
 		const model = {
 			_generate: vi.fn(async (messages) => {
+				await Promise.resolve();
 				seenGenerateMessages.push(messages);
 				return { generations: [] };
 			}),
 			_streamResponseChunks: vi.fn(async function* (messages) {
+				await Promise.resolve();
 				seenStreamMessages.push(messages);
 				yield new ChatGenerationChunk({
 					text: '',
-					message: new AIMessage({ content: '' }),
+					message: new AIMessageChunk({ content: '' }),
 				});
 			}),
 		} as unknown as BaseChatModel;
@@ -58,12 +73,44 @@ describe('chatModelMessageWrapper', () => {
 		expect(wrapped).toBe(model);
 
 		await wrapped._generate([message], {});
-		for await (const _chunk of wrapped._streamResponseChunks([message], {})) {
+		const streamChunks = [];
+		for await (const chunk of wrapped._streamResponseChunks([message], {})) {
+			streamChunks.push(chunk);
 		}
 
 		expect(seenGenerateMessages).toHaveLength(1);
 		expect(seenStreamMessages).toHaveLength(1);
+		expect(streamChunks).toHaveLength(1);
 		expect((seenGenerateMessages[0] as AIMessage[])[0].content).toBe('');
 		expect((seenStreamMessages[0] as AIMessage[])[0].content).toBe('');
+	});
+
+	it('does not wrap the same model more than once', async () => {
+		const seenGenerateMessages: unknown[] = [];
+		const model = {
+			_generate: vi.fn(async (messages) => {
+				await Promise.resolve();
+				seenGenerateMessages.push(messages);
+				return { generations: [] };
+			}),
+			_streamResponseChunks: vi.fn(async function* () {
+				await Promise.resolve();
+				yield new ChatGenerationChunk({
+					text: '',
+					message: new AIMessageChunk({ content: '' }),
+				});
+			}),
+		} as unknown as BaseChatModel;
+		const firstWrapper = vi.fn((messages: BaseMessage[]) => messages);
+		const secondWrapper = vi.fn((messages: BaseMessage[]) => messages);
+
+		wrapChatModelMessageInput(model, firstWrapper);
+		wrapChatModelMessageInput(model, secondWrapper);
+
+		await model._generate([new HumanMessage('hello')], {});
+
+		expect(firstWrapper).toHaveBeenCalledTimes(1);
+		expect(secondWrapper).not.toHaveBeenCalled();
+		expect(seenGenerateMessages).toHaveLength(1);
 	});
 });

--- a/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.test.ts
@@ -1,0 +1,69 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+
+import {
+	normalizeEmptyToolCallContent,
+	wrapChatModelMessageInput,
+} from './chatModelMessageWrapper';
+
+const toolCall = {
+	id: 'call_123',
+	name: 'Chat',
+	args: { Message: 'hello' },
+	type: 'tool_call' as const,
+};
+
+describe('chatModelMessageWrapper', () => {
+	describe('normalizeEmptyToolCallContent', () => {
+		it('converts empty array content on AI tool-call messages to an empty string', () => {
+			const message = new AIMessage({ content: [], tool_calls: [toolCall] });
+
+			const [normalized] = normalizeEmptyToolCallContent([message]);
+
+			expect(AIMessage.isInstance(normalized)).toBe(true);
+			expect(normalized.content).toBe('');
+			expect((normalized as AIMessage).tool_calls).toEqual([toolCall]);
+		});
+
+		it('leaves non-tool-call messages unchanged', () => {
+			const message = new HumanMessage('hello');
+
+			const [normalized] = normalizeEmptyToolCallContent([message]);
+
+			expect(normalized).toBe(message);
+		});
+	});
+
+	it('wraps generate and stream paths with the message transformer', async () => {
+		const seenGenerateMessages: unknown[] = [];
+		const seenStreamMessages: unknown[] = [];
+		const model = {
+			_generate: vi.fn(async (messages) => {
+				seenGenerateMessages.push(messages);
+				return { generations: [] };
+			}),
+			_streamResponseChunks: vi.fn(async function* (messages) {
+				seenStreamMessages.push(messages);
+				yield new ChatGenerationChunk({
+					text: '',
+					message: new AIMessage({ content: '' }),
+				});
+			}),
+		} as unknown as BaseChatModel;
+
+		const wrapped = wrapChatModelMessageInput(model);
+		const message = new AIMessage({ content: [], tool_calls: [toolCall] });
+
+		expect(wrapped).toBe(model);
+
+		await wrapped._generate([message], {});
+		for await (const _chunk of wrapped._streamResponseChunks([message], {})) {
+		}
+
+		expect(seenGenerateMessages).toHaveLength(1);
+		expect(seenStreamMessages).toHaveLength(1);
+		expect((seenGenerateMessages[0] as AIMessage[])[0].content).toBe('');
+		expect((seenStreamMessages[0] as AIMessage[])[0].content).toBe('');
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.ts
+++ b/packages/@n8n/nodes-langchain/utils/chatModelMessageWrapper.ts
@@ -1,0 +1,78 @@
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { AIMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk, ChatResult } from '@langchain/core/outputs';
+
+const wrappedChatModelMessageInput = Symbol('wrappedChatModelMessageInput');
+
+type GenerateMethod = (
+	messages: BaseMessage[],
+	options: unknown,
+	runManager?: CallbackManagerForLLMRun,
+) => Promise<ChatResult>;
+
+type StreamMethod = (
+	messages: BaseMessage[],
+	options: unknown,
+	runManager?: CallbackManagerForLLMRun,
+) => AsyncGenerator<ChatGenerationChunk>;
+
+type PatchableChatModel = {
+	_generate: GenerateMethod;
+	_streamResponseChunks: StreamMethod;
+	[wrappedChatModelMessageInput]?: true;
+};
+
+export type ChatModelMessageWrapper = (messages: BaseMessage[]) => BaseMessage[];
+
+export function normalizeEmptyToolCallContent(messages: BaseMessage[]): BaseMessage[] {
+	return messages.map((message) => {
+		if (
+			AIMessage.isInstance(message) &&
+			Array.isArray(message.content) &&
+			message.content.length === 0 &&
+			message.tool_calls?.length
+		) {
+			return new AIMessage({
+				id: message.id,
+				name: message.name,
+				content: '',
+				additional_kwargs: message.additional_kwargs,
+				response_metadata: message.response_metadata,
+				tool_calls: message.tool_calls,
+				invalid_tool_calls: message.invalid_tool_calls,
+				usage_metadata: message.usage_metadata,
+			});
+		}
+
+		return message;
+	});
+}
+
+/**
+ * A method that wraps langchain chat model to convert incoming messages to a format that is compatible with the model.
+ * By default, it normalizes messages with tool calls and content:[] to have content:''. Some old models expect to have some content alongside the tool calls.
+ */
+export function wrapChatModelMessageInput<TModel extends BaseChatModel>(
+	model: TModel,
+	wrapMessages: ChatModelMessageWrapper = normalizeEmptyToolCallContent,
+): TModel {
+	const patchableModel = model as TModel & PatchableChatModel;
+
+	if (patchableModel[wrappedChatModelMessageInput]) return model;
+
+	const originalGenerate = patchableModel._generate.bind(model);
+	const originalStreamResponseChunks = patchableModel._streamResponseChunks.bind(model);
+
+	patchableModel._generate = async (messages, options, runManager) =>
+		await originalGenerate(wrapMessages(messages), options, runManager);
+
+	patchableModel._streamResponseChunks = async function* (messages, options, runManager) {
+		yield* originalStreamResponseChunks(wrapMessages(messages), options, runManager);
+	};
+
+	patchableModel[wrappedChatModelMessageInput] = true;
+
+	return model;
+}


### PR DESCRIPTION
## Summary

This PR provides several fixes to reduce LLM confusion that could lead to LLM calling a tool several times. More details [here](https://linear.app/n8n/issue/NODE-4500/chat-tool-infinity-loop-in-send-message-mode#comment-6b2c2aff)

**Fix 1** - Remove tool call message
`Calling ${toolName} with input: ${JSON.stringify(toolInput)}` was appended to every tool call message, because some models couldn't send a message with no content. However, it introduces additional token usage and confuses smaller models.
Removed the message, analysed existing nodes and added custom message wrapping for problematic nodes
>Findings
>content: [] is safe for these providers:
>  - OpenAI Responses API: suppresses assistant message, preserves function_call.
>  - Anthropic: emits only tool_use blocks when content is empty.
>  - Google Gemini / Vertex: emits only functionCall parts when content is empty.
>  - AWS Bedrock Converse: emits only toolUse blocks when content is empty.
>  - Mistral: works when followed by matching ToolMessage; emits assistant toolCalls without content.
>
>content: [] **is not safe** for these:
>  - Cohere: throws for non-string content in chat history. content: "" works and preserves toolCalls.
>  - Ollama: content: [] drops the tool call unless the content array contains a tool_use block. content: "" preserves tool_calls.
>  - Groq: sends content: [] directly with tool_calls; this may be risky because Groq’s OpenAI-style chat API likely expects string/null content, not array content.

Groq safely accepts `content:[]`, so the fix is applied only to Cohere and Ollama

**Fix 2** - Format chat tool node response
Chat tool was returning messages like the example below, and they're not very clear
```
[
  {
    "sessionId": "c4677c9a178a4838b5747d2cad91023a",
    "action": "sendMessage",
    "chatInput": ""
  }
]
```
Added `sent:true` and started stripping empty `chatInput`

## How to test

Try the workflow below, send something like "tell me a joke. Call a tool to send a message". Run it with OpenAI/gpt-5-mini, Cohere, Ollama, Groq a several times.

<details>
<summary>Workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {
        "options": {
          "responseMode": "responseNodes"
        }
      },
      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
      "typeVersion": 1.4,
      "position": [
        0,
        0
      ],
      "id": "28c9f6c7-9b03-4ed7-b834-9ccf1cfc5d66",
      "name": "When chat message received",
      "webhookId": "acde12c2-617b-48b5-a370-23332421e53a"
    },
    {
      "parameters": {
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 3.1,
      "position": [
        208,
        0
      ],
      "id": "858e942f-a7c8-4b7c-b9e3-103086d5add9",
      "name": "AI Agent"
    },
    {
      "parameters": {
        "model": {
          "__rl": true,
          "value": "gpt-5-mini",
          "mode": "list",
          "cachedResultName": "gpt-5-mini"
        },
        "builtInTools": {},
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
      "typeVersion": 1.3,
      "position": [
        160,
        336
      ],
      "id": "893a6e4c-7070-4e02-a372-b16aa8d95137",
      "name": "OpenAI Chat Model",
      "credentials": {
        "openAiApi": {
          "id": "P2cxRM37KXXhQckq",
          "name": "OpenAi account"
        }
      }
    },
    {
      "parameters": {},
      "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
      "typeVersion": 1.4,
      "position": [
        304,
        336
      ],
      "id": "d004eb74-eb6a-41f3-80e6-796d48d625f4",
      "name": "Simple Memory"
    },
    {
      "parameters": {
        "message": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Message', ``, 'string') }}",
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.chatTool",
      "typeVersion": 1.3,
      "position": [
        464,
        336
      ],
      "id": "f7cc2c81-d14f-48a0-ac3c-6c883ef52a5b",
      "name": "Chat",
      "webhookId": "b98ac66d-d318-4a9e-8366-35cc7ca78d4f"
    }
  ],
  "connections": {
    "When chat message received": {
      "main": [
        [
          {
            "node": "AI Agent",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "OpenAI Chat Model": {
      "ai_languageModel": [
        [
          {
            "node": "AI Agent",
            "type": "ai_languageModel",
            "index": 0
          }
        ]
      ]
    },
    "Simple Memory": {
      "ai_memory": [
        [
          {
            "node": "AI Agent",
            "type": "ai_memory",
            "index": 0
          }
        ]
      ]
    },
    "Chat": {
      "ai_tool": [
        [
          {
            "node": "AI Agent",
            "type": "ai_tool",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4500/chat-tool-infinity-loop-in-send-message-mode

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->