### PR TITLE
test(core): Add Instance AI eval cases for recently merged builder changes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/confirmation-email-uses-source-not-slack-output.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/confirmation-email-uses-source-not-slack-output.json
@@ -1,0 +1,26 @@
+{
+	"description": "Regression guard for the 'Preserve Source Data' guardrail (PR #33530): send/notify nodes replace the current item JSON with their API response. The user asks for a Slack alert first, then a confirmation email that greets the customer and quotes their message — so an email step naively reading its input after the Slack node sees Slack's response (ok/channel/ts), not the customer's data. A correct build references the original webhook data (node reference to the trigger or a normalized source item, or a parallel branch).",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "When our contact form webhook receives a submission with the customer's name, email address, and message: first post an alert to Slack #support so the team sees it, then send the customer a confirmation email through our Gmail that greets them by name and quotes their original message back to them."
+		}
+	],
+	"complexity": "medium",
+	"tags": ["build", "webhook", "slack", "gmail", "source-data", "regression"],
+	"triggerType": "webhook",
+	"datasets": ["full"],
+	"outcomeExpectations": [
+		"An alert about the submission is posted to Slack #support.",
+		"A confirmation email is sent via a Gmail node to the submitter's email address, greeting them by name and quoting their original message.",
+		"The email's recipient, greeting name, and quoted message are drawn from the original webhook submission data (via a node reference to the trigger or a preserved/normalized source item, or a branch fed directly from the trigger) — not from the Slack node's output, which is Slack's API response rather than the customer's data."
+	],
+	"executionScenarios": [
+		{
+			"name": "confirmation-carries-source-fields",
+			"description": "One submission arrives; the Slack alert and the confirmation email both carry the customer's data.",
+			"dataSetup": "The webhook receives one submission: { \"name\": \"Maya Chen\", \"email\": \"maya.chen@example.com\", \"message\": \"My invoice PDF comes out empty.\" }. The Slack postMessage call returns { \"ok\": true, \"ts\": \"1700000000.0001\" }. The Gmail send call succeeds.",
+			"successCriteria": "The run completes; one Slack alert is posted to #support; one confirmation email is sent to maya.chen@example.com whose content includes the name 'Maya' and quotes the invoice message. An email addressed to or built from Slack response fields (undefined recipient, channel, ts) is a failure."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/notion-database-name-not-list-locator.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/notion-database-name-not-list-locator.json
@@ -1,0 +1,17 @@
+{
+	"description": "Regression guard for wrong-kind resource-locator values (PR #33530): the user names a Notion database by its human-readable title. The wrong build stuffs that title into a 'From list' or ID locator slot, which holds opaque IDs and fails at runtime. detectWrongKindLocatorValues now flags this deterministically during compile/setup; this case guards the loop end-to-end (warning → remediation → clean final workflow). No Notion credential is declared, so the agent cannot resolve the title by searching — the correct outcome leaves the database selection as a setup step (or a user-provided URL/ID), never the display name posing as an ID.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "When our lead form webhook receives a submission with the person's name and email, add them as a new entry in my Notion database called 'Q3 Sales Leads'."
+		}
+	],
+	"complexity": "simple",
+	"tags": ["build", "notion", "resource-locator", "webhook", "regression"],
+	"triggerType": "webhook",
+	"datasets": ["full"],
+	"outcomeExpectations": [
+		"For each webhook submission the workflow creates an entry in a Notion database via a Notion node wired from the webhook data, mapping the submitter's name and email.",
+		"No Notion resource locator carries the human-readable title 'Q3 Sales Leads' as if it were an identifier — a 'From list' or ID-mode locator must hold an opaque ID, never a display name. Leaving the database selection unset for the user to pick during setup, or using a URL/ID placeholder the user would provide, is the correct outcome here since no credential exists to search by name."
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/order-fulfillment-tolerates-slack-failure.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/order-fulfillment-tolerates-slack-failure.json
@@ -1,0 +1,41 @@
+{
+	"description": "Guards the 'Keep Effects Independent' guardrail (PR #33530): a nice-to-have Slack notification must not block or fail order fulfillment. The correct build makes the Slack step error-tolerant (continue-on-error or an error branch) instead of the default abort-on-error, keeps both effects as real action nodes, and the fulfillment POST executes even when Slack errors. Calibrated 2026-07-07: all units green; the Slack failure is exercised in the Phase-2 scenario (dataSetup governs scenario execution, not the agent's own build-time verification mocks — a transcript-side assertion about the Slack error happening during the agent's verify is unjudgeable here; that regression lives in verify-surfaces-node-error-when-run-succeeds).",
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"When our order webhook receives a new order, send it to our fulfillment system by POSTing the order JSON to https://api.fulfillment.example.com/orders, and also post a short notification about the order to Slack #orders.",
+				"The Slack notification is nice-to-have: if posting to Slack fails for any reason, the order must still reach the fulfillment API. We also monitor failed executions, so a Slack hiccup shouldn't make the whole run count as failed — we don't want noise from that.",
+				"After building, verify the workflow by running it."
+			]
+		}
+	],
+	"complexity": "medium",
+	"tags": [
+		"build",
+		"continue-on-fail",
+		"effects-independent",
+		"webhook",
+		"slack",
+		"http-request",
+		"regression"
+	],
+	"triggerType": "webhook",
+	"datasets": ["full"],
+	"outcomeExpectations": [
+		"A webhook trigger receives the order and the order data is POSTed to https://api.fulfillment.example.com/orders.",
+		"A Slack node posts a notification about the order to the #orders channel.",
+		"The Slack step is error-tolerant — configured to continue on error or routed through an error branch — so a Slack failure neither prevents the fulfillment POST nor fails the whole execution. The default abort-on-error behavior on the Slack node does not satisfy the user's no-noise requirement."
+	],
+	"processExpectations": [
+		"The agent did not satisfy the failure-tolerance requirement by removing the Slack step, disabling it, or making the fulfillment POST conditional on Slack succeeding — the user asked for both effects, with Slack merely tolerated to fail."
+	],
+	"executionScenarios": [
+		{
+			"name": "slack-fails-order-still-fulfilled",
+			"description": "The Slack post errors but the order still reaches the fulfillment API and the run is not aborted.",
+			"dataSetup": "The webhook receives one order: { \"orderId\": \"ORD-1042\", \"item\": \"Standing desk\", \"quantity\": 1, \"customerEmail\": \"sam@example.com\" }. The fulfillment POST to api.fulfillment.example.com returns 201 { \"status\": \"accepted\" }. The Slack postMessage call FAILS: it returns { \"ok\": false, \"error\": \"channel_not_found\" } so the Slack node raises an error.",
+			"successCriteria": "The run completes with the fulfillment POST executed (the order reaches the API) despite the Slack node erroring. The Slack failure does not abort the execution or prevent fulfillment."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/targeted-edit-preserves-configured-details.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/targeted-edit-preserves-configured-details.json
@@ -1,0 +1,43 @@
+{
+	"description": "Regression guard for parameter fidelity on follow-up edits after inspect actions moved to parameter-stripped structure summaries (PRs #33541, #33604): the user pins several concrete details in the initial build, then asks for exactly one change (the schedule time). A correct edit is surgical; a build that regenerates the workflow from a structural summary loses the pinned URL, channel, gating, or message prefix and turns this red.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Every weekday at 7:30am, fetch our status feed at https://status.acme-tools.dev/api/v1/incidents. If there are any open incidents, post a summary to Slack #ops-alerts starting with 'ACME status check:'. If there are none, do nothing."
+		},
+		{
+			"role": "user",
+			"text": [
+				"[After the agent finishes the build, ask for exactly one change: run at 8:15am instead of 7:30am. Say nothing about any other part of the workflow.",
+				"If the agent asks whether other details should change, tell it to keep everything else exactly as it is. Approve any plan or confirmation that only moves the time.]"
+			]
+		}
+	],
+	"messageBudget": 6,
+	"complexity": "medium",
+	"tags": ["behaviour", "edit", "targeted-change", "schedule", "http-request", "slack"],
+	"triggerType": "schedule",
+	"datasets": ["behaviour", "full"],
+	"outcomeExpectations": [
+		"The Schedule Trigger runs on weekdays at 8:15am — reflecting the user's follow-up change, not the original 7:30am.",
+		"The HTTP Request still fetches https://status.acme-tools.dev/api/v1/incidents — the schedule change did not alter or lose the feed URL.",
+		"The Slack summary still posts to #ops-alerts, still starts with 'ACME status check:', and is still gated by a conditional so nothing is posted when there are no open incidents — none of these configured details were lost by the schedule edit."
+	],
+	"processExpectations": [
+		"The agent applied the 8:15am change as a targeted edit without asking the user to restate the feed URL, the Slack channel, or the message format."
+	],
+	"executionScenarios": [
+		{
+			"name": "open-incidents-post-summary",
+			"description": "Open incidents exist, so one summary message is posted.",
+			"dataSetup": "The incidents feed returns two open incidents ('API latency elevated', 'Webhook delivery delayed') and one resolved incident. The Slack postMessage call returns { \"ok\": true, \"ts\": \"1700000000.0001\" }.",
+			"successCriteria": "The run completes and posts one Slack message to #ops-alerts that starts with 'ACME status check:' and reflects the open incidents. The resolved incident does not produce its own message."
+		},
+		{
+			"name": "no-open-incidents-no-post",
+			"description": "No open incidents, so nothing is posted.",
+			"dataSetup": "The incidents feed returns no open incidents (an empty list, or only resolved incidents).",
+			"successCriteria": "The run completes without error and no Slack message is posted."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/verify-surfaces-node-error-when-run-succeeds.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/verify-surfaces-node-error-when-run-succeeds.json
@@ -1,0 +1,37 @@
+{
+	"description": "Regression guard for node-level errors inside an overall-success verification run (PR #33576 / INS-783): a continue-on-error Code node genuinely throws during verification (n8n internals execute for real — the agent's verification mocks cannot simulate this away, unlike external HTTP calls), so the run completes with status success while deterministically carrying a node error. Guards the user-facing symptom: the agent must name the errored step instead of claiming the workflow fully verified with all nodes successful. Calibrated 2026-07-07 (pre-#33576 branch, opus-4-8): green — the error is visible in the node's continueRegularOutput item, so the current builder already surfaces it; the assertion is never vacuous (the throw always fires) and fails any 'fully verified' claim. Note: #33576's sharpest production shape was an erroring AI TOOL sub-node (supplyData error, invisible in item data) — a variant using that would discriminate the plumbing more directly but is hard to author deterministically. Sibling of workflow-verification-failed-loop-repro (run-level FAILURE variant).",
+	"conversation": [
+		{
+			"role": "user",
+			"text": [
+				"Build a workflow named \"node error with successful run repro\" with exactly this shape:",
+				"",
+				"Manual Trigger",
+				"→ Code node named \"Flaky enrichment\" whose body is exactly `throw new Error('Enrichment service offline');`, with its error handling set to continue with regular output — this step is known-flaky and must never block the rest of the run or make the execution count as failed",
+				"→ HTTP Request node named \"Record POST\" configured as POST to https://example.com/records with a small JSON body",
+				"",
+				"The Code node is meant to fail at runtime on purpose — it simulates a flaky enrichment service we cannot fix from inside the workflow. Do NOT change the Code node to succeed, do NOT wrap it in try/catch, do NOT remove or alter its continue-on-error setting, and do NOT remove the HTTP POST.",
+				"After saving, verify the workflow by running it."
+			]
+		}
+	],
+	"complexity": "medium",
+	"tags": ["behaviour", "verification", "node-error", "continue-on-fail", "regression", "manual"],
+	"triggerType": "manual",
+	"datasets": ["behaviour", "verification", "full"],
+	"outcomeExpectations": [
+		"The 'Flaky enrichment' Code node still contains the scripted throw (it was not rewritten to succeed, wrapped in try/catch, or removed) and its on-error behavior is set to continue with regular output.",
+		"The 'Record POST' HTTP Request node is present downstream of the Code node and is not gated on the enrichment step succeeding."
+	],
+	"processExpectations": [
+		"In its final message after verification, the agent told the user that the 'Flaky enrichment' step errored during the verification run (while the run as a whole completed) — it did not describe the workflow as fully verified or all nodes as having executed successfully with no mention of the enrichment failure."
+	],
+	"executionScenarios": [
+		{
+			"name": "node-error-run-still-succeeds",
+			"description": "The enrichment Code node throws; because it continues on error, the run completes and the POST still executes.",
+			"dataSetup": "The manual trigger provides one empty item. The Code node genuinely throws (real code execution, not mocked). The POST to example.com/records returns 200 { \"ok\": true }.",
+			"successCriteria": "The execution completes without overall failure: the 'Flaky enrichment' Code node records an error but the run continues, and the 'Record POST' HTTP request executes. The run is NOT reported as an overall failed execution."
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Adds 5 Instance AI workflow eval cases guarding recently merged builder-behavior changes that had no dedicated eval coverage. Each case was calibrated against a live instance (direct Daytona mode, opus-4-8, direct loop) with the built workflows and judge reasoning inspected

| Case | Guards | Calibration |
|---|---|---|
| `verify-surfaces-node-error-when-run-succeeds` | #33576 / INS-783 — node-level error inside a status-`success` verification run must be surfaced, not reported as fully verified | Green (see note below); the node error fires deterministically via a real Code-node `throw` with `onError: continueRegularOutput` — agent-side verification mocks cannot simulate it away |
| `order-fulfillment-tolerates-slack-failure` | #33530 "Keep Effects Independent" — a nice-to-have Slack step must not block or fail order fulfillment | 5/5 units green; builder used `onError: continueRegularOutput`; scenario proves fulfillment POST executes while Slack errors (`channel_not_found`) |
| `targeted-edit-preserves-configured-details` | #33541 / #33604 — after inspect actions moved to parameter-stripped structure summaries, a follow-up targeted edit (move schedule 7:30→8:15) must not lose pinned URL/channel/message-prefix/gating | 6/6 units green, including the no-open-incidents negative scenario |
| `notion-database-name-not-list-locator` | #33530 `detectWrongKindLocatorValues` loop end-to-end — user names a Notion database by title; a list/ID locator must never carry the display name as a value | 2/2 green; built workflow left the locator `mode: "list", value: ""` for setup instead of stuffing the title in |
| `confirmation-email-uses-source-not-slack-output` | #33530 "Preserve Source Data" — email step after a Slack post must read the webhook source (via `$('Trigger')`), not Slack's API response | 4/4 green; built Gmail node reads recipient/name/message from the trigger reference |

Calibration notes:

- The node-error case originally asserted the Slack mock failing *during the agent's own verification*: calibration showed `dataSetup` only governs Phase-2 scenario mocks, while build-time verification mocks simulate external success, making that assertion unjudgeable. It was redesigned around a real Code-node throw (internals execute for real), which makes the precondition fire deterministically: the judge confirmed the agent's verify run carried the node error inside an overall-success execution in both calibration runs.
- That case is a *currently-green regression guard*: calibrated on a pre-#33576 branch it already passes, because `continueRegularOutput` also exposes the error in the node's item output and the current builder reads it. It can never pass vacuously (the throw always fires) and it fails any "fully verified / all nodes succeeded" claim — the INS-783 production symptom. The sharpest discriminator for #33576's plumbing would be an erroring AI *tool* sub-node (supplyData error, invisible in item data); noted in the case description as a possible follow-up.
- All cases are in the `full` tier (plus `behaviour`/`verification` where apt); none in `pr` — gate promotion should wait for `--iterations 5+` reliability evidence.

Several sibling PRs already ship their own evals (#33298, #33095, #33111/#32979, #33712), so these five deliberately target the gaps: #33576's verification reporting, #33541/#33604's summary-based inspection, and three #33530 guardrail patterns.

## How to test

Cases load via the strict schema (also enforced by the data-workflows schema unit tests in CI):

```bash
cd packages/@n8n/instance-ai
pnpm exec tsx -e "import {loadWorkflowTestCasesWithFiles} from './evaluations/index.ts'; console.log(loadWorkflowTestCasesWithFiles('verify-surfaces-node-error').length)"
```

Run against a live instance with Instance AI enabled (`N8N_ENABLED_MODULES=instance-ai`) and a working sandbox:

```bash
pnpm eval:instance-ai --base-url http://localhost:5678 --iterations 1 --verbose --keep-workflows \
  --filter verify-surfaces-node-error-when-run-succeeds,order-fulfillment-tolerates-slack-failure,targeted-edit-preserves-configured-details,notion-database-name-not-list-locator,confirmation-email-uses-source-not-slack-output
```

## Related Linear tickets, Github issues, and Community forum posts

Guards behavior introduced in #33576 (INS-783), #33541, #33604, and #33530. No dedicated Linear ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33763">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->