### PR TITLE
fix(HTTP Request Node): Include UI query parameters when signing AWS requests

### DIFF
--- a/packages/nodes-base/credentials/common/aws/utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.test.ts
@@ -665,4 +665,63 @@ describe('awsGetSignInOptionsAndUpdateRequest', () => {
 			),
 		).toThrow(UserError);
 	});
+
+	it('signs and sends UI Query Parameters supplied via qs (not only qs.query)', () => {
+		const { url, signOpts } = awsGetSignInOptionsAndUpdateRequest(
+			{
+				uri: 'https://bedrock.us-east-1.amazonaws.com/foundation-models',
+				qs: { byProvider: 'anthropic', byOutputModality: 'TEXT' },
+				headers: {},
+			} as any,
+			baseCredentials,
+			'',
+			'GET',
+			'bedrock',
+			'us-east-1',
+		);
+
+		// Present in the outgoing URL...
+		const sentUrl = new URL(url);
+		expect(sentUrl.searchParams.get('byProvider')).toBe('anthropic');
+		expect(sentUrl.searchParams.get('byOutputModality')).toBe('TEXT');
+		// ...and in the signed path, so they are part of the SigV4 canonical request.
+		expect(signOpts.path).toContain('byProvider=anthropic');
+		expect(signOpts.path).toContain('byOutputModality=TEXT');
+	});
+
+	it('keeps query parameters embedded directly in the URL', () => {
+		const { url, signOpts } = awsGetSignInOptionsAndUpdateRequest(
+			{
+				uri: 'https://bedrock.us-east-1.amazonaws.com/foundation-models?byProvider=amazon',
+				headers: {},
+			} as any,
+			baseCredentials,
+			'',
+			'GET',
+			'bedrock',
+			'us-east-1',
+		);
+
+		expect(new URL(url).searchParams.get('byProvider')).toBe('amazon');
+		expect(signOpts.path).toContain('byProvider=amazon');
+	});
+
+	it('preserves the STS GetCallerIdentity special case', () => {
+		const { url } = awsGetSignInOptionsAndUpdateRequest(
+			{
+				uri: 'https://sts.us-east-1.amazonaws.com/',
+				qs: { Action: 'GetCallerIdentity' },
+				headers: {},
+			} as any,
+			baseCredentials,
+			'',
+			'POST',
+			'sts',
+			'us-east-1',
+		);
+
+		const sentUrl = new URL(url);
+		expect(sentUrl.searchParams.get('Action')).toBe('GetCallerIdentity');
+		expect(sentUrl.searchParams.get('Version')).toBe('2011-06-15');
+	});
 });

--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -250,6 +250,10 @@ export function awsGetSignInOptionsAndUpdateRequest(
 			} catch (err) {
 				console.error(err);
 			}
+		} else {
+			// UI Query Parameters are stored at the top level of requestOptions.qs, not under
+			// a nested `query` key, so merge the whole object to sign and send them.
+			query = requestWithUri.qs as IDataObject;
 		}
 		const parsed = parseAwsUrl(endpoint);
 		service = parsed.service;


### PR DESCRIPTION
## Summary

When the HTTP Request node used an AWS credential, any parameters entered in its Query Parameters field were silently dropped. AWS requires every request to be cryptographically signed (a scheme called AWS Signature Version 4), and the dropped parameters showed up neither in that signature nor in the URL that n8n actually sent. Parameters typed directly into the URL field were not affected and kept working.

The cause was in the AWS request-signing code, in `packages/nodes-base/credentials/common/aws/utils.ts`. n8n stores the Query Parameters field as plain key/value pairs on the request's `qs` object, but the signing code never looked at them — it only read a nested `qs.query` property, which the HTTP Request node never sets, so the parameters were simply ignored. The one exception was the credential test: its call to AWS's Security Token Service (STS) already included everything in `qs`, so testing a credential worked even though ordinary requests lost their parameters.

The fix brings the rest of the signing code in line with that STS path: everything in `qs` is now added to the URL before the request is signed, so the parameters end up in both the signature and the request that goes out. Parameters typed directly into the URL and the STS credential test behave exactly as before.

## How to test

The change adds three unit tests in `credentials/common/aws/utils.test.ts`. They cover that parameters from the Query Parameters field are now included, that parameters embedded in the URL still work as before, and that the STS credential test is unchanged. The test for the Query Parameters behavior failed before the fix and passes with it. Run them from `packages/nodes-base` with:

```
pnpm test credentials/common/aws/utils.test.ts
```

All 69 tests in that file pass, and the two related suites (`Aws.signing.test.ts` and `Aws.credentials.test.ts`, 43 tests) still pass.

To test manually, add an HTTP Request node with an AWS credential, enter a parameter in the Query Parameters field (for example `byProvider=anthropic`), and call an AWS API that accepts query parameters, such as Bedrock's `ListFoundationModels`. Before the fix the parameter was silently dropped; now it is signed and sent. No feature flags, license, or special setup is needed. Verifying against real AWS needs real credentials, which were not available here; that check is tracked separately in ticket ENT-69.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-145

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33679">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


