### PR TITLE
fix(core): Acquire expression isolate when resolving node parameters

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/extract-resolved-node-parameters.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/extract-resolved-node-parameters.test.ts
@@ -555,7 +555,7 @@ describe('extractResolvedNodeParameters', () => {
 		let releaseSpy: MockInstance;
 
 		beforeEach(() => {
-			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(true);
 			releaseSpy = vi.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
 		});
 

--- a/packages/cli/src/modules/instance-ai/__tests__/extract-resolved-node-parameters.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/extract-resolved-node-parameters.test.ts
@@ -1,14 +1,15 @@
 import type { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import type {
-	IConnections,
-	INode,
-	INodeParameters,
-	IPinData,
-	IRunExecutionData,
-	ITaskData,
+import {
+	Expression,
+	type IConnections,
+	type INode,
+	type INodeParameters,
+	type IPinData,
+	type IRunExecutionData,
+	type ITaskData,
 } from 'n8n-workflow';
-import type { Mocked } from 'vitest';
+import type { Mocked, MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import type { ExecutionPersistence } from '@/executions/execution-persistence';
@@ -542,5 +543,42 @@ describe('extractResolvedNodeParameters', () => {
 		const result = await extractResolvedNodeParameters(nodeTypes, 'exec-1', 'Set');
 
 		expect(parseResolved(result.resolved)).toEqual({ value: 'from-runData' });
+	});
+
+	describe('expression isolate lifecycle', () => {
+		// With N8N_EXPRESSION_ENGINE=vm, every getParameterValue call resolves in a
+		// V8 isolate that must first be acquired for the workflow's Expression
+		// instance — otherwise the VM bridge throws "No bridge acquired". Since this
+		// path builds a throwaway workflow outside the execution engine, it has to
+		// acquire/release the isolate itself. These spies pin that contract.
+		let acquireSpy: MockInstance;
+		let releaseSpy: MockInstance;
+
+		beforeEach(() => {
+			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(undefined);
+			releaseSpy = vi.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
+		});
+
+		it('acquires and releases the isolate around parameter resolution', async () => {
+			const trigger = makeNode('Trigger', 'n8n-nodes-base.manualTrigger');
+			const set = makeNode('Set', 'n8n-nodes-base.set', { value: '={{ $json.tag }}' });
+			createMockExecutionRepository(
+				makeResolutionExecution({
+					nodes: [trigger, set],
+					connections: connect('Trigger', 'Set'),
+					runData: {
+						Trigger: [makeTaskData([{ tag: 'ok' }])],
+					},
+				}),
+			);
+
+			await extractResolvedNodeParameters(nodeTypes, 'exec-1', 'Set');
+
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+			expect(acquireSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				releaseSpy.mock.invocationCallOrder[0],
+			);
+		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/extract-resolved-node-parameters.ts
+++ b/packages/cli/src/modules/instance-ai/extract-resolved-node-parameters.ts
@@ -360,7 +360,18 @@ export async function extractResolvedNodeParameters(
 	};
 
 	const parameters = (nodeJson.parameters ?? {}) as Record<string, unknown>;
-	const resolvedTree = walk(parameters, '') as Record<string, unknown>;
+	// When N8N_EXPRESSION_ENGINE=vm, expression evaluation runs in a V8 isolate
+	// that must be acquired for this workflow's Expression instance before any
+	// `getParameterValue` call — otherwise the VM bridge throws "No bridge
+	// acquired". This throwaway workflow never goes through the execution engine,
+	// so we acquire/release the isolate ourselves. No-op in legacy mode.
+	await workflow.expression.acquireIsolate();
+	let resolvedTree: Record<string, unknown>;
+	try {
+		resolvedTree = walk(parameters, '') as Record<string, unknown>;
+	} finally {
+		await workflow.expression.releaseIsolate();
+	}
 
 	// Resolved values can echo data from upstream nodes (webhook bodies, HTTP
 	// responses, etc.) so they're wrapped as untrusted data — same pattern used


### PR DESCRIPTION
## Summary

The `get-resolved-node-parameters` instance-ai tool (also folded into the `debug` action) replays expression resolution for a node's parameters against a past execution. It builds a throwaway `Workflow` and calls `workflow.expression.getParameterValue(...)` directly, **bypassing the execution engine**.

With `N8N_EXPRESSION_ENGINE=vm`, expression evaluation runs inside a V8 isolate that must first be **acquired** for that workflow's `Expression` instance. Because this replay path never acquired an isolate, every `=`-prefixed parameter failed with:

> No bridge acquired for this context. Call acquire() first.

The regular execution path handles this correctly (`WorkflowExecute` calls `acquireIsolate()`/`releaseIsolate()` around a run), as do `DynamicNodeParametersService` and the ephemeral node executor. This one replay path was simply missed. In legacy mode it worked because `acquireIsolate`/`releaseIsolate` are no-ops when the VM evaluator isn't initialized.

This PR acquires and releases the isolate around the resolution walk (try/finally), matching the existing VM-mode patterns. No-op in legacy mode.

## How to test

**Requires the experimental VM expression engine**, enabled via `N8N_EXPRESSION_ENGINE=vm`.

1. Start n8n with `N8N_EXPRESSION_ENGINE=vm`.
2. Run any workflow whose node has an expression parameter (e.g. an HTTP Request node with `={{ $json.foo }}` in the URL) so there's a saved execution.
3. In the AI assistant, invoke the `executions(action="get-resolved-node-parameters")` tool (or the `debug` action) against that execution/node.
4. **Before this fix:** every `=`-prefixed parameter comes back in `failedExpressions` with `error: "No bridge acquired for this context. Call acquire() first."`.
   **After this fix:** parameters resolve normally.

Automated: `pnpm --filter n8n test extract-resolved-node-parameters` — includes a new lifecycle test asserting the isolate is acquired before, and released after, resolution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-827

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33757">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

