### PR TITLE
fix(core): Acquire expression isolate when resolving node inputs

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -18,7 +18,7 @@ vi.mock('@n8n/instance-ai', () => ({
 	},
 }));
 
-import type { Mock, Mocked } from 'vitest';
+import type { Mock, Mocked, MockInstance } from 'vitest';
 
 vi.mock('@n8n/ai-utilities', () => ({
 	braveSearch: vi.fn(),
@@ -27,6 +27,7 @@ vi.mock('@n8n/ai-utilities', () => ({
 
 import { Container } from '@n8n/di';
 import { mock } from 'vitest-mock-extended';
+import { Expression } from 'n8n-workflow';
 import type {
 	ExecutionError,
 	IConnections,
@@ -1427,6 +1428,52 @@ describe('createNodeAdapter', () => {
 				}
 			).nodesCache,
 		).toBeNull();
+	});
+
+	describe('getResolvedNodeInputs expression isolate lifecycle', () => {
+		// Dynamic `inputs` are resolved via workflow.expression, which under
+		// N8N_EXPRESSION_ENGINE=vm needs a V8 isolate acquired for the transient
+		// workflow first. Without it the VM bridge throws "No bridge acquired" and
+		// getNodeInputs silently returns []. These spies pin the acquire/release.
+		let acquireSpy: MockInstance;
+		let releaseSpy: MockInstance;
+
+		beforeEach(() => {
+			acquireSpy = vi.spyOn(Expression.prototype, 'acquireIsolate').mockResolvedValue(true);
+			releaseSpy = vi.spyOn(Expression.prototype, 'releaseIsolate').mockResolvedValue(undefined);
+		});
+
+		it('acquires and releases the isolate around dynamic input resolution', async () => {
+			const { service, nodeService } = createNodeAdapterServiceForTests([]);
+			(service as unknown as { nodeTypes: Pick<NodeTypes, 'getByNameAndVersion'> }).nodeTypes = {
+				getByNameAndVersion: vi
+					.fn()
+					.mockReturnValue({ description: { inputs: ['main'], properties: [] } }),
+			} as unknown as NodeTypes;
+
+			const workflowJson = {
+				nodes: [
+					{
+						id: 'agent',
+						name: 'Agent',
+						type: '@n8n/n8n-nodes-langchain.agent',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+				],
+				connections: {},
+			} as unknown as WorkflowJSON;
+
+			const inputs = await nodeService.getResolvedNodeInputs!(workflowJson, 'Agent');
+
+			expect(inputs).toEqual(['main']);
+			expect(acquireSpy).toHaveBeenCalledTimes(1);
+			expect(releaseSpy).toHaveBeenCalledTimes(1);
+			expect(acquireSpy.mock.invocationCallOrder[0]).toBeLessThan(
+				releaseSpy.mock.invocationCallOrder[0],
+			);
+		});
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -2354,7 +2354,16 @@ export class InstanceAiAdapterService {
 				const workflowNode = workflow.getNode(nodeName);
 				if (!workflowNode) return [];
 
-				return NodeHelpers.getNodeInputs(workflow, workflowNode, nodeType.description);
+				// Dynamic `inputs` expressions resolve via workflow.expression, which
+				// needs a V8 isolate acquired for this workflow when
+				// N8N_EXPRESSION_ENGINE=vm — otherwise the VM bridge throws "No bridge
+				// acquired" and getNodeInputs silently returns []. No-op in legacy mode.
+				await workflow.expression.acquireIsolate();
+				try {
+					return NodeHelpers.getNodeInputs(workflow, workflowNode, nodeType.description);
+				} finally {
+					await workflow.expression.releaseIsolate();
+				}
 			},
 
 			exploreResources: async (params: ExploreResourcesParams): Promise<ExploreResourcesResult> =>


### PR DESCRIPTION
## Summary

Sibling of #33757 (same INS-827 root cause, different tool).

`getResolvedNodeInputs` in `instance-ai.adapter.service.ts` — backing the instance-ai **`validate-workflow`** tool — builds a transient `Workflow` and resolves a node's dynamic `inputs` via `NodeHelpers.getNodeInputs` → `workflow.expression.getSimpleParameterValue`, **bypassing the execution engine**.

With `N8N_EXPRESSION_ENGINE=vm`, that resolution runs in a V8 isolate that must first be **acquired** for the workflow's `Expression` instance. It never was, so the VM bridge threw `No bridge acquired for this context`. Unlike #33757, the failure is **silent**: `NodeHelpers.getNodeInputs` wraps the call in a try/catch that logs a warning and returns `[]`. The net effect under VM mode is that nodes with **dynamic inputs** (AI Agent, Vector Store, chains, etc. — where `inputs` is an expression string rather than a static array) report **zero inputs**, so the validate-workflow tool can't see their sub-node connection points.

Static-input nodes are unaffected (they return the array before the expression path), and legacy mode is unaffected.

This PR acquires and releases the isolate around the `getNodeInputs` call, matching #33757 and the existing VM-mode handling in `DynamicNodeParametersService` and the ephemeral node executor. No-op in legacy mode.

## How to test

**Requires the experimental VM expression engine**, enabled via `N8N_EXPRESSION_ENGINE=vm`.

1. Start n8n with `N8N_EXPRESSION_ENGINE=vm`.
2. Have the AI assistant validate a workflow containing a dynamic-input node (e.g. an AI Agent with a connected chat model / tool).
3. **Before this fix:** the validate-workflow tool sees no inputs for the AI node (server logs show `Could not calculate inputs dynamically for node`), so sub-node connection issues are misreported.
   **After this fix:** dynamic inputs resolve normally.

Automated: `pnpm --filter n8n test instance-ai.adapter.service` — includes a new test asserting the isolate is acquired before, and released after, dynamic input resolution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-827

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33759">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

