### PR TITLE
fix(benchmark): Locate data disk by LUN instead of device name (no-changelog)

### DIFF
--- a/packages/@n8n/benchmark/scripts/bootstrap.sh
+++ b/packages/@n8n/benchmark/scripts/bootstrap.sh
@@ -8,17 +8,22 @@ set -euo pipefail;
 CURRENT_USER=$(whoami)
 
 # Mount the data disk
+# The data disk is attached at LUN 1 (see infra/modules/benchmark-vm/vm.tf).
+# Use Azure's stable by-LUN symlink instead of /dev/sdX: kernel device order
+# shifts depending on whether the VM size has a local temp disk.
+DATA_DISK=/dev/disk/azure/scsi1/lun1
+
 # First wait for the disk to become available
 WAIT_TIME=0
 MAX_WAIT_TIME=60
 
-while [ ! -e /dev/sdc ]; do
+while [ ! -e "$DATA_DISK" ]; do
     if [ $WAIT_TIME -ge $MAX_WAIT_TIME ]; then
-        echo "Error: /dev/sdc did not become available within $MAX_WAIT_TIME seconds."
+        echo "Error: $DATA_DISK did not become available within $MAX_WAIT_TIME seconds."
         exit 1
     fi
 
-    echo "Waiting for /dev/sdc to be available... ($WAIT_TIME/$MAX_WAIT_TIME)"
+    echo "Waiting for $DATA_DISK to be available... ($WAIT_TIME/$MAX_WAIT_TIME)"
     sleep 1
     WAIT_TIME=$((WAIT_TIME + 1))
 done
@@ -30,10 +35,12 @@ if [ -d "/n8n" ]; then
 	sudo rm -rf /n8n/.[!.]*
 else
 	sudo mkdir -p /n8n
-	sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%
-	sudo mkfs.xfs /dev/sdc1
-	sudo partprobe /dev/sdc1
-	sudo mount /dev/sdc1 /n8n
+	sudo parted "$DATA_DISK" --script mklabel gpt mkpart xfspart xfs 0% 100%
+	sudo partprobe "$DATA_DISK"
+	# Wait for udev to create the partition symlink before formatting
+	sudo udevadm settle
+	sudo mkfs.xfs "${DATA_DISK}-part1"
+	sudo mount "${DATA_DISK}-part1" /n8n
 	sudo chown -R "$CURRENT_USER":"$CURRENT_USER" /n8n
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #33625. That PR fixed provisioning (the `DSv5-Type1` dedicated host now allocates), but the benchmark run then failed in `bootstrap.sh` with:

```
Error: /dev/sdc did not become available within 60 seconds.
```

Root cause: `Standard_DC8_v2` had a local temp disk that claimed `/dev/sdb`, pushing the attached data disk to `/dev/sdc`. `Standard_D8s_v5` has no local temp disk, so the data disk enumerates as `/dev/sdb` and `/dev/sdc` never appears.

Instead of hardcoding a kernel device name, the script now uses Azure's stable by-LUN udev symlink `/dev/disk/azure/scsi1/lun1` (the data disk is attached at `lun = "1"` in `infra/modules/benchmark-vm/vm.tf`). This is independent of enumeration order, so it works on any VM size with or without a temp disk. Also adds a `udevadm settle` after `partprobe` so the `-part1` partition symlink exists before `mkfs`/`mount`.

## How to test

- see successful run: https://github.com/n8n-io/n8n/actions/runs/28784502202/job/85347775737
- see failing run: https://github.com/n8n-io/n8n/actions/runs/28783496929/job/85344496605

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3669

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

