### PR TITLE
feat(Zendesk Node): Allow custom OAuth2 scopes

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -118,6 +118,7 @@ export const GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE = [
 	'googleCloudStorageOAuth2Api',
 	'googleCalendarOAuth2Api',
 	'googleSheetsOAuth2Api',
+	'zendeskOAuth2Api',
 ];
 
 export const ARTIFICIAL_TASK_DATA = {

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1736,6 +1736,32 @@ describe('OauthService', () => {
 			);
 		});
 
+		it('should not delete scope for zendeskOAuth2Api credentials', async () => {
+			const credential = mock<CredentialsEntity>({
+				id: '1',
+				type: 'zendeskOAuth2Api',
+				isManaged: false,
+			});
+			const mockDecryptedData = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockOAuthCredentials = { clientId: 'client-id', scope: 'custom-scope' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			vi.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+
+			await service.getOAuthCredentials(credential);
+
+			expect(credentialsHelper.applyDefaultsAndOverwrites).toHaveBeenCalledWith(
+				mockAdditionalData,
+				{ clientId: 'client-id', scope: 'custom-scope' },
+				credential.type,
+				'internal',
+				undefined,
+				undefined,
+			);
+		});
+
 		it('should not delete scope for non-OAuth2 credentials', async () => {
 			const credential = mock<CredentialsEntity>({
 				id: '1',

--- a/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/ZendeskOAuth2Api.credentials.ts
@@ -1,6 +1,6 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
-const scopes = ['read', 'write'];
+const defaultScopes = ['read', 'write'];
 
 export class ZendeskOAuth2Api implements ICredentialType {
 	name = 'zendeskOAuth2Api';
@@ -62,7 +62,39 @@ export class ZendeskOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: scopes.join(' '),
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
+		},
+		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set, If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',

--- a/packages/nodes-base/credentials/test/ZendeskOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/ZendeskOAuth2Api.credentials.test.ts
@@ -1,0 +1,58 @@
+import { ZendeskOAuth2Api } from '../ZendeskOAuth2Api.credentials';
+
+describe('ZendeskOAuth2Api Credential', () => {
+	const credential = new ZendeskOAuth2Api();
+	const defaultScopes = 'read write';
+
+	it('should have correct credential metadata', () => {
+		expect(credential.name).toBe('zendeskOAuth2Api');
+		expect(credential.extends).toEqual(['oAuth2Api']);
+
+		// Zendesk builds its OAuth URLs from the user-provided subdomain
+		const authUrlProperty = credential.properties.find((p) => p.name === 'authUrl');
+		expect(authUrlProperty?.default).toBe(
+			'=https://{{$self["subdomain"]}}.zendesk.com/oauth/authorizations/new',
+		);
+
+		const accessTokenUrlProperty = credential.properties.find((p) => p.name === 'accessTokenUrl');
+		expect(accessTokenUrlProperty?.default).toBe(
+			'=https://{{$self["subdomain"]}}.zendesk.com/oauth/tokens',
+		);
+	});
+
+	it('should use body authentication', () => {
+		const authenticationProperty = credential.properties.find((p) => p.name === 'authentication');
+		expect(authenticationProperty?.type).toBe('hidden');
+		expect(authenticationProperty?.default).toBe('body');
+	});
+
+	it('should have custom scopes toggle defaulting to false', () => {
+		const customScopesProperty = credential.properties.find((p) => p.name === 'customScopes');
+		expect(customScopesProperty?.type).toBe('boolean');
+		expect(customScopesProperty?.default).toBe(false);
+	});
+
+	it('should have enabledScopes defaulting to the current default scope list', () => {
+		const enabledScopesProperty = credential.properties.find((p) => p.name === 'enabledScopes');
+		expect(enabledScopesProperty?.default).toBe(defaultScopes);
+	});
+
+	it('should only show enabledScopes when customScopes is true', () => {
+		const enabledScopesProperty = credential.properties.find((p) => p.name === 'enabledScopes');
+		expect(enabledScopesProperty?.displayOptions?.show?.customScopes).toEqual([true]);
+	});
+
+	it('should only show the custom scopes notice when customScopes is true', () => {
+		const noticeProperty = credential.properties.find((p) => p.name === 'customScopesNotice');
+		expect(noticeProperty?.type).toBe('notice');
+		expect(noticeProperty?.displayOptions?.show?.customScopes).toEqual([true]);
+	});
+
+	it('should use enabledScopes when customScopes is true, otherwise fall back to defaults', () => {
+		const scopeProperty = credential.properties.find((p) => p.name === 'scope');
+		expect(scopeProperty?.type).toBe('hidden');
+		expect(scopeProperty?.default).toBe(
+			`={{$self["customScopes"] ? $self["enabledScopes"] : "${defaultScopes}"}}`,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **Custom Scopes** option to the Zendesk OAuth2 credential. Previously the OAuth2 scopes were hardcoded to `read write` in a hidden field, so users could not request additional Zendesk permissions without editing source.

This follows the established custom-scopes pattern already applied to Google Sheets, Google Calendar, Strava, etc.:

* New `customScopes` boolean toggle (default `false`) plus a `customScopesNotice`.
* New editable `enabledScopes` string (default `read write`), shown only when the toggle is on — this is the source of truth.
* The hidden `scope` field now derives its value: `={{$self["customScopes"] ? $self["enabledScopes"] : "read write"}}`.
* `zendeskOAuth2Api` registered in `GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE` (`packages/cli/src/constants.ts`) so user-entered scopes are **not** stripped on credential reconnect.

## How to test

Automated:

```bash
cd packages/nodes-base && pnpm test ZendeskOAuth2Api   # credential property/behaviour tests
cd packages/cli && pnpm test oauth.service             # reconnect-guard: scope preserved
```

Manual:

1. Run n8n (`pnpm dev`) and create a **Zendesk OAuth2 API** credential.
2. Confirm the **Custom Scopes** toggle appears and defaults to off.
3. Enable it — the **Enabled Scopes** field (prefilled `read write`) and the notice appear.
4. Edit the scopes, connect, and confirm the generated authorization URL carries the edited scopes.
5. Reconnect the credential and confirm the custom scopes are preserved (not reset to the defaults).

## Related Linear tickets, Github issues, and Community forum posts

[CE-971](https://linear.app/n8n/issue/CE-971/allow-custom-oauth-scopes-for-zendesk)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [X] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [X] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

---

![Open in Stage](https://camo.githubusercontent.com/e3b46e319aace348a9c2eabc45f307a073a3bf5a08d5220b2027eac6649007b5/68747470733a2f2f73746167657265766965772e6170702f6173736574732f67682d6f70656e2d696e2d73746167652d6c696768742e737667)