### PR TITLE
fix(editor): Correct documentation link

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.constants.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.constants.ts
@@ -1,5 +1,5 @@
 export const MCP_ENDPOINT = 'mcp-server/http';
-export const MCP_DOCS_PAGE_URL = 'https://docs.n8n.io/advanced-ai/mcp/mcp_tools_reference';
+export const MCP_DOCS_PAGE_URL = 'https://docs.n8n.io/connect/connect-to-n8n-mcp-server';
 export const ELIGIBLE_WORKFLOWS_DOCS_SECTION = 'workflow-eligibility';
 
 export const MCP_SETTINGS_VIEW = 'McpSettings';


### PR DESCRIPTION
## Summary

Fixes the in-app MCP documentation link, which points to the MCP tools page rather than the main MCP page, after discussion with Milorad and Sim. 

The "Learn more" link in the MCP access settings now points to the current MCP server documentation page (`https://docs.n8n.io/connect/connect-to-n8n-mcp-server`).

## How to test

1. Open **Settings → MCP access** in the editor.
2. Click the documentation / "Learn more" link.
3. Confirm it opens `https://docs.n8n.io/connect/connect-to-n8n-mcp-server` and the page resolves correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DOC-2053

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
