### PR TITLE
feat(core): Support custom global roles in token exchange provisioning

### DIFF
--- a/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
+++ b/packages/cli/src/modules/token-exchange/services/__tests__/identity-resolution.service.test.ts
@@ -1,0 +1,223 @@
+import type { Logger } from '@n8n/backend-common';
+import {
+	GLOBAL_MEMBER_ROLE,
+	type AuthIdentity,
+	type AuthIdentityRepository,
+	type EntityManager,
+	type User,
+	type UserRepository,
+} from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
+
+import type { EventService } from '@/events/event.service';
+import type { RoleService } from '@/services/role.service';
+import type { UserService } from '@/services/user.service';
+
+import { TokenExchangeAuthError } from '../../token-exchange.errors';
+import type { ExternalTokenClaims } from '../../token-exchange.schemas';
+import { IdentityResolutionService } from '../identity-resolution.service';
+import type { TrustedKeyService } from '../trusted-key.service';
+
+const logger = mock<Logger>({ scoped: vi.fn().mockReturnThis() });
+const entityManager = mock<EntityManager>();
+const userRepository = mock<UserRepository>({ manager: entityManager });
+const authIdentityRepository = mock<AuthIdentityRepository>();
+const eventService = mock<EventService>();
+const userService = mock<UserService>();
+const trustedKeyService = mock<TrustedKeyService>();
+const roleService = mock<RoleService>();
+
+const service = new IdentityResolutionService(
+	logger,
+	userRepository,
+	authIdentityRepository,
+	eventService,
+	userService,
+	trustedKeyService,
+	roleService,
+);
+
+const CUSTOM_ROLE = 'global:custom-abc123';
+
+function makeClaims(overrides: Partial<ExternalTokenClaims> = {}): ExternalTokenClaims {
+	return {
+		sub: 'external-user-1',
+		iss: 'https://issuer.example.com',
+		aud: 'n8n',
+		iat: 1_700_000_000,
+		exp: 1_700_000_030,
+		jti: 'unique-jti-1',
+		email: 'user@example.com',
+		...overrides,
+	};
+}
+
+describe('IdentityResolutionService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		roleService.isGlobalRole.mockResolvedValue(true);
+		roleService.isRoleLicensed.mockReturnValue(true);
+	});
+
+	describe('JIT provisioning (new user)', () => {
+		const trx = entityManager;
+
+		beforeEach(() => {
+			// No existing identity, no existing user by email → JIT path.
+			authIdentityRepository.findOne.mockResolvedValue(null);
+			userRepository.findOne.mockResolvedValue(null);
+			entityManager.transaction.mockImplementation(
+				// @ts-expect-error overloaded signature
+				async (runInTransaction: (em: EntityManager) => Promise<unknown>) =>
+					await runInTransaction(trx),
+			);
+			userRepository.createUserWithProject.mockResolvedValue({
+				user: mock<User>({ id: 'new-user-1' }),
+				project: mock(),
+			});
+		});
+
+		it('provisions a licensed custom global role', async () => {
+			const user = await service.resolve(makeClaims({ role: CUSTOM_ROLE }));
+
+			expect(user.id).toBe('new-user-1');
+			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+				expect.objectContaining({ role: { slug: CUSTOM_ROLE } }),
+				trx,
+			);
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'token-exchange-user-provisioned',
+				expect.objectContaining({ role: CUSTOM_ROLE }),
+			);
+		});
+
+		it('provisions a built-in global role without a license check', async () => {
+			await service.resolve(makeClaims({ role: 'global:member' }));
+
+			expect(roleService.isRoleLicensed).not.toHaveBeenCalled();
+			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+				expect.objectContaining({ role: { slug: 'global:member' } }),
+				trx,
+			);
+		});
+
+		it('defaults to global:member when no role claim is present', async () => {
+			await service.resolve(makeClaims());
+
+			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+				expect.objectContaining({ role: GLOBAL_MEMBER_ROLE }),
+				trx,
+			);
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'token-exchange-user-provisioned',
+				expect.objectContaining({ role: GLOBAL_MEMBER_ROLE.slug }),
+			);
+		});
+
+		it('throws when the role is not an existing global role', async () => {
+			roleService.isGlobalRole.mockResolvedValue(false);
+
+			await expect(service.resolve(makeClaims({ role: 'global:nonexistent' }))).rejects.toThrow(
+				TokenExchangeAuthError,
+			);
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+		});
+
+		it('throws when a custom role is unlicensed', async () => {
+			roleService.isRoleLicensed.mockReturnValue(false);
+
+			await expect(service.resolve(makeClaims({ role: CUSTOM_ROLE }))).rejects.toThrow(
+				TokenExchangeAuthError,
+			);
+			expect(userRepository.createUserWithProject).not.toHaveBeenCalled();
+		});
+
+		it('throws on a global:owner role claim', async () => {
+			await expect(service.resolve(makeClaims({ role: 'global:owner' }))).rejects.toThrow(
+				TokenExchangeAuthError,
+			);
+		});
+
+		it('throws when the role is not in the key allowedRoles', async () => {
+			await expect(
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member']),
+			).rejects.toThrow(TokenExchangeAuthError);
+		});
+
+		it('provisions when the role is in the key allowedRoles', async () => {
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }), [CUSTOM_ROLE]);
+
+			expect(userRepository.createUserWithProject).toHaveBeenCalledWith(
+				expect.objectContaining({ role: { slug: CUSTOM_ROLE } }),
+				trx,
+			);
+		});
+	});
+
+	describe('role sync (existing user resolved by identity)', () => {
+		function mockLinkedUser(currentRoleSlug: string) {
+			const user = mock<User>({ id: 'existing-1', role: { slug: currentRoleSlug } });
+			authIdentityRepository.findOne.mockResolvedValueOnce(mock<AuthIdentity>({ user }));
+			userRepository.findOneOrFail.mockResolvedValue(user);
+			return user;
+		}
+
+		it('changes to a licensed custom role and emits an update event', async () => {
+			mockLinkedUser('global:member');
+
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }));
+
+			expect(userService.changeUserRole).toHaveBeenCalledWith(expect.anything(), {
+				newRoleName: CUSTOM_ROLE,
+			});
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'token-exchange-role-updated',
+				expect.objectContaining({ previousRole: 'global:member', newRole: CUSTOM_ROLE }),
+			);
+		});
+
+		it('ignores an unknown role claim', async () => {
+			mockLinkedUser('global:member');
+			roleService.isGlobalRole.mockResolvedValue(false);
+
+			await service.resolve(makeClaims({ role: 'global:nonexistent' }));
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+		});
+
+		it('throws when a custom role is unlicensed', async () => {
+			mockLinkedUser('global:member');
+			roleService.isRoleLicensed.mockReturnValue(false);
+
+			await expect(service.resolve(makeClaims({ role: CUSTOM_ROLE }))).rejects.toThrow(
+				TokenExchangeAuthError,
+			);
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+		});
+
+		it('never changes the role of an existing owner', async () => {
+			mockLinkedUser('global:owner');
+
+			await service.resolve(makeClaims({ role: CUSTOM_ROLE }));
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+		});
+
+		it('ignores a global:owner role claim', async () => {
+			mockLinkedUser('global:member');
+
+			await service.resolve(makeClaims({ role: 'global:owner' }));
+
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+		});
+
+		it('throws when the custom role is not in the key allowedRoles', async () => {
+			mockLinkedUser('global:member');
+
+			await expect(
+				service.resolve(makeClaims({ role: CUSTOM_ROLE }), ['global:member']),
+			).rejects.toThrow(TokenExchangeAuthError);
+			expect(userService.changeUserRole).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
+++ b/packages/cli/src/modules/token-exchange/services/identity-resolution.service.ts
@@ -3,14 +3,15 @@ import {
 	AuthIdentity,
 	AuthIdentityRepository,
 	GLOBAL_MEMBER_ROLE,
-	GLOBAL_ROLES,
 	UserRepository,
 	type User,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
+import { isBuiltInRole } from '@n8n/permissions';
 import { createHash } from 'node:crypto';
 
 import { EventService } from '@/events/event.service';
+import { RoleService } from '@/services/role.service';
 import { UserService } from '@/services/user.service';
 
 import { TokenExchangeAuthError } from '../token-exchange.errors';
@@ -27,12 +28,6 @@ const INVALID_PASSWORD_PLACEHOLDER = '!token-exchange-no-password';
 
 /** Maximum length for first/last name columns in the database. */
 const MAX_NAME_LENGTH = 32;
-
-type GlobalRoleKey = keyof typeof GLOBAL_ROLES;
-
-function isGlobalRole(role: string): role is GlobalRoleKey {
-	return role in GLOBAL_ROLES;
-}
 
 function trimName(value: string | undefined, fallback = ''): string {
 	return (value ?? fallback).slice(0, MAX_NAME_LENGTH);
@@ -53,6 +48,7 @@ export class IdentityResolutionService {
 		private readonly eventService: EventService,
 		private readonly userService: UserService,
 		private readonly trustedKeyService: TrustedKeyService,
+		private readonly roleService: RoleService,
 	) {
 		this.logger = logger.scoped('token-exchange');
 	}
@@ -138,7 +134,7 @@ export class IdentityResolutionService {
 		tokenContext: { kid: string; issuer: string } | undefined,
 	): Promise<User> {
 		this.logger.debug('Resolved user by auth identity', { sub: claims.sub });
-		const resolvedRole = this.resolveRoleForExistingUser(
+		const resolvedRole = await this.resolveRoleForExistingUser(
 			claims.role,
 			allowedRoles,
 			identity.user.role?.slug,
@@ -158,7 +154,7 @@ export class IdentityResolutionService {
 			sub: claims.sub,
 			email,
 		});
-		const resolvedRole = this.resolveRoleForExistingUser(
+		const resolvedRole = await this.resolveRoleForExistingUser(
 			claims.role,
 			allowedRoles,
 			existingUser.role?.slug,
@@ -186,7 +182,7 @@ export class IdentityResolutionService {
 	): Promise<User> {
 		this.logger.debug('JIT provisioning new user', { sub: claims.sub, email });
 
-		const jitRole = this.resolveRoleForNewUser(claims.role, allowedRoles);
+		const jitRole = await this.resolveRoleForNewUser(claims.role, allowedRoles);
 		const targetRole = jitRole ? { slug: jitRole } : GLOBAL_MEMBER_ROLE;
 
 		const qualifiedSub = qualifiedProviderId(claims.iss, claims.sub);
@@ -234,11 +230,11 @@ export class IdentityResolutionService {
 	 * by the key's allowedRoles — OAuth flows must be strict to surface
 	 * misconfiguration early.
 	 */
-	private resolveRoleForExistingUser(
+	private async resolveRoleForExistingUser(
 		roleClaim: ExternalTokenClaims['role'],
 		allowedRoles: string[] | undefined,
 		currentRole: string | undefined,
-	): GlobalRoleKey | undefined {
+	): Promise<string | undefined> {
 		if (roleClaim === undefined) return undefined;
 
 		// Never modify the role of an existing owner via token exchange
@@ -255,9 +251,20 @@ export class IdentityResolutionService {
 			return undefined;
 		}
 
-		if (!isGlobalRole(role)) {
+		if (!(await this.roleService.isGlobalRole(role))) {
 			this.logger.warn('Unknown role claim ignored', { role });
 			return undefined;
+		}
+
+		// Gate custom roles on the custom-roles license. Unlike unknown roles, an
+		// unlicensed custom role is a valid-but-unentitled claim: throwing (rather
+		// than ignoring) surfaces the misconfiguration instead of silently keeping
+		// the stale role.
+		if (!isBuiltInRole(role) && !this.roleService.isRoleLicensed(role)) {
+			throw new TokenExchangeAuthError(
+				TokenExchangeFailureReason.RoleNotAllowed,
+				`Role '${role}' is not available in the current license`,
+			);
 		}
 
 		if (allowedRoles && allowedRoles.length > 0 && !allowedRoles.includes(role)) {
@@ -277,10 +284,10 @@ export class IdentityResolutionService {
 	 * `global:member`. Unlike existing users, invalid or disallowed roles
 	 * throw because we have no fallback role to preserve.
 	 */
-	private resolveRoleForNewUser(
+	private async resolveRoleForNewUser(
 		roleClaim: ExternalTokenClaims['role'],
 		allowedRoles: string[] | undefined,
-	): GlobalRoleKey | undefined {
+	): Promise<string | undefined> {
 		if (roleClaim === undefined) return undefined;
 
 		const role = roleClaim;
@@ -292,10 +299,19 @@ export class IdentityResolutionService {
 			);
 		}
 
-		if (!isGlobalRole(role)) {
+		if (!(await this.roleService.isGlobalRole(role))) {
 			throw new TokenExchangeAuthError(
 				TokenExchangeFailureReason.RoleNotAllowed,
 				`Unrecognized role '${role}' cannot be assigned to new user`,
+			);
+		}
+
+		// JIT provisioning bypasses changeUserRole, so gate custom roles on the
+		// custom-roles license here to prevent an entitlement bypass.
+		if (!isBuiltInRole(role) && !this.roleService.isRoleLicensed(role)) {
+			throw new TokenExchangeAuthError(
+				TokenExchangeFailureReason.RoleNotAllowed,
+				`Role '${role}' is not available in the current license`,
 			);
 		}
 
@@ -317,7 +333,7 @@ export class IdentityResolutionService {
 	private async syncProfile(
 		user: User,
 		claims: ExternalTokenClaims,
-		resolvedRole?: GlobalRoleKey,
+		resolvedRole?: string,
 		tokenContext?: { kid: string; issuer: string },
 	): Promise<User> {
 		let needsReload = false;

--- a/packages/cli/src/services/role.service.ts
+++ b/packages/cli/src/services/role.service.ts
@@ -262,6 +262,12 @@ export class RoleService {
 		}
 	}
 
+	/** True if the slug is an existing global-scoped role (built-in or custom). */
+	async isGlobalRole(slug: string): Promise<boolean> {
+		const role = await this.roleRepository.findBySlug(slug);
+		return role?.roleType === 'global';
+	}
+
 	async checkRolesExist(
 		roleSlugs: string[],
 		roleType: 'global' | 'project' | 'workflow' | 'credential',


### PR DESCRIPTION
## Summary

Token-exchange user provisioning (JIT creation and role sync) previously
validated the incoming JWT `role` claim with an in-memory check that only
recognized the four built-in global roles (`global:owner`, `global:admin`,
`global:member`, `global:chatUser`). Any custom global role — even a valid,
licensed one — was silently rejected. This PR makes token exchange resolve the
role claim against the role table so custom instance roles can be assigned to
users provisioned or updated through token exchange, matching how every other
provisioning path (user invite, `changeUserRole`, SSO/SCIM provisioning) already
validates roles.

### Why

This is part of the OAuth 2.0 Token Exchange (RFC 8693) work that lets external
systems provision and act on behalf of users in an embedded n8n. Custom global
roles are a first-class feature elsewhere in the product, but the token-exchange
path was the one place still hard-coded to built-in roles, so embedding partners
could not map their own roles onto n8n custom roles. This change closes that gap.

### How it works

- New `RoleService.isGlobalRole(slug)` — a single DB lookup that returns whether
  a slug is an existing global-scoped role (built-in **or** custom). Built-in
  roles are seeded in the `role` table, so one check covers both.
- `IdentityResolutionService` now uses that lookup instead of the removed
  built-in-only helper, for both new (JIT) and existing users.
- Custom roles are gated on the custom-roles license. The existing-user path
  already ran through `changeUserRole` (which license-checks), but the JIT path
  creates the user directly and would otherwise bypass the entitlement — so the
  gate is applied explicitly in both resolvers.
- All prior security invariants are preserved: `global:owner` can never be
  assigned via token exchange, existing owners are never demoted, and a key's
  `allowedRoles` restriction is still enforced (and now works for custom slugs).

### Key implementation decisions

- **Validation happens up front in the resolvers, not downstream in
  `changeUserRole`.** An unlicensed/invalid role caught inside `changeUserRole`
  would throw `ForbiddenError`/`BadRequestError`, which the token endpoint maps
  to a `500 server_error` (and error-reports it). Throwing
  `TokenExchangeAuthError(RoleNotAllowed)` from the resolver instead yields a
  clean `400 invalid_grant` and a proper `token-exchange-failed` event.
- **Unknown vs. unlicensed are treated differently, consistently with existing
  semantics.** An unknown role claim is *ignored* for existing users (keep
  current role) and *rejected* for new users (no fallback). An unlicensed custom
  role is a valid-but-unentitled claim, so it is *rejected* in both cases —
  surfacing the misconfiguration rather than silently keeping a stale role.

### How to test manually

Prerequisites:
- A licensed instance with custom roles enabled, and token exchange configured
  with a trusted key (static key is easiest for local testing).
- A custom global role created via the roles API/UI (note its generated slug,
  e.g. `global:support-agent-a1b2c3`).

Steps:
1. Mint a subject JWT signed by the trusted key with claims: `sub`, `iss`,
   `aud`, `exp`, `jti`, `email`, and `role` set to the custom role slug.
2. Call the embed login (`GET /rest/auth/embed?token=...`) or the RFC 8693
   endpoint (`POST /rest/auth/oauth/token`).
3. **New user:** a user is provisioned with the custom role (`token-exchange-
   user-provisioned` event carries the custom slug).
4. **Existing user:** re-send with a different valid custom role → the user's
   role is updated (`token-exchange-role-updated` event).

Edge cases worth checking:
- Unlicensed custom role slug → `400 invalid_grant` (both new and existing users).
- Unknown/nonexistent role slug → new user rejected (`400`); existing user keeps
  their current role.
- `role: global:owner` → rejected; existing owner’s role is never changed.
- Key configured with `allowedRoles` not containing the custom slug → rejected.

Automated coverage: new `identity-resolution.service.test.ts` unit-tests every
branch above (built-in and custom, licensed/unlicensed, new/existing,
allowedRoles, owner guards).

## Related Links

closes https://linear.app/n8n/issue/IAM-958

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

