### PR TITLE
fix(core): Allow-list models that support sampling parameters

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -81,17 +81,10 @@ const MIN_THINKING_BUDGET = 1024;
 const DEFAULT_MAX_TOKENS = 4096;
 
 /**
- * Anthropic returns a 400 ("`temperature` is deprecated for this model") when non-default
- * `temperature`/`top_p`/`top_k` are sent to newer-generation models — starting with Claude
- * Opus 4.7, and now also Claude Sonnet 5 and Claude Fable. Anthropic's stated direction is to
- * drop these sampling parameters from every new model going forward, so encoding "which models
- * reject them" as a list would mean an edit on every future release.
- *
- * We instead allow-list the older models that still accept sampling parameters. That set is
- * closed and only shrinks as legacy models retire, so it never needs proactive maintenance for
- * new releases — an unrecognized `claude-*` model is assumed to reject them. Non-Claude model
- * IDs (e.g. models proxied through an AI gateway) are always allowed through, since we can't
- * know their capabilities from the name alone.
+ * Anthropic is dropping temperature/top_p/top_k from every new model generation (Opus 4.7+,
+ * Sonnet 5, Fable, ...), so a deny-list would need an edit per release. Allow-listing the older
+ * models that still accept them instead only shrinks over time as those models retire; unknown
+ * `claude-*` models are assumed to reject them, non-Claude IDs (e.g. AI gateways) always pass.
  */
 function modelSupportsSamplingParams(modelName: string): boolean {
 	if (!modelName.startsWith('claude-')) {

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -79,6 +79,46 @@ const modelField: INodeProperties = {
 
 const MIN_THINKING_BUDGET = 1024;
 const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Anthropic returns a 400 ("`temperature` is deprecated for this model") when non-default
+ * `temperature`/`top_p`/`top_k` are sent to newer-generation models — starting with Claude
+ * Opus 4.7, and now also Claude Sonnet 5 and Claude Fable. Anthropic's stated direction is to
+ * drop these sampling parameters from every new model going forward, so encoding "which models
+ * reject them" as a list would mean an edit on every future release.
+ *
+ * We instead allow-list the older models that still accept sampling parameters. That set is
+ * closed and only shrinks as legacy models retire, so it never needs proactive maintenance for
+ * new releases — an unrecognized `claude-*` model is assumed to reject them. Non-Claude model
+ * IDs (e.g. models proxied through an AI gateway) are always allowed through, since we can't
+ * know their capabilities from the name alone.
+ */
+function modelSupportsSamplingParams(modelName: string): boolean {
+	if (!modelName.startsWith('claude-')) {
+		return true;
+	}
+
+	if (
+		modelName.startsWith('claude-2') ||
+		modelName.startsWith('claude-instant') ||
+		modelName.startsWith('claude-3')
+	) {
+		return true;
+	}
+
+	if (modelName.startsWith('claude-sonnet-4') || modelName.startsWith('claude-haiku-4')) {
+		return true;
+	}
+
+	// Opus 4 through 4.6 (bare or with a dated suffix, e.g. "claude-opus-4-5-20251101") still
+	// accept sampling params; 4.7 and later ("claude-opus-4-7", "claude-opus-4-8", ...) don't.
+	if (/^claude-opus-4(-[0-6])?(-\d{8})?$/.test(modelName)) {
+		return true;
+	}
+
+	return false;
+}
+
 export class LmChatAnthropic implements INodeType {
 	methods = {
 		listSearch: {
@@ -287,7 +327,7 @@ export class LmChatAnthropic implements INodeType {
 						default: 0.7,
 						typeOptions: { maxValue: 1, minValue: 0, numberPrecision: 1 },
 						description:
-							'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive.',
+							'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive. Not supported on newer Anthropic models (Claude Opus 4.7+, Claude Sonnet 5+) — ignored there.',
 						type: 'number',
 						displayOptions: {
 							hide: {
@@ -302,7 +342,7 @@ export class LmChatAnthropic implements INodeType {
 						default: -1,
 						typeOptions: { maxValue: 1, minValue: -1, numberPrecision: 1 },
 						description:
-							'Used to remove "long tail" low probability responses. Defaults to -1, which disables it.',
+							'Used to remove "long tail" low probability responses. Defaults to -1, which disables it. Not supported on newer Anthropic models (Claude Opus 4.7+, Claude Sonnet 5+) — ignored there.',
 						type: 'number',
 						displayOptions: {
 							hide: {
@@ -317,7 +357,7 @@ export class LmChatAnthropic implements INodeType {
 						default: 1,
 						typeOptions: { maxValue: 1, minValue: 0, numberPrecision: 1 },
 						description:
-							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both.',
+							'Controls diversity via nucleus sampling: 0.5 means half of all likelihood-weighted options are considered. We generally recommend altering this or temperature but not both. Not supported on newer Anthropic models (Claude Opus 4.7+, Claude Sonnet 5+) — ignored there.',
 						type: 'number',
 						displayOptions: {
 							hide: {
@@ -577,20 +617,45 @@ export class LmChatAnthropic implements INodeType {
 				}
 			: undefined;
 
+		// Backstop for the sampling-parameter deprecation that modelSupportsSamplingParams
+		// allow-lists against: catches the same 400 for gateway traffic (whose capabilities we
+		// can't inspect from the model name) and for any Claude model the allow-list doesn't yet
+		// account for, turning a generic "Bad request" into an actionable message.
+		const deprecatedSamplingParamErrorHandler = (error: unknown) => {
+			const message = error instanceof Error ? error.message : String(error);
+			const isDeprecatedSamplingParamError =
+				/(temperature|top_p|top_k).*(deprecated|not supported)/i.test(message);
+			if (isDeprecatedSamplingParamError) {
+				throw new NodeOperationError(
+					this.getNode(),
+					`The model "${modelName}" does not support the Sampling Temperature, Top K, or Top P options. Remove them from Options and try again.`,
+					{ itemIndex },
+				);
+			}
+		};
+
+		const failedAttemptHandler = (error: unknown) => {
+			gatewayErrorHandler?.(error);
+			deprecatedSamplingParamErrorHandler(error);
+		};
+
 		const chatAnthropicParams: ChatAnthropicInput = {
 			anthropicApiKey: credentials.apiKey,
 			model: modelName,
 			anthropicApiUrl: baseURL,
 			maxTokens: options.maxTokensToSample,
 			callbacks: [new N8nLlmTracing(this, { tokensUsageParser })],
-			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, gatewayErrorHandler),
+			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, failedAttemptHandler),
 			invocationKwargs,
 			clientOptions,
 			streaming: options.streaming ?? false,
 		};
 
-		// Opus 4.7 rejects temperature/topK/topP at the SDK layer regardless of thinking mode
-		if (!isOpus47Model) {
+		// Models that reject sampling params (see modelSupportsSamplingParams) get them silently
+		// dropped rather than erroring, for backwards compatibility: workflows built before a
+		// model existed (e.g. an Opus 4.7 node with Sampling Temperature already set) must keep
+		// running unchanged rather than start failing once that model rejects the parameter.
+		if (modelSupportsSamplingParams(modelName)) {
 			chatAnthropicParams.temperature = options.temperature;
 			chatAnthropicParams.topK = options.topK;
 			chatAnthropicParams.topP = options.topP;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -466,7 +466,7 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
-		it('should create failed attempt handler without gateway handler for direct API', async () => {
+		it('should create failed attempt handler for direct API', async () => {
 			const mockContext = setupMockContext();
 
 			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
@@ -477,7 +477,12 @@ describe('LmChatAnthropic', () => {
 
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
-			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext, undefined);
+			// A composed handler is always passed, even without a gateway, since it also
+			// sanitizes the sampling-parameter deprecation error.
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(
+				mockContext,
+				expect.any(Function),
+			);
 		});
 
 		it('should create failed attempt handler with gateway handler for custom URL', async () => {
@@ -535,6 +540,36 @@ describe('LmChatAnthropic', () => {
 			);
 
 			// Non-model errors should pass through without throwing
+			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
+		});
+
+		it('should sanitize the deprecated sampling parameter error into an actionable message', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-opus-4-8';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			let capturedHandler: ((error: unknown) => void) | undefined;
+			mockedMakeN8nLlmFailedAttemptHandler.mockImplementation((_ctx, handler) => {
+				capturedHandler = handler as (error: unknown) => void;
+				return vi.fn();
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(capturedHandler).toBeDefined();
+
+			expect(() =>
+				capturedHandler!(new Error('`temperature` is deprecated for this model.')),
+			).toThrow(NodeOperationError);
+			expect(() =>
+				capturedHandler!(new Error('`temperature` is deprecated for this model.')),
+			).toThrow(/claude-opus-4-8/);
+
+			// Unrelated errors should pass through without throwing
 			expect(() => capturedHandler!(new Error('rate limit exceeded'))).not.toThrow();
 		});
 
@@ -861,6 +896,57 @@ describe('LmChatAnthropic', () => {
 			expect(
 				(nonOpusEffort as { options: Array<{ value: string }> }).options.map((o) => o.value),
 			).toEqual(['low', 'medium', 'high']);
+		});
+	});
+
+	describe('sampling parameter allow-list', () => {
+		it.each([
+			'claude-opus-4-7-20251101',
+			'claude-opus-4-8',
+			'claude-opus-4-8-20260101',
+			'claude-sonnet-5',
+			'claude-fable-5',
+			'claude-mythos-5', // unrecognized future claude-* model: assumed unsupported
+		])('should strip temperature/topK/topP for %s', async (modelName) => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return modelName;
+				if (paramName === 'options') return { temperature: 0.5, topK: 40, topP: 0.9 };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0]!;
+			expect(callArgs).not.toHaveProperty('temperature');
+			expect(callArgs).not.toHaveProperty('topK');
+			expect(callArgs).not.toHaveProperty('topP');
+		});
+
+		it.each([
+			'claude-opus-4-20250514',
+			'claude-opus-4-1-20250805',
+			'claude-opus-4-5-20251101',
+			'claude-opus-4-6',
+			'claude-sonnet-4-6',
+			'claude-haiku-4-5-20251001',
+			'claude-3-5-sonnet-20241022',
+			'gpt-4o', // non-Claude gateway model: always passed through
+		])('should send temperature/topK/topP for %s', async (modelName) => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return modelName;
+				if (paramName === 'options') return { temperature: 0.5, topK: 40, topP: 0.9 };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({ temperature: 0.5, topK: 40, topP: 0.9 }),
+			);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAnthropic.test.ts
@@ -333,7 +333,12 @@ describe('LmChatAnthropic', () => {
 
 			await lmChatAnthropic.supplyData.call(mockContext, 0);
 
-			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(mockContext, undefined);
+			// A handler is always passed, even without a gateway, since it also sanitizes the
+			// sampling-parameter deprecation error.
+			expect(mockedMakeN8nLlmFailedAttemptHandler).toHaveBeenCalledWith(
+				mockContext,
+				expect.any(Function),
+			);
 		});
 
 		it('should not add custom headers when header toggle is disabled', async () => {


### PR DESCRIPTION
## Summary

Anthropic returns a 400 ("`temperature` is deprecated for this model") when non-default `temperature`/`top_p`/`top_k` are sent to newer-generation Claude models. The node's existing guard only recognized `claude-opus-4-7*`, so newer models — Opus 4.8, Sonnet 5, Fable — hit this 400 and surfaced as an unhelpful "Bad request - please check your parameters" on the AI Agent node.

This generalizes the guard into `modelSupportsSamplingParams()`, an allow-list of the older models that still accept these parameters (Claude 2.x/Instant, 3.x, Sonnet ≤ 4, Haiku ≤ 4, Opus ≤ 4.6). Unlike a deny-list, this doesn't need updating every time Anthropic ships a new model — the allow-listed set is closed and only shrinks as legacy models retire. Non-Claude model IDs (e.g. gateway-proxied models) are always passed through unchanged, since we can't know their capabilities.

Behavior for existing, previously-working configurations is unchanged: unsupported models still get the parameters silently dropped rather than erroring, so an Opus 4.7 workflow with Sampling Temperature set keeps running exactly as before.

As a backstop for gateway traffic and any model the allow-list doesn't yet account for, the node's failed-attempt handler now also recognizes Anthropic's parameter-deprecation error and rethrows it as an actionable message naming the model and option, instead of the generic 400 mapping.

Also updated the Sampling Temperature / Top K / Top P option descriptions to note they're ignored on newer Anthropic models, since the drop is silent.

## How to test

1. Create a workflow with an AI Agent connected to an Anthropic Chat Model node.
2. Set the model to `claude-opus-4-8` (or any Sonnet 5 / Fable model) and set Sampling Temperature under Options.
3. Execute the workflow — it should now run successfully, with the sampling parameters silently omitted from the API request.
4. Repeat with an older model (e.g. `claude-opus-4-6`, `claude-sonnet-4-6`) and confirm Sampling Temperature is still sent and affects output as before.
5. Unit tests: `cd packages/@n8n/nodes-langchain && pnpm vitest run nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2611/bug-out-of-date-parameter-for-anthropic-chat-model-node

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33667">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->