### PR TITLE
fix(editor): Simplify n8n Connect messaging in publish and top-up modals

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4529,8 +4529,6 @@
 	"workflows.publishModal.reattempt": "Re-publishing will retry the triggers that failed to activate.",
 	"workflows.publishModal.changes": "New changes to publish",
 	"workflows.publishModal.lastPublished": "Last published by {author}, {date} at {time}",
-	"workflows.publishModal.aiGatewayWarning.header": "The node | The nodes",
-	"workflows.publishModal.aiGatewayWarning.body": "uses an n8n Connect credential. Once your n8n Connect balance is depleted, this workflow will stop working. | use n8n Connect credentials. Once your n8n Connect balance is depleted, this workflow will stop working.",
 	"importCurlModal.title": "Import cURL command",
 	"importCurlModal.input.label": "cURL Command",
 	"importCurlModal.input.placeholder": "Paste the cURL command here",

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.test.ts
@@ -4,7 +4,6 @@ import { type MockedStore, mockedStore } from '@/__tests__/utils';
 import WorkflowPublishModal from '@/app/components/MainHeader/WorkflowPublishModal.vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import { useSettingsStore } from '@/app/stores/settings.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { WORKFLOW_PUBLISH_MODAL_KEY } from '@/app/constants';
 import { STORES } from '@n8n/stores';
@@ -87,19 +86,6 @@ const WEBHOOK_NODE_TYPE_DESCRIPTION: INodeTypeDescription = {
 	outputs: [NodeConnectionTypes.Main],
 	properties: [],
 	webhooks: [{ name: 'default', httpMethod: 'GET', path: '' }],
-};
-
-const AI_GATEWAY_NODE = {
-	id: 'ai-node-1',
-	name: 'Message a model',
-	type: '@n8n/n8n-nodes-langchain.lmOpenAi',
-	typeVersion: 1,
-	position: [100, 100] as [number, number],
-	parameters: {},
-	disabled: false,
-	credentials: {
-		openAiApi: { id: null, name: '', __aiGatewayManaged: true },
-	},
 };
 
 describe('WorkflowPublishModal', () => {
@@ -212,109 +198,6 @@ describe('WorkflowPublishModal', () => {
 				expect(mockShowMessage).not.toHaveBeenCalled();
 				expect(mockTelemetryTrack).not.toHaveBeenCalled();
 			});
-		});
-	});
-
-	describe('AI gateway warning', () => {
-		let settingsStore: MockedStore<typeof useSettingsStore>;
-
-		beforeEach(() => {
-			settingsStore = mockedStore(useSettingsStore);
-			Object.assign(settingsStore.settings, { aiGateway: { enabled: true } });
-		});
-
-		afterEach(() => {
-			Object.assign(settingsStore.settings, { aiGateway: { enabled: false } });
-		});
-
-		it('should not show warning when AI gateway is disabled', () => {
-			Object.assign(settingsStore.settings, { aiGateway: { enabled: false } });
-			workflowDocumentStore.setNodes([AI_GATEWAY_NODE]);
-
-			const { queryByTestId } = renderComponent();
-
-			expect(queryByTestId('workflow-publish-ai-gateway-warning')).not.toBeInTheDocument();
-		});
-
-		it('should not show warning when no nodes have AI gateway credentials', () => {
-			workflowDocumentStore.setNodes([
-				{
-					id: 'regular-node',
-					name: 'Regular Node',
-					type: 'n8n-nodes-base.set',
-					typeVersion: 1,
-					position: [100, 100],
-					parameters: {},
-					disabled: false,
-				},
-			]);
-
-			const { queryByTestId } = renderComponent();
-
-			expect(queryByTestId('workflow-publish-ai-gateway-warning')).not.toBeInTheDocument();
-		});
-
-		it('should not show warning when the only AI gateway node is disabled', () => {
-			workflowDocumentStore.setNodes([{ ...AI_GATEWAY_NODE, disabled: true }]);
-
-			const { queryByTestId } = renderComponent();
-
-			expect(queryByTestId('workflow-publish-ai-gateway-warning')).not.toBeInTheDocument();
-		});
-
-		it('should show warning with node name for a single active AI gateway node', () => {
-			workflowDocumentStore.setNodes([AI_GATEWAY_NODE]);
-
-			const { getByTestId } = renderComponent();
-
-			const warning = getByTestId('workflow-publish-ai-gateway-warning');
-			expect(warning).toBeInTheDocument();
-			expect(warning).toHaveTextContent('Message a model');
-		});
-
-		it('should show singular copy for a single active AI gateway node', () => {
-			workflowDocumentStore.setNodes([AI_GATEWAY_NODE]);
-
-			const { getByTestId } = renderComponent();
-
-			const warning = getByTestId('workflow-publish-ai-gateway-warning');
-			expect(warning).toHaveTextContent('The node');
-			expect(warning).toHaveTextContent('uses an n8n Connect credential');
-			expect(warning).toHaveTextContent(
-				'Once your n8n Connect balance is depleted, this workflow will stop working.',
-			);
-			expect(warning).not.toHaveTextContent('Top-up');
-		});
-
-		it('should show warning with all node names for multiple active AI gateway nodes', () => {
-			workflowDocumentStore.setNodes([
-				AI_GATEWAY_NODE,
-				{ ...AI_GATEWAY_NODE, id: 'ai-node-2', name: 'Generate Image' },
-			]);
-
-			const { getByTestId } = renderComponent();
-
-			const warning = getByTestId('workflow-publish-ai-gateway-warning');
-			expect(warning).toBeInTheDocument();
-			expect(warning).toHaveTextContent('Message a model');
-			expect(warning).toHaveTextContent('Generate Image');
-		});
-
-		it('should show plural copy for multiple active AI gateway nodes', () => {
-			workflowDocumentStore.setNodes([
-				AI_GATEWAY_NODE,
-				{ ...AI_GATEWAY_NODE, id: 'ai-node-2', name: 'Generate Image' },
-			]);
-
-			const { getByTestId } = renderComponent();
-
-			const warning = getByTestId('workflow-publish-ai-gateway-warning');
-			expect(warning).toHaveTextContent('The nodes');
-			expect(warning).toHaveTextContent('use n8n Connect credentials');
-			expect(warning).toHaveTextContent(
-				'Once your n8n Connect balance is depleted, this workflow will stop working.',
-			);
-			expect(warning).not.toHaveTextContent('Top-up');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
@@ -22,7 +22,6 @@ import { useToast } from '@/app/composables/useToast';
 import { useWorkflowActivate } from '@/app/composables/useWorkflowActivate';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
-import { useSettingsStore } from '@/app/stores/settings.store';
 import type { INodeUi } from '@/Interface';
 import type { IUsedCredential } from '@/features/credentials/credentials.types';
 import WorkflowActivationErrorMessage from '@/app/components/WorkflowActivationErrorMessage.vue';
@@ -35,7 +34,6 @@ const i18n = useI18n();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const credentialsStore = useCredentialsStore();
-const settingsStore = useSettingsStore();
 const { showMessage } = useToast();
 const workflowActivate = useWorkflowActivate();
 const publishing = ref(false);
@@ -170,19 +168,6 @@ const shouldShowFreeAiCreditsWarning = computed((): boolean => {
 	);
 });
 
-const aiGatewayWarningNodes = computed((): INodeUi[] => {
-	if (!settingsStore.isAiGatewayEnabled) return [];
-	return (workflowDocumentStore.value?.allNodes ?? []).filter(
-		(node) =>
-			!node.disabled &&
-			Object.values(node.credentials ?? {}).some((cred) => cred.__aiGatewayManaged === true),
-	);
-});
-
-const aiGatewayWarningNodeNames = computed(() =>
-	aiGatewayWarningNodes.value.map((n) => n.name).join(', '),
-);
-
 async function displayActivationError() {
 	let errorMessage: string | VNode;
 	try {
@@ -279,24 +264,6 @@ async function handlePublish() {
 		</template>
 		<template #content>
 			<div :class="$style.content">
-				<N8nCallout
-					v-if="aiGatewayWarningNodes.length > 0"
-					theme="warning"
-					:iconless="true"
-					data-test-id="workflow-publish-ai-gateway-warning"
-				>
-					{{
-						i18n.baseText('workflows.publishModal.aiGatewayWarning.header', {
-							adjustToNumber: aiGatewayWarningNodes.length,
-						})
-					}}
-					<strong>{{ aiGatewayWarningNodeNames }}</strong>
-					{{
-						i18n.baseText('workflows.publishModal.aiGatewayWarning.body', {
-							adjustToNumber: aiGatewayWarningNodes.length,
-						})
-					}}
-				</N8nCallout>
 				<N8nCallout
 					v-if="activeCalloutId === 'noTrigger'"
 					theme="danger"

--- a/packages/frontend/editor-ui/src/features/ai/gateway/components/AiGatewayTopUpModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/components/AiGatewayTopUpModal.test.ts
@@ -4,9 +4,6 @@ import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import AiGatewayTopUpModal from './AiGatewayTopUpModal.vue';
 import { createComponentRenderer } from '@/__tests__/render';
-import { useUIStore } from '@/app/stores/ui.store';
-import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { AI_GATEWAY_TOP_UP_MODAL_KEY } from '@/app/constants';
 
 vi.mock('@/app/components/Modal.vue', () => ({
 	default: {
@@ -22,27 +19,6 @@ function renderModal() {
 	const pinia = createTestingPinia();
 	setActivePinia(pinia);
 	return { ...renderComponent({ pinia }), pinia };
-}
-
-function renderModalWithCredentialType(
-	credentialTypeName: string,
-	options: { displayName?: string; documentationUrl?: string } = {},
-) {
-	const pinia = createTestingPinia();
-	setActivePinia(pinia);
-	const uiStore = useUIStore();
-	uiStore.modalsById[AI_GATEWAY_TOP_UP_MODAL_KEY] = {
-		open: true,
-		data: { credentialType: credentialTypeName },
-	};
-	const credStore = useCredentialsStore();
-	credStore.state.credentialTypes[credentialTypeName] = {
-		name: credentialTypeName,
-		displayName: options.displayName ?? credentialTypeName,
-		documentationUrl: options.documentationUrl,
-		properties: [],
-	};
-	return renderComponent({ pinia });
 }
 
 describe('AiGatewayTopUpModal.vue', () => {
@@ -62,24 +38,8 @@ describe('AiGatewayTopUpModal.vue', () => {
 		expect(screen.queryByTestId('ai-gateway-topup-buy')).not.toBeInTheDocument();
 	});
 
-	describe('credentials docs link', () => {
-		it('does not show docs link when no credentialType is provided', () => {
-			renderModal();
-			expect(
-				screen.queryByTestId('ai-gateway-topup-credentials-docs-link'),
-			).not.toBeInTheDocument();
-		});
-
-		it('shows descriptive docs link with credential display name', () => {
-			renderModalWithCredentialType('openAiApi', { displayName: 'OpenAI' });
-			const link = screen.getByTestId('ai-gateway-topup-credentials-docs-link');
-			expect(link).toBeInTheDocument();
-			expect(link.textContent).toContain('See how to configure the OpenAI credential');
-		});
-
-		it('shows docs link when credentialType has a documentationUrl', () => {
-			renderModalWithCredentialType('openAiApi', { documentationUrl: 'openai' });
-			expect(screen.getByTestId('ai-gateway-topup-credentials-docs-link')).toBeInTheDocument();
-		});
+	it('does not render a credentials docs link', () => {
+		renderModal();
+		expect(screen.queryByTestId('ai-gateway-topup-credentials-docs-link')).not.toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/gateway/components/AiGatewayTopUpModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/components/AiGatewayTopUpModal.vue
@@ -1,40 +1,7 @@
 <script lang="ts" setup>
-import { computed } from 'vue';
-import { N8nIcon, N8nLink, N8nText } from '@n8n/design-system';
-import { useUIStore } from '@/app/stores/ui.store';
-import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { BUILTIN_CREDENTIALS_DOCS_URL } from '@/app/constants/urls';
+import { N8nIcon, N8nText } from '@n8n/design-system';
 import { AI_GATEWAY_TOP_UP_MODAL_KEY } from '@/app/constants';
 import Modal from '@/app/components/Modal.vue';
-
-const uiStore = useUIStore();
-const credentialsStore = useCredentialsStore();
-
-const modalData = computed(() => uiStore.modalsById[AI_GATEWAY_TOP_UP_MODAL_KEY]?.data);
-const credentialType = computed<string | undefined>(
-	() => modalData.value?.credentialType as string | undefined,
-);
-
-const credentialTypeInfo = computed(() => {
-	if (!credentialType.value) return null;
-	return credentialsStore.getCredentialTypeByName(credentialType.value) ?? null;
-});
-
-const credentialDocsUrl = computed(() => {
-	const type = credentialTypeInfo.value;
-	if (!type?.documentationUrl) return '';
-
-	if (type.documentationUrl.startsWith('http')) {
-		return type.documentationUrl;
-	}
-
-	return `${BUILTIN_CREDENTIALS_DOCS_URL}${type.documentationUrl}/`;
-});
-
-const credentialDocsLinkText = computed(() => {
-	const name = credentialTypeInfo.value?.displayName;
-	return name ? `See how to configure the ${name} credential` : 'See credential setup guide';
-});
 </script>
 
 <template>
@@ -53,18 +20,6 @@ const credentialDocsLinkText = computed(() => {
 					<div :class="$style.paragraphs">
 						<p :class="$style.paragraph">
 							You'll be notified in the coming weeks when this feature becomes available.
-						</p>
-						<p :class="$style.paragraph">
-							In the meantime you can switch to using your own credentials.
-						</p>
-						<p v-if="credentialType" :class="$style.paragraph">
-							<N8nLink
-								:to="credentialDocsUrl"
-								new-window
-								data-test-id="ai-gateway-topup-credentials-docs-link"
-							>
-								{{ credentialDocsLinkText }}
-							</N8nLink>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Simplifies n8n Connect messaging in the editor:

- **Publish modal**: removed the credit balance warning callout shown when publishing a workflow that uses n8n Connect credentials.
- **Top-up modal**: simplified the copy — it now just says top-up is coming soon.

Publish modal after:

<img width="735" height="426" alt="Screenshot 2026-07-06 at 14 27 12" src="https://github.com/user-attachments/assets/0e912948-aaad-467d-b296-2143579a88a1" />


Top-up modal after:

<img width="751" height="547" alt="Screenshot 2026-07-06 at 14 27 54" src="https://github.com/user-attachments/assets/e7874717-9f27-41df-bbb8-eb99bc366b28" />


## How to test

1. Run an instance with AI Gateway enabled (`aiGateway.enabled` setting / n8n Connect available, e.g. cloud dev setup).
2. Create a workflow with a trigger and an AI node using an n8n Connect credential (e.g. OpenAI Chat Model with "n8n Connect" selected).
3. Click **Publish** — the modal should show no balance warning callout.
4. In the credential selector, click the balance pill (or **Top up** in Settings → n8n Connect) — the modal should only say "Top up is coming soon".

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-167

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI