### PR TITLE
feat(editor): Add composed instance settings Storybook examples (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nSettingsLayout/Examples.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nSettingsLayout/Examples.stories.ts
@@ -1,0 +1,488 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { computed, ref, type Component } from 'vue';
+
+import N8nSettingsLayout from './SettingsLayout.vue';
+import N8nButton from '../N8nButton';
+import N8nDataTableServer from '../N8nDataTableServer';
+import N8nIcon from '../N8nIcon';
+import N8nInput from '../N8nInput';
+import N8nOption from '../N8nOption';
+import N8nSelect from '../N8nSelect';
+import N8nSettingsPageHeader from '../N8nSettingsPageHeader';
+import N8nSettingsRow from '../N8nSettingsRow';
+import N8nSettingsRowConfigure from '../N8nSettingsRowConfigure';
+import N8nSettingsRowGroup from '../N8nSettingsRowGroup';
+import N8nSettingsSaveBar from '../N8nSettingsSaveBar';
+import { confirmSaved } from '../N8nSettingsSaveBar/quickSaveNotification';
+import N8nSettingsSection from '../N8nSettingsSection';
+import N8nSwitch from '../N8nSwitch';
+import N8nText from '../N8nText';
+
+const meta = {
+	title: 'Instance Settings/Examples',
+	component: N8nSettingsLayout,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Composed examples mirroring the Figma examples frame: a Security & login page (leading visual slot + merged sub-section), a This instance page (metrics custom row + back action), and an API keys page (full-width table beneath a header that stays centered in the 720px column). The **Example Settings Page** wires the floating `N8nSettingsSaveBar` to a realistic dirty-state flow — editing a high-impact field slides the bar up, Discard reverts and Save confirms through the existing app notification (the bottom-right `ElNotification` that `useToast()` shows in the app), while a low-impact toggle saves instantly.',
+			},
+		},
+	},
+} satisfies Meta<typeof N8nSettingsLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const components = {
+	N8nSettingsLayout,
+	N8nSettingsPageHeader,
+	N8nSettingsSection,
+	N8nSettingsRowGroup,
+	N8nSettingsRow,
+	N8nSettingsRowConfigure,
+	N8nSettingsSaveBar,
+	N8nSwitch,
+	N8nButton,
+	N8nInput,
+	N8nSelect,
+	N8nOption,
+	N8nIcon,
+	N8nText,
+	// Cast the generic data-table to a plain Component so its generic signature doesn't leak
+	// into (and break) the Storybook render-function types.
+	N8nDataTableServer: N8nDataTableServer as unknown as Component,
+};
+
+// Wrapper style shared by every full-page story so each reads as a real, full-height scrollable
+// settings page (no windowed box) on the app's subtle background. The flex column is part of the
+// floating save bar contract: the bar (last child, `margin-top: auto`) gets pushed to the bottom
+// of the scrollport even when the page content is shorter than the viewport, where its sticky
+// offset gives the usual 24px gap; on long pages the auto margin has no free space to absorb, so
+// scrolling behavior is unchanged.
+const fullPageViewportStyle =
+	'height: 100vh; overflow-y: auto; display: flex; flex-direction: column; background: var(--background--subtle);';
+
+// Bordered, rounded metrics card mirroring the Settings Row `Custom` story: three equal columns
+// (tiles) separated by vertical dividers, built from DS border/radius/spacing tokens. Each tile
+// shows a metric title, a "Last 7 days" sublabel, the big bold value, and either a colored trend
+// delta (success/danger) or the muted "/ unlimited" suffix. Iterates a `metrics` array from setup.
+const metricTilesCard = `
+	<div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 100%; border: var(--border-width, 1px) solid var(--border-color--subtle); border-radius: var(--radius--xs); overflow: clip;">
+		<div
+			v-for="(metric, index) in metrics"
+			:key="metric.title"
+			:style="{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 'var(--spacing--2xs)',
+				padding: 'var(--spacing--sm)',
+				borderInlineStart: index > 0 ? 'var(--border-width, 1px) solid var(--border-color--subtle)' : '',
+			}"
+		>
+			<div style="display: flex; flex-direction: column; gap: var(--spacing--5xs);">
+				<N8nText size="small" color="text-base" tag="div">{{ metric.title }}</N8nText>
+				<N8nText size="small" color="text-light" tag="div">Last 7 days</N8nText>
+			</div>
+			<div style="display: flex; align-items: center; gap: var(--spacing--2xs);">
+				<N8nText size="xlarge" bold color="text-dark" tag="span">{{ metric.value }}</N8nText>
+				<N8nText v-if="metric.suffix" size="small" color="text-light" tag="span">{{ metric.suffix }}</N8nText>
+				<span v-else style="display: inline-flex; align-items: center; gap: var(--spacing--5xs);">
+					<N8nIcon icon="triangle" :color="metric.delta" size="xsmall" />
+					<N8nText size="small" :color="metric.delta" tag="span">{{ metric.deltaText }}</N8nText>
+				</span>
+			</div>
+		</div>
+	</div>
+`;
+
+export const SecurityAndLogin: Story = {
+	render: () => ({
+		components,
+		setup() {
+			const onBack = () => alert('Back to app');
+			const onConfigurePasskey = () => alert('Configure passkeys');
+			const onLogOut = () => alert('Log out');
+			const onRevoke = () => alert('Revoke');
+			return { onBack, onConfigurePasskey, onLogOut, onRevoke };
+		},
+		template: `
+			<N8nSettingsLayout show-back back-label="Back to app" @back="onBack">
+				<N8nSettingsPageHeader
+					title="Security & login"
+					description="Your 2FA setup, passkeys, active sessions, and authorized OAuth applications."
+					docs-url="https://docs.n8n.io/user-management/"
+				/>
+
+				<N8nSettingsSection title="Sign-in" description="How you sign in to n8n.">
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="Username" description="Used in audit trails and @-mentions. Set by your admin via SSO.">
+							<template #action><N8nInput size="medium" placeholder="jan.ostrowka" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Password" description="Last changed 4 months ago.">
+							<template #action><N8nButton variant="outline" size="medium" label="Change password" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Passkey" description="Sign in with your face, fingerprint, or device PIN." clickable @click="onConfigurePasskey">
+							<template #action><N8nSettingsRowConfigure value="2 of 3 devices" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+				</N8nSettingsSection>
+
+				<N8nSettingsSection title="Active sessions" description="Devices currently signed in to your account.">
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="Chrome 138 on macOS" description="Gdynia, Poland · active now" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="hard-drive" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Log out" @click="onLogOut" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="2 other active sessions">
+							<template #action><N8nButton variant="outline" size="medium" label="Revoke all" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Safari on iPhone" description="Gdynia, Poland · last seen 4 hours ago" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="globe" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Revoke" @click="onRevoke" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="n8n CLI" description="headless · last seen 3 days ago" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="terminal" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Revoke" @click="onRevoke" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+				</N8nSettingsSection>
+			</N8nSettingsLayout>
+		`,
+	}),
+};
+
+export const PasskeysSubPage: Story = {
+	render: () => ({
+		components,
+		setup() {
+			// Nested sub-page: the back label names the parent page it returns to.
+			const onBack = () => alert('Back to Security settings');
+			const onAdd = () => alert('Add passkey');
+			const onRemove = () => alert('Remove passkey');
+			return { onBack, onAdd, onRemove };
+		},
+		template: `
+			<N8nSettingsLayout show-back back-label="Back to Security settings" @back="onBack">
+				<N8nSettingsPageHeader
+					title="Passkeys"
+					description="Manage the passkeys you use to sign in with your face, fingerprint, or device PIN."
+					docs-url="https://docs.n8n.io/user-management/"
+				/>
+
+				<N8nSettingsSection>
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="Add a passkey" description="Register this device or a hardware security key." hoverable>
+							<template #action><N8nButton variant="outline" size="medium" label="Add passkey" @click="onAdd" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="MacBook Pro" description="Added 3 months ago · last used 3 min ago" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="hard-drive" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Remove" @click="onRemove" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="iPhone" description="Added 5 months ago · last used yesterday" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="fingerprint" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Remove" @click="onRemove" /></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="YubiKey 5C" description="Added 1 year ago · last used last week" show-visual hoverable reveal-actions-on-hover>
+							<template #visual><N8nIcon icon="key-round" /></template>
+							<template #action><N8nButton variant="outline" size="medium" label="Remove" @click="onRemove" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+				</N8nSettingsSection>
+			</N8nSettingsLayout>
+		`,
+	}),
+};
+
+export const ThisInstance: Story = {
+	render: () => ({
+		components,
+		setup() {
+			const onBack = () => alert('Back');
+			// `delta` drives the colored trend (success/danger); `suffix` is the muted
+			// "/ unlimited" variant that has no trend arrow.
+			const metrics = [
+				{ title: 'Prod. executions', value: '23,432', delta: 'success', deltaText: '0.5pp' },
+				{ title: 'Active workflows', value: '865', suffix: '/ unlimited' },
+				{ title: 'Active users', value: '1.9%', delta: 'danger', deltaText: '0.5pp' },
+			];
+			return { onBack, metrics };
+		},
+		template: `
+			<N8nSettingsLayout show-back @back="onBack">
+				<N8nSettingsPageHeader
+					title="This instance"
+					description="Plan, usage, version, updates, instance details, resources, and support for this n8n instance."
+					docs-url="https://docs.n8n.io"
+				/>
+
+				<N8nSettingsSection title="Plan and usage">
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow layout="vertical" title="Usage">
+							<template #action>${metricTilesCard}</template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Plan">
+							<template #action><N8nText size="medium" color="text-dark">Enterprise</N8nText></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Billing">
+							<template #action><N8nButton variant="outline" size="medium" label="Manage plan" /></template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+				</N8nSettingsSection>
+
+				<N8nSettingsSection title="Version and updates">
+					<N8nSettingsRowGroup>
+						<N8nSettingsRow title="Current version">
+							<template #action><N8nText size="medium" color="text-dark">2.9.4</N8nText></template>
+						</N8nSettingsRow>
+						<N8nSettingsRow title="Updates" description="2.10.2 available · 3 versions behind">
+							<template #action>
+								<div style="display: flex; flex-direction: row; align-items: center; justify-content: flex-end; gap: var(--spacing--sm);">
+									<a
+										href="https://docs.n8n.io/release-notes"
+										target="_blank"
+										rel="noopener noreferrer"
+										style="color: var(--text-color--subtle); font-size: var(--font-size--sm); line-height: var(--line-height--lg); text-decoration: none; cursor: pointer;"
+									><span style="text-decoration: underline;">Release notes</span><span aria-hidden="true">↗</span></a>
+									<N8nButton variant="outline" size="medium" label="Update" />
+								</div>
+							</template>
+						</N8nSettingsRow>
+					</N8nSettingsRowGroup>
+				</N8nSettingsSection>
+			</N8nSettingsLayout>
+		`,
+	}),
+};
+
+export const ApiKeys: Story = {
+	render: () => ({
+		components,
+		setup() {
+			const onBack = () => alert('Back');
+
+			// Real n8n data-table headers: `key` maps to the item field; the trailing
+			// `actions` column has no underlying data so it uses a value accessor.
+			const headers = [
+				{ title: 'Label', key: 'label' },
+				{ title: 'API key', key: 'apiKey', disableSort: true },
+				{ title: 'Created', key: 'created' },
+				{ title: 'Last used', key: 'lastUsed' },
+				{ title: '', key: 'actions', value: () => '', disableSort: true, align: 'end', width: 64 },
+			];
+
+			const items = [
+				{
+					id: '1',
+					label: 'Production',
+					apiKey: '••••••••••••3f9a',
+					created: '7 months ago',
+					lastUsed: '3 min ago',
+				},
+				{
+					id: '2',
+					label: 'CI / CD',
+					apiKey: '••••••••••••a17c',
+					created: '7 days ago',
+					lastUsed: '14 min ago',
+				},
+				{
+					id: '3',
+					label: 'Staging',
+					apiKey: '••••••••••••4b2e',
+					created: '17 hours ago',
+					lastUsed: 'Yesterday',
+				},
+				{
+					id: '4',
+					label: 'Local dev',
+					apiKey: '••••••••••••9d05',
+					created: '3 months ago',
+					lastUsed: 'Last week',
+				},
+			];
+
+			// Dynamic slot names contain a dot, so they are bound via `#[expr]`.
+			const slotApiKey = 'item.apiKey';
+			const slotActions = 'item.actions';
+
+			return { onBack, headers, items, slotApiKey, slotActions };
+		},
+		template: `
+			<N8nSettingsLayout full-width show-back back-label="Back" @back="onBack">
+				<N8nSettingsPageHeader
+					title="API keys"
+					description="Use your API keys to control n8n programmatically."
+					docs-url="https://docs.n8n.io/api/"
+				/>
+
+				<N8nSettingsSection>
+					<N8nDataTableServer :headers="headers" :items="items" :items-length="items.length">
+						<template #[slotApiKey]="{ value }">
+							<N8nText size="small" color="text-base">{{ value }}</N8nText>
+						</template>
+						<template #[slotActions]>
+							<div style="display: flex; justify-content: flex-end">
+								<N8nButton variant="ghost" size="small" icon-only icon="ellipsis-vertical" aria-label="API key actions" />
+							</div>
+						</template>
+					</N8nDataTableServer>
+				</N8nSettingsSection>
+			</N8nSettingsLayout>
+		`,
+	}),
+};
+
+export const ExampleSettingsPage: Story = {
+	render: () => ({
+		components,
+		setup() {
+			// High-impact fields: edits stay in `draft` until the user explicitly saves, at which
+			// point they are committed to `saved`. `dirty` (draft ≠ saved) drives the save bar.
+			const saved = ref({
+				name: 'Acme Production',
+				instanceUrl: 'https://acme.app.n8n.cloud',
+				timezone: 'Europe/Warsaw',
+				senderEmail: 'no-reply@acme.io',
+				logLevel: 'info',
+			});
+			const draft = ref({ ...saved.value });
+			const saving = ref(false);
+			const dirty = computed(() => JSON.stringify(draft.value) !== JSON.stringify(saved.value));
+
+			const timezones = [
+				'Europe/Warsaw',
+				'Europe/London',
+				'America/New_York',
+				'America/Los_Angeles',
+				'Asia/Tokyo',
+				'UTC',
+			];
+			const logLevels = [
+				{ value: 'error', label: 'Error' },
+				{ value: 'warn', label: 'Warn' },
+				{ value: 'info', label: 'Info' },
+				{ value: 'debug', label: 'Debug' },
+			];
+
+			// Low-impact, instant-save toggle.
+			const telemetry = ref(true);
+
+			// Both save modes confirm through the shared app notification (see `confirmSaved`).
+			const onSave = () => {
+				saving.value = true;
+				// Simulate a request; on success commit the draft, hide the bar, and confirm.
+				setTimeout(() => {
+					saved.value = { ...draft.value };
+					saving.value = false;
+					confirmSaved('Settings saved');
+				}, 1000);
+			};
+			const onDiscard = () => {
+				draft.value = { ...saved.value };
+			};
+			const onToggleTelemetry = () => {
+				// Low-impact: persists immediately and confirms with the same notification.
+				confirmSaved('Settings saved');
+			};
+
+			return {
+				draft,
+				saving,
+				dirty,
+				timezones,
+				logLevels,
+				telemetry,
+				onSave,
+				onDiscard,
+				onToggleTelemetry,
+			};
+		},
+		// A full-height scrollable viewport hosts the realistic page so the whole settings page is
+		// visible and scrolls naturally (rather than being clipped inside a short windowed box). The
+		// floating save bar is a sibling of the layout so it can sit 744px wide (12px proud of the
+		// 720px content column) and stick to the bottom of the viewport; the layout gets 64px
+		// (--spacing--3xl) of bottom scroll padding so the last row can clear the floating bar.
+		template: `
+			<div style="${fullPageViewportStyle}">
+				<N8nSettingsLayout style="padding-block-end: var(--spacing--3xl);">
+					<N8nSettingsPageHeader
+						title="General"
+						description="Instance-wide defaults for naming, scheduling, email, and logging."
+						docs-url="https://docs.n8n.io/hosting/configuration/"
+					/>
+
+					<N8nSettingsSection title="Instance" description="High-impact fields require an explicit save.">
+						<N8nSettingsRowGroup>
+							<N8nSettingsRow title="Instance name" description="Shown in the header and in notification emails." :action-fill="true">
+								<template #action><N8nInput v-model="draft.name" size="medium" /></template>
+							</N8nSettingsRow>
+							<N8nSettingsRow title="Instance URL" description="Public base URL used in webhook and email links." :action-fill="true">
+								<template #action><N8nInput v-model="draft.instanceUrl" size="medium" /></template>
+							</N8nSettingsRow>
+							<N8nSettingsRow title="Default timezone" description="Used to schedule and display execution times." :action-fill="true">
+								<template #action>
+									<N8nSelect v-model="draft.timezone" size="medium">
+										<N8nOption v-for="tz in timezones" :key="tz" :value="tz" :label="tz" />
+									</N8nSelect>
+								</template>
+							</N8nSettingsRow>
+						</N8nSettingsRowGroup>
+					</N8nSettingsSection>
+
+					<N8nSettingsSection title="Email" description="The SMTP sender used for invites and notifications.">
+						<N8nSettingsRowGroup>
+							<N8nSettingsRow title="Sender email" description="The address recipients see in the from field." :action-fill="true">
+								<template #action><N8nInput v-model="draft.senderEmail" size="medium" /></template>
+							</N8nSettingsRow>
+						</N8nSettingsRowGroup>
+					</N8nSettingsSection>
+
+					<N8nSettingsSection title="Logging" description="How much detail n8n writes to its logs.">
+						<N8nSettingsRowGroup>
+							<N8nSettingsRow title="Log level" description="Higher levels are noisier and write more to disk." :action-fill="true">
+								<template #action>
+									<N8nSelect v-model="draft.logLevel" size="medium">
+										<N8nOption v-for="level in logLevels" :key="level.value" :value="level.value" :label="level.label" />
+									</N8nSelect>
+								</template>
+							</N8nSettingsRow>
+						</N8nSettingsRowGroup>
+					</N8nSettingsSection>
+
+					<N8nSettingsSection title="Privacy" description="Low-impact toggles save instantly.">
+						<N8nSettingsRowGroup>
+							<N8nSettingsRow title="Share anonymous telemetry" description="Help us improve n8n. Saved as soon as you toggle it.">
+								<template #action>
+									<N8nSwitch v-model="telemetry" @update:model-value="onToggleTelemetry" />
+								</template>
+							</N8nSettingsRow>
+						</N8nSettingsRowGroup>
+					</N8nSettingsSection>
+				</N8nSettingsLayout>
+
+				<N8nSettingsSaveBar
+					floating
+					:visible="dirty"
+					:saving="saving"
+					@save="onSave"
+					@discard="onDiscard"
+				/>
+			</div>
+		`,
+	}),
+	parameters: {
+		// Fill the canvas so the page reads as a real, full-height settings page (no windowed box).
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				story:
+					'A realistic General settings page built from the `N8nSettings*` family inside a full-height scrollable viewport. Editing any high-impact field (instance name/URL, timezone, sender email, log level) flips a dirty flag that slides the floating `N8nSettingsSaveBar` up — a 744px gently rounded bar (the 720px content column plus 12px on each side) with the prominent `--shadow--xl`, resting 24px above the bottom, its Save action on the far right. Discard reverts the draft and hides the bar; Save shows the loading state, commits, hides the bar, and confirms through the existing app notification (the bottom-right `ElNotification` that `useToast()` shows in the app). The low-impact telemetry toggle saves instantly through the same notification. The page carries 64px (`--spacing--3xl`) of bottom scroll padding so the last row clears the floating bar.',
+			},
+		},
+	},
+};


### PR DESCRIPTION
## Summary

Part **4/6** of splitting #32821 into reviewable chunks (PR size limit). Builds on #33703.

Adds the composed **`Instance Settings/Examples`** Storybook pages that assemble the settings components into representative settings screens:

- **Security & login** (leading visual slot + merged sub-section) and its **Passkeys sub-page**
- **This instance** (metrics custom row + back action)
- **API keys** (full-width table under a centered header)
- **Example Settings Page** (realistic dirty-state flow wiring the floating save bar: explicit save for high-impact fields, instant save for a low-impact toggle)

The **Instance level MCP** example follows in parts 5/6 and 6/6 as its own story file (it was split out of this file to stay under the PR size limit).

## How to test

Run Storybook for the design system (`pnpm storybook` in `packages/frontend/@n8n/design-system`) and open **`Instance Settings` → `Examples`**.

## Related Linear tickets, Github issues, and Community forum posts

Split from #32821. Stacked on #33703.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->