### PR TITLE
fix(Salesforce Node): Pass ParentId when creating or updating a Case

### DIFF
--- a/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
+++ b/packages/nodes-base/nodes/Salesforce/Salesforce.node.ts
@@ -2483,8 +2483,8 @@ export class Salesforce implements INodeType {
 						if (additionalFields.subject !== undefined) {
 							body.Subject = additionalFields.subject as string;
 						}
-						if (additionalFields.parentId !== undefined) {
-							body.ParentId = additionalFields.parentId as string;
+						if (additionalFields.ParentId !== undefined) {
+							body.ParentId = additionalFields.ParentId as string;
 						}
 						if (additionalFields.priority !== undefined) {
 							body.Priority = additionalFields.priority as string;
@@ -2554,8 +2554,8 @@ export class Salesforce implements INodeType {
 						if (updateFields.subject !== undefined) {
 							body.Subject = updateFields.subject as string;
 						}
-						if (updateFields.parentId !== undefined) {
-							body.ParentId = updateFields.parentId as string;
+						if (updateFields.ParentId !== undefined) {
+							body.ParentId = updateFields.ParentId as string;
 						}
 						if (updateFields.priority !== undefined) {
 							body.Priority = updateFields.priority as string;

--- a/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
+++ b/packages/nodes-base/nodes/Salesforce/__test__/Salesforce.node.test.ts
@@ -1918,6 +1918,33 @@ describe('Salesforce', () => {
 				);
 			});
 
+			it('should pass ParentId when creating a case with a parent', async () => {
+				mockExecuteFunctions.getNodeParameter.mockImplementation((param: string): any => {
+					const params: Record<string, unknown> = {
+						resource: 'case',
+						operation: 'create',
+						type: 'Problem',
+						additionalFields: {
+							ParentId: 'parentCase123',
+						},
+					};
+					return get(params, param);
+				});
+
+				salesforceApiRequestSpy.mockResolvedValue({ id: 'childCase123', success: true });
+
+				await node.execute.call(mockExecuteFunctions);
+
+				expect(salesforceApiRequestSpy).toHaveBeenCalledWith(
+					'POST',
+					'/sobjects/case',
+					expect.objectContaining({
+						Type: 'Problem',
+						ParentId: 'parentCase123',
+					}),
+				);
+			});
+
 			it('should handle case create with all additional fields', async () => {
 				mockExecuteFunctions.getNodeParameter.mockImplementation((param: string): any => {
 					const params: Record<string, unknown> = {
@@ -1930,7 +1957,7 @@ describe('Salesforce', () => {
 							status: 'New',
 							owner: 'user123',
 							subject: 'Test Case Subject',
-							parentId: 'parent123',
+							ParentId: 'parent123',
 							priority: 'High',
 							accountId: 'acc123',
 							contactId: 'contact123',
@@ -2023,7 +2050,7 @@ describe('Salesforce', () => {
 							status: 'Working',
 							owner: 'user456',
 							subject: 'Updated Case Subject',
-							parentId: 'parent456',
+							ParentId: 'parent456',
 							priority: 'Medium',
 							accountId: 'acc456',
 							recordTypeId: 'rt456',
@@ -2064,6 +2091,32 @@ describe('Salesforce', () => {
 						SuppliedEmail: 'jane@example.com',
 						SuppliedPhone: '+1987654321',
 						SuppliedCompany: 'Updated Company',
+					}),
+				);
+			});
+
+			it('should pass ParentId when updating a case to set a parent', async () => {
+				mockExecuteFunctions.getNodeParameter.mockImplementation((param: string): any => {
+					const params: Record<string, unknown> = {
+						resource: 'case',
+						operation: 'update',
+						caseId: 'childCase456',
+						updateFields: {
+							ParentId: 'parentCase456',
+						},
+					};
+					return get(params, param);
+				});
+
+				salesforceApiRequestSpy.mockResolvedValue({ success: true });
+
+				await node.execute.call(mockExecuteFunctions);
+
+				expect(salesforceApiRequestSpy).toHaveBeenCalledWith(
+					'PATCH',
+					'/sobjects/case/childCase456',
+					expect.objectContaining({
+						ParentId: 'parentCase456',
 					}),
 				);
 			});


### PR DESCRIPTION
## Summary

The Salesforce **Case → Create** and **Case → Update** operations silently dropped the **Parent ID** field: the created/updated Case always ended up with `ParentId: null`, even when a Parent ID was provided (reported in [#19686](<https://github.com/n8n-io/n8n/issues/19686>)).

**Root cause:** the field is defined as `ParentId` (capital) in `CaseDescription.ts`, but the create handler read `additionalFields.parentId` and the update handler read `updateFields.parentId` (lowercase). Those keys were always `undefined`, so `body.ParentId` was never set and Salesforce received no parent.

**Fix:** read the correctly-cased `ParentId` key in both handlers. This is backward-compatible — existing saved workflows already store the value under `ParentId`, so no migration is needed. The Account/Contact resources use a lowercase `parentId` field name and are left unchanged.

## How to test

1. Salesforce **Case → Create**: set **Parent ID** to a valid Case Id and execute → the created Case now has that `ParentId` (previously `null`).
2. Salesforce **Case → Update**: set **Parent ID** and execute → the Case's parent is set correctly.
3. Unit tests: `cd packages/nodes-base && pnpm test Salesforce.node.test` — adds focused regression tests for Case create + update, and corrects two existing tests that had mirrored the buggy lowercase key.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [#19686](<https://github.com/n8n-io/n8n/issues/19686>)<br>[NODE-3658](https://linear.app/n8n/issue/NODE-3658)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A — behaviour-only bug fix)
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (N/A)

[![Review in cubic](https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/867d923f-39cc-403a-9f53-36b4fe084a06/f1d1113d-c943-446a-93b5-95ecfca79ef8?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi84NjdkOTIzZi0zOWNjLTQwM2EtOWY1My0zNmI0ZmUwODRhMDYvZjFkMTExM2QtYzk0My00NDZhLTkzYjUtOTVlY2ZjYTc5ZWY4IiwiaWF0IjoxNzg0MTg4NzM5LCJleHAiOjE4MTU3NTkyOTl9.6xuQ1o4hoKJko39XkXHTLAniBp1bqp2OV4qAd3_Vm-E)](<https://cubic.dev/pr/n8n-io/n8n/pull/33775?utm_source=github>)