### PR TITLE
fix: Google Docs add default drive id when searching folders

### DIFF
--- a/packages/nodes-base/nodes/Google/Docs/GoogleDocs.node.ts
+++ b/packages/nodes-base/nodes/Google/Docs/GoogleDocs.node.ts
@@ -165,7 +165,7 @@ export class GoogleDocs implements INodeType {
 						value: 'default',
 					},
 				];
-				const driveId = this.getNodeParameter('driveId');
+				const driveId = this.getNodeParameter('driveId', 'myDrive');
 
 				const qs = {
 					q: `mimeType = \'application/vnd.google-apps.folder\' ${

--- a/packages/nodes-base/nodes/Google/Docs/test/GoogleDocs.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Docs/test/GoogleDocs.node.test.ts
@@ -1,0 +1,58 @@
+import type { IDataObject, ILoadOptionsFunctions } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+
+import { googleApiRequestAllItems } from '../GenericFunctions';
+import { GoogleDocs } from '../GoogleDocs.node';
+
+vi.mock('../GenericFunctions', () => ({
+	googleApiRequestAllItems: vi.fn(),
+}));
+
+const node = new GoogleDocs();
+
+let nodeParameters: Record<string, unknown>;
+
+const mockThis = {
+	getNode: () => ({ name: 'Google Docs', parameters: {} }),
+	getNodeParameter: vi.fn((name: string, ...rest: unknown[]) => {
+		if (nodeParameters[name] !== undefined) return nodeParameters[name];
+		if (rest.length === 0) {
+			throw new Error(`Could not get parameter "${name}"`);
+		}
+		return rest[0];
+	}),
+} as unknown as ILoadOptionsFunctions;
+
+const getRequestedQuery = () => (googleApiRequestAllItems as Mock).mock.calls[0][4] as IDataObject;
+
+describe('GoogleDocs Node - loadOptions', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		nodeParameters = {};
+	});
+
+	describe('getFolders', () => {
+		it('should fall back to My Drive when driveId is not set yet', async () => {
+			(googleApiRequestAllItems as Mock).mockResolvedValue([{ name: 'Reports', id: 'folder-1' }]);
+
+			const result = await node.methods.loadOptions.getFolders.call(mockThis);
+
+			expect(result).toEqual([
+				{ name: '/', value: 'default' },
+				{ name: 'Reports', value: 'folder-1' },
+			]);
+			const qs = getRequestedQuery();
+			expect(qs.q).toContain("'root' in parents");
+			expect(qs.driveId).toBeUndefined();
+		});
+
+		it('should query the selected shared drive', async () => {
+			nodeParameters = { driveId: 'drive-123' };
+			(googleApiRequestAllItems as Mock).mockResolvedValue([]);
+
+			await node.methods.loadOptions.getFolders.call(mockThis);
+
+			expect(getRequestedQuery().driveId).toBe('drive-123');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Google/Docs/test/GoogleDocs.node.test.ts
+++ b/packages/nodes-base/nodes/Google/Docs/test/GoogleDocs.node.test.ts
@@ -32,11 +32,12 @@ describe('GoogleDocs Node - loadOptions', () => {
 	});
 
 	describe('getFolders', () => {
-		it('should fall back to My Drive when driveId is not set yet', async () => {
+		it('should use myDrive when driveId is absent from node parameters', async () => {
 			(googleApiRequestAllItems as Mock).mockResolvedValue([{ name: 'Reports', id: 'folder-1' }]);
 
 			const result = await node.methods.loadOptions.getFolders.call(mockThis);
 
+			expect(mockThis.getNodeParameter).toHaveBeenCalledWith('driveId', 'myDrive');
 			expect(result).toEqual([
 				{ name: '/', value: 'default' },
 				{ name: 'Reports', value: 'folder-1' },


### PR DESCRIPTION
## Summary

Fixes an exception thrown when switching Google Docs operations. Adds a default `myDrive` drive id (same as default option in the node) in the `getFolders` dynamic options method.

## How to test

Test on master branch first, then on a fixed branch

1. create a workflow with a Google Docs node or use the attached workflow. Valid google docs credentials are not 100% required but preferable
2. oben devtools network tab
3. switch from `get` to `create` operation and vise versa.
4. on `master` (or unfixed branch) observe that there is an `xxx/options` request that fails with `message: "Could not get parameter \"driveId\""` error (with valid credentials this will be the only failing request).
5. On the fixed branch observe that there is no error

<img width="699" height="158" alt="Bildschirmfoto 2026-07-07 um 15 56 27" src="https://github.com/user-attachments/assets/93f5f685-655a-40a3-b52f-93e3624697cd" />


<details>
<summary>Example workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": {
        "operation": "get"
      },
      "type": "n8n-nodes-base.googleDocs",
      "typeVersion": 2,
      "position": [
        208,
        0
      ],
      "id": "8e565dab-a48f-43c3-bdb8-6ed5d4134482",
      "name": "Get a document",
      "credentials": {
        "googleDocsOAuth2Api": {
          "id": "7vgf7D1ngdv8w7h2",
          "name": "Google Docs account 2"
        }
      }
    }
  ],
  "connections": {},
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->