### PR TITLE
feat(core): Add Qdrant vector store backend to the agents SDK (no-changelog)

### DIFF
--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -18,6 +18,9 @@
       ],
       "vector-stores/postgres": [
         "dist/vector-stores/postgres.d.ts"
+      ],
+      "vector-stores/qdrant": [
+        "dist/vector-stores/qdrant.d.ts"
       ]
     }
   },
@@ -42,6 +45,10 @@
     "./vector-stores/postgres": {
       "types": "./dist/vector-stores/postgres.d.ts",
       "default": "./dist/vector-stores/postgres.js"
+    },
+    "./vector-stores/qdrant": {
+      "types": "./dist/vector-stores/qdrant.d.ts",
+      "default": "./dist/vector-stores/qdrant.js"
     }
   },
   "files": [
@@ -96,6 +103,7 @@
     "zod-to-json-schema": "catalog:"
   },
   "peerDependencies": {
+    "@qdrant/js-client-rest": "^1.16.2",
     "pg": "catalog:",
     "zod": "catalog:"
   },
@@ -114,11 +122,15 @@
     },
     "pg": {
       "optional": true
+    },
+    "@qdrant/js-client-rest": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
+    "@qdrant/js-client-rest": "^1.16.2",
     "@types/json-schema": "catalog:",
     "@types/pg": "^8.15.6",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -103,7 +103,7 @@
     "zod-to-json-schema": "catalog:"
   },
   "peerDependencies": {
-    "@qdrant/js-client-rest": "^1.16.2",
+    "@qdrant/js-client-rest": "catalog:",
     "pg": "catalog:",
     "zod": "catalog:"
   },
@@ -130,7 +130,7 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
-    "@qdrant/js-client-rest": "^1.16.2",
+    "@qdrant/js-client-rest": "catalog:",
     "@types/json-schema": "catalog:",
     "@types/pg": "^8.15.6",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
@@ -94,7 +94,13 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore', () => {
 	it('rejects a non-UUID, non-integer id', async () => {
 		await expect(
 			store.upsert([{ id: 'exact', vector: [1, 0, 0], content: 'bad id', metadata: {} }]),
-		).rejects.toThrow(/Qdrant requires ids to be a UUID or an unsigned integer/);
+		).rejects.toThrow(/Qdrant requires ids to be a UUID or a canonical unsigned integer/);
+	});
+
+	it('rejects a non-canonical numeric id', async () => {
+		await expect(
+			store.upsert([{ id: '007', vector: [1, 0, 0], content: 'bad id', metadata: {} }]),
+		).rejects.toThrow(/canonical unsigned integer/);
 	});
 
 	it('round-trips through the VectorStore orchestrator with a mock embedding model', async () => {
@@ -259,5 +265,23 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore — metadata filtering', () => {
 				combineWith: 'or',
 			}),
 		).toEqual([ID_A, ID_B].sort());
+	});
+
+	it('rejects a float value for eq', async () => {
+		await expect(
+			filterStore.query([1, 0, 0], {
+				topK: 10,
+				filter: { conditions: [{ key: 'count', operator: 'eq', value: 5.5 }] },
+			}),
+		).rejects.toThrow(/does not support float values/);
+	});
+
+	it('rejects a mixed-type array for in', async () => {
+		await expect(
+			filterStore.query([1, 0, 0], {
+				topK: 10,
+				filter: { conditions: [{ key: 'topic', operator: 'in', value: ['billing', 5] }] },
+			}),
+		).rejects.toThrow(/mixed-type or float values/);
 	});
 });

--- a/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
@@ -1,9 +1,8 @@
 /**
  * Integration tests against a real Qdrant instance — local or cloud. Gated on
- * QDRANT_TEST_URL and QDRANT_COLLECTION_NAME (not the usual API-key/cassette
- * convention) since Qdrant is a separate service, not LLM HTTP — these
- * self-skip when either var is unset. QDRANT_TEST_API_KEY is optional, for
- * cloud instances that require auth.
+ * QDRANT_TEST_URL (not the usual API-key/cassette convention) since Qdrant is
+ * a separate service, not LLM HTTP — these self-skip when it's unset.
+ * QDRANT_TEST_API_KEY is optional, for cloud instances that require auth.
  */
 import type { QdrantClient } from '@qdrant/js-client-rest';
 import { MockEmbeddingModelV3 } from 'ai/test';
@@ -14,7 +13,6 @@ import { QdrantVectorStore } from '../../vector-stores/qdrant';
 
 const QDRANT_URL = process.env.QDRANT_TEST_URL;
 const QDRANT_API_KEY = process.env.QDRANT_TEST_API_KEY;
-const QDRANT_COLLECTION_NAME = process.env.QDRANT_COLLECTION_NAME;
 
 // Qdrant only accepts UUID or unsigned-integer point ids.
 const ID_EXACT = '00000000-0000-4000-8000-000000000001';
@@ -26,27 +24,19 @@ const ID_B = '00000000-0000-4000-8000-00000000000b';
 const ID_C = '00000000-0000-4000-8000-00000000000c';
 const ID_D = '00000000-0000-4000-8000-00000000000d';
 
-/**
- * Stands in for the BYO user's own setup, since QdrantVectorStore itself
- * never creates collections. Idempotent (checks existence first) since
- * QDRANT_COLLECTION_NAME is a fixed, reusable name rather than a per-run
- * random one.
- */
+/** Stands in for the BYO user's own setup, since QdrantVectorStore itself never creates collections. */
 async function createVectorCollection(
 	client: QdrantClient,
 	collectionName: string,
 	opts: { dimensions: number },
 ): Promise<void> {
-	const { exists } = await client.collectionExists(collectionName);
-	if (!exists) {
-		await client.createCollection(collectionName, {
-			vectors: { size: opts.dimensions, distance: 'Cosine' },
-		});
-	}
+	await client.createCollection(collectionName, {
+		vectors: { size: opts.dimensions, distance: 'Cosine' },
+	});
 }
 
-describe.skipIf(!QDRANT_URL || !QDRANT_COLLECTION_NAME)('QdrantVectorStore', () => {
-	const collectionName = QDRANT_COLLECTION_NAME!;
+describe.skipIf(!QDRANT_URL)('QdrantVectorStore', () => {
+	const collectionName = `vs_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
 	let store: QdrantVectorStore;
 	let adminClient: QdrantClient;
 
@@ -138,139 +128,136 @@ describe.skipIf(!QDRANT_URL || !QDRANT_COLLECTION_NAME)('QdrantVectorStore', () 
 	});
 });
 
-describe.skipIf(!QDRANT_URL || !QDRANT_COLLECTION_NAME)(
-	'QdrantVectorStore — metadata filtering',
-	() => {
-		const filterCollectionName = `${QDRANT_COLLECTION_NAME}_filter`;
-		let filterStore: QdrantVectorStore;
-		let adminClient: QdrantClient;
+describe.skipIf(!QDRANT_URL)('QdrantVectorStore — metadata filtering', () => {
+	const filterCollectionName = `vs_test_filter_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+	let filterStore: QdrantVectorStore;
+	let adminClient: QdrantClient;
 
-		beforeAll(async () => {
-			const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
-			adminClient = new QdrantClientCtor({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
-			await createVectorCollection(adminClient, filterCollectionName, { dimensions: 3 });
-			// Qdrant Cloud requires a payload index to filter on a field at all, and
-			// allows only one index type per field (a second `createPayloadIndex`
-			// call on the same field replaces rather than adds) — see the `count`
-			// fixture note below for how that constrains what this suite can assert.
-			await adminClient.createPayloadIndex(filterCollectionName, {
-				field_name: 'metadata.topic',
-				field_schema: 'keyword',
-			});
-			await adminClient.createPayloadIndex(filterCollectionName, {
-				field_name: 'metadata.count',
-				field_schema: 'integer',
-			});
-			await adminClient.createPayloadIndex(filterCollectionName, {
-				field_name: 'metadata.active',
-				field_schema: 'bool',
-			});
-			filterStore = new QdrantVectorStore('qdrant-filter-integration', {
-				url: QDRANT_URL!,
-				apiKey: QDRANT_API_KEY,
-				collectionName: filterCollectionName,
-			});
-			await filterStore.upsert([
-				{
-					id: ID_A,
-					content: 'Row A content',
-					vector: [1, 0, 0],
-					metadata: { topic: 'billing', count: 5, active: true },
-				},
-				{
-					id: ID_B,
-					content: 'Row B content',
-					vector: [0.9, 0.1, 0],
-					metadata: { topic: 'ops', count: 10, active: false },
-				},
-				// Missing all keys — required to prove ne/nin match rows that never had the key.
-				{ id: ID_C, content: 'Row C content', vector: [0, 1, 0], metadata: {} },
-				// Stores count as a JSON string, not a number — proves a numeric filter
-				// doesn't match it. (The reverse — a string filter matching this row —
-				// isn't tested here: Qdrant's `metadata.count` field is indexed as
-				// `integer` above, and a field can only carry one index type at a time,
-				// so a `keyword` filter query on the same field isn't servable.)
-				{ id: ID_D, content: 'Row D content', vector: [0, 0.5, 0.5], metadata: { count: '5' } },
-			]);
+	beforeAll(async () => {
+		const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
+		adminClient = new QdrantClientCtor({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
+		await createVectorCollection(adminClient, filterCollectionName, { dimensions: 3 });
+		// Qdrant Cloud requires a payload index to filter on a field at all, and
+		// allows only one index type per field (a second `createPayloadIndex`
+		// call on the same field replaces rather than adds) — see the `count`
+		// fixture note below for how that constrains what this suite can assert.
+		await adminClient.createPayloadIndex(filterCollectionName, {
+			field_name: 'metadata.topic',
+			field_schema: 'keyword',
 		});
-
-		afterAll(async () => {
-			await adminClient.deleteCollection(filterCollectionName);
-			await filterStore.close();
+		await adminClient.createPayloadIndex(filterCollectionName, {
+			field_name: 'metadata.count',
+			field_schema: 'integer',
 		});
-
-		async function idsFor(filter: Parameters<QdrantVectorStore['query']>[1]['filter']) {
-			const results = await filterStore.query([1, 0, 0], { topK: 10, filter });
-			return results.map((r) => r.id).sort();
-		}
-
-		it('eq matches on string, number, and boolean, and is type-correct', async () => {
-			expect(
-				await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'billing' }] }),
-			).toEqual([ID_A]);
-			expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: 5 }] })).toEqual([
-				ID_A,
-			]);
-			expect(
-				await idsFor({ conditions: [{ key: 'active', operator: 'eq', value: true }] }),
-			).toEqual([ID_A]);
-			expect(
-				await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'nonexistent' }] }),
-			).toEqual([]);
+		await adminClient.createPayloadIndex(filterCollectionName, {
+			field_name: 'metadata.active',
+			field_schema: 'bool',
 		});
-
-		it('combines multiple conditions with AND', async () => {
-			expect(
-				await idsFor({
-					conditions: [
-						{ key: 'topic', operator: 'eq', value: 'billing' },
-						{ key: 'count', operator: 'eq', value: 5 },
-					],
-					combineWith: 'and',
-				}),
-			).toEqual([ID_A]);
+		filterStore = new QdrantVectorStore('qdrant-filter-integration', {
+			url: QDRANT_URL!,
+			apiKey: QDRANT_API_KEY,
+			collectionName: filterCollectionName,
 		});
+		await filterStore.upsert([
+			{
+				id: ID_A,
+				content: 'Row A content',
+				vector: [1, 0, 0],
+				metadata: { topic: 'billing', count: 5, active: true },
+			},
+			{
+				id: ID_B,
+				content: 'Row B content',
+				vector: [0.9, 0.1, 0],
+				metadata: { topic: 'ops', count: 10, active: false },
+			},
+			// Missing all keys — required to prove ne/nin match rows that never had the key.
+			{ id: ID_C, content: 'Row C content', vector: [0, 1, 0], metadata: {} },
+			// Stores count as a JSON string, not a number — proves a numeric filter
+			// doesn't match it. (The reverse — a string filter matching this row —
+			// isn't tested here: Qdrant's `metadata.count` field is indexed as
+			// `integer` above, and a field can only carry one index type at a time,
+			// so a `keyword` filter query on the same field isn't servable.)
+			{ id: ID_D, content: 'Row D content', vector: [0, 0.5, 0.5], metadata: { count: '5' } },
+		]);
+	});
 
-		it('ne excludes only the matching row, including rows missing the key', async () => {
-			const ids = await idsFor({
-				conditions: [{ key: 'topic', operator: 'ne', value: 'billing' }],
-			});
-			expect(ids).not.toContain(ID_A);
-			expect(ids).toContain(ID_B);
-			expect(ids).toContain(ID_C);
-		});
+	afterAll(async () => {
+		await adminClient.deleteCollection(filterCollectionName);
+		await filterStore.close();
+	});
 
-		it('in matches only listed values', async () => {
-			expect(
-				await idsFor({ conditions: [{ key: 'topic', operator: 'in', value: ['billing', 'ops'] }] }),
-			).toEqual([ID_A, ID_B].sort());
-		});
+	async function idsFor(filter: Parameters<QdrantVectorStore['query']>[1]['filter']) {
+		const results = await filterStore.query([1, 0, 0], { topK: 10, filter });
+		return results.map((r) => r.id).sort();
+	}
 
-		it('in is type-correct: a numeric candidate does not match a string-valued row', async () => {
-			expect(await idsFor({ conditions: [{ key: 'count', operator: 'in', value: [5] }] })).toEqual([
-				ID_A,
-			]);
-		});
+	it('eq matches on string, number, and boolean, and is type-correct', async () => {
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'billing' }] }),
+		).toEqual([ID_A]);
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: 5 }] })).toEqual([
+			ID_A,
+		]);
+		expect(await idsFor({ conditions: [{ key: 'active', operator: 'eq', value: true }] })).toEqual([
+			ID_A,
+		]);
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'nonexistent' }] }),
+		).toEqual([]);
+	});
 
-		it('nin excludes listed values but matches rows missing the key (the reference NIN bug case)', async () => {
-			const ids = await idsFor({
-				conditions: [{ key: 'topic', operator: 'nin', value: ['billing'] }],
-			});
-			expect(ids).not.toContain(ID_A);
-			expect(ids).toContain(ID_B);
-			expect(ids).toContain(ID_C); // missing key — must match, not be excluded like `!= ANY` incorrectly does
-		});
+	it('combines multiple conditions with AND', async () => {
+		expect(
+			await idsFor({
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'count', operator: 'eq', value: 5 },
+				],
+				combineWith: 'and',
+			}),
+		).toEqual([ID_A]);
+	});
 
-		it('supports an OR-combined group', async () => {
-			expect(
-				await idsFor({
-					conditions: [
-						{ key: 'topic', operator: 'eq', value: 'billing' },
-						{ key: 'topic', operator: 'eq', value: 'ops' },
-					],
-					combineWith: 'or',
-				}),
-			).toEqual([ID_A, ID_B].sort());
+	it('ne excludes only the matching row, including rows missing the key', async () => {
+		const ids = await idsFor({
+			conditions: [{ key: 'topic', operator: 'ne', value: 'billing' }],
 		});
-	},
-);
+		expect(ids).not.toContain(ID_A);
+		expect(ids).toContain(ID_B);
+		expect(ids).toContain(ID_C);
+	});
+
+	it('in matches only listed values', async () => {
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'in', value: ['billing', 'ops'] }] }),
+		).toEqual([ID_A, ID_B].sort());
+	});
+
+	it('in is type-correct: a numeric candidate does not match a string-valued row', async () => {
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'in', value: [5] }] })).toEqual([
+			ID_A,
+		]);
+	});
+
+	it('nin excludes listed values but matches rows missing the key (the reference NIN bug case)', async () => {
+		const ids = await idsFor({
+			conditions: [{ key: 'topic', operator: 'nin', value: ['billing'] }],
+		});
+		expect(ids).not.toContain(ID_A);
+		expect(ids).toContain(ID_B);
+		expect(ids).toContain(ID_C); // missing key — must match, not be excluded like `!= ANY` incorrectly does
+	});
+
+	it('supports an OR-combined group', async () => {
+		expect(
+			await idsFor({
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'topic', operator: 'eq', value: 'ops' },
+				],
+				combineWith: 'or',
+			}),
+		).toEqual([ID_A, ID_B].sort());
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration tests against a real Qdrant instance — local or cloud. Gated on
+ * QDRANT_TEST_URL and QDRANT_COLLECTION_NAME (not the usual API-key/cassette
+ * convention) since Qdrant is a separate service, not LLM HTTP — these
+ * self-skip when either var is unset. QDRANT_TEST_API_KEY is optional, for
+ * cloud instances that require auth.
+ */
+import type { QdrantClient } from '@qdrant/js-client-rest';
+import { MockEmbeddingModelV3 } from 'ai/test';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { VectorStore } from '../../sdk/vector-store';
+import { QdrantVectorStore } from '../../vector-stores/qdrant';
+
+const QDRANT_URL = process.env.QDRANT_TEST_URL;
+const QDRANT_API_KEY = process.env.QDRANT_TEST_API_KEY;
+const QDRANT_COLLECTION_NAME = process.env.QDRANT_COLLECTION_NAME;
+
+// Qdrant only accepts UUID or unsigned-integer point ids.
+const ID_EXACT = '00000000-0000-4000-8000-000000000001';
+const ID_NEAR = '00000000-0000-4000-8000-000000000002';
+const ID_FAR = '00000000-0000-4000-8000-000000000003';
+
+const ID_A = '00000000-0000-4000-8000-00000000000a';
+const ID_B = '00000000-0000-4000-8000-00000000000b';
+const ID_C = '00000000-0000-4000-8000-00000000000c';
+const ID_D = '00000000-0000-4000-8000-00000000000d';
+
+/**
+ * Stands in for the BYO user's own setup, since QdrantVectorStore itself
+ * never creates collections. Idempotent (checks existence first) since
+ * QDRANT_COLLECTION_NAME is a fixed, reusable name rather than a per-run
+ * random one.
+ */
+async function createVectorCollection(
+	client: QdrantClient,
+	collectionName: string,
+	opts: { dimensions: number },
+): Promise<void> {
+	const { exists } = await client.collectionExists(collectionName);
+	if (!exists) {
+		await client.createCollection(collectionName, {
+			vectors: { size: opts.dimensions, distance: 'Cosine' },
+		});
+	}
+}
+
+describe.skipIf(!QDRANT_URL || !QDRANT_COLLECTION_NAME)('QdrantVectorStore', () => {
+	const collectionName = QDRANT_COLLECTION_NAME!;
+	let store: QdrantVectorStore;
+	let adminClient: QdrantClient;
+
+	beforeAll(async () => {
+		const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
+		adminClient = new QdrantClientCtor({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
+		await createVectorCollection(adminClient, collectionName, { dimensions: 3 });
+		store = new QdrantVectorStore('qdrant-integration', {
+			url: QDRANT_URL!,
+			apiKey: QDRANT_API_KEY,
+			collectionName,
+		});
+	});
+
+	afterAll(async () => {
+		await adminClient.deleteCollection(collectionName);
+		await store.close();
+	});
+
+	it('upserts vectors with metadata and queries by similarity', async () => {
+		await store.upsert([
+			{ id: ID_EXACT, vector: [1, 0, 0], content: 'exact match', metadata: { topic: 'a' } },
+			{ id: ID_NEAR, vector: [0.9, 0.1, 0], content: 'near match', metadata: {} },
+			{ id: ID_FAR, vector: [0, 1, 0], content: 'far match', metadata: {} },
+		]);
+
+		const results = await store.query([1, 0, 0], { topK: 2 });
+
+		expect(results).toHaveLength(2);
+		expect(results[0].id).toBe(ID_EXACT);
+		expect(results[0].score).toBeCloseTo(1, 6);
+		expect(results[0].metadata).toEqual({ topic: 'a' });
+		expect(results[1].id).toBe(ID_NEAR);
+	});
+
+	it('re-upserting the same id updates its content', async () => {
+		await store.upsert([
+			{ id: ID_EXACT, vector: [1, 0, 0], content: 'updated content', metadata: {} },
+		]);
+
+		const results = await store.query([1, 0, 0], { topK: 1 });
+
+		expect(results[0].id).toBe(ID_EXACT);
+		expect(results[0].content).toBe('updated content');
+	});
+
+	it('deletes by ids', async () => {
+		await store.delete({ ids: [ID_FAR] });
+
+		const results = await store.query([0, 1, 0], { topK: 5 });
+
+		expect(results.find((r) => r.id === ID_FAR)).toBeUndefined();
+	});
+
+	it('rejects a non-UUID, non-integer id', async () => {
+		await expect(
+			store.upsert([{ id: 'exact', vector: [1, 0, 0], content: 'bad id', metadata: {} }]),
+		).rejects.toThrow(/Qdrant requires ids to be a UUID or an unsigned integer/);
+	});
+
+	it('round-trips through the VectorStore orchestrator with a mock embedding model', async () => {
+		const roundTripCollection = `${collectionName}_roundtrip`;
+		await createVectorCollection(adminClient, roundTripCollection, { dimensions: 3 });
+		const roundTripStore = new QdrantVectorStore('qdrant-integration-roundtrip', {
+			url: QDRANT_URL!,
+			apiKey: QDRANT_API_KEY,
+			collectionName: roundTripCollection,
+		});
+		const embeddingModel = new MockEmbeddingModelV3({
+			doEmbed: async ({ values }: { values: string[] }) => ({
+				embeddings: values.map(() => [1, 0, 0]),
+				warnings: [],
+			}),
+		});
+
+		try {
+			const knowledge = new VectorStore('roundtrip')
+				.store(roundTripStore)
+				.embeddingModel(embeddingModel);
+			await knowledge.addDocuments([{ content: 'refunds take 5 days' }]);
+
+			const results = await knowledge.search('how long do refunds take');
+
+			expect(results[0].content).toBe('refunds take 5 days');
+		} finally {
+			await adminClient.deleteCollection(roundTripCollection);
+			await roundTripStore.close();
+		}
+	});
+});
+
+describe.skipIf(!QDRANT_URL || !QDRANT_COLLECTION_NAME)(
+	'QdrantVectorStore — metadata filtering',
+	() => {
+		const filterCollectionName = `${QDRANT_COLLECTION_NAME}_filter`;
+		let filterStore: QdrantVectorStore;
+		let adminClient: QdrantClient;
+
+		beforeAll(async () => {
+			const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
+			adminClient = new QdrantClientCtor({ url: QDRANT_URL, apiKey: QDRANT_API_KEY });
+			await createVectorCollection(adminClient, filterCollectionName, { dimensions: 3 });
+			// Qdrant Cloud requires a payload index to filter on a field at all, and
+			// allows only one index type per field (a second `createPayloadIndex`
+			// call on the same field replaces rather than adds) — see the `count`
+			// fixture note below for how that constrains what this suite can assert.
+			await adminClient.createPayloadIndex(filterCollectionName, {
+				field_name: 'metadata.topic',
+				field_schema: 'keyword',
+			});
+			await adminClient.createPayloadIndex(filterCollectionName, {
+				field_name: 'metadata.count',
+				field_schema: 'integer',
+			});
+			await adminClient.createPayloadIndex(filterCollectionName, {
+				field_name: 'metadata.active',
+				field_schema: 'bool',
+			});
+			filterStore = new QdrantVectorStore('qdrant-filter-integration', {
+				url: QDRANT_URL!,
+				apiKey: QDRANT_API_KEY,
+				collectionName: filterCollectionName,
+			});
+			await filterStore.upsert([
+				{
+					id: ID_A,
+					content: 'Row A content',
+					vector: [1, 0, 0],
+					metadata: { topic: 'billing', count: 5, active: true },
+				},
+				{
+					id: ID_B,
+					content: 'Row B content',
+					vector: [0.9, 0.1, 0],
+					metadata: { topic: 'ops', count: 10, active: false },
+				},
+				// Missing all keys — required to prove ne/nin match rows that never had the key.
+				{ id: ID_C, content: 'Row C content', vector: [0, 1, 0], metadata: {} },
+				// Stores count as a JSON string, not a number — proves a numeric filter
+				// doesn't match it. (The reverse — a string filter matching this row —
+				// isn't tested here: Qdrant's `metadata.count` field is indexed as
+				// `integer` above, and a field can only carry one index type at a time,
+				// so a `keyword` filter query on the same field isn't servable.)
+				{ id: ID_D, content: 'Row D content', vector: [0, 0.5, 0.5], metadata: { count: '5' } },
+			]);
+		});
+
+		afterAll(async () => {
+			await adminClient.deleteCollection(filterCollectionName);
+			await filterStore.close();
+		});
+
+		async function idsFor(filter: Parameters<QdrantVectorStore['query']>[1]['filter']) {
+			const results = await filterStore.query([1, 0, 0], { topK: 10, filter });
+			return results.map((r) => r.id).sort();
+		}
+
+		it('eq matches on string, number, and boolean, and is type-correct', async () => {
+			expect(
+				await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'billing' }] }),
+			).toEqual([ID_A]);
+			expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: 5 }] })).toEqual([
+				ID_A,
+			]);
+			expect(
+				await idsFor({ conditions: [{ key: 'active', operator: 'eq', value: true }] }),
+			).toEqual([ID_A]);
+			expect(
+				await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'nonexistent' }] }),
+			).toEqual([]);
+		});
+
+		it('combines multiple conditions with AND', async () => {
+			expect(
+				await idsFor({
+					conditions: [
+						{ key: 'topic', operator: 'eq', value: 'billing' },
+						{ key: 'count', operator: 'eq', value: 5 },
+					],
+					combineWith: 'and',
+				}),
+			).toEqual([ID_A]);
+		});
+
+		it('ne excludes only the matching row, including rows missing the key', async () => {
+			const ids = await idsFor({
+				conditions: [{ key: 'topic', operator: 'ne', value: 'billing' }],
+			});
+			expect(ids).not.toContain(ID_A);
+			expect(ids).toContain(ID_B);
+			expect(ids).toContain(ID_C);
+		});
+
+		it('in matches only listed values', async () => {
+			expect(
+				await idsFor({ conditions: [{ key: 'topic', operator: 'in', value: ['billing', 'ops'] }] }),
+			).toEqual([ID_A, ID_B].sort());
+		});
+
+		it('in is type-correct: a numeric candidate does not match a string-valued row', async () => {
+			expect(await idsFor({ conditions: [{ key: 'count', operator: 'in', value: [5] }] })).toEqual([
+				ID_A,
+			]);
+		});
+
+		it('nin excludes listed values but matches rows missing the key (the reference NIN bug case)', async () => {
+			const ids = await idsFor({
+				conditions: [{ key: 'topic', operator: 'nin', value: ['billing'] }],
+			});
+			expect(ids).not.toContain(ID_A);
+			expect(ids).toContain(ID_B);
+			expect(ids).toContain(ID_C); // missing key — must match, not be excluded like `!= ANY` incorrectly does
+		});
+
+		it('supports an OR-combined group', async () => {
+			expect(
+				await idsFor({
+					conditions: [
+						{ key: 'topic', operator: 'eq', value: 'billing' },
+						{ key: 'topic', operator: 'eq', value: 'ops' },
+					],
+					combineWith: 'or',
+				}),
+			).toEqual([ID_A, ID_B].sort());
+		});
+	},
+);

--- a/packages/@n8n/agents/src/vector-stores/postgres.ts
+++ b/packages/@n8n/agents/src/vector-stores/postgres.ts
@@ -24,7 +24,7 @@ interface PgVectorRow {
 
 export type PgVectorStoreOptions = {
 	connectionString: string;
-	tableName?: string;
+	tableName: string;
 };
 
 /**
@@ -38,6 +38,7 @@ export type PgVectorStoreOptions = {
  * ```typescript
  * const store = new PgVectorStore('product-docs', {
  *   connectionString: 'postgresql://user:pass@localhost:5432/db',
+ *   tableName: 'product_docs',
  * });
  * ```
  */
@@ -50,7 +51,7 @@ export class PgVectorStore extends BaseVectorStore<PgVectorStoreOptions> {
 
 	constructor(name: string, options: PgVectorStoreOptions) {
 		super(name, options);
-		this.tableName = options.tableName ?? 'agent_knowledge';
+		this.tableName = options.tableName;
 		if (!IDENTIFIER_PATTERN.test(this.tableName)) {
 			throw new Error(
 				`Invalid PgVectorStore table name "${this.tableName}": must match ${IDENTIFIER_PATTERN}`,

--- a/packages/@n8n/agents/src/vector-stores/qdrant.ts
+++ b/packages/@n8n/agents/src/vector-stores/qdrant.ts
@@ -1,0 +1,155 @@
+import type { QdrantClient, Schemas } from '@qdrant/js-client-rest';
+
+import { BaseVectorStore } from '../storage/base-vector-store';
+import type {
+	FilterCondition,
+	VectorFilter,
+	VectorQueryResult,
+	VectorRecord,
+} from '../types/sdk/vector-store';
+import type { JSONObject } from '../types/utils/json';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UNSIGNED_INT_PATTERN = /^\d+$/;
+
+interface QdrantPayload {
+	content: string;
+	metadata: JSONObject;
+}
+
+export type QdrantVectorStoreOptions = {
+	url: string;
+	apiKey?: string;
+	collectionName: string;
+};
+
+/**
+ * Qdrant backend (`@qdrant/js-client-rest` is an optional peer dependency).
+ * Never creates or alters the collection: expects one that already exists
+ * with vector size matching the embedding model and Cosine distance.
+ *
+ * Qdrant point ids must be a UUID or an unsigned integer — arbitrary string
+ * ids (other than the UUIDs the `VectorStore` orchestrator generates) are
+ * rejected with a descriptive error rather than a raw Qdrant 400.
+ *
+ * @example
+ * ```typescript
+ * const store = new QdrantVectorStore('product-docs', {
+ *   url: 'http://localhost:6333',
+ *   collectionName: 'product_docs',
+ * });
+ * ```
+ */
+export class QdrantVectorStore extends BaseVectorStore<QdrantVectorStoreOptions> {
+	private readonly collectionName: string;
+
+	private client?: QdrantClient;
+
+	constructor(name: string, options: QdrantVectorStoreOptions) {
+		super(name, options);
+		this.collectionName = options.collectionName;
+	}
+
+	async upsert(records: VectorRecord[]): Promise<void> {
+		if (records.length === 0) return;
+
+		const client = await this.getClient();
+		await client.upsert(this.collectionName, {
+			wait: true,
+			points: records.map((record) => ({
+				id: toPointId(record.id),
+				vector: record.vector,
+				payload: { content: record.content, metadata: record.metadata },
+			})),
+		});
+	}
+
+	async query(
+		vector: number[],
+		opts: { topK: number; filter?: VectorFilter },
+	): Promise<VectorQueryResult[]> {
+		const client = await this.getClient();
+		const filter =
+			opts.filter && opts.filter.conditions.length > 0 ? buildQdrantFilter(opts.filter) : undefined;
+
+		const result = await client.query(this.collectionName, {
+			query: vector,
+			limit: opts.topK,
+			with_payload: true,
+			...(filter ? { filter } : {}),
+		});
+
+		return result.points.map(toQueryResult);
+	}
+
+	async delete({ ids }: { ids: string[] }): Promise<void> {
+		if (ids.length === 0) return;
+
+		const client = await this.getClient();
+		await client.delete(this.collectionName, { wait: true, points: ids.map(toPointId) });
+	}
+
+	async close(): Promise<void> {
+		this.client = undefined;
+	}
+
+	private async getClient(): Promise<QdrantClient> {
+		if (!this.client) {
+			const { QdrantClient: QdrantClientCtor } = await import('@qdrant/js-client-rest');
+			this.client = new QdrantClientCtor({
+				url: this.constructorOptions.url,
+				apiKey: this.constructorOptions.apiKey,
+			});
+		}
+		return this.client;
+	}
+}
+
+/** Qdrant only accepts UUID or unsigned-integer point ids. */
+function toPointId(id: string): string | number {
+	if (UUID_PATTERN.test(id)) return id;
+	if (UNSIGNED_INT_PATTERN.test(id) && Number(id) <= Number.MAX_SAFE_INTEGER) return Number(id);
+	throw new Error(
+		`Invalid Qdrant point id "${id}": Qdrant requires ids to be a UUID or an unsigned integer.`,
+	);
+}
+
+function toQueryResult(point: Schemas['ScoredPoint']): VectorQueryResult {
+	const payload = (point.payload ?? {}) as unknown as QdrantPayload;
+	return {
+		id: String(point.id),
+		content: payload.content,
+		metadata: payload.metadata ?? {},
+		score: point.score,
+	};
+}
+
+/** Negations are expressed as nested `must_not` filters so both `and`/`or` combinators work uniformly. */
+function buildQdrantFilter(filter: VectorFilter): Schemas['Filter'] {
+	const conditions = filter.conditions.map(buildCondition);
+	return filter.combineWith === 'or' ? { should: conditions } : { must: conditions };
+}
+
+function buildCondition(condition: FilterCondition): Schemas['Condition'] {
+	const { key, operator, value } = condition;
+	const payloadKey = `metadata.${key}`;
+
+	switch (operator) {
+		case 'eq':
+			return { key: payloadKey, match: { value } };
+		case 'ne':
+			return { must_not: [{ key: payloadKey, match: { value } }] };
+		case 'in':
+		case 'nin': {
+			if (!Array.isArray(value) || value.length === 0) {
+				throw new Error(
+					`Filter operator "${operator}" on key "${key}" requires a non-empty array value.`,
+				);
+			}
+			const anyCondition: Schemas['Condition'] = { key: payloadKey, match: { any: value } };
+			return operator === 'in' ? anyCondition : { must_not: [anyCondition] };
+		}
+		default:
+			throw new Error(`Unsupported filter operator: "${String(operator)}"`);
+	}
+}

--- a/packages/@n8n/agents/src/vector-stores/qdrant.ts
+++ b/packages/@n8n/agents/src/vector-stores/qdrant.ts
@@ -97,8 +97,10 @@ export class QdrantVectorStore extends BaseVectorStore<QdrantVectorStoreOptions>
 		await client.delete(this.collectionName, { wait: true, points: ids.map(toPointId) });
 	}
 
-	async close(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/promise-function-async -- no await needed; matches `require-await`
+	close(): Promise<void> {
 		this.client = undefined;
+		return Promise.resolve();
 	}
 
 	private async getClient(): Promise<QdrantClient> {
@@ -170,6 +172,7 @@ function buildCondition(condition: FilterCondition): Schemas['Condition'] {
 					`Filter operator "${operator}" on key "${key}" requires all array elements to be strings or all to be integers: Qdrant match does not support mixed-type or float values.`,
 				);
 			}
+			// eslint-disable-next-line id-denylist -- `any` is Qdrant's match-schema field name
 			const anyCondition: Schemas['Condition'] = { key: payloadKey, match: { any: value } };
 			return operator === 'in' ? anyCondition : { must_not: [anyCondition] };
 		}

--- a/packages/@n8n/agents/src/vector-stores/qdrant.ts
+++ b/packages/@n8n/agents/src/vector-stores/qdrant.ts
@@ -37,7 +37,8 @@ export type QdrantVectorStoreOptions = {
  * and a field can only carry one index type at a time. Filter values are
  * also more restrictive than `PgVectorStore`: Qdrant `match` only supports
  * strings, integers, and booleans, so float values for `eq`/`ne` and
- * mixed-type arrays for `in`/`nin` (e.g. `['billing', 5]`) are rejected.
+ * mixed-type arrays for `in`/`nin` (e.g. `['billing', 5]`) are rejected with
+ * a descriptive error before any request is sent.
  *
  * @example
  * ```typescript
@@ -115,9 +116,12 @@ export class QdrantVectorStore extends BaseVectorStore<QdrantVectorStoreOptions>
 /** Qdrant only accepts UUID or unsigned-integer point ids. */
 function toPointId(id: string): string | number {
 	if (UUID_PATTERN.test(id)) return id;
-	if (UNSIGNED_INT_PATTERN.test(id) && Number(id) <= Number.MAX_SAFE_INTEGER) return Number(id);
+	const numeric = Number(id);
+	if (UNSIGNED_INT_PATTERN.test(id) && Number.isSafeInteger(numeric) && String(numeric) === id) {
+		return numeric;
+	}
 	throw new Error(
-		`Invalid Qdrant point id "${id}": Qdrant requires ids to be a UUID or an unsigned integer.`,
+		`Invalid Qdrant point id "${id}": Qdrant requires ids to be a UUID or a canonical unsigned integer.`,
 	);
 }
 
@@ -143,14 +147,27 @@ function buildCondition(condition: FilterCondition): Schemas['Condition'] {
 
 	switch (operator) {
 		case 'eq':
-			return { key: payloadKey, match: { value } };
-		case 'ne':
-			return { must_not: [{ key: payloadKey, match: { value } }] };
+		case 'ne': {
+			if (typeof value === 'number' && !Number.isInteger(value)) {
+				throw new Error(
+					`Filter operator "${operator}" on key "${key}" does not support float values: Qdrant match only supports strings, integers, and booleans.`,
+				);
+			}
+			const match: Schemas['Condition'] = { key: payloadKey, match: { value } };
+			return operator === 'eq' ? match : { must_not: [match] };
+		}
 		case 'in':
 		case 'nin': {
 			if (!Array.isArray(value) || value.length === 0) {
 				throw new Error(
 					`Filter operator "${operator}" on key "${key}" requires a non-empty array value.`,
+				);
+			}
+			const allStrings = value.every((v) => typeof v === 'string');
+			const allIntegers = value.every((v) => typeof v === 'number' && Number.isInteger(v));
+			if (!allStrings && !allIntegers) {
+				throw new Error(
+					`Filter operator "${operator}" on key "${key}" requires all array elements to be strings or all to be integers: Qdrant match does not support mixed-type or float values.`,
 				);
 			}
 			const anyCondition: Schemas['Condition'] = { key: payloadKey, match: { any: value } };

--- a/packages/@n8n/agents/src/vector-stores/qdrant.ts
+++ b/packages/@n8n/agents/src/vector-stores/qdrant.ts
@@ -32,6 +32,13 @@ export type QdrantVectorStoreOptions = {
  * ids (other than the UUIDs the `VectorStore` orchestrator generates) are
  * rejected with a descriptive error rather than a raw Qdrant 400.
  *
+ * Metadata filtering requires a payload index on each filtered field
+ * (`metadata.<key>`) — Qdrant Cloud rejects filters on unindexed fields —
+ * and a field can only carry one index type at a time. Filter values are
+ * also more restrictive than `PgVectorStore`: Qdrant `match` only supports
+ * strings, integers, and booleans, so float values for `eq`/`ne` and
+ * mixed-type arrays for `in`/`nin` (e.g. `['billing', 5]`) are rejected.
+ *
  * @example
  * ```typescript
  * const store = new QdrantVectorStore('product-docs', {

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -285,7 +285,7 @@
     "@n8n/utils": "workspace:*",
     "@oracle/langchain-oracledb": "0.2.0",
     "@pinecone-database/pinecone": "^5.0.2",
-    "@qdrant/js-client-rest": "^1.16.2",
+    "@qdrant/js-client-rest": "catalog:",
     "@smithy/node-http-handler": "4.5.0",
     "@smithy/types": "4.13.1",
     "@supabase/supabase-js": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ catalogs:
     '@openrouter/ai-sdk-provider':
       specifier: ^2.8.0
       version: 2.9.0
+    '@qdrant/js-client-rest':
+      specifier: ^1.16.2
+      version: 1.16.2
     '@rudderstack/rudder-sdk-node':
       specifier: 3.0.5
       version: 3.0.5
@@ -976,7 +979,7 @@ importers:
         specifier: workspace:*
         version: link:../vitest-config
       '@qdrant/js-client-rest':
-        specifier: ^1.16.2
+        specifier: 'catalog:'
         version: 1.16.2(typescript@6.0.2)
       '@types/json-schema':
         specifier: 'catalog:'
@@ -2964,7 +2967,7 @@ importers:
         specifier: ^5.0.2
         version: 5.1.2
       '@qdrant/js-client-rest':
-        specifier: ^1.16.2
+        specifier: 'catalog:'
         version: 1.16.2(typescript@6.0.2)
       '@smithy/node-http-handler':
         specifier: 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,6 +975,9 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@qdrant/js-client-rest':
+        specifier: ^1.16.2
+        version: 1.16.2(typescript@6.0.2)
       '@types/json-schema':
         specifier: 'catalog:'
         version: 7.0.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ catalog:
   '@mozilla/readability': ^0.6.0
   '@n8n_io/ai-assistant-sdk': 1.24.0
   '@openrouter/ai-sdk-provider': ^2.8.0
+  '@qdrant/js-client-rest': ^1.16.2
   '@rudderstack/rudder-sdk-node': 3.0.5
   '@sentry/node': ^10.55.0
   '@stryker-mutator/core': 9.6.1


### PR DESCRIPTION
## Summary
Adds `QdrantVectorStore`, a Qdrant backend for the agents SDK's vector store abstraction, implemented the same way as `PgVectorStore`:
- Extends `BaseVectorStore`, implementing `upsert`, `query`, `delete`, and `close` against the official `@qdrant/js-client-rest` client (added as an optional peer dependency, lazily imported so it's never required unless used).
- Never creates or alters a collection — expects one that already exists (BYO-schema, same convention as `PgVectorStore` and its table).
- Exposed via a new subpath export, `@n8n/agents/vector-stores/qdrant`.
- Point ids are validated to be a UUID or unsigned integer (Qdrant's only supported id types) and rejected with a descriptive error otherwise, rather than surfacing a raw Qdrant 400.
- Metadata filters (`eq`/`ne`/`in`/`nin`, `and`/`or`) compile to Qdrant's filter DSL, with negations expressed as nested `must_not` filters so rows missing the filtered key are still matched correctly (mirrors the semantics already covered by the Postgres filter tests).
Also tightens both backends' constructor options: `PgVectorStoreOptions.tableName` and the new `QdrantVectorStoreOptions.collectionName` are now required rather than silently defaulting to `agent_knowledge`. Neither backend ever creates schema, so a silent default only produced a confusing runtime failure against a name the consumer never chose.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-337/feature-add-qdrant-to-supported-vector-stores

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33721">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->