### PR TITLE
feat(core): Add durable scheduler schedule-trigger task handler (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/scheduled-job.ts
+++ b/packages/@n8n/db/src/entities/scheduled-job.ts
@@ -60,7 +60,7 @@ export class ScheduledJob extends WithTimestamps {
 	/**
 	 * What kind of work this job runs.
 	 * The scheduler is generic, so this is how it knows what to do when the job
-	 * fires, e.g. `'scheduleTrigger'` for a workflow's schedule trigger.
+	 * fires, e.g. `'workflow:schedule-trigger'` for a workflow's schedule trigger.
 	 * Paired with {@link payload}, which carries the handler's input.
 	 */
 	@Column({ type: 'varchar', length: 128 })

--- a/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
@@ -7,6 +7,8 @@ import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
 import { DurableScheduler } from '../durable-scheduler';
+import { SCHEDULE_TRIGGER_TASK_TYPE } from '../schedule-trigger-node/schedule-trigger-task';
+import type { ScheduleTriggerTaskHandler } from '../schedule-trigger-node/schedule-trigger-task-handler';
 
 // Keep the real exports (e.g. executorLookaheadSeconds) so the wiring is tested
 // against the actual formula; only the scheduler factory is stubbed.
@@ -20,6 +22,9 @@ describe('DurableScheduler', () => {
 		const inner = mock<Scheduler & SchedulerPasses>();
 		vi.mocked(createScheduler).mockReturnValue(inner);
 		const logger = mockLogger();
+		const scheduleTriggerTaskHandler = mock<ScheduleTriggerTaskHandler>({
+			taskType: SCHEDULE_TRIGGER_TASK_TYPE,
+		});
 		const scheduler = new DurableScheduler(
 			logger,
 			mock<DataSource>(),
@@ -31,6 +36,7 @@ describe('DurableScheduler', () => {
 				database: { type: dbType as 'sqlite' | 'postgresdb' },
 				scheduler: { enabled, executorIntervalSeconds: 5, jitterRatio: 0.1 },
 			}),
+			scheduleTriggerTaskHandler,
 		);
 		return { scheduler, inner, logger };
 	}

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -7,6 +7,8 @@ import type { RunInTransaction, Scheduler, TaskHandler } from '@n8n/scheduler';
 import { createScheduler, executorLookaheadSeconds } from '@n8n/scheduler';
 import { InstanceSettings } from 'n8n-core';
 
+import { ScheduleTriggerTaskHandler } from './schedule-trigger-node/schedule-trigger-task-handler';
+
 /**
  * The database-backed {@link Scheduler} and its process lifecycle.
  *
@@ -24,6 +26,7 @@ export class DurableScheduler implements Scheduler {
 		tasks: ScheduledTaskRepository,
 		instanceSettings: InstanceSettings,
 		globalConfig: GlobalConfig,
+		scheduleTriggerTaskHandler: ScheduleTriggerTaskHandler,
 	) {
 		const config = globalConfig.scheduler;
 		const enabled = config.enabled && instanceSettings.instanceType === 'main';
@@ -68,6 +71,7 @@ export class DurableScheduler implements Scheduler {
 					onEvent: ({ level, message, context }) => logger[level](message, context),
 				})
 			: undefined;
+		this.registerTaskHandler(scheduleTriggerTaskHandler.taskType, scheduleTriggerTaskHandler);
 	}
 
 	registerTaskHandler(taskType: string, handler: TaskHandler): void {

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
@@ -1,0 +1,217 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/naming-convention -- item keys are pinned to the legacy ScheduleTrigger emit shape */
+import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
+import type { ExecutionEntity, ExecutionRepository } from '@n8n/db';
+import type { ClaimedTask } from '@n8n/scheduler';
+import type { INode, IWorkflowBase, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import type { EventService } from '@/events/event.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import type { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
+import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import { SCHEDULE_TRIGGER_TASK_TYPE } from '../schedule-trigger-task';
+import { ScheduleTriggerTaskHandler } from '../schedule-trigger-task-handler';
+
+describe('ScheduleTriggerTaskHandler', () => {
+	const executionRepository = mock<ExecutionRepository>();
+	const eventService = mock<EventService>();
+	const triggerExecutionContextFactory = mock<TriggerExecutionContextFactory>();
+	const workflowExecutionService = mock<WorkflowExecutionService>();
+	const globalConfig = mock<GlobalConfig>({ generic: { timezone: 'America/New_York' } });
+	const additionalData = mock<IWorkflowExecuteAdditionalData>();
+
+	const scopedLogger = mock<Logger>();
+	const rootLogger = mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) });
+
+	const handler = new ScheduleTriggerTaskHandler(
+		rootLogger,
+		globalConfig,
+		executionRepository,
+		eventService,
+		triggerExecutionContextFactory,
+		workflowExecutionService,
+	);
+
+	const triggerNode = mock<INode>({ id: 'node-1', name: 'Schedule Trigger', disabled: false });
+
+	// Plain data objects, not mock proxies: the handler reads them as values.
+	const buildWorkflowData = (overrides: Partial<IWorkflowBase> = {}): IWorkflowBase =>
+		({
+			id: 'wf-1',
+			name: 'My Scheduled Workflow',
+			active: true,
+			isArchived: false,
+			createdAt: new Date('2026-07-01T00:00:00.000Z'),
+			updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+			nodes: [triggerNode],
+			connections: {},
+			settings: { timezone: 'Europe/Berlin' },
+			...overrides,
+		}) as IWorkflowBase;
+
+	const scheduledFor = new Date('2026-07-06T07:30:00.000Z');
+
+	const buildTask = (overrides: Partial<ClaimedTask> = {}): ClaimedTask => ({
+		id: 'task-1',
+		jobId: 7,
+		taskType: 'workflow:schedule-trigger',
+		payload: { workflowId: 'wf-1', nodeId: 'node-1' },
+		scheduledFor,
+		runAt: scheduledFor,
+		status: 'running',
+		attempts: 0,
+		maxAttempts: 1,
+		leaseEpoch: 1,
+		...overrides,
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
+		triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(buildWorkflowData());
+		workflowExecutionService.runWorkflow.mockResolvedValue('exec-1');
+	});
+
+	describe('task type', () => {
+		test('declares the schedule-trigger task type it is bound under at composition', () => {
+			expect(handler.taskType).toBe(SCHEDULE_TRIGGER_TASK_TYPE);
+		});
+	});
+
+	describe('handoff', () => {
+		test('creates a trigger execution with the occurrence-derived dedup key', async () => {
+			await handler.execute(buildTask());
+
+			expect(triggerExecutionContextFactory.loadPublishedWorkflowData).toHaveBeenCalledWith('wf-1');
+			expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				triggerNode,
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				[[expect.objectContaining({ json: expect.any(Object) })]],
+				additionalData,
+				'trigger',
+				undefined,
+				'7:2026-07-06T07:30:00.000Z',
+			);
+		});
+
+		test('stamps the trigger item from the occurrence instant in the workflow timezone', async () => {
+			await handler.execute(buildTask());
+
+			const [, , data] = workflowExecutionService.runWorkflow.mock.calls[0];
+			expect(data[0][0].json).toMatchObject({
+				timestamp: '2026-07-06T09:30:00.000+02:00',
+				Timezone: 'Europe/Berlin (UTC+02:00)',
+			});
+		});
+
+		test('falls back to the instance timezone when the workflow sets none', async () => {
+			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+				buildWorkflowData({ settings: {} }),
+			);
+
+			await handler.execute(buildTask());
+
+			const [, , data] = workflowExecutionService.runWorkflow.mock.calls[0];
+			expect(data[0][0].json).toMatchObject({
+				timestamp: '2026-07-06T03:30:00.000-04:00',
+				Timezone: 'America/New_York (UTC-04:00)',
+			});
+		});
+
+		test('builds additional data for the published workflow like the activation path', async () => {
+			await handler.execute(buildTask());
+
+			expect(WorkflowExecuteAdditionalData.getBase).toHaveBeenCalledWith({
+				workflowId: 'wf-1',
+				workflowSettings: { timezone: 'Europe/Berlin' },
+			});
+		});
+
+		test('emits workflow-executed for the new execution', async () => {
+			await handler.execute(buildTask());
+
+			expect(eventService.emit).toHaveBeenCalledWith('workflow-executed', {
+				workflowId: 'wf-1',
+				workflowName: 'My Scheduled Workflow',
+				executionId: 'exec-1',
+				source: 'trigger',
+			});
+		});
+	});
+
+	describe('redelivery', () => {
+		test('completes quietly when the execution already exists for the key', async () => {
+			workflowExecutionService.runWorkflow.mockRejectedValue(
+				new DuplicateExecutionError('7:2026-07-06T07:30:00.000Z'),
+			);
+			executionRepository.findOne.mockResolvedValue(
+				mock<ExecutionEntity>({ id: 'exec-0', status: 'running' }),
+			);
+
+			await expect(handler.execute(buildTask({ attempts: 1 }))).resolves.toBeUndefined();
+
+			expect(executionRepository.findOne).toHaveBeenCalledWith({
+				where: { deduplicationKey: '7:2026-07-06T07:30:00.000Z' },
+				select: ['id', 'status'],
+			});
+			expect(scopedLogger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('redelivered'),
+				expect.objectContaining({ executionId: 'exec-0', executionStatus: 'running' }),
+			);
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('failures', () => {
+		test('rejects a task whose payload is missing workflowId or nodeId', async () => {
+			const task = buildTask({ payload: { nodeId: 'node-1' } });
+
+			await expect(handler.execute(task)).rejects.toThrow(UnexpectedError);
+			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+		});
+
+		test('propagates a missing published workflow so the executor records the failure', async () => {
+			const error = new UnexpectedError('Published version not found for workflow');
+			triggerExecutionContextFactory.loadPublishedWorkflowData.mockRejectedValue(error);
+
+			await expect(handler.execute(buildTask())).rejects.toThrow(error);
+			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+		});
+
+		test('rejects a task whose trigger node is gone from the published workflow', async () => {
+			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+				buildWorkflowData({ nodes: [] }),
+			);
+
+			await expect(handler.execute(buildTask())).rejects.toThrow(
+				'missing or disabled in the published workflow',
+			);
+			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+		});
+
+		test('rejects a task whose trigger node is disabled', async () => {
+			triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(
+				buildWorkflowData({ nodes: [mock<INode>({ id: 'node-1', disabled: true })] }),
+			);
+
+			await expect(handler.execute(buildTask())).rejects.toThrow(
+				'missing or disabled in the published workflow',
+			);
+			expect(workflowExecutionService.runWorkflow).not.toHaveBeenCalled();
+		});
+
+		test('propagates handoff failures so the executor retries with backoff', async () => {
+			const error = new Error('db unavailable');
+			workflowExecutionService.runWorkflow.mockRejectedValue(error);
+
+			await expect(handler.execute(buildTask())).rejects.toThrow(error);
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
@@ -4,6 +4,7 @@ import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import type { ExecutionEntity, ExecutionRepository } from '@n8n/db';
 import type { ClaimedTask } from '@n8n/scheduler';
+import type { ErrorReporter } from 'n8n-core';
 import type { INode, IWorkflowBase, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { UnexpectedError } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
@@ -18,6 +19,7 @@ import { SCHEDULE_TRIGGER_TASK_TYPE } from '../schedule-trigger-task';
 import { ScheduleTriggerTaskHandler } from '../schedule-trigger-task-handler';
 
 describe('ScheduleTriggerTaskHandler', () => {
+	const errorReporter = mock<ErrorReporter>();
 	const executionRepository = mock<ExecutionRepository>();
 	const eventService = mock<EventService>();
 	const triggerExecutionContextFactory = mock<TriggerExecutionContextFactory>();
@@ -30,6 +32,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 
 	const handler = new ScheduleTriggerTaskHandler(
 		rootLogger,
+		errorReporter,
 		globalConfig,
 		executionRepository,
 		eventService,
@@ -147,9 +150,8 @@ describe('ScheduleTriggerTaskHandler', () => {
 
 	describe('redelivery', () => {
 		test('completes quietly when the execution already exists for the key', async () => {
-			workflowExecutionService.runWorkflow.mockRejectedValue(
-				new DuplicateExecutionError('7:2026-07-06T07:30:00.000Z'),
-			);
+			const duplicateError = new DuplicateExecutionError('7:2026-07-06T07:30:00.000Z');
+			workflowExecutionService.runWorkflow.mockRejectedValue(duplicateError);
 			executionRepository.findOne.mockResolvedValue(
 				mock<ExecutionEntity>({ id: 'exec-0', status: 'running' }),
 			);
@@ -164,6 +166,11 @@ describe('ScheduleTriggerTaskHandler', () => {
 				expect.stringContaining('redelivered'),
 				expect.objectContaining({ executionId: 'exec-0', executionStatus: 'running' }),
 			);
+			expect(errorReporter.warn).toHaveBeenCalledWith(duplicateError, {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				extra: expect.objectContaining({ executionId: 'exec-0', executionStatus: 'running' }),
+				shouldBeLogged: false,
+			});
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable @typescript-eslint/naming-convention -- item keys are pinned to the legacy ScheduleTrigger emit shape */
+import {
+	buildScheduleTriggerItem,
+	isScheduleTriggerTaskPayload,
+	scheduleTriggerDeduplicationKey,
+} from '../schedule-trigger-task';
+
+describe('isScheduleTriggerTaskPayload', () => {
+	test('accepts a payload with workflowId and nodeId', () => {
+		expect(isScheduleTriggerTaskPayload({ workflowId: 'wf-1', nodeId: 'node-1' })).toBe(true);
+	});
+
+	test.each([
+		['empty payload', {}],
+		['missing nodeId', { workflowId: 'wf-1' }],
+		['missing workflowId', { nodeId: 'node-1' }],
+		['empty workflowId', { workflowId: '', nodeId: 'node-1' }],
+		['empty nodeId', { workflowId: 'wf-1', nodeId: '' }],
+		['non-string ids', { workflowId: 42, nodeId: true }],
+	])('rejects %s', (_name, payload) => {
+		expect(isScheduleTriggerTaskPayload(payload)).toBe(false);
+	});
+});
+
+describe('scheduleTriggerDeduplicationKey', () => {
+	test('derives jobId:scheduledFor in canonical UTC', () => {
+		const key = scheduleTriggerDeduplicationKey({
+			jobId: 7,
+			scheduledFor: new Date('2026-07-06T07:30:00.000Z'),
+		});
+
+		expect(key).toBe('7:2026-07-06T07:30:00.000Z');
+	});
+});
+
+describe('buildScheduleTriggerItem', () => {
+	const scheduledFor = new Date('2026-07-06T07:30:00.000Z');
+
+	test('mirrors the legacy Schedule Trigger emit shape, stamped from the occurrence', () => {
+		expect(buildScheduleTriggerItem(scheduledFor, 'Asia/Kathmandu')).toEqual({
+			json: {
+				timestamp: '2026-07-06T13:15:00.000+05:45',
+				'Readable date': 'July 6th 2026, 1:15:00 pm',
+				'Readable time': '1:15:00 pm',
+				'Day of week': 'Monday',
+				Year: '2026',
+				Month: 'July',
+				'Day of month': '06',
+				Hour: '13',
+				Minute: '15',
+				Second: '00',
+				Timezone: 'Asia/Kathmandu (UTC+05:45)',
+			},
+		});
+	});
+});

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -1,0 +1,139 @@
+import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
+import { ExecutionRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { ClaimedTask, TaskHandler } from '@n8n/scheduler';
+import type { INode, IWorkflowBase } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
+
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import { EventService } from '@/events/event.service';
+import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
+import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import {
+	buildScheduleTriggerItem,
+	isScheduleTriggerTaskPayload,
+	SCHEDULE_TRIGGER_TASK_TYPE,
+	scheduleTriggerDeduplicationKey,
+	type ScheduleTriggerTaskPayload,
+} from './schedule-trigger-task';
+
+/**
+ * Turns a due schedule-trigger occurrence into a real workflow execution.
+ *
+ * The handoff is the whole job: build the trigger item, create the execution
+ * with the occurrence-derived dedup key, and return.
+ */
+@Service()
+export class ScheduleTriggerTaskHandler implements TaskHandler {
+	readonly taskType = SCHEDULE_TRIGGER_TASK_TYPE;
+
+	constructor(
+		private logger: Logger,
+		private readonly globalConfig: GlobalConfig,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly eventService: EventService,
+		private readonly triggerExecutionContextFactory: TriggerExecutionContextFactory,
+		private readonly workflowExecutionService: WorkflowExecutionService,
+	) {
+		this.logger = this.logger.scoped('scheduler');
+	}
+
+	async execute(task: ClaimedTask): Promise<void> {
+		const { workflowId, nodeId } = this.parsePayload(task);
+		const workflowData =
+			await this.triggerExecutionContextFactory.loadPublishedWorkflowData(workflowId);
+		const node = this.resolveTriggerNode(workflowData, nodeId, task);
+
+		const deduplicationKey = scheduleTriggerDeduplicationKey(task);
+		const timezone = workflowData.settings?.timezone ?? this.globalConfig.generic.timezone;
+		const item = buildScheduleTriggerItem(task.scheduledFor, timezone);
+
+		const additionalData = await WorkflowExecuteAdditionalData.getBase({
+			workflowId,
+			workflowSettings: workflowData.settings,
+		});
+
+		let executionId: string;
+		try {
+			executionId = await this.workflowExecutionService.runWorkflow(
+				workflowData,
+				node,
+				[[item]],
+				additionalData,
+				'trigger',
+				/* responsePromise= */ undefined,
+				deduplicationKey,
+			);
+
+			this.eventService.emit('workflow-executed', {
+				workflowId,
+				workflowName: workflowData.name,
+				executionId,
+				source: 'trigger',
+			});
+
+			this.logger.debug('Handed off scheduled occurrence to a new execution', {
+				taskId: task.id,
+				jobId: task.jobId,
+				workflowId,
+				executionId,
+				deduplicationKey,
+			});
+		} catch (error) {
+			if (!(error instanceof DuplicateExecutionError)) {
+				throw error;
+			}
+			await this.recordExistingHandoff(task, deduplicationKey);
+		}
+	}
+
+	private parsePayload(task: ClaimedTask): ScheduleTriggerTaskPayload {
+		if (!isScheduleTriggerTaskPayload(task.payload)) {
+			throw new UnexpectedError('Schedule-trigger task payload is missing workflowId or nodeId', {
+				extra: { taskId: task.id, jobId: task.jobId },
+			});
+		}
+		return task.payload;
+	}
+
+	private resolveTriggerNode(
+		workflowData: IWorkflowBase,
+		nodeId: string,
+		task: ClaimedTask,
+	): INode {
+		const node = workflowData.nodes.find((candidate) => candidate.id === nodeId);
+		if (!node || node.disabled) {
+			// The job outlived its trigger node: deactivation should have removed it.
+			throw new UnexpectedError(
+				'Schedule-trigger task points to a node that is missing or disabled in the published workflow',
+				{ extra: { taskId: task.id, jobId: task.jobId, workflowId: workflowData.id, nodeId } },
+			);
+		}
+		return node;
+	}
+
+	/**
+	 * The redelivery backstop: an execution already exists under this key, so
+	 * find it, record the pre-existing handoff, and let the task complete. The
+	 * logged status makes the rare stuck row (inserted as `new`, never started
+	 * because the instance died mid-handoff) observable.
+	 */
+	private async recordExistingHandoff(task: ClaimedTask, deduplicationKey: string): Promise<void> {
+		const existing = await this.executionRepository.findOne({
+			where: { deduplicationKey },
+			select: ['id', 'status'],
+		});
+
+		this.logger.warn('Occurrence redelivered after a previously recorded execution; skipping', {
+			taskId: task.id,
+			jobId: task.jobId,
+			attempts: task.attempts,
+			deduplicationKey,
+			executionId: existing?.id,
+			executionStatus: existing?.status,
+		});
+	}
+}

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '@n8n/config';
 import { ExecutionRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { ClaimedTask, TaskHandler } from '@n8n/scheduler';
+import { ErrorReporter } from 'n8n-core';
 import type { INode, IWorkflowBase } from 'n8n-workflow';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -32,6 +33,7 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 
 	constructor(
 		private logger: Logger,
+		private readonly errorReporter: ErrorReporter,
 		private readonly globalConfig: GlobalConfig,
 		private readonly executionRepository: ExecutionRepository,
 		private readonly eventService: EventService,
@@ -86,7 +88,7 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 			if (!(error instanceof DuplicateExecutionError)) {
 				throw error;
 			}
-			await this.recordExistingHandoff(task, deduplicationKey);
+			await this.recordExistingHandoff(task, error);
 		}
 	}
 
@@ -121,19 +123,28 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 	 * logged status makes the rare stuck row (inserted as `new`, never started
 	 * because the instance died mid-handoff) observable.
 	 */
-	private async recordExistingHandoff(task: ClaimedTask, deduplicationKey: string): Promise<void> {
+	private async recordExistingHandoff(
+		task: ClaimedTask,
+		error: DuplicateExecutionError,
+	): Promise<void> {
+		const { deduplicationKey } = error;
 		const existing = await this.executionRepository.findOne({
 			where: { deduplicationKey },
 			select: ['id', 'status'],
 		});
 
-		this.logger.warn('Occurrence redelivered after a previously recorded execution; skipping', {
+		const context = {
 			taskId: task.id,
 			jobId: task.jobId,
 			attempts: task.attempts,
 			deduplicationKey,
 			executionId: existing?.id,
 			executionStatus: existing?.status,
-		});
+		};
+		this.logger.warn(
+			'Occurrence redelivered after a previously recorded execution; skipping',
+			context,
+		);
+		this.errorReporter.warn(error, { extra: context, shouldBeLogged: false });
 	}
 }

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/naming-convention -- item keys are pinned to the legacy ScheduleTrigger emit shape */
+import type { ClaimedTask } from '@n8n/scheduler';
+import moment from 'moment-timezone';
+import type { INodeExecutionData } from 'n8n-workflow';
+
+/**
+ * Task type schedule-trigger jobs are materialized under and their handler registers for.
+ */
+export const SCHEDULE_TRIGGER_TASK_TYPE = 'workflow:schedule-trigger';
+
+/**
+ * What a schedule-trigger job carries through materialization to its handler.
+ */
+export interface ScheduleTriggerTaskPayload {
+	workflowId: string;
+	nodeId: string;
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+	typeof value === 'string' && value !== '';
+
+/**
+ * Validates the payload snapshot the materializer copied from the job onto the task.
+ */
+export const isScheduleTriggerTaskPayload = (
+	payload: Record<string, unknown>,
+): payload is Record<string, unknown> & ScheduleTriggerTaskPayload =>
+	isNonEmptyString(payload.workflowId) && isNonEmptyString(payload.nodeId);
+
+export const scheduleTriggerDeduplicationKey = ({
+	jobId,
+	scheduledFor,
+}: Pick<ClaimedTask, 'jobId' | 'scheduledFor'>): string => `${jobId}:${scheduledFor.toISOString()}`;
+
+/**
+ * The item a firing Schedule Trigger hands to the workflow. Field-for-field
+ * identical to the legacy emit in `ScheduleTrigger.node.ts`, so a workflow
+ * reads the same shape whichever engine fired it.
+ */
+export const buildScheduleTriggerItem = (
+	scheduledFor: Date,
+	timezone: string,
+): INodeExecutionData => {
+	const momentTz = moment.tz(scheduledFor, timezone);
+	return {
+		json: {
+			timestamp: momentTz.toISOString(true),
+			'Readable date': momentTz.format('MMMM Do YYYY, h:mm:ss a'),
+			'Readable time': momentTz.format('h:mm:ss a'),
+			'Day of week': momentTz.format('dddd'),
+			Year: momentTz.format('YYYY'),
+			Month: momentTz.format('MMMM'),
+			'Day of month': momentTz.format('DD'),
+			Hour: momentTz.format('HH'),
+			Minute: momentTz.format('mm'),
+			Second: momentTz.format('ss'),
+			Timezone: `${timezone} (UTC${momentTz.format('Z')})`,
+		},
+	};
+};


### PR DESCRIPTION
## Summary

Part of the Durable Scheduler project (milestone M2 - Integration, ticket C1). Adds the handler that turns a due schedule-trigger occurrence into a real workflow execution, and registers it on the `DurableScheduler`.

* **Task contract** (`packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task.ts`)
* **Registration**: `DurableScheduler` now takes the handler via DI and registers it in its constructor, so every main resolves the scheduler with the schedule-trigger task type wired.
* **Exactly-once backstop**: reuses the existing unique partial index on `execution_entity.deduplicationKey`. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3618

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->