### PR TITLE
feat(core): Support host-controlled delegate sub-agent tool surface (no-changelog)

### DIFF
--- a/packages/@n8n/agents/docs/prompt-caching.md
+++ b/packages/@n8n/agents/docs/prompt-caching.md
@@ -78,7 +78,12 @@ Other prefix-stability hygiene, already true or verified: tool ordering is
 append-only (`getCurrentTools()` only ever appends), and none of the current
 built-in `systemInstruction` sources (`delegate_subagent`, `write_todos`,
 `recall_memory`) interpolate timestamps, run IDs, or other per-request
-nondeterminism into their text.
+nondeterminism into their text. Hosts can rename the delegate tool and replace
+its description / system instruction (`createDelegateSubAgentTool({ name,
+description, systemInstruction })`, mirrored into `write_todos` via
+`createWriteTodosTool({ delegateToolName })`), but those values are fixed at
+tool-build time, so the instructions prefix stays byte-stable for the life of
+a run.
 
 ## Anthropic: instruction-level cache breakpoint
 

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -238,6 +238,7 @@ export {
 	failedDelegatedChildSuspendOutput,
 	generateResultToDelegateSubAgentOutput,
 	getInlineDelegateSubAgentToolOptions,
+	isDelegateSubAgentTool,
 	renderDelegateSubAgentPrompt,
 } from './runtime/tools/delegate-sub-agent-tool';
 export type {
@@ -252,6 +253,7 @@ export type {
 	SubAgentTaskDifficulty,
 } from './runtime/tools/delegate-sub-agent-tool';
 export { WRITE_TODOS_TOOL_NAME, createWriteTodosTool } from './runtime/tools/write-todos-tool';
+export type { CreateWriteTodosToolOptions } from './runtime/tools/write-todos-tool';
 export { createEmbeddingModel } from './runtime/model/model-factory';
 export { generateTitleFromMessage } from './runtime/memory/title-generation';
 export {

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -2376,6 +2376,51 @@ describe('AgentRuntime — concurrent tool execution', () => {
 		}
 	});
 
+	it('batches a renamed delegate tool by maxChildren via metadata, not by tool name', async () => {
+		let activeDelegations = 0;
+		let peakDelegations = 0;
+
+		const runSubAgent: DelegateSubAgentRunner = async (request) => {
+			activeDelegations++;
+			peakDelegations = Math.max(peakDelegations, activeDelegations);
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			activeDelegations--;
+			return {
+				status: 'completed',
+				taskPath: request.taskPath,
+				answer: `done:${request.taskName}`,
+			};
+		};
+
+		const delegateTool = createDelegateSubAgentTool({
+			name: 'agent',
+			policy: { maxChildren: 2 },
+			runSubAgent,
+		});
+		const { runtime } = createRuntimeWithTools([delegateTool], 1);
+
+		generateText
+			.mockResolvedValueOnce(
+				makeGenerateWithToolCalls(
+					Array.from({ length: 4 }, (_, index) => ({
+						toolCallId: `tc-${index + 1}`,
+						toolName: 'agent',
+						args: {
+							subAgentId: 'inline',
+							taskName: `ping_${index + 1}`,
+							goal: 'Reply with ping.',
+						},
+					})),
+				),
+			)
+			.mockResolvedValueOnce(makeGenerateSuccess('Done'));
+
+		const result = await runtime.generate('spawn 4 sub agents');
+
+		expect(result.finishReason).toBe('stop');
+		expect(peakDelegations).toBe(2);
+	});
+
 	it('fails fast when delegate metadata has an invalid maxChildren batch size', async () => {
 		const malformedDelegateTool: BuiltTool = {
 			name: DELEGATE_SUB_AGENT_TOOL_NAME,

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -43,6 +43,131 @@ describe('createDelegateSubAgentTool', () => {
 		expect(tool.outputSchema).toBeDefined();
 	});
 
+	it('defaults to the delegate_subagent name when none is provided', () => {
+		const tool = createDelegateSubAgentTool();
+
+		expect(tool.name).toBe(DELEGATE_SUB_AGENT_TOOL_NAME);
+		expect(tool.systemInstruction).toContain('delegate_subagent runs a focused child agent');
+		expect(tool.systemInstruction).toContain('WHEN TO USE delegate_subagent:');
+		expect(tool.systemInstruction).toContain('WHEN NOT TO USE delegate_subagent:');
+	});
+
+	it('renames the tool and interpolates the name into the system instruction', () => {
+		const tool = createDelegateSubAgentTool({ name: 'agent' });
+
+		expect(tool.name).toBe('agent');
+		expect(tool.systemInstruction).toContain('agent runs a focused child agent');
+		expect(tool.systemInstruction).toContain('WHEN TO USE agent:');
+		expect(tool.systemInstruction).toContain('WHEN NOT TO USE agent:');
+		expect(tool.systemInstruction).not.toContain('delegate_subagent');
+	});
+
+	it('preserves a custom name across the SDK inline-completion rebuild', () => {
+		const tool = createDelegateSubAgentTool({
+			name: 'agent',
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		const rebuilt = createDelegateSubAgentTool({
+			...getInlineDelegateSubAgentToolOptions(tool),
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		expect(rebuilt.name).toBe('agent');
+	});
+
+	it('omits the system instruction when systemInstruction is null', () => {
+		const tool = createDelegateSubAgentTool({ systemInstruction: null });
+
+		expect(tool.systemInstruction).toBeUndefined();
+	});
+
+	it('omits the system instruction when systemInstruction is an empty string', () => {
+		const tool = createDelegateSubAgentTool({ systemInstruction: '' });
+
+		expect(tool.systemInstruction).toBeUndefined();
+	});
+
+	it('uses a host-provided system instruction instead of the built-in guidance', () => {
+		const tool = createDelegateSubAgentTool({
+			name: 'agent',
+			systemInstruction: 'Host-authored delegation guidance.',
+		});
+
+		expect(tool.systemInstruction).toBe('Host-authored delegation guidance.');
+		expect(tool.systemInstruction).not.toContain('WHEN TO USE agent:');
+	});
+
+	it('preserves a custom system instruction across the SDK inline-completion rebuild', () => {
+		const tool = createDelegateSubAgentTool({
+			name: 'agent',
+			systemInstruction: 'Host-authored delegation guidance.',
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		const rebuilt = createDelegateSubAgentTool({
+			...getInlineDelegateSubAgentToolOptions(tool),
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		expect(rebuilt.systemInstruction).toBe('Host-authored delegation guidance.');
+	});
+
+	it('uses the default description when none is provided', () => {
+		const tool = createDelegateSubAgentTool();
+
+		expect(tool.description).toContain('focused child agent');
+		expect(tool.description).toContain('independent workstreams');
+	});
+
+	it('falls back to the tool name when description is null', () => {
+		const tool = createDelegateSubAgentTool({ description: null });
+
+		expect(tool.description).toBe(DELEGATE_SUB_AGENT_TOOL_NAME);
+		expect(tool.description).not.toContain('independent workstreams');
+	});
+
+	it('falls back to the tool name when description is an empty string', () => {
+		const tool = createDelegateSubAgentTool({ description: '' });
+
+		expect(tool.description).toBe(DELEGATE_SUB_AGENT_TOOL_NAME);
+	});
+
+	it('falls back to a custom tool name when description is omitted', () => {
+		const tool = createDelegateSubAgentTool({ name: 'agent', description: null });
+
+		expect(tool.description).toBe('agent');
+	});
+
+	it('uses a host-provided description instead of the built-in text', () => {
+		const tool = createDelegateSubAgentTool({
+			description: 'Delegate read-only research to a sub-agent.',
+		});
+
+		expect(tool.description).toBe('Delegate read-only research to a sub-agent.');
+		expect(tool.description).not.toContain('independent workstreams');
+	});
+
+	it('preserves a custom description across the SDK inline-completion rebuild', () => {
+		const tool = createDelegateSubAgentTool({
+			description: 'Delegate read-only research to a sub-agent.',
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		const rebuilt = createDelegateSubAgentTool({
+			...getInlineDelegateSubAgentToolOptions(tool),
+			runSubAgent: async () =>
+				await Promise.resolve({ status: 'completed', taskPath: '/root/x_0', answer: 'done' }),
+		});
+
+		expect(rebuilt.description).toBe('Delegate read-only research to a sub-agent.');
+	});
+
 	it('accepts optional difficulty on the delegate input schema', () => {
 		const tool = createDelegateSubAgentTool({
 			runSubAgent: async () =>

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -9,6 +9,7 @@ import {
 	createDelegateSubAgentTool,
 	generateResultToDelegateSubAgentOutput,
 	getInlineDelegateSubAgentToolOptions,
+	isDelegateSubAgentTool,
 	renderDelegateSubAgentPrompt,
 	type DelegateSubAgentRunner,
 } from '../tools/delegate-sub-agent-tool';
@@ -78,17 +79,45 @@ describe('createDelegateSubAgentTool', () => {
 		expect(rebuilt.name).toBe('agent');
 	});
 
-	it('omits the system instruction when systemInstruction is null', () => {
-		const tool = createDelegateSubAgentTool({ systemInstruction: null });
+	it.each(['', ' ', 'has space', '1agent', 'agent!', 'a'.repeat(65)])(
+		'rejects invalid delegate tool name %j',
+		(name) => {
+			expect(() => createDelegateSubAgentTool({ name })).toThrow(
+				'Invalid delegate sub-agent tool name',
+			);
+		},
+	);
 
-		expect(tool.systemInstruction).toBeUndefined();
+	it('names a renamed tool in policy validation errors', () => {
+		expect(() => createDelegateSubAgentTool({ name: 'agent', policy: { maxChildren: 0 } })).toThrow(
+			'agent policy.maxChildren must be at least 1',
+		);
 	});
 
-	it('omits the system instruction when systemInstruction is an empty string', () => {
-		const tool = createDelegateSubAgentTool({ systemInstruction: '' });
+	it('names a renamed tool in the missing-runner error', async () => {
+		const tool = createDelegateSubAgentTool({ name: 'agent' });
 
-		expect(tool.systemInstruction).toBeUndefined();
+		await expect(tool.handler?.(input, { runId: 'parent-run-1' })).resolves.toMatchObject({
+			status: 'failed',
+			error:
+				'agent was registered without a runSubAgent callback, and no host runner was provided. Register it on an Agent (for inline delegation) or pass runSubAgent.',
+		});
 	});
+
+	it('identifies delegate tools by metadata regardless of name', () => {
+		expect(isDelegateSubAgentTool(createDelegateSubAgentTool())).toBe(true);
+		expect(isDelegateSubAgentTool(createDelegateSubAgentTool({ name: 'agent' }))).toBe(true);
+		expect(isDelegateSubAgentTool({ name: DELEGATE_SUB_AGENT_TOOL_NAME })).toBe(false);
+	});
+
+	it.each([null, '', '   '])(
+		'falls back to the default system instruction for non-string or blank value %j',
+		(systemInstruction) => {
+			const tool = createDelegateSubAgentTool({ systemInstruction });
+
+			expect(tool.systemInstruction).toContain('WHEN TO USE delegate_subagent:');
+		},
+	);
 
 	it('uses a host-provided system instruction instead of the built-in guidance', () => {
 		const tool = createDelegateSubAgentTool({
@@ -124,24 +153,14 @@ describe('createDelegateSubAgentTool', () => {
 		expect(tool.description).toContain('independent workstreams');
 	});
 
-	it('falls back to the tool name when description is null', () => {
-		const tool = createDelegateSubAgentTool({ description: null });
+	it.each([null, '', '   '])(
+		'falls back to the default description for non-string or blank value %j',
+		(description) => {
+			const tool = createDelegateSubAgentTool({ description });
 
-		expect(tool.description).toBe(DELEGATE_SUB_AGENT_TOOL_NAME);
-		expect(tool.description).not.toContain('independent workstreams');
-	});
-
-	it('falls back to the tool name when description is an empty string', () => {
-		const tool = createDelegateSubAgentTool({ description: '' });
-
-		expect(tool.description).toBe(DELEGATE_SUB_AGENT_TOOL_NAME);
-	});
-
-	it('falls back to a custom tool name when description is omitted', () => {
-		const tool = createDelegateSubAgentTool({ name: 'agent', description: null });
-
-		expect(tool.description).toBe('agent');
-	});
+			expect(tool.description).toContain('independent workstreams');
+		},
+	);
 
 	it('uses a host-provided description instead of the built-in text', () => {
 		const tool = createDelegateSubAgentTool({

--- a/packages/@n8n/agents/src/runtime/__tests__/write-todos-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/write-todos-tool.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 import { isZodSchema } from '../../utils/zod';
 import { WRITE_TODOS_TOOL_NAME, createWriteTodosTool } from '../tools/write-todos-tool';
@@ -36,6 +37,20 @@ describe('createWriteTodosTool', () => {
 		expect(tool.systemInstruction).toContain('high');
 		expect(tool.systemInstruction).toContain('delegate_subagent');
 		expect(tool.systemInstruction).toContain('same difficulty');
+	});
+
+	it('references a renamed delegate tool in the planner guidance', () => {
+		const tool = createWriteTodosTool({ delegateToolName: 'agent' });
+
+		expect(tool.description).toContain('handled separately with agent.');
+		expect(tool.description).not.toContain('delegate_subagent');
+		expect(tool.systemInstruction).toContain('good candidates for agent.');
+		expect(tool.systemInstruction).toContain('then call agent separately for that task');
+		expect(tool.systemInstruction).not.toContain('delegate_subagent');
+
+		expect(isZodSchema(tool.inputSchema)).toBe(true);
+		if (!isZodSchema(tool.inputSchema)) return;
+		expect(JSON.stringify(zodToJsonSchema(tool.inputSchema))).not.toContain('delegate_subagent');
 	});
 
 	it('returns the provided todo list with a count', async () => {

--- a/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
@@ -190,6 +190,7 @@ export type DelegateSubAgentRunner = (
 ) => Promise<DelegateSubAgentToolOutput>;
 
 export interface CreateDelegateSubAgentToolOptions {
+	name?: string;
 	/**
 	 * Sub-agents the model may choose between. Listed in the system prompt; the
 	 * model selects one by passing its id as `subAgentId`.
@@ -215,6 +216,8 @@ export interface CreateDelegateSubAgentToolOptions {
 	 * `helpers.runInlineSubAgent` for inline work.
 	 */
 	runSubAgent?: DelegateSubAgentRunner;
+	systemInstruction?: string | null;
+	description?: string | null;
 
 	toModelOutput?: (output: z.infer<typeof delegateSubAgentOutputSchema>) => unknown;
 }
@@ -260,6 +263,48 @@ function resolveDelegateSubAgentPolicy(
 	return resolvedPolicy;
 }
 
+const DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION =
+	'Delegate a bounded, self-contained subtask to a focused child agent that runs in an isolated context and returns only a concise final result. ' +
+	'Use it for reasoning-heavy subtasks, context-flooding investigations, or independent workstreams inside a larger deliverable. ' +
+	'Do not use it for trivial work, single tool calls, mechanical steps, tasks that need hidden conversation context, or pass-through delegation of the entire user request.';
+
+function resolveDelegateSubAgentDescription(
+	options: CreateDelegateSubAgentToolOptions,
+	toolName: string,
+): string {
+	if (options.description !== undefined) {
+		if (options.description === null || options.description.trim().length === 0) {
+			return toolName;
+		}
+		return options.description;
+	}
+
+	return DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION;
+}
+
+function resolveDelegateSubAgentSystemInstruction(
+	options: CreateDelegateSubAgentToolOptions,
+	toolName: string,
+	inlineProviderToolInstruction: string,
+): string | undefined {
+	if (options.systemInstruction !== undefined) {
+		if (options.systemInstruction === null || options.systemInstruction.trim().length === 0) {
+			return undefined;
+		}
+		return options.systemInstruction;
+	}
+
+	return [
+		`${toolName} runs a focused child agent in a fresh, isolated context and returns only its final answer. Always set subAgentId. Use subAgentId: "inline" to run a one-off inline child that inherits your local and deferred tools after safety filtering. ${inlineProviderToolInstruction} The child cannot see this conversation or your memory, so everything it needs must be in the call.`,
+		'Use a configured subagent ID only when one is listed and its name and useWhen guidance fit the subtask better than a generic inline child.',
+		...formatAvailableSubAgents(options.availableSubAgents),
+		...formatDelegationPolicyInstructions(options.policy, toolName),
+		`WHEN TO USE ${toolName}:\n- The request decomposes into 2+ independent workstreams that can be handled separately.\n- A workstream needs substantial research, review, comparison, or analysis.\n- Doing the work inline would flood your context with intermediate findings.\n- A fresh isolated perspective would materially improve a bounded subtask.`,
+		`WHEN NOT TO USE ${toolName}:\n- Single-step mechanical work: do it directly.\n- Trivial tasks or one/two tool calls: do them yourself.\n- Tasks that need user interaction or hidden conversation context.\n- Your core synthesis, final judgment, or recommendation.\n- The entire user request as one delegated task; that is pass-through with no value added.`,
+		`HOW TO DELEGATE:\n- Delegate bounded workstreams, not the final answer.\n- Pass all required context, constraints, language/tone, and expected output.\n- Set difficulty (low, medium, or high) when you can estimate task complexity; omit it to keep the default inline model.\n- If multiple independent workstreams exist, delegate them separately.\n- Inline children inherit your local and deferred tools after safety filtering. ${inlineProviderToolInstruction}\n- Inspect results and synthesize the final response yourself.\n- Verify side-effect claims before presenting them as done.`,
+	].join('\n');
+}
+
 export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOptions = {}) {
 	// Per-parent child path index for stable task paths (/root/name_0, /root/name_1, ...).
 	const childPathIndexes = new Map<string, number>();
@@ -267,27 +312,23 @@ export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOp
 		...options,
 		policy: resolveDelegateSubAgentPolicy(options.policy),
 	};
+	const toolName = resolvedOptions.name ?? DELEGATE_SUB_AGENT_TOOL_NAME;
 	const inlineProviderToolInstruction = resolvedOptions.resolveInlineSubAgentProviderTools
 		? "Provider-defined tools are loaded for the inline child's selected model provider."
 		: 'Inline children do not inherit provider-defined tools.';
+	const systemInstruction = resolveDelegateSubAgentSystemInstruction(
+		resolvedOptions,
+		toolName,
+		inlineProviderToolInstruction,
+	);
+	const description = resolveDelegateSubAgentDescription(resolvedOptions, toolName);
 
-	const tool = new Tool(DELEGATE_SUB_AGENT_TOOL_NAME)
-		.description(
-			'Delegate a bounded, self-contained subtask to a focused child agent that runs in an isolated context and returns only a concise final result. ' +
-				'Use it for reasoning-heavy subtasks, context-flooding investigations, or independent workstreams inside a larger deliverable. ' +
-				'Do not use it for trivial work, single tool calls, mechanical steps, tasks that need hidden conversation context, or pass-through delegation of the entire user request.',
-		)
-		.systemInstruction(
-			[
-				`delegate_subagent runs a focused child agent in a fresh, isolated context and returns only its final answer. Always set subAgentId. Use subAgentId: "inline" to run a one-off inline child that inherits your local and deferred tools after safety filtering. ${inlineProviderToolInstruction} The child cannot see this conversation or your memory, so everything it needs must be in the call.`,
-				'Use a configured subagent ID only when one is listed and its name and useWhen guidance fit the subtask better than a generic inline child.',
-				...formatAvailableSubAgents(resolvedOptions.availableSubAgents),
-				...formatDelegationPolicyInstructions(resolvedOptions.policy),
-				'WHEN TO USE delegate_subagent:\n- The request decomposes into 2+ independent workstreams that can be handled separately.\n- A workstream needs substantial research, review, comparison, or analysis.\n- Doing the work inline would flood your context with intermediate findings.\n- A fresh isolated perspective would materially improve a bounded subtask.',
-				'WHEN NOT TO USE delegate_subagent:\n- Single-step mechanical work: do it directly.\n- Trivial tasks or one/two tool calls: do them yourself.\n- Tasks that need user interaction or hidden conversation context.\n- Your core synthesis, final judgment, or recommendation.\n- The entire user request as one delegated task; that is pass-through with no value added.',
-				`HOW TO DELEGATE:\n- Delegate bounded workstreams, not the final answer.\n- Pass all required context, constraints, language/tone, and expected output.\n- Set difficulty (low, medium, or high) when you can estimate task complexity; omit it to keep the default inline model.\n- If multiple independent workstreams exist, delegate them separately.\n- Inline children inherit your local and deferred tools after safety filtering. ${inlineProviderToolInstruction}\n- Inspect results and synthesize the final response yourself.\n- Verify side-effect claims before presenting them as done.`,
-			].join('\n'),
-		)
+	let toolBuilder = new Tool(toolName).description(description);
+	if (systemInstruction !== undefined) {
+		toolBuilder = toolBuilder.systemInstruction(systemInstruction);
+	}
+
+	const tool = toolBuilder
 		.input(delegateSubAgentInputSchema)
 		.output(delegateSubAgentOutputSchema)
 		.handler(
@@ -303,6 +344,7 @@ export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOp
 		metadata: {
 			...tool.metadata,
 			[INLINE_DELEGATE_SUB_AGENT_TOOL_METADATA_KEY]: {
+				...(resolvedOptions.name !== undefined ? { name: resolvedOptions.name } : {}),
 				...(resolvedOptions.availableSubAgents !== undefined
 					? { availableSubAgents: resolvedOptions.availableSubAgents }
 					: {}),
@@ -323,6 +365,12 @@ export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOp
 					: {}),
 				...(resolvedOptions.runSubAgent !== undefined
 					? { runSubAgent: resolvedOptions.runSubAgent }
+					: {}),
+				...(resolvedOptions.systemInstruction !== undefined
+					? { systemInstruction: resolvedOptions.systemInstruction }
+					: {}),
+				...(resolvedOptions.description !== undefined
+					? { description: resolvedOptions.description }
 					: {}),
 				...(resolvedOptions.toModelOutput !== undefined
 					? { toModelOutput: resolvedOptions.toModelOutput }
@@ -354,7 +402,10 @@ function formatAvailableSubAgents(
 	];
 }
 
-function formatDelegationPolicyInstructions(policy: DelegateSubAgentPolicy | undefined): string[] {
+function formatDelegationPolicyInstructions(
+	policy: DelegateSubAgentPolicy | undefined,
+	toolName: string,
+): string[] {
 	if (policy?.maxChildren === undefined) return [];
 
 	const runLabel = policy.maxChildren === 1 ? 'run' : 'runs';
@@ -363,7 +414,7 @@ function formatDelegationPolicyInstructions(policy: DelegateSubAgentPolicy | und
 			'DELEGATION PARALLELISM:',
 			`- Up to ${policy.maxChildren} child sub-agent ${runLabel} can execute at the same time.`,
 			'- This limits parallelism, not the total number of delegated tasks.',
-			'- If more independent workstreams are useful, you may issue more delegate_subagent calls; the runtime will run them in batches.',
+			`- If more independent workstreams are useful, you may issue more ${toolName} calls; the runtime will run them in batches.`,
 		].join('\n'),
 	];
 }

--- a/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/delegate-sub-agent-tool.ts
@@ -163,15 +163,6 @@ export interface DelegateSubAgentToolOutput {
 }
 
 /**
- * Options for the `delegate_subagent` tool.
- *
- * You supply `runSubAgent` — the host callback that actually runs the child for
- * a delegation and returns its result. Everything else (input/output schema,
- * system prompt, task-path bookkeeping, parallelism policy, and the
- * `subagent-started` / `-completed` lifecycle events) is owned by
- * the tool.
- */
-/**
  * Helpers passed to a host `runSubAgent` callback so the host can route
  * `subAgentId: "inline"` while reusing the SDK inline child runner implementation.
  */
@@ -190,7 +181,12 @@ export type DelegateSubAgentRunner = (
 ) => Promise<DelegateSubAgentToolOutput>;
 
 export interface CreateDelegateSubAgentToolOptions {
+	/** Model-facing tool name. Defaults to {@link DELEGATE_SUB_AGENT_TOOL_NAME}; the default description and system instruction adapt to it. */
 	name?: string;
+	/** Model-facing tool description. Anything other than a non-blank string falls back to the built-in text. */
+	description?: string | null;
+	/** System-prompt delegation guidance. Anything other than a non-blank string falls back to the built-in guidance. */
+	systemInstruction?: string | null;
 	/**
 	 * Sub-agents the model may choose between. Listed in the system prompt; the
 	 * model selects one by passing its id as `subAgentId`.
@@ -216,13 +212,79 @@ export interface CreateDelegateSubAgentToolOptions {
 	 * `helpers.runInlineSubAgent` for inline work.
 	 */
 	runSubAgent?: DelegateSubAgentRunner;
-	systemInstruction?: string | null;
-	description?: string | null;
 
 	toModelOutput?: (output: z.infer<typeof delegateSubAgentOutputSchema>) => unknown;
 }
 
 export type DelegateSubAgentToolMetadata = CreateDelegateSubAgentToolOptions;
+
+function resolveDelegateSubAgentPolicy(
+	policy: DelegateSubAgentPolicy | undefined,
+	toolName: string,
+): DelegateSubAgentPolicy {
+	const resolvedPolicy = {
+		...policy,
+		maxChildren: policy?.maxChildren ?? DEFAULT_SUB_AGENT_MAX_CHILDREN,
+	};
+
+	if (
+		!Number.isFinite(resolvedPolicy.maxChildren) ||
+		!Number.isInteger(resolvedPolicy.maxChildren)
+	) {
+		throw new Error(`${toolName} policy.maxChildren must be a finite positive integer`);
+	}
+
+	if (resolvedPolicy.maxChildren < 1) {
+		throw new Error(`${toolName} policy.maxChildren must be at least 1`);
+	}
+
+	return resolvedPolicy;
+}
+
+const DELEGATE_SUB_AGENT_TOOL_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/;
+
+function resolveDelegateSubAgentToolName(name: string | undefined): string {
+	if (name === undefined) return DELEGATE_SUB_AGENT_TOOL_NAME;
+	if (!DELEGATE_SUB_AGENT_TOOL_NAME_PATTERN.test(name)) {
+		throw new Error(
+			`Invalid delegate sub-agent tool name "${name}": must start with a letter and contain only letters, digits, underscores, and hyphens (max 64 characters)`,
+		);
+	}
+	return name;
+}
+
+const DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION =
+	'Delegate a bounded, self-contained subtask to a focused child agent that runs in an isolated context and returns only a concise final result. ' +
+	'Use it for reasoning-heavy subtasks, context-flooding investigations, or independent workstreams inside a larger deliverable. ' +
+	'Do not use it for trivial work, single tool calls, mechanical steps, tasks that need hidden conversation context, or pass-through delegation of the entire user request.';
+
+function resolveDelegateSubAgentDescription(options: CreateDelegateSubAgentToolOptions): string {
+	const { description } = options;
+	if (typeof description === 'string' && description.trim().length > 0) return description;
+
+	return DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION;
+}
+
+function resolveDelegateSubAgentSystemInstruction(
+	options: CreateDelegateSubAgentToolOptions,
+	toolName: string,
+	inlineProviderToolInstruction: string,
+): string {
+	const { systemInstruction } = options;
+	if (typeof systemInstruction === 'string' && systemInstruction.trim().length > 0) {
+		return systemInstruction;
+	}
+
+	return [
+		`${toolName} runs a focused child agent in a fresh, isolated context and returns only its final answer. Always set subAgentId. Use subAgentId: "inline" to run a one-off inline child that inherits your local and deferred tools after safety filtering. ${inlineProviderToolInstruction} The child cannot see this conversation or your memory, so everything it needs must be in the call.`,
+		'Use a configured subagent ID only when one is listed and its name and useWhen guidance fit the subtask better than a generic inline child.',
+		...formatAvailableSubAgents(options.availableSubAgents),
+		...formatDelegationPolicyInstructions(options.policy, toolName),
+		`WHEN TO USE ${toolName}:\n- The request decomposes into 2+ independent workstreams that can be handled separately.\n- A workstream needs substantial research, review, comparison, or analysis.\n- Doing the work inline would flood your context with intermediate findings.\n- A fresh isolated perspective would materially improve a bounded subtask.`,
+		`WHEN NOT TO USE ${toolName}:\n- Single-step mechanical work: do it directly.\n- Trivial tasks or one/two tool calls: do them yourself.\n- Tasks that need user interaction or hidden conversation context.\n- Your core synthesis, final judgment, or recommendation.\n- The entire user request as one delegated task; that is pass-through with no value added.`,
+		`HOW TO DELEGATE:\n- Delegate bounded workstreams, not the final answer.\n- Pass all required context, constraints, language/tone, and expected output.\n- Set difficulty (low, medium, or high) when you can estimate task complexity; omit it to keep the default inline model.\n- If multiple independent workstreams exist, delegate them separately.\n- Inline children inherit your local and deferred tools after safety filtering. ${inlineProviderToolInstruction}\n- Inspect results and synthesize the final response yourself.\n- Verify side-effect claims before presenting them as done.`,
+	].join('\n');
+}
 
 /**
  * Build the generic `delegate_subagent` tool — lets a parent agent hand a
@@ -241,94 +303,27 @@ export type DelegateSubAgentToolMetadata = CreateDelegateSubAgentToolOptions;
  *     policy: { maxChildren: 10 },
  *   }));
  */
-function resolveDelegateSubAgentPolicy(
-	policy: DelegateSubAgentPolicy | undefined,
-): DelegateSubAgentPolicy {
-	const resolvedPolicy = {
-		...policy,
-		maxChildren: policy?.maxChildren ?? DEFAULT_SUB_AGENT_MAX_CHILDREN,
-	};
-
-	if (
-		!Number.isFinite(resolvedPolicy.maxChildren) ||
-		!Number.isInteger(resolvedPolicy.maxChildren)
-	) {
-		throw new Error('delegate_subagent policy.maxChildren must be a finite positive integer');
-	}
-
-	if (resolvedPolicy.maxChildren < 1) {
-		throw new Error('delegate_subagent policy.maxChildren must be at least 1');
-	}
-
-	return resolvedPolicy;
-}
-
-const DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION =
-	'Delegate a bounded, self-contained subtask to a focused child agent that runs in an isolated context and returns only a concise final result. ' +
-	'Use it for reasoning-heavy subtasks, context-flooding investigations, or independent workstreams inside a larger deliverable. ' +
-	'Do not use it for trivial work, single tool calls, mechanical steps, tasks that need hidden conversation context, or pass-through delegation of the entire user request.';
-
-function resolveDelegateSubAgentDescription(
-	options: CreateDelegateSubAgentToolOptions,
-	toolName: string,
-): string {
-	if (options.description !== undefined) {
-		if (options.description === null || options.description.trim().length === 0) {
-			return toolName;
-		}
-		return options.description;
-	}
-
-	return DEFAULT_DELEGATE_SUB_AGENT_DESCRIPTION;
-}
-
-function resolveDelegateSubAgentSystemInstruction(
-	options: CreateDelegateSubAgentToolOptions,
-	toolName: string,
-	inlineProviderToolInstruction: string,
-): string | undefined {
-	if (options.systemInstruction !== undefined) {
-		if (options.systemInstruction === null || options.systemInstruction.trim().length === 0) {
-			return undefined;
-		}
-		return options.systemInstruction;
-	}
-
-	return [
-		`${toolName} runs a focused child agent in a fresh, isolated context and returns only its final answer. Always set subAgentId. Use subAgentId: "inline" to run a one-off inline child that inherits your local and deferred tools after safety filtering. ${inlineProviderToolInstruction} The child cannot see this conversation or your memory, so everything it needs must be in the call.`,
-		'Use a configured subagent ID only when one is listed and its name and useWhen guidance fit the subtask better than a generic inline child.',
-		...formatAvailableSubAgents(options.availableSubAgents),
-		...formatDelegationPolicyInstructions(options.policy, toolName),
-		`WHEN TO USE ${toolName}:\n- The request decomposes into 2+ independent workstreams that can be handled separately.\n- A workstream needs substantial research, review, comparison, or analysis.\n- Doing the work inline would flood your context with intermediate findings.\n- A fresh isolated perspective would materially improve a bounded subtask.`,
-		`WHEN NOT TO USE ${toolName}:\n- Single-step mechanical work: do it directly.\n- Trivial tasks or one/two tool calls: do them yourself.\n- Tasks that need user interaction or hidden conversation context.\n- Your core synthesis, final judgment, or recommendation.\n- The entire user request as one delegated task; that is pass-through with no value added.`,
-		`HOW TO DELEGATE:\n- Delegate bounded workstreams, not the final answer.\n- Pass all required context, constraints, language/tone, and expected output.\n- Set difficulty (low, medium, or high) when you can estimate task complexity; omit it to keep the default inline model.\n- If multiple independent workstreams exist, delegate them separately.\n- Inline children inherit your local and deferred tools after safety filtering. ${inlineProviderToolInstruction}\n- Inspect results and synthesize the final response yourself.\n- Verify side-effect claims before presenting them as done.`,
-	].join('\n');
-}
-
 export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOptions = {}) {
 	// Per-parent child path index for stable task paths (/root/name_0, /root/name_1, ...).
 	const childPathIndexes = new Map<string, number>();
+	const toolName = resolveDelegateSubAgentToolName(options.name);
 	const resolvedOptions: CreateDelegateSubAgentToolOptions = {
 		...options,
-		policy: resolveDelegateSubAgentPolicy(options.policy),
+		policy: resolveDelegateSubAgentPolicy(options.policy, toolName),
 	};
-	const toolName = resolvedOptions.name ?? DELEGATE_SUB_AGENT_TOOL_NAME;
 	const inlineProviderToolInstruction = resolvedOptions.resolveInlineSubAgentProviderTools
 		? "Provider-defined tools are loaded for the inline child's selected model provider."
 		: 'Inline children do not inherit provider-defined tools.';
-	const systemInstruction = resolveDelegateSubAgentSystemInstruction(
-		resolvedOptions,
-		toolName,
-		inlineProviderToolInstruction,
-	);
-	const description = resolveDelegateSubAgentDescription(resolvedOptions, toolName);
 
-	let toolBuilder = new Tool(toolName).description(description);
-	if (systemInstruction !== undefined) {
-		toolBuilder = toolBuilder.systemInstruction(systemInstruction);
-	}
-
-	const tool = toolBuilder
+	const tool = new Tool(toolName)
+		.description(resolveDelegateSubAgentDescription(resolvedOptions))
+		.systemInstruction(
+			resolveDelegateSubAgentSystemInstruction(
+				resolvedOptions,
+				toolName,
+				inlineProviderToolInstruction,
+			),
+		)
 		.input(delegateSubAgentInputSchema)
 		.output(delegateSubAgentOutputSchema)
 		.handler(
@@ -381,11 +376,16 @@ export function createDelegateSubAgentTool(options: CreateDelegateSubAgentToolOp
 }
 
 export function getInlineDelegateSubAgentToolOptions(
-	tool: BuiltTool,
+	tool: Pick<BuiltTool, 'metadata'>,
 ): DelegateSubAgentToolMetadata | undefined {
 	const value = tool.metadata?.[INLINE_DELEGATE_SUB_AGENT_TOOL_METADATA_KEY];
 	if (typeof value !== 'object' || value === null) return undefined;
 	return value as DelegateSubAgentToolMetadata;
+}
+
+/** Whether a tool is a delegate sub-agent tool built by {@link createDelegateSubAgentTool}, regardless of its configured name. */
+export function isDelegateSubAgentTool(tool: Pick<BuiltTool, 'name' | 'metadata'>): boolean {
+	return getInlineDelegateSubAgentToolOptions(tool) !== undefined;
 }
 
 function formatAvailableSubAgents(
@@ -464,15 +464,16 @@ async function handleDelegateSubAgent(
 
 		startedAt = Date.now();
 		emitSubAgentStarted(ctx, request, startedAt);
+		const toolName = options.name ?? DELEGATE_SUB_AGENT_TOOL_NAME;
 		if (!options.runSubAgent) {
 			throw new Error(
-				'delegate_subagent was registered without a runSubAgent callback, and no host runner was provided. Register it on an Agent (for inline delegation) or pass runSubAgent.',
+				`${toolName} was registered without a runSubAgent callback, and no host runner was provided. Register it on an Agent (for inline delegation) or pass runSubAgent.`,
 			);
 		}
 		const output = await options.runSubAgent(request, {
 			runInlineSubAgent: () => {
 				throw new Error(
-					'delegate_subagent host runner does not support inline delegation without helpers.runInlineSubAgent from an Agent build.',
+					`${toolName} host runner does not support inline delegation without helpers.runInlineSubAgent from an Agent build.`,
 				);
 			},
 		});

--- a/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
+++ b/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
@@ -1,9 +1,6 @@
 import { zodToJsonSchema, type JsonSchema7Type } from 'zod-to-json-schema';
 
-import {
-	DELEGATE_SUB_AGENT_TOOL_NAME,
-	getInlineDelegateSubAgentToolOptions,
-} from './delegate-sub-agent-tool';
+import { getInlineDelegateSubAgentToolOptions } from './delegate-sub-agent-tool';
 import { toJsonValue } from '../json-value';
 import { DEFAULT_SUB_AGENT_MAX_CHILDREN } from './sub-agent-task-path';
 import { executeTool, isSuspendedToolResult, type SuspendedToolResult } from './tool-adapter';
@@ -186,12 +183,13 @@ export class ToolCallExecutor {
 		return this.deps.concurrency;
 	}
 
-	private isDelegateSubAgentCall(toolName: string): boolean {
-		return toolName === DELEGATE_SUB_AGENT_TOOL_NAME;
+	private isDelegateSubAgentCall(toolName: string, toolMap: Map<string, BuiltTool>): boolean {
+		const tool = toolMap.get(toolName);
+		return tool !== undefined && getInlineDelegateSubAgentToolOptions(tool) !== undefined;
 	}
 
 	private getToolCallBatchSize(toolName: string, toolMap: Map<string, BuiltTool>): number {
-		if (!this.isDelegateSubAgentCall(toolName)) return this.concurrency;
+		if (!this.isDelegateSubAgentCall(toolName, toolMap)) return this.concurrency;
 
 		const tool = toolMap.get(toolName);
 		const delegateOptions = tool ? getInlineDelegateSubAgentToolOptions(tool) : undefined;
@@ -208,7 +206,7 @@ export class ToolCallExecutor {
 			throw new Error('Unable to build tool-call batch');
 		}
 
-		const isDelegateBatch = this.isDelegateSubAgentCall(first.toolName);
+		const isDelegateBatch = this.isDelegateSubAgentCall(first.toolName, toolMap);
 		const batchSize = this.getToolCallBatchSize(first.toolName, toolMap);
 		if (
 			batchSize < 1 ||
@@ -221,7 +219,7 @@ export class ToolCallExecutor {
 
 		for (let i = start; i < calls.length && batch.length < batchSize; i++) {
 			const candidate = calls[i];
-			if (this.isDelegateSubAgentCall(candidate.toolName) !== isDelegateBatch) break;
+			if (this.isDelegateSubAgentCall(candidate.toolName, toolMap) !== isDelegateBatch) break;
 			batch.push(candidate);
 		}
 
@@ -231,7 +229,7 @@ export class ToolCallExecutor {
 	/**
 	 * Execute tool calls concurrently in batches.
 	 *
-	 * Regular tools use `toolCallConcurrency`. Consecutive `delegate_subagent`
+	 * Regular tools use `toolCallConcurrency`. Consecutive delegate-subagent
 	 * calls use the effective `maxChildren` policy from the built delegate tool.
 	 * Provider-executed calls are skipped.
 	 *

--- a/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
+++ b/packages/@n8n/agents/src/runtime/tools/tool-call-executor.ts
@@ -1,6 +1,9 @@
 import { zodToJsonSchema, type JsonSchema7Type } from 'zod-to-json-schema';
 
-import { getInlineDelegateSubAgentToolOptions } from './delegate-sub-agent-tool';
+import {
+	getInlineDelegateSubAgentToolOptions,
+	isDelegateSubAgentTool,
+} from './delegate-sub-agent-tool';
 import { toJsonValue } from '../json-value';
 import { DEFAULT_SUB_AGENT_MAX_CHILDREN } from './sub-agent-task-path';
 import { executeTool, isSuspendedToolResult, type SuspendedToolResult } from './tool-adapter';
@@ -185,15 +188,14 @@ export class ToolCallExecutor {
 
 	private isDelegateSubAgentCall(toolName: string, toolMap: Map<string, BuiltTool>): boolean {
 		const tool = toolMap.get(toolName);
-		return tool !== undefined && getInlineDelegateSubAgentToolOptions(tool) !== undefined;
+		return tool !== undefined && isDelegateSubAgentTool(tool);
 	}
 
 	private getToolCallBatchSize(toolName: string, toolMap: Map<string, BuiltTool>): number {
-		if (!this.isDelegateSubAgentCall(toolName, toolMap)) return this.concurrency;
-
 		const tool = toolMap.get(toolName);
 		const delegateOptions = tool ? getInlineDelegateSubAgentToolOptions(tool) : undefined;
-		return delegateOptions?.policy?.maxChildren ?? DEFAULT_SUB_AGENT_MAX_CHILDREN;
+		if (!delegateOptions) return this.concurrency;
+		return delegateOptions.policy?.maxChildren ?? DEFAULT_SUB_AGENT_MAX_CHILDREN;
 	}
 
 	private takeNextToolCallBatch<T extends { toolName: string }>(

--- a/packages/@n8n/agents/src/runtime/tools/write-todos-tool.ts
+++ b/packages/@n8n/agents/src/runtime/tools/write-todos-tool.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
-import { SUB_AGENT_TASK_DIFFICULTIES } from './delegate-sub-agent-tool';
+import {
+	DELEGATE_SUB_AGENT_TOOL_NAME,
+	SUB_AGENT_TASK_DIFFICULTIES,
+} from './delegate-sub-agent-tool';
 import { withSdkOwnedBuiltInMetadata } from './sdk-owned-tool';
 import { Tool } from '../../sdk/tool';
 import type { BuiltTool } from '../../types/sdk/tool';
@@ -11,93 +14,116 @@ const todoStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'blocked
 
 const todoDifficultySchema = z.enum(SUB_AGENT_TASK_DIFFICULTIES);
 
-const todoDelegateHintSchema = z
-	.object({
-		subAgentId: z
-			.string()
-			.optional()
-			.describe(
-				'Optional sub-agent id when this task is a delegate_subagent candidate. Use "inline" for one-off inline sub-agents.',
-			),
-		expectedOutput: z
-			.string()
-			.optional()
-			.describe('Optional expected output shape when delegating this task.'),
-	})
-	.optional();
+function buildTodoItemSchema(delegateToolName: string) {
+	const todoDelegateHintSchema = z
+		.object({
+			subAgentId: z
+				.string()
+				.optional()
+				.describe(
+					`Optional sub-agent id when this task is a ${delegateToolName} candidate. Use "inline" for one-off inline sub-agents.`,
+				),
+			expectedOutput: z
+				.string()
+				.optional()
+				.describe('Optional expected output shape when delegating this task.'),
+		})
+		.optional();
 
-const todoItemSchema = z.object({
-	id: z.string().min(1).describe('Stable identifier for this task within the current plan.'),
-	content: z.string().min(1).describe('Concrete, self-contained task description.'),
-	status: todoStatusSchema,
-	difficulty: todoDifficultySchema.describe(
-		'Task difficulty: "low", "medium", or "high". Use the same value when delegating this task with delegate_subagent.',
-	),
-	delegateHint: todoDelegateHintSchema,
-});
-
-const writeTodosInputSchema = z
-	.object({
-		todos: z
-			.array(todoItemSchema)
-			.describe('Full task list for the current run. Replaces any previous list.'),
-	})
-	.superRefine((value, ctx) => {
-		const seen = new Set<string>();
-		for (const [index, todo] of value.todos.entries()) {
-			if (seen.has(todo.id)) {
-				ctx.addIssue({
-					code: 'custom',
-					message: `Duplicate todo id "${todo.id}". Each task must have a unique id.`,
-					path: ['todos', index, 'id'],
-				});
-			}
-			seen.add(todo.id);
-		}
+	return z.object({
+		id: z.string().min(1).describe('Stable identifier for this task within the current plan.'),
+		content: z.string().min(1).describe('Concrete, self-contained task description.'),
+		status: todoStatusSchema,
+		difficulty: todoDifficultySchema.describe(
+			`Task difficulty: "low", "medium", or "high". Use the same value when delegating this task with ${delegateToolName}.`,
+		),
+		delegateHint: todoDelegateHintSchema,
 	});
+}
 
-const writeTodosOutputSchema = z.object({
-	status: z.literal('ok'),
-	todoCount: z.number(),
-	todos: z.array(todoItemSchema),
-});
+type TodoItemSchema = ReturnType<typeof buildTodoItemSchema>;
 
-const WRITE_TODOS_DESCRIPTION =
-	'Create or update a structured task list for complex agent work. Use it to decompose a larger request into concrete workstreams, track progress, and identify which tasks should be handled separately with delegate_subagent. Do not use it for trivial work, single-step tasks, or purely conversational answers. This tool only updates the task list; it does not run sub-agents or answer the user.';
+function buildWriteTodosInputSchema(todoItemSchema: TodoItemSchema) {
+	return z
+		.object({
+			todos: z
+				.array(todoItemSchema)
+				.describe('Full task list for the current run. Replaces any previous list.'),
+		})
+		.superRefine((value, ctx) => {
+			const seen = new Set<string>();
+			for (const [index, todo] of value.todos.entries()) {
+				if (seen.has(todo.id)) {
+					ctx.addIssue({
+						code: 'custom',
+						message: `Duplicate todo id "${todo.id}". Each task must have a unique id.`,
+						path: ['todos', index, 'id'],
+					});
+				}
+				seen.add(todo.id);
+			}
+		});
+}
 
-const WRITE_TODOS_SYSTEM_INSTRUCTION = [
-	'write_todos helps you plan and track complex objectives before and during execution. It updates the current task list only; it does not complete tasks, run sub-agents, or answer the user.',
-	'WHEN TO USE write_todos:',
-	'- The user request has 3+ meaningful steps or multiple deliverables.',
-	'- The request decomposes into 2+ independent workstreams.',
-	'- Some workstreams are good candidates for delegate_subagent.',
-	'- You need to track progress, revise the plan, or avoid losing context.',
-	'WHEN NOT TO USE write_todos:',
-	'- The request is trivial, conversational, or informational.',
-	'- The task can be completed directly in one or two simple steps.',
-	"- You would only create a todo list to restate the user's request.",
-	'HOW TO USE write_todos:',
-	'- Write concrete, self-contained tasks, not vague phases.',
-	'- Assign difficulty to every task: low for simple mechanical or localized work, medium for normal implementation or review requiring judgment, high for complex, broad, ambiguous, or high-risk work.',
-	'- Mark the first active task, or independent active tasks, as in_progress immediately.',
-	'- For sub-agent-worthy work, create one todo per bounded workstream, then call delegate_subagent separately for that task; pass the same difficulty on the delegate call.',
-	'- Do not delegate the entire user request as one task.',
-	'- Update task status as soon as work completes; do not batch completions at the end.',
-	'- Revise the list when new information changes the plan.',
-	'- Do not call write_todos multiple times in parallel; send one full list update at a time.',
-	'- After all work is done, send the final answer as normal assistant text after the last write_todos call.',
-].join('\n');
+function buildWriteTodosOutputSchema(todoItemSchema: TodoItemSchema) {
+	return z.object({
+		status: z.literal('ok'),
+		todoCount: z.number(),
+		todos: z.array(todoItemSchema),
+	});
+}
+
+function buildWriteTodosDescription(delegateToolName: string): string {
+	return `Create or update a structured task list for complex agent work. Use it to decompose a larger request into concrete workstreams, track progress, and identify which tasks should be handled separately with ${delegateToolName}. Do not use it for trivial work, single-step tasks, or purely conversational answers. This tool only updates the task list; it does not run sub-agents or answer the user.`;
+}
+
+function buildWriteTodosSystemInstruction(delegateToolName: string): string {
+	return [
+		'write_todos helps you plan and track complex objectives before and during execution. It updates the current task list only; it does not complete tasks, run sub-agents, or answer the user.',
+		'WHEN TO USE write_todos:',
+		'- The user request has 3+ meaningful steps or multiple deliverables.',
+		'- The request decomposes into 2+ independent workstreams.',
+		`- Some workstreams are good candidates for ${delegateToolName}.`,
+		'- You need to track progress, revise the plan, or avoid losing context.',
+		'WHEN NOT TO USE write_todos:',
+		'- The request is trivial, conversational, or informational.',
+		'- The task can be completed directly in one or two simple steps.',
+		"- You would only create a todo list to restate the user's request.",
+		'HOW TO USE write_todos:',
+		'- Write concrete, self-contained tasks, not vague phases.',
+		'- Assign difficulty to every task: low for simple mechanical or localized work, medium for normal implementation or review requiring judgment, high for complex, broad, ambiguous, or high-risk work.',
+		'- Mark the first active task, or independent active tasks, as in_progress immediately.',
+		`- For sub-agent-worthy work, create one todo per bounded workstream, then call ${delegateToolName} separately for that task; pass the same difficulty on the delegate call.`,
+		'- Do not delegate the entire user request as one task.',
+		'- Update task status as soon as work completes; do not batch completions at the end.',
+		'- Revise the list when new information changes the plan.',
+		'- Do not call write_todos multiple times in parallel; send one full list update at a time.',
+		'- After all work is done, send the final answer as normal assistant text after the last write_todos call.',
+	].join('\n');
+}
+
+export interface CreateWriteTodosToolOptions {
+	/**
+	 * Name of the delegate sub-agent tool referenced in the planner guidance.
+	 * Defaults to {@link DELEGATE_SUB_AGENT_TOOL_NAME}; pass the custom name when
+	 * the host renamed the delegate tool so the guidance points at a real tool.
+	 */
+	delegateToolName?: string;
+}
 
 /**
  * Build the planner-only `write_todos` tool — lets a parent agent maintain a
  * structured task list for complex work without auto-dispatching sub-agents.
  */
-export function createWriteTodosTool(): BuiltTool {
+export function createWriteTodosTool(options: CreateWriteTodosToolOptions = {}): BuiltTool {
+	const delegateToolName = options.delegateToolName ?? DELEGATE_SUB_AGENT_TOOL_NAME;
+	const todoItemSchema = buildTodoItemSchema(delegateToolName);
+
 	const tool = new Tool(WRITE_TODOS_TOOL_NAME)
-		.description(WRITE_TODOS_DESCRIPTION)
-		.systemInstruction(WRITE_TODOS_SYSTEM_INSTRUCTION)
-		.input(writeTodosInputSchema)
-		.output(writeTodosOutputSchema)
+		.description(buildWriteTodosDescription(delegateToolName))
+		.systemInstruction(buildWriteTodosSystemInstruction(delegateToolName))
+		.input(buildWriteTodosInputSchema(todoItemSchema))
+		.output(buildWriteTodosOutputSchema(todoItemSchema))
 		.handler(async (input) => {
 			const todos = [...input.todos];
 

--- a/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/inline-sub-agent-tools.test.ts
@@ -132,6 +132,12 @@ describe('inline sub-agent tool filtering', () => {
 			blockedTools: ['host_tool'],
 			expected: ['lookup'],
 		},
+		{
+			name: 'blocks a renamed delegate tool by metadata, not by tool name',
+			tools: [createDelegateSubAgentTool({ name: 'agent' }), makeTool('lookup')],
+			blockedTools: undefined,
+			expected: ['lookup'],
+		},
 	])('$name', ({ tools, blockedTools, expected }) => {
 		expect(filterInlineSubAgentTools(tools, blockedTools).map((tool) => tool.name)).toEqual(
 			expected,

--- a/packages/@n8n/agents/src/sdk/__tests__/tool-name-collisions.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/tool-name-collisions.test.ts
@@ -49,4 +49,16 @@ describe('SDK reserved built-in tool names', () => {
 		]);
 		expect(agent.declaredTools.every((tool) => isSdkOwnedBuiltInTool(tool))).toBe(true);
 	});
+
+	it('allows a delegate tool renamed to a non-reserved name', () => {
+		const agent = makeAgent().tool(createDelegateSubAgentTool({ name: 'agent' }));
+
+		expect(agent.declaredTools.map((tool) => tool.name)).toEqual(['agent']);
+	});
+
+	it('rejects a delegate tool renamed to another reserved built-in name', () => {
+		expect(() =>
+			makeAgent().tool(createDelegateSubAgentTool({ name: WRITE_TODOS_TOOL_NAME })),
+		).toThrow(`Tool name "${WRITE_TODOS_TOOL_NAME}" is reserved for SDK built-in tools`);
+	});
 });

--- a/packages/@n8n/agents/src/sdk/agent.ts
+++ b/packages/@n8n/agents/src/sdk/agent.ts
@@ -26,6 +26,7 @@ import {
 	failedDelegatedChildSuspendOutput,
 	generateResultToDelegateSubAgentOutput,
 	getInlineDelegateSubAgentToolOptions,
+	isDelegateSubAgentTool,
 	renderDelegateSubAgentPrompt,
 	type DelegateSubAgentRequest,
 	type DelegateSubAgentToolOutput,
@@ -1139,7 +1140,11 @@ export class Agent implements BuiltAgent, AgentBuilder {
 
 	private assertReservedSdkBuiltInToolName(tool: BuiltTool): void {
 		if (!SDK_RESERVED_BUILTIN_TOOL_NAMES.has(tool.name)) return;
-		if (isSdkOwnedBuiltInTool(tool)) return;
+		if (isDelegateSubAgentTool(tool)) {
+			if (tool.name === DELEGATE_SUB_AGENT_TOOL_NAME) return;
+		} else if (isSdkOwnedBuiltInTool(tool)) {
+			return;
+		}
 
 		throw new Error(`Tool name "${tool.name}" is reserved for SDK built-in tools`);
 	}
@@ -1210,7 +1215,7 @@ export function filterInlineSubAgentTools<T extends { readonly name: string }>(
 	hostBlockedTools?: string[],
 ): T[] {
 	const blocked = buildInlineSubAgentBlockedToolNames(hostBlockedTools);
-	return tools.filter((tool) => !blocked.has(tool.name));
+	return tools.filter((tool) => !blocked.has(tool.name) && !isDelegateSubAgentTool(tool));
 }
 
 function findDuplicateToolNames(tools: BuiltTool[]): string[] {


### PR DESCRIPTION
## Summary

SDK prerequisite for Instance AI sub-agent delegation ([#33583](https://github.com/n8n-io/n8n/pull/33583)).

Instance AI registers the delegate tool as `agent` and owns delegation guidance in its system prompt (`## Delegation / Sub-Agent Routing`). Without host overrides, the model would see duplicate, conflicting text: the SDK's built-in tool description plus WHEN TO USE / HOW TO DELEGATE system instruction, on top of Instance AI's own routing rules.

This PR makes the delegate tool's model-facing surface host-controlled while keeping SDK defaults for other consumers:

- **`name`** — expose the tool under a host-chosen name (e.g. `agent` instead of `delegate_subagent`). Custom names are validated (letter-first, alphanumeric/underscore/hyphen, max 64 chars). Default description and system instruction interpolate the chosen name; policy and runner error messages use it too.
- **`description`** — replace the built-in tool-list description. Blank or missing values keep the SDK default.
- **`systemInstruction`** — replace the built-in delegation guidance. Blank or missing values keep the SDK default so hosts can still supply guidance elsewhere (system prompt, skills, etc.) without duplicating SDK text.
- **Metadata-based detection** — delegate tools are identified via SDK-owned tool metadata (`isDelegateSubAgentTool`) instead of a hardcoded name. This keeps `maxChildren` batching, inline-child tool inheritance filtering, and reserved built-in name checks correct when the tool is renamed.
- **`write_todos` integration** — `createWriteTodosTool({ delegateToolName })` threads the configured delegate tool name into planner guidance and schema descriptions so renamed tools stay consistent across the planning and delegation flow.

Unset options preserve today's behavior (`delegate_subagent` name, default description, default system instruction).

## How to test

```bash
cd packages/@n8n/agents
pnpm typecheck
pnpm test src/runtime/__tests__/delegate-sub-agent-tool.test.ts
pnpm test src/runtime/__tests__/agent-runtime.test.ts
pnpm test src/runtime/__tests__/write-todos-tool.test.ts
pnpm test src/sdk/__tests__/inline-sub-agent-tools.test.ts
pnpm test src/sdk/__tests__/tool-name-collisions.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

- Prerequisite for Instance AI sub-agent delegation: [#33583](https://github.com/n8n-io/n8n/pull/33583)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI