### PR TITLE
refactor(editor): Remove N8N_ENV_FEAT_CUSTOM_INSTANCE_ROLES dark-launch flag

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3380,7 +3380,6 @@
 	"settings.users.table.row.role.description.chatUser": "Can use Chat but cannot create or view workflows or access other features",
 	"settings.users.table.row.2fa.enabled": "@:_reusableBaseText.enabled",
 	"settings.users.table.row.2fa.disabled": "@:_reusableBaseText.disabled",
-	"settings.projectRoles": "Project roles",
 	"settings.roles": "Roles",
 	"settings.api": "API",
 	"settings.n8napi": "n8n API",

--- a/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSettingsItems.ts
@@ -21,27 +21,6 @@ export function useSettingsItems() {
 	const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
 
 	const settingsItems = computed<IMenuItem[]>(() => {
-		const customInstanceRoles = envFeatureFlagCheck.value('CUSTOM_INSTANCE_ROLES');
-		const rolesItem: IMenuItem = customInstanceRoles
-			? {
-					id: 'settings-roles',
-					icon: 'user-round',
-					label: i18n.baseText('settings.roles'),
-					position: 'top',
-					available: canUserAccessRouteByName(VIEWS.ROLES_SETTINGS),
-					route: { to: { name: VIEWS.ROLES_SETTINGS } },
-					new: true,
-				}
-			: {
-					id: 'settings-roles',
-					icon: 'user-round',
-					label: i18n.baseText('settings.projectRoles'),
-					position: 'top',
-					available: canUserAccessRouteByName(VIEWS.PROJECT_ROLES_SETTINGS),
-					route: { to: { name: VIEWS.PROJECT_ROLES_SETTINGS } },
-					new: true,
-				};
-
 		const menuItems: IMenuItem[] = [
 			{
 				id: 'settings-usage-and-plan',
@@ -91,7 +70,15 @@ export function useSettingsItems() {
 							})
 						: undefined,
 			},
-			rolesItem,
+			{
+				id: 'settings-roles',
+				icon: 'user-round',
+				label: i18n.baseText('settings.roles'),
+				position: 'top',
+				available: canUserAccessRouteByName(VIEWS.ROLES_SETTINGS),
+				route: { to: { name: VIEWS.ROLES_SETTINGS } },
+				new: true,
+			},
 			{
 				id: 'settings-api',
 				icon: 'plug',

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -345,6 +345,13 @@ describe('router', () => {
 			expect(router.currentRoute.value.name).toBe(VIEWS.ROLES_SETTINGS);
 			expect(router.currentRoute.value.query.tab).toBe('project');
 		});
+
+		test('redirects /settings/instance-roles to the Roles shell (instance tab)', async () => {
+			await router.push('/settings/instance-roles');
+
+			expect(router.currentRoute.value.name).toBe(VIEWS.ROLES_SETTINGS);
+			expect(router.currentRoute.value.query.tab).toBe('instance');
+		});
 	});
 
 	test('should set props: true for PROJECT_ROLE_SETTINGS route', () => {

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -339,19 +339,7 @@ describe('router', () => {
 			await router.push('/workflows');
 		});
 
-		test('resolves /settings/project-roles to project roles when custom instance roles disabled', async () => {
-			settingsStore.settings.envFeatureFlags = {} as typeof settingsStore.settings.envFeatureFlags;
-
-			await router.push('/settings/project-roles');
-
-			expect(router.currentRoute.value.name).toBe(VIEWS.PROJECT_ROLES_SETTINGS);
-		});
-
-		test('redirects /settings/project-roles to the Roles shell (project tab) when enabled', async () => {
-			settingsStore.settings.envFeatureFlags = {
-				N8N_ENV_FEAT_CUSTOM_INSTANCE_ROLES: true,
-			} as typeof settingsStore.settings.envFeatureFlags;
-
+		test('redirects /settings/project-roles to the Roles shell (project tab)', async () => {
 			await router.push('/settings/project-roles');
 
 			expect(router.currentRoute.value.name).toBe(VIEWS.ROLES_SETTINGS);

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -846,6 +846,12 @@ export const routes: RouteRecordRaw[] = [
 				component: RouterView,
 				children: [
 					{
+						path: '',
+						// Instance roles are listed inside the tabbed Roles shell; the bare
+						// path has no standalone page, so redirect it to the instance tab.
+						redirect: () => ({ name: VIEWS.ROLES_SETTINGS, query: { tab: 'instance' } }),
+					},
+					{
 						path: 'new',
 						name: VIEWS.INSTANCE_NEW_ROLE,
 						component: async () => await import('@/features/roles/instance/InstanceRoleView.vue'),

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -824,13 +824,6 @@ export const routes: RouteRecordRaw[] = [
 				path: 'roles',
 				name: VIEWS.ROLES_SETTINGS,
 				component: async () => await import('@/features/roles/RolesView.vue'),
-				beforeEnter: () => {
-					const { check } = useEnvFeatureFlag();
-					if (!check.value('CUSTOM_INSTANCE_ROLES')) {
-						return { name: VIEWS.PROJECT_ROLES_SETTINGS };
-					}
-					return true;
-				},
 				meta: {
 					middleware: ['authenticated', 'rbac'],
 					middlewareOptions: {
@@ -851,15 +844,6 @@ export const routes: RouteRecordRaw[] = [
 			{
 				path: 'instance-roles',
 				component: RouterView,
-				// Instance role create/edit/view are gated behind the env flag; when off,
-				// fall back to the canonical project-roles page.
-				beforeEnter: () => {
-					const { check } = useEnvFeatureFlag();
-					if (!check.value('CUSTOM_INSTANCE_ROLES')) {
-						return { name: VIEWS.PROJECT_ROLES_SETTINGS };
-					}
-					return true;
-				},
 				children: [
 					{
 						path: 'new',
@@ -906,16 +890,9 @@ export const routes: RouteRecordRaw[] = [
 					{
 						path: '',
 						name: VIEWS.PROJECT_ROLES_SETTINGS,
-						component: async () => await import('@/features/roles/project/ProjectRolesView.vue'),
-						// When custom instance roles are enabled, the standalone project-roles page
-						// is superseded by the tabbed Roles shell; redirect old deep links there.
-						beforeEnter: () => {
-							const { check } = useEnvFeatureFlag();
-							if (check.value('CUSTOM_INSTANCE_ROLES')) {
-								return { name: VIEWS.ROLES_SETTINGS, query: { tab: 'project' } };
-							}
-							return true;
-						},
+						// The standalone project-roles page is superseded by the tabbed Roles shell;
+						// redirect old deep links to the project tab there.
+						redirect: () => ({ name: VIEWS.ROLES_SETTINGS, query: { tab: 'project' } }),
 					},
 					{
 						path: 'new',

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.vue
@@ -102,7 +102,7 @@ onMounted(async () => {
 		</div>
 
 		<InstanceRolesView v-if="activeTab === 'instance' && canManageInstanceRoles" />
-		<ProjectRolesView v-else embedded />
+		<ProjectRolesView v-else />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/roles/project/ProjectRolesView.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/project/ProjectRolesView.test.ts
@@ -2,7 +2,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/vue';
-import { MODAL_CONFIRM, VIEWS } from '@/app/constants';
+import { MODAL_CONFIRM } from '@/app/constants';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { mockedStore, type MockedStore } from '@/__tests__/utils';
 import ProjectRolesView from './ProjectRolesView.vue';
@@ -114,26 +114,6 @@ describe('ProjectRolesView', () => {
 		settingsStore.isCustomRolesFeatureEnabled = true;
 	});
 
-	it('should render the page heading and Add Role button', () => {
-		rolesStore.processedProjectRoles = [...mockSystemRoles, ...mockCustomRoles];
-
-		const { getByText, getByRole } = renderComponent();
-
-		expect(getByText('Project roles')).toBeInTheDocument();
-		expect(getByRole('button', { name: 'Add role' })).toBeInTheDocument();
-	});
-
-	it('should navigate to new role page when Add Role button is clicked', async () => {
-		rolesStore.processedProjectRoles = [];
-
-		const { getByRole } = renderComponent();
-		const addButton = getByRole('button', { name: 'Add role' });
-
-		await userEvent.click(addButton);
-
-		expect(mockPush).toHaveBeenCalledWith({ name: VIEWS.PROJECT_NEW_ROLE });
-	});
-
 	it('should render data table with correct headers', () => {
 		rolesStore.processedProjectRoles = [];
 
@@ -216,11 +196,7 @@ describe('ProjectRolesView', () => {
 	it('should render empty state when no roles are present', () => {
 		rolesStore.processedProjectRoles = [];
 
-		const { getByText, getByRole } = renderComponent();
-
-		// Should still show the heading and add button
-		expect(getByText('Project roles')).toBeInTheDocument();
-		expect(getByRole('button', { name: 'Add role' })).toBeInTheDocument();
+		const { getByText } = renderComponent();
 
 		// Data table should be present but empty
 		expect(getByText('Name')).toBeInTheDocument();

--- a/packages/frontend/editor-ui/src/features/roles/project/ProjectRolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/project/ProjectRolesView.vue
@@ -1,44 +1,19 @@
 <script setup lang="ts">
-import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useMessage } from '@/app/composables/useMessage';
-import { useTelemetry } from '@/app/composables/useTelemetry';
-import { useToast } from '@/app/composables/useToast';
 import { MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { N8nButton, N8nHeading, N8nTag } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import type { Role } from '@n8n/permissions';
-import { onMounted, useCssModule } from 'vue';
 import { useRouter } from 'vue-router';
 import RolesTable from '../components/RolesTable.vue';
 import { useRolesListActions } from '../composables/useRolesListActions';
-
-const props = defineProps<{
-	/** When rendered inside the tabbed Roles shell, the shell owns the page heading. */
-	embedded?: boolean;
-}>();
-
-const { showError } = useToast();
 
 const rolesStore = useRolesStore();
 const router = useRouter();
 const message = useMessage();
 const i18n = useI18n();
-const $style = useCssModule();
 const settingsStore = useSettingsStore();
-const telemetry = useTelemetry();
-
-onMounted(async () => {
-	if (!props.embedded) {
-		useDocumentTitle().set(i18n.baseText('settings.projectRoles'));
-		try {
-			await rolesStore.fetchRoles();
-		} catch (error) {
-			showError(error, i18n.baseText('roles.fetch.error'));
-		}
-	}
-});
 
 function projectAssignmentsRoute(item: Role) {
 	return {
@@ -90,32 +65,10 @@ const { rowActions, handleAction, handleRowClick } = useRolesListActions({
 	views: { viewRoute: VIEWS.PROJECT_ROLE_VIEW, editRoute: VIEWS.PROJECT_ROLE_SETTINGS },
 	onBeforeDelete,
 });
-
-function addRole() {
-	telemetry.track('User clicked add role');
-	void router.push({ name: VIEWS.PROJECT_NEW_ROLE });
-}
 </script>
 
 <template>
 	<div class="pb-xl">
-		<div v-if="!embedded" class="mb-xl" :class="$style.headerContainer">
-			<div :class="$style.headerTitle">
-				<N8nHeading tag="h1" size="2xlarge">
-					{{ i18n.baseText('settings.projectRoles') }}
-				</N8nHeading>
-				<N8nTag :clickable="false" text="New" :class="$style.newTag" />
-			</div>
-			<N8nButton
-				v-if="settingsStore.isCustomRolesFeatureEnabled"
-				variant="solid"
-				icon="plus"
-				@click="addRole"
-			>
-				{{ i18n.baseText('roles.addRole') }}
-			</N8nButton>
-		</div>
-
 		<RolesTable
 			:roles="rolesStore.processedProjectRoles"
 			:show-paywall="!settingsStore.isCustomRolesFeatureEnabled"
@@ -128,30 +81,3 @@ function addRole() {
 		/>
 	</div>
 </template>
-
-<style lang="css" module>
-.headerContainer {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-}
-
-.headerTitle {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing--2xs);
-}
-
-.newTag {
-	background-color: var(--color--foreground--shade-2);
-	color: var(--color--background);
-	border-color: var(--color--foreground--shade-2);
-	font-size: var(--font-size--3xs);
-	font-weight: var(--font-weight--bold);
-	padding: var(--spacing--5xs) var(--spacing--4xs);
-	border-radius: var(--spacing--sm);
-	min-height: auto;
-	height: auto;
-	line-height: 1;
-}
-</style>

--- a/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/InviteUsersModal.vue
@@ -10,7 +10,6 @@ import { ROLE } from '@n8n/api-types';
 import { useUsersStore } from '../users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { createFormEventBus } from '@n8n/design-system/utils';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useClipboard } from '@/app/composables/useClipboard';
@@ -40,12 +39,6 @@ const NAME_EMAIL_FORMAT_REGEX = /^.* <(.*)>$/;
 const usersStore = useUsersStore();
 const settingsStore = useSettingsStore();
 const rolesStore = useRolesStore();
-const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
-
-// Custom instance roles can only be invited when the feature is enabled.
-const customInstanceRolesEnabled = computed(() =>
-	envFeatureFlagCheck.value('CUSTOM_INSTANCE_ROLES'),
-);
 
 const clipboard = useClipboard();
 const { showMessage, showError } = useToast();
@@ -329,13 +322,11 @@ onMounted(() => {
 						label: i18n.baseText('auth.roles.admin'),
 						disabled: !isAdvancedPermissionsEnabled.value,
 					},
-					...(customInstanceRolesEnabled.value
-						? rolesStore.customInstanceRoles.map((role) => ({
-								value: role.slug,
-								label: role.displayName,
-								disabled: !role.licensed,
-							}))
-						: []),
+					...rolesStore.customInstanceRoles.map((role) => ({
+						value: role.slug,
+						label: role.displayName,
+						disabled: !role.licensed,
+					})),
 				],
 				capitalize: true,
 			},

--- a/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.test.ts
@@ -8,17 +8,6 @@ import SettingsUsersRoleCell from './SettingsUsersRoleCell.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 
-// Feature flag is toggled per test via this hoisted state.
-const { envFlagState } = vi.hoisted(() => ({ envFlagState: { customInstanceRoles: true } }));
-vi.mock('@/features/shared/envFeatureFlag/useEnvFeatureFlag', () => ({
-	useEnvFeatureFlag: () => ({
-		check: {
-			value: (flag: string) =>
-				flag === 'CUSTOM_INSTANCE_ROLES' ? envFlagState.customInstanceRoles : false,
-		},
-	}),
-}));
-
 // Mock the dropdown primitives to expose items as buttons and the trigger slot for assertions.
 vi.mock('@n8n/design-system', async (importOriginal) => {
 	const original = await importOriginal<object>();
@@ -55,27 +44,6 @@ vi.mock('@n8n/design-system', async (importOriginal) => {
 		N8nSelect2Item: {
 			name: 'N8nSelect2Item',
 			template: '<span><slot name="item-label" /><slot name="item-trailing" /></span>',
-		},
-		N8nActionDropdown: {
-			name: 'N8nActionDropdown',
-			props: { items: { type: Array, default: () => [] } },
-			emits: ['select'],
-			template: `
-				<div>
-					<div data-test-id="legacy-activator"><slot name="activator" /></div>
-					<ul>
-						<li v-for="item in items" :key="item.id">
-							<button
-								:data-test-id="'legacy-action-' + item.id"
-								:disabled="item.disabled"
-								@click="$emit('select', item.id)"
-							>
-								<slot name="menuItem" v-bind="item" />
-							</button>
-						</li>
-					</ul>
-				</div>
-			`,
 		},
 	};
 });
@@ -161,7 +129,6 @@ let renderComponent: ReturnType<typeof createComponentRenderer>;
 
 describe('SettingsUsersRoleCell', () => {
 	beforeEach(() => {
-		envFlagState.customInstanceRoles = true;
 		vi.mocked(hasPermission).mockReturnValue(true);
 		renderComponent = createComponentRenderer(SettingsUsersRoleCell, {
 			pinia: pinia(),
@@ -235,32 +202,6 @@ describe('SettingsUsersRoleCell', () => {
 			await user.click(screen.getByTestId(`role-${UNLICENSED_ROLE_SLUG}`));
 
 			expect(emitted()['update:role']).toBeUndefined();
-		});
-	});
-
-	describe('when the CUSTOM_INSTANCE_ROLES feature flag is off', () => {
-		beforeEach(() => {
-			envFlagState.customInstanceRoles = false;
-		});
-
-		it('should render the legacy dropdown without custom roles', () => {
-			renderComponent();
-
-			expect(
-				within(screen.getByTestId('legacy-activator')).getByText('Member'),
-			).toBeInTheDocument();
-			expect(screen.queryByTestId('select-trigger')).not.toBeInTheDocument();
-			// Custom roles are not offered in the legacy dropdown.
-			expect(screen.queryByTestId(`legacy-action-${CUSTOM_ROLE_SLUG}`)).not.toBeInTheDocument();
-		});
-
-		it('should emit "update:role" from the legacy dropdown', async () => {
-			const { emitted } = renderComponent();
-			const user = userEvent.setup();
-
-			await user.click(screen.getByTestId(`legacy-action-${ROLE.Admin}`));
-
-			expect(emitted()['update:role'][0]).toEqual([{ role: ROLE.Admin, userId: '1' }]);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/components/SettingsUsersRoleCell.vue
@@ -1,13 +1,9 @@
 <script lang="ts" setup>
-import { ElRadio } from 'element-plus';
-import { N8nActionDropdown, N8nIcon, N8nText, type ActionDropdownItem } from '@n8n/design-system';
 import { ROLE, type UsersList } from '@n8n/api-types';
 import type { Role } from '@n8n/permissions';
 import { computed, ref } from 'vue';
-import { useI18n } from '@n8n/i18n';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { VIEWS } from '@/app/constants';
 import {
@@ -29,15 +25,8 @@ const emit = defineEmits<{
 	'update:role': [payload: { role: string; userId: string }];
 }>();
 
-const i18n = useI18n();
 const settingsStore = useSettingsStore();
 const rolesStore = useRolesStore();
-const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
-
-// Gates the new role-selection UX (custom roles + redesigned dropdown).
-const customInstanceRolesEnabled = computed(() =>
-	envFeatureFlagCheck.value('CUSTOM_INSTANCE_ROLES'),
-);
 
 const currentRole = computed<string>(() => props.data.role ?? ROLE.Default);
 // Resolve the label against the full global list (incl. owner) so non-editable rows render.
@@ -67,50 +56,10 @@ const upgradeModalVisible = ref(false);
 const onRoleUpdate = (role: string) => {
 	emit('update:role', { role, userId: props.data.id });
 };
-
-/* -------------------------------------------------------------------------- */
-/* Legacy design (flag off): simple action dropdown with system roles only    */
-/* -------------------------------------------------------------------------- */
-
-const legacyRoleLabels = computed<Record<string, { label: string; desc: string }>>(() => ({
-	[ROLE.Owner]: { label: i18n.baseText('auth.roles.owner'), desc: '' },
-	[ROLE.Admin]: {
-		label: i18n.baseText('auth.roles.admin'),
-		desc: i18n.baseText('settings.users.table.row.role.description.admin'),
-	},
-	[ROLE.Member]: {
-		label: i18n.baseText('auth.roles.member'),
-		desc: i18n.baseText('settings.users.table.row.role.description.member'),
-	},
-	...(settingsStore.isChatFeatureEnabled && {
-		[ROLE.ChatUser]: {
-			label: i18n.baseText('auth.roles.chatUser'),
-			desc: i18n.baseText('settings.users.table.row.role.description.chatUser'),
-		},
-	}),
-	[ROLE.Default]: { label: i18n.baseText('auth.roles.default'), desc: '' },
-}));
-
-const legacyRoleLabel = computed(
-	() => legacyRoleLabels.value[currentRole.value]?.label ?? selectedRole.value?.displayName,
-);
-
-const legacyRoleActions = computed<Array<ActionDropdownItem<string>>>(() => [
-	{ id: ROLE.Member, label: i18n.baseText('auth.roles.member') },
-	...(settingsStore.isChatFeatureEnabled
-		? [{ id: ROLE.ChatUser, label: i18n.baseText('auth.roles.chatUser') }]
-		: []),
-	{ id: ROLE.Admin, label: i18n.baseText('auth.roles.admin') },
-]);
-
-const onLegacyActionSelect = (role: string) => {
-	emit('update:role', { role, userId: props.data.id });
-};
 </script>
 
 <template>
-	<!-- New design (custom instance roles feature) -->
-	<div v-if="customInstanceRolesEnabled" :class="$style.flagBranch">
+	<div :class="$style.roleCell">
 		<RoleSelectDropdown
 			v-if="isEditable && canChangeRole"
 			:system-roles="systemRoles"
@@ -132,42 +81,11 @@ const onLegacyActionSelect = (role: string) => {
 		<span v-else :class="$style.roleName">{{ selectedRole?.displayName }}</span>
 		<CustomRolesUpgradeModal v-model="upgradeModalVisible" />
 	</div>
-
-	<!-- Legacy design -->
-	<div v-else>
-		<N8nActionDropdown
-			v-if="isEditable && canChangeRole"
-			placement="bottom-start"
-			:items="legacyRoleActions"
-			:disabled="loading"
-			data-test-id="user-role-dropdown"
-			@select="onLegacyActionSelect"
-		>
-			<template #activator>
-				<button :class="$style.roleLabel" type="button" :disabled="loading">
-					<N8nText color="text-dark">{{ legacyRoleLabel }}</N8nText>
-					<N8nIcon v-if="loading" color="text-dark" icon="spinner" spin size="large" />
-					<N8nIcon v-else color="text-dark" icon="chevron-down" size="large" />
-				</button>
-			</template>
-			<template #menuItem="item">
-				<ElRadio :model-value="currentRole" :label="item.id">
-					<span :class="$style.radioLabel">
-						<N8nText color="text-dark" class="pb-3xs">{{ item.label }}</N8nText>
-						<N8nText color="text-dark" size="small">
-							{{ legacyRoleLabels[item.id]?.desc }}
-						</N8nText>
-					</span>
-				</ElRadio>
-			</template>
-		</N8nActionDropdown>
-		<span v-else :class="$style.roleName">{{ legacyRoleLabel }}</span>
-	</div>
 </template>
 
 <style lang="scss" module>
-/* Wrapper for the feature-flag branch; renders as if it weren't there. */
-.flagBranch {
+/* Wrapper renders as if it weren't there. */
+.roleCell {
 	display: contents;
 }
 
@@ -178,32 +96,5 @@ const onLegacyActionSelect = (role: string) => {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	max-width: 200px;
-}
-
-/* Legacy design */
-.roleLabel {
-	display: inline-flex;
-	align-items: center;
-	gap: var(--spacing--3xs);
-	background: transparent;
-	padding: 0;
-	border: none;
-	cursor: pointer;
-
-	&:disabled {
-		cursor: default;
-		opacity: 0.7;
-	}
-}
-
-.radioLabel {
-	max-width: 268px;
-	display: inline-flex;
-	flex-direction: column;
-	padding: var(--spacing--2xs) 0;
-
-	span {
-		white-space: normal;
-	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.test.ts
@@ -792,7 +792,6 @@ describe('SettingsUsersView', () => {
 		});
 
 		it('should allow reinvite for a custom role', async () => {
-			settingsStore.settings.envFeatureFlags = { N8N_ENV_FEAT_CUSTOM_INSTANCE_ROLES: 'true' };
 			rolesStore.customInstanceRoles = [
 				{
 					slug: 'custom:developer',
@@ -926,7 +925,6 @@ describe('SettingsUsersView', () => {
 		});
 
 		it('should use displayName from custom role in success toast message', async () => {
-			settingsStore.settings.envFeatureFlags = { N8N_ENV_FEAT_CUSTOM_INSTANCE_ROLES: 'true' };
 			rolesStore.customInstanceRoles = [
 				{
 					slug: 'custom:developer',

--- a/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/users/views/SettingsUsersView.vue
@@ -32,7 +32,6 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import SettingsUsersTable from '../components/SettingsUsersTable.vue';
 import { I18nT } from 'vue-i18n';
 import { useUserRoleProvisioningStore } from '@/features/settings/sso/provisioning/composables/userRoleProvisioning.store';
-import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
 import N8nAlert from '@n8n/design-system/components/N8nAlert/Alert.vue';
 import {
 	N8nActionBox,
@@ -59,12 +58,6 @@ const ssoStore = useSSOStore();
 const documentTitle = useDocumentTitle();
 const pageRedirectionHelper = usePageRedirectionHelper();
 const userRoleProvisioningStore = useUserRoleProvisioningStore();
-const { check: envFeatureFlagCheck } = useEnvFeatureFlag();
-
-// Gates assigning custom instance roles (invite/change/reinvite).
-const customInstanceRolesEnabled = computed(() =>
-	envFeatureFlagCheck.value('CUSTOM_INSTANCE_ROLES'),
-);
 
 const i18n = useI18n();
 
@@ -165,13 +158,11 @@ const userRoles = computed((): Array<{ value: string; label: string; disabled?: 
 			label: i18n.baseText('auth.roles.admin'),
 			disabled: !isAdvancedPermissionsEnabled.value,
 		},
-		...(customInstanceRolesEnabled.value
-			? rolesStore.customInstanceRoles.map((role) => ({
-					value: role.slug,
-					label: role.displayName,
-					disabled: !role.licensed,
-				}))
-			: []),
+		...rolesStore.customInstanceRoles.map((role) => ({
+			value: role.slug,
+			label: role.displayName,
+			disabled: !role.licensed,
+		})),
 	];
 });
 
@@ -225,11 +216,9 @@ async function onReinvite(userId: string) {
 	try {
 		const user = usersStore.usersList.state.items.find((u) => u.id === userId);
 		if (user?.email && user?.role) {
-			// With custom instance roles, any assignable role (not owner/default/chat) can be
-			// reinvited; otherwise only the original member/admin roles are allowed.
-			const canReinvite = customInstanceRolesEnabled.value
-				? user.role !== ROLE.Owner && user.role !== ROLE.Default && user.role !== ROLE.ChatUser
-				: ([ROLE.Admin, ROLE.Member] as string[]).includes(user.role);
+			// Any assignable role (not owner/default/chat) can be reinvited.
+			const canReinvite =
+				user.role !== ROLE.Owner && user.role !== ROLE.Default && user.role !== ROLE.ChatUser;
 			if (!canReinvite) {
 				throw new Error('Invalid role name on reinvite');
 			}

--- a/packages/testing/playwright/pages/SettingsUsersPage.ts
+++ b/packages/testing/playwright/pages/SettingsUsersPage.ts
@@ -23,7 +23,7 @@ export class SettingsUsersPage extends BasePage {
 	}
 
 	clickAccountType(email: string) {
-		return this.getRow(email).getByTestId('user-role-dropdown').getByRole('button').click();
+		return this.getRow(email).getByTestId('user-role-dropdown').click();
 	}
 
 	async search(email: string) {
@@ -73,9 +73,9 @@ export class SettingsUsersPage extends BasePage {
 	async selectAccountType(email: string, type: 'Admin' | 'Member') {
 		await this.clickAccountType(email);
 		await this.page
-			.getByRole('menu')
+			.getByRole('listbox')
 			.filter({ visible: true })
-			.getByRole('menuitem', { name: new RegExp(`^${type}\\b`) })
+			.getByRole('option', { name: new RegExp(`^${type}\\b`) })
 			.click();
 	}
 


### PR DESCRIPTION
## Summary

The custom instance roles UI shipped behind the dark-launch env flag `N8N_ENV_FEAT_CUSTOM_INSTANCE_ROLES` so the work could merge incrementally. Now that the feature is enabled by default and stable, the flag is dead weight. This PR removes it entirely — the instance-roles surface (tabbed Roles shell, instance-role create/edit/view, "Add role" action, custom-role assignment in the users table) is now always available, gated only by the customRoles license and RBAC scopes, which were always the real gates.

**What was removed**
- All `useEnvFeatureFlag().check.value('CUSTOM_INSTANCE_ROLES')` call sites (router.ts, useSettingsItems.ts, InviteUsersModal.vue, SettingsUsersView.vue, SettingsUsersRoleCell.vue).
- The `beforeEnter` route guards that fell back to the legacy `project-roles` page. `/settings/project-roles `becomes a plain redirect to the Roles shell (`?tab=project`) for old deep links.
- Dead legacy branches the flag used to gate:
  - the legacy role dropdown in `SettingsUsersRoleCell.vue` (kept only the new `RoleSelectDropdown design`);
  - the standalone (non-embedded) mode of `ProjectRolesView.vue` — it's now only rendered as an embedded tab inside `RolesView`, which owns the heading, role fetch, and "Add role" button.
- The now-orphaned i18n key `settings.projectRoles`.

##  How to test

Without setting any env var, on an instance with the customRoles license:
1. Go to Settings → Roles — the tabbed shell opens with Instance and Project tabs.
2. Click Add role on each tab → lands on the instance/project role create page.
3. Open an existing custom role → edit/view/assignments work.
4. In Settings → Users, the role cell uses the new RoleSelectDropdown; inviting/reinviting can assign custom instance roles.
5. Hit old deep links /settings/project-roles → redirects to /settings/roles?tab=project.

On an instance without the license, the surface is reachable but paywalled (as before). No env var affects any of the above.

##  Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-860


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

