### PR TITLE
feat(core): Add private credential usage telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1478,7 +1478,6 @@ describe('TelemetryEventRelay', () => {
 				workflow_id: 'workflow123',
 				public_api: true,
 				source: 'api',
-				uses_private_credentials: false,
 				private_credentials_count: 0,
 				private_credential_types: [],
 			});
@@ -1512,7 +1511,6 @@ describe('TelemetryEventRelay', () => {
 				workflow_id: 'workflow123',
 				public_api: false,
 				source: 'ui',
-				uses_private_credentials: false,
 				private_credentials_count: 0,
 				private_credential_types: [],
 			});
@@ -1786,7 +1784,6 @@ describe('TelemetryEventRelay', () => {
 				ai_builder_assisted: false,
 				identity_extractor_changed: false,
 				redaction_policy: undefined,
-				uses_private_credentials: false,
 				private_credentials_count: 0,
 				private_credential_types: [],
 				otel_workflow_custom_tags_count: 0,
@@ -1914,7 +1911,6 @@ describe('TelemetryEventRelay', () => {
 				credential_resolver_id: 'resolver-123',
 				identity_extractor_changed: false,
 				redaction_policy: undefined,
-				uses_private_credentials: false,
 				private_credentials_count: 0,
 				private_credential_types: [],
 				otel_workflow_custom_tags_count: 0,
@@ -2017,7 +2013,6 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.track).toHaveBeenCalledWith(
 				'User saved workflow',
 				expect.objectContaining({
-					uses_private_credentials: true,
 					private_credentials_count: 2,
 					private_credential_types: ['slackApi', 'notionApi'],
 				}),
@@ -2065,9 +2060,75 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.track).toHaveBeenCalledWith(
 				'User activated workflow',
 				expect.objectContaining({
-					uses_private_credentials: true,
 					private_credentials_count: 1,
 					private_credential_types: ['slackApi'],
+				}),
+			);
+		});
+
+		it('should count each private credential but de-duplicate types when several share a type', async () => {
+			licenseState.isDynamicCredentialsLicensed.mockReturnValueOnce(true);
+			credentialsRepository.find.mockResolvedValueOnce([
+				mock<CredentialsEntity>({ id: 'cred-1', type: 'slackApi' }),
+				mock<CredentialsEntity>({ id: 'cred-2', type: 'slackApi' }),
+				mock<CredentialsEntity>({ id: 'cred-3', type: 'notionApi' }),
+			]);
+
+			const event: RelayEventMap['workflow-saved'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					connections: {},
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Slack 1',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { slackApi: { id: 'cred-1', name: 'Slack account 1' } },
+						},
+						{
+							id: 'node-2',
+							name: 'Slack 2',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { slackApi: { id: 'cred-2', name: 'Slack account 2' } },
+						},
+						{
+							id: 'node-3',
+							name: 'Notion',
+							type: 'n8n-nodes-base.notion',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { notionApi: { id: 'cred-3', name: 'Notion account' } },
+						},
+					],
+				}),
+				publicApi: false,
+			};
+
+			eventService.emit('workflow-saved', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User saved workflow',
+				expect.objectContaining({
+					// Three credentials, but only two distinct types.
+					private_credentials_count: 3,
+					private_credential_types: ['slackApi', 'notionApi'],
 				}),
 			);
 		});

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1711,7 +1711,7 @@ describe('TelemetryEventRelay', () => {
 		});
 
 		it('should count attempted vs resolved private credentials and the effective resolver', async () => {
-			dynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue('system-n8n');
+			dynamicCredentialsProxy.getEffectiveResolverId.mockReturnValueOnce('system-n8n');
 
 			const event: RelayEventMap['workflow-post-execute'] = {
 				workflow: mock<IWorkflowDb>({
@@ -1964,8 +1964,8 @@ describe('TelemetryEventRelay', () => {
 		});
 
 		it('should report private credential usage on `workflow-saved` event', async () => {
-			licenseState.isDynamicCredentialsLicensed.mockReturnValue(true);
-			credentialsRepository.find.mockResolvedValue([
+			licenseState.isDynamicCredentialsLicensed.mockReturnValueOnce(true);
+			credentialsRepository.find.mockResolvedValueOnce([
 				mock<CredentialsEntity>({ id: 'cred-1', type: 'slackApi' }),
 				mock<CredentialsEntity>({ id: 'cred-2', type: 'notionApi' }),
 			]);
@@ -2025,8 +2025,8 @@ describe('TelemetryEventRelay', () => {
 		});
 
 		it('should report private credential usage on `workflow-activated` event', async () => {
-			licenseState.isDynamicCredentialsLicensed.mockReturnValue(true);
-			credentialsRepository.find.mockResolvedValue([
+			licenseState.isDynamicCredentialsLicensed.mockReturnValueOnce(true);
+			credentialsRepository.find.mockResolvedValueOnce([
 				mock<CredentialsEntity>({ id: 'cred-1', type: 'slackApi' }),
 			]);
 

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -10,6 +10,7 @@ import {
 	type WorkflowEntity,
 	type WorkflowRepository,
 	GLOBAL_OWNER_ROLE,
+	In,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { type BinaryDataConfig, InstanceSettings } from 'n8n-core';
@@ -1448,7 +1449,7 @@ describe('TelemetryEventRelay', () => {
 			});
 		});
 
-		it('should track on `workflow-activated` event with source', () => {
+		it('should track on `workflow-activated` event with source', async () => {
 			const event: RelayEventMap['workflow-activated'] = {
 				user: {
 					id: 'user123',
@@ -1470,15 +1471,20 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('workflow-activated', event);
 
+			await flushPromises();
+
 			expect(telemetry.track).toHaveBeenCalledWith('User activated workflow', {
 				user_id: 'user123',
 				workflow_id: 'workflow123',
 				public_api: true,
 				source: 'api',
+				uses_private_credentials: false,
+				private_credentials_count: 0,
+				private_credential_types: [],
 			});
 		});
 
-		it('should default source to ui on `workflow-activated` event', () => {
+		it('should default source to ui on `workflow-activated` event', async () => {
 			const event: RelayEventMap['workflow-activated'] = {
 				user: {
 					id: 'user123',
@@ -1499,11 +1505,16 @@ describe('TelemetryEventRelay', () => {
 
 			eventService.emit('workflow-activated', event);
 
+			await flushPromises();
+
 			expect(telemetry.track).toHaveBeenCalledWith('User activated workflow', {
 				user_id: 'user123',
 				workflow_id: 'workflow123',
 				public_api: false,
 				source: 'ui',
+				uses_private_credentials: false,
+				private_credentials_count: 0,
+				private_credential_types: [],
 			});
 		});
 
@@ -1659,6 +1670,8 @@ describe('TelemetryEventRelay', () => {
 				version_cli: N8N_VERSION,
 				workflow_id: 'workflow123',
 				used_private_credentials: false,
+				private_credentials_attempted_count: 0,
+				private_credentials_resolved_count: 0,
 			});
 		});
 
@@ -1689,7 +1702,49 @@ describe('TelemetryEventRelay', () => {
 			await flushPromises();
 
 			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
-				expect.objectContaining({ used_private_credentials: true }),
+				expect.objectContaining({
+					used_private_credentials: true,
+					private_credentials_attempted_count: 1,
+					private_credentials_resolved_count: 0,
+				}),
+			);
+		});
+
+		it('should count attempted vs resolved private credentials and the effective resolver', async () => {
+			dynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue('system-n8n');
+
+			const event: RelayEventMap['workflow-post-execute'] = {
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					nodes: [],
+				}),
+				userId: 'user123',
+				executionId: 'execution123',
+				runData: {
+					data: {
+						resultData: {
+							runData: {
+								Slack: [{ attemptedDynamicCredentials: true, usedDynamicCredentials: true }],
+								// Attempted but not resolved (e.g. running user has not connected).
+								Notion: [{ attemptedDynamicCredentials: true }],
+							},
+						},
+					},
+				} as unknown as IRun,
+			};
+
+			eventService.emit('workflow-post-execute', event);
+
+			await flushPromises();
+
+			expect(telemetry.trackWorkflowExecution).toHaveBeenCalledWith(
+				expect.objectContaining({
+					used_private_credentials: true,
+					private_credentials_attempted_count: 2,
+					private_credentials_resolved_count: 1,
+					credential_resolver_id: 'system-n8n',
+				}),
 			);
 		});
 
@@ -1731,6 +1786,9 @@ describe('TelemetryEventRelay', () => {
 				ai_builder_assisted: false,
 				identity_extractor_changed: false,
 				redaction_policy: undefined,
+				uses_private_credentials: false,
+				private_credentials_count: 0,
+				private_credential_types: [],
 				otel_workflow_custom_tags_count: 0,
 				otel_nodes_with_custom_tags_count: 0,
 				otel_node_custom_tags_count: 0,
@@ -1856,6 +1914,9 @@ describe('TelemetryEventRelay', () => {
 				credential_resolver_id: 'resolver-123',
 				identity_extractor_changed: false,
 				redaction_policy: undefined,
+				uses_private_credentials: false,
+				private_credentials_count: 0,
+				private_credential_types: [],
 				otel_workflow_custom_tags_count: 0,
 				otel_nodes_with_custom_tags_count: 0,
 				otel_node_custom_tags_count: 0,
@@ -1898,6 +1959,115 @@ describe('TelemetryEventRelay', () => {
 				'User saved workflow',
 				expect.objectContaining({
 					credential_resolver_id: 'system-resolver',
+				}),
+			);
+		});
+
+		it('should report private credential usage on `workflow-saved` event', async () => {
+			licenseState.isDynamicCredentialsLicensed.mockReturnValue(true);
+			credentialsRepository.find.mockResolvedValue([
+				mock<CredentialsEntity>({ id: 'cred-1', type: 'slackApi' }),
+				mock<CredentialsEntity>({ id: 'cred-2', type: 'notionApi' }),
+			]);
+
+			const event: RelayEventMap['workflow-saved'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					connections: {},
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Slack',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { slackApi: { id: 'cred-1', name: 'Slack account' } },
+						},
+						{
+							id: 'node-2',
+							name: 'Notion',
+							type: 'n8n-nodes-base.notion',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { notionApi: { id: 'cred-2', name: 'Notion account' } },
+						},
+					],
+				}),
+				publicApi: false,
+			};
+
+			eventService.emit('workflow-saved', event);
+
+			await flushPromises();
+
+			expect(credentialsRepository.find).toHaveBeenCalledWith({
+				where: { id: In(['cred-1', 'cred-2']), isResolvable: true },
+				select: ['id', 'type'],
+			});
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User saved workflow',
+				expect.objectContaining({
+					uses_private_credentials: true,
+					private_credentials_count: 2,
+					private_credential_types: ['slackApi', 'notionApi'],
+				}),
+			);
+		});
+
+		it('should report private credential usage on `workflow-activated` event', async () => {
+			licenseState.isDynamicCredentialsLicensed.mockReturnValue(true);
+			credentialsRepository.find.mockResolvedValue([
+				mock<CredentialsEntity>({ id: 'cred-1', type: 'slackApi' }),
+			]);
+
+			const event: RelayEventMap['workflow-activated'] = {
+				user: {
+					id: 'user123',
+					email: 'user@example.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					role: { slug: GLOBAL_OWNER_ROLE.slug },
+				},
+				workflowId: 'workflow123',
+				workflow: mock<IWorkflowDb>({
+					id: 'workflow123',
+					name: 'Test Workflow',
+					connections: {},
+					nodes: [
+						{
+							id: 'node-1',
+							name: 'Slack',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+							credentials: { slackApi: { id: 'cred-1', name: 'Slack account' } },
+						},
+					],
+				}),
+				publicApi: false,
+			};
+
+			eventService.emit('workflow-activated', event);
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User activated workflow',
+				expect.objectContaining({
+					uses_private_credentials: true,
+					private_credentials_count: 1,
+					private_credential_types: ['slackApi'],
 				}),
 			);
 		});

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -956,8 +956,8 @@ export class TelemetryEventRelay extends EventRelay {
 			privateCredentialTypes: [] as string[],
 		};
 
-		// No credential can be resolvable when the feature isn't licensed, so skip the DB
-		// lookup entirely on instances that don't use private credentials.
+		// Report zeros when the feature isn't licensed: resolvable rows may persist in the
+		// DB (e.g. after a license downgrade) but are inactive, so skip the lookup.
 		if (!this.licenseState.isDynamicCredentialsLicensed()) {
 			return empty;
 		}

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -946,12 +946,10 @@ export class TelemetryEventRelay extends EventRelay {
 	 * on save/activate. Returns zeroed counts when the workflow references none.
 	 */
 	private async getPrivateCredentialUsage(workflow: IWorkflowBase | IWorkflowDb): Promise<{
-		usesPrivateCredentials: boolean;
 		privateCredentialsCount: number;
 		privateCredentialTypes: string[];
 	}> {
 		const empty = {
-			usesPrivateCredentials: false,
 			privateCredentialsCount: 0,
 			privateCredentialTypes: [] as string[],
 		};
@@ -979,7 +977,6 @@ export class TelemetryEventRelay extends EventRelay {
 		});
 
 		return {
-			usesPrivateCredentials: privateCredentials.length > 0,
 			privateCredentialsCount: privateCredentials.length,
 			privateCredentialTypes: [...new Set(privateCredentials.map((credential) => credential.type))],
 		};
@@ -992,7 +989,7 @@ export class TelemetryEventRelay extends EventRelay {
 		publicApi,
 		source = 'ui',
 	}: RelayEventMap['workflow-activated']) {
-		const { usesPrivateCredentials, privateCredentialsCount, privateCredentialTypes } =
+		const { privateCredentialsCount, privateCredentialTypes } =
 			await this.getPrivateCredentialUsage(workflow);
 
 		this.telemetry.track('User activated workflow', {
@@ -1000,7 +997,6 @@ export class TelemetryEventRelay extends EventRelay {
 			workflow_id: workflowId,
 			public_api: publicApi,
 			source,
-			uses_private_credentials: usesPrivateCredentials,
 			private_credentials_count: privateCredentialsCount,
 			private_credential_types: privateCredentialTypes,
 		});
@@ -1135,7 +1131,7 @@ export class TelemetryEventRelay extends EventRelay {
 			workflow,
 		);
 
-		const { usesPrivateCredentials, privateCredentialsCount, privateCredentialTypes } =
+		const { privateCredentialsCount, privateCredentialTypes } =
 			await this.getPrivateCredentialUsage(workflow);
 
 		this.telemetry.track('User saved workflow', {
@@ -1155,7 +1151,6 @@ export class TelemetryEventRelay extends EventRelay {
 			credential_resolver_id: credentialResolverId,
 			identity_extractor_changed: identityExtractorChanged,
 			redaction_policy: redactionPolicy,
-			uses_private_credentials: usesPrivateCredentials,
 			private_credentials_count: privateCredentialsCount,
 			private_credential_types: privateCredentialTypes,
 			otel_workflow_custom_tags_count: countWorkflowCustomTelemetryTags(workflow),

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -2,6 +2,7 @@ import { LicenseState } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import {
 	CredentialsRepository,
+	In,
 	ProjectRelationRepository,
 	SharedWorkflowRepository,
 	WorkflowRepository,
@@ -166,7 +167,7 @@ export class TelemetryEventRelay extends EventRelay {
 			'n8n-package-imported': (event) => this.packageImported(event),
 			'n8n-package-exported': (event) => this.packageExported(event),
 			'workflow-saved': async (event) => await this.workflowSaved(event),
-			'workflow-activated': (event) => this.workflowActivated(event),
+			'workflow-activated': async (event) => await this.workflowActivated(event),
 			'workflow-deactivated': (event) => this.workflowDeactivated(event),
 			'server-started': async () => await this.serverStarted(),
 			'server-cli-import': (event) => this.serverCliImportCommand(event),
@@ -939,17 +940,69 @@ export class TelemetryEventRelay extends EventRelay {
 		});
 	}
 
-	private workflowActivated({
+	/**
+	 * Looks up which private (resolvable) credentials a workflow references by
+	 * inspecting node credential ids. Used to report private-credential adoption
+	 * on save/activate. Returns zeroed counts when the workflow references none.
+	 */
+	private async getPrivateCredentialUsage(workflow: IWorkflowBase | IWorkflowDb): Promise<{
+		usesPrivateCredentials: boolean;
+		privateCredentialsCount: number;
+		privateCredentialTypes: string[];
+	}> {
+		const empty = {
+			usesPrivateCredentials: false,
+			privateCredentialsCount: 0,
+			privateCredentialTypes: [] as string[],
+		};
+
+		// No credential can be resolvable when the feature isn't licensed, so skip the DB
+		// lookup entirely on instances that don't use private credentials.
+		if (!this.licenseState.isDynamicCredentialsLicensed()) {
+			return empty;
+		}
+
+		const credentialIds = new Set<string>();
+		for (const node of workflow.nodes) {
+			for (const credential of Object.values(node.credentials ?? {})) {
+				if (credential?.id) credentialIds.add(credential.id);
+			}
+		}
+
+		if (credentialIds.size === 0) {
+			return empty;
+		}
+
+		const privateCredentials = await this.credentialsRepository.find({
+			where: { id: In([...credentialIds]), isResolvable: true },
+			select: ['id', 'type'],
+		});
+
+		return {
+			usesPrivateCredentials: privateCredentials.length > 0,
+			privateCredentialsCount: privateCredentials.length,
+			privateCredentialTypes: [...new Set(privateCredentials.map((credential) => credential.type))],
+		};
+	}
+
+	private async workflowActivated({
 		user,
 		workflowId,
+		workflow,
 		publicApi,
 		source = 'ui',
 	}: RelayEventMap['workflow-activated']) {
+		const { usesPrivateCredentials, privateCredentialsCount, privateCredentialTypes } =
+			await this.getPrivateCredentialUsage(workflow);
+
 		this.telemetry.track('User activated workflow', {
 			user_id: user.id,
 			workflow_id: workflowId,
 			public_api: publicApi,
 			source,
+			uses_private_credentials: usesPrivateCredentials,
+			private_credentials_count: privateCredentialsCount,
+			private_credential_types: privateCredentialTypes,
 		});
 	}
 
@@ -1082,6 +1135,9 @@ export class TelemetryEventRelay extends EventRelay {
 			workflow,
 		);
 
+		const { usesPrivateCredentials, privateCredentialsCount, privateCredentialTypes } =
+			await this.getPrivateCredentialUsage(workflow);
+
 		this.telemetry.track('User saved workflow', {
 			user_id: user.id,
 			workflow_id: workflow.id,
@@ -1099,6 +1155,9 @@ export class TelemetryEventRelay extends EventRelay {
 			credential_resolver_id: credentialResolverId,
 			identity_extractor_changed: identityExtractorChanged,
 			redaction_policy: redactionPolicy,
+			uses_private_credentials: usesPrivateCredentials,
+			private_credentials_count: privateCredentialsCount,
+			private_credential_types: privateCredentialTypes,
 			otel_workflow_custom_tags_count: countWorkflowCustomTelemetryTags(workflow),
 			otel_nodes_with_custom_tags_count: countNodesWithCustomTelemetryTags(workflow.nodes),
 			otel_node_custom_tags_count: countNodeCustomTelemetryTags(workflow.nodes),
@@ -1120,19 +1179,37 @@ export class TelemetryEventRelay extends EventRelay {
 
 		const executionTelemetryProperties = getExecutionTelemetryProperties(source, telemetryMetadata);
 
+		// Aggregate per-node private-credential usage. `attemptedDynamicCredentials` is a
+		// superset of `usedDynamicCredentials`: it also counts nodes where resolution failed
+		// (e.g. the running user had not connected the credential), giving a resolution funnel.
+		let privateCredentialsAttemptedCount = 0;
+		let privateCredentialsResolvedCount = 0;
+		for (const taskDataList of Object.values(runData?.data?.resultData?.runData ?? {})) {
+			if (taskDataList.some((taskData) => taskData.attemptedDynamicCredentials)) {
+				privateCredentialsAttemptedCount++;
+			}
+			if (taskDataList.some((taskData) => taskData.usedDynamicCredentials)) {
+				privateCredentialsResolvedCount++;
+			}
+		}
+
 		const telemetryProperties: IExecutionTrackProperties = {
 			workflow_id: workflow.id,
 			is_manual: false,
 			version_cli: N8N_VERSION,
 			success: false,
 			...executionTelemetryProperties,
-			// True when the execution attempted to run with a private credential, whether
-			// resolution succeeded or failed (e.g. the running user had not connected it).
-			// `attemptedDynamicCredentials` is a superset of `usedDynamicCredentials`.
-			used_private_credentials: Object.values(runData?.data?.resultData?.runData ?? {}).some(
-				(taskDataList) => taskDataList.some((taskData) => taskData.attemptedDynamicCredentials),
-			),
+			used_private_credentials: privateCredentialsAttemptedCount > 0,
+			private_credentials_attempted_count: privateCredentialsAttemptedCount,
+			private_credentials_resolved_count: privateCredentialsResolvedCount,
 		};
+
+		if (privateCredentialsAttemptedCount > 0) {
+			const resolverId = this.dynamicCredentialsProxy.getEffectiveResolverId(workflow.settings);
+			if (resolverId) {
+				telemetryProperties.credential_resolver_id = resolverId;
+			}
+		}
 
 		if (userId) {
 			telemetryProperties.user_id = userId;
@@ -1229,6 +1306,11 @@ export class TelemetryEventRelay extends EventRelay {
 					eval_rows_left: null,
 					meta: JSON.stringify(workflow.meta),
 					used_private_credentials: telemetryProperties.used_private_credentials,
+					private_credentials_attempted_count:
+						telemetryProperties.private_credentials_attempted_count,
+					private_credentials_resolved_count:
+						telemetryProperties.private_credentials_resolved_count,
+					credential_resolver_id: telemetryProperties.credential_resolver_id,
 					...executionTelemetryProperties,
 					...TelemetryHelpers.resolveAIMetrics(workflow.nodes, this.nodeTypes),
 					...TelemetryHelpers.resolveVectorStoreMetrics(workflow.nodes, this.nodeTypes, runData),

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -188,6 +188,12 @@ export interface IExecutionTrackProperties extends ITelemetryTrackProperties {
 	is_manual: boolean;
 	crashed?: boolean;
 	used_private_credentials?: boolean;
+	/** Number of nodes that attempted to resolve a private credential (regardless of success). */
+	private_credentials_attempted_count?: number;
+	/** Number of nodes that successfully resolved a private credential. */
+	private_credentials_resolved_count?: number;
+	/** Effective resolver id the execution ran with (workflow override or seeded system resolver). */
+	credential_resolver_id?: string;
 	execution_source?: WorkflowExecutionSource;
 	mock_data_sources?: string;
 }


### PR DESCRIPTION
## Summary

Adds telemetry to measure private (dynamic) credential usage in workflows, beyond the existing setup/lifecycle events. Workflow execution events now carry a resolution funnel — `private_credentials_attempted_count`, `private_credentials_resolved_count`, and the effective `credential_resolver_id` — so we can see how often private credentials are used and whether resolution succeeds (a failed attempt means the running user hasn't connected). The `User saved workflow` and `User activated workflow` events now include `uses_private_credentials`, `private_credentials_count`, and `private_credential_types`, letting us count distinct saved vs. published workflows that reference private credentials (published excludes manual-trigger workflows, which cannot be activated). The credential lookup needed for the save/activate events runs off the request path on the async event relay, only on save/activate (never per-execution), and is gated behind the dynamic-credentials license so it is skipped entirely on instances without the feature.

## How to test

On an instance with the dynamic-credentials feature licensed: create a private credential, add it to a node, then (1) save the workflow and (2) activate it — verify `User saved workflow` / `User activated workflow` telemetry carry `uses_private_credentials: true` with the correct count and types. Then execute the workflow and verify `Workflow execution with private credentials` reports the attempted/resolved counts and resolver id (attempt a run as a user who has not connected the credential to see `attempted > resolved`).

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket referenced yet — add https://linear.app/n8n/issue/[TICKET-ID] if one exists. -->

https://linear.app/n8n/issue/IAM-972/add-private-per-user-credential-usage-telemetry

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33735">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

