### PR TITLE
fix(core): Decouple executions visibility from the sharing license feature

### DIFF
--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -57,7 +57,6 @@ describe('ExecutionService', () => {
 		mock(),
 		mock(),
 		mock(),
-		mock(),
 		executionRedactionServiceProxy,
 		executionStopService,
 	);
@@ -168,7 +167,6 @@ describe('ExecutionService', () => {
 				mock(),
 				mock(),
 				mock(),
-				mock(),
 				localExecutionRedactionProxy,
 				executionStopService,
 			);
@@ -249,7 +247,6 @@ describe('ExecutionService', () => {
 				waitTracker,
 				workflowRunner,
 				concurrencyControl,
-				mock(),
 				mock(),
 				mock(),
 				mock(),

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -1,5 +1,5 @@
 import { ExecutionRedactionQueryDtoSchema } from '@n8n/api-types';
-import { LicenseState, Logger } from '@n8n/backend-common';
+import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import type {
 	CreateExecutionPayload,
@@ -17,7 +17,7 @@ import {
 	WorkflowRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 import { stringify } from 'flatted';
 import { validate as jsonSchemaValidate } from 'jsonschema';
 import type {
@@ -124,7 +124,6 @@ export class ExecutionService {
 		private readonly workflowRunner: WorkflowRunner,
 		private readonly concurrencyControl: ConcurrencyControlService,
 		private readonly license: License,
-		private readonly licenseState: LicenseState,
 		private readonly roleService: RoleService,
 		private readonly workflowSharingService: WorkflowSharingService,
 		private readonly eventService: EventService,
@@ -133,21 +132,16 @@ export class ExecutionService {
 	) {}
 
 	/**
-	 * Build sharing options for execution queries based on whether sharing is licensed.
+	 * Build sharing options for execution queries. Visibility is resolved from
+	 * the user's role scopes — same as the workflow list — and is deliberately
+	 * not gated on the sharing license, which only gates sharing actions.
 	 */
 	async buildSharingOptions(
 		scope: Scope,
 	): Promise<ExecutionSummaries.RangeQuery['sharingOptions']> {
-		if (this.licenseState.isSharingLicensed()) {
-			const projectRoles = await this.roleService.rolesWithScope('project', [scope]);
-			const workflowRoles = await this.roleService.rolesWithScope('workflow', [scope]);
-			return { scopes: [scope], projectRoles, workflowRoles };
-		}
-
-		return {
-			workflowRoles: ['workflow:owner'],
-			projectRoles: [PROJECT_OWNER_ROLE_SLUG],
-		};
+		const projectRoles = await this.roleService.rolesWithScope('project', [scope]);
+		const workflowRoles = await this.roleService.rolesWithScope('workflow', [scope]);
+		return { scopes: [scope], projectRoles, workflowRoles };
 	}
 
 	async findOne(

--- a/packages/cli/src/executions/executions.controller.ts
+++ b/packages/cli/src/executions/executions.controller.ts
@@ -1,6 +1,6 @@
 import type { User, ExecutionSummaries } from '@n8n/db';
 import { Get, Patch, Post, RestController } from '@n8n/decorators';
-import { PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
+import type { Scope } from '@n8n/permissions';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -24,14 +24,7 @@ export class ExecutionsController {
 	) {}
 
 	private async getAccessibleWorkflowIds(user: User, scope: Scope) {
-		if (this.license.isSharingEnabled()) {
-			return await this.workflowSharingService.getSharedWorkflowIds(user, { scopes: [scope] });
-		} else {
-			return await this.workflowSharingService.getSharedWorkflowIds(user, {
-				workflowRoles: ['workflow:owner'],
-				projectRoles: [PROJECT_OWNER_ROLE_SLUG],
-			});
-		}
+		return await this.workflowSharingService.getSharedWorkflowIds(user, { scopes: [scope] });
 	}
 
 	@Get('/', { middlewares: [parseRangeQuery] })

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -2453,42 +2453,27 @@ describe('createExecutionAdapter', () => {
 		vi.clearAllMocks();
 	});
 
-	it('passes user and sharingOptions to execution query when sharing is enabled', async () => {
-		const { adapter, mockExecutionRepository, mockUser } = createExecutionAdapterForTests({
-			sharingEnabled: true,
-		});
+	it.each([true, false])(
+		'passes scope-based sharingOptions to execution query (sharing licensed: %s)',
+		async (sharingEnabled) => {
+			const { adapter, mockExecutionRepository, mockUser } = createExecutionAdapterForTests({
+				sharingEnabled,
+			});
 
-		await adapter.list();
+			await adapter.list();
 
-		expect(mockExecutionRepository.findManyByRangeQuery).toHaveBeenCalledWith(
-			expect.objectContaining({
-				user: mockUser,
-				sharingOptions: {
-					scopes: ['workflow:read'],
-					projectRoles: ['project:editor'],
-					workflowRoles: ['workflow:owner', 'workflow:editor'],
-				},
-			}),
-		);
-	});
-
-	it('passes user and owner-only sharingOptions when sharing is disabled', async () => {
-		const { adapter, mockExecutionRepository, mockUser } = createExecutionAdapterForTests({
-			sharingEnabled: false,
-		});
-
-		await adapter.list();
-
-		expect(mockExecutionRepository.findManyByRangeQuery).toHaveBeenCalledWith(
-			expect.objectContaining({
-				user: mockUser,
-				sharingOptions: {
-					workflowRoles: ['workflow:owner'],
-					projectRoles: ['project:personalOwner'],
-				},
-			}),
-		);
-	});
+			expect(mockExecutionRepository.findManyByRangeQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					user: mockUser,
+					sharingOptions: {
+						scopes: ['workflow:read'],
+						projectRoles: ['project:editor'],
+						workflowRoles: ['workflow:owner', 'workflow:editor'],
+					},
+				}),
+			);
+		},
+	);
 
 	it('does not pass accessibleWorkflowIds to execution query', async () => {
 		const { adapter, mockExecutionRepository } = createExecutionAdapterForTests({

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -71,7 +71,7 @@ import {
 import { Logger } from '@n8n/backend-common';
 import { OutboundHttp, SsrfProtectionService } from '@n8n/backend-network';
 import { Container, Service } from '@n8n/di';
-import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
+import { hasGlobalScope, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { LessThan } from '@n8n/typeorm';
 import {
@@ -832,7 +832,6 @@ export class InstanceAiAdapterService {
 			executionRepository,
 			nodeTypes,
 			allowSendingParameterValues,
-			license,
 			roleService,
 			telemetry,
 			logger,
@@ -872,17 +871,15 @@ export class InstanceAiAdapterService {
 			async list(options) {
 				const scope: Scope = 'workflow:read';
 
-				let sharingOptions: ExecutionSummaries.RangeQuery['sharingOptions'];
-				if (license.isSharingEnabled()) {
-					const projectRoles = await roleService.rolesWithScope('project', [scope]);
-					const workflowRoles = await roleService.rolesWithScope('workflow', [scope]);
-					sharingOptions = { scopes: [scope], projectRoles, workflowRoles };
-				} else {
-					sharingOptions = {
-						workflowRoles: ['workflow:owner'],
-						projectRoles: [PROJECT_OWNER_ROLE_SLUG],
-					};
-				}
+				// Visibility from role scopes, not the sharing license — mirrors
+				// ExecutionService.buildSharingOptions and the REST executions list.
+				const projectRoles = await roleService.rolesWithScope('project', [scope]);
+				const workflowRoles = await roleService.rolesWithScope('workflow', [scope]);
+				const sharingOptions: ExecutionSummaries.RangeQuery['sharingOptions'] = {
+					scopes: [scope],
+					projectRoles,
+					workflowRoles,
+				};
 
 				const query: ExecutionSummaries.RangeQuery = {
 					kind: 'range' as const,

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -47,7 +47,6 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
-			mock(),
 		);
 
 		owner = await createOwner();

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -118,7 +118,7 @@ describe('GET /executions/:id', () => {
 		expect(response.body.data).toBeDefined();
 	});
 
-	test('returns executions of workflows shared with the user regardless of sharing license', async () => {
+	test('returns executions of workflows shared with the user without the sharing license', async () => {
 		const workflow = await createWorkflow({}, owner);
 		await shareWorkflowWithUsers(workflow, [member]);
 		const execution = await createSuccessfulExecution(workflow);

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -48,18 +48,36 @@ beforeEach(async () => {
 });
 
 describe('GET /executions', () => {
-	test('only returns executions of shared workflows if sharing is enabled', async () => {
+	test('returns executions of workflows shared with the user regardless of sharing license', async () => {
 		const workflow = await createWorkflow({}, owner);
 		await shareWorkflowWithUsers(workflow, [member]);
 		await createSuccessfulExecution(workflow);
 
-		const response1 = await testServer.authAgentFor(member).get('/executions').expect(200);
-		expect(response1.body.data.count).toBe(0);
+		const responseWithoutLicense = await testServer
+			.authAgentFor(member)
+			.get('/executions')
+			.expect(200);
+		expect(responseWithoutLicense.body.data.count).toBe(1);
 
 		testServer.license.enable('feat:sharing');
 
-		const response2 = await testServer.authAgentFor(member).get('/executions').expect(200);
-		expect(response2.body.data.count).toBe(1);
+		const responseWithLicense = await testServer
+			.authAgentFor(member)
+			.get('/executions')
+			.expect(200);
+		expect(responseWithLicense.body.data.count).toBe(1);
+	});
+
+	test('project admins can list executions of project workflows without the sharing license', async () => {
+		const teamProject = await createTeamProject();
+		await linkUserToProject(member, teamProject, 'project:admin');
+
+		const workflow = await createWorkflow({}, teamProject);
+		await createSuccessfulExecution(workflow);
+
+		const response = await testServer.authAgentFor(member).get('/executions').expect(200);
+
+		expect(response.body.data.count).toBe(1);
 	});
 
 	test('should return a scopes array for each execution', async () => {

--- a/packages/cli/test/integration/executions.controller.test.ts
+++ b/packages/cli/test/integration/executions.controller.test.ts
@@ -93,10 +93,6 @@ describe('GET /executions', () => {
 
 describe('GET /executions/:id', () => {
 	test('project viewers can view executions for workflows in the project', async () => {
-		// if sharing is not enabled, we're only returning the executions of
-		// personal workflows
-		testServer.license.enable('feat:sharing');
-
 		const teamProject = await createTeamProject();
 		await linkUserToProject(member, teamProject, 'project:viewer');
 
@@ -109,14 +105,23 @@ describe('GET /executions/:id', () => {
 		expect(response.body.data).toBeDefined();
 	});
 
-	test('only returns executions of shared workflows if sharing is enabled', async () => {
+	test('project admins can view executions for workflows in the project without the sharing license', async () => {
+		const teamProject = await createTeamProject();
+		await linkUserToProject(member, teamProject, 'project:admin');
+
+		const workflow = await createWorkflow({}, teamProject);
+		const execution = await createSuccessfulExecution(workflow);
+
+		const response = await testServer.authAgentFor(member).get(`/executions/${execution.id}`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data).toBeDefined();
+	});
+
+	test('returns executions of workflows shared with the user regardless of sharing license', async () => {
 		const workflow = await createWorkflow({}, owner);
 		await shareWorkflowWithUsers(workflow, [member]);
 		const execution = await createSuccessfulExecution(workflow);
-
-		await testServer.authAgentFor(member).get(`/executions/${execution.id}`).expect(404);
-
-		testServer.license.enable('feat:sharing');
 
 		const response = await testServer
 			.authAgentFor(member)


### PR DESCRIPTION
## Summary

Execution visibility was gated on the `feat:sharing` license feature: whenever sharing was unlicensed, execution access fell back to "personal-project owner only," which hid all executions from team-project members (project admins, editors, viewers) — even though the workflow list resolves access purely from role scopes and kept showing those workflows as visible and runnable. Instance owners/admins were unaffected (global scope), which made the gap look like a data issue.

This PR removes the license fork in the three places it existed, so execution visibility is always resolved from the user's project/workflow role scopes (`workflow:read` / `workflow:execute`), exactly like the workflow list:

- `ExecutionService.buildSharingOptions` — executions list (`GET /rest/executions`) and the MCP `search-executions` tool. The now-unused `LicenseState` dependency is removed.
- `ExecutionsController.getAccessibleWorkflowIds` — single execution read, versions, stop, stopMany, retry, delete, and annotation update.
- The Instance AI execution adapter's `list` — the AI assistant's execution listing.

`feat:sharing` continues to gate what it was meant to gate: creating shares, and the enterprise shared-with metadata enrichment in `GET /executions/:id` (that fork is intentionally untouched, as is `isAdvancedExecutionFiltersEnabled`).

**Deliberate behavior change:** with sharing unlicensed, executions of workflows *directly shared* with a user (grandfathered shares created while the license was active) become visible again. This matches the workflow list, which already shows those workflows without the license — the PR makes executions consistent with it rather than widening access beyond it. Mutating endpoints (stop/retry/delete) still require `workflow:execute`, which any project member with those scopes could already exercise via a direct manual run (`POST /workflows/:id/run` has no license gate).

**Note on the ticket's "Regression" section:** the gate has existed since the original RBAC work (#8922) and is present in both versions the customer compared (the 2.19.5 → 2.23.3 diff of this path is a pure refactor). This is a long-standing inconsistency that became visible after the upgrade, not a new regression.

**Follow-up (separate ticket):** the Public API workflow list has the same owner-only-when-unlicensed fallback (`packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts:27-35`) and is intentionally out of scope here.

View project admins, editors, viewers saw:
<img width="989" height="392" alt="Screenshot 2026-07-08 at 13 14 50" src="https://github.com/user-attachments/assets/03588da6-87b1-472f-a8ce-64bb40ad6172" />

The correct view the project owner, instance owner and instance admin saw:
<img width="902" height="422" alt="Screenshot 2026-07-08 at 13 15 03" src="https://github.com/user-attachments/assets/e09298d0-7332-4094-80d5-6e42f64b3653" />



## How to test

Requires an enterprise-style setup where `feat:sharing` can be toggled (e.g. a license with sharing disabled, or the test server helpers).

1. On an instance with `feat:sharing` **disabled** (`enterprise.sharing: false` in `/rest/settings`), create a team project and add a `global:member` user as `project:admin`.
2. Create a workflow in that project and execute it.
3. As the project admin: before this fix, the Executions list shows 0 executions while the workflow remains visible and runnable; with this fix, the executions are visible (list and detail), and stop/retry/delete work per the user's `workflow:execute` scope.
4. Toggling `feat:sharing` on no longer changes execution visibility.

Covered by DB-backed integration tests (`packages/cli/test/integration/executions.controller.test.ts`): project-admin list + detail visibility with the license off (the customer repro), project-viewer detail visibility, and directly-shared workflow visibility with the license both off and on. Unit tests updated for the `ExecutionService` constructor change and the AI adapter's now-license-independent sharing options.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-938

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

