### PR TITLE
fix(core): Propagate sub-workflow credential usage to the parent execution

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -266,6 +266,110 @@ describe('WorkflowExecuteAdditionalData', () => {
 			expect(getVariablesSpy).toHaveBeenCalledWith(workflowId, undefined);
 		});
 
+		describe('sub-workflow dynamic credential reporting', () => {
+			const getMockRunWithCredentialFlags = (task: Partial<ITaskData>, executedByUserId?: string) =>
+				mock<IRun>({
+					data: {
+						resultData: {
+							runData: {
+								[LAST_NODE_EXECUTED]: [
+									{ startTime: 100, data: { main: [[{ json: { test: 1 } }]] }, ...task },
+								],
+							},
+							lastNodeExecuted: LAST_NODE_EXECUTED,
+						},
+						executionData: { runtimeData: { executedByUserId } },
+					},
+					finished: true,
+					mode: 'manual',
+					startedAt: new Date(),
+					status: 'new',
+					waitTill: undefined,
+				});
+
+			it('reports usedDynamicCredentials and the resolved user when the sub-workflow resolved a private credential', async () => {
+				processRunExecutionData.mockReturnValue(
+					getCancelablePromise(
+						getMockRunWithCredentialFlags({ usedDynamicCredentials: true }, 'resolved-user'),
+					),
+				);
+
+				const response = await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>(),
+					mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
+				);
+
+				expect(response.usedDynamicCredentials).toBe(true);
+				expect(response.dynamicCredentialsResolvedUserId).toBe('resolved-user');
+			});
+
+			it('reports the attempted flag for telemetry', async () => {
+				processRunExecutionData.mockReturnValue(
+					getCancelablePromise(
+						getMockRunWithCredentialFlags({ attemptedDynamicCredentials: true }),
+					),
+				);
+
+				const response = await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>(),
+					mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
+				);
+
+				expect(response.attemptedDynamicCredentials).toBe(true);
+			});
+
+			it('reports nothing when the sub-workflow used no private credentials', async () => {
+				processRunExecutionData.mockReturnValue(
+					getCancelablePromise(getMockRunWithCredentialFlags({})),
+				);
+
+				const response = await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>(),
+					mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
+				);
+
+				expect(response.usedDynamicCredentials).toBeUndefined();
+				expect(response.attemptedDynamicCredentials).toBeUndefined();
+				expect(response.dynamicCredentialsResolvedUserId).toBeUndefined();
+			});
+
+			it('reports the used flag without a user when the resolver maps to no n8n user', async () => {
+				processRunExecutionData.mockReturnValue(
+					getCancelablePromise(getMockRunWithCredentialFlags({ usedDynamicCredentials: true })),
+				);
+
+				const response = await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>(),
+					mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: false }),
+				);
+
+				expect(response.usedDynamicCredentials).toBe(true);
+				expect(response.dynamicCredentialsResolvedUserId).toBeUndefined();
+			});
+
+			it('reports nothing for detached sub-workflows (no embedded output)', async () => {
+				processRunExecutionData.mockReturnValue(
+					getCancelablePromise(
+						getMockRunWithCredentialFlags({ usedDynamicCredentials: true }, 'resolved-user'),
+					),
+				);
+
+				const response = await executeWorkflow(
+					mock<IExecuteWorkflowInfo>(),
+					mock<IWorkflowExecuteAdditionalData>(),
+					mock<ExecuteWorkflowOptions>({ loadedWorkflowData: undefined, doNotWaitToFinish: true }),
+				);
+
+				expect(response.data).toEqual([null]);
+				expect(response.usedDynamicCredentials).toBeUndefined();
+				expect(response.dynamicCredentialsResolvedUserId).toBeUndefined();
+			});
+		});
+
 		/**
 		 * Tests for workflow version selection based on execution mode.
 		 *

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -368,6 +368,98 @@ describe('WorkflowExecuteAdditionalData', () => {
 				expect(response.usedDynamicCredentials).toBeUndefined();
 				expect(response.dynamicCredentialsResolvedUserId).toBeUndefined();
 			});
+
+			describe('failed sub-workflow', () => {
+				const getMockFailedRunWithCredentialFlags = (
+					task: Partial<ITaskData>,
+					executedByUserId?: string,
+				) =>
+					mock<IRun>({
+						data: {
+							resultData: {
+								runData: {
+									[LAST_NODE_EXECUTED]: [{ startTime: 100, ...task }],
+								},
+								lastNodeExecuted: LAST_NODE_EXECUTED,
+								error: { message: 'child failed', name: 'NodeOperationError' },
+							},
+							executionData: { runtimeData: { executedByUserId } },
+						},
+						finished: false,
+						mode: 'manual',
+						startedAt: new Date(),
+						status: 'error',
+						waitTill: undefined,
+					});
+
+				it('attaches the attempted flag to the thrown error', async () => {
+					processRunExecutionData.mockReturnValue(
+						getCancelablePromise(
+							getMockFailedRunWithCredentialFlags({ attemptedDynamicCredentials: true }),
+						),
+					);
+
+					await expect(
+						executeWorkflow(
+							mock<IExecuteWorkflowInfo>(),
+							mock<IWorkflowExecuteAdditionalData>(),
+							mock<ExecuteWorkflowOptions>({
+								loadedWorkflowData: undefined,
+								doNotWaitToFinish: false,
+							}),
+						),
+					).rejects.toMatchObject({
+						message: 'child failed',
+						dynamicCredentialsUsage: { attemptedDynamicCredentials: true },
+					});
+				});
+
+				it('attaches usage and the resolved user when a credential resolved before the failure', async () => {
+					processRunExecutionData.mockReturnValue(
+						getCancelablePromise(
+							getMockFailedRunWithCredentialFlags(
+								{ usedDynamicCredentials: true, attemptedDynamicCredentials: true },
+								'resolved-user',
+							),
+						),
+					);
+
+					await expect(
+						executeWorkflow(
+							mock<IExecuteWorkflowInfo>(),
+							mock<IWorkflowExecuteAdditionalData>(),
+							mock<ExecuteWorkflowOptions>({
+								loadedWorkflowData: undefined,
+								doNotWaitToFinish: false,
+							}),
+						),
+					).rejects.toMatchObject({
+						message: 'child failed',
+						dynamicCredentialsUsage: {
+							usedDynamicCredentials: true,
+							attemptedDynamicCredentials: true,
+							dynamicCredentialsResolvedUserId: 'resolved-user',
+						},
+					});
+				});
+
+				it('attaches nothing when the failed sub-workflow used no private credentials', async () => {
+					processRunExecutionData.mockReturnValue(
+						getCancelablePromise(getMockFailedRunWithCredentialFlags({})),
+					);
+
+					const promise = executeWorkflow(
+						mock<IExecuteWorkflowInfo>(),
+						mock<IWorkflowExecuteAdditionalData>(),
+						mock<ExecuteWorkflowOptions>({
+							loadedWorkflowData: undefined,
+							doNotWaitToFinish: false,
+						}),
+					);
+					await expect(promise).rejects.toThrow('child failed');
+					await expect(promise).rejects.not.toHaveProperty('dynamicCredentialsUsage');
+				});
+			});
 		});
 
 		/**

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -3,6 +3,7 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import type { CredentialsEntity, IExecutionResponse, Project, Variables } from '@n8n/db';
 import { CredentialsRepository } from '@n8n/db';
 import type {
+	DynamicCredentialsUsage,
 	ExecutionError,
 	IRun,
 	ITaskData,
@@ -802,18 +803,24 @@ describe('updateParentExecutionWithChildResults', () => {
 		lastNode: string,
 		nodeRun: Partial<ITaskData>,
 		error?: ExecutionError,
+		executedByUserId?: string,
 	): IRun =>
 		({
 			mode: 'integrated',
 			status,
 			data: {
 				resultData: { lastNodeExecuted: lastNode, error, runData: { [lastNode]: [nodeRun] } },
+				...(executedByUserId ? { executionData: { runtimeData: { executedByUserId } } } : {}),
 			},
 		}) as unknown as IRun;
 
 	type StackEntry = {
 		data?: unknown;
-		metadata?: { resumeError?: ExecutionError; subExecution?: RelatedExecution };
+		metadata?: {
+			resumeError?: ExecutionError;
+			subExecution?: RelatedExecution;
+			dynamicCredentialsUsage?: DynamicCredentialsUsage;
+		};
 	};
 
 	// Runs the workflow helper against a waiting parent and returns the updated stack entry.
@@ -850,6 +857,133 @@ describe('updateParentExecutionWithChildResults', () => {
 
 		expect(entry.data).toEqual({ main: [[{ json: { out: 2 } }]] });
 		expect(entry.metadata?.resumeError).toBeUndefined();
+		expect(entry.metadata?.dynamicCredentialsUsage).toBeUndefined();
+	});
+
+	// The parent's waiting task is popped and its node re-runs disabled on resume, so the
+	// child's private-credential usage must ride on the stack entry to reach the new task.
+	it('stashes the child dynamic-credential usage on the resumed stack entry', async () => {
+		const entry = await resumeWith(
+			childRun(
+				'success',
+				'Done',
+				{
+					data: { main: [[{ json: { out: 2 } }]] },
+					usedDynamicCredentials: true,
+					attemptedDynamicCredentials: true,
+				},
+				undefined,
+				'resolved-user',
+			),
+		);
+
+		expect(entry.metadata?.dynamicCredentialsUsage).toEqual({
+			usedDynamicCredentials: true,
+			attemptedDynamicCredentials: true,
+			dynamicCredentialsResolvedUserId: 'resolved-user',
+		});
+	});
+
+	it('stashes the attempted flag even when the child failed', async () => {
+		const error = { name: 'NodeOperationError', message: 'ERROR' } as unknown as ExecutionError;
+		const entry = await resumeWith(
+			childRun('error', 'Stop and Error', { error, attemptedDynamicCredentials: true }, error),
+		);
+
+		expect(entry.metadata?.resumeError).toMatchObject({ message: 'ERROR' });
+		expect(entry.metadata?.dynamicCredentialsUsage).toEqual({ attemptedDynamicCredentials: true });
+	});
+
+	// "Run once for each item" spawns several children per wait; a weaker later report
+	// (attempted-only) must not clobber a sibling's used flag or resolved user.
+	it('unions the stash across sibling children instead of replacing it', async () => {
+		let stored = waitingParent();
+		const executionPersistence = mockInstance(ExecutionPersistence);
+		executionPersistence.findSingleExecution.mockImplementation(async () =>
+			structuredClone(stored),
+		);
+		executionPersistence.updateExistingExecution.mockImplementation(async (_id, patch) => {
+			stored = { ...stored, ...patch } as IExecutionResponse;
+			return true;
+		});
+
+		const usedChild = childRun(
+			'success',
+			'Done',
+			{
+				data: { main: [[{ json: { out: 1 } }]] },
+				usedDynamicCredentials: true,
+				attemptedDynamicCredentials: true,
+			},
+			undefined,
+			'resolved-user',
+		);
+		const error = { name: 'NodeOperationError', message: 'ERROR' } as unknown as ExecutionError;
+		const attemptedChild = childRun(
+			'error',
+			'Stop and Error',
+			{ error, attemptedDynamicCredentials: true },
+			error,
+		);
+
+		await updateParentExecutionWithChildResults(PARENT_ID, usedChild);
+		await updateParentExecutionWithChildResults(PARENT_ID, attemptedChild);
+
+		const entry = stored.data.executionData!.nodeExecutionStack[0] as unknown as StackEntry;
+		expect(entry.metadata?.dynamicCredentialsUsage).toEqual({
+			usedDynamicCredentials: true,
+			attemptedDynamicCredentials: true,
+			dynamicCredentialsResolvedUserId: 'resolved-user',
+		});
+	});
+
+	// The parent can sit in 'waiting' for a long time with the child's output already
+	// embedded, so the waiting task must be flagged immediately, not only after resume.
+	it('stamps the parent waiting task and runtime data at stash time', async () => {
+		const parent = waitingParent();
+		parent.data.resultData = {
+			runData: {
+				'Execute Sub-workflow': [
+					{
+						startTime: 0,
+						executionTime: 0,
+						executionIndex: 0,
+						executionStatus: 'waiting',
+						source: [],
+					} as ITaskData,
+				],
+			},
+		} as unknown as IExecutionResponse['data']['resultData'];
+		parent.data.executionData!.runtimeData = {
+			version: 1,
+			establishedAt: 0,
+			source: 'trigger',
+		};
+
+		const executionPersistence = mockInstance(ExecutionPersistence);
+		executionPersistence.findSingleExecution.mockResolvedValue(parent);
+
+		await updateParentExecutionWithChildResults(
+			PARENT_ID,
+			childRun(
+				'success',
+				'Done',
+				{
+					data: { main: [[{ json: { out: 2 } }]] },
+					usedDynamicCredentials: true,
+					attemptedDynamicCredentials: true,
+				},
+				undefined,
+				'resolved-user',
+			),
+		);
+
+		const [, payload] = executionPersistence.updateExistingExecution.mock.calls[0];
+		const persisted = payload as IExecutionResponse;
+		const waitingTask = persisted.data.resultData.runData['Execute Sub-workflow'][0];
+		expect(waitingTask.usedDynamicCredentials).toBe(true);
+		expect(waitingTask.attemptedDynamicCredentials).toBe(true);
+		expect(persisted.data.executionData?.runtimeData?.executedByUserId).toBe('resolved-user');
 	});
 
 	// In "run once for each item" mode multiple children update the same waiting

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -21,6 +21,7 @@ import type {
 	RelatedExecution,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
+import { runDataAttemptedDynamicCredentials, runDataUsedDynamicCredentials } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
 import { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -604,13 +605,10 @@ function hookFunctionsSave(
 				fullExecutionData.data.pushRef = pushRef;
 			}
 
-			fullExecutionData.usedPrivateCredentials = Object.values(
-				fullRunData.data?.resultData?.runData ?? {},
-			).some((taskDataList) =>
-				taskDataList.some(
-					(t) => t.usedDynamicCredentials === true || t.attemptedDynamicCredentials === true,
-				),
-			);
+			const resultRunData = fullRunData.data?.resultData?.runData;
+			fullExecutionData.usedPrivateCredentials =
+				runDataUsedDynamicCredentials(resultRunData) ||
+				runDataAttemptedDynamicCredentials(resultRunData);
 
 			await updateExistingExecution({
 				executionId: this.executionId,
@@ -694,13 +692,10 @@ function hookFunctionsSaveWorker(
 				fullExecutionData.data.pushRef = pushRef;
 			}
 
-			fullExecutionData.usedPrivateCredentials = Object.values(
-				fullRunData.data?.resultData?.runData ?? {},
-			).some((taskDataList) =>
-				taskDataList.some(
-					(t) => t.usedDynamicCredentials === true || t.attemptedDynamicCredentials === true,
-				),
-			);
+			const resultRunData = fullRunData.data?.resultData?.runData;
+			fullExecutionData.usedPrivateCredentials =
+				runDataUsedDynamicCredentials(resultRunData) ||
+				runDataAttemptedDynamicCredentials(resultRunData);
 
 			// In scaling mode, worker saves execution without metadata
 			// Main process will save metadata after deletion decisions to avoid FK violations

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -1,6 +1,11 @@
 import { LicenseState, Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-import { channelsToPolicy, WorkflowExecuteMode, WorkflowSettings } from 'n8n-workflow';
+import {
+	channelsToPolicy,
+	runDataUsedDynamicCredentials,
+	WorkflowExecuteMode,
+	WorkflowSettings,
+} from 'n8n-workflow';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { ScopeForbiddenError } from '@/errors/response-errors/scope-forbidden.error';
@@ -270,11 +275,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 * mere presence of credential context infrastructure.
 	 */
 	private hasDynamicCredentials(execution: RedactableExecution): boolean {
-		return Object.values(execution.data.resultData?.runData ?? {}).some((taskDataList) =>
-			// runData node arrays can hold null placeholder slots at runtime despite
-			// the ITaskData[] type, so guard the element deref.
-			taskDataList.some((taskData) => taskData?.usedDynamicCredentials),
-		);
+		return runDataUsedDynamicCredentials(execution.data.resultData?.runData);
 	}
 
 	/**

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -1233,7 +1233,10 @@ describe('JobProcessor', () => {
 							runData: expect.objectContaining({ Calculator: expect.any(Array) }),
 						}),
 					}),
+					usedPrivateCredentials: false,
 				}),
+				// A cancel racing the tool call must keep its status.
+				{ requireNotCanceled: true },
 			);
 		});
 
@@ -1317,6 +1320,7 @@ describe('JobProcessor', () => {
 						}),
 					}),
 				}),
+				{ requireNotCanceled: true },
 			);
 		});
 
@@ -1415,6 +1419,7 @@ describe('JobProcessor', () => {
 						}),
 					}),
 				}),
+				{ requireNotCanceled: true },
 			);
 		});
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -384,19 +384,25 @@ export class JobProcessor {
 			// Persist the tool call's run data, since the save hook fired before it ran.
 			try {
 				const toolRunData = run.data.resultData?.runData;
-				await this.executionPersistence.updateExistingExecution(executionId, {
-					...prepareExecutionDataForDbUpdate({
-						runData: run,
-						workflowData: execution.workflowData,
-						workflowStatusFinal: run.status,
-						retryOf: execution.retryOf ?? undefined,
-					}),
-					// The save hook computed this marker before the tool ran, so recompute it now
-					// that the tool task may carry dynamic-credential flags.
-					usedPrivateCredentials:
-						runDataUsedDynamicCredentials(toolRunData) ||
-						runDataAttemptedDynamicCredentials(toolRunData),
-				});
+				await this.executionPersistence.updateExistingExecution(
+					executionId,
+					{
+						...prepareExecutionDataForDbUpdate({
+							runData: run,
+							workflowData: execution.workflowData,
+							workflowStatusFinal: run.status,
+							retryOf: execution.retryOf ?? undefined,
+						}),
+						// The save hook computed this marker before the tool ran, so recompute it now
+						// that the tool task may carry dynamic-credential flags.
+						usedPrivateCredentials:
+							runDataUsedDynamicCredentials(toolRunData) ||
+							runDataAttemptedDynamicCredentials(toolRunData),
+					},
+					// A cancel racing the tool call must keep its status; skip the tool-run persist
+					// entirely rather than write over `canceled` (matches the completion hook).
+					{ requireNotCanceled: true },
+				);
 			} catch (error) {
 				this.logger.error('Failed to persist tool call run data for MCP Trigger', {
 					executionId,

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -33,6 +33,8 @@ import {
 	Workflow,
 	UnexpectedError,
 	createRunExecutionData,
+	runDataAttemptedDynamicCredentials,
+	runDataUsedDynamicCredentials,
 } from 'n8n-workflow';
 import type PCancelable from 'p-cancelable';
 
@@ -381,15 +383,20 @@ export class JobProcessor {
 
 			// Persist the tool call's run data, since the save hook fired before it ran.
 			try {
-				await this.executionPersistence.updateExistingExecution(
-					executionId,
-					prepareExecutionDataForDbUpdate({
+				const toolRunData = run.data.resultData?.runData;
+				await this.executionPersistence.updateExistingExecution(executionId, {
+					...prepareExecutionDataForDbUpdate({
 						runData: run,
 						workflowData: execution.workflowData,
 						workflowStatusFinal: run.status,
 						retryOf: execution.retryOf ?? undefined,
 					}),
-				);
+					// The save hook computed this marker before the tool ran, so recompute it now
+					// that the tool task may carry dynamic-credential flags.
+					usedPrivateCredentials:
+						runDataUsedDynamicCredentials(toolRunData) ||
+						runDataAttemptedDynamicCredentials(toolRunData),
+				});
 			} catch (error) {
 				this.logger.error('Failed to persist tool call run data for MCP Trigger', {
 					executionId,

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -42,6 +42,8 @@ import {
 	Workflow,
 	createRunExecutionData,
 	mergeRunsPerBranch,
+	runDataAttemptedDynamicCredentials,
+	runDataUsedDynamicCredentials,
 } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -445,6 +447,39 @@ export function buildSubWorkflowOutput(
 	return WorkflowHelpers.getLastExecutedNodeData(data)?.data?.main ?? [null];
 }
 
+/**
+ * Summarizes a sub-workflow's dynamic-credential usage so the calling node can report it back.
+ * Credentials resolve under the sub-workflow's own context, so the parent would otherwise never
+ * flag that its embedded output used a private credential. The engine applies this to the parent
+ * (see `BaseExecuteContext.executeWorkflow`); recurses via the child's task flags.
+ */
+function summarizeSubworkflowDynamicCredentials(
+	childRun: IRun,
+): Pick<
+	ExecuteWorkflowData,
+	'usedDynamicCredentials' | 'attemptedDynamicCredentials' | 'dynamicCredentialsResolvedUserId'
+> {
+	const runData = childRun.data.resultData?.runData;
+	const summary: Pick<
+		ExecuteWorkflowData,
+		'usedDynamicCredentials' | 'attemptedDynamicCredentials' | 'dynamicCredentialsResolvedUserId'
+	> = {};
+
+	if (runDataUsedDynamicCredentials(runData)) {
+		summary.usedDynamicCredentials = true;
+		const resolvedUserId = childRun.data.executionData?.runtimeData?.executedByUserId;
+		if (resolvedUserId) {
+			summary.dynamicCredentialsResolvedUserId = resolvedUserId;
+		}
+	}
+
+	if (runDataAttemptedDynamicCredentials(runData)) {
+		summary.attemptedDynamicCredentials = true;
+	}
+
+	return summary;
+}
+
 async function startExecution(
 	additionalData: IWorkflowExecuteAdditionalData,
 	options: ExecuteWorkflowOptions,
@@ -598,6 +633,8 @@ async function startExecution(
 			executionId,
 			data: buildSubWorkflowOutput(data, workflowData.nodes, options.returnLastRunOnly ?? false),
 			waitTill: data.waitTill,
+			// Report private-credential usage to the caller (detached runs return earlier, skipping this).
+			...summarizeSubworkflowDynamicCredentials(data),
 		};
 	}
 	activeExecutions.finalizeExecution(executionId, data);

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -42,8 +42,8 @@ import {
 	Workflow,
 	createRunExecutionData,
 	mergeRunsPerBranch,
-	runDataAttemptedDynamicCredentials,
-	runDataUsedDynamicCredentials,
+	attachDynamicCredentialsUsage,
+	summarizeDynamicCredentialsUsage,
 } from 'n8n-workflow';
 
 import { ActiveExecutions } from '@/active-executions';
@@ -447,39 +447,6 @@ export function buildSubWorkflowOutput(
 	return WorkflowHelpers.getLastExecutedNodeData(data)?.data?.main ?? [null];
 }
 
-/**
- * Summarizes a sub-workflow's dynamic-credential usage so the calling node can report it back.
- * Credentials resolve under the sub-workflow's own context, so the parent would otherwise never
- * flag that its embedded output used a private credential. The engine applies this to the parent
- * (see `BaseExecuteContext.executeWorkflow`); recurses via the child's task flags.
- */
-function summarizeSubworkflowDynamicCredentials(
-	childRun: IRun,
-): Pick<
-	ExecuteWorkflowData,
-	'usedDynamicCredentials' | 'attemptedDynamicCredentials' | 'dynamicCredentialsResolvedUserId'
-> {
-	const runData = childRun.data.resultData?.runData;
-	const summary: Pick<
-		ExecuteWorkflowData,
-		'usedDynamicCredentials' | 'attemptedDynamicCredentials' | 'dynamicCredentialsResolvedUserId'
-	> = {};
-
-	if (runDataUsedDynamicCredentials(runData)) {
-		summary.usedDynamicCredentials = true;
-		const resolvedUserId = childRun.data.executionData?.runtimeData?.executedByUserId;
-		if (resolvedUserId) {
-			summary.dynamicCredentialsResolvedUserId = resolvedUserId;
-		}
-	}
-
-	if (runDataAttemptedDynamicCredentials(runData)) {
-		summary.attemptedDynamicCredentials = true;
-	}
-
-	return summary;
-}
-
 async function startExecution(
 	additionalData: IWorkflowExecuteAdditionalData,
 	options: ExecuteWorkflowOptions,
@@ -611,15 +578,21 @@ async function startExecution(
 			executionId,
 			fullExecutionData,
 		);
-		throw objectToError(
-			{
-				...executionError,
-				executionId,
-				workflowId: workflowData.id,
-				stack: executionError?.stack,
-				message: executionError?.message,
-			},
-			workflow,
+		// The engine mutates `runData.executionData` in place, so a mid-run crash may leave
+		// credential flags on already-executed tasks — ride them on the error like the
+		// regular failure path below.
+		throw attachDynamicCredentialsUsage(
+			objectToError(
+				{
+					...executionError,
+					executionId,
+					workflowId: workflowData.id,
+					stack: executionError?.stack,
+					message: executionError?.message,
+				},
+				workflow,
+			),
+			summarizeDynamicCredentialsUsage(runData.executionData),
 		);
 	}
 
@@ -634,7 +607,7 @@ async function startExecution(
 			data: buildSubWorkflowOutput(data, workflowData.nodes, options.returnLastRunOnly ?? false),
 			waitTill: data.waitTill,
 			// Report private-credential usage to the caller (detached runs return earlier, skipping this).
-			...summarizeSubworkflowDynamicCredentials(data),
+			...summarizeDynamicCredentialsUsage(data.data),
 		};
 	}
 	activeExecutions.finalizeExecution(executionId, data);
@@ -642,14 +615,20 @@ async function startExecution(
 	// Workflow did fail
 	const { error } = data.data.resultData;
 
-	throw objectToError(
-		{
-			...error,
-			executionId,
-			workflowId: workflowData.id,
-			stack: error?.stack,
-		},
-		workflow,
+	// A failed child may still have attempted or resolved private credentials before failing;
+	// ride the usage on the error so a continue-on-fail caller still flags its task
+	// (see `BaseExecuteContext.executeWorkflow`).
+	throw attachDynamicCredentialsUsage(
+		objectToError(
+			{
+				...error,
+				executionId,
+				workflowId: workflowData.id,
+				stack: error?.stack,
+			},
+			workflow,
+		),
+		summarizeDynamicCredentialsUsage(data.data),
 	);
 }
 

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -8,6 +8,7 @@ import {
 	resolveNodeWebhookId,
 	resolveVariables,
 	safeParseWorkflowStructure,
+	summarizeDynamicCredentialsUsage,
 	validateNodeSelectionForGrouping,
 	type IDataObject,
 	type INode,
@@ -558,6 +559,46 @@ export async function updateParentExecutionWithChildResults(
 	const nodeExecutionStack = parentWithSubWorkflowResults.data.executionData?.nodeExecutionStack;
 	if (!nodeExecutionStack || nodeExecutionStack?.length === 0) {
 		return;
+	}
+
+	// On resume the parent's flagged 'waiting' task is popped and the node re-runs disabled
+	// (never calling `executeWorkflow` again), so the child's private-credential usage must
+	// ride on the stack entry to reach the freshly stamped task (see `WorkflowExecute`).
+	const dynamicCredentialsUsage = summarizeDynamicCredentialsUsage(subworkflowResults.data);
+	if (Object.keys(dynamicCredentialsUsage).length > 0) {
+		// Union with a sibling child's earlier report ("run once for each item" spawns several
+		// children per wait) — flags only ever accumulate, like every other flag writer.
+		nodeExecutionStack[0].metadata = {
+			...nodeExecutionStack[0].metadata,
+			dynamicCredentialsUsage: {
+				...nodeExecutionStack[0].metadata?.dynamicCredentialsUsage,
+				...dynamicCredentialsUsage,
+			},
+		};
+
+		// Also stamp the parent's waiting task and runtime data right away: the parent may sit
+		// in 'waiting' for a long time with the child's output already embedded in its data,
+		// and redaction scans runData task flags. The resume pops this task; the stash above
+		// restores the flags onto its replacement.
+		const waitingTasks =
+			parentWithSubWorkflowResults.data.resultData?.runData?.[nodeExecutionStack[0].node.name];
+		const waitingTask = waitingTasks?.[waitingTasks.length - 1];
+		if (waitingTask) {
+			if (dynamicCredentialsUsage.usedDynamicCredentials) {
+				waitingTask.usedDynamicCredentials = true;
+			}
+			if (dynamicCredentialsUsage.attemptedDynamicCredentials) {
+				waitingTask.attemptedDynamicCredentials = true;
+			}
+		}
+		const { runtimeData } = parentWithSubWorkflowResults.data.executionData ?? {};
+		if (
+			dynamicCredentialsUsage.usedDynamicCredentials &&
+			dynamicCredentialsUsage.dynamicCredentialsResolvedUserId &&
+			runtimeData
+		) {
+			runtimeData.executedByUserId = dynamicCredentialsUsage.dynamicCredentialsResolvedUserId;
+		}
 	}
 
 	if (subworkflowError) {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -229,6 +229,112 @@ describe('processRunExecutionData', () => {
 			// the status was `waiting` before
 			expect(result.data.resultData.runData.waitingNode[0].executionStatus).toEqual('success');
 		});
+
+		test('restores dynamic-credential usage stashed on the resumed stack entry', async () => {
+			// ARRANGE
+			// The waiting task carrying the flags is popped on resume and the node re-runs
+			// disabled, so the usage a sub-execution reported while this execution waited
+			// rides on the stack entry metadata and must reach the freshly stamped task.
+			const node = createNodeData({ name: 'waitingNode', type: types.passThrough });
+			const workflow = new DirectedGraph()
+				.addNodes(node)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const data: IDataObject = { foo: 1 };
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: node.name, sourceData: null }] },
+				resultData: {
+					runData: {
+						waitingNode: [
+							toITaskData([{ data }], {
+								executionStatus: 'waiting',
+								usedDynamicCredentials: true,
+							}),
+						],
+					},
+					lastNodeExecuted: 'waitingNode',
+				},
+				executionData: {
+					nodeExecutionStack: [
+						{
+							data: { main: [[{ json: data }]] },
+							node,
+							source: null,
+							metadata: {
+								dynamicCredentialsUsage: {
+									usedDynamicCredentials: true,
+									attemptedDynamicCredentials: true,
+									dynamicCredentialsResolvedUserId: 'resolved-user',
+								},
+							},
+						},
+					],
+					runtimeData: { version: 1, establishedAt: 0, source: 'trigger' },
+				},
+				waitTill: new Date('2024-01-01'),
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			const [taskData] = result.data.resultData.runData.waitingNode;
+			expect(result.data.resultData.runData.waitingNode).toHaveLength(1);
+			expect(taskData.executionStatus).toEqual('success');
+			expect(taskData.usedDynamicCredentials).toBe(true);
+			expect(taskData.attemptedDynamicCredentials).toBe(true);
+			expect(result.data.executionData?.runtimeData?.executedByUserId).toBe('resolved-user');
+			// The stash is transport-only and must not persist into the task metadata.
+			expect(taskData.metadata?.dynamicCredentialsUsage).toBeUndefined();
+		});
+
+		test('restores an attempted-only stash without recording a resolved user', async () => {
+			// ARRANGE
+			const node = createNodeData({ name: 'waitingNode', type: types.passThrough });
+			const workflow = new DirectedGraph()
+				.addNodes(node)
+				.toWorkflow({ name: '', active: false, nodeTypes, settings: { executionOrder: 'v1' } });
+
+			const data: IDataObject = { foo: 1 };
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: node.name, sourceData: null }] },
+				resultData: {
+					runData: { waitingNode: [toITaskData([{ data }], { executionStatus: 'waiting' })] },
+					lastNodeExecuted: 'waitingNode',
+				},
+				executionData: {
+					nodeExecutionStack: [
+						{
+							data: { main: [[{ json: data }]] },
+							node,
+							source: null,
+							metadata: {
+								dynamicCredentialsUsage: {
+									attemptedDynamicCredentials: true,
+									// Must be ignored: a resolved user requires a used flag.
+									dynamicCredentialsResolvedUserId: 'resolved-user',
+								},
+							},
+						},
+					],
+					runtimeData: { version: 1, establishedAt: 0, source: 'trigger' },
+				},
+				waitTill: new Date('2024-01-01'),
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			// ACT
+			const result = await workflowExecute.processRunExecutionData(workflow);
+
+			// ASSERT
+			const [taskData] = result.data.resultData.runData.waitingNode;
+			expect(taskData.attemptedDynamicCredentials).toBe(true);
+			expect(taskData.usedDynamicCredentials).toBeUndefined();
+			expect(result.data.executionData?.runtimeData?.executedByUserId).toBeUndefined();
+		});
 	});
 
 	describe('workflow issues', () => {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -26,6 +26,7 @@ import type {
 	IRunData,
 	IRunExecutionData,
 	ITaskData,
+	ITaskMetadata,
 	ITriggerResponse,
 	IWorkflowExecuteAdditionalData,
 	WorkflowTestData,
@@ -2007,6 +2008,7 @@ describe('WorkflowExecute', () => {
 
 		async function runResumedSubError(
 			nodeOverrides: Partial<INode> = {},
+			metadataExtras: ITaskMetadata = {},
 		): Promise<{ result: IRun; runNodeCalls: number }> {
 			const subNode: INode = {
 				...createNodeData({ name: SUB_NODE, type: 'sub' }),
@@ -2044,6 +2046,7 @@ describe('WorkflowExecute', () => {
 							metadata: {
 								resumeError: { name: 'NodeOperationError', message: SUB_ERROR },
 								subExecution: SUB_EXECUTION,
+								...metadataExtras,
 							},
 						} as unknown as IExecuteData,
 					],
@@ -2114,6 +2117,18 @@ describe('WorkflowExecute', () => {
 				expect(errorItem?.metadata).toEqual({ subExecution: SUB_EXECUTION });
 			},
 		);
+
+		it('should restore a dynamic-credential stash also when the resume carries a sub-workflow error', async () => {
+			const { result } = await runResumedSubError(
+				{ onError: 'continueRegularOutput' },
+				{ dynamicCredentialsUsage: { attemptedDynamicCredentials: true } },
+			);
+
+			expect(result.status).toBe('success');
+			const run = lastRun(result);
+			expect(run.attemptedDynamicCredentials).toBe(true);
+			expect(run.usedDynamicCredentials).toBeUndefined();
+		});
 	});
 
 	describe('prepareWaitingToExecution', () => {

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -398,5 +398,31 @@ export const describeCommonTests = (
 				expect(childParentExecution.executionContext).toBeUndefined();
 			});
 		});
+
+		describe('sub-workflow dynamic credential reporting', () => {
+			it('forwards the sub-workflow dynamic-credential usage onto the parent execution', async () => {
+				additionalData.executeWorkflow.mockResolvedValue({
+					...executeWorkflowData,
+					usedDynamicCredentials: true,
+					dynamicCredentialsResolvedUserId: 'sub-user',
+				});
+
+				await context.executeWorkflow(workflowInfo);
+
+				expect(additionalData.currentNodeUsedDynamicCredentials).toBe(true);
+				expect(additionalData.dynamicCredentialsResolvedUserId).toBe('sub-user');
+			});
+
+			it('forwards the attempted flag onto the parent execution', async () => {
+				additionalData.executeWorkflow.mockResolvedValue({
+					...executeWorkflowData,
+					attemptedDynamicCredentials: true,
+				});
+
+				await context.executeWorkflow(workflowInfo);
+
+				expect(additionalData.currentNodeAttemptedDynamicCredentials).toBe(true);
+			});
+		});
 	});
 };

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -400,6 +400,13 @@ export const describeCommonTests = (
 		});
 
 		describe('sub-workflow dynamic credential reporting', () => {
+			beforeEach(() => {
+				// The shared mock keeps assigned flags across tests; reset like the engine loop does.
+				additionalData.currentNodeUsedDynamicCredentials = false;
+				additionalData.currentNodeAttemptedDynamicCredentials = false;
+				additionalData.dynamicCredentialsResolvedUserId = undefined;
+			});
+
 			it('forwards the sub-workflow dynamic-credential usage onto the parent execution', async () => {
 				additionalData.executeWorkflow.mockResolvedValue({
 					...executeWorkflowData,
@@ -422,6 +429,35 @@ export const describeCommonTests = (
 				await context.executeWorkflow(workflowInfo);
 
 				expect(additionalData.currentNodeAttemptedDynamicCredentials).toBe(true);
+			});
+
+			it('forwards usage attached to a failed sub-workflow error and rethrows', async () => {
+				const error = Object.assign(new Error('sub-workflow failed'), {
+					dynamicCredentialsUsage: {
+						usedDynamicCredentials: true,
+						attemptedDynamicCredentials: true,
+						dynamicCredentialsResolvedUserId: 'sub-user',
+					},
+				});
+				additionalData.executeWorkflow.mockRejectedValue(error);
+
+				await expect(context.executeWorkflow(workflowInfo)).rejects.toThrow('sub-workflow failed');
+
+				expect(additionalData.currentNodeUsedDynamicCredentials).toBe(true);
+				expect(additionalData.currentNodeAttemptedDynamicCredentials).toBe(true);
+				expect(additionalData.dynamicCredentialsResolvedUserId).toBe('sub-user');
+				// The marker is transport-only and must not persist into the node's taskData.error.
+				expect('dynamicCredentialsUsage' in error).toBe(false);
+			});
+
+			it('rethrows a failed sub-workflow error without usage untouched', async () => {
+				additionalData.executeWorkflow.mockRejectedValue(new Error('sub-workflow failed'));
+
+				await expect(context.executeWorkflow(workflowInfo)).rejects.toThrow('sub-workflow failed');
+
+				expect(additionalData.currentNodeUsedDynamicCredentials).toBe(false);
+				expect(additionalData.currentNodeAttemptedDynamicCredentials).toBe(false);
+				expect(additionalData.dynamicCredentialsResolvedUserId).toBeUndefined();
 			});
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -20,6 +20,7 @@ import {
 	createRunExecutionData,
 	ManualExecutionCancelledError,
 	NodeConnectionTypes,
+	NodeOperationError,
 } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
@@ -623,6 +624,148 @@ describe('SupplyDataContext', () => {
 			expect(taskData.hints).toHaveLength(1);
 			expect(taskData.hints![0].message).toContain('null or undefined');
 			expect(taskData.hints![0].location).toBe('outputPane');
+		});
+	});
+
+	// Sub-node executions can run during a trigger's webhook phase (e.g. MCP Trigger tool
+	// calls), where no engine loop stamps the per-node credential flags — the context must
+	// stamp them itself so the persisted execution still gets redacted.
+	describe('dynamic credential flag stamping', () => {
+		const buildStampingContext = () => {
+			const testAdditionalData = mock<IWorkflowExecuteAdditionalData>({
+				credentialsHelper,
+				hooks: { runHook: vi.fn().mockResolvedValue(undefined) },
+				currentNodeExecutionIndex: 0,
+				webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
+				formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+			});
+			testAdditionalData.currentNodeUsedDynamicCredentials = false;
+			testAdditionalData.currentNodeAttemptedDynamicCredentials = false;
+			testAdditionalData.dynamicCredentialsResolvedUserId = undefined;
+
+			const testRunExecutionData = createRunExecutionData({
+				resultData: {
+					runData: {
+						[node.name]: [
+							{
+								startTime: Date.now(),
+								executionTime: 0,
+								executionIndex: 0,
+								executionStatus: 'running' as const,
+								source: [],
+							},
+						],
+					},
+				},
+				executionData: {
+					metadata: {},
+					contextData: {},
+					nodeExecutionStack: [],
+					waitingExecution: {},
+					waitingExecutionSource: {},
+					runtimeData: { version: 1, establishedAt: 0, source: 'trigger' },
+				},
+			});
+
+			const testContext = new SupplyDataContext(
+				workflow,
+				node,
+				testAdditionalData,
+				mode,
+				testRunExecutionData,
+				runIndex,
+				connectionInputData,
+				inputData,
+				NodeConnectionTypes.AiTool,
+				executeData,
+				[closeFn],
+				abortSignal,
+			);
+
+			return { testAdditionalData, testRunExecutionData, testContext };
+		};
+
+		it('stamps the flags and resolved user onto the output task data', async () => {
+			const { testAdditionalData, testRunExecutionData, testContext } = buildStampingContext();
+			testAdditionalData.currentNodeUsedDynamicCredentials = true;
+			testAdditionalData.currentNodeAttemptedDynamicCredentials = true;
+			testAdditionalData.dynamicCredentialsResolvedUserId = 'resolved-user';
+
+			await testContext.addExecutionDataFunctions(
+				'output',
+				[[{ json: { result: 'success' } }]],
+				NodeConnectionTypes.AiTool,
+				node.name,
+				0,
+			);
+
+			const taskData = testRunExecutionData.resultData.runData[node.name][0];
+			expect(taskData.usedDynamicCredentials).toBe(true);
+			expect(taskData.attemptedDynamicCredentials).toBe(true);
+			expect(testRunExecutionData.executionData?.runtimeData?.executedByUserId).toBe(
+				'resolved-user',
+			);
+		});
+
+		it('stamps the attempted flag on an error output', async () => {
+			const { testAdditionalData, testRunExecutionData, testContext } = buildStampingContext();
+			testAdditionalData.currentNodeAttemptedDynamicCredentials = true;
+
+			await testContext.addExecutionDataFunctions(
+				'output',
+				new NodeOperationError(node, 'tool failed'),
+				NodeConnectionTypes.AiTool,
+				node.name,
+				0,
+			);
+
+			const taskData = testRunExecutionData.resultData.runData[node.name][0];
+			expect(taskData.executionStatus).toBe('error');
+			expect(taskData.attemptedDynamicCredentials).toBe(true);
+			expect(taskData.usedDynamicCredentials).toBeUndefined();
+			expect(testRunExecutionData.executionData?.runtimeData?.executedByUserId).toBeUndefined();
+		});
+
+		it('stamps nothing when no credential was attempted', async () => {
+			const { testRunExecutionData, testContext } = buildStampingContext();
+
+			await testContext.addExecutionDataFunctions(
+				'output',
+				[[{ json: { result: 'success' } }]],
+				NodeConnectionTypes.AiTool,
+				node.name,
+				0,
+			);
+
+			const taskData = testRunExecutionData.resultData.runData[node.name][0];
+			expect(taskData.usedDynamicCredentials).toBeUndefined();
+			expect(taskData.attemptedDynamicCredentials).toBeUndefined();
+			expect(testRunExecutionData.executionData?.runtimeData?.executedByUserId).toBeUndefined();
+		});
+
+		// The flags are execution-shared and only reset per top-level engine node, so a
+		// sibling sub-node's earlier resolution must not be attributed to this run's task.
+		it('does not stamp flags that were already set before this run started', async () => {
+			const { testAdditionalData, testRunExecutionData, testContext } = buildStampingContext();
+			testAdditionalData.currentNodeUsedDynamicCredentials = true;
+			testAdditionalData.currentNodeAttemptedDynamicCredentials = true;
+			testAdditionalData.dynamicCredentialsResolvedUserId = 'sibling-user';
+
+			const { index } = testContext.addInputData(NodeConnectionTypes.AiTool, [
+				[{ json: { query: 'test' } }],
+			]);
+			await testContext.addExecutionDataFunctions(
+				'output',
+				[[{ json: { result: 'success' } }]],
+				NodeConnectionTypes.AiTool,
+				node.name,
+				index,
+			);
+
+			const taskData = testRunExecutionData.resultData.runData[node.name][index];
+			expect(taskData.usedDynamicCredentials).toBeUndefined();
+			expect(taskData.attemptedDynamicCredentials).toBeUndefined();
+			expect(testRunExecutionData.executionData?.runtimeData?.executedByUserId).toBeUndefined();
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -34,6 +34,8 @@ import {
 	WAIT_INDEFINITELY,
 	WorkflowDataProxy,
 	createEnvProviderState,
+	applyDynamicCredentialsUsage,
+	takeAttachedDynamicCredentialsUsage,
 } from 'n8n-workflow';
 
 import { PLACEHOLDER_EMPTY_EXECUTION_ID } from '@/constants';
@@ -142,28 +144,29 @@ export class BaseExecuteContext extends NodeExecutionContext {
 				options.parentExecution.executionContext = this.getExecutionContext();
 			}
 		}
-		const result = await this.additionalData.executeWorkflow(workflowInfo, this.additionalData, {
-			...options,
-			parentWorkflowId: this.workflow.id,
-			inputData,
-			parentWorkflowSettings: this.workflow.settings,
-			node: this.node,
-			parentCallbackManager,
-		});
+		let result: ExecuteWorkflowData;
+		try {
+			result = await this.additionalData.executeWorkflow(workflowInfo, this.additionalData, {
+				...options,
+				parentWorkflowId: this.workflow.id,
+				inputData,
+				parentWorkflowSettings: this.workflow.settings,
+				node: this.node,
+				parentCallbackManager,
+			});
+		} catch (error) {
+			// A failed sub-workflow may still have attempted or resolved private credentials
+			// before failing; the usage rides on the error so a continue-on-fail parent task
+			// still inherits the flags.
+			const usage = takeAttachedDynamicCredentialsUsage(error);
+			if (usage) applyDynamicCredentialsUsage(this.additionalData, usage);
+			throw error;
+		}
 
-		// The sub-workflow resolved its credentials under its own context; forward the reported usage
-		// onto this parent node so its task inherits the flag and redaction covers the embedded output.
-		// Resolved user id is execution-scoped, so a present value wins (matches credential resolution).
-		if (result.usedDynamicCredentials) {
-			this.additionalData.currentNodeUsedDynamicCredentials = true;
-			if (result.dynamicCredentialsResolvedUserId) {
-				this.additionalData.dynamicCredentialsResolvedUserId =
-					result.dynamicCredentialsResolvedUserId;
-			}
-		}
-		if (result.attemptedDynamicCredentials) {
-			this.additionalData.currentNodeAttemptedDynamicCredentials = true;
-		}
+		// The sub-workflow resolved its credentials under its own context; forward the reported
+		// usage onto this parent node so its task inherits the flag and redaction covers the
+		// embedded output.
+		applyDynamicCredentialsUsage(this.additionalData, result);
 
 		// If a sub-workflow execution goes into the waiting state
 		if (result.waitTill) {

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -151,6 +151,20 @@ export class BaseExecuteContext extends NodeExecutionContext {
 			parentCallbackManager,
 		});
 
+		// The sub-workflow resolved its credentials under its own context; forward the reported usage
+		// onto this parent node so its task inherits the flag and redaction covers the embedded output.
+		// Resolved user id is execution-scoped, so a present value wins (matches credential resolution).
+		if (result.usedDynamicCredentials) {
+			this.additionalData.currentNodeUsedDynamicCredentials = true;
+			if (result.dynamicCredentialsResolvedUserId) {
+				this.additionalData.dynamicCredentialsResolvedUserId =
+					result.dynamicCredentialsResolvedUserId;
+			}
+		}
+		if (result.attemptedDynamicCredentials) {
+			this.additionalData.currentNodeAttemptedDynamicCredentials = true;
+		}
+
 		// If a sub-workflow execution goes into the waiting state
 		if (result.waitTill) {
 			// then put the parent workflow execution also into the waiting state,

--- a/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/supply-data-context.ts
@@ -50,6 +50,17 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 
 	readonly hints: NodeExecutionHint[] = [];
 
+	/**
+	 * The `additionalData` credential flags at 'input' time, per run index. The flags are
+	 * execution-shared and only reset per top-level engine node, so a sibling sub-node's
+	 * earlier resolution would otherwise be stamped onto this run's task too — stamping
+	 * only flags raised between 'input' and 'output' attributes usage to the right task.
+	 */
+	private readonly dynamicCredentialsFlagsAtInput = new Map<
+		number,
+		{ used: boolean; attempted: boolean }
+	>();
+
 	constructor(
 		workflow: Workflow,
 		node: INode,
@@ -272,6 +283,10 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			: [];
 
 		if (type === 'input') {
+			this.dynamicCredentialsFlagsAtInput.set(currentNodeRunIndex, {
+				used: additionalData.currentNodeUsedDynamicCredentials === true,
+				attempted: additionalData.currentNodeAttemptedDynamicCredentials === true,
+			});
 			taskData = {
 				startTime: Date.now(),
 				executionTime: 0,
@@ -310,6 +325,10 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 			taskData.data = {
 				[connectionType]: data,
 			} as ITaskDataConnections;
+		}
+
+		if (type === 'output') {
+			this.stampDynamicCredentialsUsage(taskData, currentNodeRunIndex);
 		}
 
 		if (type === 'input') {
@@ -362,6 +381,41 @@ export class SupplyDataContext extends BaseExecuteContext implements ISupplyData
 				node: nodeName,
 				runIndex: currentNodeRunIndex,
 			});
+		}
+	}
+
+	/**
+	 * Sub-node executions can run during a trigger's webhook phase (e.g. MCP Trigger tool
+	 * calls), where no engine loop stamps the per-node credential flags onto task data —
+	 * stamp them here so the persisted execution still gets redacted. Engine-phase nodes
+	 * are stamped by `WorkflowExecute` from the same `additionalData` flags. Only flags
+	 * raised since this run's 'input' write are stamped, so a sibling sub-node's earlier
+	 * resolution is not attributed to this task.
+	 */
+	private stampDynamicCredentialsUsage(taskData: ITaskData, currentNodeRunIndex: number) {
+		const { additionalData, runExecutionData } = this;
+		const atInput = this.dynamicCredentialsFlagsAtInput.get(currentNodeRunIndex) ?? {
+			used: false,
+			attempted: false,
+		};
+		this.dynamicCredentialsFlagsAtInput.delete(currentNodeRunIndex);
+
+		const used = additionalData.currentNodeUsedDynamicCredentials === true && !atInput.used;
+		if (used) {
+			taskData.usedDynamicCredentials = true;
+		}
+		if (additionalData.currentNodeAttemptedDynamicCredentials === true && !atInput.attempted) {
+			taskData.attemptedDynamicCredentials = true;
+		}
+		if (
+			used &&
+			additionalData.dynamicCredentialsResolvedUserId &&
+			runExecutionData.executionData?.runtimeData
+		) {
+			// Record the resolved user like the engine loop does, so the redaction layer can
+			// grant that user access to their own data (identity is execution-scoped).
+			runExecutionData.executionData.runtimeData.executedByUserId =
+				additionalData.dynamicCredentialsResolvedUserId;
 		}
 	}
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -57,6 +57,7 @@ import {
 	TimeoutExecutionCancelledError,
 	ManualExecutionCancelledError,
 	createRunExecutionData,
+	applyDynamicCredentialsUsage,
 } from 'n8n-workflow';
 import PCancelable from 'p-cancelable';
 
@@ -1680,6 +1681,17 @@ export class WorkflowExecute {
 					// Reset per-node dynamic credential flags before each node execution
 					this.additionalData.currentNodeUsedDynamicCredentials = false;
 					this.additionalData.currentNodeAttemptedDynamicCredentials = false;
+
+					// A sub-execution that finished while this execution was waiting reported its
+					// private-credential usage on the resumed stack entry (the node re-runs disabled,
+					// so `executeWorkflow` never reports again) — restore it so the new task and
+					// `runtimeData.executedByUserId` still inherit the flags. The stash is
+					// transport-only, so consume it to keep it out of the persisted task metadata.
+					const reportedUsage = executionData.metadata?.dynamicCredentialsUsage;
+					if (reportedUsage) {
+						applyDynamicCredentialsUsage(this.additionalData, reportedUsage);
+						delete executionData.metadata?.dynamicCredentialsUsage;
+					}
 
 					const taskStartedData: ITaskStartedData = {
 						startTime: Date.now(),

--- a/packages/workflow/src/dynamic-credentials-helpers.ts
+++ b/packages/workflow/src/dynamic-credentials-helpers.ts
@@ -1,4 +1,5 @@
-import type { IRunData } from './interfaces';
+import type { DynamicCredentialsUsage, IRunData } from './interfaces';
+import type { IRunExecutionData } from './run-execution-data/run-execution-data';
 
 /**
  * True when any node in the run resolved a private (resolvable) credential dynamically.
@@ -22,4 +23,101 @@ export function runDataAttemptedDynamicCredentials(runData: IRunData | undefined
 	return Object.values(runData ?? {}).some((tasks) =>
 		tasks.some((task) => task?.attemptedDynamicCredentials === true),
 	);
+}
+
+/**
+ * Summarizes a run's private-credential usage so a sub-execution can report it to its caller.
+ * Credentials resolve under the sub-workflow's own context, so the parent would otherwise never
+ * flag that its embedded output used a private credential; recurses via the child's task flags.
+ */
+export function summarizeDynamicCredentialsUsage(
+	executionData: IRunExecutionData | undefined,
+): DynamicCredentialsUsage {
+	const runData = executionData?.resultData?.runData;
+	const usage: DynamicCredentialsUsage = {};
+
+	if (runDataUsedDynamicCredentials(runData)) {
+		usage.usedDynamicCredentials = true;
+		const resolvedUserId = executionData?.executionData?.runtimeData?.executedByUserId;
+		if (resolvedUserId) {
+			usage.dynamicCredentialsResolvedUserId = resolvedUserId;
+		}
+	}
+
+	if (runDataAttemptedDynamicCredentials(runData)) {
+		usage.attemptedDynamicCredentials = true;
+	}
+
+	return usage;
+}
+
+/** The per-node dynamic-credential flags carried on `IWorkflowExecuteAdditionalData`. */
+interface DynamicCredentialsUsageTarget {
+	currentNodeUsedDynamicCredentials?: boolean;
+	currentNodeAttemptedDynamicCredentials?: boolean;
+	dynamicCredentialsResolvedUserId?: string;
+}
+
+/**
+ * Applies a reported usage summary onto the per-node flags additively (flags only ever get set,
+ * matching the other flag writers — the engine resets them per node). Resolved user id is
+ * execution-scoped, so a present value wins (matches credential resolution).
+ */
+export function applyDynamicCredentialsUsage(
+	target: DynamicCredentialsUsageTarget,
+	usage: DynamicCredentialsUsage,
+): void {
+	if (usage.usedDynamicCredentials) {
+		target.currentNodeUsedDynamicCredentials = true;
+		if (usage.dynamicCredentialsResolvedUserId) {
+			target.dynamicCredentialsResolvedUserId = usage.dynamicCredentialsResolvedUserId;
+		}
+	}
+	if (usage.attemptedDynamicCredentials) {
+		target.currentNodeAttemptedDynamicCredentials = true;
+	}
+}
+
+/**
+ * Rides a usage summary on an error crossing the sub-execution boundary, so a caller that
+ * continues on fail can still flag its task (a failed resolution is the primary case
+ * `attemptedDynamicCredentials` exists for). Read back via
+ * {@link takeAttachedDynamicCredentialsUsage}.
+ */
+export function attachDynamicCredentialsUsage(error: Error, usage: DynamicCredentialsUsage): Error {
+	if (Object.keys(usage).length > 0) {
+		Object.assign(error, { dynamicCredentialsUsage: usage });
+	}
+	return error;
+}
+
+/**
+ * Reads back and strips a usage summary attached via {@link attachDynamicCredentialsUsage},
+ * validating its shape. The marker is transport-only: stripping it keeps it out of the
+ * persisted `taskData.error` when the caller's node fails with this error.
+ */
+export function takeAttachedDynamicCredentialsUsage(
+	error: unknown,
+): DynamicCredentialsUsage | undefined {
+	if (typeof error !== 'object' || error === null || !('dynamicCredentialsUsage' in error)) {
+		return undefined;
+	}
+	const attached = error.dynamicCredentialsUsage;
+	Reflect.deleteProperty(error, 'dynamicCredentialsUsage');
+	if (typeof attached !== 'object' || attached === null) return undefined;
+
+	const usage: DynamicCredentialsUsage = {};
+	if ('usedDynamicCredentials' in attached && attached.usedDynamicCredentials === true) {
+		usage.usedDynamicCredentials = true;
+	}
+	if ('attemptedDynamicCredentials' in attached && attached.attemptedDynamicCredentials === true) {
+		usage.attemptedDynamicCredentials = true;
+	}
+	if (
+		'dynamicCredentialsResolvedUserId' in attached &&
+		typeof attached.dynamicCredentialsResolvedUserId === 'string'
+	) {
+		usage.dynamicCredentialsResolvedUserId = attached.dynamicCredentialsResolvedUserId;
+	}
+	return Object.keys(usage).length > 0 ? usage : undefined;
 }

--- a/packages/workflow/src/dynamic-credentials-helpers.ts
+++ b/packages/workflow/src/dynamic-credentials-helpers.ts
@@ -1,0 +1,25 @@
+import type { IRunData } from './interfaces';
+
+/**
+ * True when any node in the run resolved a private (resolvable) credential dynamically.
+ * The redaction layer relies on this to decide whether an execution must be redacted, and it is
+ * forwarded from a sub-workflow onto its calling node.
+ */
+export function runDataUsedDynamicCredentials(runData: IRunData | undefined): boolean {
+	return Object.values(runData ?? {}).some((tasks) =>
+		// runData node arrays can hold null placeholder slots at runtime despite the
+		// ITaskData[] type, so guard the element deref.
+		tasks.some((task) => task?.usedDynamicCredentials === true),
+	);
+}
+
+/**
+ * True when any node in the run attempted to resolve a private credential, regardless of success.
+ * Superset of {@link runDataUsedDynamicCredentials} (it also captures failed attempts); used for
+ * telemetry and the `usedPrivateCredentials` marker.
+ */
+export function runDataAttemptedDynamicCredentials(runData: IRunData | undefined): boolean {
+	return Object.values(runData ?? {}).some((tasks) =>
+		tasks.some((task) => task?.attemptedDynamicCredentials === true),
+	);
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -11,6 +11,7 @@ export * from './data-table.types';
 export * from './execution-context';
 export * from './execution-context-establishment-hooks';
 export * from './redaction-channels';
+export * from './dynamic-credentials-helpers';
 export * from './global-state';
 export * from './interfaces';
 export * from './sub-workflow-output';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2069,17 +2069,21 @@ export interface ITriggerResponse {
 	manualTriggerResponse?: Promise<INodeExecutionData[][]>;
 }
 
-export interface ExecuteWorkflowData {
+/** Private-credential usage a sub-execution reports to its caller, so the calling node's task inherits the flags and redaction covers the embedded output. */
+export interface DynamicCredentialsUsage {
+	/** True when the run resolved a private credential. */
+	usedDynamicCredentials?: boolean;
+	/** True when the run attempted to resolve a private credential (telemetry superset of `usedDynamicCredentials`). */
+	attemptedDynamicCredentials?: boolean;
+	/** The n8n user a resolved private credential belonged to; keeps the parent execution revealable to that user. */
+	dynamicCredentialsResolvedUserId?: string;
+}
+
+export interface ExecuteWorkflowData extends DynamicCredentialsUsage {
 	executionId: string;
 	/** Terminal node output: items from every run concatenated per output branch, unless the caller sets `returnLastRunOnly`. */
 	data: Array<INodeExecutionData[] | null>;
 	waitTill?: Date | null;
-	/** True when the sub-workflow resolved a private credential; the calling node inherits it so redaction covers its embedded output. */
-	usedDynamicCredentials?: boolean;
-	/** True when the sub-workflow attempted to resolve a private credential (telemetry superset of `usedDynamicCredentials`). */
-	attemptedDynamicCredentials?: boolean;
-	/** The n8n user a resolved private credential belonged to; keeps the parent execution revealable to that user. */
-	dynamicCredentialsResolvedUserId?: string;
 }
 
 export interface ExecuteAgentInfo {
@@ -3071,6 +3075,12 @@ export interface ITaskMetadata {
 	parentExecution?: RelatedExecution;
 	subExecution?: RelatedExecution;
 	subExecutionsCount?: number;
+	/**
+	 * Private-credential usage a sub-execution reported while this execution was
+	 * waiting. The waiting task is popped and the node re-runs disabled on resume,
+	 * so the usage rides on the stack entry to reach the freshly stamped task.
+	 */
+	dynamicCredentialsUsage?: DynamicCredentialsUsage;
 	subNodeExecutionData?: {
 		actions: SubNodeExecutionDataAction[];
 		metadata: object;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2074,6 +2074,12 @@ export interface ExecuteWorkflowData {
 	/** Terminal node output: items from every run concatenated per output branch, unless the caller sets `returnLastRunOnly`. */
 	data: Array<INodeExecutionData[] | null>;
 	waitTill?: Date | null;
+	/** True when the sub-workflow resolved a private credential; the calling node inherits it so redaction covers its embedded output. */
+	usedDynamicCredentials?: boolean;
+	/** True when the sub-workflow attempted to resolve a private credential (telemetry superset of `usedDynamicCredentials`). */
+	attemptedDynamicCredentials?: boolean;
+	/** The n8n user a resolved private credential belonged to; keeps the parent execution revealable to that user. */
+	dynamicCredentialsResolvedUserId?: string;
 }
 
 export interface ExecuteAgentInfo {

--- a/packages/workflow/test/dynamic-credentials-helpers.test.ts
+++ b/packages/workflow/test/dynamic-credentials-helpers.test.ts
@@ -1,0 +1,60 @@
+import {
+	runDataAttemptedDynamicCredentials,
+	runDataUsedDynamicCredentials,
+} from '../src/dynamic-credentials-helpers';
+import type { IRunData, ITaskData } from '../src/interfaces';
+
+const task = (flags: Partial<ITaskData>): ITaskData =>
+	({ startTime: 0, executionTime: 0, ...flags }) as ITaskData;
+
+describe('dynamic-credentials-helpers', () => {
+	describe('runDataUsedDynamicCredentials', () => {
+		it('returns false for undefined or empty run data', () => {
+			expect(runDataUsedDynamicCredentials(undefined)).toBe(false);
+			expect(runDataUsedDynamicCredentials({})).toBe(false);
+		});
+
+		it('returns false when no task used a dynamic credential', () => {
+			const runData: IRunData = { node: [task({}), task({ attemptedDynamicCredentials: true })] };
+			expect(runDataUsedDynamicCredentials(runData)).toBe(false);
+		});
+
+		it('returns true when any task of any node used a dynamic credential', () => {
+			const runData: IRunData = {
+				A: [task({})],
+				B: [task({}), task({ usedDynamicCredentials: true })],
+			};
+			expect(runDataUsedDynamicCredentials(runData)).toBe(true);
+		});
+	});
+
+	describe('runDataAttemptedDynamicCredentials', () => {
+		it('returns false for undefined or empty run data', () => {
+			expect(runDataAttemptedDynamicCredentials(undefined)).toBe(false);
+			expect(runDataAttemptedDynamicCredentials({})).toBe(false);
+		});
+
+		it('returns true on an attempt even when resolution did not succeed', () => {
+			const runData: IRunData = { node: [task({ attemptedDynamicCredentials: true })] };
+			expect(runDataAttemptedDynamicCredentials(runData)).toBe(true);
+			expect(runDataUsedDynamicCredentials(runData)).toBe(false);
+		});
+
+		it('reports both when a credential was used', () => {
+			const runData: IRunData = {
+				node: [task({ usedDynamicCredentials: true, attemptedDynamicCredentials: true })],
+			};
+			expect(runDataAttemptedDynamicCredentials(runData)).toBe(true);
+			expect(runDataUsedDynamicCredentials(runData)).toBe(true);
+		});
+	});
+
+	it('ignores null placeholder slots in a node task array', () => {
+		// runData arrays can hold null placeholder slots at runtime despite the ITaskData[] type.
+		const runData = {
+			node: [null, task({ usedDynamicCredentials: true })],
+		} as unknown as IRunData;
+		expect(runDataUsedDynamicCredentials(runData)).toBe(true);
+		expect(runDataAttemptedDynamicCredentials(runData)).toBe(false);
+	});
+});

--- a/packages/workflow/test/dynamic-credentials-helpers.test.ts
+++ b/packages/workflow/test/dynamic-credentials-helpers.test.ts
@@ -1,11 +1,22 @@
 import {
+	applyDynamicCredentialsUsage,
+	attachDynamicCredentialsUsage,
 	runDataAttemptedDynamicCredentials,
 	runDataUsedDynamicCredentials,
+	summarizeDynamicCredentialsUsage,
+	takeAttachedDynamicCredentialsUsage,
 } from '../src/dynamic-credentials-helpers';
 import type { IRunData, ITaskData } from '../src/interfaces';
+import type { IRunExecutionData } from '../src/run-execution-data/run-execution-data';
 
 const task = (flags: Partial<ITaskData>): ITaskData =>
 	({ startTime: 0, executionTime: 0, ...flags }) as ITaskData;
+
+const executionData = (runData: IRunData, executedByUserId?: string): IRunExecutionData =>
+	({
+		resultData: { runData },
+		...(executedByUserId ? { executionData: { runtimeData: { executedByUserId } } } : {}),
+	}) as unknown as IRunExecutionData;
 
 describe('dynamic-credentials-helpers', () => {
 	describe('runDataUsedDynamicCredentials', () => {
@@ -56,5 +67,115 @@ describe('dynamic-credentials-helpers', () => {
 		} as unknown as IRunData;
 		expect(runDataUsedDynamicCredentials(runData)).toBe(true);
 		expect(runDataAttemptedDynamicCredentials(runData)).toBe(false);
+	});
+
+	describe('summarizeDynamicCredentialsUsage', () => {
+		it('returns an empty summary for undefined execution data or when nothing was used', () => {
+			expect(summarizeDynamicCredentialsUsage(undefined)).toEqual({});
+			expect(summarizeDynamicCredentialsUsage(executionData({ node: [task({})] }))).toEqual({});
+		});
+
+		it('reports usage and the resolved user when a credential was resolved', () => {
+			const usage = summarizeDynamicCredentialsUsage(
+				executionData(
+					{
+						node: [task({ usedDynamicCredentials: true, attemptedDynamicCredentials: true })],
+					},
+					'resolved-user',
+				),
+			);
+			expect(usage).toEqual({
+				usedDynamicCredentials: true,
+				attemptedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+		});
+
+		it('reports only the attempted flag when resolution never succeeded', () => {
+			const usage = summarizeDynamicCredentialsUsage(
+				executionData({ node: [task({ attemptedDynamicCredentials: true })] }, 'resolved-user'),
+			);
+			expect(usage).toEqual({ attemptedDynamicCredentials: true });
+		});
+	});
+
+	describe('attach/takeAttachedDynamicCredentialsUsage', () => {
+		it('round-trips a usage summary through an error and strips the marker', () => {
+			const error = attachDynamicCredentialsUsage(new Error('boom'), {
+				usedDynamicCredentials: true,
+				attemptedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+			expect(takeAttachedDynamicCredentialsUsage(error)).toEqual({
+				usedDynamicCredentials: true,
+				attemptedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+			// The marker is transport-only; taking it removes it so the error can persist cleanly.
+			expect('dynamicCredentialsUsage' in error).toBe(false);
+			expect(takeAttachedDynamicCredentialsUsage(error)).toBeUndefined();
+		});
+
+		it('does not attach an empty summary', () => {
+			const error = attachDynamicCredentialsUsage(new Error('boom'), {});
+			expect('dynamicCredentialsUsage' in error).toBe(false);
+			expect(takeAttachedDynamicCredentialsUsage(error)).toBeUndefined();
+		});
+
+		it('returns undefined for errors without an attachment and non-error values', () => {
+			expect(takeAttachedDynamicCredentialsUsage(new Error('boom'))).toBeUndefined();
+			expect(takeAttachedDynamicCredentialsUsage(undefined)).toBeUndefined();
+			expect(takeAttachedDynamicCredentialsUsage('boom')).toBeUndefined();
+		});
+
+		it('drops malformed attachment fields', () => {
+			const error = Object.assign(new Error('boom'), {
+				dynamicCredentialsUsage: {
+					usedDynamicCredentials: 'yes',
+					attemptedDynamicCredentials: true,
+					dynamicCredentialsResolvedUserId: 42,
+				},
+			});
+			expect(takeAttachedDynamicCredentialsUsage(error)).toEqual({
+				attemptedDynamicCredentials: true,
+			});
+			expect('dynamicCredentialsUsage' in error).toBe(false);
+		});
+	});
+
+	describe('applyDynamicCredentialsUsage', () => {
+		it('sets flags additively and records the resolved user', () => {
+			const target: {
+				currentNodeUsedDynamicCredentials?: boolean;
+				currentNodeAttemptedDynamicCredentials?: boolean;
+				dynamicCredentialsResolvedUserId?: string;
+			} = { currentNodeUsedDynamicCredentials: false };
+
+			applyDynamicCredentialsUsage(target, {
+				usedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+			expect(target).toEqual({
+				currentNodeUsedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+
+			// An attempted-only report must not clear previously set flags.
+			applyDynamicCredentialsUsage(target, { attemptedDynamicCredentials: true });
+			expect(target).toEqual({
+				currentNodeUsedDynamicCredentials: true,
+				currentNodeAttemptedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+		});
+
+		it('does not record a resolved user without a used flag', () => {
+			const target: { dynamicCredentialsResolvedUserId?: string } = {};
+			applyDynamicCredentialsUsage(target, {
+				attemptedDynamicCredentials: true,
+				dynamicCredentialsResolvedUserId: 'resolved-user',
+			});
+			expect(target.dynamicCredentialsResolvedUserId).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Sub-workflows resolve their credentials under their own execution context, so a sub-workflow's dynamic (private) credential usage was never recorded on the calling *Execute Sub-workflow* node's task in the parent execution — the parent reported `usedPrivateCredentials: false`. This PR reports that usage back from the sub-workflow and stamps it onto the parent node, covering every path a sub-workflow result can take:

- **Synchronous completion** — the sub-workflow reports usage via `ExecuteWorkflowData`; `BaseExecuteContext.executeWorkflow` applies it to the parent node's flags.
- **Wait/resume** — when the child finishes while the parent is waiting, `updateParentExecutionWithChildResults` stamps the parent's waiting task immediately and stashes the usage on the resumed stack entry (union-merged across "run once for each item" siblings); the engine restores it when the node re-runs disabled on resume.
- **Failure** — the usage rides on the error thrown from `startExecution`, so a continue-on-fail parent task still inherits the flags; the transport marker is stripped before the error persists.
- **Sub-node/tool output** — `SupplyDataContext` stamps task data written outside the engine loop (e.g. MCP Trigger tool calls in the webhook phase), attributing only flags raised during that run; in queue mode the `usedPrivateCredentials` marker is recomputed after worker-side tool calls.

Shared helpers in `packages/workflow` (`summarize`/`apply`/`attach`/`take` + the `runData` scans) dedupe these checks across the execution-save, telemetry, and redaction paths.

## How to test

Requires the dynamic-credentials (private credentials) module/license (and data redaction for the redaction check).

1. Connect a resolvable/private credential (e.g. Google Drive) for your user, and build a parent workflow: manual trigger → *Execute Sub-workflow*, where the sub-workflow uses that credential.
2. Run the parent: the execution reports `usedPrivateCredentials: true`, the *Execute Sub-workflow* task carries `usedDynamicCredentials: true`, and a non-owner with execution access sees the embedded output redacted via `GET /rest/executions/<id>?includeData=true`, while the executing user sees full data.
3. Add a Wait node to the sub-workflow and re-run: the parent execution reports the same flags both while waiting and after it resumes.
4. Make the sub-workflow fail after resolving the credential, with the parent node set to continue on error: the parent task still carries the flags.
5. Expose the sub-workflow as an MCP Server Trigger tool and call it: the trigger's execution carries the flags on the tool task and is redacted the same way.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-953

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


