### PR TITLE
feat(core): Import project shells from a package (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/CLAUDE.md
+++ b/packages/cli/src/modules/n8n-packages/CLAUDE.md
@@ -24,15 +24,17 @@ flowchart LR
 - Prefer an **existing** domain service from the main n8n codebase (`FolderService`, `ProjectService`,
   `WorkflowService`, …). When the importer needs a capability the service lacks — reusing a source id,
   or a fetch-by-ids for matching — **extend that existing service with a general method** rather than
-  reaching for the repository or spinning up an import-only service. Canonical example:
+  reaching for the repository or spinning up an import-only service. Canonical examples:
+  `ProjectService.createTeamProject(data, overrides)` (preset id + description) and
   `FolderService.createFolder(dto, projectId, id?)` / `FolderService.getFoldersByIds(ids)`.
-- `N8nPackagesService.importPackage` is the entry: it builds the reader, reads the manifest, and
-  dispatches to a package-shape importer (today only `WorkflowPackageImporter`). That manifest read is
-  the seam where a future **project**-shaped package would route to its own importer.
+- `N8nPackagesService.importPackage` is a thin **dispatcher**: it builds the reader, reads the manifest,
+  and delegates to a per-package-shape importer. Shapes mirror export's mutual exclusivity — a **project
+  package** (projects defined by the package) → `ProjectPackageImporter`, or a **workflow package** (loose
+  workflows + their folder shells + credential deps into a target project) → `WorkflowPackageImporter`.
 - `WorkflowPackageImporter` resolves the target scope from the request, then delegates the plan/gate/apply
   work to `ImportOrchestrator` (brings folders + workflows + credential deps into one project scope).
-  A follow-up adds whole-**project** package import (its own shape + scope resolution) reusing the same
-  `ImportOrchestrator` core. Don't split folder vs workflow: they share target resolution, credential
+  `ProjectPackageImporter` creates the project shells; reusing `ImportOrchestrator` for a project's own
+  contents is a follow-up. Don't split folder vs workflow: they share target resolution, credential
   resolution, and publishing.
 
 ### Adding an IMPORT property

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-projects.integration.test.ts
@@ -1,0 +1,207 @@
+import { LicenseState } from '@n8n/backend-common';
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { FolderRepository, ProjectRelationRepository, ProjectRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { createOwner } from '@test-integration/db/users';
+import { LicenseMocker } from '@test-integration/license';
+
+import { N8nPackagesService } from '../n8n-packages.service';
+import type { ImportPackageRequest } from '../n8n-packages.types';
+import {
+	buildEntityPackageBuffer,
+	serializedFolder,
+	serializedProject,
+	serializedWorkflow,
+} from './fixtures/package-fixtures';
+
+async function importProjects(user: User, packageBuffer: Buffer, apiKeyScopes?: string[]) {
+	const request: ImportPackageRequest = {
+		user,
+		packageBuffer,
+		apiKeyScopes,
+		credentialMatchingMode: 'id-only',
+		credentialMissingMode: 'must-preexist',
+		workflowConflictPolicy: 'new-version',
+		workflowPublishingPolicy: 'preserve-published-state',
+		workflowIdPolicy: 'new',
+		folderConflictPolicy: 'merge',
+	};
+	return await Container.get(N8nPackagesService).importPackage(request);
+}
+
+const licenseMocker = new LicenseMocker();
+
+async function findProject(id: string) {
+	return await Container.get(ProjectRepository).findOne({ where: { id } });
+}
+
+async function isAdminOf(projectId: string, userId: string): Promise<boolean> {
+	const count = await Container.get(ProjectRelationRepository).count({
+		where: { projectId, userId, role: { slug: 'project:admin' } },
+	});
+	return count > 0;
+}
+
+beforeAll(async () => {
+	await testModules.loadModules(['n8n-packages']);
+	await testDb.init();
+	licenseMocker.mockLicenseState(Container.get(LicenseState));
+	licenseMocker.setDefaults({
+		features: ['feat:projectRole:admin'],
+		quotas: { 'quota:maxTeamProjects': 100 },
+	});
+});
+
+afterAll(async () => {
+	await testDb.terminate();
+});
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'Folder',
+		'Project',
+		'ProjectRelation',
+		'SharedWorkflow',
+		'WorkflowEntity',
+	]);
+	licenseMocker.reset();
+});
+
+describe('project shell import', () => {
+	let owner: User;
+
+	beforeEach(async () => {
+		owner = await createOwner();
+	});
+
+	it('creates a team project owned by the importer, reusing the source id', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects).toEqual([
+			{ sourceProjectId: 'P1', localId: 'P1', name: 'brie', status: 'created' },
+		]);
+		const project = await findProject('P1');
+		expect(project?.name).toBe('brie');
+		expect(project?.type).toBe('team');
+		expect(await isAdminOf('P1', owner.id)).toBe(true);
+	});
+
+	it('creates multiple projects in one package', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				{ target: 'projects/stilton', project: serializedProject({ id: 'P2', name: 'stilton' }) },
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects.map((p) => p.localId).sort()).toEqual(['P1', 'P2']);
+		expect(await findProject('P1')).not.toBeNull();
+		expect(await findProject('P2')).not.toBeNull();
+	});
+
+	it('creates two distinct projects that share a name but differ by id', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				{ target: 'projects/brie-1', project: serializedProject({ id: 'P2', name: 'brie' }) },
+			],
+		});
+
+		await importProjects(owner, packageBuffer);
+
+		expect((await findProject('P1'))?.name).toBe('brie');
+		expect((await findProject('P2'))?.name).toBe('brie');
+	});
+
+	it('matches an existing project by id on re-import and updates it in place', async () => {
+		await importProjects(
+			owner,
+			await buildEntityPackageBuffer({
+				projects: [
+					{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+				],
+			}),
+		);
+
+		const result = await importProjects(
+			owner,
+			await buildEntityPackageBuffer({
+				projects: [
+					{
+						target: 'projects/brie',
+						project: serializedProject({ id: 'P1', name: 'brie renamed' }),
+					},
+				],
+			}),
+		);
+
+		expect(result.projects).toEqual([
+			{ sourceProjectId: 'P1', localId: 'P1', name: 'brie renamed', status: 'updated' },
+		]);
+		expect(await Container.get(ProjectRepository).count({ where: { type: 'team' } })).toBe(1);
+		expect((await findProject('P1'))?.name).toBe('brie renamed');
+	});
+
+	it('rejects a project package when the API key lacks the project:create scope', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+		});
+
+		await expect(importProjects(owner, packageBuffer, ['workflow:import'])).rejects.toBeInstanceOf(
+			ForbiddenError,
+		);
+	});
+
+	it('refuses to import over an existing personal project id', async () => {
+		const personal = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: personal.id, name: 'brie' }) },
+			],
+		});
+
+		await expect(importProjects(owner, packageBuffer)).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	it('ignores folders and workflows nested inside the project (deferred to a follow-up)', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			projects: [
+				{ target: 'projects/brie', project: serializedProject({ id: 'P1', name: 'brie' }) },
+			],
+			folders: [
+				{
+					target: 'projects/brie/folders/in_progress',
+					folder: serializedFolder({ id: 'NestedFolder', name: 'in_progress' }),
+				},
+			],
+			workflows: [
+				{
+					target: 'projects/brie/folders/in_progress/workflows/triage',
+					workflow: serializedWorkflow({ id: 'NestedWf', name: 'triage' }),
+				},
+			],
+		});
+
+		const result = await importProjects(owner, packageBuffer);
+
+		expect(result.projects.map((p) => p.localId)).toEqual(['P1']);
+		expect(result.folders).toEqual([]);
+		expect(result.workflows).toEqual([]);
+		expect(await Container.get(FolderRepository).findOneBy({ id: 'NestedFolder' })).toBeNull();
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/engine/import-result.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-result.ts
@@ -5,6 +5,7 @@ import { serializeBindings } from '../n8n-packages.types';
 import type {
 	ImportCredentialSummary,
 	ImportedFolderSummary,
+	ImportedProjectSummary,
 	ImportPackageSummary,
 	ImportResult,
 	PackageImportBindings,
@@ -25,6 +26,7 @@ export function buildImportResult(input: {
 	projectId: string | null;
 	workflows: WorkflowImportOutcome[];
 	folders: ImportedFolderSummary[];
+	projects: ImportedProjectSummary[];
 	bindings: PackageImportBindings;
 	credentials?: ImportCredentialSummary;
 }): ImportResult {
@@ -41,6 +43,7 @@ export function buildImportResult(input: {
 			status,
 		})),
 		folders: input.folders,
+		projects: input.projects,
 		bindings: serializeBindings(input.bindings),
 		credentials: input.credentials ?? { matched: [], stubbed: [] },
 	};

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -8,12 +8,14 @@ import * as WorkflowHelpers from '@/workflow-helpers';
 
 import { topLevelFolders, topLevelWorkflows } from './package-layout';
 import type { PreparedFolder } from '../entities/folder/folder-import.types';
+import type { PreparedProject } from '../entities/project/project-import.types';
 import type { PreparedWorkflow } from '../entities/workflow/workflow-import.types';
 import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
 import type { PackageReader } from '../io/package-reader';
 import type { ManifestEntry, PackageManifest } from '../spec/manifest.schema';
 import { packageManifestSchema } from '../spec/manifest.schema';
 import { serializedFolderSchema } from '../spec/serialized/folder.schema';
+import { serializedProjectSchema } from '../spec/serialized/project.schema';
 import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
 
 /**
@@ -59,6 +61,17 @@ export class N8nPackageParser {
 		return folders;
 	}
 
+	/** Reads the package's project shells. */
+	async getProjects(reader: PackageReader): Promise<PreparedProject[]> {
+		const manifest = await this.getManifest(reader);
+
+		const projects: PreparedProject[] = [];
+		for (const entry of manifest.projects ?? []) {
+			projects.push(await this.readProject(reader, entry));
+		}
+		return projects;
+	}
+
 	private async readWorkflow(
 		reader: PackageReader,
 		entry: ManifestEntry,
@@ -98,6 +111,26 @@ export class N8nPackageParser {
 		} catch (cause) {
 			if (cause instanceof ZodError) {
 				throw new UserError(`Package folder file at ${path} failed schema validation.`, { cause });
+			}
+			throw cause;
+		}
+	}
+
+	private async readProject(reader: PackageReader, entry: ManifestEntry): Promise<PreparedProject> {
+		const path = `${entry.target}/project.json`;
+		const wire = await this.readJson(reader, path, 'project');
+
+		try {
+			const project = serializedProjectSchema.parse(wire);
+			return {
+				sourceProjectId: project.id,
+				name: project.name,
+				...(project.description !== undefined ? { description: project.description } : {}),
+				...(project.icon !== undefined ? { icon: project.icon } : {}),
+			};
+		} catch (cause) {
+			if (cause instanceof ZodError) {
+				throw new UserError(`Package project file at ${path} failed schema validation.`, { cause });
 			}
 			throw cause;
 		}

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -1,0 +1,45 @@
+import { Service } from '@n8n/di';
+
+import { ProjectImporter } from '../entities/project/project-importer';
+import { createBindings } from '../n8n-packages.types';
+import type { ImportPackageRequest, ImportResult } from '../n8n-packages.types';
+import type { PackageReader } from '../io/package-reader';
+import type { PackageManifest } from '../spec/manifest.schema';
+import {
+	assertPackageImportApiKeyScopes,
+	buildImportResult,
+	toPackageSummary,
+} from './import-result';
+import { N8nPackageParser } from './n8n-package-parser';
+
+/**
+ * Imports a package containing projects into the target instance.
+ **/
+@Service()
+export class ProjectPackageImporter {
+	constructor(
+		private readonly packageParser: N8nPackageParser,
+		private readonly projectImporter: ProjectImporter,
+	) {}
+
+	async import(
+		request: ImportPackageRequest,
+		reader: PackageReader,
+		manifest: PackageManifest,
+	): Promise<ImportResult> {
+		assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create']);
+
+		const projects = await this.packageParser.getProjects(reader);
+		const plan = await this.projectImporter.plan(request.user, projects);
+		const projectSummaries = await this.projectImporter.apply(request.user, plan);
+
+		return buildImportResult({
+			package: toPackageSummary(manifest),
+			projectId: null,
+			workflows: [],
+			folders: [],
+			projects: projectSummaries,
+			bindings: createBindings(),
+		});
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -27,7 +27,7 @@ export class ProjectPackageImporter {
 		reader: PackageReader,
 		manifest: PackageManifest,
 	): Promise<ImportResult> {
-		assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create']);
+assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create', 'project:update']);
 
 		const projects = await this.packageParser.getProjects(reader);
 		const plan = await this.projectImporter.plan(request.user, projects);

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -27,7 +27,7 @@ export class ProjectPackageImporter {
 		reader: PackageReader,
 		manifest: PackageManifest,
 	): Promise<ImportResult> {
-assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create', 'project:update']);
+		assertPackageImportApiKeyScopes(request.apiKeyScopes, ['project:create', 'project:update']);
 
 		const projects = await this.packageParser.getProjects(reader);
 		const plan = await this.projectImporter.plan(request.user, projects);

--- a/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/project-package-importer.ts
@@ -1,16 +1,16 @@
 import { Service } from '@n8n/di';
 
 import { ProjectImporter } from '../entities/project/project-importer';
+import type { PackageReader } from '../io/package-reader';
 import { createBindings } from '../n8n-packages.types';
 import type { ImportPackageRequest, ImportResult } from '../n8n-packages.types';
-import type { PackageReader } from '../io/package-reader';
-import type { PackageManifest } from '../spec/manifest.schema';
 import {
 	assertPackageImportApiKeyScopes,
 	buildImportResult,
 	toPackageSummary,
 } from './import-result';
 import { N8nPackageParser } from './n8n-package-parser';
+import type { PackageManifest } from '../spec/manifest.schema';
 
 /**
  * Imports a package containing projects into the target instance.

--- a/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/workflow-package-importer.ts
@@ -83,6 +83,7 @@ export class WorkflowPackageImporter {
 			projectId: context.projectId,
 			workflows: imported.workflowOutcomes,
 			folders: imported.folderSummaries,
+			projects: [],
 			bindings: imported.bindings,
 			credentials: {
 				matched: imported.credentialResult.matched,

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
@@ -1,6 +1,5 @@
 import type { SerializedProject } from '../../spec/serialized/project.schema';
 
-/** A project shell parsed out of the package, ready to reconcile against the instance. */
 export interface PreparedProject {
 	sourceProjectId: string;
 	name: string;
@@ -10,7 +9,6 @@ export interface PreparedProject {
 
 export type ProjectPlannedAction = 'create' | 'update';
 
-/** The decided action for one package project (matched by id). */
 export interface ProjectPlanItem {
 	action: ProjectPlannedAction;
 	sourceProjectId: string;

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-import.types.ts
@@ -1,0 +1,20 @@
+import type { SerializedProject } from '../../spec/serialized/project.schema';
+
+/** A project shell parsed out of the package, ready to reconcile against the instance. */
+export interface PreparedProject {
+	sourceProjectId: string;
+	name: string;
+	description?: string;
+	icon?: SerializedProject['icon'];
+}
+
+export type ProjectPlannedAction = 'create' | 'update';
+
+/** The decided action for one package project (matched by id). */
+export interface ProjectPlanItem {
+	action: ProjectPlannedAction;
+	sourceProjectId: string;
+	name: string;
+	description?: string;
+	icon?: SerializedProject['icon'];
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
@@ -1,0 +1,112 @@
+import { LicenseState } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { ProjectService } from '@/services/project.service.ee';
+
+import type { PreparedProject, ProjectPlanItem } from './project-import.types';
+import type { ImportedProjectSummary } from '../../n8n-packages.types';
+
+/**
+ * Imports the package's project shells. Project ids are reused verbatim (no id policy),
+ * so a package project matched by id in the target instance is updated in place; otherwise
+ * a fresh team project is created with the importing user as its sole admin.
+ *
+ * {@link plan} resolves each project's action and enforces authorization up front (so apply
+ * cannot fail a permission check partway through); {@link apply} writes the decided plan.
+ */
+@Service()
+export class ProjectImporter {
+	constructor(
+		private readonly projectService: ProjectService,
+		private readonly licenseState: LicenseState,
+	) {}
+
+	async plan(user: User, projects: PreparedProject[]): Promise<ProjectPlanItem[]> {
+		const items: ProjectPlanItem[] = [];
+
+		for (const project of projects) {
+			const existing = await this.projectService.findProject(project.sourceProjectId);
+
+			if (existing) {
+				// Never import over a personal project — matching by id must not clobber unrelated data.
+				if (existing.type !== 'team') {
+					throw new ForbiddenError(
+						`Cannot import project "${project.name}": its id belongs to a non-team project on this instance.`,
+					);
+				}
+				const authorized = await this.projectService.getProjectWithScope(user, existing.id, [
+					'project:update',
+				]);
+				if (!authorized) {
+					throw new ForbiddenError(
+						`You do not have permission to update the existing project "${project.name}".`,
+					);
+				}
+				items.push({ action: 'update', ...toFields(project) });
+			} else {
+				this.assertCanCreateProjects(user);
+				items.push({ action: 'create', ...toFields(project) });
+			}
+		}
+
+		return items;
+	}
+
+	async apply(user: User, items: ProjectPlanItem[]): Promise<ImportedProjectSummary[]> {
+		const summaries: ImportedProjectSummary[] = [];
+
+		for (const item of items) {
+			if (item.action === 'create') {
+				// createTeamProject enforces the team-project quota and links the importer as admin.
+				const project = await this.projectService.createTeamProject(
+					user,
+					{ name: item.name, icon: item.icon },
+					{ id: item.sourceProjectId, description: item.description ?? null },
+				);
+				summaries.push({
+					sourceProjectId: item.sourceProjectId,
+					localId: project.id,
+					name: project.name,
+					status: 'created',
+				});
+			} else {
+				await this.projectService.updateProject(item.sourceProjectId, {
+					name: item.name,
+					icon: item.icon,
+					description: item.description,
+				});
+				summaries.push({
+					sourceProjectId: item.sourceProjectId,
+					localId: item.sourceProjectId,
+					name: item.name,
+					status: 'updated',
+				});
+			}
+		}
+
+		return summaries;
+	}
+
+	private assertCanCreateProjects(user: User): void {
+		if (!hasGlobalScope(user, 'project:create')) {
+			throw new ForbiddenError('You do not have permission to create projects.');
+		}
+		if (!this.licenseState.isLicensed('feat:projectRole:admin')) {
+			throw new ForbiddenError(
+				'Your license does not allow creating team projects. Project import requires a license that supports team projects.',
+			);
+		}
+	}
+}
+
+function toFields(project: PreparedProject): Omit<ProjectPlanItem, 'action'> {
+	return {
+		sourceProjectId: project.sourceProjectId,
+		name: project.name,
+		...(project.description !== undefined ? { description: project.description } : {}),
+		...(project.icon !== undefined ? { icon: project.icon } : {}),
+	};
+}

--- a/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/project/project-importer.ts
@@ -9,14 +9,6 @@ import { ProjectService } from '@/services/project.service.ee';
 import type { PreparedProject, ProjectPlanItem } from './project-import.types';
 import type { ImportedProjectSummary } from '../../n8n-packages.types';
 
-/**
- * Imports the package's project shells. Project ids are reused verbatim (no id policy),
- * so a package project matched by id in the target instance is updated in place; otherwise
- * a fresh team project is created with the importing user as its sole admin.
- *
- * {@link plan} resolves each project's action and enforces authorization up front (so apply
- * cannot fail a permission check partway through); {@link apply} writes the decided plan.
- */
 @Service()
 export class ProjectImporter {
 	constructor(
@@ -31,7 +23,7 @@ export class ProjectImporter {
 			const existing = await this.projectService.findProject(project.sourceProjectId);
 
 			if (existing) {
-				// Never import over a personal project — matching by id must not clobber unrelated data.
+				// Never import over a personal project
 				if (existing.type !== 'team') {
 					throw new ForbiddenError(
 						`Cannot import project "${project.name}": its id belongs to a non-team project on this instance.`,
@@ -60,7 +52,6 @@ export class ProjectImporter {
 
 		for (const item of items) {
 			if (item.action === 'create') {
-				// createTeamProject enforces the team-project quota and links the importer as admin.
 				const project = await this.projectService.createTeamProject(
 					user,
 					{ name: item.name, icon: item.icon },

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -150,12 +150,10 @@ export class N8nPackagesService {
 	async importPackage(request: ImportPackageRequest): Promise<ImportResult> {
 		const reader = new TarPackageReader(request.packageBuffer, this.packageImportConfig);
 		const manifest = await this.packageParser.getManifest(reader);
-		// A project package defines its own projects, so the request's target projectId/folderId
-		// don't apply — the package shape selects the importer.
-		const importer = isProjectPackage(manifest)
-			? this.projectPackageImporter
-			: this.workflowPackageImporter;
-		return await importer.import(request, reader, manifest);
+		if (isProjectPackage(manifest)) {
+			return await this.projectPackageImporter.import(request, reader, manifest);
+		}
+		return await this.workflowPackageImporter.import(request, reader, manifest);
 	}
 
 	filterWorkflowsAlreadyInFolders(workflowsInFolders: ManifestEntry[] = [], workflowIds: string[]) {
@@ -164,7 +162,6 @@ export class N8nPackagesService {
 	}
 }
 
-/** A project package carries whole projects; a workflow package carries loose workflows + folders. */
 function isProjectPackage(manifest: PackageManifest): boolean {
 	return (manifest.projects?.length ?? 0) > 0;
 }

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -6,6 +6,7 @@ import { N8N_VERSION } from '@/constants';
 import { EventService } from '@/events/event.service';
 
 import { N8nPackageParser } from './engine/n8n-package-parser';
+import { ProjectPackageImporter } from './engine/project-package-importer';
 import { WorkflowPackageImporter } from './engine/workflow-package-importer';
 import { CredentialExporter } from './entities/credential/credential.exporter';
 import { FolderExporter } from './entities/folder/folder.exporter';
@@ -21,7 +22,11 @@ import type {
 	ImportResult,
 } from './n8n-packages.types';
 import { FORMAT_VERSION } from './spec/constants';
-import { type ManifestEntry, packageManifestSchema } from './spec/manifest.schema';
+import {
+	type ManifestEntry,
+	type PackageManifest,
+	packageManifestSchema,
+} from './spec/manifest.schema';
 
 @Service()
 export class N8nPackagesService {
@@ -33,6 +38,7 @@ export class N8nPackagesService {
 		private readonly instanceSettings: InstanceSettings,
 		private readonly packageParser: N8nPackageParser,
 		private readonly packageImportConfig: PackageImportConfig,
+		private readonly projectPackageImporter: ProjectPackageImporter,
 		private readonly workflowPackageImporter: WorkflowPackageImporter,
 		private readonly eventService: EventService,
 	) {}
@@ -144,11 +150,21 @@ export class N8nPackagesService {
 	async importPackage(request: ImportPackageRequest): Promise<ImportResult> {
 		const reader = new TarPackageReader(request.packageBuffer, this.packageImportConfig);
 		const manifest = await this.packageParser.getManifest(reader);
-		return await this.workflowPackageImporter.import(request, reader, manifest);
+		// A project package defines its own projects, so the request's target projectId/folderId
+		// don't apply — the package shape selects the importer.
+		const importer = isProjectPackage(manifest)
+			? this.projectPackageImporter
+			: this.workflowPackageImporter;
+		return await importer.import(request, reader, manifest);
 	}
 
 	filterWorkflowsAlreadyInFolders(workflowsInFolders: ManifestEntry[] = [], workflowIds: string[]) {
 		const folderWorkflowIds = new Set(workflowsInFolders.map((entry) => entry.id) ?? []);
 		return workflowIds.filter((id) => !folderWorkflowIds.has(id));
 	}
+}
+
+/** A project package carries whole projects; a workflow package carries loose workflows + folders. */
+function isProjectPackage(manifest: PackageManifest): boolean {
+	return (manifest.projects?.length ?? 0) > 0;
 }

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -149,6 +149,14 @@ export interface ImportedFolderSummary {
 	status: 'created' | 'skipped';
 }
 
+export interface ImportedProjectSummary {
+	sourceProjectId: string;
+	/** Local id of the imported project; equal to `sourceProjectId` since project ids are reused. */
+	localId: string;
+	name: string;
+	status: 'created' | 'updated';
+}
+
 /**
  * A reason the import cannot proceed, produced by some policy from any subsystem.
  * Discriminated by `type` so new gates add a variant rather than a new throw site.
@@ -226,6 +234,7 @@ export interface ImportResult {
 	package: ImportPackageSummary;
 	workflows: ImportedWorkflowSummary[];
 	folders: ImportedFolderSummary[];
+	projects: ImportedProjectSummary[];
 	bindings: SerializedBindings;
 	credentials: ImportCredentialSummary;
 }

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -151,7 +151,6 @@ export interface ImportedFolderSummary {
 
 export interface ImportedProjectSummary {
 	sourceProjectId: string;
-	/** Local id of the imported project; equal to `sourceProjectId` since project ids are reused. */
 	localId: string;
 	name: string;
 	status: 'created' | 'updated';

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -153,6 +153,7 @@ post:
               - package
               - workflows
               - folders
+              - projects
               - bindings
               - credentials
             properties:
@@ -287,6 +288,33 @@ post:
                         - created
                         - skipped
                       description: Import outcome for this package folder.
+              projects:
+                type: array
+                description: >
+                  Project shells created or matched-and-updated. Present for project
+                  packages; empty when importing loose workflows/folders.
+                items:
+                  type: object
+                  required:
+                    - sourceProjectId
+                    - localId
+                    - name
+                    - status
+                  properties:
+                    sourceProjectId:
+                      type: string
+                      description: Project id as it appeared in the package.
+                    localId:
+                      type: string
+                      description: Project id on the target instance (equal to `sourceProjectId`; project ids are reused).
+                    name:
+                      type: string
+                    status:
+                      type: string
+                      enum:
+                        - created
+                        - updated
+                      description: Import outcome for this package project.
               credentials:
                 type: object
                 description: >

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -64,9 +64,7 @@ class ProjectNotFoundError extends NotFoundError {
 	}
 }
 
-/** Identity fields a caller can set on a new team project beyond {@link CreateProjectDto}. */
 export interface ProjectCreateOverrides {
-	/** Reuse a specific id instead of minting one (e.g. importing a project by its source id). */
 	id?: string;
 	description?: string | null;
 }
@@ -386,11 +384,6 @@ export class ProjectService {
 		return project;
 	}
 
-	/**
-	 * Creates a team project owned by `adminUser`. `overrides` lets callers that
-	 * carry their own identity — the package importer reuses a source project id and
-	 * restores its description — set fields outside {@link CreateProjectDto}.
-	 */
 	async createTeamProject(
 		adminUser: User,
 		data: CreateProjectDto,

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -64,6 +64,13 @@ class ProjectNotFoundError extends NotFoundError {
 	}
 }
 
+/** Identity fields a caller can set on a new team project beyond {@link CreateProjectDto}. */
+export interface ProjectCreateOverrides {
+	/** Reuse a specific id instead of minting one (e.g. importing a project by its source id). */
+	id?: string;
+	description?: string | null;
+}
+
 @Service()
 export class ProjectService {
 	constructor(
@@ -353,6 +360,7 @@ export class ProjectService {
 		adminUser: User,
 		data: CreateProjectDto,
 		trx: EntityManager,
+		overrides: ProjectCreateOverrides = {},
 	) {
 		const limit = this.licenseState.getMaxTeamProjects();
 		if (limit !== UNLIMITED_LICENSE_QUOTA) {
@@ -364,7 +372,12 @@ export class ProjectService {
 
 		const project = await trx.save(
 			Project,
-			this.projectRepository.create({ ...data, type: 'team', creatorId: adminUser.id }),
+			this.projectRepository.create({
+				...data,
+				...overrides,
+				type: 'team',
+				creatorId: adminUser.id,
+			}),
 		);
 
 		// Link admin
@@ -373,11 +386,20 @@ export class ProjectService {
 		return project;
 	}
 
-	async createTeamProject(adminUser: User, data: CreateProjectDto): Promise<Project> {
+	/**
+	 * Creates a team project owned by `adminUser`. `overrides` lets callers that
+	 * carry their own identity — the package importer reuses a source project id and
+	 * restores its description — set fields outside {@link CreateProjectDto}.
+	 */
+	async createTeamProject(
+		adminUser: User,
+		data: CreateProjectDto,
+		overrides: ProjectCreateOverrides = {},
+	): Promise<Project> {
 		// This needs to be SERIALIZABLE otherwise the count would not block a
 		// concurrent transaction and we could insert multiple projects.
 		return await this.projectRepository.manager.transaction('SERIALIZABLE', async (trx) => {
-			return await this.createTeamProjectWithEntityManager(adminUser, data, trx);
+			return await this.createTeamProjectWithEntityManager(adminUser, data, trx, overrides);
 		});
 	}
 

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -219,6 +219,7 @@ describe('POST /n8n-packages/import', () => {
 				},
 			],
 			folders: [],
+			projects: [],
 			bindings: {
 				workflows: { 'wf-http-source': expect.any(String) },
 				credentials: {},


### PR DESCRIPTION
## Summary

**Unit 2 of 2** of the package-import work (split out of #33698). **Stacked on the folder-shells PR**
(base is `ligo-722-import-a-folder-empty`) — review/merge that first; retarget as the stack lands.

Builds on the folder-shells import to add whole-**project** shell import — reads back the `projects[]`
the exporter emits:

- Introduces a second package shape: the import pipeline becomes a **dispatcher** that routes a
  *project package* (projects defined by the package; request `projectId`/`folderId` ignored) to a new
  `ProjectPackageImporter`, and everything else to the workflow-package importer.
- Projects are **created** — or **matched by their reused source id and updated in place** — owned by
  the importing user. Guards: refuse importing over a personal project, require `project:update` on a
  matched project and `project:create` + the team-project quota to create.
- `ImportResult` gains a `projects[]` array; `ProjectService` gains `findProject` + a
  `createTeamProject` overrides bag (preset id + description).

> **Scope note:** folders/workflows nested inside a project are intentionally ignored for now — a
> follow-up populates each project by reusing the `ScopedEntityImporter` core per project.

## How to test

`POST /api/v1/n8n-packages/import` (or `n8n package import`) with a `.n8np` whose manifest declares
`projects[]`:

- Creates/matches the project shells (owned by the caller); the response `projects[]` reports
  `created` / `updated`.
- Re-importing matches by id and updates in place — no duplicate projects.
- Importing over an existing personal project id is refused.

Covered by `import-projects.integration.test.ts` (`pnpm --filter n8n test:integration <path>`).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-741

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with a backport label (if urgent fix).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->