### PR TITLE
test: Verify command bar opens with keyboard shortcut on executions view (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/components/CommandBar.ts
+++ b/packages/testing/playwright/pages/components/CommandBar.ts
@@ -28,6 +28,11 @@ export class CommandBar {
 		await expect(this.getContainer()).toBeVisible();
 	}
 
+	async openWithShortcut(): Promise<void> {
+		await this.page.keyboard.press('ControlOrMeta+k');
+		await expect(this.getContainer()).toBeVisible();
+	}
+
 	async search(query: string): Promise<void> {
 		await this.open();
 		await this.getInput().fill(query);

--- a/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
@@ -108,6 +108,16 @@ test.describe('Workflow Executions', () => {
 			await expect(n8n.executions.getFirstExecutionItem()).toHaveClass(/_active_/);
 		});
 
+		test('should open command bar with keyboard shortcut on executions view', async ({ n8n }) => {
+			await n8n.executionsComposer.createExecutions(1);
+
+			await n8n.canvas.clickExecutionsTab();
+			await expect(n8n.executions.getPreview()).toBeVisible();
+
+			await n8n.commandBar.openWithShortcut();
+			await expect(n8n.commandBar.getItem('Delete this execution')).toBeVisible();
+		});
+
 		test('should not redirect back to execution tab when request is not done before leaving the page', async ({
 			n8n,
 		}) => {


### PR DESCRIPTION
## Summary

Adds regression e2e coverage for [CAT-3574](https://linear.app/n8n/issue/CAT-3574) ("Cmd+K launcher doesn't work on executions view"). **No product change is included, because the bug is already fixed on master** — the investigation is summarized below so reviewers understand why this PR is test-only.

### Root cause & timeline

- The report (video recorded **Jun 23, 12:35 CEST** on internal cloud) shows Cmd+K working on the Editor/Evaluations tabs but dead on the Executions tab.
- Cause: the **pre-2.28.0 iframe-based execution preview**. `WorkflowPreview.vue` stole focus into the `<iframe src="/workflows/demo">` on every load (`focusOnLoad: true` → `contentWindow.focus()`). Keyboard events don't cross document boundaries, so the parent document's Cmd+K capture listener (`CommandBar.vue`) never fired. The Editor/Evaluations tabs are native, hence unaffected.
- #32296 replaced the iframe with the native `ExecutionPreviewHost` (merged Jun 16) and thereby fixed this. The first release containing it is **n8n@2.28.0, tagged Jun 23 13:31 CEST — about an hour after the video was recorded**, so internal cloud was still running the iframe build at report time. (The ticket comment suggesting #32296 *caused* the bug had the causality reversed.)
- Verified on current master with trusted key presses (headless Playwright probes): the launcher opens on `/workflow/:id/executions/:executionId` in every focus state (fresh load, after clicking canvas/node/logs panel/sidebar/header), with the "Execution ⋅ …" context badge and execution commands populated.

### Changes

- `pages/components/CommandBar.ts`: new `openWithShortcut()` (keyboard-driven open, complementing the button-based `open()`).
- `tests/e2e/workflows/executions/list.spec.ts`: new test asserting Cmd+K opens the command bar on the executions view and shows an execution-scoped command ("Delete this execution"), which also pins the `EXECUTION_PREVIEW` → execution command group wiring in `useCommandBar.ts`.

This UX had no e2e coverage, which is why the regression shipped undetected — this test closes that gap.

## How to test

```
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/executions/list.spec.ts --grep "command bar"
```

Passes locally (3× repeat + full-spec run).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3574

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] ~Docs updated~ (n/a — test-only)
- [x] Tests included.
- [ ] ~Backport labels~ (n/a)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33672">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

