### PR TITLE
fix(Odoo Node): Support domain filters on custom resource getAll

### DIFF
--- a/packages/nodes-base/nodes/Odoo/test/v2/node/custom/getAll.test.ts
+++ b/packages/nodes-base/nodes/Odoo/test/v2/node/custom/getAll.test.ts
@@ -43,6 +43,7 @@ describe('OdooV2 — custom:getAll', () => {
 			customResource: 'res.partner',
 			returnAll: false,
 			limit: 10,
+			filters: {},
 			options: {},
 			...overrides,
 		};
@@ -88,6 +89,38 @@ describe('OdooV2 — custom:getAll', () => {
 		expect(transport.odooApiRequest).toHaveBeenCalledWith('res.partner', 'search_read', {
 			domain: [],
 			fields: ['name', 'email'],
+			limit: 10,
+			offset: 0,
+		});
+	});
+
+	it('builds the domain from the filters parameter', async () => {
+		setupParams({
+			filters: { filter: [{ fieldName: 'name', operator: 'like', value: 'Acme' }] },
+		});
+		(transport.odooApiRequest as Mock).mockResolvedValue(MOCK_RECORDS);
+
+		await node.execute.call(exec);
+
+		expect(transport.odooApiRequest).toHaveBeenCalledWith('res.partner', 'search_read', {
+			domain: [['name', 'like', 'Acme']],
+			fields: [],
+			limit: 10,
+			offset: 0,
+		});
+	});
+
+	it('coerces comma-separated values into a list for the "in" operator', async () => {
+		setupParams({
+			filters: { filter: [{ fieldName: 'id', operator: 'in', value: '1, 2, 3' }] },
+		});
+		(transport.odooApiRequest as Mock).mockResolvedValue(MOCK_RECORDS);
+
+		await node.execute.call(exec);
+
+		expect(transport.odooApiRequest).toHaveBeenCalledWith('res.partner', 'search_read', {
+			domain: [['id', 'in', [1, 2, 3]]],
+			fields: [],
 			limit: 10,
 			offset: 0,
 		});

--- a/packages/nodes-base/nodes/Odoo/v2/actions/custom/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Odoo/v2/actions/custom/getAll.operation.ts
@@ -6,6 +6,7 @@ import type {
 } from 'n8n-workflow';
 
 import { odooApiRequest } from '../../transport';
+import { buildDomain, type IOdooFilters } from '../../helpers/utils';
 import { updateDisplayOptions } from '../../../../../utils/utilities';
 
 const properties: INodeProperties[] = [
@@ -24,6 +25,52 @@ const properties: INodeProperties[] = [
 		displayOptions: { show: { returnAll: [false] } },
 		typeOptions: { minValue: 1, maxValue: 1000 },
 		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filters',
+		name: 'filters',
+		type: 'fixedCollection',
+		default: {},
+		placeholder: 'Add Filter',
+		typeOptions: { multipleValues: true },
+		options: [
+			{
+				name: 'filter',
+				displayName: 'Filter',
+				values: [
+					{
+						displayName: 'Field Name',
+						name: 'fieldName',
+						type: 'string',
+						default: '',
+						// Custom resources use a dynamic model, so field names can't be
+						// loaded via loadOptions — accept them as free text.
+						description: 'The technical name of the field to filter on',
+						placeholder: 'e.g. name',
+					},
+					{
+						displayName: 'Operator',
+						name: 'operator',
+						type: 'options',
+						default: 'equal',
+						// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
+						options: [
+							{ name: 'Equal', value: 'equal' },
+							{ name: 'Not Equal', value: 'notEqual' },
+							{ name: 'Greater Than', value: 'greaterThen' },
+							{ name: 'Less Than', value: 'lesserThen' },
+							{ name: 'Greater or Equal', value: 'greaterOrEqual' },
+							{ name: 'Less or Equal', value: 'lesserOrEqual' },
+							{ name: 'Like', value: 'like' },
+							{ name: 'In', value: 'in' },
+							{ name: 'Not In', value: 'notIn' },
+							{ name: 'Child Of', value: 'childOf' },
+						],
+					},
+					{ displayName: 'Value', name: 'value', type: 'string', default: '' },
+				],
+			},
+		],
 	},
 	{
 		displayName: 'Options',
@@ -63,6 +110,7 @@ export async function execute(
 				extractValue: true,
 			}) as string;
 			const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+			const filters = this.getNodeParameter('filters', i) as unknown as IOdooFilters;
 			const options = this.getNodeParameter('options', i) as IDataObject;
 
 			const fieldsRaw = (options.fieldsList as string) ?? '';
@@ -73,7 +121,9 @@ export async function execute(
 						.filter(Boolean)
 				: [];
 
-			const body: IDataObject = { domain: [], fields, offset: 0 };
+			const domain = buildDomain(filters);
+
+			const body: IDataObject = { domain, fields, offset: 0 };
 			if (!returnAll) body.limit = this.getNodeParameter('limit', i) as number;
 
 			const response = (await odooApiRequest.call(


### PR DESCRIPTION
## Summary

The **Custom Resource → Get Many** operation of the Odoo node offered no way to filter records: it hardcoded an empty domain (`domain: []`) and only exposed the *Options* collection. As a result, users could not narrow down results for arbitrary Odoo models.

This PR adds a **Filters** collection to the custom `getAll` operation, mirroring the one already used by the **Contact** and **Opportunity** operations, and builds the Odoo domain through the existing shared `buildDomain()` helper (`nodes/Odoo/v2/helpers/utils.ts`).

**Intentional difference from Contact/Opportunity:** the **Field Name** is a free-text `string` rather than a `loadOptions` dropdown, because a custom resource is a *dynamic* model whose fields cannot be pre-loaded. This mirrors how the operation's existing *Fields to Include* option already takes free text. An inline comment documents the reason.

No other operations are affected — `get`/`create`/`update`/`delete` on custom resources don't take domain filters.

## How to test

1. Add Odoo credentials and a node with **Resource: Custom Resource**, **Operation: Get Many**.
2. Pick a custom model (e.g. `res.partner`).
3. Under **Filters → Add Filter**, add e.g. `Field Name: name`, `Operator: Like`, `Value: Acme`.
4. Execute — only matching records are returned. Previously the filter UI was absent and all records were returned.
5. For the `In` / `Not In` operators, a comma-separated **Value** (e.g. `1, 2, 3`) is split into a list; purely-numeric entries are coerced to numbers.

Covered by unit tests in `nodes/Odoo/test/v2/node/custom/getAll.test.ts`:
- builds the domain array from the `filters` parameter
- coerces comma-separated values into a list for the `in` operator

```
✓ nodes/Odoo/test/v2/node/custom/getAll.test.ts (9 tests)
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33124 (refers to #13996)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Behaviour matches the existing Contact/Opportunity filters already documented; happy to open a docs follow-up if wanted. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

