### PR TITLE
fix(core): Guard against null run-data slots in execution redaction

### DIFF
--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -715,6 +715,25 @@ describe('ExecutionRedactionService', () => {
 			expect(fullItemRedactionStrategy.apply).not.toHaveBeenCalled();
 		});
 
+		it('detects dynamic credentials when a runData node array holds a null slot', async () => {
+			const execution = makeExecution({
+				policy: 'none',
+				mode: 'manual',
+				withDynamicCredentials: true,
+			});
+			// runData arrays can contain null placeholder slots at runtime.
+			execution.data.resultData.runData = {
+				SomeNode: [
+					null,
+					{ startTime: 0, executionTime: 0, usedDynamicCredentials: true } as ITaskData,
+				] as unknown as ITaskData[],
+			};
+
+			await service.processExecution(execution, { user: mockUser });
+
+			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(1);
+		});
+
 		it('scrubs runtimeData.credentials from the execution data', async () => {
 			const execution = makeExecution({
 				policy: 'none',

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -271,7 +271,9 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 */
 	private hasDynamicCredentials(execution: RedactableExecution): boolean {
 		return Object.values(execution.data.resultData?.runData ?? {}).some((taskDataList) =>
-			taskDataList.some((taskData) => taskData.usedDynamicCredentials),
+			// runData node arrays can hold null placeholder slots at runtime despite
+			// the ITaskData[] type, so guard the element deref.
+			taskDataList.some((taskData) => taskData?.usedDynamicCredentials),
 		);
 	}
 


### PR DESCRIPTION
## Summary

`ExecutionRedactionService.hasDynamicCredentials` iterates every node's `runData`
array and reads `usedDynamicCredentials` off each entry, assuming each element is a
populated `ITaskData`. The `IRunData` type declares those arrays as non-nullable
(`ITaskData[]`), but at runtime a node array can contain `null` placeholder slots.
When redaction hit such a slot it threw `TypeError: Cannot read properties of null
(reading 'usedDynamicCredentials')`, crashing the execution-list redaction path.

This was a widespread backend error on production (394 events / 376 affected users
on `n8n@2.29.5`). The fix guards the per-element dereference with optional chaining,
so a `null` slot is treated as "no dynamic credentials for this slot" instead of
throwing. The dynamic-credential detection and forced-redaction behavior are
otherwise unchanged.

### How to test manually

This is a null-safety fix on an internal service; the reliable reproduction is the
added unit test, but it can also be exercised end-to-end:

1. Load or trigger an execution whose stored `resultData.runData` contains a node
   array with a `null` entry (occurs naturally for certain partial/errored runs).
2. Fetch the executions list as any user via the REST API / UI executions view.
3. **Before this change:** the request errors with a 500 and the Sentry
   `TypeError: Cannot read properties of null (reading 'usedDynamicCredentials')`.
4. **After this change:** the list loads normally and redaction is applied
   correctly (executions that genuinely used dynamic credentials are still
   force-redacted).

### Key implementation decisions

- **Minimal, surgical guard.** Only the inner element access is unsafe. The outer
  array (`taskDataList`) is proven non-null by the stack trace (its `.some` was
  already executing when the throw occurred), so it needs no guard — adding one
  would be dead defensiveness.
- **Regression test asserts both halves of the contract.** The new test builds a
  `runData` node array with a leading `null` slot followed by a real
  `usedDynamicCredentials: true` entry, and asserts (a) redaction no longer throws
  and (b) the dynamic credential is still detected (force-redaction still fires).
  It fails with the pre-fix code, reproducing the exact production `TypeError`.

## Related Links

- Linear ticket: https://linear.app/n8n/issue/IAM-951

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33718">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

