### PR TITLE
fix: Chat works when running on separate webhook server

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-server.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-server.test.ts
@@ -1,0 +1,54 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
+import { GlobalConfig } from '@n8n/config';
+import { DbConnection } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type express from 'express';
+import type * as http from 'node:http';
+import { mock } from 'vitest-mock-extended';
+
+import { ChatServer } from '@/chat/chat-server';
+import { WebhookServer } from '@/webhooks/webhook-server';
+
+const mockApp = mock<express.Application>();
+vi.mock('express', async () => ({ __esModule: true, default: () => mockApp }));
+
+describe('WebhookServer', () => {
+	it('should mount the chat WebSocket server', () => {
+		mockInstance(Logger);
+		Container.set(DbConnection, mock<DbConnection>());
+		Container.set(
+			GlobalConfig,
+			mock<GlobalConfig>({
+				path: '/',
+				protocol: 'http',
+				port: 5678,
+				listen_address: '0.0.0.0',
+				proxy_hops: 0,
+				ssl_key: '',
+				ssl_cert: '',
+				endpoints: {
+					rest: 'rest',
+					form: 'form',
+					formTest: 'form-test',
+					formWaiting: 'form-waiting',
+					webhook: 'webhook',
+					webhookTest: 'webhook-test',
+					webhookWaiting: 'webhook-waiting',
+					mcp: 'mcp',
+					mcpTest: 'mcp-test',
+					health: '/healthz',
+				},
+			}),
+		);
+		const chatServer = mockInstance(ChatServer);
+
+		const webhookServer = new WebhookServer();
+		const httpServer = mock<http.Server>();
+		Object.assign(webhookServer, { server: httpServer });
+
+		webhookServer['setupPushServer']();
+
+		expect(chatServer.setup).toHaveBeenCalledWith(httpServer, mockApp);
+	});
+});

--- a/packages/cli/src/webhooks/webhook-server.ts
+++ b/packages/cli/src/webhooks/webhook-server.ts
@@ -1,6 +1,7 @@
 import { Container, Service } from '@n8n/di';
 
 import { AbstractServer } from '@/abstract-server';
+import { ChatServer } from '@/chat/chat-server';
 
 @Service()
 export class WebhookServer extends AbstractServer {
@@ -10,5 +11,10 @@ export class WebhookServer extends AbstractServer {
 			const { PrometheusMetricsService } = await import('@/metrics/prometheus');
 			Container.get(PrometheusMetricsService).init(this.app);
 		}
+	}
+
+	/** The chat widget opens its WebSocket against the same origin that served the chat webhook */
+	protected setupPushServer() {
+		Container.get(ChatServer).setup(this.server, this.app);
 	}
 }

--- a/packages/testing/containers/services/load-balancer.ts
+++ b/packages/testing/containers/services/load-balancer.ts
@@ -20,8 +20,11 @@ export interface LoadBalancerMeta {
 export type LoadBalancerResult = ServiceResult<LoadBalancerMeta>;
 
 // Production paths the `n8n webhook` proc serves. Test/waiting/form-test paths
-// stay on main, per `packages/cli/src/commands/webhook.ts`.
-const WEBHOOK_PROC_PATHS = ['/webhook/*', '/form/*'] as const;
+// stay on main, per `packages/cli/src/commands/webhook.ts`. `/chat` is the chat
+// widget's WebSocket endpoint: the widget always connects to the origin that
+// served the chat webhook, so it must route to the webhook procs too — same as
+// production setups where WEBHOOK_URL points at the dedicated webhook server.
+const WEBHOOK_PROC_PATHS = ['/webhook/*', '/form/*', '/chat'] as const;
 
 function buildCaddyConfig(
 	mainUpstreams: string[],

--- a/packages/testing/playwright/tests/infrastructure/webhook-proc/chat-send-and-wait.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/webhook-proc/chat-send-and-wait.spec.ts
@@ -1,0 +1,138 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+
+const HEARTBEAT = 'n8n|heartbeat';
+const HEARTBEAT_ACK = 'n8n|heartbeat-ack';
+const QUESTION = 'What is your name?';
+
+test.use({ capability: { webhooks: 1, workers: 1 } });
+
+function withChatWebhookId(webhookId: string) {
+	return (workflow: Partial<IWorkflowBase>) => {
+		workflow.nodes?.forEach((node) => {
+			if (node.type === '@n8n/n8n-nodes-langchain.chatTrigger') {
+				node.webhookId = webhookId;
+			}
+		});
+		return workflow;
+	};
+}
+
+function buildChatWsUrl(
+	backendUrl: string,
+	params: { sessionId: string; executionId: string; resumeToken?: string },
+) {
+	const url = new URL('/chat', backendUrl);
+	url.protocol = url.protocol.replace('http', 'ws');
+	url.searchParams.set('sessionId', params.sessionId);
+	url.searchParams.set('executionId', params.executionId);
+	url.searchParams.set('isPublic', 'true');
+	if (params.resumeToken) url.searchParams.set('token', params.resumeToken);
+	return url.toString();
+}
+
+function openChatSocket(wsUrl: string) {
+	const socket = new WebSocket(wsUrl);
+	const received: string[] = [];
+	const waiters: Array<{
+		predicate: (message: string) => boolean;
+		resolve: (message: string) => void;
+	}> = [];
+
+	socket.addEventListener('message', (event) => {
+		const message = String(event.data);
+		if (message === HEARTBEAT) {
+			socket.send(HEARTBEAT_ACK);
+			return;
+		}
+		received.push(message);
+		const index = waiters.findIndex(({ predicate }) => predicate(message));
+		if (index !== -1) waiters.splice(index, 1)[0].resolve(message);
+	});
+
+	const opened = new Promise<void>((resolve, reject) => {
+		socket.addEventListener('open', () => resolve());
+		socket.addEventListener('error', () =>
+			reject(new Error(`WebSocket connection to ${wsUrl} failed`)),
+		);
+	});
+
+	const waitForMessage = async (predicate: (message: string) => boolean, timeoutMs = 30_000) => {
+		const existing = received.find(predicate);
+		if (existing) return existing;
+
+		return await new Promise<string>((resolve, reject) => {
+			const waiter = {
+				predicate,
+				resolve: (message: string) => {
+					clearTimeout(timeout);
+					resolve(message);
+				},
+			};
+			const timeout = setTimeout(() => {
+				waiters.splice(waiters.indexOf(waiter), 1);
+				reject(
+					new Error(
+						`No matching chat message within ${timeoutMs}ms. Received: ${JSON.stringify(received)}`,
+					),
+				);
+			}, timeoutMs);
+			waiters.push(waiter);
+		});
+	};
+
+	return { socket, opened, waitForMessage };
+}
+
+test.describe(
+	'Chat sendAndWait with dedicated webhook process @mode:queue',
+	{ annotation: [{ type: 'owner', description: 'NODES' }] },
+	() => {
+		test('should deliver the sendAndWait message over WebSocket and resume the execution on reply', async ({
+			api,
+			backendUrl,
+		}) => {
+			const webhookId = nanoid();
+			const { workflowId } = await api.workflows.importWorkflowFromFile('chat-send-and-wait.json', {
+				transform: withChatWebhookId(webhookId),
+			});
+
+			const sessionId = nanoid();
+			const triggerResponse = await api.webhooks.trigger(`/webhook/${webhookId}/chat`, {
+				method: 'POST',
+				data: { action: 'sendMessage', sessionId, chatInput: 'hello' },
+			});
+			expect(triggerResponse.ok()).toBe(true);
+
+			const { executionId, resumeToken } = (await triggerResponse.json()) as {
+				executionId: string;
+				resumeToken?: string;
+			};
+			expect(executionId).toBeTruthy();
+
+			await api.workflows.waitForWorkflowStatus(workflowId, 'waiting', 30_000);
+
+			const chat = openChatSocket(
+				buildChatWsUrl(backendUrl, { sessionId, executionId, resumeToken }),
+			);
+
+			try {
+				await chat.opened;
+
+				const question = await chat.waitForMessage((message) => message.includes(QUESTION));
+				expect(question).toContain(QUESTION);
+
+				chat.socket.send(
+					JSON.stringify({ action: 'sendMessage', sessionId, chatInput: 'E2E reply' }),
+				);
+
+				const execution = await api.workflows.waitForWorkflowStatus(workflowId, 'success', 30_000);
+				expect(execution.status).toBe('success');
+			} finally {
+				chat.socket.close();
+			}
+		});
+	},
+);

--- a/packages/testing/playwright/workflows/chat-send-and-wait.json
+++ b/packages/testing/playwright/workflows/chat-send-and-wait.json
@@ -1,0 +1,74 @@
+{
+	"name": "Chat sendAndWait",
+	"active": true,
+	"nodes": [
+		{
+			"parameters": {
+				"public": true,
+				"mode": "hostedChat",
+				"authentication": "none",
+				"initialMessages": "",
+				"options": {
+					"responseMode": "responseNodes"
+				}
+			},
+			"id": "d3a7f2b1-5c4e-4b8a-9f01-2e6d8c7a1b23",
+			"name": "When chat message received",
+			"type": "@n8n/n8n-nodes-langchain.chatTrigger",
+			"typeVersion": 1.4,
+			"position": [0, 0],
+			"webhookId": "chat-send-and-wait-trigger"
+		},
+		{
+			"parameters": {
+				"operation": "sendAndWait",
+				"message": "What is your name?",
+				"responseType": "freeTextChat",
+				"options": {}
+			},
+			"id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+			"name": "Ask question",
+			"type": "@n8n/n8n-nodes-langchain.chat",
+			"typeVersion": 1.3,
+			"position": [220, 0],
+			"webhookId": "f0e9d8c7-b6a5-4433-9211-0f1e2d3c4b5a"
+		},
+		{
+			"parameters": {
+				"mode": "raw",
+				"jsonOutput": "={ \"reply\": \"{{ $json.chatInput }}\" }",
+				"options": {}
+			},
+			"id": "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",
+			"name": "Capture Result",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [440, 0]
+		}
+	],
+	"connections": {
+		"When chat message received": {
+			"main": [
+				[
+					{
+						"node": "Ask question",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Ask question": {
+			"main": [
+				[
+					{
+						"node": "Capture Result",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {}
+}


### PR DESCRIPTION
## Summary

Fixes chat functionality when n8n is run with separate webhook server and main process disabled (via `N8N_DISABLE_PRODUCTION_MAIN_PROCESS=true`). The problem comes form webhook server not registering `webhook/{webhookId}/chat` endpoint for websocket communication that is used in the chat, so disabling the main process is not strictly required for reproduction but without the main process there is no other way to reach the chat webhook endpoint other than on the separate webhook url (webhook server)

## How to test


### Run e2e tests

1. Build the n8n docker container via 
```
pnpm build:docker
```

2. Run the e2e tests (see new tests added in the PR)
```
pnpm --filter=n8n-playwright exec playwright test --project='queue:infrastructure' tests/infrastructure/webhook-proc/chat-send-and-wait.spec.ts --reporter=list
```

### Manual testing

#### 1. Start database + redis

```
pnpm --filter n8n-containers services --services postgres,redis
```

This starts the two containers and writes their connection vars (DB_TYPE=postgresdb, DB_POSTGRESDB_HOST/PORT/USER/PASSWORD/DATABASE, QUEUE_BULL_REDIS_HOST/PORT) into packages/cli/bin/.env.

cleanup later with

```
pnpm --filter n8n-containers services:clean
```

#### 2. Start n8n environment

Open 3 terminal windows pointing to `packages/cli/bin`

##### Main (with disabled main process as in the bug report)

```
EXECUTIONS_MODE=queue \
N8N_DISABLE_PRODUCTION_MAIN_PROCESS=true \
WEBHOOK_URL=http://localhost:5680 \
./n8n start
```

##### Dedicated webhook server:

```
EXECUTIONS_MODE=queue \
N8N_PORT=5680 \
WEBHOOK_URL=http://localhost:5680 \
./n8n webhook
```

##### Worker

```
EXECUTIONS_MODE=queue \
N8N_DISABLE_PRODUCTION_MAIN_PROCESS=true \
N8N_RUNNERS_BROKER_PORT=5681 \
WEBHOOK_URL=http://localhost:5680 \
./n8n worker
```

#### 3. Configure workflow

1. open http://localhost:5678 and set up a user
2. add following workflow
<details>
<summary>Test workflow with chat trigger, response per response node and wait for response</summary>

```json
{
  "nodes": [
    {
      "parameters": {
        "public": true,
        "options": {
          "responseMode": "responseNodes"
        }
      },
      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
      "typeVersion": 1.4,
      "position": [
        0,
        0
      ],
      "id": "ec7e0960-1a30-427a-a5e5-2eae4c980d6e",
      "name": "When chat message received",
      "webhookId": "a3c241d9-1812-4c31-bc45-141e25ed06cf"
    },
    {
      "parameters": {
        "operation": "sendAndWait",
        "message": "I wait for response",
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.chat",
      "typeVersion": 1.3,
      "position": [
        208,
        0
      ],
      "id": "8992187b-965f-4437-b1fd-a94f752fb595",
      "name": "Chat",
      "webhookId": "3dfe389e-79a1-4cd0-a266-dbfca54949fb"
    },
    {
      "parameters": {
        "message": "success",
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.chat",
      "typeVersion": 1.3,
      "position": [
        416,
        0
      ],
      "id": "761e5b76-43f9-4c69-a7b9-65d61691abcb",
      "name": "Chat1",
      "webhookId": "c71687a4-6125-4bfc-bfe9-83ccc5fd636c"
    }
  ],
  "connections": {
    "When chat message received": {
      "main": [
        [
          {
            "node": "Chat",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Chat": {
      "main": [
        [
          {
            "node": "Chat1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```
</details>
3. publish the workflow, open the chat trigger node and open the webhook displayed there (the url should point port 5680)
4. open the webhook chat url and write to the chat. you should see `I wait for response`, write another message and you should see `success`
5. check that the execution was successful in the executions tab


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5375/bug-chat-sendandwait-websocket-relay-silently-broken-when-using

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->