### PR TITLE
fix(core): Serve RFC 9728 metadata at bare /.well-known/oauth-protected-resource

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.api.test.ts
@@ -146,6 +146,47 @@ describe('GET /.well-known/oauth-protected-resource/mcp-server/http', () => {
 	});
 });
 
+describe('GET /.well-known/oauth-protected-resource (bare path)', () => {
+	test('resolves to the default registered resource', async () => {
+		const response = await testServer.restlessAgent.get('/.well-known/oauth-protected-resource');
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toEqual({
+			resource: expect.stringContaining('/mcp-server/http'),
+			bearer_methods_supported: ['header'],
+			authorization_servers: [expect.any(String)],
+			...(SUPPORTED_SCOPES.length > 0 && { scopes_supported: SUPPORTED_SCOPES }),
+		});
+	});
+
+	test('matches the resource-scoped metadata for the default resource', async () => {
+		const bareResponse = await testServer.restlessAgent.get(
+			'/.well-known/oauth-protected-resource',
+		);
+		const scopedResponse = await testServer.restlessAgent.get(
+			'/.well-known/oauth-protected-resource/mcp-server/http',
+		);
+
+		expect(bareResponse.statusCode).toBe(200);
+		expect(bareResponse.body).toEqual(scopedResponse.body);
+	});
+
+	test('is accessible without authentication', async () => {
+		const response = await testServer.restlessAgent.get('/.well-known/oauth-protected-resource');
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('responds to OPTIONS with CORS headers', async () => {
+		const response = await testServer.restlessAgent.options(
+			'/.well-known/oauth-protected-resource',
+		);
+
+		expect(response.statusCode).toBe(204);
+		expect(response.headers['access-control-allow-origin']).toBe('*');
+	});
+});
+
 describe('POST /mcp-oauth/register', () => {
 	beforeEach(async () => {
 		await mcpSettingsService.setEnabled(true);
@@ -823,6 +864,8 @@ describe('IP rate limit configuration', () => {
 		'metadataOptions',
 		'protectedResourceMetadata',
 		'protectedResourceMetadataOptions',
+		'defaultProtectedResourceMetadata',
+		'defaultProtectedResourceMetadataOptions',
 	])('applies the configured well-known limit to %s', (handlerName) => {
 		const config = Container.get(OAuthServerConfig);
 		const routeMetadata = Container.get(ControllerRegistryMetadata).getRouteMetadata(

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -15,6 +15,7 @@ import {
 import { Container } from '@n8n/di';
 import type { Response, Request, RequestHandler, Router } from 'express';
 
+import type { ProtectedResource } from '@/services/protected-resource.registry';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 
@@ -213,6 +214,54 @@ export class OAuthController {
 			return;
 		}
 
+		res.json(this.buildProtectedResourceMetadata(resource));
+	}
+
+	@Options('/.well-known/oauth-protected-resource', {
+		skipAuth: true,
+		usesTemplates: true,
+		ipRateLimit: wellKnownIpRateLimit,
+	})
+	defaultProtectedResourceMetadataOptions(_req: Request, res: Response) {
+		this.setCorsHeaders(res);
+		res.status(204).end();
+	}
+
+	/**
+	 * RFC 9728 protected-resource metadata for the bare `/.well-known/
+	 * oauth-protected-resource` path (no resource-path suffix).
+	 *
+	 * Per RFC 9728 §3.1, a resource server whose resource identifier has no
+	 * path component publishes its metadata at this exact well-known URI.
+	 * We also serve it as a courtesy for clients that probe the origin-level
+	 * document before (or instead of) the resource-scoped one advertised via
+	 * `WWW-Authenticate: resource_metadata=...` — without this route, such a
+	 * probe previously fell through to the SPA's catch-all handler, which
+	 * answered with `200 text/html` instead of a clean `404`, breaking OAuth
+	 * discovery for clients that don't special-case a non-JSON `200`.
+	 *
+	 * Resolves to this instance's default protected resource (today, always
+	 * the single instance-wide MCP resource); returns 404 when no default is
+	 * registered so the caller can fall back to the resource-scoped URL.
+	 */
+	@Get('/.well-known/oauth-protected-resource', {
+		skipAuth: true,
+		usesTemplates: true,
+		ipRateLimit: wellKnownIpRateLimit,
+	})
+	defaultProtectedResourceMetadata(_req: Request, res: Response) {
+		this.setCorsHeaders(res);
+
+		const resource = this.resourceRegistry.getDefaultResource();
+		if (!resource) {
+			res.status(404).json({ message: 'Unknown protected resource' });
+			return;
+		}
+
+		res.json(this.buildProtectedResourceMetadata(resource));
+	}
+
+	private buildProtectedResourceMetadata(resource: ProtectedResource): Record<string, unknown> {
 		const baseUrl = this.urlService.getInstanceBaseUrl();
 		const metadata: Record<string, unknown> = {
 			resource: resource.getResourceUrl(),
@@ -224,6 +273,6 @@ export class OAuthController {
 			metadata.scopes_supported = resource.scopes;
 		}
 
-		res.json(metadata);
+		return metadata;
 	}
 }


### PR DESCRIPTION
## Summary

Adds an exact-match route for the bare `/.well-known/oauth-protected-resource` path (no resource-path suffix), which resolves to the instance's default registered protected resource via `ProtectedResourceRegistry.getDefaultResource()`.

## Problem

Only the resource-scoped RFC 9728 metadata route is currently registered:

```
GET /.well-known/oauth-protected-resource/mcp-server/http  -> 200, correct JSON
```

The bare, origin-level path has no matching route, so it falls through to the frontend SPA's catch-all handler:

```
GET /.well-known/oauth-protected-resource  -> 200 text/html (index.html)
```

Some MCP/OAuth clients probe this origin-level path per RFC 9728 §3.1 (either as their primary discovery lookup, or as an additional/fallback probe alongside the resource-scoped URL advertised via `WWW-Authenticate: resource_metadata=...`). Because the response is `200` instead of `404`, these clients can't tell the probe failed — they attempt to parse HTML as JSON and the OAuth discovery flow breaks silently (observed in the wild as the authorization redirect hanging indefinitely with no actionable error, when going through a private-network MCP tunnel/proxy in front of an n8n instance).

## Fix

- Register `GET`/`OPTIONS` handlers for the bare `/.well-known/oauth-protected-resource` path.
- Resolve the resource via the existing `ProtectedResourceRegistry.getDefaultResource()` (already used elsewhere for token requests that omit an RFC 8707 `resource` parameter), so behavior stays correct as more resources get registered (e.g. per-workflow MCP triggers) — no resource path guessing needed.
- Extracted the metadata-shape building into a shared `buildProtectedResourceMetadata` helper, reused by both the new bare-path handler and the existing resource-scoped one, so the two routes can never drift.
- Returns `404` (matching the resource-scoped route's shape) when no default resource is registered, so well-behaved clients can still fall back to the resource-scoped URL.

## Test plan

- [x] Added `describe('GET /.well-known/oauth-protected-resource (bare path)')` integration tests: returns `200` with correct metadata, matches the resource-scoped response for the default resource, works unauthenticated, and responds to `OPTIONS` with CORS headers.
- [x] Extended the existing rate-limit `test.each` to cover the two new handlers.
- [x] Confirmed via `tsc --noEmit` that this change introduces **zero new type errors** (identical error count before/after — remaining errors are pre-existing, from unbuilt workspace package type declarations in this sandboxed environment, unrelated to this diff).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33776">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

