### PR TITLE
fix(Google Workspace Admin Node): Reactivate user when Suspend is turned off

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -770,7 +770,9 @@ export class GSuiteAdmin implements INodeType {
 							body.primaryEmail = updateFields.primaryEmail as string;
 						}
 
-						if (updateFields.suspendUi) {
+						// Explicit undefined check: the field is a three-state boolean, so
+						// setting it OFF (false) must still send `suspended: false` to reactivate.
+						if (updateFields.suspendUi !== undefined) {
 							body.suspended = updateFields.suspendUi as boolean;
 						}
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/unsuspend.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/unsuspend.test.ts
@@ -1,0 +1,46 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Google GSuiteAdmin Node - Update User (reactivate)', () => {
+	beforeEach(() => {
+		nock.disableNetConnect();
+
+		// Setting the Suspend toggle to OFF must send `suspended: false` so the account is reactivated.
+		nock('https://www.googleapis.com/admin')
+			.put('/directory/v1/users/101071249467630629404', {
+				suspended: false,
+			})
+			.reply(200, {
+				kind: 'admin#directory#user',
+				id: '101071249467630629404',
+				etag: '"example"',
+				primaryEmail: 'one@example.com',
+				name: {
+					givenName: 'test',
+					familyName: 'new',
+				},
+				isAdmin: false,
+				isDelegatedAdmin: false,
+				lastLoginTime: '1970-01-01T00:00:00.000Z',
+				creationTime: '2025-03-26T21:28:53.000Z',
+				agreedToTerms: false,
+				suspended: false,
+				archived: false,
+				changePasswordAtNextLogin: false,
+				ipWhitelisted: false,
+				aliases: ['new22@example.com'],
+				nonEditableAliases: ['new22@example.com.test-google-a.com'],
+				customerId: 'C0442hnz1',
+				orgUnitPath: '/',
+				isMailboxSetup: false,
+				includeInGlobalAddressList: true,
+				thumbnailPhotoUrl: '//example',
+				thumbnailPhotoEtag: '"example"',
+				recoveryEmail: '',
+			});
+	});
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['unsuspend.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/unsuspend.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/unsuspend.workflow.json
@@ -1,0 +1,84 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [120, 700],
+			"id": "0e76b314-4994-4141-975f-9614c6094c80",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "update",
+				"userId": {
+					"__rl": true,
+					"value": "101071249467630629404",
+					"mode": "list",
+					"cachedResultName": "NewOne22 User22"
+				},
+				"updateFields": {
+					"suspendUi": false
+				}
+			},
+			"type": "n8n-nodes-base.gSuiteAdmin",
+			"typeVersion": 1,
+			"position": [140, 1100],
+			"id": "b4cd1391-cfdc-4f36-8c2f-f18a9ad4f795",
+			"name": "Update User",
+			"credentials": {
+				"gSuiteAdminOAuth2Api": {
+					"id": "OXfPMaggXFJ0RLkw",
+					"name": "Google Workspace Admin account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Update User",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Update User": [
+			{
+				"json": {
+					"kind": "admin#directory#user",
+					"id": "101071249467630629404",
+					"etag": "\"example\"",
+					"primaryEmail": "one@example.com",
+					"name": {
+						"givenName": "test",
+						"familyName": "new"
+					},
+					"isAdmin": false,
+					"isDelegatedAdmin": false,
+					"lastLoginTime": "1970-01-01T00:00:00.000Z",
+					"creationTime": "2025-03-26T21:28:53.000Z",
+					"agreedToTerms": false,
+					"suspended": false,
+					"archived": false,
+					"changePasswordAtNextLogin": false,
+					"ipWhitelisted": false,
+					"aliases": ["new22@example.com"],
+					"nonEditableAliases": ["new22@example.com.test-google-a.com"],
+					"customerId": "C0442hnz1",
+					"orgUnitPath": "/",
+					"isMailboxSetup": false,
+					"includeInGlobalAddressList": true,
+					"thumbnailPhotoUrl": "//example",
+					"thumbnailPhotoEtag": "\"example\"",
+					"recoveryEmail": ""
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

The **User > Update** operation in the Google Workspace Admin node could not reactivate (unsuspend) a user. The **Suspend** field is a three-state toggle whose help text reads:

> Whether to set the user as suspended. If set to OFF, the user will be reactivated. If not added, the status will remain unchanged.

But the field was guarded by a truthiness check:

```ts
if (updateFields.suspendUi) {
    body.suspended = updateFields.suspendUi as boolean;
}
```

When the toggle was set to OFF, `updateFields.suspendUi === false`, so the block was skipped and `suspended` was omitted from the `PUT /admin/directory/v1/users/{userId}` request body. Suspending worked, but unsuspending silently did nothing because "field present but false" (reactivate) and "field not added" (leave unchanged) both took the same no-op path.

This changes the guard to an explicit `!== undefined` check (matching the `changePasswordAtNextLogin` handling directly above it), so an OFF value now sends `{ "suspended": false }` and reactivates the user.

## How to test

Automated: a new workflow test asserts the outgoing request body for an OFF toggle is exactly `{ "suspended": false }`.

```
cd packages/nodes-base
pnpm test unsuspend      # new reactivate test
pnpm test update.test    # existing update tests, no regression
```

Manual:
1. Have a user that is currently suspended in Google Workspace.
2. Google Workspace Admin node, resource **User**, operation **Update**, select that user.
3. Under **Update Fields**, add **Suspend** and set it to **OFF**.
4. Execute. The user is reactivated and the request body contains `suspended: false`.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33715

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33716">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

