### PR TITLE
chore(core): Follow redirects when loading Keycloak authorization page

### DIFF
--- a/packages/testing/containers/services/keycloak.ts
+++ b/packages/testing/containers/services/keycloak.ts
@@ -421,11 +421,60 @@ export class KeycloakHelper {
 
 		try {
 			// Step 1: GET the Keycloak authorization page (HTML with login form).
-			// Use undiciRequest to access raw set-cookie headers for forwarding.
-			const authPageResult = await undiciRequest(authorizationUrl, {
-				method: 'GET',
-				dispatcher: agent,
-			});
+			// Keycloak intermittently answers this GET with a 302 rather than the login
+			// page — either to re-establish an authentication session (redirect back into
+			// Keycloak to set AUTH_SESSION_ID) or, if an SSO session already exists,
+			// straight to the n8n callback with a `code`. undiciRequest does NOT follow
+			// redirects, so follow them ourselves, accumulating cookies across hops.
+			// Cookies are keyed by name so later hops override earlier ones.
+			const cookieJar = new Map<string, string>();
+			const collectCookies = (setCookie: string | string[] | undefined) => {
+				for (const raw of Array.isArray(setCookie) ? setCookie : [setCookie]) {
+					if (!raw) continue;
+					const pair = raw.split(';')[0];
+					const eq = pair.indexOf('=');
+					if (eq > 0) cookieJar.set(pair.slice(0, eq), pair.slice(eq + 1));
+				}
+			};
+			const cookieHeaderFrom = (jar: Map<string, string>) =>
+				[...jar].map(([name, value]) => `${name}=${value}`).join('; ');
+
+			let currentUrl = authorizationUrl;
+			let authPageResult = await undiciRequest(currentUrl, { method: 'GET', dispatcher: agent });
+			collectCookies(authPageResult.headers['set-cookie']);
+
+			for (
+				let hop = 0;
+				authPageResult.statusCode >= 300 && authPageResult.statusCode < 400;
+				hop++
+			) {
+				await authPageResult.body.text();
+				const rawLocation = authPageResult.headers.location;
+				const location = Array.isArray(rawLocation) ? rawLocation[0] : rawLocation;
+				if (!location) {
+					throw new Error(
+						`Keycloak authorization page redirected (HTTP ${authPageResult.statusCode}) without a Location header`,
+					);
+				}
+				const nextUrl = new URL(location, currentUrl).toString();
+
+				// Already-authenticated short circuit: Keycloak redirected straight to the
+				// n8n OAuth2 callback with the authorization code — no login form needed.
+				if (nextUrl.includes('/rest/oauth2-credential/callback')) {
+					return nextUrl;
+				}
+				if (hop >= 5) {
+					throw new Error('Too many redirects loading the Keycloak authorization page');
+				}
+
+				currentUrl = nextUrl;
+				authPageResult = await undiciRequest(currentUrl, {
+					method: 'GET',
+					headers: cookieJar.size ? { Cookie: cookieHeaderFrom(cookieJar) } : undefined,
+					dispatcher: agent,
+				});
+				collectCookies(authPageResult.headers['set-cookie']);
+			}
 
 			if (authPageResult.statusCode < 200 || authPageResult.statusCode >= 300) {
 				await authPageResult.body.text();
@@ -434,14 +483,9 @@ export class KeycloakHelper {
 				);
 			}
 
-			// Extract session cookies from the response to forward with the login POST.
-			// Keycloak sets cookies like AUTH_SESSION_ID, KC_RESTART that are required
-			// for the login form submission to succeed.
-			const rawCookies = authPageResult.headers['set-cookie'];
-			const cookieHeader = (Array.isArray(rawCookies) ? rawCookies : [rawCookies])
-				.filter(Boolean)
-				.map((c) => (c as string).split(';')[0])
-				.join('; ');
+			// Session cookies (AUTH_SESSION_ID, KC_RESTART, ...) accumulated across the
+			// redirect chain are required for the login form submission to succeed.
+			const cookieHeader = cookieHeaderFrom(cookieJar);
 
 			const html = await authPageResult.body.text();
 

--- a/packages/testing/containers/services/keycloak.ts
+++ b/packages/testing/containers/services/keycloak.ts
@@ -456,18 +456,24 @@ export class KeycloakHelper {
 						`Keycloak authorization page redirected (HTTP ${authPageResult.statusCode}) without a Location header`,
 					);
 				}
-				const nextUrl = new URL(location, currentUrl).toString();
+				const nextUrl = new URL(location, currentUrl);
 
 				// Already-authenticated short circuit: Keycloak redirected straight to the
 				// n8n OAuth2 callback with the authorization code — no login form needed.
-				if (nextUrl.includes('/rest/oauth2-credential/callback')) {
-					return nextUrl;
+				// Match on the pathname and require `code`, so a Keycloak restart redirect
+				// that merely echoes `redirect_uri=…/callback` in its query isn't mistaken
+				// for the final callback.
+				if (
+					nextUrl.pathname.endsWith('/rest/oauth2-credential/callback') &&
+					nextUrl.searchParams.has('code')
+				) {
+					return nextUrl.toString();
 				}
 				if (hop >= 5) {
 					throw new Error('Too many redirects loading the Keycloak authorization page');
 				}
 
-				currentUrl = nextUrl;
+				currentUrl = nextUrl.toString();
 				authPageResult = await undiciRequest(currentUrl, {
 					method: 'GET',
 					headers: cookieJar.size ? { Cookie: cookieHeaderFrom(cookieJar) } : undefined,


### PR DESCRIPTION
## Summary

The Keycloak authorization-page GET in `KeycloakHelper.completeAuthorizationCodeFlow` assumed a `2xx` response and threw on anything else, but Keycloak intermittently answers that GET with a `302` — either to re-establish an authentication session (redirect back into Keycloak to set `AUTH_SESSION_ID`) or, when an SSO session already exists, straight to the n8n callback with a `code`. Since `undiciRequest` does not follow redirects, this surfaced as `Failed to load Keycloak authorization page: HTTP 302` and quarantined the `mcp-trigger-credential-gate` e2e. This PR makes the helper follow the redirect chain (bounded to avoid loops), accumulate cookies across hops, and short-circuit to the callback when Keycloak redirects straight there.

## How to test

Requires the enterprise license (`N8N_LICENSE_TENANT_ID` / `N8N_LICENSE_ACTIVATION_KEY`) and a locally built image (`pnpm build:docker`). Then run the previously-quarantined spec in multi-main mode:

\`\`\`bash
pnpm --filter=n8n-playwright test:container:multi-main:e2e \
  tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts
\`\`\`

Verified locally: both legs pass, and the connect-then-execute test passed 3/3 with `--repeat-each=3`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-903

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33707">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

