### PR TITLE
chore(core): Add LS iAI report tooling (no-changelog)

### DIFF
--- a/.agents/skills/langsmith-cost-report/SKILL.md
+++ b/.agents/skills/langsmith-cost-report/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: n8n:langsmith-cost-report
+description: >-
+  Compares token usage, prompt-cache metrics, and cost across two or more
+  LangSmith instance-ai eval experiments: downloads per-thread data, enriches it
+  with tokens/cache/cost, verifies it against LangSmith, and prints a markdown
+  report. Use when the user asks to compare experiment costs, analyze cache hit
+  rates, or build a cost report from LangSmith experiment/session URLs or IDs.
+---
+
+# LangSmith experiment cost report
+
+Given 2+ experiments on the `instance-ai-evals` dataset, produce a verified
+cost/cache comparison. One experiment works too (skip the report or pass it
+twice), but the report is designed for baseline-vs-candidate.
+
+## Committed baseline
+
+The current baseline is committed at `baselines/baseline.json` (relative to
+this skill); its `experiment` field records which experiment it came from
+(currently `iai-opus-cache-cost-10-f3e390c4`). Unless the user names a
+different baseline, compare candidates against it — only the candidate
+experiments need to be fetched/enriched/verified.
+
+To promote a new baseline: run the full workflow on the experiment, replace
+`baselines/baseline.json` with the verified JSON, and commit it.
+
+## Prerequisites
+
+- `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT` (EU: `https://eu.api.smith.langchain.com`)
+  — both live in `.env.local`, so run every script through
+  `pnpm dotenvx run -f .env.local -- node scripts/...`.
+- Session IDs: in a compare URL like
+  `.../datasets/<datasetId>/compare?selectedSessions=<sessionId>`, the session
+  ID is the `selectedSessions` value. Experiment names work too.
+
+## Rate limiting
+
+LangSmith 429s easily. Rules that have worked:
+
+- Keep `--delay-ms 6000` (the default 3000 can survive but 6000 is safe).
+- Process experiments **sequentially**, never in parallel.
+- Always pass `--checkpoint` so an aborted run resumes without re-fetching.
+- A 60-thread experiment takes ~7 minutes to enrich and ~7 to verify. Run the
+  commands in the background and poll the log; do not shorten the delay to
+  speed it up.
+
+## Workflow
+
+For **each** experiment (sequentially), from the repo root:
+
+```bash
+# 1. Download: thread skeleton grouped by eval + iteration
+pnpm dotenvx run -f .env.local -- node scripts/fetch-experiment-threads.mjs \
+  --session <sessionId> --out <experiment>-threads.json
+
+# 2. Enrich: add input/output tokens, cache read/write, hit rate, cost per thread
+pnpm dotenvx run -f .env.local -- node scripts/enrich-thread-cost-json.mjs \
+  --input <experiment>-threads.json \
+  --checkpoint .cache/<experiment>-checkpoint.json --delay-ms 6000
+
+# 3. Verify: re-fetch and confirm every thread matches LangSmith exactly
+pnpm dotenvx run -f .env.local -- node scripts/verify-thread-cost-json.mjs \
+  --input <experiment>-threads.json \
+  --checkpoint .cache/<experiment>-verify-checkpoint.json --delay-ms 6000
+```
+
+Verify must end with `Result: N/N threads match LangSmith exactly` (exit code
+0). If it reports diffs, delete the stale entries from the enrich checkpoint
+and re-run step 2.
+
+Then compare (first file = baseline):
+
+```bash
+# 4. Report: markdown overview + per-eval cost table with % deltas
+node scripts/report-thread-cost-json.mjs \
+  .agents/skills/langsmith-cost-report/baselines/baseline.json \
+  <candidate>-threads.json [more...]
+```
+
+## Conventions
+
+- Name candidate output files `<experiment-name>-threads.json` in the repo
+  root (untracked scratch); checkpoints and logs go in `.cache/` (gitignored).
+  Only promoted baselines get committed, under `baselines/` in this skill.
+- The JSON shape (`evals` grouped by test case + flat `rows`) is what enrich,
+  verify, and report all consume — don't restructure it.
+- Present the report's markdown to the user; add a one-line takeaway
+  (e.g. avg cost/thread delta and cache hit rate change).

--- a/.agents/skills/langsmith-cost-report/baselines/baseline.json
+++ b/.agents/skills/langsmith-cost-report/baselines/baseline.json
@@ -1,0 +1,2145 @@
+{
+  "experiment": "iai-opus-cache-cost-10-f3e390c4",
+  "sessionId": "f7972d9f-2fc2-4370-9024-afa786a327e4",
+  "datasetId": "12148a6c-f625-4df6-b004-6aa36c6c1213",
+  "traceProject": "instance-ai-evals",
+  "githubRunId": "28646318294",
+  "branch": "master",
+  "iterations": 10,
+  "targetRuns": 120,
+  "uniqueThreads": 60,
+  "evals": [
+    {
+      "testCase": "airtable-split-to-slack",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "9903c6bd-092d-4c57-9292-50862fac6241",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1142849,
+          "outputTokens": 5751,
+          "totalTokens": 1148600,
+          "cacheReadTokens": 1080471,
+          "cacheWriteTokens": 62346,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9454,
+          "costUsd": 1.0738
+        },
+        {
+          "iteration": 1,
+          "threadId": "697e9e7c-b39c-47c1-a8d4-eebeca58b846",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1142928,
+          "outputTokens": 5445,
+          "totalTokens": 1148373,
+          "cacheReadTokens": 1080364,
+          "cacheWriteTokens": 62532,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9453,
+          "costUsd": 1.0673
+        },
+        {
+          "iteration": 2,
+          "threadId": "991effe2-4f4b-4e6e-8887-7bccb92068fc",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1268563,
+          "outputTokens": 6576,
+          "totalTokens": 1275139,
+          "cacheReadTokens": 1200264,
+          "cacheWriteTokens": 68265,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9462,
+          "costUsd": 1.1914
+        },
+        {
+          "iteration": 3,
+          "threadId": "0ae5bd21-eb4c-4dff-8e80-455d5faa1a3b",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1142295,
+          "outputTokens": 5828,
+          "totalTokens": 1148123,
+          "cacheReadTokens": 1079872,
+          "cacheWriteTokens": 62391,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9454,
+          "costUsd": 1.0757
+        },
+        {
+          "iteration": 4,
+          "threadId": "c4605078-15f5-4a78-9e20-d2539d1a4c08",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1326310,
+          "outputTokens": 5921,
+          "totalTokens": 1332231,
+          "cacheReadTokens": 1255107,
+          "cacheWriteTokens": 71169,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9463,
+          "costUsd": 1.2206
+        },
+        {
+          "iteration": 5,
+          "threadId": "b18c82a3-7aff-485e-a388-21e6c4162a6b",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 19,
+          "inputTokens": 1373150,
+          "outputTokens": 6261,
+          "totalTokens": 1379411,
+          "cacheReadTokens": 1309129,
+          "cacheWriteTokens": 63983,
+          "uncachedInputTokens": 38,
+          "cacheHitRate": 0.9534,
+          "costUsd": 1.2112
+        },
+        {
+          "iteration": 6,
+          "threadId": "00894ac0-24cd-4ffd-beb5-d69aab040b69",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1268003,
+          "outputTokens": 6698,
+          "totalTokens": 1274701,
+          "cacheReadTokens": 1199721,
+          "cacheWriteTokens": 68248,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9461,
+          "costUsd": 1.194
+        },
+        {
+          "iteration": 7,
+          "threadId": "d57bf0d3-eb30-4e85-aa95-3ee902fee37b",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1143090,
+          "outputTokens": 5764,
+          "totalTokens": 1148854,
+          "cacheReadTokens": 1109615,
+          "cacheWriteTokens": 33443,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9707,
+          "costUsd": 0.9081
+        },
+        {
+          "iteration": 8,
+          "threadId": "c3d1aa87-b4bb-4188-83f0-0666c1168f43",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1290325,
+          "outputTokens": 6295,
+          "totalTokens": 1296620,
+          "cacheReadTokens": 1221570,
+          "cacheWriteTokens": 68721,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9467,
+          "costUsd": 1.1978
+        },
+        {
+          "iteration": 9,
+          "threadId": "7c8b0dee-5ae8-4f1f-ab21-94f0e27ed16b",
+          "scenarios": [
+            "empty-records",
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1271142,
+          "outputTokens": 5975,
+          "totalTokens": 1277117,
+          "cacheReadTokens": 1203447,
+          "cacheWriteTokens": 67661,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9467,
+          "costUsd": 1.1741
+        }
+      ]
+    },
+    {
+      "testCase": "notification-router",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "50e15795-1005-4458-9f75-4df3e65f403a",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 14,
+          "inputTokens": 948815,
+          "outputTokens": 7401,
+          "totalTokens": 956216,
+          "cacheReadTokens": 883088,
+          "cacheWriteTokens": 65699,
+          "uncachedInputTokens": 28,
+          "cacheHitRate": 0.9307,
+          "costUsd": 1.0373
+        },
+        {
+          "iteration": 1,
+          "threadId": "9d025093-285f-4cb2-8bba-8abcfa3e3b16",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 11,
+          "inputTokens": 712731,
+          "outputTokens": 5071,
+          "totalTokens": 717802,
+          "cacheReadTokens": 649502,
+          "cacheWriteTokens": 63207,
+          "uncachedInputTokens": 22,
+          "cacheHitRate": 0.9113,
+          "costUsd": 0.8467
+        },
+        {
+          "iteration": 2,
+          "threadId": "9b5833a5-b33e-470f-a825-e07ad182fc40",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 778890,
+          "outputTokens": 5737,
+          "totalTokens": 784627,
+          "cacheReadTokens": 714693,
+          "cacheWriteTokens": 64173,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9176,
+          "costUsd": 0.902
+        },
+        {
+          "iteration": 3,
+          "threadId": "662bbc9d-f5d7-4a5e-97b2-8f81b04a1bee",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 830451,
+          "outputTokens": 5265,
+          "totalTokens": 835716,
+          "cacheReadTokens": 760422,
+          "cacheWriteTokens": 70005,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9157,
+          "costUsd": 0.9495
+        },
+        {
+          "iteration": 4,
+          "threadId": "67771025-1f74-425e-8047-8326b0c054b6",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 779676,
+          "outputTokens": 5406,
+          "totalTokens": 785082,
+          "cacheReadTokens": 715399,
+          "cacheWriteTokens": 64253,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9176,
+          "costUsd": 0.8946
+        },
+        {
+          "iteration": 5,
+          "threadId": "f8d75b7b-bfaf-4372-9be8-9537444214b5",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 13,
+          "inputTokens": 850908,
+          "outputTokens": 4976,
+          "totalTokens": 855884,
+          "cacheReadTokens": 786316,
+          "cacheWriteTokens": 64566,
+          "uncachedInputTokens": 26,
+          "cacheHitRate": 0.9241,
+          "costUsd": 0.9212
+        },
+        {
+          "iteration": 6,
+          "threadId": "4c7017bd-ead9-4b8c-8fd0-ed0fc653e6f5",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1149848,
+          "outputTokens": 6849,
+          "totalTokens": 1156697,
+          "cacheReadTokens": 1085106,
+          "cacheWriteTokens": 64710,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9437,
+          "costUsd": 1.1184
+        },
+        {
+          "iteration": 7,
+          "threadId": "74fd9ede-e848-448b-bf7c-c7893f502020",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 10,
+          "inputTokens": 622670,
+          "outputTokens": 5052,
+          "totalTokens": 627722,
+          "cacheReadTokens": 563300,
+          "cacheWriteTokens": 59350,
+          "uncachedInputTokens": 20,
+          "cacheHitRate": 0.9047,
+          "costUsd": 0.779
+        },
+        {
+          "iteration": 8,
+          "threadId": "1e8d93be-99fe-424e-8eec-29cbe94c1cf2",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 793288,
+          "outputTokens": 6211,
+          "totalTokens": 799499,
+          "cacheReadTokens": 701951,
+          "cacheWriteTokens": 91313,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.8849,
+          "costUsd": 1.0771
+        },
+        {
+          "iteration": 9,
+          "threadId": "09c3c48b-7ab5-4ea6-8e6a-da26bdaecfba",
+          "scenarios": [
+            "high-priority",
+            "low-priority",
+            "medium-priority"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1353921,
+          "outputTokens": 12151,
+          "totalTokens": 1366072,
+          "cacheReadTokens": 1272647,
+          "cacheWriteTokens": 81240,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.94,
+          "costUsd": 1.448
+        }
+      ]
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "a0e3e3d2-a3b4-46bb-842c-b1f6e6d6da45",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 19,
+          "inputTokens": 1559778,
+          "outputTokens": 11980,
+          "totalTokens": 1571758,
+          "cacheReadTokens": 1487429,
+          "cacheWriteTokens": 72311,
+          "uncachedInputTokens": 38,
+          "cacheHitRate": 0.9536,
+          "costUsd": 1.4953
+        },
+        {
+          "iteration": 1,
+          "threadId": "0599f642-161c-4c65-850e-c5c65bf9e6da",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1240879,
+          "outputTokens": 13985,
+          "totalTokens": 1254864,
+          "cacheReadTokens": 1173736,
+          "cacheWriteTokens": 67111,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9459,
+          "costUsd": 1.3561
+        },
+        {
+          "iteration": 2,
+          "threadId": "2a05365d-f1d6-43f3-b770-4f45197c2950",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 21,
+          "inputTokens": 1734464,
+          "outputTokens": 9823,
+          "totalTokens": 1744287,
+          "cacheReadTokens": 1662200,
+          "cacheWriteTokens": 72222,
+          "uncachedInputTokens": 42,
+          "cacheHitRate": 0.9583,
+          "costUsd": 1.5283
+        },
+        {
+          "iteration": 3,
+          "threadId": "b5cb2ba7-711c-42a9-8192-0b037debe3f6",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 22,
+          "inputTokens": 1797537,
+          "outputTokens": 13361,
+          "totalTokens": 1810898,
+          "cacheReadTokens": 1725706,
+          "cacheWriteTokens": 71787,
+          "uncachedInputTokens": 44,
+          "cacheHitRate": 0.96,
+          "costUsd": 1.6458
+        },
+        {
+          "iteration": 4,
+          "threadId": "9375d62a-cab2-4f07-a54b-7f4fb9d83648",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 19,
+          "inputTokens": 1525382,
+          "outputTokens": 12350,
+          "totalTokens": 1537732,
+          "cacheReadTokens": 1453829,
+          "cacheWriteTokens": 71515,
+          "uncachedInputTokens": 38,
+          "cacheHitRate": 0.9531,
+          "costUsd": 1.4828
+        },
+        {
+          "iteration": 5,
+          "threadId": "3acf1951-c3d8-4fa8-9131-da00c0df9485",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 26,
+          "inputTokens": 2122290,
+          "outputTokens": 14370,
+          "totalTokens": 2136660,
+          "cacheReadTokens": 2050024,
+          "cacheWriteTokens": 72214,
+          "uncachedInputTokens": 52,
+          "cacheHitRate": 0.9659,
+          "costUsd": 1.8359
+        },
+        {
+          "iteration": 6,
+          "threadId": "ad18bb56-1f1c-48bf-9c6f-39919b0670be",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 24,
+          "inputTokens": 2036307,
+          "outputTokens": 18067,
+          "totalTokens": 2054374,
+          "cacheReadTokens": 1960269,
+          "cacheWriteTokens": 75990,
+          "uncachedInputTokens": 48,
+          "cacheHitRate": 0.9627,
+          "costUsd": 1.907
+        },
+        {
+          "iteration": 7,
+          "threadId": "62190a1c-38dc-458d-8c68-923eb660abeb",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 24,
+          "inputTokens": 2019410,
+          "outputTokens": 10759,
+          "totalTokens": 2030169,
+          "cacheReadTokens": 1974390,
+          "cacheWriteTokens": 44972,
+          "uncachedInputTokens": 48,
+          "cacheHitRate": 0.9777,
+          "costUsd": 1.5375
+        },
+        {
+          "iteration": 8,
+          "threadId": "022a0a0d-4262-43ba-8a26-edead9e26dc6",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 24,
+          "inputTokens": 2004797,
+          "outputTokens": 12226,
+          "totalTokens": 2017023,
+          "cacheReadTokens": 1929914,
+          "cacheWriteTokens": 74835,
+          "uncachedInputTokens": 48,
+          "cacheHitRate": 0.9626,
+          "costUsd": 1.7386
+        },
+        {
+          "iteration": 9,
+          "threadId": "ffd21c70-78be-4e34-8efd-3e26baf9b2a8",
+          "scenarios": [
+            "all-filtered",
+            "empty-response",
+            "happy-path"
+          ],
+          "llmSpans": 20,
+          "inputTokens": 1648390,
+          "outputTokens": 10846,
+          "totalTokens": 1659236,
+          "cacheReadTokens": 1575437,
+          "cacheWriteTokens": 72913,
+          "uncachedInputTokens": 40,
+          "cacheHitRate": 0.9557,
+          "costUsd": 1.5148
+        }
+      ]
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "69611e22-d8e9-46e7-8663-4a7b0b4c323e",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 9,
+          "inputTokens": 580016,
+          "outputTokens": 2878,
+          "totalTokens": 582894,
+          "cacheReadTokens": 521298,
+          "cacheWriteTokens": 58700,
+          "uncachedInputTokens": 18,
+          "cacheHitRate": 0.8988,
+          "costUsd": 0.6996
+        },
+        {
+          "iteration": 1,
+          "threadId": "3e733efa-a238-4d5d-9350-fdab17f58c07",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 15,
+          "inputTokens": 1091934,
+          "outputTokens": 4223,
+          "totalTokens": 1096157,
+          "cacheReadTokens": 1023938,
+          "cacheWriteTokens": 67966,
+          "uncachedInputTokens": 30,
+          "cacheHitRate": 0.9377,
+          "costUsd": 1.0425
+        },
+        {
+          "iteration": 2,
+          "threadId": "347d06cf-3800-4dcd-a4bd-26c63df0a6b4",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 797628,
+          "outputTokens": 3749,
+          "totalTokens": 801377,
+          "cacheReadTokens": 737286,
+          "cacheWriteTokens": 60318,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9243,
+          "costUsd": 0.8395
+        },
+        {
+          "iteration": 3,
+          "threadId": "10be12ac-d1b6-4ae3-bf43-8e56383df345",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 9,
+          "inputTokens": 580117,
+          "outputTokens": 3047,
+          "totalTokens": 583164,
+          "cacheReadTokens": 521572,
+          "cacheWriteTokens": 58527,
+          "uncachedInputTokens": 18,
+          "cacheHitRate": 0.8991,
+          "costUsd": 0.7028
+        },
+        {
+          "iteration": 4,
+          "threadId": "4fbb41f7-68bc-4c06-9172-11fcd8e6df55",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 8,
+          "inputTokens": 511097,
+          "outputTokens": 2775,
+          "totalTokens": 513872,
+          "cacheReadTokens": 452428,
+          "cacheWriteTokens": 58653,
+          "uncachedInputTokens": 16,
+          "cacheHitRate": 0.8852,
+          "costUsd": 0.6623
+        },
+        {
+          "iteration": 5,
+          "threadId": "a753be2a-c560-450d-b10d-0f74719825ba",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 8,
+          "inputTokens": 511383,
+          "outputTokens": 2956,
+          "totalTokens": 514339,
+          "cacheReadTokens": 452824,
+          "cacheWriteTokens": 58543,
+          "uncachedInputTokens": 16,
+          "cacheHitRate": 0.8855,
+          "costUsd": 0.6663
+        },
+        {
+          "iteration": 6,
+          "threadId": "8d3193c9-d17a-4c86-9d05-f06145682495",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 8,
+          "inputTokens": 511354,
+          "outputTokens": 2941,
+          "totalTokens": 514295,
+          "cacheReadTokens": 452802,
+          "cacheWriteTokens": 58536,
+          "uncachedInputTokens": 16,
+          "cacheHitRate": 0.8855,
+          "costUsd": 0.6659
+        },
+        {
+          "iteration": 7,
+          "threadId": "18ee662f-22c2-4851-95e7-49eace0cca6b",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 9,
+          "inputTokens": 601043,
+          "outputTokens": 3044,
+          "totalTokens": 604087,
+          "cacheReadTokens": 538453,
+          "cacheWriteTokens": 62572,
+          "uncachedInputTokens": 18,
+          "cacheHitRate": 0.8959,
+          "costUsd": 0.7365
+        },
+        {
+          "iteration": 8,
+          "threadId": "1f572303-2165-45f7-ad82-5788ada5a07f",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 857292,
+          "outputTokens": 3701,
+          "totalTokens": 860993,
+          "cacheReadTokens": 789885,
+          "cacheWriteTokens": 67383,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9214,
+          "costUsd": 0.9087
+        },
+        {
+          "iteration": 9,
+          "threadId": "1634dcc1-8089-4f2a-8269-d13935f2c571",
+          "scenarios": [
+            "distinct-telegram-chat"
+          ],
+          "llmSpans": 9,
+          "inputTokens": 575940,
+          "outputTokens": 2963,
+          "totalTokens": 578903,
+          "cacheReadTokens": 517913,
+          "cacheWriteTokens": 58009,
+          "uncachedInputTokens": 18,
+          "cacheHitRate": 0.8992,
+          "costUsd": 0.6957
+        }
+      ]
+    },
+    {
+      "testCase": "weather-alert",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "1d9fd501-3d52-404b-810e-04cb408c848d",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 14,
+          "inputTokens": 971637,
+          "outputTokens": 4850,
+          "totalTokens": 976487,
+          "cacheReadTokens": 907410,
+          "cacheWriteTokens": 64199,
+          "uncachedInputTokens": 28,
+          "cacheHitRate": 0.9339,
+          "costUsd": 0.9763
+        },
+        {
+          "iteration": 1,
+          "threadId": "a14e3abe-f9dc-4a52-9c03-00b3da90c328",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1107883,
+          "outputTokens": 7364,
+          "totalTokens": 1115247,
+          "cacheReadTokens": 1049690,
+          "cacheWriteTokens": 58161,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9475,
+          "costUsd": 1.0726
+        },
+        {
+          "iteration": 2,
+          "threadId": "1782401a-280e-400e-9654-85daa450dd79",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1200064,
+          "outputTokens": 6866,
+          "totalTokens": 1206930,
+          "cacheReadTokens": 1135026,
+          "cacheWriteTokens": 65006,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9458,
+          "costUsd": 1.1456
+        },
+        {
+          "iteration": 3,
+          "threadId": "26354d23-c02d-4535-8cce-a9ead0fd2ad4",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 21,
+          "inputTokens": 1787264,
+          "outputTokens": 7781,
+          "totalTokens": 1795045,
+          "cacheReadTokens": 1711539,
+          "cacheWriteTokens": 75683,
+          "uncachedInputTokens": 42,
+          "cacheHitRate": 0.9576,
+          "costUsd": 1.5235
+        },
+        {
+          "iteration": 4,
+          "threadId": "b381acd3-6967-45a9-b459-4808c1e14cea",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 13,
+          "inputTokens": 935178,
+          "outputTokens": 5229,
+          "totalTokens": 940407,
+          "cacheReadTokens": 872949,
+          "cacheWriteTokens": 62203,
+          "uncachedInputTokens": 26,
+          "cacheHitRate": 0.9335,
+          "costUsd": 0.9561
+        },
+        {
+          "iteration": 5,
+          "threadId": "06f8af01-d739-461c-9f05-e33dce7bca85",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 11,
+          "inputTokens": 725697,
+          "outputTokens": 7480,
+          "totalTokens": 733177,
+          "cacheReadTokens": 668389,
+          "cacheWriteTokens": 57286,
+          "uncachedInputTokens": 22,
+          "cacheHitRate": 0.921,
+          "costUsd": 0.8793
+        },
+        {
+          "iteration": 6,
+          "threadId": "b2dd849b-c9f9-46c2-ba37-dfd0dd7fade0",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 814094,
+          "outputTokens": 5130,
+          "totalTokens": 819224,
+          "cacheReadTokens": 753810,
+          "cacheWriteTokens": 60260,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.9259,
+          "costUsd": 0.8819
+        },
+        {
+          "iteration": 7,
+          "threadId": "71bca48c-ddb4-45d9-a6b5-ff9a782c2dbe",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 20,
+          "inputTokens": 1580964,
+          "outputTokens": 8483,
+          "totalTokens": 1589447,
+          "cacheReadTokens": 1513251,
+          "cacheWriteTokens": 67673,
+          "uncachedInputTokens": 40,
+          "cacheHitRate": 0.9572,
+          "costUsd": 1.3919
+        },
+        {
+          "iteration": 8,
+          "threadId": "a80ad478-50f4-4aca-97bd-f3b97aadf9c5",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 12,
+          "inputTokens": 826232,
+          "outputTokens": 5464,
+          "totalTokens": 831696,
+          "cacheReadTokens": 763461,
+          "cacheWriteTokens": 62747,
+          "uncachedInputTokens": 24,
+          "cacheHitRate": 0.924,
+          "costUsd": 0.9106
+        },
+        {
+          "iteration": 9,
+          "threadId": "b14c8fad-07d2-4d16-bde3-fd4e55fe04f5",
+          "scenarios": [
+            "happy-path",
+            "rain-not-expected"
+          ],
+          "llmSpans": 13,
+          "inputTokens": 883265,
+          "outputTokens": 4659,
+          "totalTokens": 887924,
+          "cacheReadTokens": 826300,
+          "cacheWriteTokens": 56939,
+          "uncachedInputTokens": 26,
+          "cacheHitRate": 0.9355,
+          "costUsd": 0.8856
+        }
+      ]
+    },
+    {
+      "testCase": "workflow-data-table",
+      "threads": [
+        {
+          "iteration": 0,
+          "threadId": "29c82d2d-0911-4b36-85e1-afae36eed2a1",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 11,
+          "inputTokens": 695941,
+          "outputTokens": 6216,
+          "totalTokens": 702157,
+          "cacheReadTokens": 641384,
+          "cacheWriteTokens": 54535,
+          "uncachedInputTokens": 22,
+          "cacheHitRate": 0.9216,
+          "costUsd": 0.817
+        },
+        {
+          "iteration": 1,
+          "threadId": "f313fadf-02a3-4649-a548-5e515b90b600",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 13,
+          "inputTokens": 824438,
+          "outputTokens": 7924,
+          "totalTokens": 832362,
+          "cacheReadTokens": 765727,
+          "cacheWriteTokens": 58685,
+          "uncachedInputTokens": 26,
+          "cacheHitRate": 0.9288,
+          "costUsd": 0.9479
+        },
+        {
+          "iteration": 2,
+          "threadId": "dd6510de-5134-4766-bedc-56e5959c3ac0",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1189625,
+          "outputTokens": 11096,
+          "totalTokens": 1200721,
+          "cacheReadTokens": 1125754,
+          "cacheWriteTokens": 63837,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9463,
+          "costUsd": 1.2394
+        },
+        {
+          "iteration": 3,
+          "threadId": "3f3274ee-0982-497e-989e-31fd465cb066",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 17,
+          "inputTokens": 1124722,
+          "outputTokens": 8085,
+          "totalTokens": 1132807,
+          "cacheReadTokens": 1066059,
+          "cacheWriteTokens": 58629,
+          "uncachedInputTokens": 34,
+          "cacheHitRate": 0.9478,
+          "costUsd": 1.1018
+        },
+        {
+          "iteration": 4,
+          "threadId": "2bed7cee-0b2c-41ef-9f66-3670a55a4c59",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 22,
+          "inputTokens": 1454431,
+          "outputTokens": 12126,
+          "totalTokens": 1466557,
+          "cacheReadTokens": 1385501,
+          "cacheWriteTokens": 68886,
+          "uncachedInputTokens": 44,
+          "cacheHitRate": 0.9526,
+          "costUsd": 1.4267
+        },
+        {
+          "iteration": 5,
+          "threadId": "5e1667cf-9995-4775-91b2-6618d5076440",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 14,
+          "inputTokens": 898264,
+          "outputTokens": 8036,
+          "totalTokens": 906300,
+          "cacheReadTokens": 840054,
+          "cacheWriteTokens": 58182,
+          "uncachedInputTokens": 28,
+          "cacheHitRate": 0.9352,
+          "costUsd": 0.9847
+        },
+        {
+          "iteration": 6,
+          "threadId": "6127aff9-3668-456d-a54a-0b6a33e6d322",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 19,
+          "inputTokens": 1339970,
+          "outputTokens": 9538,
+          "totalTokens": 1349508,
+          "cacheReadTokens": 1278023,
+          "cacheWriteTokens": 61909,
+          "uncachedInputTokens": 38,
+          "cacheHitRate": 0.9538,
+          "costUsd": 1.2646
+        },
+        {
+          "iteration": 7,
+          "threadId": "9f306d22-73d7-4884-8819-3ebfd2098e9f",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 21,
+          "inputTokens": 1532244,
+          "outputTokens": 9595,
+          "totalTokens": 1541839,
+          "cacheReadTokens": 1468962,
+          "cacheWriteTokens": 63240,
+          "uncachedInputTokens": 42,
+          "cacheHitRate": 0.9587,
+          "costUsd": 1.3698
+        },
+        {
+          "iteration": 8,
+          "threadId": "2e4dabbe-2019-4256-988e-0b4a55c80d5c",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 16,
+          "inputTokens": 1043258,
+          "outputTokens": 10689,
+          "totalTokens": 1053947,
+          "cacheReadTokens": 984655,
+          "cacheWriteTokens": 58571,
+          "uncachedInputTokens": 32,
+          "cacheHitRate": 0.9438,
+          "costUsd": 1.1258
+        },
+        {
+          "iteration": 9,
+          "threadId": "74fbd448-36bd-46d3-ba38-e80b972ca9f8",
+          "scenarios": [
+            "happy-path"
+          ],
+          "llmSpans": 18,
+          "inputTokens": 1080150,
+          "outputTokens": 9949,
+          "totalTokens": 1090099,
+          "cacheReadTokens": 1016671,
+          "cacheWriteTokens": 63443,
+          "uncachedInputTokens": 36,
+          "cacheHitRate": 0.9412,
+          "costUsd": 1.1538
+        }
+      ]
+    }
+  ],
+  "rows": [
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 0,
+      "threadId": "9903c6bd-092d-4c57-9292-50862fac6241",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1142849,
+      "outputTokens": 5751,
+      "totalTokens": 1148600,
+      "cacheReadTokens": 1080471,
+      "cacheWriteTokens": 62346,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9454,
+      "costUsd": 1.0738
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 1,
+      "threadId": "697e9e7c-b39c-47c1-a8d4-eebeca58b846",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1142928,
+      "outputTokens": 5445,
+      "totalTokens": 1148373,
+      "cacheReadTokens": 1080364,
+      "cacheWriteTokens": 62532,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9453,
+      "costUsd": 1.0673
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 2,
+      "threadId": "991effe2-4f4b-4e6e-8887-7bccb92068fc",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1268563,
+      "outputTokens": 6576,
+      "totalTokens": 1275139,
+      "cacheReadTokens": 1200264,
+      "cacheWriteTokens": 68265,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9462,
+      "costUsd": 1.1914
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 3,
+      "threadId": "0ae5bd21-eb4c-4dff-8e80-455d5faa1a3b",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1142295,
+      "outputTokens": 5828,
+      "totalTokens": 1148123,
+      "cacheReadTokens": 1079872,
+      "cacheWriteTokens": 62391,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9454,
+      "costUsd": 1.0757
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 4,
+      "threadId": "c4605078-15f5-4a78-9e20-d2539d1a4c08",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1326310,
+      "outputTokens": 5921,
+      "totalTokens": 1332231,
+      "cacheReadTokens": 1255107,
+      "cacheWriteTokens": 71169,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9463,
+      "costUsd": 1.2206
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 5,
+      "threadId": "b18c82a3-7aff-485e-a388-21e6c4162a6b",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 19,
+      "inputTokens": 1373150,
+      "outputTokens": 6261,
+      "totalTokens": 1379411,
+      "cacheReadTokens": 1309129,
+      "cacheWriteTokens": 63983,
+      "uncachedInputTokens": 38,
+      "cacheHitRate": 0.9534,
+      "costUsd": 1.2112
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 6,
+      "threadId": "00894ac0-24cd-4ffd-beb5-d69aab040b69",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1268003,
+      "outputTokens": 6698,
+      "totalTokens": 1274701,
+      "cacheReadTokens": 1199721,
+      "cacheWriteTokens": 68248,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9461,
+      "costUsd": 1.194
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 7,
+      "threadId": "d57bf0d3-eb30-4e85-aa95-3ee902fee37b",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1143090,
+      "outputTokens": 5764,
+      "totalTokens": 1148854,
+      "cacheReadTokens": 1109615,
+      "cacheWriteTokens": 33443,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9707,
+      "costUsd": 0.9081
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 8,
+      "threadId": "c3d1aa87-b4bb-4188-83f0-0666c1168f43",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1290325,
+      "outputTokens": 6295,
+      "totalTokens": 1296620,
+      "cacheReadTokens": 1221570,
+      "cacheWriteTokens": 68721,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9467,
+      "costUsd": 1.1978
+    },
+    {
+      "testCase": "airtable-split-to-slack",
+      "iteration": 9,
+      "threadId": "7c8b0dee-5ae8-4f1f-ab21-94f0e27ed16b",
+      "scenarios": [
+        "airtable-split-to-slack/empty-records",
+        "airtable-split-to-slack/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1271142,
+      "outputTokens": 5975,
+      "totalTokens": 1277117,
+      "cacheReadTokens": 1203447,
+      "cacheWriteTokens": 67661,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9467,
+      "costUsd": 1.1741
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 0,
+      "threadId": "50e15795-1005-4458-9f75-4df3e65f403a",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 14,
+      "inputTokens": 948815,
+      "outputTokens": 7401,
+      "totalTokens": 956216,
+      "cacheReadTokens": 883088,
+      "cacheWriteTokens": 65699,
+      "uncachedInputTokens": 28,
+      "cacheHitRate": 0.9307,
+      "costUsd": 1.0373
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 1,
+      "threadId": "9d025093-285f-4cb2-8bba-8abcfa3e3b16",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 11,
+      "inputTokens": 712731,
+      "outputTokens": 5071,
+      "totalTokens": 717802,
+      "cacheReadTokens": 649502,
+      "cacheWriteTokens": 63207,
+      "uncachedInputTokens": 22,
+      "cacheHitRate": 0.9113,
+      "costUsd": 0.8467
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 2,
+      "threadId": "9b5833a5-b33e-470f-a825-e07ad182fc40",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 778890,
+      "outputTokens": 5737,
+      "totalTokens": 784627,
+      "cacheReadTokens": 714693,
+      "cacheWriteTokens": 64173,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9176,
+      "costUsd": 0.902
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 3,
+      "threadId": "662bbc9d-f5d7-4a5e-97b2-8f81b04a1bee",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 830451,
+      "outputTokens": 5265,
+      "totalTokens": 835716,
+      "cacheReadTokens": 760422,
+      "cacheWriteTokens": 70005,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9157,
+      "costUsd": 0.9495
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 4,
+      "threadId": "67771025-1f74-425e-8047-8326b0c054b6",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 779676,
+      "outputTokens": 5406,
+      "totalTokens": 785082,
+      "cacheReadTokens": 715399,
+      "cacheWriteTokens": 64253,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9176,
+      "costUsd": 0.8946
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 5,
+      "threadId": "f8d75b7b-bfaf-4372-9be8-9537444214b5",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 13,
+      "inputTokens": 850908,
+      "outputTokens": 4976,
+      "totalTokens": 855884,
+      "cacheReadTokens": 786316,
+      "cacheWriteTokens": 64566,
+      "uncachedInputTokens": 26,
+      "cacheHitRate": 0.9241,
+      "costUsd": 0.9212
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 6,
+      "threadId": "4c7017bd-ead9-4b8c-8fd0-ed0fc653e6f5",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1149848,
+      "outputTokens": 6849,
+      "totalTokens": 1156697,
+      "cacheReadTokens": 1085106,
+      "cacheWriteTokens": 64710,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9437,
+      "costUsd": 1.1184
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 7,
+      "threadId": "74fd9ede-e848-448b-bf7c-c7893f502020",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 10,
+      "inputTokens": 622670,
+      "outputTokens": 5052,
+      "totalTokens": 627722,
+      "cacheReadTokens": 563300,
+      "cacheWriteTokens": 59350,
+      "uncachedInputTokens": 20,
+      "cacheHitRate": 0.9047,
+      "costUsd": 0.779
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 8,
+      "threadId": "1e8d93be-99fe-424e-8eec-29cbe94c1cf2",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 793288,
+      "outputTokens": 6211,
+      "totalTokens": 799499,
+      "cacheReadTokens": 701951,
+      "cacheWriteTokens": 91313,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.8849,
+      "costUsd": 1.0771
+    },
+    {
+      "testCase": "notification-router",
+      "iteration": 9,
+      "threadId": "09c3c48b-7ab5-4ea6-8e6a-da26bdaecfba",
+      "scenarios": [
+        "notification-router/high-priority",
+        "notification-router/low-priority",
+        "notification-router/medium-priority"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1353921,
+      "outputTokens": 12151,
+      "totalTokens": 1366072,
+      "cacheReadTokens": 1272647,
+      "cacheWriteTokens": 81240,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.94,
+      "costUsd": 1.448
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 0,
+      "threadId": "a0e3e3d2-a3b4-46bb-842c-b1f6e6d6da45",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 19,
+      "inputTokens": 1559778,
+      "outputTokens": 11980,
+      "totalTokens": 1571758,
+      "cacheReadTokens": 1487429,
+      "cacheWriteTokens": 72311,
+      "uncachedInputTokens": 38,
+      "cacheHitRate": 0.9536,
+      "costUsd": 1.4953
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 1,
+      "threadId": "0599f642-161c-4c65-850e-c5c65bf9e6da",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1240879,
+      "outputTokens": 13985,
+      "totalTokens": 1254864,
+      "cacheReadTokens": 1173736,
+      "cacheWriteTokens": 67111,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9459,
+      "costUsd": 1.3561
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 2,
+      "threadId": "2a05365d-f1d6-43f3-b770-4f45197c2950",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 21,
+      "inputTokens": 1734464,
+      "outputTokens": 9823,
+      "totalTokens": 1744287,
+      "cacheReadTokens": 1662200,
+      "cacheWriteTokens": 72222,
+      "uncachedInputTokens": 42,
+      "cacheHitRate": 0.9583,
+      "costUsd": 1.5283
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 3,
+      "threadId": "b5cb2ba7-711c-42a9-8192-0b037debe3f6",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 22,
+      "inputTokens": 1797537,
+      "outputTokens": 13361,
+      "totalTokens": 1810898,
+      "cacheReadTokens": 1725706,
+      "cacheWriteTokens": 71787,
+      "uncachedInputTokens": 44,
+      "cacheHitRate": 0.96,
+      "costUsd": 1.6458
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 4,
+      "threadId": "9375d62a-cab2-4f07-a54b-7f4fb9d83648",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 19,
+      "inputTokens": 1525382,
+      "outputTokens": 12350,
+      "totalTokens": 1537732,
+      "cacheReadTokens": 1453829,
+      "cacheWriteTokens": 71515,
+      "uncachedInputTokens": 38,
+      "cacheHitRate": 0.9531,
+      "costUsd": 1.4828
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 5,
+      "threadId": "3acf1951-c3d8-4fa8-9131-da00c0df9485",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 26,
+      "inputTokens": 2122290,
+      "outputTokens": 14370,
+      "totalTokens": 2136660,
+      "cacheReadTokens": 2050024,
+      "cacheWriteTokens": 72214,
+      "uncachedInputTokens": 52,
+      "cacheHitRate": 0.9659,
+      "costUsd": 1.8359
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 6,
+      "threadId": "ad18bb56-1f1c-48bf-9c6f-39919b0670be",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 24,
+      "inputTokens": 2036307,
+      "outputTokens": 18067,
+      "totalTokens": 2054374,
+      "cacheReadTokens": 1960269,
+      "cacheWriteTokens": 75990,
+      "uncachedInputTokens": 48,
+      "cacheHitRate": 0.9627,
+      "costUsd": 1.907
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 7,
+      "threadId": "62190a1c-38dc-458d-8c68-923eb660abeb",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 24,
+      "inputTokens": 2019410,
+      "outputTokens": 10759,
+      "totalTokens": 2030169,
+      "cacheReadTokens": 1974390,
+      "cacheWriteTokens": 44972,
+      "uncachedInputTokens": 48,
+      "cacheHitRate": 0.9777,
+      "costUsd": 1.5375
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 8,
+      "threadId": "022a0a0d-4262-43ba-8a26-edead9e26dc6",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 24,
+      "inputTokens": 2004797,
+      "outputTokens": 12226,
+      "totalTokens": 2017023,
+      "cacheReadTokens": 1929914,
+      "cacheWriteTokens": 74835,
+      "uncachedInputTokens": 48,
+      "cacheHitRate": 0.9626,
+      "costUsd": 1.7386
+    },
+    {
+      "testCase": "rest-api-data-pipeline",
+      "iteration": 9,
+      "threadId": "ffd21c70-78be-4e34-8efd-3e26baf9b2a8",
+      "scenarios": [
+        "rest-api-data-pipeline/all-filtered",
+        "rest-api-data-pipeline/empty-response",
+        "rest-api-data-pipeline/happy-path"
+      ],
+      "llmSpans": 20,
+      "inputTokens": 1648390,
+      "outputTokens": 10846,
+      "totalTokens": 1659236,
+      "cacheReadTokens": 1575437,
+      "cacheWriteTokens": 72913,
+      "uncachedInputTokens": 40,
+      "cacheHitRate": 0.9557,
+      "costUsd": 1.5148
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 0,
+      "threadId": "69611e22-d8e9-46e7-8663-4a7b0b4c323e",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 9,
+      "inputTokens": 580016,
+      "outputTokens": 2878,
+      "totalTokens": 582894,
+      "cacheReadTokens": 521298,
+      "cacheWriteTokens": 58700,
+      "uncachedInputTokens": 18,
+      "cacheHitRate": 0.8988,
+      "costUsd": 0.6996
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 1,
+      "threadId": "3e733efa-a238-4d5d-9350-fdab17f58c07",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 15,
+      "inputTokens": 1091934,
+      "outputTokens": 4223,
+      "totalTokens": 1096157,
+      "cacheReadTokens": 1023938,
+      "cacheWriteTokens": 67966,
+      "uncachedInputTokens": 30,
+      "cacheHitRate": 0.9377,
+      "costUsd": 1.0425
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 2,
+      "threadId": "347d06cf-3800-4dcd-a4bd-26c63df0a6b4",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 797628,
+      "outputTokens": 3749,
+      "totalTokens": 801377,
+      "cacheReadTokens": 737286,
+      "cacheWriteTokens": 60318,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9243,
+      "costUsd": 0.8395
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 3,
+      "threadId": "10be12ac-d1b6-4ae3-bf43-8e56383df345",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 9,
+      "inputTokens": 580117,
+      "outputTokens": 3047,
+      "totalTokens": 583164,
+      "cacheReadTokens": 521572,
+      "cacheWriteTokens": 58527,
+      "uncachedInputTokens": 18,
+      "cacheHitRate": 0.8991,
+      "costUsd": 0.7028
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 4,
+      "threadId": "4fbb41f7-68bc-4c06-9172-11fcd8e6df55",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 8,
+      "inputTokens": 511097,
+      "outputTokens": 2775,
+      "totalTokens": 513872,
+      "cacheReadTokens": 452428,
+      "cacheWriteTokens": 58653,
+      "uncachedInputTokens": 16,
+      "cacheHitRate": 0.8852,
+      "costUsd": 0.6623
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 5,
+      "threadId": "a753be2a-c560-450d-b10d-0f74719825ba",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 8,
+      "inputTokens": 511383,
+      "outputTokens": 2956,
+      "totalTokens": 514339,
+      "cacheReadTokens": 452824,
+      "cacheWriteTokens": 58543,
+      "uncachedInputTokens": 16,
+      "cacheHitRate": 0.8855,
+      "costUsd": 0.6663
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 6,
+      "threadId": "8d3193c9-d17a-4c86-9d05-f06145682495",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 8,
+      "inputTokens": 511354,
+      "outputTokens": 2941,
+      "totalTokens": 514295,
+      "cacheReadTokens": 452802,
+      "cacheWriteTokens": 58536,
+      "uncachedInputTokens": 16,
+      "cacheHitRate": 0.8855,
+      "costUsd": 0.6659
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 7,
+      "threadId": "18ee662f-22c2-4851-95e7-49eace0cca6b",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 9,
+      "inputTokens": 601043,
+      "outputTokens": 3044,
+      "totalTokens": 604087,
+      "cacheReadTokens": 538453,
+      "cacheWriteTokens": 62572,
+      "uncachedInputTokens": 18,
+      "cacheHitRate": 0.8959,
+      "costUsd": 0.7365
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 8,
+      "threadId": "1f572303-2165-45f7-ad82-5788ada5a07f",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 857292,
+      "outputTokens": 3701,
+      "totalTokens": 860993,
+      "cacheReadTokens": 789885,
+      "cacheWriteTokens": 67383,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9214,
+      "costUsd": 0.9087
+    },
+    {
+      "testCase": "telegram-chatbot-memory-session",
+      "iteration": 9,
+      "threadId": "1634dcc1-8089-4f2a-8269-d13935f2c571",
+      "scenarios": [
+        "telegram-chatbot-memory-session/distinct-telegram-chat"
+      ],
+      "llmSpans": 9,
+      "inputTokens": 575940,
+      "outputTokens": 2963,
+      "totalTokens": 578903,
+      "cacheReadTokens": 517913,
+      "cacheWriteTokens": 58009,
+      "uncachedInputTokens": 18,
+      "cacheHitRate": 0.8992,
+      "costUsd": 0.6957
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 0,
+      "threadId": "1d9fd501-3d52-404b-810e-04cb408c848d",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 14,
+      "inputTokens": 971637,
+      "outputTokens": 4850,
+      "totalTokens": 976487,
+      "cacheReadTokens": 907410,
+      "cacheWriteTokens": 64199,
+      "uncachedInputTokens": 28,
+      "cacheHitRate": 0.9339,
+      "costUsd": 0.9763
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 1,
+      "threadId": "a14e3abe-f9dc-4a52-9c03-00b3da90c328",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1107883,
+      "outputTokens": 7364,
+      "totalTokens": 1115247,
+      "cacheReadTokens": 1049690,
+      "cacheWriteTokens": 58161,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9475,
+      "costUsd": 1.0726
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 2,
+      "threadId": "1782401a-280e-400e-9654-85daa450dd79",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1200064,
+      "outputTokens": 6866,
+      "totalTokens": 1206930,
+      "cacheReadTokens": 1135026,
+      "cacheWriteTokens": 65006,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9458,
+      "costUsd": 1.1456
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 3,
+      "threadId": "26354d23-c02d-4535-8cce-a9ead0fd2ad4",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 21,
+      "inputTokens": 1787264,
+      "outputTokens": 7781,
+      "totalTokens": 1795045,
+      "cacheReadTokens": 1711539,
+      "cacheWriteTokens": 75683,
+      "uncachedInputTokens": 42,
+      "cacheHitRate": 0.9576,
+      "costUsd": 1.5235
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 4,
+      "threadId": "b381acd3-6967-45a9-b459-4808c1e14cea",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 13,
+      "inputTokens": 935178,
+      "outputTokens": 5229,
+      "totalTokens": 940407,
+      "cacheReadTokens": 872949,
+      "cacheWriteTokens": 62203,
+      "uncachedInputTokens": 26,
+      "cacheHitRate": 0.9335,
+      "costUsd": 0.9561
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 5,
+      "threadId": "06f8af01-d739-461c-9f05-e33dce7bca85",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 11,
+      "inputTokens": 725697,
+      "outputTokens": 7480,
+      "totalTokens": 733177,
+      "cacheReadTokens": 668389,
+      "cacheWriteTokens": 57286,
+      "uncachedInputTokens": 22,
+      "cacheHitRate": 0.921,
+      "costUsd": 0.8793
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 6,
+      "threadId": "b2dd849b-c9f9-46c2-ba37-dfd0dd7fade0",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 814094,
+      "outputTokens": 5130,
+      "totalTokens": 819224,
+      "cacheReadTokens": 753810,
+      "cacheWriteTokens": 60260,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.9259,
+      "costUsd": 0.8819
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 7,
+      "threadId": "71bca48c-ddb4-45d9-a6b5-ff9a782c2dbe",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 20,
+      "inputTokens": 1580964,
+      "outputTokens": 8483,
+      "totalTokens": 1589447,
+      "cacheReadTokens": 1513251,
+      "cacheWriteTokens": 67673,
+      "uncachedInputTokens": 40,
+      "cacheHitRate": 0.9572,
+      "costUsd": 1.3919
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 8,
+      "threadId": "a80ad478-50f4-4aca-97bd-f3b97aadf9c5",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 12,
+      "inputTokens": 826232,
+      "outputTokens": 5464,
+      "totalTokens": 831696,
+      "cacheReadTokens": 763461,
+      "cacheWriteTokens": 62747,
+      "uncachedInputTokens": 24,
+      "cacheHitRate": 0.924,
+      "costUsd": 0.9106
+    },
+    {
+      "testCase": "weather-alert",
+      "iteration": 9,
+      "threadId": "b14c8fad-07d2-4d16-bde3-fd4e55fe04f5",
+      "scenarios": [
+        "weather-alert/happy-path",
+        "weather-alert/rain-not-expected"
+      ],
+      "llmSpans": 13,
+      "inputTokens": 883265,
+      "outputTokens": 4659,
+      "totalTokens": 887924,
+      "cacheReadTokens": 826300,
+      "cacheWriteTokens": 56939,
+      "uncachedInputTokens": 26,
+      "cacheHitRate": 0.9355,
+      "costUsd": 0.8856
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 0,
+      "threadId": "29c82d2d-0911-4b36-85e1-afae36eed2a1",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 11,
+      "inputTokens": 695941,
+      "outputTokens": 6216,
+      "totalTokens": 702157,
+      "cacheReadTokens": 641384,
+      "cacheWriteTokens": 54535,
+      "uncachedInputTokens": 22,
+      "cacheHitRate": 0.9216,
+      "costUsd": 0.817
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 1,
+      "threadId": "f313fadf-02a3-4649-a548-5e515b90b600",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 13,
+      "inputTokens": 824438,
+      "outputTokens": 7924,
+      "totalTokens": 832362,
+      "cacheReadTokens": 765727,
+      "cacheWriteTokens": 58685,
+      "uncachedInputTokens": 26,
+      "cacheHitRate": 0.9288,
+      "costUsd": 0.9479
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 2,
+      "threadId": "dd6510de-5134-4766-bedc-56e5959c3ac0",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1189625,
+      "outputTokens": 11096,
+      "totalTokens": 1200721,
+      "cacheReadTokens": 1125754,
+      "cacheWriteTokens": 63837,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9463,
+      "costUsd": 1.2394
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 3,
+      "threadId": "3f3274ee-0982-497e-989e-31fd465cb066",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 17,
+      "inputTokens": 1124722,
+      "outputTokens": 8085,
+      "totalTokens": 1132807,
+      "cacheReadTokens": 1066059,
+      "cacheWriteTokens": 58629,
+      "uncachedInputTokens": 34,
+      "cacheHitRate": 0.9478,
+      "costUsd": 1.1018
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 4,
+      "threadId": "2bed7cee-0b2c-41ef-9f66-3670a55a4c59",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 22,
+      "inputTokens": 1454431,
+      "outputTokens": 12126,
+      "totalTokens": 1466557,
+      "cacheReadTokens": 1385501,
+      "cacheWriteTokens": 68886,
+      "uncachedInputTokens": 44,
+      "cacheHitRate": 0.9526,
+      "costUsd": 1.4267
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 5,
+      "threadId": "5e1667cf-9995-4775-91b2-6618d5076440",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 14,
+      "inputTokens": 898264,
+      "outputTokens": 8036,
+      "totalTokens": 906300,
+      "cacheReadTokens": 840054,
+      "cacheWriteTokens": 58182,
+      "uncachedInputTokens": 28,
+      "cacheHitRate": 0.9352,
+      "costUsd": 0.9847
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 6,
+      "threadId": "6127aff9-3668-456d-a54a-0b6a33e6d322",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 19,
+      "inputTokens": 1339970,
+      "outputTokens": 9538,
+      "totalTokens": 1349508,
+      "cacheReadTokens": 1278023,
+      "cacheWriteTokens": 61909,
+      "uncachedInputTokens": 38,
+      "cacheHitRate": 0.9538,
+      "costUsd": 1.2646
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 7,
+      "threadId": "9f306d22-73d7-4884-8819-3ebfd2098e9f",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 21,
+      "inputTokens": 1532244,
+      "outputTokens": 9595,
+      "totalTokens": 1541839,
+      "cacheReadTokens": 1468962,
+      "cacheWriteTokens": 63240,
+      "uncachedInputTokens": 42,
+      "cacheHitRate": 0.9587,
+      "costUsd": 1.3698
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 8,
+      "threadId": "2e4dabbe-2019-4256-988e-0b4a55c80d5c",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 16,
+      "inputTokens": 1043258,
+      "outputTokens": 10689,
+      "totalTokens": 1053947,
+      "cacheReadTokens": 984655,
+      "cacheWriteTokens": 58571,
+      "uncachedInputTokens": 32,
+      "cacheHitRate": 0.9438,
+      "costUsd": 1.1258
+    },
+    {
+      "testCase": "workflow-data-table",
+      "iteration": 9,
+      "threadId": "74fbd448-36bd-46d3-ba38-e80b972ca9f8",
+      "scenarios": [
+        "workflow-data-table/happy-path"
+      ],
+      "llmSpans": 18,
+      "inputTokens": 1080150,
+      "outputTokens": 9949,
+      "totalTokens": 1090099,
+      "cacheReadTokens": 1016671,
+      "cacheWriteTokens": 63443,
+      "uncachedInputTokens": 36,
+      "cacheHitRate": 0.9412,
+      "costUsd": 1.1538
+    }
+  ]
+}

--- a/.claude/plugins/n8n/skills/langsmith-cost-report
+++ b/.claude/plugins/n8n/skills/langsmith-cost-report
@@ -1,0 +1,1 @@
+../../../../.agents/skills/langsmith-cost-report

--- a/scripts/enrich-thread-cost-json.mjs
+++ b/scripts/enrich-thread-cost-json.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Enrich an existing threads JSON with LangSmith cost/cache metrics, one thread at a time.
+ * Uses LangSmith SDK (EU workspace) for LLM spans in instance-ai-evals.
+ */
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { Client } = require('langsmith');
+
+const TENANT = '27a59feb-374e-458b-be53-df2f86940838';
+const TRACE_PROJECT = 'instance-ai-evals';
+
+const args = process.argv.slice(2);
+function arg(name) {
+	const i = args.indexOf(name);
+	return i >= 0 ? args[i + 1] : undefined;
+}
+
+const INPUT_FILE = arg('--input');
+const CHECKPOINT = arg('--checkpoint');
+const DELAY_MS = Number(arg('--delay-ms') ?? '3000');
+const ONLY_THREAD = arg('--thread');
+
+if (!INPUT_FILE) {
+	console.error('Usage: --input <threads.json> [--checkpoint <file.json>] [--delay-ms <ms>] [--thread <uuid>]');
+	process.exit(1);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function num(v) {
+	return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+function extractCache(run) {
+	const usage = run.outputs?.usage || run.outputs?.token_usage || run.extra?.metadata?.usage || {};
+	const inputDetails =
+		run.prompt_token_details ||
+		run.prompt_tokens_details ||
+		run.input_token_details ||
+		usage.input_token_details ||
+		usage.prompt_tokens_details ||
+		{};
+	const meta = run.extra?.metadata || {};
+	const cacheRead =
+		num(inputDetails.cache_read) ||
+		num(inputDetails.cached_read) ||
+		num(inputDetails.cache_read_input_tokens) ||
+		num(meta.cache_read_input_tokens) ||
+		num(meta.anthropic_cache_read_input_tokens) ||
+		num(usage.cache_read_input_tokens);
+	const cacheWrite =
+		num(inputDetails.cache_creation) ||
+		num(inputDetails.cache_creation_input_tokens) ||
+		num(meta.cache_creation_input_tokens) ||
+		num(meta.anthropic_cache_creation_input_tokens) ||
+		num(usage.cache_creation_input_tokens);
+	return { cacheRead, cacheWrite };
+}
+
+function aggregateLlmRuns(llmRuns) {
+	let cost = 0;
+	let prompt = 0;
+	let completion = 0;
+	let total = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	for (const run of llmRuns) {
+		const c = extractCache(run);
+		cacheRead += c.cacheRead;
+		cacheWrite += c.cacheWrite;
+		cost += num(run.total_cost);
+		prompt += num(run.prompt_tokens);
+		completion += num(run.completion_tokens);
+		total += num(run.total_tokens);
+	}
+	return {
+		llmSpans: llmRuns.length,
+		inputTokens: prompt,
+		outputTokens: completion,
+		totalTokens: total,
+		cacheReadTokens: cacheRead,
+		cacheWriteTokens: cacheWrite,
+		uncachedInputTokens: Math.max(0, prompt - cacheRead - cacheWrite),
+		cacheHitRate: prompt > 0 ? +(cacheRead / prompt).toFixed(4) : 0,
+		costUsd: +cost.toFixed(4),
+	};
+}
+
+function loadCheckpoint() {
+	if (!CHECKPOINT || !fs.existsSync(CHECKPOINT)) return { analyzedThreads: {} };
+	return JSON.parse(fs.readFileSync(CHECKPOINT, 'utf8'));
+}
+
+function saveCheckpoint(state) {
+	if (CHECKPOINT) fs.writeFileSync(CHECKPOINT, JSON.stringify(state, null, 2));
+}
+
+async function listThreadLlmRuns(client, projectId, threadId) {
+	for (let attempt = 0; attempt < 12; attempt++) {
+		try {
+			const runs = [];
+			for await (const run of client.listRuns({
+				projectId,
+				filter: `and(eq(thread_id, "${threadId}"), eq(run_type, "llm"))`,
+			})) {
+				runs.push(run);
+			}
+			return runs;
+		} catch (e) {
+			if (e.status === 429 || String(e.message).includes('429')) {
+				const wait = 5000 * (attempt + 1);
+				console.error(`429 listRuns ${threadId}, wait ${wait}ms`);
+				await sleep(wait);
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw new Error(`rate limited listing ${threadId}`);
+}
+
+function mergeMetrics(target, metrics) {
+	for (const [key, value] of Object.entries(metrics)) {
+		if (value !== null && value !== undefined) target[key] = value;
+	}
+}
+
+function collectThreads(data) {
+	const entries = [];
+	for (const ev of data.evals ?? []) {
+		for (const t of ev.threads ?? []) {
+			entries.push({
+				threadId: t.threadId,
+				testCase: ev.testCase,
+				iteration: t.iteration,
+				scenarios: t.scenarios,
+				ref: t,
+			});
+		}
+	}
+	return entries;
+}
+
+function applyToRows(data, byThreadId) {
+	for (const row of data.rows ?? []) {
+		const m = byThreadId.get(row.threadId);
+		if (m) mergeMetrics(row, m);
+	}
+}
+
+function seedCheckpointFromJson(data, checkpoint) {
+	for (const ev of data.evals ?? []) {
+		for (const t of ev.threads ?? []) {
+			if (t.costUsd == null) continue;
+			checkpoint.analyzedThreads[t.threadId] = {
+				testCase: ev.testCase,
+				iteration: t.iteration,
+				threadId: t.threadId,
+				scenarios: t.scenarios,
+				llmSpans: t.llmSpans,
+				inputTokens: t.inputTokens,
+				outputTokens: t.outputTokens,
+				totalTokens: t.totalTokens,
+				cacheReadTokens: t.cacheReadTokens,
+				cacheWriteTokens: t.cacheWriteTokens,
+				uncachedInputTokens: t.uncachedInputTokens,
+				cacheHitRate: t.cacheHitRate,
+				costUsd: t.costUsd,
+			};
+		}
+	}
+}
+
+async function main() {
+	const data = JSON.parse(fs.readFileSync(INPUT_FILE, 'utf8'));
+	const checkpoint = loadCheckpoint();
+	seedCheckpointFromJson(data, checkpoint);
+
+	const client = new Client({
+		apiKey: process.env.LANGSMITH_API_KEY,
+		apiUrl: process.env.LANGSMITH_ENDPOINT,
+		workspaceId: TENANT,
+	});
+	const project = await client.readProject({ projectName: TRACE_PROJECT });
+
+	let entries = collectThreads(data);
+	if (ONLY_THREAD) entries = entries.filter((e) => e.threadId === ONLY_THREAD);
+
+	console.log(`Input: ${INPUT_FILE}, threads: ${entries.length}, delay: ${DELAY_MS}ms`);
+
+	const byThreadId = new Map();
+	let analyzed = 0;
+	let skipped = 0;
+
+	for (const entry of entries) {
+		const { threadId } = entry;
+		let metrics = checkpoint.analyzedThreads[threadId];
+		if (metrics) {
+			skipped++;
+		} else {
+			console.log(`  analyzing ${threadId} (${entry.testCase} iter ${entry.iteration})...`);
+			await sleep(DELAY_MS);
+			const llmRuns = await listThreadLlmRuns(client, project.id, threadId);
+			if (llmRuns.length === 0) {
+				console.warn(`  no LLM spans for ${threadId}`);
+				continue;
+			}
+			metrics = aggregateLlmRuns(llmRuns);
+			checkpoint.analyzedThreads[threadId] = {
+				testCase: entry.testCase,
+				iteration: entry.iteration,
+				threadId,
+				scenarios: entry.scenarios,
+				...metrics,
+			};
+			saveCheckpoint(checkpoint);
+			analyzed++;
+			console.log(`    costUsd=${metrics.costUsd} input=${metrics.inputTokens} cacheRead=${metrics.cacheReadTokens}`);
+		}
+
+		mergeMetrics(entry.ref, metrics);
+		byThreadId.set(threadId, metrics);
+	}
+
+	applyToRows(data, byThreadId);
+	fs.writeFileSync(INPUT_FILE, JSON.stringify(data, null, 2) + '\n');
+	console.log(`Done: ${skipped} cached, ${analyzed} newly analyzed, wrote ${INPUT_FILE}`);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/fetch-experiment-threads.mjs
+++ b/scripts/fetch-experiment-threads.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Build a per-thread skeleton JSON for a LangSmith instance-ai eval experiment.
+ * Groups the experiment's root runs by test case + iteration. Enrich the output
+ * with scripts/enrich-thread-cost-json.mjs, then verify with
+ * scripts/verify-thread-cost-json.mjs.
+ */
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const TENANT = '27a59feb-374e-458b-be53-df2f86940838';
+const TRACE_PROJECT = 'instance-ai-evals';
+
+// langsmith isn't hoisted to the repo root; fall back to resolving through
+// @n8n/instance-ai, which depends on it.
+function requireLangsmith() {
+	const bases = [
+		import.meta.url,
+		new URL('../packages/@n8n/instance-ai/node_modules/_resolve.js', import.meta.url),
+	];
+	for (const base of bases) {
+		try {
+			return createRequire(base)('langsmith');
+		} catch {}
+	}
+	throw new Error('Cannot resolve the langsmith SDK. Run pnpm install first.');
+}
+
+const { Client } = requireLangsmith();
+
+const args = process.argv.slice(2);
+function arg(name) {
+	const i = args.indexOf(name);
+	return i >= 0 ? args[i + 1] : undefined;
+}
+
+const SESSION = arg('--session');
+const OUT = arg('--out');
+
+if (!SESSION) {
+	console.error('Usage: --session <session-uuid-or-experiment-name> [--out <file.json>]');
+	process.exit(1);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(SESSION);
+
+async function listRootRuns(client, sessionId) {
+	for (let attempt = 0; attempt < 12; attempt++) {
+		try {
+			const runs = [];
+			for await (const run of client.listRuns({
+				projectId: sessionId,
+				isRoot: true,
+				select: ['id', 'inputs', 'outputs'],
+			})) {
+				runs.push(run);
+			}
+			return runs;
+		} catch (e) {
+			if (e.status === 429 || String(e.message).includes('429')) {
+				const wait = 5000 * (attempt + 1);
+				console.error(`429 listing root runs, wait ${wait}ms`);
+				await sleep(wait);
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw new Error('rate limited listing root runs');
+}
+
+async function main() {
+	const client = new Client({
+		apiKey: process.env.LANGSMITH_API_KEY,
+		apiUrl: process.env.LANGSMITH_ENDPOINT,
+		workspaceId: TENANT,
+	});
+
+	const project = await client.readProject(
+		isUuid ? { projectId: SESSION } : { projectName: SESSION },
+	);
+	const meta = project.extra?.metadata ?? {};
+	const roots = await listRootRuns(client, project.id);
+
+	// Root runs are one per scenario; scenarios of the same test case + iteration
+	// share a single build thread.
+	const byThread = new Map();
+	for (const run of roots) {
+		const testCase = run.inputs?.testCaseFile;
+		const iteration = run.inputs?._iteration;
+		const scenario = run.inputs?.scenarioName;
+		const threadId = run.outputs?.threadId;
+		if (!testCase || threadId == null) {
+			console.warn(`skipping root run ${run.id}: missing testCaseFile or outputs.threadId`);
+			continue;
+		}
+		const key = `${testCase}|${iteration}`;
+		if (!byThread.has(key)) {
+			byThread.set(key, { testCase, iteration, threadId, scenarios: new Set() });
+		}
+		const entry = byThread.get(key);
+		if (entry.threadId !== threadId) {
+			console.warn(`thread mismatch for ${key}: ${entry.threadId} vs ${threadId}`);
+		}
+		entry.scenarios.add(scenario);
+	}
+
+	const entries = [...byThread.values()].sort(
+		(a, b) => a.testCase.localeCompare(b.testCase) || a.iteration - b.iteration,
+	);
+
+	const evalsMap = new Map();
+	for (const e of entries) {
+		if (!evalsMap.has(e.testCase)) evalsMap.set(e.testCase, []);
+		evalsMap.get(e.testCase).push({
+			iteration: e.iteration,
+			threadId: e.threadId,
+			scenarios: [...e.scenarios].sort(),
+		});
+	}
+
+	const data = {
+		experiment: project.name,
+		sessionId: project.id,
+		datasetId: project.reference_dataset_id ?? null,
+		traceProject: TRACE_PROJECT,
+		githubRunId: meta.runId ?? null,
+		branch: meta.branch ?? meta.git?.branch ?? null,
+		iterations: meta.iterations ?? null,
+		targetRuns: roots.length,
+		uniqueThreads: entries.length,
+		evals: [...evalsMap.entries()].map(([testCase, threads]) => ({ testCase, threads })),
+		rows: entries.map((e) => ({
+			testCase: e.testCase,
+			iteration: e.iteration,
+			threadId: e.threadId,
+			scenarios: [...e.scenarios].sort().map((s) => `${e.testCase}/${s}`),
+		})),
+	};
+
+	const outFile = OUT ?? `${project.name}-threads.json`;
+	fs.writeFileSync(outFile, JSON.stringify(data, null, 2) + '\n');
+	console.log(
+		`Wrote ${outFile}: ${entries.length} threads across ${evalsMap.size} evals (${roots.length} root runs)`,
+	);
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/scripts/report-thread-cost-json.mjs
+++ b/scripts/report-thread-cost-json.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Markdown cost/cache comparison for two or more enriched *-threads.json files.
+ * The first file is the baseline. Read-only; prints to stdout.
+ */
+
+import fs from 'node:fs';
+
+const files = process.argv.slice(2);
+if (files.length < 2) {
+	console.error(
+		'Usage: node scripts/report-thread-cost-json.mjs <baseline-threads.json> <other-threads.json> [...]',
+	);
+	process.exit(1);
+}
+
+const sum = (rows, key) => rows.reduce((acc, r) => acc + (r[key] ?? 0), 0);
+const money = (v) => `$${v.toFixed(2)}`;
+const tokens = (v) => (v >= 1e6 ? `${(v / 1e6).toFixed(1)}M` : `${(v / 1e3).toFixed(0)}K`);
+const pct = (v) => `${(v * 100).toFixed(1)}%`;
+const delta = (v, base) => `${v >= base ? '+' : ''}${(((v - base) / base) * 100).toFixed(0)}%`;
+
+const experiments = files.map((file) => {
+	const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+	const rows = data.rows ?? [];
+	const missing = rows.filter((r) => r.costUsd == null).length;
+	if (missing > 0) {
+		console.error(`WARNING: ${file} has ${missing} rows without costUsd — run enrich first`);
+	}
+	return {
+		name: data.experiment ?? file,
+		rows,
+		threads: rows.length,
+		llmSpans: sum(rows, 'llmSpans'),
+		inputTokens: sum(rows, 'inputTokens'),
+		outputTokens: sum(rows, 'outputTokens'),
+		cacheRead: sum(rows, 'cacheReadTokens'),
+		cacheWrite: sum(rows, 'cacheWriteTokens'),
+		cost: sum(rows, 'costUsd'),
+	};
+});
+
+const baseline = experiments[0];
+const baseAvg = baseline.cost / baseline.threads;
+
+console.log('# LangSmith experiment cost report\n');
+console.log(`Baseline: **${baseline.name}**\n`);
+console.log('## Overview\n');
+console.log(
+	'| Experiment | Threads | LLM spans | Input | Output | Cache read | Cache write | Hit rate | Total cost | Avg cost/thread |',
+);
+console.log('|---|---|---|---|---|---|---|---|---|---|');
+for (const exp of experiments) {
+	const avg = exp.cost / exp.threads;
+	const vsBase = exp === baseline ? '' : ` (${delta(avg, baseAvg)})`;
+	console.log(
+		`| ${exp.name} | ${exp.threads} | ${exp.llmSpans} | ${tokens(exp.inputTokens)} | ` +
+			`${tokens(exp.outputTokens)} | ${tokens(exp.cacheRead)} | ${tokens(exp.cacheWrite)} | ` +
+			`${pct(exp.cacheRead / exp.inputTokens)} | ${money(exp.cost)} | ${money(avg)}${vsBase} |`,
+	);
+}
+
+console.log('\n## Avg cost per thread by eval\n');
+const testCases = [...new Set(experiments.flatMap((e) => e.rows.map((r) => r.testCase)))].sort();
+console.log(`| Eval | ${experiments.map((e) => e.name).join(' | ')} |`);
+console.log(`|---|${experiments.map(() => '---').join('|')}|`);
+for (const tc of testCases) {
+	const baseRows = baseline.rows.filter((r) => r.testCase === tc);
+	const baseEvalAvg = baseRows.length > 0 ? sum(baseRows, 'costUsd') / baseRows.length : null;
+	const cells = experiments.map((exp) => {
+		const rows = exp.rows.filter((r) => r.testCase === tc);
+		if (rows.length === 0) return 'n/a';
+		const avg = sum(rows, 'costUsd') / rows.length;
+		if (exp === baseline || baseEvalAvg == null) return money(avg);
+		return `${money(avg)} (${delta(avg, baseEvalAvg)})`;
+	});
+	console.log(`| ${tc} | ${cells.join(' | ')} |`);
+}

--- a/scripts/verify-thread-cost-json.mjs
+++ b/scripts/verify-thread-cost-json.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Verify a threads JSON against LangSmith by re-fetching LLM spans per thread
+ * and recomputing metrics. Read-only: never modifies the input file.
+ */
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { Client } = require('langsmith');
+
+const TENANT = '27a59feb-374e-458b-be53-df2f86940838';
+const TRACE_PROJECT = 'instance-ai-evals';
+
+const args = process.argv.slice(2);
+function arg(name) {
+	const i = args.indexOf(name);
+	return i >= 0 ? args[i + 1] : undefined;
+}
+
+const INPUT_FILE = arg('--input');
+const DELAY_MS = Number(arg('--delay-ms') ?? '3000');
+const CHECKPOINT = arg('--checkpoint');
+
+if (!INPUT_FILE) {
+	console.error('Usage: --input <threads.json> [--checkpoint <file.json>] [--delay-ms <ms>]');
+	process.exit(1);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function num(v) {
+	return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+function extractCache(run) {
+	const usage = run.outputs?.usage || run.outputs?.token_usage || run.extra?.metadata?.usage || {};
+	const inputDetails =
+		run.prompt_token_details ||
+		run.prompt_tokens_details ||
+		run.input_token_details ||
+		usage.input_token_details ||
+		usage.prompt_tokens_details ||
+		{};
+	const meta = run.extra?.metadata || {};
+	const cacheRead =
+		num(inputDetails.cache_read) ||
+		num(inputDetails.cached_read) ||
+		num(inputDetails.cache_read_input_tokens) ||
+		num(meta.cache_read_input_tokens) ||
+		num(meta.anthropic_cache_read_input_tokens) ||
+		num(usage.cache_read_input_tokens);
+	const cacheWrite =
+		num(inputDetails.cache_creation) ||
+		num(inputDetails.cache_creation_input_tokens) ||
+		num(meta.cache_creation_input_tokens) ||
+		num(meta.anthropic_cache_creation_input_tokens) ||
+		num(usage.cache_creation_input_tokens);
+	return { cacheRead, cacheWrite };
+}
+
+function aggregateLlmRuns(llmRuns) {
+	let cost = 0;
+	let prompt = 0;
+	let completion = 0;
+	let total = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	for (const run of llmRuns) {
+		const c = extractCache(run);
+		cacheRead += c.cacheRead;
+		cacheWrite += c.cacheWrite;
+		cost += num(run.total_cost);
+		prompt += num(run.prompt_tokens);
+		completion += num(run.completion_tokens);
+		total += num(run.total_tokens);
+	}
+	return {
+		llmSpans: llmRuns.length,
+		inputTokens: prompt,
+		outputTokens: completion,
+		totalTokens: total,
+		cacheReadTokens: cacheRead,
+		cacheWriteTokens: cacheWrite,
+		uncachedInputTokens: Math.max(0, prompt - cacheRead - cacheWrite),
+		cacheHitRate: prompt > 0 ? +(cacheRead / prompt).toFixed(4) : 0,
+		costUsd: +cost.toFixed(4),
+	};
+}
+
+async function listThreadLlmRuns(client, projectId, threadId) {
+	for (let attempt = 0; attempt < 12; attempt++) {
+		try {
+			const runs = [];
+			for await (const run of client.listRuns({
+				projectId,
+				filter: `and(eq(thread_id, "${threadId}"), eq(run_type, "llm"))`,
+			})) {
+				runs.push(run);
+			}
+			return runs;
+		} catch (e) {
+			if (e.status === 429 || String(e.message).includes('429')) {
+				const wait = 5000 * (attempt + 1);
+				console.error(`429 listRuns ${threadId}, wait ${wait}ms`);
+				await sleep(wait);
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw new Error(`rate limited listing ${threadId}`);
+}
+
+const KEYS = [
+	'llmSpans',
+	'inputTokens',
+	'outputTokens',
+	'totalTokens',
+	'cacheReadTokens',
+	'cacheWriteTokens',
+	'uncachedInputTokens',
+	'cacheHitRate',
+	'costUsd',
+];
+
+function loadCheckpoint() {
+	if (!CHECKPOINT || !fs.existsSync(CHECKPOINT)) return { verified: {} };
+	return JSON.parse(fs.readFileSync(CHECKPOINT, 'utf8'));
+}
+
+function saveCheckpoint(state) {
+	if (CHECKPOINT) fs.writeFileSync(CHECKPOINT, JSON.stringify(state, null, 2));
+}
+
+async function main() {
+	const data = JSON.parse(fs.readFileSync(INPUT_FILE, 'utf8'));
+	const checkpoint = loadCheckpoint();
+
+	const client = new Client({
+		apiKey: process.env.LANGSMITH_API_KEY,
+		apiUrl: process.env.LANGSMITH_ENDPOINT,
+		workspaceId: TENANT,
+	});
+	const project = await client.readProject({ projectName: TRACE_PROJECT });
+
+	const entries = [];
+	for (const ev of data.evals ?? []) {
+		for (const t of ev.threads ?? []) {
+			entries.push({ testCase: ev.testCase, thread: t });
+		}
+	}
+
+	console.log(`Verifying ${entries.length} threads from ${INPUT_FILE}, delay ${DELAY_MS}ms`);
+
+	let ok = 0;
+	const mismatches = [];
+
+	for (const { testCase, thread } of entries) {
+		const { threadId } = thread;
+		let fresh = checkpoint.verified[threadId];
+		if (!fresh) {
+			await sleep(DELAY_MS);
+			const llmRuns = await listThreadLlmRuns(client, project.id, threadId);
+			fresh = aggregateLlmRuns(llmRuns);
+			checkpoint.verified[threadId] = fresh;
+			saveCheckpoint(checkpoint);
+		}
+
+		const diffs = KEYS.filter((k) => thread[k] !== fresh[k]).map(
+			(k) => `${k}: file=${thread[k]} langsmith=${fresh[k]}`,
+		);
+		if (diffs.length === 0) {
+			ok++;
+			console.log(`OK   ${testCase} iter ${thread.iteration} ${threadId}`);
+		} else {
+			mismatches.push({ testCase, iteration: thread.iteration, threadId, diffs });
+			console.log(`DIFF ${testCase} iter ${thread.iteration} ${threadId}`);
+			for (const dline of diffs) console.log(`     ${dline}`);
+		}
+	}
+
+	console.log(`\nResult: ${ok}/${entries.length} threads match LangSmith exactly`);
+	if (mismatches.length > 0) {
+		console.log(`${mismatches.length} mismatched threads:`);
+		console.log(JSON.stringify(mismatches, null, 2));
+		process.exitCode = 2;
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a 4-step LangSmith pipeline for comparing instance-ai eval experiment costs: fetch thread skeletons, enrich with token/cache/cost metrics, verify against LangSmith, and print a markdown comparison report
- Includes an agent skill (`langsmith-cost-report`) documenting the workflow, rate-limiting guidance, and a committed baseline experiment JSON

## How to test

1. Ensure `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT` are set in `.env.local`
2. Fetch an experiment:
   ```bash
   pnpm dotenvx run -f .env.local -- node scripts/fetch-experiment-threads.mjs \
     --session <sessionId> --out /tmp/candidate-threads.json
   ```
3. Enrich and verify:
   ```bash
   pnpm dotenvx run -f .env.local -- node scripts/enrich-thread-cost-json.mjs \
     --input /tmp/candidate-threads.json --checkpoint /tmp/enrich-checkpoint.json --delay-ms 6000
   pnpm dotenvx run -f .env.local -- node scripts/verify-thread-cost-json.mjs \
     --input /tmp/candidate-threads.json --checkpoint /tmp/verify-checkpoint.json --delay-ms 6000
   ```
4. Compare against baseline:
   ```bash
   node scripts/report-thread-cost-json.mjs \
     .agents/skills/langsmith-cost-report/baselines/baseline.json \
     /tmp/candidate-threads.json
   ```

Extracted from #33583 to keep that PR focused on sub-agent delegation.


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33760">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->