### PR TITLE
fix(core): select module path before importing

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -1,10 +1,15 @@
 import type { ModuleInterface, ModuleMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import path from 'path';
 import { mock } from 'vitest-mock-extended';
 
 import type { LicenseState } from '../../license-state';
+import type { Logger } from '../../logging/logger';
+import { MissingModuleError } from '../errors/missing-module.error';
 import { ModuleConfusionError } from '../errors/module-confusion.error';
 import { ModuleRegistry } from '../module-registry';
+import type { ModuleName } from '../modules.config';
 
 beforeEach(() => {
 	vi.resetAllMocks();
@@ -125,6 +130,133 @@ describe('loadModules', () => {
 		await moduleRegistry.loadModules([]);
 
 		expect(moduleRegistry.entities).toEqual([]);
+	});
+
+	describe('module path selection', () => {
+		let tempRoot: string;
+		let modulesDir: string;
+		let originalProcessArgv1: string | undefined;
+		let createdGlobalKeys: string[];
+
+		const createTestModuleName = (suffix: string) =>
+			`module-registry-test-${suffix}-${Math.random().toString(36).slice(2)}` as ModuleName;
+
+		const registerGlobalKey = (key: string) => {
+			createdGlobalKeys.push(key);
+			return key;
+		};
+
+		const writeModuleFile = (directoryName: string, moduleName: string, contents: string) => {
+			const moduleDir = path.join(modulesDir, directoryName);
+			mkdirSync(moduleDir, { recursive: true });
+			writeFileSync(path.join(moduleDir, `${moduleName}.module.ts`), `${contents}\nexport {};\n`);
+		};
+
+		const createModuleRegistry = (logger: Logger = mock<Logger>()) => {
+			const moduleMetadata = mock<ModuleMetadata>({
+				getClasses: vi.fn().mockReturnValue([]),
+			});
+
+			return new ModuleRegistry(moduleMetadata, mock(), logger, mock());
+		};
+
+		beforeEach(() => {
+			tempRoot = mkdtempSync(path.join('D:\\AI', 'module-registry-'));
+			modulesDir = path.join(tempRoot, 'dist', 'modules');
+			createdGlobalKeys = [];
+
+			mkdirSync(modulesDir, { recursive: true });
+			mkdirSync(path.join(tempRoot, 'bin'), { recursive: true });
+
+			originalProcessArgv1 = process.argv[1];
+			process.argv[1] = path.join(tempRoot, 'bin', 'n8n');
+		});
+
+		afterEach(() => {
+			process.argv[1] = originalProcessArgv1 ?? '';
+			rmSync(tempRoot, { recursive: true, force: true });
+
+			for (const key of createdGlobalKeys) {
+				Reflect.deleteProperty(globalThis, key);
+			}
+		});
+
+		it('should skip module gracefully when neither CE nor EE directory exists and log debug message', async () => {
+			const moduleName = createTestModuleName('missing');
+			const logger = mock<Logger>();
+			const moduleRegistry = createModuleRegistry(logger);
+
+			await expect(moduleRegistry.loadModules([moduleName])).resolves.not.toThrow();
+
+			expect(logger.debug).toHaveBeenCalledWith(`Module "${moduleName}" not found, skipping`);
+		});
+
+		it('should keep the CE selection error and avoid EE fallback when the CE directory exists', async () => {
+			const moduleName = createTestModuleName('ce-error');
+			const ceLoadedKey = registerGlobalKey(`${moduleName}-ce-loaded`);
+			const eeLoadedKey = registerGlobalKey(`${moduleName}-ee-loaded`);
+			const ceErrorMessage = `${moduleName} ce import failed`;
+			const moduleRegistry = createModuleRegistry();
+
+			writeModuleFile(
+				moduleName,
+				moduleName,
+				`Reflect.set(globalThis, ${JSON.stringify(ceLoadedKey)}, true);\nthrow new Error(${JSON.stringify(ceErrorMessage)});`,
+			);
+			writeModuleFile(
+				`${moduleName}.ee`,
+				moduleName,
+				`Reflect.set(globalThis, ${JSON.stringify(eeLoadedKey)}, true);`,
+			);
+
+			const loadPromise = moduleRegistry.loadModules([moduleName]);
+
+			await expect(loadPromise).rejects.toBeInstanceOf(MissingModuleError);
+			await expect(loadPromise).rejects.toMatchObject({
+				message: expect.stringContaining(ceErrorMessage),
+			});
+			expect(Reflect.get(globalThis, ceLoadedKey)).toBe(true);
+			expect(Reflect.get(globalThis, eeLoadedKey)).toBeUndefined();
+		});
+
+		it('should select the EE path when only the EE directory exists', async () => {
+			const moduleName = createTestModuleName('ee-only');
+			const eeLoadedKey = registerGlobalKey(`${moduleName}-ee-loaded`);
+			const moduleRegistry = createModuleRegistry();
+
+			writeModuleFile(
+				`${moduleName}.ee`,
+				moduleName,
+				`Reflect.set(globalThis, ${JSON.stringify(eeLoadedKey)}, true);`,
+			);
+
+			await expect(moduleRegistry.loadModules([moduleName])).resolves.not.toThrow();
+
+			expect(Reflect.get(globalThis, eeLoadedKey)).toBe(true);
+		});
+
+		it('should prefer the CE path when both CE and EE directories exist', async () => {
+			const moduleName = createTestModuleName('ce-priority');
+			const ceLoadedKey = registerGlobalKey(`${moduleName}-ce-loaded`);
+			const eeLoadedKey = registerGlobalKey(`${moduleName}-ee-loaded`);
+			const moduleRegistry = createModuleRegistry();
+
+			writeModuleFile(
+				moduleName,
+				moduleName,
+				`Reflect.set(globalThis, ${JSON.stringify(ceLoadedKey)}, true);`,
+			);
+			writeModuleFile(
+				`${moduleName}.ee`,
+				moduleName,
+				`Reflect.set(globalThis, ${JSON.stringify(eeLoadedKey)}, true);`,
+			);
+
+			await expect(moduleRegistry.loadModules([moduleName])).resolves.not.toThrow();
+
+			expect(Reflect.get(globalThis, ceLoadedKey)).toBe(true);
+			expect(Reflect.get(globalThis, eeLoadedKey)).toBeUndefined();
+		});
 	});
 });
 

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -102,21 +102,30 @@ export class ModuleRegistry {
 		}
 
 		for (const moduleName of modules ?? this.eligibleModules) {
+			const modulePath = path.join(modulesDir, moduleName);
+			const eeModulePath = path.join(modulesDir, `${moduleName}.ee`);
+
+			if (!existsSync(modulePath) && !existsSync(eeModulePath)) {
+				this.logger.debug(`Module "${moduleName}" not found, skipping`);
+				continue;
+			}
+
 			try {
 				await import(`${modulesDir}/${moduleName}/${moduleName}.module`);
 			} catch (primaryError) {
-				try {
-					await import(`${modulesDir}/${moduleName}.ee/${moduleName}.module`);
-				} catch (error) {
-					const loggedError =
-						primaryError instanceof Error &&
-						'code' in primaryError &&
-						primaryError.code !== 'MODULE_NOT_FOUND'
-							? primaryError
-							: error;
+				// Only try .ee fallback if primary module directory doesn't exist
+				// This prevents misleading errors when primary module exists but has dependency issues
+				if (!existsSync(modulePath)) {
+					try {
+						await import(`${modulesDir}/${moduleName}.ee/${moduleName}.module`);
+					} catch (error) {
+						throw new MissingModuleError(moduleName, error instanceof Error ? error.message : '');
+					}
+				} else {
+					// Primary module directory exists but import failed - report the actual error
 					throw new MissingModuleError(
 						moduleName,
-						loggedError instanceof Error ? loggedError.message : '',
+						primaryError instanceof Error ? primaryError.message : '',
 					);
 				}
 			}


### PR DESCRIPTION
## Summary

When `n8n-node dev` is run from a custom node project bootstrapped via `npx`, the `ModuleRegistry.loadModules` method fails because it attempts to import the Community Edition module entry first before falling back to the Enterprise Edition path. In the npm-published package, only the EE variant directory exists, so the CE import predictably fails. The EE fallback then also fails because its entrypoint file structure does not match what the fallback path expects, producing a misleading `MissingModuleError`.

The fix ensures the module importer selects the correct entrypoint path upfront based on which directory actually exists on disk, removing the unnecessary CE-first-then-EE-fallback pattern.

## How to test

1. Bootstrap a custom node project:
   ```
   npx n8n-node init my-node
   cd my-node
   npm install
   npm run dev
   ```
2. Verify the dev server starts without the `Failed to load module "community-packages"` error.
3. Run existing backend-common unit tests:
   ```
   cd packages/@n8n/backend-common && pnpm test
   ```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33582

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33642">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

