### PR TITLE
docs: Improve create-instance-ai-eval skill

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -95,6 +95,27 @@ gated tier, not as a routine step (each iteration is a full build + execution).
 Gut-check: if you can't picture a plausible *wrong* build that this case
 reliably turns **red**, the assertions are too loose to guard anything.
 
+**Confirm the precondition fired, not just the green.** For any *conditional*
+assertion — "when X happened, the agent did Y" (most `processExpectations`, and
+any behaviour case) — a pass has two readings: the agent did Y, or **X never
+happened** and the assertion passed vacuously. A behaviour case that hinges on
+the mock producing a specific failure (e.g. an AI node simulated to empty so a
+downstream parse node fails) is the classic trap: if the mock instead returns
+parseable data, the failure never occurs and the case guards nothing while
+showing green. Calibration must read the execution trace and the agent's
+`finalText` (`buildTrace.finalText` in the verifier snapshot, or the HTML report)
+and verify X actually materialised — the direct-loop `eval-results.json` does not
+persist per-expectation judge reasoning, so pass/fail alone can't tell you which
+reading you got.
+
+**A sourced failure that no longer reproduces is still worth keeping — it's now a
+regression guard.** When you encode a real failure and calibration shows the
+current build handling it correctly (behaviour drifts across versions), the case
+doesn't lose value: it flips from *capability-gap* (currently red) to *regression
+guard* (currently green, catches a re-introduction). Keep it — but only after the
+non-vacuous check above proves it *would* turn red on the bad behaviour, else the
+"guard" guards nothing.
+
 ## Example
 
 Minimal build case:
@@ -311,6 +332,16 @@ existing workflows). Narrow a run with `--filter <slug>` / `--tier <name>` /
 parallel lanes, tiers, and baselines, and the
 [README](../../../packages/@n8n/instance-ai/evaluations/README.md) for the full
 flag list.
+
+## After authoring: where a case lives
+
+The JSON file in `data/workflows/` is the durable artifact — commit it. Once
+merged, the **managed `n8n-workflows` LangTracer suite mirrors the repo
+automatically** (it's the synced baseline; you don't hand-add cases to it). The
+**LangTracer MCP is read-only** — `list_*` / `get_*` / `export_suite` only, no
+create/add tool — so a case can't be written into a suite through it;
+manually-curated (non-managed) suites are edited in the LangTracer UI. In short:
+repo file → merged PR → managed mirror; manual suites are UI-only.
 
 ## Other eval harnesses (not this skill)
 

--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -333,16 +333,6 @@ parallel lanes, tiers, and baselines, and the
 [README](../../../packages/@n8n/instance-ai/evaluations/README.md) for the full
 flag list.
 
-## After authoring: where a case lives
-
-The JSON file in `data/workflows/` is the durable artifact — commit it. Once
-merged, the **managed `n8n-workflows` LangTracer suite mirrors the repo
-automatically** (it's the synced baseline; you don't hand-add cases to it). The
-**LangTracer MCP is read-only** — `list_*` / `get_*` / `export_suite` only, no
-create/add tool — so a case can't be written into a suite through it;
-manually-curated (non-managed) suites are edited in the LangTracer UI. In short:
-repo file → merged PR → managed mirror; manual suites are UI-only.
-
 ## Other eval harnesses (not this skill)
 
 This skill is for `data/workflows/` cases. Three siblings exist with their own

--- a/.agents/skills/create-instance-ai-eval/running-evals.md
+++ b/.agents/skills/create-instance-ai-eval/running-evals.md
@@ -68,6 +68,59 @@ Describe-what-you-need, not a fixed recipe: on a dev instance you already use,
 the login and model are usually already set, and you only add the eval-specific
 keys.
 
+## Run locally against a dev instance
+
+The pieces above assume a configured instance; this is the concrete recipe that
+works end-to-end (direct Daytona mode, no proxy), plus the footguns that don't
+surface until you hit them.
+
+**Point the run with the `--base-url` flag, not the `N8N_EVAL_BASE_URL` env var.**
+If you load env via `dotenvx` / `.env.local` (a common dev setup), the file's
+value silently overrides the `N8N_EVAL_BASE_URL` you export, and the run
+authenticates against the wrong instance (a confusing 401). The CLI `--base-url`
+flag wins — use it.
+
+**Direct-mode env combo** (bypass the proxy; your own Daytona + Anthropic keys):
+
+- `N8N_AI_ASSISTANT_BASE_URL=` **empty** — direct mode is only selected when the
+  proxy base URL is unset.
+- `DAYTONA_API_KEY` + `DAYTONA_API_URL` — sandbox auth; without them every build
+  crashes at `DaytonaAuthManager requires exactly one of staticApiKey or
+  getAuthToken`.
+- `ANTHROPIC_API_KEY` — the non-proxy orchestrator reads this (not just
+  `N8N_AI_ANTHROPIC_KEY`); the eval helper (mock-gen / verify / judge) reads
+  either.
+- `E2E_TESTS=true` — exposes `POST /rest/e2e/reset` so you can seed a known owner.
+
+**Seed an owner** (a fresh instance has none → login 401s). Full payload shape in
+the [README](../../../packages/@n8n/instance-ai/evaluations/README.md) quick
+start:
+
+```bash
+curl -sf -X POST <base>/rest/e2e/reset -H 'Content-Type: application/json' \
+  -d '{"owner":{"email":"nathan@n8n.io","password":"PlaywrightTest123","firstName":"Eval","lastName":"Owner"},"admin":{"email":"admin@n8n.io","password":"PlaywrightTest123","firstName":"Admin","lastName":"User"},"members":[],"chat":{"email":"chat@n8n.io","password":"PlaywrightTest123","firstName":"Chat","lastName":"User"}}'
+```
+
+**Run isolated alongside an already-running dev instance** (rather than killing
+it): a running instance holds both its main port *and* the task-broker port
+(default 5679), and the default DB is one shared SQLite file in `~/.n8n`. Give the
+second instance its own everything:
+
+```bash
+N8N_PORT=5680 N8N_RUNNERS_BROKER_PORT=5681 N8N_USER_FOLDER=/tmp/n8n-eval-run \
+E2E_TESTS=true N8N_AI_ASSISTANT_BASE_URL= ANTHROPIC_API_KEY=… \
+  npx dotenvx run -f .env.local -f .env.eval -- pnpm start
+# then seed the owner (above), and run the eval with: --base-url http://localhost:5680
+```
+
+`pnpm start` (built dist) is enough — no need for `pnpm dev:ai`. Case JSON is read
+from source at run time, so new/edited cases need no rebuild.
+
+**Two WARNs are benign, not failures:** `Run debug capture skipped … Run debug is
+not enabled` (a 404 from an optional debug endpoint) and workflow-checks
+`errored, excluded from scoring` — both are expected locally and don't affect
+your case's pass/fail.
+
 ## Parallel lanes
 
 The **build** is the slow step and is capped at **4 concurrent builds per

--- a/.agents/skills/create-instance-ai-eval/sourcing-cases.md
+++ b/.agents/skills/create-instance-ai-eval/sourcing-cases.md
@@ -46,3 +46,16 @@ connected.)
    authored case ([SKILL.md](SKILL.md), [`case-shapes.md`](case-shapes.md)). The
    failure mode is the anchor; the conversation is yours to write, in the user's
    voice.
+
+## Two practical notes on `get_conversation_analysis`
+
+- **It hands you draft cases.** The response's
+  `aiAnalysis.structured.extractedCases[]` are pre-drafted candidates — each with
+  `expectedBehavior`, `proposedCheck`, and `failurePattern` that map almost 1:1
+  onto `outcomeExpectations` / `processExpectations`. Start from these rather than
+  a blank case (still verify against the raw trace per step 3, and rewrite the
+  prompt in the user's voice). `verdict` and `findings` sit alongside them.
+- **The payload is large** — tens of thousands of characters, enough to exceed a
+  tool's token cap and be spilled to a file. The useful part is
+  `aiAnalysis.structured`; `jq` into that (or into `.extractedCases`) rather than
+  reading the whole blob.


### PR DESCRIPTION
## Summary

Improves the `create-instance-ai-eval` skill (`.agents/skills/create-instance-ai-eval/`) with concrete learnings from authoring two eval cases from a real LangTracer thread and running them locally. Every change here is grounded in friction hit during that run — none of it was documented before.

## Changes

**`running-evals.md` — new "Run locally against a dev instance" recipe.** The doc was abstract about the local run; the actual blockers were undocumented:
- **`--base-url` flag vs `N8N_EVAL_BASE_URL` env var** — `dotenvx`/`.env.local` silently overrides the env var, so the run 401s against the wrong instance. Use the flag.
- The **direct-Daytona env combo** (`N8N_AI_ASSISTANT_BASE_URL=` empty, `DAYTONA_*`, `ANTHROPIC_API_KEY`, `E2E_TESTS=true`).
- **Owner seeding** via `/rest/e2e/reset` (fresh instance → login 401).
- **Isolated second instance** alongside a running one (main port + task-broker port 5679 + shared-SQLite `N8N_USER_FOLDER`).
- The two **benign WARNs** (`Run debug is not enabled`; workflow-checks `errored, excluded from scoring`).

**`SKILL.md` — calibration + lifecycle.**
- **Vacuous-pass trap:** for a conditional/behaviour expectation ("when X, agent did Y"), a green pass can mean X never happened. Calibration must confirm the precondition fired (read `buildTrace.finalText` / HTML report; direct-loop `eval-results.json` doesn't persist per-expectation reasoning).
- **Sourced failure that no longer reproduces** = a valid regression guard (not a dead case), *if* the non-vacuous check proves it would still turn red.
- New **"After authoring: where a case lives"** section — repo file → merged PR → managed `n8n-workflows` mirror; the LangTracer MCP is read-only; manual suites are UI-only.

**`sourcing-cases.md` — two `get_conversation_analysis` notes.** It returns draft-ready `extractedCases[]` (mapping ~1:1 onto expectations), and its payload is large — `jq` into `aiAnalysis.structured`.

## Notes

- Docs-only; no changelog entry. `skill_links_check` hook passed.
- The two eval cases that produced these learnings (`honest-verification-when-ai-node-simulated`, `derives-trade-direction-from-prices`) are **not** in this PR — kept scoped to the skill. Can follow up separately to land them in `data/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

