### PR TITLE
fix(MCP Server Trigger Node): Prevent memory leak under active MCP client polling

### DIFF
--- a/packages/@n8n/config/src/configs/mcp-server.config.ts
+++ b/packages/@n8n/config/src/configs/mcp-server.config.ts
@@ -10,10 +10,10 @@ export class McpServerConfig {
 	 * Time in milliseconds a session may stay idle before it is evicted and its
 	 * resources (MCP server, transport, tools) released. Streamable HTTP clients
 	 * that disconnect without sending an explicit DELETE rely on this to avoid
-	 * leaking sessions. Default: 1 hour.
+	 * leaking sessions. Default: 15 minutes.
 	 */
 	@Env('N8N_MCP_SERVER_SESSION_IDLE_TTL_MS', positiveIntSchema)
-	sessionIdleTtl: number = Time.hours.toMilliseconds;
+	sessionIdleTtl: number = 15 * Time.minutes.toMilliseconds;
 
 	/**
 	 * Interval in milliseconds between sweeps that evict idle sessions.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -304,7 +304,7 @@ describe('GlobalConfig', () => {
 			cacheMaxSize: 500,
 		},
 		mcpServer: {
-			sessionIdleTtl: 3600000,
+			sessionIdleTtl: 900000,
 			sessionSweepInterval: 300000,
 		},
 		chatHub: {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts
@@ -209,7 +209,7 @@ export class McpServer {
 			try {
 				await new Promise<void>((resolve) => {
 					this.resolveFunctions[callId] = resolve;
-					void transport.handleRequest(req, resp, message as IncomingMessage);
+					void transport.handleRequest(req, resp, message as IncomingMessage).finally(resolve);
 				});
 			} finally {
 				delete this.resolveFunctions[callId];

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpServer.test.ts
@@ -314,6 +314,20 @@ describe('McpServer', () => {
 			expect(mcpServer.getTransport('busy-2')).toBeUndefined();
 		});
 
+		it('should evict a session whose only traffic was a handshake (no in-flight tool call)', async () => {
+			await registerSession('handshake-1');
+
+			void mcpServer.handlePostMessage(
+				createMockRequestWithSessionId('handshake-1', createListToolsMessage()),
+				createMockResponse(),
+				[],
+			);
+
+			await vi.advanceTimersByTimeAsync(TTL + INTERVAL);
+
+			expect(mcpServer.getTransport('handshake-1')).toBeUndefined();
+		});
+
 		it('should stop evicting once the sweep is stopped', async () => {
 			await registerSession('idle-2');
 			mcpServer.stopSweep();


### PR DESCRIPTION
## Summary

Under active MCP client polling, an `MCP Server Trigger` container's V8 heap grew monotonically until it OOM-crashed (`FATAL ERROR: Ineffective mark-compacts near heap limit`), typically within ~2 hours on the reporting customer's setup.

**Root cause.** In `McpServer.handlePostMessage`, every POST on an existing session is wrapped in `await new Promise((resolve) => { resolveFunctions[callId] = resolve; void transport.handleRequest(...) })`. Only tool-call handlers ever called `resolve`. The MCP handshake also sends **non-tool-call** POSTs on this same path — `notifications/initialized` and `tools/list` — whose handlers never call `resolve`. So the promise never settled: the `finally` cleanup never ran, the request frame (`req`, `resp`, and the `rawBody` buffer) stayed pinned, and the dangling `resolveFunctions` entry kept `hasInFlightWork()` permanently `true`, which meant the idle-session sweep skipped that session forever. Result: unbounded growth regardless of client behaviour.

**Fix.**
1. Settle the promise on request completion: `void transport.handleRequest(...).finally(resolve)`. Every message path (tool call, `tools/list`, notifications, `initialize`, …) now releases its frame, and idle sessions become sweep-eligible. Idempotent — the existing explicit `resolve()` on tool-call paths (including queue mode's early resolve) still fires first.
2. Lower the default idle-session TTL from **1 hour → 15 minutes** so the now-working (and recently introduced) sweep bounds memory sooner for Streamable HTTP clients that never send an explicit `DELETE`. Still overridable via `N8N_MCP_SERVER_SESSION_IDLE_TTL_MS`. Eviction is MCP-spec-safe — the server may end a session at any time, after which the client re-initializes on its next request. 

A complementary **client-side** improvement (n8n's own MCP Client node sending the spec's `DELETE` on close) does not affect this server-side fix and is tracked as a follow-up in [NODE-5394](https://linear.app/n8n/issue/NODE-5394/mcp-client-node-send-session-delete-on-close-to-release-server-side).

## How to test

The leak reproduces with a single MCP session that just polls `tools/list` — which is what a real MCP client does continuously. On a small heap the difference is immediate: before this PR the server OOM-crashes within a few thousand polls; with it, memory stays flat.

1. Build and start n8n with a small heap so the leak surfaces fast:
   ```bash
   pnpm build
   NODE_OPTIONS="--max-old-space-size=300" pnpm start
   ```
2. Import and **activate** the load-test server workflow below. It exposes an `MCP Server Trigger` at `POST http://localhost:5678/mcp/leak`.
3. Save the poll script below and run it: `node mcp-poll.mjs`. It opens one MCP session and hammers `tools/list` on it (no session churn, no `DELETE`).
4. Observe:
   - **Before this PR** (e.g. on `master`): the n8n process heap climbs and it OOM-crashes within a few thousand polls; the script then prints `❌ server died (likely OOM)`.
   - **With this PR:** heap stays flat and the script runs to completion (`✅ DONE — server survived`).

Measured on a 300 MB heap: **before** — OOM at ~3,000 polls; **after** — 196,000 polls with heap flat at ~350 MB.

<details>
<summary>MCP load test server workflow (import &amp; activate)</summary>

```json
{
  "name": "MCP load test server",
  "nodes": [
    {
      "parameters": {},
      "type": "@n8n/n8n-nodes-langchain.toolCalculator",
      "typeVersion": 1,
      "position": [-96, 48],
      "id": "f89cbda6-567c-49a8-9205-fc4f758730d4",
      "name": "Calculator"
    },
    {
      "parameters": {},
      "type": "@n8n/n8n-nodes-langchain.toolCode",
      "typeVersion": 1.3,
      "position": [80, 48],
      "id": "4a378844-94ed-47e0-b621-7678e83aae10",
      "name": "Code Tool"
    },
    {
      "parameters": { "path": "leak" },
      "type": "@n8n/n8n-nodes-langchain.mcpTrigger",
      "typeVersion": 2,
      "position": [-176, -160],
      "id": "fdf0431d-a259-4f57-9692-210a31d58d7b",
      "name": "MCP Server Trigger1",
      "webhookId": "204af627-e6eb-4583-8b54-87fed58c282c"
    }
  ],
  "connections": {
    "Calculator": { "ai_tool": [[{ "node": "MCP Server Trigger1", "type": "ai_tool", "index": 0 }]] },
    "Code Tool": { "ai_tool": [[{ "node": "MCP Server Trigger1", "type": "ai_tool", "index": 0 }]] }
  },
  "settings": { "executionOrder": "v1" }
}
```
</details>

<details>
<summary>Poll script (mcp-poll.mjs)</summary>

```js
// One MCP session, poll tools/list forever (no churn, no DELETE).
// Before the fix: heap climbs -> server OOMs. After: flat, runs to completion.
// Usage: node mcp-poll.mjs [totalPolls] [concurrency]
const URL = process.env.MCP_URL ?? 'http://localhost:5678/mcp/leak';
const TOTAL = Number(process.argv[2] ?? 200000);
const CONC = Number(process.argv[3] ?? 40);
const ACCEPT = 'application/json, text/event-stream';

let done = 0, failed = 0, stop = false;

async function post(body, sessionId) {
	const headers = { 'content-type': 'application/json', accept: ACCEPT };
	if (sessionId) headers['mcp-session-id'] = sessionId;
	const res = await fetch(URL, { method: 'POST', headers, body: JSON.stringify(body) });
	const sid = res.headers.get('mcp-session-id');
	await res.text().catch(() => {});
	return sid;
}

async function initialize() {
	const sid = await post({
		jsonrpc: '2.0', id: 1, method: 'initialize',
		params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'mcp-poll', version: '1' } },
	});
	if (!sid) throw new Error('no mcp-session-id — is the server workflow active at ' + URL + '?');
	await post({ jsonrpc: '2.0', method: 'notifications/initialized' }, sid);
	return sid;
}

let nextId = 100;
async function worker(sid) {
	while (!stop && done + failed < TOTAL) {
		try {
			await post({ jsonrpc: '2.0', id: nextId++, method: 'tools/list', params: {} }, sid);
			if (++done % 1000 === 0) console.log(`polls=${done} failed=${failed}`);
		} catch (e) {
			failed++;
			if (String(e.message).includes('fetch failed') || String(e.message).includes('ECONNREFUSED')) {
				if (!stop) console.log(`\n❌ server died (likely OOM) after ${done} polls`);
				stop = true;
			}
		}
	}
}

const sid = await initialize();
console.log(`polling tools/list on one session (${sid}) — ${URL}`);
await Promise.all(Array.from({ length: CONC }, () => worker(sid)));
if (failed && stop) { console.log(`STOPPED: server did not survive — ${done} polls (expected pre-fix)`); process.exit(1); }
else console.log(`✅ DONE — server survived ${done} polls (flat heap = fix works)`);
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5380
- Related reports (client-side, not closed by this PR — tracked for the follow-up): #24666, #23388, #25742

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->