### PR TITLE
fix(editor): Avoid next prev buttons from being disabled 

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -484,6 +484,10 @@ export class NodeDetailsViewPage extends BasePage {
 		await this.inlineExpressionEditor.selectPrevItem();
 	}
 
+	async moveMouseAwayFromRunData() {
+		await this.inlineExpressionEditor.moveMouseAway();
+	}
+
 	async openExpressionEditorModal(parameterName: string) {
 		await this.inlineExpressionEditor.openModal(parameterName);
 	}

--- a/packages/testing/playwright/pages/components/InlineExpressionEditor.ts
+++ b/packages/testing/playwright/pages/components/InlineExpressionEditor.ts
@@ -74,11 +74,18 @@ export class InlineExpressionEditor {
 		return this.page.getByTestId('inline-expression-editor-item-next');
 	}
 
+	// Park the cursor away from run-data rows; hovering one disables the item next/prev buttons.
+	async moveMouseAway(): Promise<void> {
+		await this.page.mouse.move(0, 0);
+	}
+
 	async selectNextItem(): Promise<void> {
+		await this.moveMouseAway();
 		await this.getItemNextButton().click();
 	}
 
 	async selectPrevItem(): Promise<void> {
+		await this.moveMouseAway();
 		await this.getItemPrevButton().click();
 	}
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts
@@ -175,10 +175,6 @@ test.describe(
 					'My test workflow 2',
 				);
 
-				await n8n.workflowComposer.executeWorkflowAndWaitForNotification(
-					'Workflow executed successfully',
-				);
-
 				await n8n.canvas.openNode('Set');
 
 				await n8n.ndv.getAssignmentExpressionToggle('assignments').click();
@@ -189,6 +185,10 @@ test.describe(
 				await n8n.ndv.typeInExpressionEditor('{{ $json.input[0].count');
 
 				await expect(n8n.ndv.getInlineExpressionEditorOutput()).toHaveText('0');
+
+				// Clear any run-data-row hover and wait for the item selector to enable before using it.
+				await n8n.ndv.moveMouseAwayFromRunData();
+				await expect(n8n.ndv.getInlineExpressionEditorItemNextButton()).toBeEnabled();
 
 				await n8n.ndv.expressionSelectNextItem();
 				await expect(n8n.ndv.getInlineExpressionEditorOutput()).toHaveText('1');


### PR DESCRIPTION
## Summary
Fixes flakiness in the E2E test NDV Parameters > Expression Editor Features > should allow selecting item for expressions, which was quarantined.

Root cause

The test drives the inline expression editor's item selector (the ‹ [n] › next/prev buttons). Those buttons are disabled and the previewed item index is overridden whenever hoveringItem is set in the NDV store — which happens purely from the cursor resting over a run-data table cell. Depending on where Playwright left the pointer and on render timing, the cursor could incidentally sit on a row, silently disabling the button the test clicked, so the item never advanced.


<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-5546/flaky-test-quarantined-should-allow-selecting-item-for-expressions
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33774">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->