### PR TITLE
feat(core): Import project and folder shells (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -12,6 +12,7 @@ describe('ImportPackageRequestDto', () => {
 				workflowConflictPolicy: 'fail',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
+				folderConflictPolicy: 'new-version',
 			});
 		}
 	});
@@ -31,6 +32,7 @@ describe('ImportPackageRequestDto', () => {
 				workflowConflictPolicy: 'fail',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
+				folderConflictPolicy: 'new-version',
 			});
 		}
 	});
@@ -52,6 +54,7 @@ describe('ImportPackageRequestDto', () => {
 				workflowConflictPolicy: 'new-version',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
+				folderConflictPolicy: 'new-version',
 			});
 		}
 	});
@@ -72,6 +75,7 @@ describe('ImportPackageRequestDto', () => {
 				workflowConflictPolicy: 'skip',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
+				folderConflictPolicy: 'new-version',
 			});
 		}
 	});

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -12,6 +12,7 @@ export const IMPORT_PACKAGE_REQUEST_FORM_FIELDS = [
 	'workflowConflictPolicy',
 	'workflowPublishingPolicy',
 	'workflowIdPolicy',
+	'folderConflictPolicy',
 ] as const;
 
 /** Multipart text fields: empty / whitespace-only values become `undefined`. */
@@ -74,4 +75,5 @@ export class ImportPackageRequestDto extends Z.class({
 		.optional()
 		.default('preserve-published-state'),
 	workflowIdPolicy: z.enum(['new', 'source']).optional().default('new'),
+	folderConflictPolicy: z.enum(['new-version', 'fail', 'skip']).optional().default('new-version'),
 }) {}

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -46,6 +46,7 @@ n8n-cli package import --file=export.n8np --conflict-policy=fail --credential-mi
 | `--project` | Target project ID. Defaults to your personal project. |
 | `--folder` | Target folder ID within the project. Defaults to the project root. |
 | `--workflow-id-policy` | Whether imported workflows keep their source ID (`source`) or receive a new one (`new`). |
+| `--folder-conflict-policy` | What to do when a package folder already exists in the target project: `new-version` (default), `fail`, or `skip`. Requires a folders-enabled license when the package contains folders. |
 | `--credential-matching-mode` | How credential references are matched on the target instance (`id-only`). |
 | `--credential-missing-mode` | What to do when a referenced credential cannot be resolved. `create-stub` (instance default) creates empty placeholder credentials in the target project; `must-preexist` requires every referenced credential to already exist. |
 

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -16,6 +16,7 @@ export interface ImportPackageFields {
 	credentialMissingMode?: string;
 	workflowConflictPolicy: string;
 	workflowIdPolicy?: string;
+	folderConflictPolicy?: string;
 }
 
 export class ApiError extends Error {

--- a/packages/@n8n/cli/src/commands/package/import.ts
+++ b/packages/@n8n/cli/src/commands/package/import.ts
@@ -34,6 +34,11 @@ export default class PackageImport extends BaseCommand {
 			options: ['new', 'source'],
 			aliases: ['workflow-id-policy'],
 		}),
+		folderConflictPolicy: Flags.string({
+			description: 'What to do when a package folder already exists in the target project',
+			options: ['new-version', 'fail', 'skip'],
+			aliases: ['folder-conflict-policy'],
+		}),
 		credentialMatchingMode: Flags.string({
 			description: 'How credential references are matched on the target instance',
 			options: ['id-only'],
@@ -66,6 +71,7 @@ export default class PackageImport extends BaseCommand {
 						folderId: flags.folder,
 						workflowConflictPolicy: flags.conflictPolicy,
 						workflowIdPolicy: flags.workflowIdPolicy,
+						folderConflictPolicy: flags.folderConflictPolicy,
 						credentialMatchingMode: flags.credentialMatchingMode,
 						credentialMissingMode: flags.credentialMissingMode,
 					},

--- a/packages/cli/src/modules/n8n-packages/CLAUDE.md
+++ b/packages/cli/src/modules/n8n-packages/CLAUDE.md
@@ -18,6 +18,21 @@ flowchart LR
   A --> C["4. CLI<br/>@n8n/cli"]
 ```
 
+### Importer rules
+- Importers **plan and decide**; they must never touch a repository directly. All persistence and
+  lookups go through a **service**.
+- Prefer an **existing** domain service from the main n8n codebase (`FolderService`, `ProjectService`,
+  `WorkflowService`, …). When the importer needs a capability the service lacks — reusing a source id,
+  or a fetch-by-ids for matching — **extend that existing service with a general method** rather than
+  reaching for the repository or spinning up an import-only service. Canonical examples:
+  `ProjectService.createTeamProject(data, overrides)` (preset id + description) and
+  `FolderService.createFolder(dto, projectId, id?)` / `FolderService.getFoldersByIds(ids)`.
+- The pipeline is a thin **dispatcher**: it reads the manifest and delegates to a per-package-shape
+  importer (`ProjectPackageImporter` / `WorkflowPackageImporter`). Package shapes mirror export's
+  mutual exclusivity — a **project package** (projects defined by the package) vs a **workflow package**
+  (loose workflows + their folders + credential deps into a target project). Don't split folder vs
+  workflow: they share target resolution, credential resolution, and publishing.
+
 ### Adding an IMPORT property
 
 1. **Module** (here)

--- a/packages/cli/src/modules/n8n-packages/__tests__/fixtures/package-fixtures.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/fixtures/package-fixtures.ts
@@ -4,6 +4,8 @@ import { TarPackageWriter } from '../../io/tar/tar-package-writer';
 import { FORMAT_VERSION } from '../../spec/constants';
 import type { PackageManifest } from '../../spec/manifest.schema';
 import type { PackageCredentialRequirement } from '../../spec/requirements.schema';
+import type { SerializedFolder } from '../../spec/serialized/folder.schema';
+import type { SerializedProject } from '../../spec/serialized/project.schema';
 import type { SerializedWorkflow } from '../../spec/serialized/workflow.schema';
 import { streamToBuffer } from '../utils/tar-support';
 
@@ -145,6 +147,99 @@ export async function buildImportPackageBuffer(
 		writer.writeDirectory(`workflows/wf-${idx}`);
 		writer.writeFile(`workflows/wf-${idx}/workflow.json`, JSON.stringify(wf));
 	});
+
+	return await streamToBuffer(writer.finalize());
+}
+
+export function serializedFolder(overrides: Partial<SerializedFolder> = {}): SerializedFolder {
+	return { id: 'folder-id', name: 'Folder', parentFolderId: null, ...overrides };
+}
+
+export function serializedProject(overrides: Partial<SerializedProject> = {}): SerializedProject {
+	return { id: 'project-id', name: 'Project', ...overrides };
+}
+
+export interface PackageFolderEntry {
+	target: string;
+	folder: SerializedFolder;
+}
+
+export interface PackageProjectEntry {
+	target: string;
+	project: SerializedProject;
+}
+
+export interface PackageWorkflowEntry {
+	target: string;
+	workflow: SerializedWorkflow;
+}
+
+/**
+ * Builds a package at explicit target paths, so tests can shape the exact package layout
+ * (top-level folders, nested folders, project-namespaced entities). Manifest entries are
+ * derived from each entity's id/name and the given target.
+ */
+export async function buildEntityPackageBuffer(options: {
+	workflows?: PackageWorkflowEntry[];
+	folders?: PackageFolderEntry[];
+	projects?: PackageProjectEntry[];
+	manifestExtras?: Partial<PackageManifest>;
+	sourceId?: string;
+}): Promise<Buffer> {
+	const writer = new TarPackageWriter();
+	const workflows = options.workflows ?? [];
+	const folders = options.folders ?? [];
+	const projects = options.projects ?? [];
+
+	const manifest: PackageManifest = {
+		packageFormatVersion: FORMAT_VERSION,
+		exportedAt: new Date().toISOString(),
+		sourceN8nVersion: '1.0.0',
+		sourceId: options.sourceId ?? 'integration-test-source',
+		...(workflows.length > 0
+			? {
+					workflows: workflows.map(({ target, workflow }) => ({
+						id: workflow.id,
+						name: workflow.name,
+						target,
+					})),
+				}
+			: {}),
+		...(folders.length > 0
+			? {
+					folders: folders.map(({ target, folder }) => ({
+						id: folder.id,
+						name: folder.name,
+						target,
+					})),
+				}
+			: {}),
+		...(projects.length > 0
+			? {
+					projects: projects.map(({ target, project }) => ({
+						id: project.id,
+						name: project.name,
+						target,
+					})),
+				}
+			: {}),
+		...options.manifestExtras,
+	};
+
+	// Manifest first: the reader/parser resolves it before reading any referenced file.
+	writer.writeFile('manifest.json', JSON.stringify(manifest));
+	for (const { target, workflow } of workflows) {
+		writer.writeDirectory(target);
+		writer.writeFile(`${target}/workflow.json`, JSON.stringify(workflow));
+	}
+	for (const { target, folder } of folders) {
+		writer.writeDirectory(target);
+		writer.writeFile(`${target}/folder.json`, JSON.stringify(folder));
+	}
+	for (const { target, project } of projects) {
+		writer.writeDirectory(target);
+		writer.writeFile(`${target}/project.json`, JSON.stringify(project));
+	}
 
 	return await streamToBuffer(writer.finalize());
 }

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
@@ -1,0 +1,340 @@
+import { LicenseState } from '@n8n/backend-common';
+import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
+import type { Project, User } from '@n8n/db';
+import { FolderRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { createFolder } from '@test-integration/db/folders';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { FolderConflictPolicy, ImportPackageRequest } from '../n8n-packages.types';
+import { buildEntityPackageBuffer, serializedFolder } from './fixtures/package-fixtures';
+
+type FolderImportParams = {
+	user: User;
+	projectId?: string;
+	folderId?: string;
+	packageBuffer: Buffer;
+	folderConflictPolicy?: FolderConflictPolicy;
+	apiKeyScopes?: string[];
+};
+
+async function importFolders(params: FolderImportParams) {
+	const request: ImportPackageRequest = {
+		user: params.user,
+		projectId: params.projectId,
+		folderId: params.folderId,
+		packageBuffer: params.packageBuffer,
+		apiKeyScopes: params.apiKeyScopes,
+		credentialMatchingMode: 'id-only',
+		credentialMissingMode: 'must-preexist',
+		workflowConflictPolicy: 'new-version',
+		workflowPublishingPolicy: 'preserve-published-state',
+		workflowIdPolicy: 'new',
+		folderConflictPolicy: params.folderConflictPolicy ?? 'new-version',
+	};
+	return await Container.get(N8nPackagesService).importPackage(request);
+}
+
+const licenseMocker = new LicenseMocker();
+
+async function findFolder(id: string) {
+	return await Container.get(FolderRepository).findOne({
+		where: { id },
+		relations: { homeProject: true },
+	});
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	licenseMocker.setDefaults({ features: ['feat:folders'] });
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['Folder', 'Project', 'SharedWorkflow', 'WorkflowEntity']);
+	licenseMocker.reset();
+});
+
+describe('folder shell import', () => {
+	let owner: User;
+	let project: Project;
+
+	beforeEach(async () => {
+		owner = await createOwner();
+		project = await createTeamProject('Target', owner);
+	});
+
+	it('creates a single empty folder at project root', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/to_production',
+					folder: serializedFolder({ id: 'F1', name: 'to_production' }),
+				},
+			],
+		});
+
+		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect(result.folders).toEqual([
+			{
+				sourceFolderId: 'F1',
+				localId: 'F1',
+				name: 'to_production',
+				parentFolderId: null,
+				status: 'created',
+			},
+		]);
+		expect(result.workflows).toEqual([]);
+		const persisted = await findFolder('F1');
+		expect(persisted?.name).toBe('to_production');
+		expect(persisted?.parentFolderId).toBeNull();
+		expect(persisted?.homeProject.id).toBe(project.id);
+	});
+
+	it('creates two empty folders at project root', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/to_production',
+					folder: serializedFolder({ id: 'F1', name: 'to_production' }),
+				},
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'F2', name: 'in_progress' }),
+				},
+			],
+		});
+
+		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect(result.folders.map((f) => f.status)).toEqual(['created', 'created']);
+		expect(await findFolder('F1')).not.toBeNull();
+		expect(await findFolder('F2')).not.toBeNull();
+	});
+
+	it('recreates a nested folder under its parent', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'P', name: 'in_progress' }),
+				},
+				{
+					target: 'folders/in_progress/nested',
+					folder: serializedFolder({ id: 'C', name: 'nested', parentFolderId: 'P' }),
+				},
+			],
+		});
+
+		await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect((await findFolder('C'))?.parentFolderId).toBe('P');
+	});
+
+	it('anchors top-level folders under the request folderId', async () => {
+		const anchor = await createFolder(project, { name: 'anchor' });
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/to_production',
+					folder: serializedFolder({ id: 'F1', name: 'to_production' }),
+				},
+			],
+		});
+
+		const result = await importFolders({
+			user: owner,
+			projectId: project.id,
+			folderId: anchor.id,
+			packageBuffer,
+		});
+
+		expect(result.folders[0].parentFolderId).toBe(anchor.id);
+		expect((await findFolder('F1'))?.parentFolderId).toBe(anchor.id);
+	});
+
+	it('topologically sorts a child listed before its parent', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/in_progress/nested',
+					folder: serializedFolder({ id: 'C', name: 'nested', parentFolderId: 'P' }),
+				},
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'P', name: 'in_progress' }),
+				},
+			],
+		});
+
+		await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect((await findFolder('P'))?.parentFolderId).toBeNull();
+		expect((await findFolder('C'))?.parentFolderId).toBe('P');
+	});
+
+	it('allows a duplicate name with a different id alongside an existing folder', async () => {
+		await createFolder(project, { name: 'in_progress' });
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'B', name: 'in_progress' }),
+				},
+			],
+		});
+
+		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect(result.folders[0]).toMatchObject({ sourceFolderId: 'B', status: 'created' });
+		const inProgress = await Container.get(FolderRepository).findBy({ name: 'in_progress' });
+		expect(inProgress).toHaveLength(2);
+	});
+
+	describe('re-import (matched by id)', () => {
+		const packageWith = async (name: string) =>
+			await buildEntityPackageBuffer({
+				folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name }) }],
+			});
+
+		it('updates the folder in place under new-version', async () => {
+			await importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await packageWith('old'),
+			});
+			const result = await importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await packageWith('new'),
+				folderConflictPolicy: 'new-version',
+			});
+
+			expect(result.folders[0].status).toBe('updated');
+			expect((await findFolder('F1'))?.name).toBe('new');
+		});
+
+		it('leaves the folder unchanged under skip', async () => {
+			await importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await packageWith('old'),
+			});
+			const result = await importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await packageWith('new'),
+				folderConflictPolicy: 'skip',
+			});
+
+			expect(result.folders[0].status).toBe('skipped');
+			expect((await findFolder('F1'))?.name).toBe('old');
+		});
+
+		it('blocks under fail', async () => {
+			await importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await packageWith('old'),
+			});
+			await expect(
+				importFolders({
+					user: owner,
+					projectId: project.id,
+					packageBuffer: await packageWith('new'),
+					folderConflictPolicy: 'fail',
+				}),
+			).rejects.toBeInstanceOf(ConflictError);
+			expect((await findFolder('F1'))?.name).toBe('old');
+		});
+	});
+
+	it('blocks and persists nothing when a matched folder sits under a different parent', async () => {
+		// First import places F1 at the project root.
+		await importFolders({
+			user: owner,
+			projectId: project.id,
+			packageBuffer: await buildEntityPackageBuffer({
+				folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) }],
+			}),
+		});
+		const anchor = await createFolder(project, { name: 'anchor' });
+		const foldersBefore = await Container.get(FolderRepository).count();
+
+		// Re-import anchored elsewhere: F1 would move → parent-mismatch conflict.
+		await expect(
+			importFolders({
+				user: owner,
+				projectId: project.id,
+				folderId: anchor.id,
+				packageBuffer: await buildEntityPackageBuffer({
+					folders: [
+						{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) },
+						{ target: 'folders/f2', folder: serializedFolder({ id: 'F2', name: 'f2' }) },
+					],
+				}),
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+
+		expect(await Container.get(FolderRepository).count()).toBe(foldersBefore);
+		expect(await findFolder('F2')).toBeNull();
+	});
+
+	it('blocks when the folder id already exists in a different project', async () => {
+		const otherProject = await createTeamProject('Other', owner);
+		await importFolders({
+			user: owner,
+			projectId: otherProject.id,
+			packageBuffer: await buildEntityPackageBuffer({
+				folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) }],
+			}),
+		});
+
+		await expect(
+			importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer: await buildEntityPackageBuffer({
+					folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) }],
+				}),
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('rejects a package with folders when folders are not licensed', async () => {
+		licenseMocker.disable('feat:folders');
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) }],
+		});
+
+		await expect(
+			importFolders({ user: owner, projectId: project.id, packageBuffer }),
+		).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it('rejects a folders package when the API key lacks the folder:create scope', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'F1', name: 'f' }) }],
+		});
+
+		await expect(
+			importFolders({
+				user: owner,
+				projectId: project.id,
+				packageBuffer,
+				apiKeyScopes: ['workflow:import'],
+			}),
+		).rejects.toBeInstanceOf(ForbiddenError);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -32,6 +32,7 @@ import { initNodeTypes } from '@test-integration/utils';
 import { TarPackageWriter } from '../io/tar/tar-package-writer';
 import { N8nPackagesService } from '../n8n-packages.service';
 import {
+	FolderConflictPolicy,
 	WorkflowConflictPolicy,
 	WorkflowIdPolicy,
 	WorkflowPublishingPolicy,
@@ -57,6 +58,7 @@ type ImportPackageParams = Omit<
 	| 'workflowConflictPolicy'
 	| 'workflowPublishingPolicy'
 	| 'workflowIdPolicy'
+	| 'folderConflictPolicy'
 > &
 	Partial<
 		Pick<
@@ -67,6 +69,7 @@ type ImportPackageParams = Omit<
 			| 'workflowConflictPolicy'
 			| 'workflowPublishingPolicy'
 			| 'workflowIdPolicy'
+			| 'folderConflictPolicy'
 		>
 	>;
 
@@ -77,6 +80,7 @@ async function importPackage(params: ImportPackageParams) {
 		workflowConflictPolicy: WorkflowConflictPolicy.Fail,
 		workflowPublishingPolicy: WorkflowPublishingPolicy.PreservePublishedState,
 		workflowIdPolicy: WorkflowIdPolicy.New,
+		folderConflictPolicy: FolderConflictPolicy.NewVersion,
 		...params,
 	});
 }

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
@@ -1,0 +1,207 @@
+import { LicenseState } from '@n8n/backend-common';
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { FolderRepository, ProjectRelationRepository, ProjectRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { ImportPackageRequest } from '../n8n-packages.types';
+import {
+	buildEntityPackageBuffer,
+	serializedFolder,
+	serializedProject,
+	serializedWorkflow,
+} from './fixtures/package-fixtures';
+
+async function importProjects(user: User, packageBuffer: Buffer, apiKeyScopes?: string[]) {
+	const request: ImportPackageRequest = {
+		user,
+		packageBuffer,
+		apiKeyScopes,
+		credentialMatchingMode: 'id-only',
+		credentialMissingMode: 'must-preexist',
+		workflowConflictPolicy: 'new-version',
+		workflowPublishingPolicy: 'preserve-published-state',
+		workflowIdPolicy: 'new',
+		folderConflictPolicy: 'new-version',
+	};
+	return await Container.get(N8nPackagesService).importPackage(request);
+}
+
+const licenseMocker = new LicenseMocker();
+
+async function findProject(id: string) {
+	return await Container.get(ProjectRepository).findOne({ where: { id } });
+}
+
+async function isAdminOf(projectId: string, userId: string): Promise<boolean> {
+	const count = await Container.get(ProjectRelationRepository).count({
+		where: { projectId, userId, role: { slug: 'project:admin' } },
+	});
+	return count > 0;
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	licenseMocker.setDefaults({
+		features: ['feat:projectRole:admin'],
+		quotas: { 'quota:maxTeamProjects': 100 },
+	});
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'Folder',
+		'Project',
+		'ProjectRelation',
+		'SharedWorkflow',
+		'WorkflowEntity',
+	]);
+	licenseMocker.reset();
+});
+
+describe('project shell import', () => {
+	let owner: User;
+
+	beforeEach(async () => {
+		owner = await createOwner();
+	});
+
+	it('creates a team project owned by the importer, reusing the source id', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects).toEqual([
+			{ sourceProjectId: 'P1', localId: 'P1', name: 'brie', status: 'created' },
+		]);
+		const project = await findProject('P1');
+		expect(project?.name).toBe('brie');
+		expect(project?.type).toBe('team');
+		expect(await isAdminOf('P1', owner.id)).toBe(true);
+	});
+
+	it('creates multiple projects in one package', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				{ target: 'projects/stilton', project: serializedProject({ id: 'P2', name: 'stilton' }) },
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects.map((p) => p.localId).sort()).toEqual(['P1', 'P2']);
+		expect(await findProject('P1')).not.toBeNull();
+		expect(await findProject('P2')).not.toBeNull();
+	});
+
+	it('creates two distinct projects that share a name but differ by id', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				{ target: 'projects/brie-1', project: serializedProject({ id: 'P2', name: 'brie' }) },
+			],
+		});
+
+		await importProjects(owner, packageBuffer);
+
+		expect((await findProject('P1'))?.name).toBe('brie');
+		expect((await findProject('P2'))?.name).toBe('brie');
+	});
+
+	it('matches an existing project by id on re-import and updates it in place', async () => {
+		await importProjects(
+			owner,
+			await buildEntityPackageBuffer({
+				projects: [
+					{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				],
+			}),
+		);
+
+		const result = await importProjects(
+			owner,
+			await buildEntityPackageBuffer({
+				projects: [
+					{
+						target: 'projects/brie',
+						project: serializedProject({ id: 'P1', name: 'brie renamed' }),
+					},
+				],
+			}),
+		);
+
+		expect(result.projects).toEqual([
+			{ sourceProjectId: 'P1', localId: 'P1', name: 'brie renamed', status: 'updated' },
+		]);
+		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(1);
+		expect((await findProject('P1'))?.name).toBe('brie renamed');
+	});
+
+	it('rejects a project package when the API key lacks the project:create scope', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+		});
+
+		await expect(importProjects(owner, packageBuffer, ['workflow:import'])).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
+	});
+
+	it('refuses to import over an existing personal project id', async () => {
+		const personal = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: personal.id, name: 'brie' }) },
+			],
+		});
+
+		await expect(importProjects(owner, packageBuffer)).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it('ignores folders and workflows nested inside the project (deferred to a follow-up)', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+			folders: [
+				{
+					target: 'projects/brie/folders/in_progress',
+					folder: serializedFolder({ id: 'NestedFolder', name: 'in_progress' }),
+				},
+			],
+			workflows: [
+				{
+					target: 'projects/brie/folders/in_progress/workflows/triage',
+					workflow: serializedWorkflow({ id: 'NestedWf', name: 'triage' }),
+				},
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects.map((p) => p.localId)).toEqual(['P1']);
+		expect(result.folders).toEqual([]);
+		expect(result.workflows).toEqual([]);
+		expect(await Container.get(FolderRepository).findOneBy({ id: 'NestedFolder' })).toBeNull();
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/import-blocked.error.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/import-blocked.error.test.ts
@@ -1,0 +1,38 @@
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
+
+import type { BlockingIssue } from '../../n8n-packages.types';
+import { toImportBlockedError } from '../import-blocked.error';
+
+const folderConflict: BlockingIssue = {
+	type: 'folder-conflict',
+	kind: 'parent-mismatch',
+	sourceFolderId: 'f1',
+	name: 'in_progress',
+	existingParentFolderId: null,
+	expectedParentFolderId: 'anchor',
+};
+
+const credentialUnresolved: BlockingIssue = {
+	type: 'credential-unresolved',
+	kind: 'not_found',
+	sourceId: 'c1',
+	usedByWorkflows: ['w1'],
+};
+
+describe('toImportBlockedError', () => {
+	it('maps a folder-conflict to 409 Conflict', () => {
+		const error = toImportBlockedError([folderConflict]);
+		expect(error).toBeInstanceOf(ConflictError);
+	});
+
+	it('still maps credential-only blocks to 422', () => {
+		const error = toImportBlockedError([credentialUnresolved]);
+		expect(error).toBeInstanceOf(UnprocessableRequestError);
+	});
+
+	it('prefers 409 when a folder-conflict is mixed with credential issues', () => {
+		const error = toImportBlockedError([credentialUnresolved, folderConflict]);
+		expect(error).toBeInstanceOf(ConflictError);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
@@ -1,0 +1,52 @@
+import type { ManifestEntry } from '../../spec/manifest.schema';
+import { isTopLevelTarget, topLevelFolders, topLevelWorkflows } from '../package-layout';
+
+const entry = (id: string, target: string): ManifestEntry => ({ id, name: id, target });
+
+describe('package-layout', () => {
+	describe('isTopLevelTarget', () => {
+		it('treats a direct child of the dir as top-level', () => {
+			expect(isTopLevelTarget('folders/a', 'folders')).toBe(true);
+			expect(isTopLevelTarget('workflows/wf', 'workflows')).toBe(true);
+		});
+
+		it('treats a nested folder tree entry as top-level (folders/ appears once per scope)', () => {
+			expect(isTopLevelTarget('folders/a/b', 'folders')).toBe(true);
+		});
+
+		it('rejects project-nested entries', () => {
+			expect(isTopLevelTarget('projects/x/folders/a', 'folders')).toBe(false);
+			expect(isTopLevelTarget('projects/x/workflows/wf', 'workflows')).toBe(false);
+		});
+
+		it('rejects folder-nested workflows', () => {
+			expect(isTopLevelTarget('folders/a/workflows/wf', 'workflows')).toBe(false);
+		});
+	});
+
+	describe('topLevelFolders', () => {
+		it('keeps only folders/… entries and drops project-nested ones', () => {
+			const entries = [
+				entry('a', 'folders/a'),
+				entry('b', 'folders/a/b'),
+				entry('c', 'projects/x/folders/c'),
+			];
+			expect(topLevelFolders(entries).map((e) => e.id)).toEqual(['a', 'b']);
+		});
+
+		it('returns [] for undefined', () => {
+			expect(topLevelFolders(undefined)).toEqual([]);
+		});
+	});
+
+	describe('topLevelWorkflows', () => {
+		it('keeps only workflows/… entries and drops folder/project-nested ones', () => {
+			const entries = [
+				entry('top', 'workflows/top'),
+				entry('inFolder', 'folders/a/workflows/inFolder'),
+				entry('inProject', 'projects/x/workflows/inProject'),
+			];
+			expect(topLevelWorkflows(entries).map((e) => e.id)).toEqual(['top']);
+		});
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
@@ -15,7 +15,8 @@ export function toImportBlockedError(
 			(issue) =>
 				issue.type === 'workflow-conflict' ||
 				issue.type === 'workflow-id-conflict' ||
-				issue.type === 'workflow-folder-conflict',
+				issue.type === 'workflow-folder-conflict' ||
+				issue.type === 'folder-conflict',
 		)
 	) {
 		return new ConflictError(message, undefined, { issues });

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -1,266 +1,41 @@
-import type { Project, User } from '@n8n/db';
-import { ProjectRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { UserError } from 'n8n-workflow';
 
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
-import { EventService } from '@/events/event.service';
-import { FolderService } from '@/services/folder.service';
-import { ProjectService } from '@/services/project.service.ee';
-
-import { CredentialImporter } from '../entities/credential/credential-importer';
-import { workflowsBlockedFromPublish } from '../entities/credential/credential-missing-mode';
-import type {
-	CredentialBindingRequest,
-	CredentialResolution,
-} from '../entities/credential/credential.types';
-import type {
-	WorkflowImportOutcome,
-	WorkflowImportPlan,
-} from '../entities/workflow/workflow-import.types';
-import { WorkflowImporter } from '../entities/workflow/workflow-importer';
-import { WorkflowPublisher } from '../entities/workflow/workflow-publisher';
-import { toImportBlockedError } from './import-blocked.error';
+import { ProjectPackageImporter } from './project-package-importer';
+import { WorkflowPackageImporter } from './workflow-package-importer';
 import { N8nPackageParser } from './n8n-package-parser';
 import { TarPackageReader } from '../io/tar/tar-package-reader';
 import { PackageImportConfig } from '../n8n-packages.config';
+import type { ImportPackageRequest, ImportResult } from '../n8n-packages.types';
+import type { PackageManifest } from '../spec/manifest.schema';
 
-import { createBindings, serializeBindings } from '../n8n-packages.types';
-import type {
-	BlockingIssue,
-	ImportContext,
-	ImportCredentialSummary,
-	ImportPackageRequest,
-	ImportPackageSummary,
-	ImportResult,
-	PackageImportBindings,
-} from '../n8n-packages.types';
-
+/**
+ * Entry point for package import. Reads the manifest, decides the package shape, and delegates
+ * to the matching importer — a **project package** (projects defined by the package) or a
+ * **workflow package** (loose workflows + folders + credentials imported into a target project).
+ */
 @Service()
 export class ImportPipeline {
 	constructor(
 		private readonly packageParser: N8nPackageParser,
-		private readonly credentialImporter: CredentialImporter,
 		private readonly packageImportConfig: PackageImportConfig,
-		private readonly projectRepository: ProjectRepository,
-		private readonly projectService: ProjectService,
-		private readonly folderService: FolderService,
-		private readonly eventService: EventService,
-		private readonly workflowImporter: WorkflowImporter,
-		private readonly workflowPublisher: WorkflowPublisher,
+		private readonly projectPackageImporter: ProjectPackageImporter,
+		private readonly workflowPackageImporter: WorkflowPackageImporter,
 	) {}
 
 	async run(request: ImportPackageRequest): Promise<ImportResult> {
-		const context = await this.resolveTarget(request.user, request.projectId, request.folderId);
-
-		// PublishAll requires publish scope up front; other policies are checked per workflow
-		await this.workflowPublisher.assertCanPublish(
-			context.user,
-			context.projectId,
-			request.workflowPublishingPolicy,
-		);
-
+		// A project package defines its own projects, so the request's target projectId/folderId
+		// do not apply — that distinction is what selects the importer.
 		const reader = new TarPackageReader(request.packageBuffer, this.packageImportConfig);
 		const manifest = await this.packageParser.getManifest(reader);
-		const workflowsForImport = await this.packageParser.getWorkflows(reader);
 
-		const credentialRequest: CredentialBindingRequest = {
-			requirements: manifest.requirements?.credentials,
-			matchingMode: request.credentialMatchingMode,
-			missingMode: request.credentialMissingMode,
-			credentialBindings: request.credentialBindings,
-		};
+		const importer = isProjectPackage(manifest)
+			? this.projectPackageImporter
+			: this.workflowPackageImporter;
 
-		const credentialPlan = await this.credentialImporter.plan(context, credentialRequest);
-		const workflowPlan = await this.workflowImporter.plan(context, workflowsForImport, request);
-
-		const blockingIssues = this.collectBlockingIssues(
-			workflowPlan,
-			credentialPlan,
-			credentialRequest,
-		);
-
-		const packageSummary: ImportPackageSummary = {
-			sourceN8nVersion: manifest.sourceN8nVersion,
-			sourceId: manifest.sourceId,
-			exportedAt: manifest.exportedAt,
-		};
-
-		if (blockingIssues.length > 0) {
-			throw toImportBlockedError(blockingIssues);
-		}
-
-		const credentialApply = await this.credentialImporter.apply(
-			context,
-			credentialRequest,
-			credentialPlan,
-		);
-		const publishBlockedSourceWorkflowIds = workflowsBlockedFromPublish(
-			credentialRequest.requirements,
-			new Set(credentialApply.stubbed),
-		);
-
-		const { outcomes, bindings } = await this.workflowImporter.apply(
-			{
-				...context,
-				publishingPolicy: request.workflowPublishingPolicy,
-				publishBlockedSourceWorkflowIds,
-			},
-			workflowPlan,
-			createBindings({ credentials: credentialApply.bindings }),
-		);
-
-		const imported = outcomes.filter(({ status }) => status !== 'skipped');
-		const countByStatus = (status: WorkflowImportOutcome['status']) =>
-			outcomes.filter((outcome) => outcome.status === status).length;
-		this.eventService.emit('n8n-package-imported', {
-			user: context.user,
-			projectId: context.projectId,
-			folderId: context.folderId,
-			workflowIds: imported.map(({ workflow }) => workflow.id),
-			options: {
-				workflowConflictPolicy: request.workflowConflictPolicy,
-				workflowIdPolicy: request.workflowIdPolicy,
-				credentialMatchingMode: request.credentialMatchingMode,
-				credentialMissingMode: request.credentialMissingMode,
-				workflowPublishingPolicy: request.workflowPublishingPolicy,
-			},
-			packageSourceId: manifest.sourceId,
-			packageVersion: manifest.packageFormatVersion,
-			credentialIds: {
-				matched: credentialApply.matched.map((sourceId) => credentialApply.bindings.get(sourceId)!),
-				created: credentialApply.stubbed.map((sourceId) => credentialApply.bindings.get(sourceId)!),
-				updated: [],
-			},
-			counts: {
-				workflows: {
-					created: countByStatus('created'),
-					updated: countByStatus('updated'),
-					skipped: countByStatus('skipped'),
-				},
-				credentials: {
-					matched: credentialApply.matched.length,
-					created: credentialApply.stubbed.length,
-					requirements: credentialRequest.requirements?.length ?? 0,
-				},
-			},
-		});
-
-		return this.buildResult(packageSummary, context.projectId, outcomes, bindings, {
-			matched: credentialApply.matched,
-			stubbed: credentialApply.stubbed,
-		});
+		return await importer.import(request, reader, manifest);
 	}
+}
 
-	/** Folds every subsystem's blocking conditions into one uniformly-typed list. */
-	private collectBlockingIssues(
-		workflowPlan: WorkflowImportPlan,
-		credentialResolution: CredentialResolution,
-		credentialRequest: CredentialBindingRequest,
-	): BlockingIssue[] {
-		const workflowConflicts: BlockingIssue[] = workflowPlan.conflicts.map((conflict) => ({
-			type: 'workflow-conflict',
-			...conflict,
-		}));
-
-		const workflowIdConflicts: BlockingIssue[] = workflowPlan.idConflicts.map((conflict) => ({
-			type: 'workflow-id-conflict',
-			...conflict,
-		}));
-
-		const workflowFolderConflicts: BlockingIssue[] = workflowPlan.folderConflicts.map(
-			(conflict) => ({
-				type: 'workflow-folder-conflict',
-				...conflict,
-			}),
-		);
-
-		const credentialFailures: BlockingIssue[] = this.credentialImporter
-			.blockingFailures(credentialRequest, credentialResolution)
-			.map(({ kind, sourceId, targetId, expectedType, actualType, usedByWorkflows }) => ({
-				type: 'credential-unresolved',
-				kind,
-				sourceId,
-				...(targetId ? { targetId } : {}),
-				...(expectedType ? { expectedType } : {}),
-				...(actualType ? { actualType } : {}),
-				usedByWorkflows,
-			}));
-
-		return [
-			...workflowConflicts,
-			...workflowIdConflicts,
-			...workflowFolderConflicts,
-			...credentialFailures,
-		];
-	}
-
-	private buildResult(
-		packageSummary: ImportPackageSummary,
-		projectId: string,
-		outcomes: WorkflowImportOutcome[],
-		bindings: PackageImportBindings,
-		credentials: ImportCredentialSummary,
-	): ImportResult {
-		return {
-			package: packageSummary,
-			workflows: outcomes.map(({ workflow, sourceWorkflowId, status, publishing }) => ({
-				sourceWorkflowId,
-				localId: workflow.id,
-				name: workflow.name,
-				projectId,
-				parentFolderId: workflow.parentFolder?.id ?? null,
-				activeVersionId: workflow.activeVersionId ?? null,
-				publishing,
-				status,
-			})),
-			bindings: serializeBindings(bindings),
-			credentials,
-		};
-	}
-
-	private async resolveTarget(
-		user: User,
-		projectId: string | undefined,
-		folderId: string | undefined,
-	): Promise<ImportContext> {
-		const project = await this.resolveImportProject(user, projectId);
-		await this.assertFolderExistsInProject(folderId, project.id);
-
-		return { user, projectId: project.id, folderId: folderId ?? null };
-	}
-
-	private async resolveImportProject(user: User, projectId: string | undefined): Promise<Project> {
-		if (projectId === undefined) {
-			return await this.projectRepository.getPersonalProjectForUserOrFail(user.id);
-		}
-
-		const project = await this.projectService.getProjectWithScope(user, projectId, [
-			'workflow:import',
-		]);
-		if (project) {
-			return project;
-		}
-
-		if (!(await this.projectRepository.existsBy({ id: projectId }))) {
-			throw new NotFoundError(`Project not found: ${projectId}`);
-		}
-		throw new ForbiddenError('You do not have permission to import workflows into this project.');
-	}
-
-	private async assertFolderExistsInProject(
-		folderId: string | undefined,
-		projectId: string,
-	): Promise<void> {
-		if (folderId === undefined) {
-			return;
-		}
-
-		try {
-			await this.folderService.findFolderInProjectOrFail(folderId, projectId);
-		} catch (cause) {
-			throw new UserError(`Folder not found in target project: ${folderId}`, { cause });
-		}
-	}
+function isProjectPackage(manifest: PackageManifest): boolean {
+	return (manifest.projects?.length ?? 0) > 0;
 }

--- a/packages/cli/src/modules/n8n-packages/engine/import-result.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-result.ts
@@ -1,0 +1,67 @@
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+import type { WorkflowImportOutcome } from '../entities/workflow/workflow-import.types';
+import { serializeBindings } from '../n8n-packages.types';
+import type {
+	ImportCredentialSummary,
+	ImportedFolderSummary,
+	ImportedProjectSummary,
+	ImportPackageSummary,
+	ImportResult,
+	PackageImportBindings,
+} from '../n8n-packages.types';
+import type { PackageManifest } from '../spec/manifest.schema';
+
+/** The package-level provenance carried on every {@link ImportResult}. */
+export function toPackageSummary(manifest: PackageManifest): ImportPackageSummary {
+	return {
+		sourceN8nVersion: manifest.sourceN8nVersion,
+		sourceId: manifest.sourceId,
+		exportedAt: manifest.exportedAt,
+	};
+}
+
+/** Assembles the wire {@link ImportResult} from each entity importer's outcome. */
+export function buildImportResult(input: {
+	package: ImportPackageSummary;
+	projectId: string | null;
+	workflows: WorkflowImportOutcome[];
+	folders: ImportedFolderSummary[];
+	projects: ImportedProjectSummary[];
+	bindings: PackageImportBindings;
+	credentials?: ImportCredentialSummary;
+}): ImportResult {
+	return {
+		package: input.package,
+		workflows: input.workflows.map(({ workflow, sourceWorkflowId, status, publishing }) => ({
+			sourceWorkflowId,
+			localId: workflow.id,
+			name: workflow.name,
+			projectId: input.projectId ?? '',
+			parentFolderId: workflow.parentFolder?.id ?? null,
+			activeVersionId: workflow.activeVersionId ?? null,
+			publishing,
+			status,
+		})),
+		folders: input.folders,
+		projects: input.projects,
+		bindings: serializeBindings(input.bindings),
+		credentials: input.credentials ?? { matched: [], stubbed: [] },
+	};
+}
+
+/**
+ * Asserts the caller's API key carries the scopes the package's contents require (public API only).
+ * Internal callers omit `apiKeyScopes` and are authorized by user RBAC alone.
+ */
+export function assertPackageImportApiKeyScopes(
+	apiKeyScopes: string[] | undefined,
+	required: string[],
+): void {
+	if (apiKeyScopes === undefined) return;
+	for (const scope of required) {
+		if (!apiKeyScopes.includes(scope)) {
+			throw new ForbiddenError('Forbidden');
+		}
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -6,11 +6,16 @@ import { ZodError } from 'zod';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
+import { topLevelFolders, topLevelWorkflows } from './package-layout';
+import type { PreparedFolder } from '../entities/folder/folder-import.types';
+import type { PreparedProject } from '../entities/project/project-import.types';
 import type { PreparedWorkflow } from '../entities/workflow/workflow-import.types';
 import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
 import type { PackageReader } from '../io/package-reader';
 import type { ManifestEntry, PackageManifest } from '../spec/manifest.schema';
 import { packageManifestSchema } from '../spec/manifest.schema';
+import { serializedFolderSchema } from '../spec/serialized/folder.schema';
+import { serializedProjectSchema } from '../spec/serialized/project.schema';
 import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
 
 /**
@@ -34,14 +39,41 @@ export class N8nPackageParser {
 		}
 	}
 
+	/**
+	 * Reads the package's top-level workflows. Workflows nested inside a folder or
+	 * project are deliberately skipped here — placing them into their recreated
+	 * folder is a follow-up concern; a plain workflow package is unaffected.
+	 */
 	async getWorkflows(reader: PackageReader): Promise<PreparedWorkflow[]> {
 		const manifest = await this.getManifest(reader);
 
 		const workflows: PreparedWorkflow[] = [];
-		for (const entry of manifest.workflows ?? []) {
+		for (const entry of topLevelWorkflows(manifest.workflows)) {
 			workflows.push(await this.readWorkflow(reader, entry));
 		}
 		return workflows;
+	}
+
+	/** Reads the package's top-level folder shells (project-nested folders are skipped). */
+	async getFolders(reader: PackageReader): Promise<PreparedFolder[]> {
+		const manifest = await this.getManifest(reader);
+
+		const folders: PreparedFolder[] = [];
+		for (const entry of topLevelFolders(manifest.folders)) {
+			folders.push(await this.readFolder(reader, entry));
+		}
+		return folders;
+	}
+
+	/** Reads the package's project shells. */
+	async getProjects(reader: PackageReader): Promise<PreparedProject[]> {
+		const manifest = await this.getManifest(reader);
+
+		const projects: PreparedProject[] = [];
+		for (const entry of manifest.projects ?? []) {
+			projects.push(await this.readProject(reader, entry));
+		}
+		return projects;
 	}
 
 	private async readWorkflow(
@@ -49,19 +81,7 @@ export class N8nPackageParser {
 		entry: ManifestEntry,
 	): Promise<PreparedWorkflow> {
 		const path = `${entry.target}/workflow.json`;
-
-		let content: Buffer;
-		try {
-			content = await reader.readFile(path);
-		} catch (cause) {
-			throw new UserError(`Package manifest references a missing workflow file at ${path}.`, {
-				cause,
-			});
-		}
-
-		const wire = jsonParse<SerializedWorkflow>(content.toString('utf-8'), {
-			errorMessage: `Package workflow file at ${path} is not valid JSON.`,
-		});
+		const wire = await this.readJson<SerializedWorkflow>(reader, path, 'workflow');
 
 		let entity: WorkflowEntity;
 		try {
@@ -79,5 +99,63 @@ export class N8nPackageParser {
 		WorkflowHelpers.validateWorkflowStructure(entity);
 
 		return { entity, sourceWorkflowId: entry.id, sourcePublished: wire.isPublished };
+	}
+
+	private async readFolder(reader: PackageReader, entry: ManifestEntry): Promise<PreparedFolder> {
+		const path = `${entry.target}/folder.json`;
+		const wire = await this.readJson(reader, path, 'folder');
+
+		try {
+			const folder = serializedFolderSchema.parse(wire);
+			return {
+				sourceFolderId: folder.id,
+				name: folder.name,
+				parentFolderId: folder.parentFolderId,
+			};
+		} catch (cause) {
+			if (cause instanceof ZodError) {
+				throw new UserError(`Package folder file at ${path} failed schema validation.`, { cause });
+			}
+			throw cause;
+		}
+	}
+
+	private async readProject(reader: PackageReader, entry: ManifestEntry): Promise<PreparedProject> {
+		const path = `${entry.target}/project.json`;
+		const wire = await this.readJson(reader, path, 'project');
+
+		try {
+			const project = serializedProjectSchema.parse(wire);
+			return {
+				sourceProjectId: project.id,
+				name: project.name,
+				...(project.description !== undefined ? { description: project.description } : {}),
+				...(project.icon !== undefined ? { icon: project.icon } : {}),
+			};
+		} catch (cause) {
+			if (cause instanceof ZodError) {
+				throw new UserError(`Package project file at ${path} failed schema validation.`, { cause });
+			}
+			throw cause;
+		}
+	}
+
+	private async readJson<T = unknown>(
+		reader: PackageReader,
+		path: string,
+		label: string,
+	): Promise<T> {
+		let content: Buffer;
+		try {
+			content = await reader.readFile(path);
+		} catch (cause) {
+			throw new UserError(`Package manifest references a missing ${label} file at ${path}.`, {
+				cause,
+			});
+		}
+
+		return jsonParse<T>(content.toString('utf-8'), {
+			errorMessage: `Package ${label} file at ${path} is not valid JSON.`,
+		});
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
@@ -1,0 +1,35 @@
+import type { ManifestEntry } from '../spec/manifest.schema';
+
+/**
+ * Top-level package directories. An entry's `target` path begins with one of
+ * these, or is nested beneath a folder/project scope.
+ */
+export const PACKAGE_TOP_LEVEL_DIRS = {
+	workflows: 'workflows',
+	folders: 'folders',
+	projects: 'projects',
+} as const;
+
+type TopLevelDir = (typeof PACKAGE_TOP_LEVEL_DIRS)[keyof typeof PACKAGE_TOP_LEVEL_DIRS];
+
+/**
+ * True when an entry sits at the package top level under `dir` rather than nested
+ * inside a folder or project. The export writes the `folders/`/`workflows/`/`projects/`
+ * segment once per scope, so a top-level entry's target begins with `${dir}/` while a
+ * project-nested entry begins with `projects/…` (e.g. `projects/x/folders/a`,
+ * `projects/x/workflows/wf`) and a folder-nested workflow begins with `folders/…`
+ * (e.g. `folders/a/workflows/wf`).
+ */
+export function isTopLevelTarget(target: string, dir: TopLevelDir): boolean {
+	return target.startsWith(`${dir}/`);
+}
+
+/** Manifest folder entries at the package top level (`folders/…`), excluding project-nested ones. */
+export function topLevelFolders(entries: ManifestEntry[] | undefined): ManifestEntry[] {
+	return (entries ?? []).filter((entry) => isTopLevelTarget(entry.target, 'folders'));
+}
+
+/** Manifest workflow entries at the package top level (`workflows/…`), excluding folder/project-nested ones. */
+export function topLevelWorkflows(entries: ManifestEntry[] | undefined): ManifestEntry[] {
+	return (entries ?? []).filter((entry) => isTopLevelTarget(entry.target, 'workflows'));
+}

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -1,0 +1,45 @@
+import { Service } from '@n8n/di';
+
+import { ProjectImporter } from '../entities/project/project-importer';
+import { createBindings } from '../n8n-packages.types';
+import type { ImportPackageRequest, ImportResult } from '../n8n-packages.types';
+import type { PackageReader } from '../io/package-reader';
+import type { PackageManifest } from '../spec/manifest.schema';
+import {
+	assertPackageImportApiKeyScopes,
+	buildImportResult,
+	toPackageSummary,
+} from './import-result';
+import { N8nPackageParser } from './n8n-package-parser';
+
+/**
+ * Imports a package containing projects into the target instance.
+ **/
+@Service()
+export class ProjectPackageImporter {
+	constructor(
+		private readonly packageParser: N8nPackageParser,
+		private readonly projectImporter: ProjectImporter,
+	) {}
+
+	async import(
+		request: ImportPackageRequest,
+		reader: PackageReader,
+		manifest: PackageManifest,
+	): Promise<ImportResult> {
+		assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create']);
+
+		const projects = await this.packageParser.getProjects(reader);
+		const plan = await this.projectImporter.plan(request.user, projects);
+		const projectSummaries = await this.projectImporter.apply(request.user, plan);
+
+		return buildImportResult({
+			package: toPackageSummary(manifest),
+			projectId: null,
+			workflows: [],
+			folders: [],
+			projects: projectSummaries,
+			bindings: createBindings(),
+		});
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/engine/scoped-entity-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/scoped-entity-importer.ts
@@ -1,0 +1,153 @@
+import { Service } from '@n8n/di';
+
+import { CredentialImporter } from '../entities/credential/credential-importer';
+import { workflowsBlockedFromPublish } from '../entities/credential/credential-missing-mode';
+import type {
+	CredentialBindingRequest,
+	CredentialResolution,
+} from '../entities/credential/credential.types';
+import { FolderImporter } from '../entities/folder/folder-importer';
+import type { FolderImportPlan, PreparedFolder } from '../entities/folder/folder-import.types';
+import type {
+	PreparedWorkflow,
+	WorkflowImportOutcome,
+	WorkflowImportPlan,
+} from '../entities/workflow/workflow-import.types';
+import { WorkflowImporter } from '../entities/workflow/workflow-importer';
+import { WorkflowPublisher } from '../entities/workflow/workflow-publisher';
+import { createBindings } from '../n8n-packages.types';
+import type {
+	BlockingIssue,
+	ImportContext,
+	ImportedFolderSummary,
+	ImportFolderProperties,
+	ImportWorkflowProperties,
+	PackageImportBindings,
+} from '../n8n-packages.types';
+import { toImportBlockedError } from './import-blocked.error';
+
+export interface ScopedImportInput {
+	context: ImportContext;
+	folders: PreparedFolder[];
+	workflows: PreparedWorkflow[];
+	credentialRequest: CredentialBindingRequest;
+	options: ImportWorkflowProperties & ImportFolderProperties;
+}
+
+export interface ScopedImportResult {
+	workflowOutcomes: WorkflowImportOutcome[];
+	folderSummaries: ImportedFolderSummary[];
+	bindings: PackageImportBindings;
+	credentialResult: Awaited<ReturnType<CredentialImporter['apply']>>;
+}
+
+/**
+ * Imports a set of folders, workflows, and credentials into a single project scope
+ */
+@Service()
+export class ScopedEntityImporter {
+	constructor(
+		private readonly credentialImporter: CredentialImporter,
+		private readonly folderImporter: FolderImporter,
+		private readonly workflowImporter: WorkflowImporter,
+		private readonly workflowPublisher: WorkflowPublisher,
+	) {}
+
+	async import(input: ScopedImportInput): Promise<ScopedImportResult> {
+		const { context, folders, workflows, credentialRequest, options } = input;
+
+		// PublishAll requires publish scope up front; other policies are checked per workflow.
+		await this.workflowPublisher.assertCanPublish(
+			context.user,
+			context.projectId,
+			options.workflowPublishingPolicy,
+		);
+
+		const credentialPlan = await this.credentialImporter.plan(context, credentialRequest);
+		const workflowPlan = await this.workflowImporter.plan(context, workflows, options);
+		const folderContext = { ...context, folderConflictPolicy: options.folderConflictPolicy };
+		const folderPlan = await this.folderImporter.plan(folderContext, folders);
+
+		const blockingIssues = this.collectBlockingIssues(
+			workflowPlan,
+			credentialPlan,
+			credentialRequest,
+			folderPlan,
+		);
+		if (blockingIssues.length > 0) {
+			throw toImportBlockedError(blockingIssues);
+		}
+
+		const folderSummaries = await this.folderImporter.apply(folderContext, folderPlan);
+
+		const credentialResult = await this.credentialImporter.apply(
+			context,
+			credentialRequest,
+			credentialPlan,
+		);
+		const publishBlockedSourceWorkflowIds = workflowsBlockedFromPublish(
+			credentialRequest.requirements,
+			new Set(credentialResult.stubbed),
+		);
+
+		const { outcomes, bindings } = await this.workflowImporter.apply(
+			{
+				...context,
+				publishingPolicy: options.workflowPublishingPolicy,
+				publishBlockedSourceWorkflowIds,
+			},
+			workflowPlan,
+			createBindings({ credentials: credentialResult.bindings }),
+		);
+
+		return {
+			workflowOutcomes: outcomes,
+			folderSummaries,
+			bindings,
+			credentialResult,
+		};
+	}
+
+	/** Folds every subsystem's blocking conditions into one uniformly-typed list. */
+	private collectBlockingIssues(
+		workflowPlan: WorkflowImportPlan,
+		credentialResolution: CredentialResolution,
+		credentialRequest: CredentialBindingRequest,
+		folderPlan: FolderImportPlan,
+	): BlockingIssue[] {
+		const workflowConflicts: BlockingIssue[] = workflowPlan.conflicts.map((conflict) => ({
+			type: 'workflow-conflict',
+			...conflict,
+		}));
+		const workflowIdConflicts: BlockingIssue[] = workflowPlan.idConflicts.map((conflict) => ({
+			type: 'workflow-id-conflict',
+			...conflict,
+		}));
+		const workflowFolderConflicts: BlockingIssue[] = workflowPlan.folderConflicts.map(
+			(conflict) => ({ type: 'workflow-folder-conflict', ...conflict }),
+		);
+		const folderConflicts: BlockingIssue[] = folderPlan.conflicts.map((conflict) => ({
+			type: 'folder-conflict',
+			...conflict,
+		}));
+		const credentialFailures: BlockingIssue[] = this.credentialImporter
+			.blockingFailures(credentialRequest, credentialResolution)
+			.map(({ kind, sourceId, targetId, expectedType, actualType, usedByWorkflows }) => ({
+				type: 'credential-unresolved',
+				kind,
+				sourceId,
+				...(targetId ? { targetId } : {}),
+				...(expectedType ? { expectedType } : {}),
+				...(actualType ? { actualType } : {}),
+				usedByWorkflows,
+			}));
+
+		return [
+			...workflowConflicts,
+			...workflowIdConflicts,
+			...workflowFolderConflicts,
+			...folderConflicts,
+			...credentialFailures,
+		];
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
@@ -1,0 +1,204 @@
+import { LicenseState } from '@n8n/backend-common';
+import type { Project, User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { Scope } from '@n8n/permissions';
+import { UserError } from 'n8n-workflow';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { EventService } from '@/events/event.service';
+import { FolderService } from '@/services/folder.service';
+import { ProjectService } from '@/services/project.service.ee';
+
+import type { CredentialBindingRequest } from '../entities/credential/credential.types';
+import type { WorkflowImportOutcome } from '../entities/workflow/workflow-import.types';
+import type { ImportContext, ImportPackageRequest, ImportResult } from '../n8n-packages.types';
+import type { PackageReader } from '../io/package-reader';
+import type { PackageManifest } from '../spec/manifest.schema';
+import {
+	assertPackageImportApiKeyScopes,
+	buildImportResult,
+	toPackageSummary,
+} from './import-result';
+import { N8nPackageParser } from './n8n-package-parser';
+import { ScopedEntityImporter } from './scoped-entity-importer';
+
+/**
+ * Imports a workflow package — loose top-level workflows, their organizing folder shells, and
+ * their credential dependencies — into a single target project (request `projectId`/`folderId`).
+ * Resolves the target scope, then delegates the plan/gate/apply work to {@link ScopedEntityImporter}.
+ * Entities nested inside a folder or project are not placed here; that is a follow-up.
+ */
+@Service()
+export class WorkflowPackageImporter {
+	constructor(
+		private readonly packageParser: N8nPackageParser,
+		private readonly scopedEntityImporter: ScopedEntityImporter,
+		private readonly projectService: ProjectService,
+		private readonly folderService: FolderService,
+		private readonly eventService: EventService,
+		private readonly licenseState: LicenseState,
+	) {}
+
+	async import(
+		request: ImportPackageRequest,
+		reader: PackageReader,
+		manifest: PackageManifest,
+	): Promise<ImportResult> {
+		const folders = await this.packageParser.getFolders(reader);
+		if (folders.length > 0) {
+			assertPackageImportApiKeyScopes(request.apiKeyScopes, ['folder:create']);
+			this.assertFoldersLicensed();
+		}
+
+		const context = await this.resolveTarget(
+			request.user,
+			request.projectId,
+			request.folderId,
+			folders.length > 0,
+		);
+
+		const workflows = await this.packageParser.getWorkflows(reader);
+		const credentialRequest: CredentialBindingRequest = {
+			requirements: manifest.requirements?.credentials,
+			matchingMode: request.credentialMatchingMode,
+			missingMode: request.credentialMissingMode,
+			credentialBindings: request.credentialBindings,
+		};
+
+		const scoped = await this.scopedEntityImporter.import({
+			context,
+			folders,
+			workflows,
+			credentialRequest,
+			options: request,
+		});
+
+		this.emitImportedEvent(request, context, manifest, scoped, credentialRequest);
+
+		return buildImportResult({
+			package: toPackageSummary(manifest),
+			projectId: context.projectId,
+			workflows: scoped.workflowOutcomes,
+			folders: scoped.folderSummaries,
+			projects: [],
+			bindings: scoped.bindings,
+			credentials: {
+				matched: scoped.credentialResult.matched,
+				stubbed: scoped.credentialResult.stubbed,
+			},
+		});
+	}
+
+	private assertFoldersLicensed(): void {
+		if (!this.licenseState.isLicensed('feat:folders')) {
+			throw new ForbiddenError(
+				'Your license does not allow folders. Importing a package with folders requires a license that supports folders.',
+			);
+		}
+	}
+
+	private emitImportedEvent(
+		request: ImportPackageRequest,
+		context: ImportContext,
+		manifest: PackageManifest,
+		scoped: Awaited<ReturnType<ScopedEntityImporter['import']>>,
+		credentialRequest: CredentialBindingRequest,
+	): void {
+		const { workflowOutcomes, credentialResult } = scoped;
+		const imported = workflowOutcomes.filter(({ status }) => status !== 'skipped');
+		const countByStatus = (status: WorkflowImportOutcome['status']) =>
+			workflowOutcomes.filter((outcome) => outcome.status === status).length;
+
+		this.eventService.emit('n8n-package-imported', {
+			user: context.user,
+			projectId: context.projectId,
+			folderId: context.folderId,
+			workflowIds: imported.map(({ workflow }) => workflow.id),
+			options: {
+				workflowConflictPolicy: request.workflowConflictPolicy,
+				workflowIdPolicy: request.workflowIdPolicy,
+				credentialMatchingMode: request.credentialMatchingMode,
+				credentialMissingMode: request.credentialMissingMode,
+				workflowPublishingPolicy: request.workflowPublishingPolicy,
+			},
+			packageSourceId: manifest.sourceId,
+			packageVersion: manifest.packageFormatVersion,
+			credentialIds: {
+				matched: credentialResult.matched.map(
+					(sourceId) => credentialResult.bindings.get(sourceId)!,
+				),
+				created: credentialResult.stubbed.map(
+					(sourceId) => credentialResult.bindings.get(sourceId)!,
+				),
+				updated: [],
+			},
+			counts: {
+				workflows: {
+					created: countByStatus('created'),
+					updated: countByStatus('updated'),
+					skipped: countByStatus('skipped'),
+				},
+				credentials: {
+					matched: credentialResult.matched.length,
+					created: credentialResult.stubbed.length,
+					requirements: credentialRequest.requirements?.length ?? 0,
+				},
+			},
+		});
+	}
+
+	private async resolveTarget(
+		user: User,
+		projectId: string | undefined,
+		folderId: string | undefined,
+		needsFolderCreate: boolean,
+	): Promise<ImportContext> {
+		const scopes: Scope[] = needsFolderCreate
+			? ['workflow:import', 'folder:create']
+			: ['workflow:import'];
+		const project = await this.resolveImportProject(user, projectId, scopes);
+		await this.assertFolderExistsInProject(folderId, project.id);
+
+		return { user, projectId: project.id, folderId: folderId ?? null };
+	}
+
+	private async resolveImportProject(
+		user: User,
+		projectId: string | undefined,
+		scopes: Scope[],
+	): Promise<Project> {
+		if (projectId === undefined) {
+			const personalProject = await this.projectService.getPersonalProject(user);
+			if (!personalProject) {
+				throw new NotFoundError('Personal project not found');
+			}
+			return personalProject;
+		}
+
+		const project = await this.projectService.getProjectWithScope(user, projectId, scopes);
+		if (project) {
+			return project;
+		}
+
+		if (!(await this.projectService.findProject(projectId))) {
+			throw new NotFoundError(`Project not found: ${projectId}`);
+		}
+		throw new ForbiddenError('You do not have permission to import into this project.');
+	}
+
+	private async assertFolderExistsInProject(
+		folderId: string | undefined,
+		projectId: string,
+	): Promise<void> {
+		if (folderId === undefined) {
+			return;
+		}
+
+		try {
+			await this.folderService.findFolderInProjectOrFail(folderId, projectId);
+		} catch (cause) {
+			throw new UserError(`Folder not found in target project: ${folderId}`, { cause });
+		}
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder-conflict-policy.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/__tests__/folder-conflict-policy.test.ts
@@ -1,0 +1,15 @@
+import { decideMatchedFolderAction } from '../folder-conflict-policy';
+
+describe('decideMatchedFolderAction', () => {
+	it('updates an already-imported folder under new-version, never blocking', () => {
+		expect(decideMatchedFolderAction('new-version')).toEqual({ action: 'update', blocked: false });
+	});
+
+	it('blocks under fail', () => {
+		expect(decideMatchedFolderAction('fail')).toEqual({ action: 'skip', blocked: true });
+	});
+
+	it('leaves the folder unchanged under skip, never blocking', () => {
+		expect(decideMatchedFolderAction('skip')).toEqual({ action: 'skip', blocked: false });
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder-conflict-policy.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder-conflict-policy.ts
@@ -1,0 +1,24 @@
+import type { FolderConflictPolicy } from '../../n8n-packages.types';
+
+/**
+ * A conflict policy's verdict for a folder that already exists in the target project
+ * *at the position the package places it*. Position/ownership mismatches (different
+ * parent, or id owned by another project) are always blocked regardless of policy and
+ * are decided before this runs.
+ */
+export interface MatchedFolderDecision {
+	action: 'update' | 'skip';
+	blocked: boolean;
+}
+
+/* eslint-disable @typescript-eslint/naming-convention -- API folder conflict policy keys */
+const FOLDER_CONFLICT_POLICIES: Record<FolderConflictPolicy, MatchedFolderDecision> = {
+	'new-version': { action: 'update', blocked: false },
+	fail: { action: 'skip', blocked: true },
+	skip: { action: 'skip', blocked: false },
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export function decideMatchedFolderAction(policy: FolderConflictPolicy): MatchedFolderDecision {
+	return FOLDER_CONFLICT_POLICIES[policy];
+}

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder-import.types.ts
@@ -1,0 +1,37 @@
+import type { FolderConflict, FolderConflictPolicy, ImportContext } from '../../n8n-packages.types';
+
+/** A folder shell parsed out of the package, ready to reconcile against the target project. */
+export interface PreparedFolder {
+	sourceFolderId: string;
+	name: string;
+	/**
+	 * Parent folder id relative to the exported set: null when the folder roots the
+	 * exported forest, otherwise another package folder's id (ids are reused on import).
+	 */
+	parentFolderId: string | null;
+}
+
+/** Apply-time context for the folder importer. */
+export interface FolderImportContext extends ImportContext {
+	folderConflictPolicy: FolderConflictPolicy;
+}
+
+export type FolderPlannedAction = 'create' | 'update' | 'skip';
+
+/**
+ * The decided plan for one folder. `create` carries the resolved target parent id
+ * (the folder is written under it); `update`/`skip` operate on the matched folder.
+ */
+export type FolderPlanItem =
+	| { action: 'create'; sourceFolderId: string; name: string; targetParentFolderId: string | null }
+	| { action: 'update'; sourceFolderId: string; name: string }
+	| { action: 'skip'; sourceFolderId: string; name: string };
+
+/**
+ * The planned actions for the package folders plus any conflicts that abort the
+ * import before anything is written. Folders are ordered parent-before-child.
+ */
+export interface FolderImportPlan {
+	items: FolderPlanItem[];
+	conflicts: FolderConflict[];
+}

--- a/packages/cli/src/modules/n8n-packages/entities/folder/folder-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/folder/folder-importer.ts
@@ -1,0 +1,202 @@
+import { Service } from '@n8n/di';
+import { UserError } from 'n8n-workflow';
+
+import { FolderService } from '@/services/folder.service';
+
+import { decideMatchedFolderAction } from './folder-conflict-policy';
+import type {
+	FolderImportContext,
+	FolderImportPlan,
+	FolderPlanItem,
+	PreparedFolder,
+} from './folder-import.types';
+import type { FolderConflict, ImportedFolderSummary } from '../../n8n-packages.types';
+
+/** Target-state of a package folder id that already exists somewhere on the instance. */
+interface ExistingFolder {
+	projectId: string;
+	parentFolderId: string | null;
+	name: string;
+}
+
+/**
+ * Imports the package's folder shells into the target project in two phases:
+ * {@link plan} orders them parent-before-child, matches each against the target and decides
+ * create/update/skip (or records a blocking conflict); {@link apply} writes the plan.
+ *
+ * Folder ids are reused verbatim (no id policy), so a package folder's id is both its
+ * source id and its target id, and a nested folder's `parentFolderId` already names its
+ * in-package parent. Persistence goes through {@link FolderService}, never the repository.
+ */
+@Service()
+export class FolderImporter {
+	constructor(private readonly folderService: FolderService) {}
+
+	async plan(context: FolderImportContext, folders: PreparedFolder[]): Promise<FolderImportPlan> {
+		const ordered = orderParentsFirst(folders);
+		const existing = await this.findExisting(ordered.map(({ sourceFolderId }) => sourceFolderId));
+
+		const items: FolderPlanItem[] = [];
+		const conflicts: FolderConflict[] = [];
+
+		for (const folder of ordered) {
+			// Root-of-forest folders anchor under the request folder (or project root); nested
+			// folders reuse their in-package parent id, which is the same id in the target.
+			const targetParentFolderId =
+				folder.parentFolderId === null ? (context.folderId ?? null) : folder.parentFolderId;
+
+			const match = existing.get(folder.sourceFolderId);
+
+			if (!match) {
+				items.push({
+					action: 'create',
+					sourceFolderId: folder.sourceFolderId,
+					name: folder.name,
+					targetParentFolderId,
+				});
+				continue;
+			}
+
+			if (match.projectId !== context.projectId) {
+				conflicts.push({
+					kind: 'id-in-other-project',
+					sourceFolderId: folder.sourceFolderId,
+					name: folder.name,
+					existingProjectId: match.projectId,
+				});
+				continue;
+			}
+
+			//	If this is different then it's essentially a folder "move" which we don't want.
+			if (match.parentFolderId !== targetParentFolderId) {
+				conflicts.push({
+					kind: 'parent-mismatch',
+					sourceFolderId: folder.sourceFolderId,
+					name: folder.name,
+					existingParentFolderId: match.parentFolderId,
+					expectedParentFolderId: targetParentFolderId,
+				});
+				continue;
+			}
+
+			const decision = decideMatchedFolderAction(context.folderConflictPolicy);
+			if (decision.blocked) {
+				conflicts.push({
+					kind: 'fail-policy',
+					sourceFolderId: folder.sourceFolderId,
+					name: folder.name,
+				});
+				continue;
+			}
+
+			items.push({
+				action: decision.action,
+				sourceFolderId: folder.sourceFolderId,
+				name: folder.name,
+			});
+		}
+
+		return { items, conflicts };
+	}
+
+	/**
+	 * Writes the plan folder-by-folder through {@link FolderService}. Ordering is parent-first
+	 * (from {@link plan}), so a nested folder's parent already exists when it is created. Conflicts
+	 * are gated in {@link plan}, so nothing is written when the import is blocked.
+	 */
+	async apply(
+		context: FolderImportContext,
+		plan: FolderImportPlan,
+	): Promise<ImportedFolderSummary[]> {
+		const summaries: ImportedFolderSummary[] = [];
+
+		for (const item of plan.items) {
+			if (item.action === 'skip') {
+				summaries.push(toSummary(item, null, 'skipped'));
+				continue;
+			}
+
+			if (item.action === 'update') {
+				await this.folderService.updateFolder(item.sourceFolderId, context.projectId, {
+					name: item.name,
+				});
+				summaries.push(toSummary(item, null, 'updated'));
+				continue;
+			}
+
+			await this.folderService.createFolder(
+				{ name: item.name, parentFolderId: item.targetParentFolderId ?? undefined },
+				context.projectId,
+				item.sourceFolderId,
+			);
+			summaries.push(toSummary(item, item.targetParentFolderId, 'created'));
+		}
+
+		return summaries;
+	}
+
+	private async findExisting(folderIds: string[]): Promise<Map<string, ExistingFolder>> {
+		const folders = await this.folderService.getFoldersByIds(folderIds);
+		return new Map(
+			folders.map((folder) => [
+				folder.id,
+				{
+					projectId: folder.homeProject.id,
+					parentFolderId: folder.parentFolderId,
+					name: folder.name,
+				},
+			]),
+		);
+	}
+}
+
+function toSummary(
+	item: FolderPlanItem,
+	parentFolderId: string | null,
+	status: ImportedFolderSummary['status'],
+): ImportedFolderSummary {
+	return {
+		sourceFolderId: item.sourceFolderId,
+		localId: item.sourceFolderId,
+		name: item.name,
+		parentFolderId,
+		status,
+	};
+}
+
+/**
+ * Orders folders so every parent precedes its children (the parent must exist before a child
+ * references it). A `parentFolderId` that names no in-package folder, or a cycle, is a malformed package.
+ */
+function orderParentsFirst(folders: PreparedFolder[]): PreparedFolder[] {
+	const byId = new Map(folders.map((folder) => [folder.sourceFolderId, folder]));
+	const ordered: PreparedFolder[] = [];
+	const visited = new Set<string>();
+	const onStack = new Set<string>();
+
+	const visit = (folder: PreparedFolder): void => {
+		if (visited.has(folder.sourceFolderId)) return;
+		if (onStack.has(folder.sourceFolderId)) {
+			throw new UserError('Package folder hierarchy contains a cycle.');
+		}
+		onStack.add(folder.sourceFolderId);
+
+		const parentId = folder.parentFolderId;
+		if (parentId !== null) {
+			const parent = byId.get(parentId);
+			if (!parent) {
+				throw new UserError(
+					`Package folder "${folder.name}" references a parent folder that is not in the package.`,
+				);
+			}
+			visit(parent);
+		}
+
+		onStack.delete(folder.sourceFolderId);
+		visited.add(folder.sourceFolderId);
+		ordered.push(folder);
+	};
+
+	for (const folder of folders) visit(folder);
+	return ordered;
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
@@ -1,0 +1,20 @@
+import type { SerializedProject } from '../../spec/serialized/project.schema';
+
+/** A project shell parsed out of the package, ready to reconcile against the instance. */
+export interface PreparedProject {
+	sourceProjectId: string;
+	name: string;
+	description?: string;
+	icon?: SerializedProject['icon'];
+}
+
+export type ProjectPlannedAction = 'create' | 'update';
+
+/** The decided action for one package project (matched by id). */
+export interface ProjectPlanItem {
+	action: ProjectPlannedAction;
+	sourceProjectId: string;
+	name: string;
+	description?: string;
+	icon?: SerializedProject['icon'];
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
@@ -1,0 +1,112 @@
+import { LicenseState } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { ProjectService } from '@/services/project.service.ee';
+
+import type { PreparedProject, ProjectPlanItem } from './project-import.types';
+import type { ImportedProjectSummary } from '../../n8n-packages.types';
+
+/**
+ * Imports the package's project shells. Project ids are reused verbatim (no id policy),
+ * so a package project matched by id in the target instance is updated in place; otherwise
+ * a fresh team project is created with the importing user as its sole admin.
+ *
+ * {@link plan} resolves each project's action and enforces authorization up front (so apply
+ * cannot fail a permission check partway through); {@link apply} writes the decided plan.
+ */
+@Service()
+export class ProjectImporter {
+	constructor(
+		private readonly projectService: ProjectService,
+		private readonly licenseState: LicenseState,
+	) {}
+
+	async plan(user: User, projects: PreparedProject[]): Promise<ProjectPlanItem[]> {
+		const items: ProjectPlanItem[] = [];
+
+		for (const project of projects) {
+			const existing = await this.projectService.findProject(project.sourceProjectId);
+
+			if (existing) {
+				// Never import over a personal project — matching by id must not clobber unrelated data.
+				if (existing.type !== 'team') {
+					throw new ForbiddenError(
+						`Cannot import project "${project.name}": its id belongs to a non-team project on this instance.`,
+					);
+				}
+				const authorized = await this.projectService.getProjectWithScope(user, existing.id, [
+					'project:update',
+				]);
+				if (!authorized) {
+					throw new ForbiddenError(
+						`You do not have permission to update the existing project "${project.name}".`,
+					);
+				}
+				items.push({ action: 'update', ...toFields(project) });
+			} else {
+				this.assertCanCreateProjects(user);
+				items.push({ action: 'create', ...toFields(project) });
+			}
+		}
+
+		return items;
+	}
+
+	async apply(user: User, items: ProjectPlanItem[]): Promise<ImportedProjectSummary[]> {
+		const summaries: ImportedProjectSummary[] = [];
+
+		for (const item of items) {
+			if (item.action === 'create') {
+				// createTeamProject enforces the team-project quota and links the importer as admin.
+				const project = await this.projectService.createTeamProject(
+					user,
+					{ name: item.name, icon: item.icon },
+					{ id: item.sourceProjectId, description: item.description ?? null },
+				);
+				summaries.push({
+					sourceProjectId: item.sourceProjectId,
+					localId: project.id,
+					name: project.name,
+					status: 'created',
+				});
+			} else {
+				await this.projectService.updateProject(item.sourceProjectId, {
+					name: item.name,
+					icon: item.icon,
+					description: item.description,
+				});
+				summaries.push({
+					sourceProjectId: item.sourceProjectId,
+					localId: item.sourceProjectId,
+					name: item.name,
+					status: 'updated',
+				});
+			}
+		}
+
+		return summaries;
+	}
+
+	private assertCanCreateProjects(user: User): void {
+		if (!hasGlobalScope(user, 'project:create')) {
+			throw new ForbiddenError('You do not have permission to create projects.');
+		}
+		if (!this.licenseState.isLicensed('feat:projectRole:admin')) {
+			throw new ForbiddenError(
+				'Your license does not allow creating team projects. Project import requires a license that supports team projects.',
+			);
+		}
+	}
+}
+
+function toFields(project: PreparedProject): Omit<ProjectPlanItem, 'action'> {
+	return {
+		sourceProjectId: project.sourceProjectId,
+		name: project.name,
+		...(project.description !== undefined ? { description: project.description } : {}),
+		...(project.icon !== undefined ? { icon: project.icon } : {}),
+	};
+}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -28,12 +28,23 @@ export const WorkflowIdPolicy = {
 	/** Reuses the package's own workflow id in the target instance. */
 	Source: 'source',
 } as const;
+
+export const FolderConflictPolicy = {
+	/** Updates an already-imported folder (matched by id) in place; otherwise creates it. */
+	NewVersion: 'new-version',
+	/** Fails the import if any package folder already exists in the target project. */
+	Fail: 'fail',
+	/** Leaves an already-imported folder unchanged; creates the rest of the package folders. */
+	Skip: 'skip',
+} as const;
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export type WorkflowConflictPolicy =
 	(typeof WorkflowConflictPolicy)[keyof typeof WorkflowConflictPolicy];
 
 export type WorkflowIdPolicy = (typeof WorkflowIdPolicy)[keyof typeof WorkflowIdPolicy];
+
+export type FolderConflictPolicy = (typeof FolderConflictPolicy)[keyof typeof FolderConflictPolicy];
 
 export interface ExportPackageRequest {
 	user: User;
@@ -47,8 +58,15 @@ export type ImportPackageRequest = {
 	projectId?: string;
 	folderId?: string;
 	packageBuffer: Buffer;
+	/**
+	 * API-key scopes of the caller (public API only). When present, the pipeline asserts the key
+	 * carries the scopes the package's contents require (e.g. `folder:create`, `project:create`),
+	 * mirroring export. Absent for internal callers, which are authorized by user RBAC alone.
+	 */
+	apiKeyScopes?: string[];
 } & ImportCredentialProperties &
-	ImportWorkflowProperties;
+	ImportWorkflowProperties &
+	ImportFolderProperties;
 
 export type ImportCredentialProperties = {
 	credentialMatchingMode: CredentialMatchingMode;
@@ -60,6 +78,10 @@ export type ImportWorkflowProperties = {
 	workflowConflictPolicy: WorkflowConflictPolicy;
 	workflowPublishingPolicy: WorkflowPublishingPolicy;
 	workflowIdPolicy: WorkflowIdPolicy;
+};
+
+export type ImportFolderProperties = {
+	folderConflictPolicy: FolderConflictPolicy;
 };
 
 /**
@@ -120,6 +142,23 @@ export interface ImportedWorkflowSummary {
 	status: 'created' | 'updated' | 'skipped';
 }
 
+export interface ImportedFolderSummary {
+	sourceFolderId: string;
+	/** Local id of the imported folder; equal to `sourceFolderId` since folder ids are reused. */
+	localId: string;
+	name: string;
+	parentFolderId: string | null;
+	status: 'created' | 'updated' | 'skipped';
+}
+
+export interface ImportedProjectSummary {
+	sourceProjectId: string;
+	/** Local id of the imported project; equal to `sourceProjectId` since project ids are reused. */
+	localId: string;
+	name: string;
+	status: 'created' | 'updated';
+}
+
 /**
  * A reason the import cannot proceed, produced by some policy from any subsystem.
  * Discriminated by `type` so new gates add a variant rather than a new throw site.
@@ -158,7 +197,28 @@ export type BlockingIssue =
 			/** For `type_mismatch`: the actual type of the resolved target credential. */
 			actualType?: string;
 			usedByWorkflows: string[];
-	  };
+	  }
+	| ({ type: 'folder-conflict' } & FolderConflict);
+
+/**
+ * A package folder that cannot be imported as-is. `kind` distinguishes the cause:
+ * - `parent-mismatch`: an already-imported folder (matched by id in the target project) sits under a
+ *   different parent than the package places it — re-importing would move it, so the import is blocked.
+ * - `id-in-other-project`: the folder id already exists in a *different* project on the instance
+ *   (folder ids are a global primary key), so it cannot be reused here.
+ * - `fail-policy`: the folder already exists and `folderConflictPolicy` is `fail`.
+ */
+export interface FolderConflict {
+	kind: 'parent-mismatch' | 'id-in-other-project' | 'fail-policy';
+	sourceFolderId: string;
+	name: string;
+	/** The matched folder's current parent in the target (for `parent-mismatch`). */
+	existingParentFolderId?: string | null;
+	/** The parent the package would place the folder under (for `parent-mismatch`). */
+	expectedParentFolderId?: string | null;
+	/** The project that already owns the id (for `id-in-other-project`). */
+	existingProjectId?: string | null;
+}
 
 /** Source id → target id mapping for one entity type within an imported package. */
 export type ImportBindingMap = Map<string, string>;
@@ -202,10 +262,12 @@ export interface ImportCredentialSummary {
 	stubbed: string[];
 }
 
-/** Result of an import: the workflows written to the database. */
+/** Result of an import: the entities written to the database. */
 export interface ImportResult {
 	package: ImportPackageSummary;
 	workflows: ImportedWorkflowSummary[];
+	folders: ImportedFolderSummary[];
+	projects: ImportedProjectSummary[];
 	bindings: SerializedBindings;
 	credentials: ImportCredentialSummary;
 }

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -122,6 +122,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 
 			const result = await Container.get(N8nPackagesService).importPackage({
 				user: req.user,
+				apiKeyScopes: req.tokenGrant?.apiKeyScopes,
 				projectId: payload.data.projectId,
 				folderId: payload.data.folderId,
 				credentialMatchingMode: payload.data.credentialMatchingMode,
@@ -130,6 +131,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 				workflowConflictPolicy: payload.data.workflowConflictPolicy,
 				workflowPublishingPolicy: payload.data.workflowPublishingPolicy,
 				workflowIdPolicy: payload.data.workflowIdPolicy,
+				folderConflictPolicy: payload.data.folderConflictPolicy,
 				packageBuffer: packageFile.buffer,
 			});
 			return res.status(200).json(result);

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -119,6 +119,21 @@ post:
                 `publish-all` publishes every imported workflow.
                 `unpublish-all` leaves new workflows inactive and unpublishes
                 updated workflows that were published.
+            folderConflictPolicy:
+              type: string
+              enum:
+                - new-version
+                - fail
+                - skip
+              default: new-version
+              description: >
+                Controls what happens when a package folder (matched by id in the
+                target project) already exists at the same position. `new-version`
+                (default) updates it in place, `fail` rejects the import, and `skip`
+                leaves it unchanged. A folder whose id exists under a different parent,
+                or belongs to another project, always blocks the import. Requires the
+                `folder:create` scope and a license that supports folders when the
+                package contains folders.
   responses:
     '200':
       description: Import succeeded; the listed workflows were written to the target project.
@@ -129,6 +144,8 @@ post:
             required:
               - package
               - workflows
+              - folders
+              - projects
               - bindings
               - credentials
             properties:
@@ -233,6 +250,64 @@ post:
                         - updated
                         - skipped
                       description: Import outcome for this package workflow.
+              folders:
+                type: array
+                description: Folder shells created, updated, or skipped in the target project.
+                items:
+                  type: object
+                  required:
+                    - sourceFolderId
+                    - localId
+                    - name
+                    - parentFolderId
+                    - status
+                  properties:
+                    sourceFolderId:
+                      type: string
+                      description: Folder id as it appeared in the package.
+                    localId:
+                      type: string
+                      description: Folder id on the target instance (equal to `sourceFolderId`; folder ids are reused).
+                    name:
+                      type: string
+                    parentFolderId:
+                      type: string
+                      nullable: true
+                      description: Resolved parent folder on the target, or `null` at the project root.
+                    status:
+                      type: string
+                      enum:
+                        - created
+                        - updated
+                        - skipped
+                      description: Import outcome for this package folder.
+              projects:
+                type: array
+                description: >
+                  Project shells created or matched-and-updated. Present for project
+                  packages; empty when importing loose workflows/folders.
+                items:
+                  type: object
+                  required:
+                    - sourceProjectId
+                    - localId
+                    - name
+                    - status
+                  properties:
+                    sourceProjectId:
+                      type: string
+                      description: Project id as it appeared in the package.
+                    localId:
+                      type: string
+                      description: Project id on the target instance (equal to `sourceProjectId`; project ids are reused).
+                    name:
+                      type: string
+                    status:
+                      type: string
+                      enum:
+                        - created
+                        - updated
+                      description: Import outcome for this package project.
               credentials:
                 type: object
                 description: >
@@ -280,8 +355,9 @@ post:
                       type: string
     '409':
       description: >
-        Import blocked, with at least one workflow source-id conflict among the
-        issues.
+        Import blocked by at least one conflict among the issues — a workflow
+        source-id conflict or a folder conflict (id under a different parent, id
+        owned by another project, or a `fail`-policy match).
       content:
         application/json:
           schema:

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
@@ -86,6 +86,45 @@ oneOf:
       name:
         type: string
   - type: object
+    description: >
+      A package folder that cannot be imported as-is. `kind` distinguishes the cause:
+      `parent-mismatch` (a folder matched by id sits under a different parent than the
+      package places it), `id-in-other-project` (the folder id already exists in a
+      different project — ids are globally unique), or `fail-policy` (the folder already
+      exists and `folderConflictPolicy` is `fail`).
+    required:
+      - type
+      - kind
+      - sourceFolderId
+      - name
+    properties:
+      type:
+        type: string
+        enum:
+          - folder-conflict
+      kind:
+        type: string
+        enum:
+          - parent-mismatch
+          - id-in-other-project
+          - fail-policy
+      sourceFolderId:
+        type: string
+      name:
+        type: string
+      existingParentFolderId:
+        type: string
+        nullable: true
+        description: "For `parent-mismatch`: the matched folder's current parent in the target."
+      expectedParentFolderId:
+        type: string
+        nullable: true
+        description: 'For `parent-mismatch`: the parent the package would place the folder under.'
+      existingProjectId:
+        type: string
+        nullable: true
+        description: 'For `id-in-other-project`: the project that already owns the id.'
+  - type: object
     description: A credential reference that could not be resolved in the target project.
     required:
       - type

--- a/packages/cli/src/services/folder.service.ts
+++ b/packages/cli/src/services/folder.service.ts
@@ -7,7 +7,7 @@ import type {
 import { Folder, FolderTagMappingRepository, FolderRepository, WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import type { EntityManager } from '@n8n/typeorm';
+import { In, type EntityManager } from '@n8n/typeorm';
 import { UserError, PROJECT_ROOT } from 'n8n-workflow';
 
 import { FolderNotFoundError } from '@/errors/folder-not-found.error';
@@ -38,13 +38,16 @@ export class FolderService {
 		private readonly eventService: EventService,
 	) {}
 
-	async createFolder({ parentFolderId, name }: CreateFolderDto, projectId: string) {
+	async createFolder({ parentFolderId, name }: CreateFolderDto, projectId: string, id?: string) {
 		let parentFolder = null;
 		if (parentFolderId) {
 			parentFolder = await this.findFolderInProjectOrFail(parentFolderId, projectId);
 		}
 
 		const folderEntity = this.folderRepository.create({
+			// A preset id lets callers reuse an id from another instance (e.g. package import);
+			// `@BeforeInsert` only mints an id when one isn't already set.
+			...(id ? { id } : {}),
 			name,
 			homeProject: { id: projectId },
 			parentFolder,
@@ -53,6 +56,15 @@ export class FolderService {
 		const { homeProject, ...folder } = await this.folderRepository.save(folderEntity);
 
 		return folder;
+	}
+
+	/** Fetches folders by id across all projects, with their home project loaded. */
+	async getFoldersByIds(folderIds: string[]): Promise<Folder[]> {
+		if (folderIds.length === 0) return [];
+		return await this.folderRepository.find({
+			where: { id: In(folderIds) },
+			relations: { homeProject: true },
+		});
 	}
 
 	async updateFolder(

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -64,6 +64,13 @@ class ProjectNotFoundError extends NotFoundError {
 	}
 }
 
+/** Identity fields a caller can set on a new team project beyond {@link CreateProjectDto}. */
+export interface ProjectCreateOverrides {
+	/** Reuse a specific id instead of minting one (e.g. importing a project by its source id). */
+	id?: string;
+	description?: string | null;
+}
+
 @Service()
 export class ProjectService {
 	constructor(
@@ -351,6 +358,7 @@ export class ProjectService {
 		adminUser: User,
 		data: CreateProjectDto,
 		trx: EntityManager,
+		overrides: ProjectCreateOverrides = {},
 	) {
 		const limit = this.licenseState.getMaxTeamProjects();
 		if (limit !== UNLIMITED_LICENSE_QUOTA) {
@@ -362,7 +370,12 @@ export class ProjectService {
 
 		const project = await trx.save(
 			Project,
-			this.projectRepository.create({ ...data, type: 'team', creatorId: adminUser.id }),
+			this.projectRepository.create({
+				...data,
+				...overrides,
+				type: 'team',
+				creatorId: adminUser.id,
+			}),
 		);
 
 		// Link admin
@@ -371,11 +384,20 @@ export class ProjectService {
 		return project;
 	}
 
-	async createTeamProject(adminUser: User, data: CreateProjectDto): Promise<Project> {
+	/**
+	 * Creates a team project owned by `adminUser`. `overrides` lets callers that
+	 * carry their own identity — the package importer reuses a source project id and
+	 * restores its description — set fields outside {@link CreateProjectDto}.
+	 */
+	async createTeamProject(
+		adminUser: User,
+		data: CreateProjectDto,
+		overrides: ProjectCreateOverrides = {},
+	): Promise<Project> {
 		// This needs to be SERIALIZABLE otherwise the count would not block a
 		// concurrent transaction and we could insert multiple projects.
 		return await this.projectRepository.manager.transaction('SERIALIZABLE', async (trx) => {
-			return await this.createTeamProjectWithEntityManager(adminUser, data, trx);
+			return await this.createTeamProjectWithEntityManager(adminUser, data, trx, overrides);
 		});
 	}
 
@@ -765,6 +787,11 @@ export class ProjectService {
 				id: projectId,
 			},
 		});
+	}
+
+	/** Finds a project by id, or `null` when it does not exist. */
+	async findProject(projectId: string): Promise<Project | null> {
+		return await this.projectRepository.findOne({ where: { id: projectId } });
 	}
 
 	async getProjectRelations(projectId: string): Promise<ProjectRelation[]> {

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -146,6 +146,8 @@ describe('POST /n8n-packages/import', () => {
 					status: 'created',
 				},
 			],
+			folders: [],
+			projects: [],
 			bindings: {
 				workflows: { 'wf-http-source': expect.any(String) },
 				credentials: {},


### PR DESCRIPTION
## Summary

Import counterpart to the package **export** work — stacked on #33531 (base is the export branch;
retarget to `master` once that merges). Reads back the `folders[]` and `projects[]` the exporter
already emits and creates **empty shells** on import:

- **Folder shells** (LIGO-722) into the target project, with a new `folderConflictPolicy`
  (`new-version` | `fail` | `skip`), a tree-position guard (a matched folder under a different
  parent is blocked rather than moved), a cross-project id-collision guard, and a new
  `folder-conflict` blocking issue (HTTP 409).
- **Project shells** (LIGO-741) created — or matched by their reused source id and updated in
  place — owned by the importing user.

The import pipeline is now a thin **dispatcher** over two package shapes — a *project package* vs a
*workflow package* (loose workflows + their folders + credential deps) — sharing a
`ScopedEntityImporter` core (plan → gate → apply into one project scope). Importers go through
domain services, never repositories.

`folderConflictPolicy` and the new `folders[]` / `projects[]` result arrays are threaded through the
DTO, the public API + OpenAPI spec, and the CLI.

> **Scope note:** this is the "empty shells" half. Workflows/folders nested *inside* a project, and
> workflows nested inside a folder, are intentionally ignored here — a fast-follow (LIGO-723 +
> LIGO-742) routes them, reusing the `ScopedEntityImporter` core per project.

## How to test

`POST /api/v1/n8n-packages/import` (or `n8n package import`) with a `.n8np` whose manifest declares
`folders[]` / `projects[]`:

- A folders-only package creates the folder tree in the target project; the response `folders[]`
  reports `created` / `updated` / `skipped` per `folderConflictPolicy`.
- Re-importing under a different `folderId` (a "move"), or when the id exists in another project, is
  blocked with a `folder-conflict` (409) and nothing is persisted.
- A project package creates/matches the project shells (owned by the caller); re-import matches by id
  and updates in place — no duplicates.

New integration tests cover the acceptance criteria: `import-folders.integration.test.ts` and
`import-projects.integration.test.ts` (`pnpm --filter n8n test:integration <path>`).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-722
- https://linear.app/n8n/issue/LIGO-741

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if urgent fix).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->