### PR TITLE
feat(editor): Add N8nSettingsPageHeader component and settings row Storybook stories

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.stories.ts
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+
+import N8nSettingsPageHeader from './SettingsPageHeader.vue';
+
+const meta = {
+	title: 'Instance Settings/Page Header',
+	component: N8nSettingsPageHeader,
+	argTypes: {
+		showDocsLink: { control: 'boolean' },
+		docsUrl: { control: 'text' },
+		docsLabel: { control: 'text' },
+		docsLeadingText: { control: 'text' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Page title with an optional 1-2 sentence description and an inline documentation link. The docs link is ON by default (`show-docs-link`), so every settings page links to docs — set `:show-docs-link="false"` to remove it, and provide `docs-url` so the link points somewhere (a dev warning fires if it is enabled without a URL). The header always caps itself at the content max-width (`--settings-content--max-width`, 45rem / 720px). The link renders inline at the end of the description in the description base color: the word is underlined and the trailing `↗` is not.',
+			},
+		},
+	},
+} satisfies Meta<typeof N8nSettingsPageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Wider than 720px to show the header capping itself at the content max-width.
+const frame = (inner: string) => `<div style="max-width: 60rem;">${inner}</div>`;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { N8nSettingsPageHeader },
+		setup: () => ({ args }),
+		template: frame('<N8nSettingsPageHeader v-bind="args" />'),
+	}),
+	args: {
+		title: 'This instance',
+		description:
+			'Plan, usage, version, updates, instance details, resources, and support for this n8n instance.',
+		docsUrl: 'https://docs.n8n.io',
+	},
+};
+
+export const CustomLeadingCopy: Story = {
+	render: (args) => ({
+		components: { N8nSettingsPageHeader },
+		setup: () => ({ args }),
+		template: frame('<N8nSettingsPageHeader v-bind="args" />'),
+	}),
+	args: {
+		title: 'API keys',
+		description: 'Use your API keys to control n8n programmatically.',
+		docsLeadingText: 'Read the ',
+		docsLabel: 'API reference',
+		docsUrl: 'https://docs.n8n.io/api/',
+	},
+};
+
+export const WithoutDocsLink: Story = {
+	render: (args) => ({
+		components: { N8nSettingsPageHeader },
+		setup: () => ({ args }),
+		template: frame('<N8nSettingsPageHeader v-bind="args" />'),
+	}),
+	args: {
+		title: 'Members',
+		description: 'People with access to this instance.',
+		showDocsLink: false,
+	},
+};
+
+export const TitleOnly: Story = {
+	render: (args) => ({
+		components: { N8nSettingsPageHeader },
+		setup: () => ({ args }),
+		template: frame('<N8nSettingsPageHeader v-bind="args" />'),
+	}),
+	args: {
+		title: 'Members',
+		showDocsLink: false,
+	},
+};
+
+export const LongDescription: Story = {
+	render: (args) => ({
+		components: { N8nSettingsPageHeader },
+		setup: () => ({ args }),
+		template: frame('<N8nSettingsPageHeader v-bind="args" />'),
+	}),
+	args: {
+		title: 'Page title',
+		description:
+			'Description of the page explaining what it does, followed up by a link to full feature documentation as the next sentence. It should not be overly long, rather 1-2 sentences.',
+		docsUrl: 'https://docs.n8n.io',
+	},
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.test.ts
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/vue';
+
+import N8nSettingsPageHeader from './SettingsPageHeader.vue';
+
+describe('N8nSettingsPageHeader', () => {
+	it('renders the title as an h1 by default', () => {
+		render(N8nSettingsPageHeader, { props: { title: 'This instance', showDocsLink: false } });
+
+		const title = screen.getByText('This instance');
+		expect(title).toBeInTheDocument();
+		expect(title.tagName).toBe('H1');
+	});
+
+	it('renders the title with the requested heading tag', () => {
+		render(N8nSettingsPageHeader, {
+			props: { title: 'This instance', headingTag: 'h2', showDocsLink: false },
+		});
+
+		expect(screen.getByText('This instance').tagName).toBe('H2');
+	});
+
+	it('renders the description', () => {
+		render(N8nSettingsPageHeader, {
+			props: {
+				title: 'This instance',
+				description: 'Plan, usage and version.',
+				showDocsLink: false,
+			},
+		});
+
+		expect(screen.getByText('Plan, usage and version.')).toBeInTheDocument();
+	});
+
+	it('renders the docs link on by default with the default "documentation" label', () => {
+		render(N8nSettingsPageHeader, {
+			props: {
+				title: 'This instance',
+				description: 'Plan, usage and version.',
+				docsUrl: 'https://docs.n8n.io',
+			},
+		});
+
+		const link = screen.getByRole('link', { name: 'documentation' });
+		expect(link).toHaveAttribute('href', 'https://docs.n8n.io');
+	});
+
+	it('hides the docs link when showDocsLink is false', () => {
+		render(N8nSettingsPageHeader, {
+			props: {
+				title: 'This instance',
+				description: 'Plan, usage and version.',
+				docsUrl: 'https://docs.n8n.io',
+				showDocsLink: false,
+			},
+		});
+
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('settings-page-header-docs')).not.toBeInTheDocument();
+	});
+
+	it('renders custom leading copy and a custom label', () => {
+		render(N8nSettingsPageHeader, {
+			props: {
+				title: 'API keys',
+				description: 'Use your API keys to control n8n programmatically.',
+				docsLeadingText: 'Read the ',
+				docsLabel: 'API reference',
+				docsUrl: 'https://docs.n8n.io/api/',
+			},
+		});
+
+		expect(screen.getByText(/Read the/)).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'API reference' })).toBeInTheDocument();
+	});
+
+	it('renders the docs link inline as an underlined word followed by a non-underlined arrow', () => {
+		render(N8nSettingsPageHeader, {
+			props: {
+				title: 'This instance',
+				description: 'Plan, usage and version.',
+				docsUrl: 'https://docs.n8n.io',
+			},
+		});
+
+		const link = screen.getByRole('link', { name: 'documentation' });
+
+		const label = link.querySelector('[class*="docsLabel"]') as HTMLElement;
+		expect(label).toHaveTextContent('documentation');
+
+		const arrow = link.querySelector('[aria-hidden="true"]') as HTMLElement;
+		expect(arrow).toHaveTextContent('↗');
+		// The arrow is decorative, so it is hidden from assistive tech and excluded from the link name.
+		expect(arrow).toHaveAttribute('aria-hidden', 'true');
+		expect(link).toHaveAccessibleName('documentation');
+	});
+
+	it('warns and renders a non-navigational placeholder when shown without a docsUrl', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+		render(N8nSettingsPageHeader, {
+			props: { title: 'This instance', description: 'Plan, usage and version.' },
+		});
+
+		// Placeholder text is still shown to nudge the developer, but it is not a real link.
+		const placeholder = screen.getByTestId('settings-page-header-docs');
+		expect(placeholder).toHaveTextContent('documentation');
+		expect(placeholder).not.toHaveAttribute('href');
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('docsUrl'));
+
+		warn.mockRestore();
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/SettingsPageHeader.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { computed, useSlots, watchEffect } from 'vue';
+
+import N8nHeading from '../N8nHeading';
+import N8nText from '../N8nText';
+
+export interface SettingsPageHeaderProps {
+	/** Page title. */
+	title: string;
+	/** Optional 1-2 sentence description. */
+	description?: string;
+	/**
+	 * Whether to render the inline documentation link at the end of the header. On by default
+	 * so every settings page links to docs; set `:show-docs-link="false"` to remove it.
+	 */
+	showDocsLink?: boolean;
+	/** Documentation link target. When omitted (while the link is shown) a dev warning fires. */
+	docsUrl?: string;
+	/** The underlined link word. */
+	docsLabel?: string;
+	/** Leading copy rendered before the link word (e.g. "Learn more in the "). */
+	docsLeadingText?: string;
+	/** Heading element for the page title. */
+	headingTag?: string;
+}
+
+defineOptions({ name: 'N8nSettingsPageHeader' });
+
+const props = withDefaults(defineProps<SettingsPageHeaderProps>(), {
+	description: undefined,
+	showDocsLink: true,
+	docsUrl: undefined,
+	docsLabel: 'documentation',
+	docsLeadingText: 'Learn more in the ',
+	headingTag: 'h1',
+});
+
+const slots = useSlots();
+
+const hasDescription = computed(() => Boolean(props.description || slots.description));
+
+// Default-on means a developer who forgets to wire a docs URL is nudged (not silently broken):
+// the link word still renders as a placeholder and a dev-only warning prompts them to act.
+if (import.meta.env.DEV) {
+	watchEffect(() => {
+		if (props.showDocsLink && !props.docsUrl) {
+			console.warn(
+				'[N8nSettingsPageHeader] The docs link is enabled but no `docsUrl` was provided. ' +
+					'Set `docs-url` to your documentation page, or pass `:show-docs-link="false"` to remove it.',
+			);
+		}
+	});
+}
+</script>
+
+<template>
+	<header :class="$style.header">
+		<N8nHeading :tag="headingTag" :class="$style.title" step="xl" color="text-dark">
+			{{ title }}
+		</N8nHeading>
+		<p v-if="hasDescription || showDocsLink" :class="$style.description">
+			<slot name="description">
+				<N8nText v-if="description" size="medium" color="text-base">{{ description }}</N8nText>
+			</slot>
+			<!--
+				The separating space sits OUTSIDE the nowrap docs phrase so the whole "leading copy +
+				link + arrow" can wrap to the next line as a single unit; only added after a description.
+			-->
+			<template v-if="showDocsLink"
+				>{{ hasDescription ? ' ' : ''
+				}}<span :class="$style.docsPhrase"
+					><N8nText size="medium" color="text-base">{{ docsLeadingText }}</N8nText
+					><a
+						:class="$style.docsLink"
+						:href="docsUrl || undefined"
+						target="_blank"
+						rel="noopener noreferrer"
+						data-test-id="settings-page-header-docs"
+						><span :class="$style.docsLabel">{{ docsLabel }}</span
+						><span aria-hidden="true">↗</span></a
+					></span
+				></template
+			>
+		</p>
+	</header>
+</template>
+
+<style lang="scss" module>
+.header {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+	width: 100%;
+	/* The header column stays capped even when the layout content is full-width. */
+	max-width: var(--settings-content--max-width, 45rem);
+	/*
+	 * The 48px gap to the content below is owned and enforced by N8nSettingsLayout
+	 * (`.content > header + *`), not by an external margin here, so it stays deterministic
+	 * and never relies on margin-collapsing.
+	 */
+}
+
+.title {
+	letter-spacing: var(--letter-spacing--tight);
+}
+
+.description {
+	margin: 0;
+	display: inline;
+	/* Intentionally the standard body line-height (lg). */
+	line-height: var(--line-height--lg);
+}
+
+/* The inline N8nText pieces already use the body line-height (lg); keep them consistent. */
+.description :global(.n8n-text) {
+	line-height: var(--line-height--lg);
+}
+
+/* Keeps "leading copy + link + arrow" together so the docs sentence wraps as a single unit. */
+.docsPhrase {
+	white-space: nowrap;
+}
+
+.docsLink {
+	/* Reads as part of the description: same base text color, no link/primary color. */
+	color: var(--text-color--subtle);
+	font-size: var(--font-size--sm);
+	line-height: var(--line-height--lg);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+/* Only the link word is underlined; the ↗ indicator (plain span) stays bare. */
+.docsLabel {
+	text-decoration: underline;
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsPageHeader/index.ts
@@ -1,0 +1,2 @@
+export { default } from './SettingsPageHeader.vue';
+export type { SettingsPageHeaderProps } from './SettingsPageHeader.vue';

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsRow/SettingsRow.stories.ts
@@ -1,0 +1,468 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { ref } from 'vue';
+
+import N8nSettingsRow from './SettingsRow.vue';
+import N8nButton from '../N8nButton';
+import N8nIcon from '../N8nIcon';
+import N8nInput from '../N8nInput';
+import N8nSettingsRowConfigure from '../N8nSettingsRowConfigure';
+import N8nSettingsRowGroup from '../N8nSettingsRowGroup';
+import N8nSwitch from '../N8nSwitch';
+import N8nText from '../N8nText';
+
+const meta = {
+	title: 'Instance Settings/Settings Row',
+	component: N8nSettingsRow,
+	argTypes: {
+		layout: { control: 'select', options: ['horizontal', 'vertical', 'custom'] },
+		description: {
+			control: 'text',
+			description:
+				'Short, scannable, plain-language summary of the setting (ideally one sentence). Keep it concise — link to the docs for anything longer rather than writing long inline copy.',
+		},
+		maxDescriptionLines: { control: { type: 'number', min: 1, max: 3 } },
+		truncateTitle: { control: 'boolean' },
+		showDivider: { control: 'boolean' },
+		showVisual: { control: 'boolean' },
+		actionMaxWidth: { control: 'text' },
+		actionFill: { control: 'boolean' },
+		expandLabel: { control: 'text' },
+		collapseLabel: { control: 'text' },
+		hoverable: { control: 'boolean' },
+		clickable: { control: 'boolean' },
+		revealActionsOnHover: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The core description-list row: left info (title/description + optional leading visual) and an action slot, arranged horizontally, vertically, or as a fully custom full-width slot. In horizontal rows, action controls should use the medium size (`size="medium"`) so their height matches input fields and stays consistent across rows.\n\n**Writing the description:** keep it short, scannable, and plain-language — one clear sentence stating what the setting does or its current state. Avoid long, paragraph-length copy; descriptions clamp to `maxDescriptionLines` (max 3) and reveal the rest in a tooltip on hover, but that is a safety net, not a license to write long text. If a setting needs more explanation, link to the docs rather than inlining the detail.',
+			},
+		},
+	},
+} satisfies Meta<typeof N8nSettingsRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const card = (inner: string) =>
+	`<div style="max-width: 45rem;"><N8nSettingsRowGroup>${inner}</N8nSettingsRowGroup></div>`;
+
+export const Horizontal: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow v-bind="args">
+				<template #action><N8nButton variant="outline" size="medium" label="Change password" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Password',
+		description: 'Last changed 4 months ago.',
+		layout: 'horizontal',
+	},
+};
+
+export const Vertical: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nInput },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow v-bind="args">
+				<template #action><N8nInput placeholder="https://example.com/webhook" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Webhook URL',
+		description: 'The full action below gets the entire row width.',
+		layout: 'vertical',
+	},
+};
+
+// Bordered, rounded metrics card: three equal columns (tiles) separated by vertical dividers,
+// built from DS border/radius/spacing tokens. Each tile shows a metric title, a "Last 7 days"
+// sublabel, the big bold value, and either a colored trend delta (success/danger) or the muted
+// "/ unlimited" suffix.
+const metricTilesCard = `
+	<div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 100%; border: var(--border-width, 1px) solid var(--border-color--subtle); border-radius: var(--radius--xs); overflow: clip;">
+		<div
+			v-for="(metric, index) in metrics"
+			:key="metric.title"
+			:style="{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 'var(--spacing--2xs)',
+				padding: 'var(--spacing--sm)',
+				borderInlineStart: index > 0 ? 'var(--border-width, 1px) solid var(--border-color--subtle)' : '',
+			}"
+		>
+			<div style="display: flex; flex-direction: column; gap: var(--spacing--5xs);">
+				<N8nText size="small" color="text-base" tag="div">{{ metric.title }}</N8nText>
+				<N8nText size="small" color="text-light" tag="div">Last 7 days</N8nText>
+			</div>
+			<div style="display: flex; align-items: center; gap: var(--spacing--2xs);">
+				<N8nText size="xlarge" bold color="text-dark" tag="span">{{ metric.value }}</N8nText>
+				<N8nText v-if="metric.suffix" size="small" color="text-light" tag="span">{{ metric.suffix }}</N8nText>
+				<span v-else style="display: inline-flex; align-items: center; gap: var(--spacing--5xs);">
+					<N8nIcon icon="triangle" :color="metric.delta" size="xsmall" />
+					<N8nText size="small" :color="metric.delta" tag="span">{{ metric.deltaText }}</N8nText>
+				</span>
+			</div>
+		</div>
+	</div>
+`;
+
+export const Custom: Story = {
+	render: () => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nText, N8nIcon, N8nButton },
+		setup() {
+			// `delta` drives the colored trend (success/danger); `suffix` is the muted
+			// "/ unlimited" variant that has no trend arrow.
+			const metrics = [
+				{ title: 'Prod. executions', value: '23,432', delta: 'success', deltaText: '0.5pp' },
+				{ title: 'Active workflows', value: '865', suffix: '/ unlimited' },
+				{ title: 'Active users', value: '1.9%', delta: 'danger', deltaText: '0.5pp' },
+			];
+			return { metrics };
+		},
+		// "Usage" is a `vertical` row: its title is "Usage" and the full-width slot below holds
+		// the bordered three-column metrics card. It composes inside a row group next to plain
+		// horizontal rows (Plan, Billing) so the rich custom content reads naturally among
+		// regular settings rows.
+		template: card(`
+			<N8nSettingsRow layout="vertical" title="Usage">
+				<template #action>${metricTilesCard}</template>
+			</N8nSettingsRow>
+			<N8nSettingsRow title="Plan">
+				<template #action><N8nText size="medium" color="text-dark">Enterprise</N8nText></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow title="Billing">
+				<template #action><N8nButton variant="outline" size="medium" label="Manage plan" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'A `vertical` row whose title is "Usage" and whose full-width slot below holds a bordered three-column metrics card (with success/danger trend deltas), composed inside a row group alongside plain Plan/Billing rows. This is the recommended pattern for "a labelled row with rich custom content below the title".',
+			},
+		},
+	},
+};
+
+export const WithVisual: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton, N8nIcon },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow v-bind="args">
+				<template #visual><N8nIcon icon="globe" /></template>
+				<template #action><N8nButton variant="outline" size="small" label="Log out" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Chrome 138 on macOS',
+		description: 'Gdynia, Poland · active now',
+		showVisual: true,
+	},
+};
+
+export const WithoutDescription: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nSwitch },
+		setup() {
+			const enabled = ref(false);
+			return { args, enabled };
+		},
+		template: card(`
+			<N8nSettingsRow v-bind="args">
+				<template #action><N8nSwitch v-model="enabled" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Compact mode',
+	},
+};
+
+export const DescriptionTruncation: Story = {
+	render: () => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nSwitch },
+		setup() {
+			const telemetry = ref(true);
+			const heartbeat = ref(true);
+			const longDescription =
+				'Share anonymous usage data and diagnostic logs so we can understand how workflows are built, prioritise the improvements that matter most, and catch regressions early. You can turn this off at any time, and we never collect the contents of your workflows, your credentials, or the data your executions process.';
+			return { telemetry, heartbeat, longDescription };
+		},
+		template: card(`
+			<N8nSettingsRow
+				title="Telemetry & diagnostics"
+				:description="longDescription"
+				:max-description-lines="2"
+			>
+				<template #action><N8nSwitch v-model="telemetry" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Instance heartbeat"
+				description="Sends a lightweight ping so you can see when this instance is online."
+			>
+				<template #action><N8nSwitch v-model="heartbeat" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"The description clamps to `maxDescriptionLines` (max 3) with an ellipsis. When the copy actually overflows the clamp — like the first row — hovering (or focusing) it reveals the full text in a tooltip. Rows whose description already fits — like the second — show no tooltip, so the affordance is never redundant. Truncation is detected from the rendered element and re-evaluated on resize, so it stays correct as the row width changes.\n\n**Note:** the first row's description is unrealistically long purely to demonstrate the truncation + tooltip behavior — it is not a recommended pattern. In real settings, keep descriptions short and scannable (see the component docs) and link out for any longer detail.",
+			},
+		},
+	},
+};
+
+export const ActionMaxWidth: Story = {
+	render: () => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nInput, N8nButton },
+		template: card(`
+			<N8nSettingsRow
+				title="Fill · 50% (default)"
+				description="The recommended horizontal default: the action fills up to half the 720px row."
+				action-fill
+				action-max-width="50%"
+			>
+				<template #action><N8nInput style="width: 100%" placeholder="Fills 50%" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Fill · 20%"
+				description="A compact action; the info keeps the remaining ~80%."
+				action-fill
+				action-max-width="20%"
+			>
+				<template #action><N8nInput style="width: 100%" placeholder="20%" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Fill · 5%"
+				description="A minimal action — almost all the space goes to the info."
+				action-fill
+				action-max-width="5%"
+			>
+				<template #action>
+					<N8nButton style="width: 100%" variant="outline" size="medium" icon-only icon="ellipsis-vertical" aria-label="More" />
+				</template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Fill · 100% requested → still ~50%"
+				description="In horizontal, a filled action shares the row with the info, so it stays about half even when you ask for more."
+				action-fill
+				action-max-width="100%"
+			>
+				<template #action><N8nInput style="width: 100%" placeholder="Still ~50%" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Hug (default sizing)"
+				description="Without fill, the action sizes to its own content and sits on the right."
+			>
+				<template #action><N8nButton variant="outline" size="medium" label="Edit" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow
+				title="Override · uncapped (false)"
+				description="action-max-width=false removes the cap, so intrinsically wide content can exceed 50%."
+				:action-max-width="false"
+			>
+				<template #action><N8nInput style="width: 30rem" placeholder="Wider than 50% — uncapped" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'`actionMaxWidth` (horizontal only) accepts any CSS max-width string — percentages ("50%", the default), absolute lengths ("30rem", "200px") — or `false` to remove the cap. By default the action **hugs** its content; add `action-fill` so it **fills** up to the cap. A filled action also shares the row with the info, so it never grows past ~50% in horizontal even when the cap is higher; use `:action-max-width="false"` with intrinsically wide content to exceed that.',
+			},
+		},
+	},
+};
+
+export const NoDivider: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow title="2 other active sessions" :show-divider="false">
+				<template #action><N8nButton variant="outline" size="small" label="Revoke all" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow v-bind="args">
+				<template #action><N8nButton variant="outline" size="small" label="Revoke" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Safari on iPhone',
+		description: 'Gdynia, Poland · last seen 4 hours ago',
+	},
+};
+
+export const Expandable: Story = {
+	render: () => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nSwitch, N8nButton, N8nInput },
+		setup() {
+			// The switch in the action slot owns the expanded state via `v-model`; the row
+			// animates its `#expanded` region open/closed in response. `:disclosure="false"`
+			// hides the built-in chevron since the switch is the trigger here.
+			const enabled = ref(true);
+			return { enabled };
+		},
+		template: card(`
+			<N8nSettingsRow
+				title="Single sign-on (SSO)"
+				description="Turn on to reveal the SSO configuration below."
+				expandable
+				:disclosure="false"
+				v-model="enabled"
+			>
+				<template #action><N8nSwitch v-model="enabled" /></template>
+				<template #expanded>
+					<N8nSettingsRow title="Identity provider URL" layout="vertical">
+						<template #action><N8nInput placeholder="https://idp.example.com/sso" /></template>
+					</N8nSettingsRow>
+					<N8nSettingsRow title="Require SSO for all members" description="Members must sign in through your identity provider.">
+						<template #action><N8nButton variant="outline" size="medium" label="Configure" /></template>
+					</N8nSettingsRow>
+					<N8nSettingsRow title="Test connection" :show-divider="false">
+						<template #action><N8nButton variant="outline" size="medium" label="Run test" /></template>
+					</N8nSettingsRow>
+				</template>
+			</N8nSettingsRow>
+		`),
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Stateful disclosure: the row exposes the expanded state through `v-model`, so any control can drive it. Here a switch in the action slot reveals nested settings rows with a ~200ms height + fade + blur animation (respecting `prefers-reduced-motion`).',
+			},
+		},
+	},
+};
+
+export const ExpandableChevron: Story = {
+	render: () => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton },
+		setup() {
+			const expanded = ref(false);
+			return { expanded };
+		},
+		// The built-in chevron is the default trigger affordance: it carries `aria-expanded` /
+		// `aria-controls` and rotates to reflect state. No `#action` control is required.
+		template: card(`
+			<N8nSettingsRow
+				title="Advanced options"
+				description="Use the chevron to reveal the additional settings."
+				expandable
+				v-model="expanded"
+			>
+				<template #expanded>
+					<N8nSettingsRow title="Beta features" description="Opt into experimental functionality.">
+						<template #action><N8nButton variant="outline" size="medium" label="Manage" /></template>
+					</N8nSettingsRow>
+					<N8nSettingsRow title="Reset to defaults" :show-divider="false">
+						<template #action><N8nButton variant="outline" size="medium" label="Reset" /></template>
+					</N8nSettingsRow>
+				</template>
+			</N8nSettingsRow>
+		`),
+	}),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'When no action control drives the state, the built-in chevron disclosure (default `disclosure: true`) is the trigger — a text label ("View more" → "Show less", customizable via `expandLabel`/`collapseLabel`) beside a rotating chevron, fully keyboard operable with `aria-expanded`/`aria-controls`.',
+			},
+		},
+	},
+};
+
+export const Hoverable: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow v-bind="args" hoverable>
+				<template #action><N8nButton variant="outline" size="small" label="Manage" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Hover me',
+		description: 'A subtle hover background highlights the row.',
+	},
+};
+
+export const Clickable: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nSettingsRowConfigure },
+		setup() {
+			const onRowClick = () => alert('Row clicked');
+			return { args, onRowClick };
+		},
+		template: card(`
+			<N8nSettingsRow v-bind="args" clickable @click="onRowClick">
+				<template #action><N8nSettingsRowConfigure /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Passkey',
+		description: 'Whole-row clickable with a text + chevron configure affordance.',
+	},
+};
+
+export const ConfigureWithStatus: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nSettingsRowConfigure },
+		setup() {
+			const onRowClick = () => alert('Configure');
+			return { args, onRowClick };
+		},
+		template: card(`
+			<N8nSettingsRow v-bind="args" clickable @click="onRowClick">
+				<template #action><N8nSettingsRowConfigure value="2 of 3 devices" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow title="OAuth applications" description="Apps authorized to access your account." clickable @click="onRowClick">
+				<template #action><N8nSettingsRowConfigure /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Two-factor authentication',
+		description:
+			'The affordance shows "Configure" when unset, or the configured-state text once set up.',
+	},
+};
+
+export const RevealActionsOnHover: Story = {
+	render: (args) => ({
+		components: { N8nSettingsRow, N8nSettingsRowGroup, N8nButton, N8nIcon },
+		setup: () => ({ args }),
+		template: card(`
+			<N8nSettingsRow v-bind="args" hoverable reveal-actions-on-hover show-visual>
+				<template #visual><N8nIcon icon="hard-drive" /></template>
+				<template #action><N8nButton variant="outline" size="small" label="Log out" /></template>
+			</N8nSettingsRow>
+			<N8nSettingsRow title="Safari on iPhone" description="Gdynia, Poland · last seen 4 hours ago" hoverable reveal-actions-on-hover show-visual>
+				<template #visual><N8nIcon icon="globe" /></template>
+				<template #action><N8nButton variant="outline" size="small" label="Revoke" /></template>
+			</N8nSettingsRow>
+		`),
+	}),
+	args: {
+		title: 'Chrome 138 on macOS',
+		description: 'Gdynia, Poland · active now. Hover (or focus) to reveal the action.',
+	},
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsRowConfigure/SettingsRowConfigure.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsRowConfigure/SettingsRowConfigure.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+
+import N8nSettingsRowConfigure from './SettingsRowConfigure.vue';
+
+const meta = {
+	title: 'Instance Settings/Settings Row Configure',
+	component: N8nSettingsRowConfigure,
+	argTypes: {
+		value: { control: 'text' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The always-visible affordance for a whole-row-clickable `N8nSettingsRow`: a single text plus a trailing right chevron. It shows "Configure" when not configured, or the configured-state free text once set up. Drop it into the row `#action` slot — it is presentational only, the parent row owns the click/keyboard behaviour.',
+			},
+		},
+	},
+} satisfies Meta<typeof N8nSettingsRowConfigure>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {},
+};
+
+export const Configured: Story = {
+	args: {
+		value: '2 of 3 devices',
+	},
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsRowGroup/SettingsRowGroup.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsRowGroup/SettingsRowGroup.stories.ts
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { ref } from 'vue';
+
+import N8nSettingsRowGroup from './SettingsRowGroup.vue';
+import N8nButton from '../N8nButton';
+import N8nInput from '../N8nInput';
+import N8nSettingsRow from '../N8nSettingsRow';
+import N8nSwitch from '../N8nSwitch';
+
+const meta = {
+	title: 'Instance Settings/Settings Row Group',
+	component: N8nSettingsRowGroup,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A bordered, rounded card that stacks settings rows. The last row hides its divider automatically; individual rows can opt out to merge into a sub-section.',
+			},
+		},
+	},
+} satisfies Meta<typeof N8nSettingsRowGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const frame = (inner: string) => `<div style="max-width: 45rem;">${inner}</div>`;
+
+export const Default: Story = {
+	render: () => ({
+		components: { N8nSettingsRowGroup, N8nSettingsRow, N8nSwitch },
+		setup() {
+			const a = ref(true);
+			const b = ref(false);
+			const c = ref(true);
+			return { a, b, c };
+		},
+		template: frame(`
+			<N8nSettingsRowGroup>
+				<N8nSettingsRow title="Telemetry" description="Share anonymous usage data.">
+					<template #action><N8nSwitch v-model="a" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="Beta features" description="Opt in to early features.">
+					<template #action><N8nSwitch v-model="b" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="Email notifications" description="Last row hides its divider automatically.">
+					<template #action><N8nSwitch v-model="c" /></template>
+				</N8nSettingsRow>
+			</N8nSettingsRowGroup>
+		`),
+	}),
+};
+
+export const MixedLayouts: Story = {
+	render: () => ({
+		components: { N8nSettingsRowGroup, N8nSettingsRow, N8nSwitch, N8nButton, N8nInput },
+		setup() {
+			const enabled = ref(true);
+			return { enabled };
+		},
+		template: frame(`
+			<N8nSettingsRowGroup>
+				<N8nSettingsRow title="Telemetry" description="Horizontal row with a switch.">
+					<template #action><N8nSwitch v-model="enabled" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="Webhook URL" description="Vertical row with a wide input." layout="vertical">
+					<template #action><N8nInput placeholder="https://example.com/webhook" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="Password" description="Horizontal row with a button.">
+					<template #action><N8nButton variant="outline" size="small" label="Change password" /></template>
+				</N8nSettingsRow>
+			</N8nSettingsRowGroup>
+		`),
+	}),
+};
+
+export const MergedSubsection: Story = {
+	render: () => ({
+		components: { N8nSettingsRowGroup, N8nSettingsRow, N8nButton },
+		template: frame(`
+			<N8nSettingsRowGroup>
+				<N8nSettingsRow title="2 other active sessions" :show-divider="false">
+					<template #action><N8nButton variant="outline" size="small" label="Revoke all" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="Safari on iPhone" description="Gdynia, Poland · last seen 4 hours ago" :show-divider="false">
+					<template #action><N8nButton variant="outline" size="small" label="Revoke" /></template>
+				</N8nSettingsRow>
+				<N8nSettingsRow title="n8n CLI" description="headless · last seen 3 days ago" />
+			</N8nSettingsRowGroup>
+		`),
+	}),
+};
+
+export const SingleRow: Story = {
+	render: () => ({
+		components: { N8nSettingsRowGroup, N8nSettingsRow, N8nButton },
+		template: frame(`
+			<N8nSettingsRowGroup>
+				<N8nSettingsRow title="Plan" description="Enterprise">
+					<template #action><N8nButton variant="outline" size="small" label="Manage plan" /></template>
+				</N8nSettingsRow>
+			</N8nSettingsRowGroup>
+		`),
+	}),
+};

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -70,6 +70,8 @@ export { default as N8nOption } from './N8nOption';
 export { default as N8nPagination } from './N8nPagination';
 export { default as N8nSectionHeader } from './N8nSectionHeader';
 export { default as N8nSelectableList } from './N8nSelectableList';
+export { default as N8nSettingsPageHeader } from './N8nSettingsPageHeader';
+export type { SettingsPageHeaderProps } from './N8nSettingsPageHeader';
 export { default as N8nSettingsRow } from './N8nSettingsRow';
 export type { SettingsRowProps, SettingsRowLayout } from './N8nSettingsRow';
 export { default as N8nSettingsRowConfigure } from './N8nSettingsRowConfigure';

--- a/packages/frontend/@n8n/storybook/.storybook/preview.ts
+++ b/packages/frontend/@n8n/storybook/.storybook/preview.ts
@@ -83,6 +83,7 @@ export const parameters = {
 				'Docs',
 				'Styleguide',
 				'Core',
+				'Instance Settings',
 				'Assistant',
 				'Chat',
 				'Tables',

--- a/packages/frontend/@n8n/storybook/.storybook/storybook.scss
+++ b/packages/frontend/@n8n/storybook/.storybook/storybook.scss
@@ -38,3 +38,13 @@ body {
 .sbdocs .sbdocs-content th {
 	font-weight: var(--font-weight--bold);
 }
+
+/*
+ * The prose-table styling above is meant for Markdown/args tables in docs. Rendered component
+ * previews live inside `.sb-story` and bring their own table styling (e.g. N8nDataTableServer),
+ * so the docs prose block margin must not leak in — otherwise it pushes the header row down and
+ * leaves an empty gap at the top of the table card.
+ */
+.sbdocs .sbdocs-content .sb-story table {
+	margin-block: 0;
+}


### PR DESCRIPTION
## Summary

Part **2/6** of splitting #32821 into reviewable chunks (PR size limit). Builds on #33701.

- Adds **`N8nSettingsPageHeader`** — settings page title/header with an optional docs link (component + tests + stories).
- Adds the Storybook stories for the row primitives from part 1/6 (`N8nSettingsRow`, `N8nSettingsRowGroup`, `N8nSettingsRowConfigure`). They land here because the three row stories import each other, so they need all three components in place.
- Registers the new **`Instance Settings`** Storybook category (sidebar sort order) and fixes the docs prose-table styling so it doesn't leak into rendered component previews.

## How to test

Run Storybook for the design system (`pnpm storybook` in `packages/frontend/@n8n/design-system`) and open the **`Instance Settings`** category. Unit tests: `pnpm test` in the package.

## Related Linear tickets, Github issues, and Community forum posts

Split from #32821. Stacked on #33701.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

