### PR TITLE
fix(core): Retry initial database connection on startup

### DIFF
--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -230,6 +230,20 @@ export class DatabaseConfig {
 	@Env('DB_CONNECTION_ACQUISITION_TIMEOUT_MS', z.coerce.number().int().gte(0))
 	connectionAcquisitionTimeoutMs: number = 30 * Time.seconds.toMilliseconds;
 
+	/**
+	 * Number of times to retry the *initial* database connection on startup
+	 * before giving up and crashing. Each retry waits with the same exponential
+	 * backoff as connection recovery
+	 * (`DB_RECOVERY_BACKOFF_MIN_MS` .. `DB_RECOVERY_BACKOFF_MAX_MS`).
+	 *
+	 * A transient DNS/network blip at boot self-heals; a genuinely unreachable or
+	 * misconfigured database still fails loudly once the retries are exhausted.
+	 *
+	 * Must be >= 0 (0 keeps the legacy single-attempt behavior).
+	 */
+	@Env('DB_STARTUP_CONNECT_MAX_RETRIES', z.coerce.number().int().gte(0))
+	startupConnectMaxRetries: number = 5;
+
 	@Nested
 	logging: LoggingConfig;
 

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -125,6 +125,7 @@ describe('GlobalConfig', () => {
 			minRecoveryBackoffMs: 1_000,
 			maxRecoveryBackoffMs: 30_000,
 			connectionAcquisitionTimeoutMs: 30_000,
+			startupConnectMaxRetries: 5,
 		} as DatabaseConfig,
 		credentials: {
 			defaultName: 'My credentials',
@@ -717,6 +718,7 @@ describe('GlobalConfig', () => {
 				minRecoveryBackoffMs: 1_000,
 				maxRecoveryBackoffMs: 30_000,
 				connectionAcquisitionTimeoutMs: 30_000,
+				startupConnectMaxRetries: 5,
 			},
 			endpoints: {
 				...defaultConfig.endpoints,

--- a/packages/@n8n/db/src/connection/__tests__/backoff.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/backoff.test.ts
@@ -1,0 +1,18 @@
+import { computeBackoff } from '../backoff';
+
+describe('computeBackoff', () => {
+	it('ramps exponentially from the floor', () => {
+		expect(computeBackoff(1, 1000, 30000)).toBe(1000);
+		expect(computeBackoff(2, 1000, 30000)).toBe(2000);
+		expect(computeBackoff(3, 1000, 30000)).toBe(4000);
+	});
+
+	it('caps at the ceiling', () => {
+		expect(computeBackoff(10, 1000, 30000)).toBe(30000);
+	});
+
+	it('degrades to a constant floor when max < min', () => {
+		expect(computeBackoff(1, 5000, 1000)).toBe(5000);
+		expect(computeBackoff(5, 5000, 1000)).toBe(5000);
+	});
+});

--- a/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection.test.ts
@@ -23,6 +23,12 @@ vi.mock('@n8n/typeorm', async () => ({
 
 vi.mock('../db-connection-monitor');
 
+vi.mock('timers/promises', async () => ({
+	// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+	...(await vi.importActual<typeof import('timers/promises')>('timers/promises')),
+	setTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('DbConnection', () => {
 	let dbConnection: DbConnection;
 	const migrations = [{ name: 'TestMigration1' }, { name: 'TestMigration2' }] as Migration[];
@@ -48,6 +54,10 @@ describe('DbConnection', () => {
 		vi.resetAllMocks();
 
 		connectionOptions.getOptions.mockReturnValue(postgresOptions);
+		// Default to legacy single-attempt behavior; retry tests override startupConnectMaxRetries.
+		databaseConfig.startupConnectMaxRetries = 0;
+		databaseConfig.minRecoveryBackoffMs = 1;
+		databaseConfig.maxRecoveryBackoffMs = 1;
 		vi.mocked(DbConnectionMonitor).mockImplementation(function () {
 			return monitor;
 		});
@@ -107,6 +117,36 @@ describe('DbConnection', () => {
 			dataSource.initialize.mockRejectedValue(error);
 
 			await expect(dbConnection.init()).rejects.toThrow('Some other error');
+		});
+
+		it('should retry a transient failure and succeed', async () => {
+			databaseConfig.startupConnectMaxRetries = 3;
+			dataSource.initialize
+				.mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND'))
+				.mockResolvedValue(dataSource);
+
+			await dbConnection.init();
+
+			expect(dataSource.initialize).toHaveBeenCalledTimes(2);
+			expect(dbConnection.connectionState.connected).toBe(true);
+			expect(monitor.start).toHaveBeenCalled();
+		});
+
+		it('should give up after exhausting retries', async () => {
+			databaseConfig.startupConnectMaxRetries = 2;
+			dataSource.initialize.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+
+			await expect(dbConnection.init()).rejects.toThrow('getaddrinfo ENOTFOUND');
+			expect(dataSource.initialize).toHaveBeenCalledTimes(3);
+			expect(dbConnection.connectionState.connected).toBe(false);
+		});
+
+		it('should not retry when startupConnectMaxRetries is 0', async () => {
+			databaseConfig.startupConnectMaxRetries = 0;
+			dataSource.initialize.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+
+			await expect(dbConnection.init()).rejects.toThrow('getaddrinfo ENOTFOUND');
+			expect(dataSource.initialize).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/@n8n/db/src/connection/backoff.ts
+++ b/packages/@n8n/db/src/connection/backoff.ts
@@ -1,0 +1,11 @@
+/**
+ * Exponential backoff for a 1-based attempt, ramping from `minMs` and capped at `maxMs`.
+ *
+ * The ceiling is clamped to never fall below the floor, so a misconfiguration
+ * (`maxMs < minMs`) degrades to a constant `minMs` delay rather than silently
+ * collapsing every retry onto the smaller max value (which would defeat the floor).
+ */
+export function computeBackoff(attempt: number, minMs: number, maxMs: number): number {
+	const ceiling = Math.max(minMs, maxMs);
+	return Math.min(minMs * 2 ** (attempt - 1), ceiling);
+}

--- a/packages/@n8n/db/src/connection/db-connection-monitor.ts
+++ b/packages/@n8n/db/src/connection/db-connection-monitor.ts
@@ -8,6 +8,7 @@ import type { ErrorReporter } from 'n8n-core';
 import { OperationalError } from 'n8n-workflow';
 import { setTimeout as setTimeoutP } from 'timers/promises';
 
+import { computeBackoff } from './backoff';
 import type { DbConnectionMetrics } from './db-connection-metrics';
 
 /** The chokepoint every TypeORM query funnels through to acquire a master connection. */
@@ -298,7 +299,8 @@ export class DbConnectionMonitor {
 				} catch (error) {
 					const wrapped = ensureError(error);
 					this.errorReporter.error(wrapped);
-					const backoff = this.computeBackoff(attempt);
+					const { minRecoveryBackoffMs, maxRecoveryBackoffMs } = this.databaseConfig;
+					const backoff = computeBackoff(attempt, minRecoveryBackoffMs, maxRecoveryBackoffMs);
 					this.logger.warn(
 						`Recovery attempt ${attempt} failed: ${wrapped.message}. Retrying in ${backoff}ms`,
 					);
@@ -326,22 +328,6 @@ export class DbConnectionMonitor {
 		} finally {
 			this.stopRecovery();
 		}
-	}
-
-	/**
-	 * Exponential backoff for the given (1-based) recovery attempt, ramping from
-	 * `minRecoveryBackoffMs` and capped at `maxRecoveryBackoffMs`.
-	 *
-	 * The cap is clamped to never fall below the floor, so a misconfiguration
-	 * (`maxRecoveryBackoffMs < minRecoveryBackoffMs`) degrades to a constant
-	 * `minRecoveryBackoffMs` delay rather than silently collapsing every retry
-	 * onto the smaller max value (which would defeat the floor). The
-	 * misconfiguration is warned about once at `start()`.
-	 */
-	private computeBackoff(attempt: number) {
-		const { minRecoveryBackoffMs, maxRecoveryBackoffMs } = this.databaseConfig;
-		const ceiling = Math.max(minRecoveryBackoffMs, maxRecoveryBackoffMs);
-		return Math.min(minRecoveryBackoffMs * 2 ** (attempt - 1), ceiling);
 	}
 
 	private get isPostgres(): boolean {

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -6,7 +6,9 @@ import { DataSource } from '@n8n/typeorm';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { ErrorReporter } from 'n8n-core';
 import { DbConnectionTimeoutError } from 'n8n-workflow';
+import { setTimeout as setTimeoutP } from 'timers/promises';
 
+import { computeBackoff } from './backoff';
 import { DbConnectionMetrics } from './db-connection-metrics';
 import { DbConnectionMonitor } from './db-connection-monitor';
 import { DbConnectionOptions } from './db-connection-options';
@@ -61,20 +63,32 @@ export class DbConnection {
 			);
 		}
 
-		try {
-			await this.dataSource.initialize();
-		} catch (e) {
-			let error = ensureError(e);
-			if (
-				options.type === 'postgres' &&
-				error.message === 'Connection terminated due to connection timeout'
-			) {
-				error = new DbConnectionTimeoutError({
-					cause: error,
-					configuredTimeoutInMs: options.connectTimeoutMS!,
-				});
+		const { minRecoveryBackoffMs, maxRecoveryBackoffMs, startupConnectMaxRetries } =
+			this.databaseConfig;
+		const maxAttempts = startupConnectMaxRetries + 1;
+		for (let attempt = 1; ; attempt++) {
+			try {
+				await this.dataSource.initialize();
+				break;
+			} catch (e) {
+				let error = ensureError(e);
+				if (
+					options.type === 'postgres' &&
+					error.message === 'Connection terminated due to connection timeout'
+				) {
+					error = new DbConnectionTimeoutError({
+						cause: error,
+						configuredTimeoutInMs: options.connectTimeoutMS!,
+					});
+				}
+				if (attempt >= maxAttempts) throw error;
+
+				const backoff = computeBackoff(attempt, minRecoveryBackoffMs, maxRecoveryBackoffMs);
+				this.logger.warn(
+					`Initial database connection attempt ${attempt} failed: ${error.message}. Retrying in ${backoff}ms`,
+				);
+				await setTimeoutP(backoff);
 			}
-			throw error;
 		}
 
 		connectionState.connected = true;

--- a/packages/@n8n/db/src/connection/db-connection.ts
+++ b/packages/@n8n/db/src/connection/db-connection.ts
@@ -53,7 +53,7 @@ export class DbConnection {
 	}
 
 	async init(): Promise<void> {
-		const { connectionState, options } = this;
+		const { connectionState } = this;
 		if (connectionState.connected) return;
 
 		// TODO(CAT-3314): Remove N8N_DB_PING_TIMEOUT fallback in v3.
@@ -63,33 +63,7 @@ export class DbConnection {
 			);
 		}
 
-		const { minRecoveryBackoffMs, maxRecoveryBackoffMs, startupConnectMaxRetries } =
-			this.databaseConfig;
-		const maxAttempts = startupConnectMaxRetries + 1;
-		for (let attempt = 1; ; attempt++) {
-			try {
-				await this.dataSource.initialize();
-				break;
-			} catch (e) {
-				let error = ensureError(e);
-				if (
-					options.type === 'postgres' &&
-					error.message === 'Connection terminated due to connection timeout'
-				) {
-					error = new DbConnectionTimeoutError({
-						cause: error,
-						configuredTimeoutInMs: options.connectTimeoutMS!,
-					});
-				}
-				if (attempt >= maxAttempts) throw error;
-
-				const backoff = computeBackoff(attempt, minRecoveryBackoffMs, maxRecoveryBackoffMs);
-				this.logger.warn(
-					`Initial database connection attempt ${attempt} failed: ${error.message}. Retrying in ${backoff}ms`,
-				);
-				await setTimeoutP(backoff);
-			}
-		}
+		await this.connectWithRetry();
 
 		connectionState.connected = true;
 		this.monitor = new DbConnectionMonitor(
@@ -118,6 +92,41 @@ export class DbConnection {
 		if (this.dataSource.isInitialized) {
 			await this.dataSource.destroy();
 			this.connectionState.connected = false;
+		}
+	}
+
+	/**
+	 * Opens the initial connection, retrying transient failures with exponential
+	 * backoff before giving up. Throws once `startupConnectMaxRetries` is exhausted.
+	 */
+	private async connectWithRetry(): Promise<void> {
+		const { options } = this;
+		const { minRecoveryBackoffMs, maxRecoveryBackoffMs, startupConnectMaxRetries } =
+			this.databaseConfig;
+		const maxAttempts = startupConnectMaxRetries + 1;
+		for (let attempt = 1; ; attempt++) {
+			try {
+				await this.dataSource.initialize();
+				return;
+			} catch (e) {
+				let error = ensureError(e);
+				if (
+					options.type === 'postgres' &&
+					error.message === 'Connection terminated due to connection timeout'
+				) {
+					error = new DbConnectionTimeoutError({
+						cause: error,
+						configuredTimeoutInMs: options.connectTimeoutMS!,
+					});
+				}
+				if (attempt >= maxAttempts) throw error;
+
+				const backoff = computeBackoff(attempt, minRecoveryBackoffMs, maxRecoveryBackoffMs);
+				this.logger.warn(
+					`Initial database connection attempt ${attempt} failed: ${error.message}. Retrying in ${backoff}ms`,
+				);
+				await setTimeoutP(backoff);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The initial database connection had no retry. `DbConnection.init()` called `dataSource.initialize()` exactly once, and any failure — including a transient DNS `getaddrinfo` hiccup at boot — propagated to `exitWithCrash` and killed the process (fatal). The connection recovery monitor (ping + exponential backoff + reconnect) only starts *after* the first successful connect, so the very first connection was entirely unprotected. A transient blip at startup was therefore unrecoverable, surfacing as an opaque `There was an error initializing DB`.

This retries the initial connect with bounded exponential backoff before giving up:

- Reuses the existing recovery backoff config (`DB_RECOVERY_BACKOFF_MIN_MS` / `DB_RECOVERY_BACKOFF_MAX_MS`) for the backoff curve.
- Adds one new config field, `DB_STARTUP_CONNECT_MAX_RETRIES` (default `5`, `>= 0`; `0` keeps the legacy single-attempt behavior).
- Extracts the `computeBackoff` formula into a small shared helper so `init()` and the monitor use one implementation.

Behavior: a transient DNS/network blip self-heals; a genuinely unreachable or misconfigured database still fails loudly (crash) once retries are exhausted, so orchestrators can crashloop-restart. With the defaults (5 retries over the 1s→30s curve) the startup waits ~31s before crashing.

## How to test

Automated:

```bash
pnpm --filter=@n8n/db test src/connection/__tests__/db-connection.test.ts src/connection/__tests__/backoff.test.ts src/connection/__tests__/db-connection-monitor.test.ts
```

Manual (Postgres):

1. Set `DB_TYPE=postgresdb` with a valid Postgres and `DB_STARTUP_CONNECT_MAX_RETRIES=5`.
2. Point `DB_POSTGRESDB_HOST` at an unresolvable hostname and start n8n → logs show `Initial database connection attempt N failed: … Retrying in Xms` for each attempt, then a crash after the budget is exhausted.
3. Alternatively, start with the DB briefly unreachable and bring it up mid-retry → n8n connects on a later attempt and boots normally (self-heal).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3590

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33647">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

