### PR TITLE
feat(core): Add Pinecone vector store backend to agents SDK (no-changelog)

### DIFF
--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -19,6 +19,9 @@
       "vector-stores/postgres": [
         "dist/vector-stores/postgres.d.ts"
       ],
+      "vector-stores/pinecone": [
+        "dist/vector-stores/pinecone.d.ts"
+      ],
       "vector-stores/qdrant": [
         "dist/vector-stores/qdrant.d.ts"
       ],
@@ -48,6 +51,10 @@
     "./vector-stores/postgres": {
       "types": "./dist/vector-stores/postgres.d.ts",
       "default": "./dist/vector-stores/postgres.js"
+    },
+    "./vector-stores/pinecone": {
+      "types": "./dist/vector-stores/pinecone.d.ts",
+      "default": "./dist/vector-stores/pinecone.js"
     },
     "./vector-stores/qdrant": {
       "types": "./dist/vector-stores/qdrant.d.ts",
@@ -111,6 +118,7 @@
     "zod-to-json-schema": "catalog:"
   },
   "peerDependencies": {
+    "@pinecone-database/pinecone": "catalog:",
     "@qdrant/js-client-rest": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "pg": "catalog:",
@@ -132,6 +140,9 @@
     "pg": {
       "optional": true
     },
+    "@pinecone-database/pinecone": {
+      "optional": true
+    },
     "@qdrant/js-client-rest": {
       "optional": true
     },
@@ -142,6 +153,7 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
+    "@pinecone-database/pinecone": "catalog:",
     "@qdrant/js-client-rest": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "@types/json-schema": "catalog:",

--- a/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-pinecone.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-pinecone.test.ts
@@ -50,7 +50,7 @@ describe.skipIf(!PINECONE_API_KEY || !hasKeys)('Agent + PineconeVectorStore end-
 
 	afterAll(async () => {
 		await adminClient.deleteIndex(indexName);
-		await store.close();
+		store.close();
 	});
 
 	registerAgentVectorStoreTests(() => knowledge);

--- a/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-pinecone.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-pinecone.test.ts
@@ -1,0 +1,57 @@
+/**
+ * End-to-end: a real model searches a real Pinecone-backed VectorStore
+ * populated with the fixture corpus (see fixtures/generate-bulk-vector-fixture.ts)
+ * and answers from the results. Gated on PINECONE_TEST_API_KEY plus both
+ * provider keys; self-skips in CI replay since Pinecone can't be replayed
+ * from cassettes.
+ */
+import type { Pinecone } from '@pinecone-database/pinecone';
+import { afterAll, beforeAll, describe } from 'vitest';
+
+import {
+	createPineconeIndex,
+	loadBulkFixture,
+	registerAgentVectorStoreTests,
+	upsertFixtureDocuments,
+	waitForPineconeRecordCount,
+} from './vector-store-helpers';
+import { VectorStore } from '../../index';
+import { PineconeVectorStore } from '../../vector-stores/pinecone';
+
+const PINECONE_API_KEY = process.env.PINECONE_TEST_API_KEY;
+const hasKeys = Boolean(process.env.ANTHROPIC_API_KEY) && Boolean(process.env.OPENAI_API_KEY);
+
+const HOOK_TIMEOUT_MS = 240_000;
+
+const fixture = loadBulkFixture();
+
+describe.skipIf(!PINECONE_API_KEY || !hasKeys)('Agent + PineconeVectorStore end-to-end', () => {
+	const indexName = `vs-e2e-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+	let adminClient: Pinecone;
+	let store: PineconeVectorStore;
+	let knowledge: VectorStore;
+
+	beforeAll(async () => {
+		const { Pinecone: PineconeCtor } = await import('@pinecone-database/pinecone');
+		adminClient = new PineconeCtor({ apiKey: PINECONE_API_KEY! });
+		await createPineconeIndex(adminClient, indexName, fixture.dimensions);
+
+		store = new PineconeVectorStore('knowledge-base', {
+			apiKey: PINECONE_API_KEY!,
+			indexName,
+		});
+		await upsertFixtureDocuments(store, fixture);
+		await waitForPineconeRecordCount(adminClient.index(indexName), fixture.documents.length);
+		knowledge = new VectorStore('knowledge-base')
+			.store(store)
+			.embeddingModel('openai/text-embedding-3-small')
+			.description('Search the knowledge base of encyclopedia articles');
+	}, HOOK_TIMEOUT_MS);
+
+	afterAll(async () => {
+		await adminClient.deleteIndex(indexName);
+		await store.close();
+	});
+
+	registerAgentVectorStoreTests(() => knowledge);
+});

--- a/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-qdrant.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-qdrant.test.ts
@@ -53,7 +53,7 @@ describe.skipIf(!QDRANT_URL || !hasKeys)('Agent + QdrantVectorStore end-to-end',
 
 	afterAll(async () => {
 		await adminClient.deleteCollection(collectionName);
-		await store.close();
+		store.close();
 	});
 
 	registerAgentVectorStoreTests(() => knowledge);

--- a/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-supabase.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-vector-store-supabase.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(!SUPABASE_URL || !SUPABASE_API_KEY || !SUPABASE_DB_URL || !hasKe
 
 		afterAll(async () => {
 			await dropSupabaseVectorTableAndFunction(adminPool, tableName, queryName);
-			await store.close();
+			store.close();
 			await adminPool.end();
 		});
 

--- a/packages/@n8n/agents/src/__tests__/integration/pinecone-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/pinecone-vector-store.test.ts
@@ -48,7 +48,7 @@ describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore', () => {
 
 	afterAll(async () => {
 		await adminClient.deleteIndex(indexName);
-		await store.close();
+		store.close();
 	});
 
 	it('upserts vectors with metadata and queries by similarity', async () => {
@@ -127,7 +127,7 @@ describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore', () => {
 				expect(results[0].content).toBe('refunds take 5 days');
 			});
 		} finally {
-			await roundTripStore.close();
+			roundTripStore.close();
 		}
 	});
 });
@@ -174,7 +174,7 @@ describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore — metadata filtering',
 
 	afterAll(async () => {
 		await adminClient.deleteIndex(indexName);
-		await filterStore.close();
+		filterStore.close();
 	});
 
 	async function idsFor(filter: Parameters<PineconeVectorStore['query']>[1]['filter']) {

--- a/packages/@n8n/agents/src/__tests__/integration/pinecone-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/pinecone-vector-store.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Integration tests against a real Pinecone project. Gated on
+ * PINECONE_TEST_API_KEY (not the usual API-key/cassette convention) since
+ * Pinecone is a separate service, not LLM HTTP — these self-skip when it's
+ * unset. Pinecone writes and deletes are eventually consistent, so every
+ * assertion that depends on a preceding mutation is wrapped in `eventually`,
+ * which retries the assertion until it passes or a timeout elapses.
+ */
+import type { Pinecone } from '@pinecone-database/pinecone';
+import { MockEmbeddingModelV3 } from 'ai/test';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPineconeIndex } from './vector-store-helpers';
+import { VectorStore } from '../../sdk/vector-store';
+import { PineconeVectorStore } from '../../vector-stores/pinecone';
+
+const PINECONE_API_KEY = process.env.PINECONE_TEST_API_KEY;
+
+const HOOK_TIMEOUT_MS = 180_000;
+
+async function eventually(fn: () => void | Promise<void>, timeoutMs = 15_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		try {
+			await fn();
+			return;
+		} catch (error) {
+			if (Date.now() > deadline) throw error;
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+	}
+}
+
+describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore', () => {
+	const indexName = `vs-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+	let store: PineconeVectorStore;
+	let adminClient: Pinecone;
+
+	beforeAll(async () => {
+		const { Pinecone: PineconeCtor } = await import('@pinecone-database/pinecone');
+		adminClient = new PineconeCtor({ apiKey: PINECONE_API_KEY! });
+		await createPineconeIndex(adminClient, indexName, 3);
+		store = new PineconeVectorStore('pinecone-integration', {
+			apiKey: PINECONE_API_KEY!,
+			indexName,
+		});
+	}, HOOK_TIMEOUT_MS);
+
+	afterAll(async () => {
+		await adminClient.deleteIndex(indexName);
+		await store.close();
+	});
+
+	it('upserts vectors with metadata and queries by similarity', async () => {
+		await store.upsert([
+			{ id: 'exact', vector: [1, 0, 0], content: 'exact match', metadata: { topic: 'a' } },
+			{ id: 'near', vector: [0.9, 0.1, 0], content: 'near match', metadata: {} },
+			{ id: 'far', vector: [0, 1, 0], content: 'far match', metadata: {} },
+		]);
+
+		await eventually(async () => {
+			const results = await store.query([1, 0, 0], { topK: 2 });
+			expect(results).toHaveLength(2);
+			expect(results[0].id).toBe('exact');
+			expect(results[0].score).toBeCloseTo(1, 3);
+			expect(results[0].metadata).toEqual({ topic: 'a' });
+			expect(results[1].id).toBe('near');
+		});
+	});
+
+	it('re-upserting the same id updates its content', async () => {
+		await store.upsert([
+			{ id: 'exact', vector: [1, 0, 0], content: 'updated content', metadata: {} },
+		]);
+
+		await eventually(async () => {
+			const results = await store.query([1, 0, 0], { topK: 1 });
+			expect(results[0].id).toBe('exact');
+			expect(results[0].content).toBe('updated content');
+		});
+	});
+
+	it('deletes by ids', async () => {
+		await store.delete({ ids: ['far'] });
+
+		await eventually(async () => {
+			const results = await store.query([0, 1, 0], { topK: 5 });
+			expect(results.find((r) => r.id === 'far')).toBeUndefined();
+		});
+	});
+
+	it('rejects upserting metadata that uses the reserved _content key', async () => {
+		await expect(
+			store.upsert([{ id: 'bad', vector: [1, 0, 0], content: 'x', metadata: { _content: 'y' } }]),
+		).rejects.toThrow(/reserved for the document content/);
+	});
+
+	it('rejects upserting a nested-object metadata value', async () => {
+		await expect(
+			store.upsert([
+				{ id: 'bad', vector: [1, 0, 0], content: 'x', metadata: { nested: { a: 1 } } },
+			]),
+		).rejects.toThrow(/unsupported/);
+	});
+
+	it('round-trips through the VectorStore orchestrator with a mock embedding model', async () => {
+		const roundTripStore = new PineconeVectorStore('pinecone-integration-roundtrip', {
+			apiKey: PINECONE_API_KEY!,
+			indexName,
+			namespace: 'roundtrip',
+		});
+		const embeddingModel = new MockEmbeddingModelV3({
+			doEmbed: async ({ values }: { values: string[] }) => ({
+				embeddings: values.map(() => [1, 0, 0]),
+				warnings: [],
+			}),
+		});
+
+		try {
+			const knowledge = new VectorStore('roundtrip')
+				.store(roundTripStore)
+				.embeddingModel(embeddingModel);
+			await knowledge.addDocuments([{ content: 'refunds take 5 days' }]);
+
+			await eventually(async () => {
+				const results = await knowledge.search('how long do refunds take');
+				expect(results[0].content).toBe('refunds take 5 days');
+			});
+		} finally {
+			await roundTripStore.close();
+		}
+	});
+});
+
+describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore — metadata filtering', () => {
+	const indexName = `vs-test-filter-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+	let filterStore: PineconeVectorStore;
+	let adminClient: Pinecone;
+
+	beforeAll(async () => {
+		const { Pinecone: PineconeCtor } = await import('@pinecone-database/pinecone');
+		adminClient = new PineconeCtor({ apiKey: PINECONE_API_KEY! });
+		await createPineconeIndex(adminClient, indexName, 3);
+		filterStore = new PineconeVectorStore('pinecone-filter-integration', {
+			apiKey: PINECONE_API_KEY!,
+			indexName,
+		});
+		await filterStore.upsert([
+			{
+				id: 'a',
+				content: 'Row A content',
+				vector: [1, 0, 0],
+				metadata: { topic: 'billing', count: 5, active: true },
+			},
+			{
+				id: 'b',
+				content: 'Row B content',
+				vector: [0.9, 0.1, 0],
+				metadata: { topic: 'ops', count: 10, active: false },
+			},
+			// Missing all keys — required to prove ne/nin match rows that never had the key.
+			{ id: 'c', content: 'Row C content', vector: [0, 1, 0], metadata: {} },
+			// Stores count as a JSON string, not a number — proves a numeric filter
+			// doesn't match it, and (unlike Qdrant, which restricts a field to one
+			// index type) that a string filter on the same field matches it back.
+			{ id: 'd', content: 'Row D content', vector: [0, 0.5, 0.5], metadata: { count: '5' } },
+		]);
+		// Pinecone writes are eventually consistent — wait for the full corpus to be queryable before any test runs.
+		await eventually(async () => {
+			const results = await filterStore.query([1, 0, 0], { topK: 10 });
+			expect(results.map((r) => r.id).sort()).toEqual(['a', 'b', 'c', 'd']);
+		}, 30_000);
+	}, HOOK_TIMEOUT_MS);
+
+	afterAll(async () => {
+		await adminClient.deleteIndex(indexName);
+		await filterStore.close();
+	});
+
+	async function idsFor(filter: Parameters<PineconeVectorStore['query']>[1]['filter']) {
+		const results = await filterStore.query([1, 0, 0], { topK: 10, filter });
+		return results.map((r) => r.id).sort();
+	}
+
+	it('eq matches on string, number, and boolean, and is type-correct', async () => {
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'billing' }] }),
+		).toEqual(['a']);
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: 5 }] })).toEqual([
+			'a',
+		]);
+		expect(await idsFor({ conditions: [{ key: 'active', operator: 'eq', value: true }] })).toEqual([
+			'a',
+		]);
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'eq', value: 'nonexistent' }] }),
+		).toEqual([]);
+	});
+
+	it('eq is type-correct in both directions between numeric and string-typed values', async () => {
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: 5 }] })).toEqual([
+			'a',
+		]);
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'eq', value: '5' }] })).toEqual([
+			'd',
+		]);
+	});
+
+	it('combines multiple conditions with AND', async () => {
+		expect(
+			await idsFor({
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'count', operator: 'eq', value: 5 },
+				],
+				combineWith: 'and',
+			}),
+		).toEqual(['a']);
+	});
+
+	it('ne excludes only the matching row, including rows missing the key', async () => {
+		const ids = await idsFor({
+			conditions: [{ key: 'topic', operator: 'ne', value: 'billing' }],
+		});
+		expect(ids).not.toContain('a');
+		expect(ids).toContain('b');
+		expect(ids).toContain('c');
+	});
+
+	it('in matches only listed values', async () => {
+		expect(
+			await idsFor({ conditions: [{ key: 'topic', operator: 'in', value: ['billing', 'ops'] }] }),
+		).toEqual(['a', 'b']);
+	});
+
+	it('in is type-correct: a numeric candidate does not match a string-valued row', async () => {
+		expect(await idsFor({ conditions: [{ key: 'count', operator: 'in', value: [5] }] })).toEqual([
+			'a',
+		]);
+	});
+
+	it('nin excludes listed values but matches rows missing the key (the reference NIN bug case)', async () => {
+		const ids = await idsFor({
+			conditions: [{ key: 'topic', operator: 'nin', value: ['billing'] }],
+		});
+		expect(ids).not.toContain('a');
+		expect(ids).toContain('b');
+		expect(ids).toContain('c'); // missing key — must match, not be excluded like `!= ANY` incorrectly does
+	});
+
+	it('supports an OR-combined group', async () => {
+		expect(
+			await idsFor({
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'topic', operator: 'eq', value: 'ops' },
+				],
+				combineWith: 'or',
+			}),
+		).toEqual(['a', 'b']);
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/qdrant-vector-store.test.ts
@@ -53,7 +53,7 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore', () => {
 
 	afterAll(async () => {
 		await adminClient.deleteCollection(collectionName);
-		await store.close();
+		store.close();
 	});
 
 	it('upserts vectors with metadata and queries by similarity', async () => {
@@ -129,7 +129,7 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore', () => {
 			expect(results[0].content).toBe('refunds take 5 days');
 		} finally {
 			await adminClient.deleteCollection(roundTripCollection);
-			await roundTripStore.close();
+			roundTripStore.close();
 		}
 	});
 });
@@ -190,7 +190,7 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore — metadata filtering', () => {
 
 	afterAll(async () => {
 		await adminClient.deleteCollection(filterCollectionName);
-		await filterStore.close();
+		filterStore.close();
 	});
 
 	async function idsFor(filter: Parameters<QdrantVectorStore['query']>[1]['filter']) {

--- a/packages/@n8n/agents/src/__tests__/integration/supabase-vector-store.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/supabase-vector-store.test.ts
@@ -49,7 +49,7 @@ describe.skipIf(!SUPABASE_URL || !SUPABASE_API_KEY || !SUPABASE_DB_URL)(
 
 		afterAll(async () => {
 			await dropSupabaseVectorTableAndFunction(adminPool, tableName, queryName);
-			await store.close();
+			store.close();
 			await adminPool.end();
 		});
 
@@ -124,7 +124,7 @@ describe.skipIf(!SUPABASE_URL || !SUPABASE_API_KEY || !SUPABASE_DB_URL)(
 					expect(results[0].content).toBe('refunds take 5 days');
 				} finally {
 					await dropSupabaseVectorTableAndFunction(adminPool, roundTripTable, roundTripQueryName);
-					await roundTripStore.close();
+					roundTripStore.close();
 				}
 			},
 			HOOK_TIMEOUT_MS,
@@ -174,7 +174,7 @@ describe.skipIf(!SUPABASE_URL || !SUPABASE_API_KEY || !SUPABASE_DB_URL)(
 
 		afterAll(async () => {
 			await dropSupabaseVectorTableAndFunction(adminPool, filterTableName, filterQueryName);
-			await filterStore.close();
+			filterStore.close();
 			await adminPool.end();
 		});
 

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-pinecone.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-pinecone.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Bulk retrieval-quality suite run against PineconeVectorStore using a
+ * committed 30-document fixture with precomputed embeddings (see
+ * fixtures/generate-bulk-vector-fixture.ts). No OpenAI calls at test time —
+ * both document and query vectors are precomputed, so "ground truth" is
+ * computed locally via cosine similarity and compared against what the
+ * backend actually returns.
+ */
+import type { Pinecone } from '@pinecone-database/pinecone';
+import { afterAll, beforeAll, describe } from 'vitest';
+
+import {
+	createPineconeIndex,
+	loadBulkFixture,
+	registerBulkVectorStoreTests,
+	upsertFixtureDocuments,
+	waitForPineconeRecordCount,
+} from './vector-store-helpers';
+import { PineconeVectorStore } from '../../vector-stores/pinecone';
+
+const PINECONE_API_KEY = process.env.PINECONE_TEST_API_KEY;
+
+const HOOK_TIMEOUT_MS = 240_000;
+const DELETED_COUNT = 20;
+
+const fixture = loadBulkFixture();
+
+describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore — bulk fixture corpus', () => {
+	const indexName = `vs-bulk-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+	let adminClient: Pinecone;
+	let store: PineconeVectorStore;
+
+	beforeAll(async () => {
+		const { Pinecone: PineconeCtor } = await import('@pinecone-database/pinecone');
+		adminClient = new PineconeCtor({ apiKey: PINECONE_API_KEY! });
+		await createPineconeIndex(adminClient, indexName, fixture.dimensions);
+		store = new PineconeVectorStore('bulk-pinecone', {
+			apiKey: PINECONE_API_KEY!,
+			indexName,
+		});
+		await upsertFixtureDocuments(store, fixture);
+		await waitForPineconeRecordCount(adminClient.index(indexName), fixture.documents.length);
+	}, HOOK_TIMEOUT_MS);
+
+	afterAll(async () => {
+		await adminClient.deleteIndex(indexName);
+		await store.close();
+	});
+
+	registerBulkVectorStoreTests(fixture, () => store, {
+		afterDelete: async () =>
+			await waitForPineconeRecordCount(
+				adminClient.index(indexName),
+				fixture.documents.length - DELETED_COUNT,
+			),
+	});
+});

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-pinecone.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-pinecone.test.ts
@@ -21,7 +21,6 @@ import { PineconeVectorStore } from '../../vector-stores/pinecone';
 const PINECONE_API_KEY = process.env.PINECONE_TEST_API_KEY;
 
 const HOOK_TIMEOUT_MS = 240_000;
-const DELETED_COUNT = 20;
 
 const fixture = loadBulkFixture();
 
@@ -44,14 +43,11 @@ describe.skipIf(!PINECONE_API_KEY)('PineconeVectorStore — bulk fixture corpus'
 
 	afterAll(async () => {
 		await adminClient.deleteIndex(indexName);
-		await store.close();
+		store.close();
 	});
 
 	registerBulkVectorStoreTests(fixture, () => store, {
-		afterDelete: async () =>
-			await waitForPineconeRecordCount(
-				adminClient.index(indexName),
-				fixture.documents.length - DELETED_COUNT,
-			),
+		afterDelete: async (remainingCount) =>
+			await waitForPineconeRecordCount(adminClient.index(indexName), remainingCount),
 	});
 });

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-qdrant.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-qdrant.test.ts
@@ -49,7 +49,7 @@ describe.skipIf(!QDRANT_URL)('QdrantVectorStore — bulk fixture corpus', () => 
 
 	afterAll(async () => {
 		await adminClient.deleteCollection(collectionName);
-		await store.close();
+		store.close();
 	});
 
 	registerBulkVectorStoreTests(fixture, () => store);

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-supabase.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-bulk-supabase.test.ts
@@ -52,7 +52,7 @@ describe.skipIf(!SUPABASE_URL || !SUPABASE_API_KEY || !SUPABASE_DB_URL)(
 
 		afterAll(async () => {
 			await dropSupabaseVectorTableAndFunction(pool, tableName, queryName);
-			await store.close();
+			store.close();
 			await pool.end();
 		});
 

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-helpers.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-helpers.ts
@@ -198,7 +198,7 @@ export async function upsertFixtureDocuments(
 export function registerBulkVectorStoreTests(
 	fixture: BulkFixture,
 	getStore: () => BaseVectorStore,
-	opts?: { afterDelete?: () => Promise<void> },
+	opts?: { afterDelete?: (remainingCount: number) => Promise<void> },
 ): void {
 	it('returns the expected best match for each known-answer query', async () => {
 		const store = getStore();
@@ -249,7 +249,7 @@ export function registerBulkVectorStoreTests(
 		expect(idsToDelete).toContain(fixture.queries[1].expectedTopId);
 
 		await store.delete({ ids: idsToDelete });
-		await opts?.afterDelete?.();
+		await opts?.afterDelete?.(fixture.documents.length - idsToDelete.length);
 
 		const remaining = fixture.documents.filter((doc) => !idsToDelete.includes(doc.id));
 		const expectedTopIds = localTopIds(remaining, fixture.queries[1].vector, 5);

--- a/packages/@n8n/agents/src/__tests__/integration/vector-store-helpers.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/vector-store-helpers.ts
@@ -1,9 +1,10 @@
 /**
  * Shared helpers for the vector-store integration suites (Postgres, Qdrant,
- * Supabase) — fixture loading, locally computed ground truth, Postgres/
- * Supabase DDL setup, and shared test-body registration, deduplicated from
- * the per-backend test files.
+ * Supabase, Pinecone) — fixture loading, locally computed ground truth,
+ * Postgres/Supabase DDL setup, Pinecone index provisioning, and shared
+ * test-body registration, deduplicated from the per-backend test files.
  */
+import type { Index, Pinecone } from '@pinecone-database/pinecone';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import type { Pool } from 'pg';
@@ -143,6 +144,36 @@ export async function waitUntilQueryable(
 	}
 }
 
+/** Stands in for the BYO user's own setup, since PineconeVectorStore itself never creates indexes. */
+export async function createPineconeIndex(
+	pc: Pinecone,
+	name: string,
+	dimensions: number,
+): Promise<void> {
+	await pc.createIndex({
+		name,
+		dimension: dimensions,
+		metric: 'cosine',
+		spec: { serverless: { cloud: 'aws', region: 'us-east-1' } },
+		waitUntilReady: true,
+	});
+}
+
+/** Pinecone writes are eventually consistent — poll index stats until the expected record count is visible. */
+export async function waitForPineconeRecordCount(index: Index, expected: number): Promise<void> {
+	const deadline = Date.now() + SCHEMA_WAIT_TIMEOUT_MS * 4;
+	for (;;) {
+		const stats = await index.describeIndexStats();
+		if (stats.totalRecordCount === expected) return;
+		if (Date.now() > deadline) {
+			throw new Error(
+				`Timed out waiting for Pinecone record count to reach ${expected} (last seen: ${stats.totalRecordCount ?? 0}).`,
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+}
+
 export async function upsertFixtureDocuments(
 	store: BaseVectorStore,
 	fixture: BulkFixture,
@@ -158,7 +189,7 @@ export async function upsertFixtureDocuments(
 }
 
 /**
- * Registers the bulk retrieval-quality `it` blocks shared by all three
+ * Registers the bulk retrieval-quality `it` blocks shared by all four
  * backends' `vector-store-bulk-*.test.ts` suites. Must be called inside the
  * suite's `describe` body, after `getStore` is guaranteed to resolve (i.e.
  * after `beforeAll` populates the store). Order matters: the delete test
@@ -167,6 +198,7 @@ export async function upsertFixtureDocuments(
 export function registerBulkVectorStoreTests(
 	fixture: BulkFixture,
 	getStore: () => BaseVectorStore,
+	opts?: { afterDelete?: () => Promise<void> },
 ): void {
 	it('returns the expected best match for each known-answer query', async () => {
 		const store = getStore();
@@ -217,6 +249,7 @@ export function registerBulkVectorStoreTests(
 		expect(idsToDelete).toContain(fixture.queries[1].expectedTopId);
 
 		await store.delete({ ids: idsToDelete });
+		await opts?.afterDelete?.();
 
 		const remaining = fixture.documents.filter((doc) => !idsToDelete.includes(doc.id));
 		const expectedTopIds = localTopIds(remaining, fixture.queries[1].vector, 5);
@@ -230,7 +263,7 @@ export function registerBulkVectorStoreTests(
 }
 
 /**
- * Registers the agent end-to-end `it` blocks shared by all three backends'
+ * Registers the agent end-to-end `it` blocks shared by all four backends'
  * `agent-vector-store-*.test.ts` suites. Must be called inside the suite's
  * `describe` body, after `getKnowledge` is guaranteed to resolve.
  */

--- a/packages/@n8n/agents/src/__tests__/pinecone-filter-translation.test.ts
+++ b/packages/@n8n/agents/src/__tests__/pinecone-filter-translation.test.ts
@@ -245,4 +245,38 @@ describe('PineconeVectorStore filter translation', () => {
 			{ id: '1', values: [0], metadata: { _content: 'hi', tags: ['a', 'b'] } },
 		]);
 	});
+
+	it('splits large upserts into sequential batches of 200', async () => {
+		const { store, stub } = createStore();
+		const records = Array.from({ length: 401 }, (_, i) => ({
+			id: String(i),
+			vector: [0],
+			content: 'c',
+			metadata: {},
+		}));
+
+		await store.upsert(records);
+
+		expect(stub.upsert).toHaveBeenCalledTimes(3);
+		const calls = stub.upsert.mock.calls as Array<[Array<{ id: string }>]>;
+		expect(calls[0][0]).toHaveLength(200);
+		expect(calls[1][0]).toHaveLength(200);
+		expect(calls[2][0]).toHaveLength(1);
+		expect(calls[0][0][0].id).toBe('0');
+		expect(calls[1][0][0].id).toBe('200');
+		expect(calls[2][0][0].id).toBe('400');
+	});
+
+	it('rejects invalid metadata without sending any batch', async () => {
+		const { store, stub } = createStore();
+		const records = Array.from({ length: 201 }, (_, i) => ({
+			id: String(i),
+			vector: [0],
+			content: 'c',
+			metadata: i === 200 ? { nested: { a: 1 } } : {},
+		}));
+
+		await expect(store.upsert(records)).rejects.toThrow(/unsupported/);
+		expect(stub.upsert).not.toHaveBeenCalled();
+	});
 });

--- a/packages/@n8n/agents/src/__tests__/pinecone-filter-translation.test.ts
+++ b/packages/@n8n/agents/src/__tests__/pinecone-filter-translation.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit coverage for the metadata-filter translation and metadata-shape
+ * validation in `PineconeVectorStore` — logic that never runs in CI because
+ * the integration suites self-skip without a real Pinecone project.
+ *
+ * Exercises `query()`/`upsert()` through the public API with a stubbed
+ * `Index` (assigned directly to the private `index` field) so no network
+ * calls or `@pinecone-database/pinecone` import happen.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { PineconeVectorStore } from '../vector-stores/pinecone';
+
+function createStub(queryResult: { matches: unknown[] }) {
+	const query = vi.fn().mockResolvedValue(queryResult);
+	const upsert = vi.fn().mockResolvedValue(undefined);
+	return { query, upsert };
+}
+
+function createStore(): { store: PineconeVectorStore; stub: ReturnType<typeof createStub> } {
+	const store = new PineconeVectorStore('test-store', {
+		apiKey: 'test-key',
+		indexName: 'docs',
+	});
+	const stub = createStub({ matches: [] });
+	(store as unknown as { index: unknown }).index = stub;
+	return { store, stub };
+}
+
+describe('PineconeVectorStore filter translation', () => {
+	it('queries with topK and includeMetadata, with no filter key when absent', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([1, 2, 3], { topK: 4 });
+
+		expect(stub.query).toHaveBeenCalledWith({
+			vector: [1, 2, 3],
+			topK: 4,
+			includeMetadata: true,
+		});
+	});
+
+	it('omits the filter key when the filter has no conditions', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], { topK: 1, filter: { conditions: [] } });
+
+		expect(stub.query).toHaveBeenCalledWith({ vector: [0], topK: 1, includeMetadata: true });
+	});
+
+	it('translates eq to an $eq term wrapped in $and', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: { conditions: [{ key: 'topic', operator: 'eq', value: 'billing' }] },
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({ filter: { $and: [{ topic: { $eq: 'billing' } }] } }),
+		);
+	});
+
+	it('translates ne to an $or with an $exists:false arm', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: { conditions: [{ key: 'topic', operator: 'ne', value: 'billing' }] },
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filter: {
+					$and: [{ $or: [{ topic: { $ne: 'billing' } }, { topic: { $exists: false } }] }],
+				},
+			}),
+		);
+	});
+
+	it('translates in to an $in term', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: { conditions: [{ key: 'topic', operator: 'in', value: ['billing', 'ops'] }] },
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({ filter: { $and: [{ topic: { $in: ['billing', 'ops'] } }] } }),
+		);
+	});
+
+	it('translates nin to an $or with an $exists:false arm', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: { conditions: [{ key: 'topic', operator: 'nin', value: ['billing', 'ops'] }] },
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filter: {
+					$and: [
+						{
+							$or: [{ topic: { $nin: ['billing', 'ops'] } }, { topic: { $exists: false } }],
+						},
+					],
+				},
+			}),
+		);
+	});
+
+	it('combines multiple conditions under $and, in condition order', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: {
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'active', operator: 'eq', value: true },
+				],
+				combineWith: 'and',
+			},
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filter: { $and: [{ topic: { $eq: 'billing' } }, { active: { $eq: true } }] },
+			}),
+		);
+	});
+
+	it('combines multiple conditions under $or', async () => {
+		const { store, stub } = createStore();
+
+		await store.query([0], {
+			topK: 1,
+			filter: {
+				conditions: [
+					{ key: 'topic', operator: 'eq', value: 'billing' },
+					{ key: 'topic', operator: 'eq', value: 'ops' },
+				],
+				combineWith: 'or',
+			},
+		});
+
+		expect(stub.query).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filter: { $or: [{ topic: { $eq: 'billing' } }, { topic: { $eq: 'ops' } }] },
+			}),
+		);
+	});
+
+	it('rejects an empty array for in without calling query', async () => {
+		const { store, stub } = createStore();
+
+		await expect(
+			store.query([0], {
+				topK: 1,
+				filter: { conditions: [{ key: 'topic', operator: 'in', value: [] }] },
+			}),
+		).rejects.toThrow(/requires a non-empty array value/);
+		expect(stub.query).not.toHaveBeenCalled();
+	});
+
+	it('rejects an empty array for nin without calling query', async () => {
+		const { store, stub } = createStore();
+
+		await expect(
+			store.query([0], {
+				topK: 1,
+				filter: { conditions: [{ key: 'topic', operator: 'nin', value: [] }] },
+			}),
+		).rejects.toThrow(/requires a non-empty array value/);
+		expect(stub.query).not.toHaveBeenCalled();
+	});
+
+	it('maps matches to query results, stripping _content into content', async () => {
+		const { store, stub } = createStore();
+		stub.query.mockResolvedValue({
+			matches: [{ id: 7, score: 0.5, metadata: { _content: 'hello', topic: 'billing' } }],
+		});
+
+		const results = await store.query([0], { topK: 1 });
+
+		expect(results).toEqual([
+			{ id: '7', content: 'hello', metadata: { topic: 'billing' }, score: 0.5 },
+		]);
+	});
+
+	it('defaults content to an empty string and score to 0 when absent', async () => {
+		const { store, stub } = createStore();
+		stub.query.mockResolvedValue({ matches: [{ id: 'a', metadata: {} }] });
+
+		const results = await store.query([0], { topK: 1 });
+
+		expect(results).toEqual([{ id: 'a', content: '', metadata: {}, score: 0 }]);
+	});
+
+	it('upserts records with content stored under the reserved _content key', async () => {
+		const { store, stub } = createStore();
+
+		await store.upsert([
+			{ id: '1', vector: [1, 0], content: 'hello', metadata: { topic: 'billing' } },
+		]);
+
+		expect(stub.upsert).toHaveBeenCalledWith([
+			{ id: '1', values: [1, 0], metadata: { _content: 'hello', topic: 'billing' } },
+		]);
+	});
+
+	it('rejects upserting metadata that uses the reserved _content key', async () => {
+		const { store } = createStore();
+
+		await expect(
+			store.upsert([{ id: '1', vector: [0], content: 'hi', metadata: { _content: 'x' } }]),
+		).rejects.toThrow(/reserved for the document content/);
+	});
+
+	it('rejects upserting a nested-object metadata value', async () => {
+		const { store } = createStore();
+
+		await expect(
+			store.upsert([{ id: '1', vector: [0], content: 'hi', metadata: { nested: { a: 1 } } }]),
+		).rejects.toThrow(/unsupported/);
+	});
+
+	it('rejects upserting a mixed-type array metadata value', async () => {
+		const { store } = createStore();
+
+		await expect(
+			store.upsert([{ id: '1', vector: [0], content: 'hi', metadata: { tags: ['a', 1] } }]),
+		).rejects.toThrow(/unsupported/);
+	});
+
+	it('accepts a string-array metadata value', async () => {
+		const { store, stub } = createStore();
+
+		await store.upsert([{ id: '1', vector: [0], content: 'hi', metadata: { tags: ['a', 'b'] } }]);
+
+		expect(stub.upsert).toHaveBeenCalledWith([
+			{ id: '1', values: [0], metadata: { _content: 'hi', tags: ['a', 'b'] } },
+		]);
+	});
+});

--- a/packages/@n8n/agents/src/storage/base-vector-store.ts
+++ b/packages/@n8n/agents/src/storage/base-vector-store.ts
@@ -28,5 +28,5 @@ export abstract class BaseVectorStore<TConstructorOptions extends JSONObject = J
 		throw new Error('Method not implemented.');
 	}
 
-	close?(): Promise<void>;
+	close?(): void | Promise<void>;
 }

--- a/packages/@n8n/agents/src/types/sdk/vector-store.ts
+++ b/packages/@n8n/agents/src/types/sdk/vector-store.ts
@@ -46,5 +46,5 @@ export interface BuiltVectorStoreBackend {
 	): Promise<VectorQueryResult[]>;
 	delete(opts: { ids: string[] }): Promise<void>;
 	/** Close the connection pool / release resources. */
-	close?(): Promise<void>;
+	close?(): void | Promise<void>;
 }

--- a/packages/@n8n/agents/src/vector-stores/pinecone.ts
+++ b/packages/@n8n/agents/src/vector-stores/pinecone.ts
@@ -12,6 +12,9 @@ import type { JSONObject, JSONValue } from '../types/utils/json';
 /** Metadata key reserved for document content — Pinecone has no separate content column. */
 const CONTENT_KEY = '_content';
 
+/** Pinecone caps upserts at 1,000 records / 2MB per request and the client does not auto-batch. */
+const UPSERT_BATCH_SIZE = 200;
+
 export type PineconeVectorStoreOptions = {
 	apiKey: string;
 	indexName: string;
@@ -28,7 +31,9 @@ export type PineconeVectorStoreOptions = {
  * values — no nested objects, no null), so document content is stored under
  * a reserved `_content` metadata key alongside the caller's metadata spread
  * at the top level. Metadata containing that reserved key, or a value of an
- * unsupported shape, is rejected before any request is sent.
+ * unsupported shape, is rejected before any request is sent. Because content
+ * is stored as metadata, Pinecone's 40KB per-record metadata limit applies
+ * to the document content plus its metadata combined.
  *
  * Pinecone's `$ne`/`$nin` filter operators do not match records missing the
  * filtered key, unlike `PgVectorStore`/`QdrantVectorStore`/`SupabaseVectorStore`
@@ -57,13 +62,14 @@ export class PineconeVectorStore extends BaseVectorStore<PineconeVectorStoreOpti
 		if (records.length === 0) return;
 
 		const index = await this.getIndex();
-		await index.upsert(
-			records.map((record) => ({
-				id: record.id,
-				values: record.vector,
-				metadata: toPineconeMetadata(record.content, record.metadata),
-			})),
-		);
+		const mapped = records.map((record) => ({
+			id: record.id,
+			values: record.vector,
+			metadata: toPineconeMetadata(record.content, record.metadata),
+		}));
+		for (let i = 0; i < mapped.length; i += UPSERT_BATCH_SIZE) {
+			await index.upsert(mapped.slice(i, i + UPSERT_BATCH_SIZE));
+		}
 	}
 
 	async query(
@@ -119,14 +125,19 @@ function toPineconeMetadata(content: string, metadata: JSONObject): RecordMetada
 			`Metadata key "${CONTENT_KEY}" is reserved for the document content and cannot be set.`,
 		);
 	}
+	const result: RecordMetadata = { [CONTENT_KEY]: content };
 	for (const [key, value] of Object.entries(metadata)) {
 		assertValidMetadataValue(key, value);
+		result[key] = value;
 	}
-	return { [CONTENT_KEY]: content, ...metadata } as RecordMetadata;
+	return result;
 }
 
 /** Pinecone metadata values are flat: string, number, boolean, or an array of strings — no nested objects or null. */
-function assertValidMetadataValue(key: string, value: JSONValue | undefined): void {
+function assertValidMetadataValue(
+	key: string,
+	value: JSONValue | undefined,
+): asserts value is string | number | boolean | string[] {
 	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
 		return;
 	}

--- a/packages/@n8n/agents/src/vector-stores/pinecone.ts
+++ b/packages/@n8n/agents/src/vector-stores/pinecone.ts
@@ -1,0 +1,185 @@
+import type { Index, RecordMetadata, ScoredPineconeRecord } from '@pinecone-database/pinecone';
+
+import { BaseVectorStore } from '../storage/base-vector-store';
+import type {
+	FilterCondition,
+	VectorFilter,
+	VectorQueryResult,
+	VectorRecord,
+} from '../types/sdk/vector-store';
+import type { JSONObject, JSONValue } from '../types/utils/json';
+
+/** Metadata key reserved for document content — Pinecone has no separate content column. */
+const CONTENT_KEY = '_content';
+
+export type PineconeVectorStoreOptions = {
+	apiKey: string;
+	indexName: string;
+	/** Pinecone namespace. Default: the index's default namespace (`''`). */
+	namespace?: string;
+};
+
+/**
+ * Pinecone backend (`@pinecone-database/pinecone` is an optional peer dependency).
+ * Never creates or alters the index: expects one that already exists with vector
+ * dimension matching the embedding model and Cosine metric.
+ *
+ * Pinecone metadata is flat only (string, number, boolean, or string-array
+ * values — no nested objects, no null), so document content is stored under
+ * a reserved `_content` metadata key alongside the caller's metadata spread
+ * at the top level. Metadata containing that reserved key, or a value of an
+ * unsupported shape, is rejected before any request is sent.
+ *
+ * Pinecone's `$ne`/`$nin` filter operators do not match records missing the
+ * filtered key, unlike `PgVectorStore`/`QdrantVectorStore`/`SupabaseVectorStore`
+ * — `ne`/`nin` are translated into an `$or` with an `$exists: false` arm so
+ * behavior matches the other backends.
+ *
+ * Pinecone writes and deletes are eventually consistent: a query issued
+ * immediately after an upsert or delete may not reflect it yet.
+ *
+ * Pinecone only guarantees score-sorted results for unfiltered queries —
+ * a filtered query's `matches` can come back out of order, so results are
+ * explicitly re-sorted by score before being returned.
+ *
+ * @example
+ * ```typescript
+ * const store = new PineconeVectorStore('product-docs', {
+ *   apiKey: process.env.PINECONE_API_KEY!,
+ *   indexName: 'product-docs',
+ * });
+ * ```
+ */
+export class PineconeVectorStore extends BaseVectorStore<PineconeVectorStoreOptions> {
+	private index?: Index;
+
+	async upsert(records: VectorRecord[]): Promise<void> {
+		if (records.length === 0) return;
+
+		const index = await this.getIndex();
+		await index.upsert(
+			records.map((record) => ({
+				id: record.id,
+				values: record.vector,
+				metadata: toPineconeMetadata(record.content, record.metadata),
+			})),
+		);
+	}
+
+	async query(
+		vector: number[],
+		opts: { topK: number; filter?: VectorFilter },
+	): Promise<VectorQueryResult[]> {
+		const index = await this.getIndex();
+		const filter =
+			opts.filter && opts.filter.conditions.length > 0
+				? buildPineconeFilter(opts.filter)
+				: undefined;
+
+		const result = await index.query({
+			vector,
+			topK: opts.topK,
+			includeMetadata: true,
+			...(filter ? { filter } : {}),
+		});
+
+		// Pinecone does not guarantee score-sorted results for filtered queries
+		// (only for unfiltered ones) — sort explicitly to match the other backends.
+		const sorted = [...result.matches].sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+		return sorted.map(toQueryResult);
+	}
+
+	async delete({ ids }: { ids: string[] }): Promise<void> {
+		if (ids.length === 0) return;
+
+		const index = await this.getIndex();
+		await index.deleteMany(ids);
+	}
+
+	close(): void {
+		this.index = undefined;
+	}
+
+	private async getIndex(): Promise<Index> {
+		if (!this.index) {
+			const { Pinecone } = await import('@pinecone-database/pinecone');
+			const pc = new Pinecone({ apiKey: this.constructorOptions.apiKey });
+			const target = pc.index(this.constructorOptions.indexName);
+			this.index = this.constructorOptions.namespace
+				? target.namespace(this.constructorOptions.namespace)
+				: target;
+		}
+		return this.index;
+	}
+}
+
+function toPineconeMetadata(content: string, metadata: JSONObject): RecordMetadata {
+	if (CONTENT_KEY in metadata) {
+		throw new Error(
+			`Metadata key "${CONTENT_KEY}" is reserved for the document content and cannot be set.`,
+		);
+	}
+	for (const [key, value] of Object.entries(metadata)) {
+		assertValidMetadataValue(key, value);
+	}
+	return { [CONTENT_KEY]: content, ...metadata } as RecordMetadata;
+}
+
+/** Pinecone metadata values are flat: string, number, boolean, or an array of strings — no nested objects or null. */
+function assertValidMetadataValue(key: string, value: JSONValue | undefined): void {
+	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+		return;
+	}
+	if (Array.isArray(value) && value.every((item) => typeof item === 'string')) return;
+
+	throw new Error(
+		`Metadata value for key "${key}" is unsupported: Pinecone only supports string, number, boolean, and string-array metadata values.`,
+	);
+}
+
+function toQueryResult(match: ScoredPineconeRecord): VectorQueryResult {
+	const { [CONTENT_KEY]: content, ...metadata } = (match.metadata ?? {}) as JSONObject;
+	return {
+		id: String(match.id),
+		content: typeof content === 'string' ? content : '',
+		metadata,
+		score: match.score ?? 0,
+	};
+}
+
+/** Negations are compensated with `$exists: false` so missing-key rows match, like the other backends. */
+function buildPineconeFilter(filter: VectorFilter): object {
+	const terms = filter.conditions.map(buildCondition);
+	return filter.combineWith === 'or' ? { $or: terms } : { $and: terms };
+}
+
+function buildCondition(condition: FilterCondition): object {
+	const { key, operator, value } = condition;
+
+	switch (operator) {
+		case 'eq':
+			return { [key]: { $eq: value } };
+		case 'ne':
+			return { $or: [{ [key]: { $ne: value } }, { [key]: { $exists: false } }] };
+		case 'in':
+			assertNonEmptyArray(operator, key, value);
+			return { [key]: { $in: value } };
+		case 'nin':
+			assertNonEmptyArray(operator, key, value);
+			return { $or: [{ [key]: { $nin: value } }, { [key]: { $exists: false } }] };
+		default:
+			throw new Error(`Unsupported filter operator: "${String(operator)}"`);
+	}
+}
+
+function assertNonEmptyArray(
+	operator: string,
+	key: string,
+	value: unknown,
+): asserts value is Array<string | number> {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error(
+			`Filter operator "${operator}" on key "${key}" requires a non-empty array value.`,
+		);
+	}
+}

--- a/packages/@n8n/agents/src/vector-stores/qdrant.ts
+++ b/packages/@n8n/agents/src/vector-stores/qdrant.ts
@@ -105,10 +105,8 @@ export class QdrantVectorStore extends BaseVectorStore<QdrantVectorStoreOptions>
 		await client.delete(this.collectionName, { wait: true, points: ids.map(toPointId) });
 	}
 
-	// eslint-disable-next-line @typescript-eslint/promise-function-async -- no await needed; matches `require-await`
-	close(): Promise<void> {
+	close(): void {
 		this.client = undefined;
-		return Promise.resolve();
 	}
 
 	private async getClient(): Promise<QdrantClient> {

--- a/packages/@n8n/agents/src/vector-stores/supabase.ts
+++ b/packages/@n8n/agents/src/vector-stores/supabase.ts
@@ -149,10 +149,8 @@ export class SupabaseVectorStore extends BaseVectorStore<SupabaseVectorStoreOpti
 		if (error) throw new Error(`Supabase delete failed: ${error.message}`);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/promise-function-async -- no await needed; matches `require-await`
-	close(): Promise<void> {
+	close(): void {
 		this.client = undefined;
-		return Promise.resolve();
 	}
 
 	private async getClient(): Promise<SupabaseClient> {

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -284,7 +284,7 @@
     "@n8n/typescript-config": "workspace:*",
     "@n8n/utils": "workspace:*",
     "@oracle/langchain-oracledb": "0.2.0",
-    "@pinecone-database/pinecone": "^5.0.2",
+    "@pinecone-database/pinecone": "catalog:",
     "@qdrant/js-client-rest": "catalog:",
     "@smithy/node-http-handler": "4.5.0",
     "@smithy/types": "4.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2976,7 +2976,7 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@langchain/textsplitters@1.0.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(oracledb@6.10.0)
       '@pinecone-database/pinecone':
-        specifier: ^5.0.2
+        specifier: 'catalog:'
         version: 5.1.2
       '@qdrant/js-client-rest':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ catalogs:
     '@openrouter/ai-sdk-provider':
       specifier: ^2.8.0
       version: 2.9.0
+    '@pinecone-database/pinecone':
+      specifier: ^5.0.2
+      version: 5.1.2
     '@qdrant/js-client-rest':
       specifier: ^1.16.2
       version: 1.16.2
@@ -978,6 +981,9 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@pinecone-database/pinecone':
+        specifier: 'catalog:'
+        version: 5.1.2
       '@qdrant/js-client-rest':
         specifier: 'catalog:'
         version: 1.16.2(typescript@6.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ catalog:
   '@mozilla/readability': ^0.6.0
   '@n8n_io/ai-assistant-sdk': 1.24.0
   '@openrouter/ai-sdk-provider': ^2.8.0
+  '@pinecone-database/pinecone': ^5.0.2
   '@qdrant/js-client-rest': ^1.16.2
   '@rudderstack/rudder-sdk-node': 3.0.5
   '@sentry/node': ^10.55.0


### PR DESCRIPTION
## Summary

Adds `PineconeVectorStore` as a fourth vector store backend in `@n8n/agents`, alongside `PgVectorStore`, `QdrantVectorStore`, and `SupabaseVectorStore`. Importable via the new `@n8n/agents/vector-stores/pinecone` subpath export.

- Built on `@pinecone-database/pinecone` (new optional peer dependency, lazy-imported so the SDK stays light when the backend is unused)
- Never creates or alters the index — expects one that already exists with matching vector dimension and Cosine metric
- Pinecone metadata is flat only (string/number/boolean/string-array, no nested objects or `null`), so document content is stored under a reserved `_content` metadata key alongside the caller's metadata; upserts reject the reserved key or an unsupported value shape before any request is sent
- Full `VectorFilter` support (`eq`/`ne`/`in`/`nin`, `and`/`or`). Pinecone's `$ne`/`$nin` don't match records missing the filtered key (unlike the other three backends), so they're compiled to an `$or` with an `$exists: false` arm to keep behavior consistent
- Pinecone only guarantees score-sorted results for **unfiltered** queries — a filtered query's matches can come back out of order (confirmed against a live index). Results are explicitly re-sorted by score before being returned so this backend honors the same ordering contract as the others
- Writes/deletes are eventually consistent, called out in the class docs

## How to test

Integration tests mirror the qdrant/supabase suites and self-provision a uniquely-named serverless index per run, polling `describeIndexStats()`/retrying assertions to account for eventual consistency.

Set in `packages/@n8n/agents/.env`:

- `PINECONE_TEST_API_KEY` — a Pinecone API key

Then run from `packages/@n8n/agents`:

    pnpm test:integration pinecone-vector-store
    pnpm test:integration vector-store-bulk-pinecone
    pnpm test:integration agent-vector-store-pinecone

20 integration tests covering upsert/query/update/delete, round-trip through the `VectorStore` orchestrator, and all metadata filter operators, plus 17 unit tests for filter translation and metadata validation (`pinecone-filter-translation.test.ts`) that run in CI without any credentials. All integration files self-skip when the env var is unset, so CI is unaffected and no cassettes are needed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-339

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI