### PR TITLE
fix(MCP Client Tool Node): Stop wrapping tool arguments in a value object

### DIFF
--- a/packages/@n8n/json-schema-to-zod/package.json
+++ b/packages/@n8n/json-schema-to-zod/package.json
@@ -60,8 +60,8 @@
     "type": "git",
     "url": "https://github.com/n8n-io/n8n"
   },
-  "dependencies": {
-    "zod": "^3.25.76"
+  "peerDependencies": {
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/utils.test.ts
@@ -80,7 +80,7 @@ describe('isZodObjectSchema', () => {
 	});
 
 	it('should recognize a zod v4 object schema via its type marker', () => {
-		const zodV4Object = { _def: { type: 'object' } } as unknown as z.ZodTypeAny;
+		const zodV4Object = { _zod: { def: { type: 'object' } } } as unknown as z.ZodTypeAny;
 		expect(isZodObjectSchema(zodV4Object)).toBe(true);
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/utils.test.ts
@@ -1,4 +1,10 @@
-import { buildMcpToolName } from '../utils';
+import type { JSONSchema7 } from 'json-schema';
+import { z } from 'zod';
+
+import { convertJsonSchemaToZod } from '@utils/schemaParsing';
+
+import type { McpTool } from '../../shared/types';
+import { buildMcpToolName, isZodObjectSchema, mcpToolToDynamicTool } from '../utils';
 
 vi.mock('@utils/schemaParsing', () => ({
 	convertJsonSchemaToZod: vi.fn(),
@@ -56,5 +62,61 @@ describe('buildMcpToolName', () => {
 	it('should return original tool name when tool name is exactly 64 characters', () => {
 		const toolName = 'a'.repeat(64); // maxPrefixLen = 64 - 64 - 1 = -1, so <= 0
 		expect(buildMcpToolName('Server', toolName)).toBe(toolName);
+	});
+});
+
+describe('isZodObjectSchema', () => {
+	it('should recognize a real ZodObject', () => {
+		expect(isZodObjectSchema(z.object({ url: z.string() }))).toBe(true);
+	});
+
+	it('should reject a non-object schema', () => {
+		expect(isZodObjectSchema(z.string())).toBe(false);
+	});
+
+	it('should recognize an object schema built by a different zod module instance', () => {
+		const foreignInstanceObject = { _def: { typeName: 'ZodObject' } } as unknown as z.ZodTypeAny;
+		expect(isZodObjectSchema(foreignInstanceObject)).toBe(true);
+	});
+
+	it('should recognize a zod v4 object schema via its type marker', () => {
+		const zodV4Object = { _def: { type: 'object' } } as unknown as z.ZodTypeAny;
+		expect(isZodObjectSchema(zodV4Object)).toBe(true);
+	});
+});
+
+describe('mcpToolToDynamicTool', () => {
+	const tool: McpTool = {
+		name: 'browser_navigate',
+		description: 'Navigate the browser',
+		inputSchema: { type: 'object', properties: { url: { type: 'string' } } } as JSONSchema7,
+	};
+
+	it('should keep an object schema unwrapped so args are forwarded top-level', () => {
+		vi.mocked(convertJsonSchemaToZod).mockReturnValue(z.object({ url: z.string() }));
+
+		const dynamicTool = mcpToolToDynamicTool(tool, vi.fn());
+
+		expect(Object.keys((dynamicTool.schema as z.ZodObject<z.ZodRawShape>).shape)).toEqual(['url']);
+	});
+
+	it('should wrap a non-object schema in a value object', () => {
+		vi.mocked(convertJsonSchemaToZod).mockReturnValue(z.string());
+
+		const dynamicTool = mcpToolToDynamicTool(tool, vi.fn());
+
+		expect(Object.keys((dynamicTool.schema as z.ZodObject<z.ZodRawShape>).shape)).toEqual([
+			'value',
+		]);
+	});
+
+	it('should forward object-schema args to the callback top-level, not wrapped in value', async () => {
+		vi.mocked(convertJsonSchemaToZod).mockReturnValue(z.object({ url: z.string() }));
+		const onCallTool = vi.fn().mockResolvedValue('ok');
+
+		const dynamicTool = mcpToolToDynamicTool(tool, onCallTool);
+		await dynamicTool.invoke({ url: 'https://example.com' });
+
+		expect(onCallTool.mock.calls[0][0]).toEqual({ url: 'https://example.com' });
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -123,12 +123,13 @@ export function buildMcpToolName(serverName: string, toolName: string): string {
 }
 
 export function isZodObjectSchema(schema: z.ZodTypeAny): schema is z.ZodObject<z.ZodRawShape> {
-	const def: unknown = schema?._def;
-	if (typeof def !== 'object' || def === null) return false;
-	// zod v3 marks objects with `_def.typeName`, v4 with `_def.type`
-	return (
-		('typeName' in def && def.typeName === 'ZodObject') || ('type' in def && def.type === 'object')
-	);
+	// zod v4 exposes internals under `_zod.def` (type: 'object'); zod v3 under `_def` (typeName: 'ZodObject').
+	const internals = schema as {
+		_zod?: { def?: { type?: unknown } };
+		_def?: { typeName?: unknown };
+	};
+	if (internals._zod?.def) return internals._zod.def.type === 'object';
+	return internals._def?.typeName === 'ZodObject';
 }
 
 export function mcpToolToDynamicTool(

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -122,6 +122,15 @@ export function buildMcpToolName(serverName: string, toolName: string): string {
 	return maxPrefixLen > 0 ? `${sanitizedServerName.slice(0, maxPrefixLen)}_${toolName}` : toolName;
 }
 
+export function isZodObjectSchema(schema: z.ZodTypeAny): schema is z.ZodObject<z.ZodRawShape> {
+	const def: unknown = schema?._def;
+	if (typeof def !== 'object' || def === null) return false;
+	// zod v3 marks objects with `_def.typeName`, v4 with `_def.type`
+	return (
+		('typeName' in def && def.typeName === 'ZodObject') || ('type' in def && def.type === 'object')
+	);
+}
+
 export function mcpToolToDynamicTool(
 	tool: McpTool,
 	onCallTool: DynamicStructuredToolInput['func'],
@@ -129,8 +138,7 @@ export function mcpToolToDynamicTool(
 	const rawSchema = convertJsonSchemaToZod(tool.inputSchema);
 
 	// Ensure we always have an object schema for structured tools
-	const objectSchema =
-		rawSchema instanceof z.ZodObject ? rawSchema : z.object({ value: rawSchema });
+	const objectSchema = isZodObjectSchema(rawSchema) ? rawSchema : z.object({ value: rawSchema });
 
 	return new DynamicStructuredTool({
 		name: tool.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2464,10 +2464,6 @@ importers:
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
 
   packages/@n8n/json-schema-to-zod:
-    dependencies:
-      zod:
-        specifier: 3.25.67
-        version: 3.25.67
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*
@@ -2487,6 +2483,9 @@ importers:
       vitest-mock-extended:
         specifier: 'catalog:'
         version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
 
   packages/@n8n/local-gateway:
     dependencies:

--- a/scripts/check-zod-peer-deps.mjs
+++ b/scripts/check-zod-peer-deps.mjs
@@ -31,6 +31,7 @@ export const PACKAGES_REQUIRING_ZOD_PEER = [
 	'packages/workflow',
 	'packages/core',
 	'packages/@n8n/agents',
+	'packages/@n8n/json-schema-to-zod',
 ];
 
 /** Pure, testable core: return a problem string for a manifest, or null if OK. */


### PR DESCRIPTION
## Summary

The MCP Client Tool node wrapped object-shaped tool arguments in a `{ value: ... }` object before sending them to the MCP server. Servers that expect top-level fields — e.g. Playwright MCP's `browser_navigate` (`{ url }`) — then failed with `expected string, received undefined → at url`.

**Root cause:** `@n8n/json-schema-to-zod` declared `zod` in `dependencies` (`^3.25.76`) while every other schema-composing package uses the catalog pin. On a registry `npm install n8n`, npm resolves a *separate* physical `zod` copy for the converter, so the schemas it builds are instances of a different `ZodObject` class. `rawSchema instanceof z.ZodObject` in the MCP Client Tool therefore returned `false` even for genuine object schemas, and they got wrapped in `{ value }`. (The monorepo's `pnpm.overrides` dedupes zod, so this only reproduces on a clean npm install, not in local dev.)

**Fix:**
- Declare `zod` as a `peerDependency` in `@n8n/json-schema-to-zod` so a single shared zod instance is used on npm installs (matches the existing convention for schema-composing packages).
- Detect object schemas via their `_def.typeName` marker instead of `instanceof`, so detection stays correct even if module skew ever recurs.
- Add `@n8n/json-schema-to-zod` to `scripts/check-zod-peer-deps.mjs` so the dependency declaration can't regress.

## How to test

Run the following workflow, you should see playwright working.

[Playwright MCP.json](https://github.com/user-attachments/files/29703880/Playwright.MCP.json)

you can run playwright locally via `npx @playwright/mcp@latest --port 8931`

On reproducing the not working i found it very difficult, but if you change the old `instanceOf` check to false (aka simulate the hypothesis) then you see it failing exactly as reported. But reproducing it fully locally is quite difficult. 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5376

closes #33512

Also will be doing some follow up thinking on preventing such issues in the future. @Matsuuu already did some work on this via the `scripts/check-zod-peer-deps.mjs` script. 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->