### PR TITLE
fix(Google Workspace Admin Node): Send suspended flag when Suspend toggle is off

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -770,7 +770,8 @@ export class GSuiteAdmin implements INodeType {
 							body.primaryEmail = updateFields.primaryEmail as string;
 						}
 
-						if (updateFields.suspendUi) {
+						// Presence check: `false` must still be sent to reactivate the user
+						if (updateFields.suspendUi !== undefined) {
 							body.suspended = updateFields.suspendUi as boolean;
 						}
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/updateUnsuspend.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/updateUnsuspend.test.ts
@@ -1,0 +1,43 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Google GSuiteAdmin Node - Update User (unsuspend)', () => {
+	beforeEach(() => {
+		nock.disableNetConnect();
+
+		// Strict body match: the request must contain `suspended: false`,
+		// otherwise toggling Suspend off is a no-op and the user stays suspended
+		nock('https://www.googleapis.com/admin')
+			.put('/directory/v1/users/101071249467630629404', {
+				suspended: false,
+			})
+			.reply(200, {
+				kind: 'admin#directory#user',
+				id: '101071249467630629404',
+				etag: '"example"',
+				primaryEmail: 'one@example.com',
+				name: {
+					givenName: 'test',
+					familyName: 'new',
+				},
+				isAdmin: false,
+				isDelegatedAdmin: false,
+				lastLoginTime: '1970-01-01T00:00:00.000Z',
+				creationTime: '2025-03-26T21:28:53.000Z',
+				agreedToTerms: false,
+				suspended: false,
+				archived: false,
+				changePasswordAtNextLogin: false,
+				ipWhitelisted: false,
+				customerId: 'C0442hnz1',
+				orgUnitPath: '/',
+				isMailboxSetup: false,
+				includeInGlobalAddressList: true,
+				recoveryEmail: '',
+			});
+	});
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['updateUnsuspend.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/updateUnsuspend.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/updateUnsuspend.workflow.json
@@ -1,0 +1,80 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [120, 700],
+			"id": "0e76b314-4994-4141-975f-9614c6094c81",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"operation": "update",
+				"userId": {
+					"__rl": true,
+					"value": "101071249467630629404",
+					"mode": "list",
+					"cachedResultName": "NewOne22 User22"
+				},
+				"updateFields": {
+					"suspendUi": false
+				}
+			},
+			"type": "n8n-nodes-base.gSuiteAdmin",
+			"typeVersion": 1,
+			"position": [140, 1100],
+			"id": "b4cd1391-cfdc-4f36-8c2f-f18a9ad4f796",
+			"name": "Unsuspend User",
+			"credentials": {
+				"gSuiteAdminOAuth2Api": {
+					"id": "OXfPMaggXFJ0RLkw",
+					"name": "Google Workspace Admin account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [
+				[
+					{
+						"node": "Unsuspend User",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Unsuspend User": [
+			{
+				"json": {
+					"kind": "admin#directory#user",
+					"id": "101071249467630629404",
+					"etag": "\"example\"",
+					"primaryEmail": "one@example.com",
+					"name": {
+						"givenName": "test",
+						"familyName": "new"
+					},
+					"isAdmin": false,
+					"isDelegatedAdmin": false,
+					"lastLoginTime": "1970-01-01T00:00:00.000Z",
+					"creationTime": "2025-03-26T21:28:53.000Z",
+					"agreedToTerms": false,
+					"suspended": false,
+					"archived": false,
+					"changePasswordAtNextLogin": false,
+					"ipWhitelisted": false,
+					"customerId": "C0442hnz1",
+					"orgUnitPath": "/",
+					"isMailboxSetup": false,
+					"includeInGlobalAddressList": true,
+					"recoveryEmail": ""
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

The **User → Update** operation of the Google Workspace Admin node cannot reactivate a suspended user. The **Suspend** field is guarded by a truthiness check, so toggling Suspend **off** never sends `suspended: false` to the Directory API — the block is skipped and the account silently stays suspended, even though the field's own description says OFF reactivates the user.

This PR changes the guard to a presence check (`!== undefined`), matching how `changePasswordAtNextLogin` is already handled a few lines above in the same operation. Field not added → status unchanged (as before); Suspend ON → suspend; Suspend OFF → `{ "suspended": false }` is sent and the user is reactivated.

## How to test

1. Have a user that is currently suspended in Google Workspace.
2. Add a **Google Workspace Admin** node → resource **User**, operation **Update**, select the user, add **Suspend** under Update Fields and set it to **OFF**, then execute.
3. Before this fix the outgoing `PUT /admin/directory/v1/users/{userId}` body omits `suspended` and the user stays suspended; with the fix the body contains `suspended: false` and the user is reactivated.

Added a workflow regression test (`test/user/updateUnsuspend.test.ts`) whose nock mock strictly requires `{"suspended": false}` in the PUT body — it fails against the previous code and passes with the fix. Full GSuiteAdmin suite: 20 files / 54 tests passing locally.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33715 (GHC-8887)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- not needed: the fix makes behavior match the already-documented description of the Suspend field -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33787">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

