### PR TITLE
feat(editor): Link to data tables referenced by ID in resource locator

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.test.ts
@@ -6,9 +6,11 @@ import * as dataTableApi from '@/features/core/dataTable/dataTable.api';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import type { DataTable } from '@/features/core/dataTable/dataTable.types';
+import { hasPermission } from '@/app/utils/rbac/permissions';
 
 vi.mock('@/features/collaboration/projects/projects.store');
 vi.mock('@/app/stores/settings.store');
+vi.mock('@/app/utils/rbac/permissions', () => ({ hasPermission: vi.fn(() => true) }));
 
 function createTable(data: Partial<DataTable>) {
 	return {
@@ -263,6 +265,36 @@ describe('dataTable.store', () => {
 			const result = await dataTableStore.fetchDataTableDetails('dt-1', 'p1');
 
 			expect(result).toBeNull();
+		});
+	});
+
+	describe('fetchDataTableById', () => {
+		it('should look up a table across projects via the global endpoint', async () => {
+			const mockTable = createTable({ id: 'dt-1', projectId: 'p9' });
+			const spy = vi.spyOn(dataTableApi, 'fetchDataTablesApi').mockResolvedValue({
+				count: 1,
+				data: [mockTable],
+			});
+
+			const result = await dataTableStore.fetchDataTableById('dt-1');
+
+			expect(spy).toHaveBeenCalledWith(rootStore.restApiContext, '', undefined, { id: 'dt-1' });
+			expect(result).toBe(mockTable);
+			expect(dataTableStore.dataTables).toEqual([]); // does not mutate the list
+		});
+
+		it('should return null when the table does not exist', async () => {
+			vi.spyOn(dataTableApi, 'fetchDataTablesApi').mockResolvedValue({ count: 0, data: [] });
+
+			expect(await dataTableStore.fetchDataTableById('dt-1')).toBeNull();
+		});
+
+		it('should return null without a request when the user cannot list data tables', async () => {
+			vi.mocked(hasPermission).mockReturnValueOnce(false);
+			const spy = vi.spyOn(dataTableApi, 'fetchDataTablesApi');
+
+			expect(await dataTableStore.fetchDataTableById('dt-1')).toBeNull();
+			expect(spy).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
@@ -233,6 +233,16 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		return null;
 	};
 
+	// Looks up a data table across every project the user can access, without
+	// mutating the store's list. Used to resolve a link for an id typed by hand.
+	const fetchDataTableById = async (dataTableId: string): Promise<DataTable | null> => {
+		if (!canViewDataTables.value) return null;
+		const response = await fetchDataTablesApi(rootStore.restApiContext, '', undefined, {
+			id: dataTableId,
+		});
+		return response.data[0] ?? null;
+	};
+
 	const fetchOrFindDataTable = async (dataTableId: string, projectId: string) => {
 		const existingTable = dataTables.value.find((table) => table.id === dataTableId);
 		if (existingTable) {
@@ -431,6 +441,7 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		deleteDataTable,
 		updateDataTable,
 		fetchDataTableDetails,
+		fetchDataTableById,
 		fetchOrFindDataTable,
 		addDataTableColumn,
 		deleteDataTableColumn,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -56,6 +56,8 @@ import {
 import { completeExpressionSyntax } from '@/app/utils/expressions';
 import { DEBOUNCE_TIME, ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
+import { DATA_TABLE_NODES } from '@/app/constants/nodeTypes';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import FromAiOverrideButton from '../ParameterInputOverrides/FromAiOverrideButton.vue';
 import FromAiOverrideField from '../ParameterInputOverrides/FromAiOverrideField.vue';
@@ -160,6 +162,7 @@ const ndvStore = injectNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const projectsStore = useProjectsStore();
+const dataTableStore = useDataTableStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);
 
@@ -186,6 +189,8 @@ const selectedMode = computed(() => {
 });
 
 const isListMode = computed(() => selectedMode.value === 'list');
+
+const isDataTableNode = computed(() => !!props.node && DATA_TABLE_NODES.includes(props.node.type));
 
 /**
  * Check if the current response contains an error that indicates a credential issue.
@@ -268,6 +273,18 @@ const urlValue = computedAsync(async () => {
 		if (typeof valueToDisplay.value === 'string' && valueToDisplay.value.startsWith('http')) {
 			return valueToDisplay.value;
 		}
+	}
+
+	// Data table nodes have no url template, so resolve a link from the id by
+	// looking the table up — only link it when it actually exists for the user.
+	if (isDataTableNode.value && selectedMode.value === 'id') {
+		// Use the resolved value for expressions, but only if it's a concrete id —
+		// an unresolved template (still containing `{{ }}`) can't identify a table.
+		const raw = props.isValueExpression ? props.expressionComputedValue : valueToDisplay.value;
+		const id = typeof raw === 'string' ? raw.trim() : '';
+		if (!id || id.includes('{{') || id.includes('}}')) return null;
+		const table = await dataTableStore.fetchDataTableById(id);
+		return table ? `/projects/${table.projectId}/datatables/${table.id}` : null;
 	}
 
 	if (currentMode.value.url) {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -57,7 +57,9 @@ import { completeExpressionSyntax } from '@/app/utils/expressions';
 import { DEBOUNCE_TIME, ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
+import { DATA_TABLE_DETAILS } from '@/features/core/dataTable/constants';
 import { DATA_TABLE_NODES } from '@/app/constants/nodeTypes';
+import { useRouter } from 'vue-router';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import FromAiOverrideButton from '../ParameterInputOverrides/FromAiOverrideButton.vue';
 import FromAiOverrideField from '../ParameterInputOverrides/FromAiOverrideField.vue';
@@ -163,6 +165,7 @@ const rootStore = useRootStore();
 const uiStore = useUIStore();
 const projectsStore = useProjectsStore();
 const dataTableStore = useDataTableStore();
+const router = useRouter();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);
 
@@ -284,7 +287,13 @@ const urlValue = computedAsync(async () => {
 		const id = typeof raw === 'string' ? raw.trim() : '';
 		if (!id || id.includes('{{') || id.includes('}}')) return null;
 		const table = await dataTableStore.fetchDataTableById(id);
-		return table ? `/projects/${table.projectId}/datatables/${table.id}` : null;
+		// Resolve via the router so the link honours the configured base path (N8N_PATH).
+		return table
+			? router.resolve({
+					name: DATA_TABLE_DETAILS,
+					params: { projectId: table.projectId, id: table.id },
+				}).href
+			: null;
 	}
 
 	if (currentMode.value.url) {


### PR DESCRIPTION
## Summary

Data table resource locator fields (e.g. the Data Table node) only rendered the external-link icon in **list** mode. Now **ID** mode also gets a clickable link, resolved by looking the table up across every project the user can access — the link only appears when the table actually exists and is visible to the user. Expression values are supported too, as long as they resolve to a concrete id (no unresolved `{{ }}`).

<img width="469" height="379" alt="image" src="https://github.com/user-attachments/assets/cf906127-47a3-45de-ac73-14c89dd4a9a2" />


## How to test

1. Add a **Data Table** node and pick a table via the list — note the external-link icon.
2. Switch the resource locator to **By ID** and paste the same table's id → the link appears and opens the table.
3. Enter a random/non-existent id, or an id in a project you can't access → no link is shown.
4. Enter an expression that resolves to a valid table id → the link appears.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33654">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

