### PR TITLE
test: De-flake templates 'should save template id' e2e test (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/templates/templates.spec.ts
@@ -230,11 +230,11 @@ test.describe(
 
 			test('should save template id with the workflow', async ({ n8n }) => {
 				await n8n.templatesComposer.importFirstTemplate();
+				await n8n.canvas.waitForCanvasReady();
 
-				// Execute workflow to trigger autosave (imported templates don't auto-save immediately)
-				await n8n.canvas.hitExecuteWorkflow();
-
+				// Arm the save listener before executing: the run's immediate save can land before we listen.
 				const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted();
+				await n8n.canvas.hitExecuteWorkflow();
 				const saveResponse = await saveResponsePromise;
 
 				const requestBody = saveResponse.request().postDataJSON();


### PR DESCRIPTION
## Summary

De-flakes the quarantined Playwright test `Workflow templates > For a custom template host > should save template id with the workflow`.

1. **Save listener attached too late.** Imported templates stay pristine (`keepPristine: true`), so the debounced autosave never schedules. Pressing Ctrl+Enter on a never-saved workflow triggers an *immediate* save-before-run POST (`useRunWorkflow` → `saveCurrentWorkflow`). The listener was armed *after* `hitExecuteWorkflow()`, so the POST could land before `waitForResponse` attached → 2000ms timeout.
2. **No canvas-ready wait.** The composer only asserted the redirect URL, so the execute keypress could fire before the editor finished mounting.

## How to test

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5547

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33768">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->