### PR TITLE
fix(editor): Disable private credential connect and actions in execution view

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialPrivateConnectionRow.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialPrivateConnectionRow.vue
@@ -20,11 +20,13 @@ interface Props {
 	canModify: boolean;
 	canConnect?: boolean;
 	connectedAccountName?: string;
+	readonly?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
 	canConnect: true,
 	connectedAccountName: undefined,
+	readonly: false,
 });
 
 const emit = defineEmits<{
@@ -109,7 +111,7 @@ function onDisconnectConfirm() {
 		</div>
 
 		<div :class="$style.right">
-			<N8nTooltip v-if="!isConnected" :disabled="canConnect" placement="top">
+			<N8nTooltip v-if="!isConnected" :disabled="canConnect || readonly" placement="top">
 				<template #content>{{
 					i18n.baseText('credentials.private.row.connect.noPermission')
 				}}</template>
@@ -117,7 +119,7 @@ function onDisconnectConfirm() {
 					size="mini"
 					variant="outline"
 					:label="i18n.baseText('credentials.private.row.connect')"
-					:disabled="!canConnect"
+					:disabled="readonly || !canConnect"
 					data-test-id="node-credential-private-connect"
 					@click="emit('connect')"
 				/>
@@ -126,12 +128,13 @@ function onDisconnectConfirm() {
 				v-else
 				:items="connectedActions"
 				placement="bottom-end"
+				:disabled="readonly"
 				:extra-popper-class="$style.connectedDropdown"
 				data-test-id="node-credential-private-connected-actions"
 				@select="onActionSelect"
 			>
 				<template #activator>
-					<N8nButton size="mini" variant="outline">
+					<N8nButton size="mini" variant="outline" :disabled="readonly">
 						<span :class="$style.connectedBadge" />
 						<span>{{ i18n.baseText('credentials.private.row.connected') }}</span>
 						<N8nIcon icon="chevron-down" size="small" />

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -1773,6 +1773,32 @@ describe('NodeCredentials', () => {
 			expect(screen.getByTestId('node-credential-private-connect')).toBeDisabled();
 		});
 
+		it('disables the Connect button in readonly (execution view) mode', async () => {
+			credentialsStore.state.credentials = {
+				'private-cred-id': { ...privateCredential, connectedByMe: false },
+			};
+			renderComponent({
+				props: { node: notionNode, overrideCredType: 'openAiApi', readonly: true },
+			});
+
+			expect(screen.getByTestId('node-credential-private-connect')).toBeDisabled();
+		});
+
+		it('disables the Connected actions dropdown in readonly (execution view) mode', async () => {
+			credentialsStore.state.credentials = {
+				'private-cred-id': { ...privateCredential, connectedByMe: true },
+			};
+			renderComponent({
+				props: { node: notionNode, overrideCredType: 'openAiApi', readonly: true },
+			});
+
+			const dropdown = screen.getByTestId('node-credential-private-connected-actions');
+			await userEvent.click(dropdown);
+
+			// The connected/disconnect actions menu must not open while readonly
+			expect(screen.queryByText('Disconnect')).not.toBeInTheDocument();
+		});
+
 		it('clicking the Connect button runs the OAuth flow without opening the edit modal', async () => {
 			credentialsStore.state.credentials = {
 				'private-cred-id': { ...privateCredential, connectedByMe: false },

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -1028,6 +1028,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 					:connected-account-name="usersStore.currentUser?.email ?? undefined"
 					:can-modify="canEditPrivateCredential(type.name)"
 					:can-connect="canConnectPrivateCredential(type.name)"
+					:readonly="readonly"
 					data-test-id="node-credential-private-row"
 					@connect="onConnectFromRow(type.name)"
 					@modify="editCredential(type.name)"


### PR DESCRIPTION
## Summary

When viewing a workflow **execution** (read-only mode) and opening a node that uses a private credential, the **Connect** button and the **Connected** actions menu (Modify / Disconnect) below the credentials select stayed interactive, even though every other field in the NDV is disabled. The private-credential row (`CredentialPrivateConnectionRow.vue`) is rendered outside the `readonly` branch in `NodeCredentials.vue` and never received the read-only state, so a user could still trigger an OAuth connect/disconnect flow from a read-only execution. This adds a `readonly` prop to the row that disables the Connect button and the actions dropdown (and its activator), wired from the existing `readonly` prop, and adds regression tests.

## How to test

1. Create a workflow with a node using a private (dynamic/resolvable) credential and run it.
2. Open the execution and open the node in the NDV.
3. Verify the Connect button is disabled (when not connected) and the Connected actions menu cannot be opened (when connected), matching the other disabled fields.
4. Confirm normal editor behavior is unchanged when not viewing an execution.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-961

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

