### PR TITLE
fix(Gmail Node): Stringify expressions for parameters that expect strings

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/GenericFunctions.ts
@@ -401,7 +401,7 @@ export function prepareEmailsInput(
 	itemIndex: number,
 ) {
 	let emails = '';
-
+	input = String(input ?? '');
 	input.split(',').forEach((entry) => {
 		const email = entry.trim();
 
@@ -429,7 +429,7 @@ export function prepareEmailBody(
 	instanceId?: string,
 ) {
 	const emailType = this.getNodeParameter('emailType', itemIndex) as string;
-	let message = (this.getNodeParameter('message', itemIndex, '') as string).trim();
+	let message = String(this.getNodeParameter('message', itemIndex, '') ?? '').trim();
 
 	if (appendAttribution) {
 		const attributionText = 'This email was sent automatically with ';
@@ -472,7 +472,7 @@ export async function prepareEmailAttachments(
 
 	if (attachments && !isEmpty(attachments)) {
 		for (const { property } of attachments) {
-			for (const name of (property as string).split(',')) {
+			for (const name of String(property ?? '').split(',')) {
 				const binaryData = this.helpers.assertBinaryData(itemIndex, name);
 				const binaryDataBuffer = await this.helpers.getBinaryDataBuffer(itemIndex, name);
 

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -156,10 +156,10 @@ describe('email input preparation', () => {
 
 	it('should convert message body to a string before trimming', () => {
 		const executionFunctions = mock<IExecuteFunctions>({
-			getNodeParameter: vi.fn((parameterName) => {
+			getNodeParameter: ((parameterName: string) => {
 				if (parameterName === 'emailType') return 'text';
 				return 123;
-			}),
+			}) as IExecuteFunctions['getNodeParameter'],
 		});
 
 		expect(prepareEmailBody.call(executionFunctions, 0)).toEqual({
@@ -172,7 +172,11 @@ describe('email input preparation', () => {
 		const binaryData = Buffer.from('file contents');
 		const executionFunctions = mock<IExecuteFunctions>({
 			helpers: mock<IExecuteFunctions['helpers']>({
-				assertBinaryData: vi.fn(() => ({ fileName: 'test.txt', mimeType: 'text/plain' })),
+				assertBinaryData: vi.fn(() => ({
+					data: binaryData.toString('base64'),
+					fileName: 'test.txt',
+					mimeType: 'text/plain',
+				})),
 				getBinaryDataBuffer: vi.fn(async () => binaryData),
 			}),
 		});

--- a/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/v2/utils.test.ts
@@ -5,7 +5,14 @@ import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import type { IEmail } from '@utils/sendAndWait/interfaces';
 
 import * as GenericFunctions from '../../GenericFunctions';
-import { parseRawEmail, prepareQuery, prepareTimestamp } from '../../GenericFunctions';
+import {
+	parseRawEmail,
+	prepareEmailAttachments,
+	prepareEmailBody,
+	prepareEmailsInput,
+	prepareQuery,
+	prepareTimestamp,
+} from '../../GenericFunctions';
 import { addThreadHeadersToEmail } from '../../v2/utils/draft';
 
 const node: INode = {
@@ -130,6 +137,55 @@ describe('parseRawEmail', () => {
 
 		// ASSERT
 		expect(typeof json.date).toBe('string');
+	});
+});
+
+describe('email input preparation', () => {
+	it('should convert recipient input to a string before splitting', () => {
+		const executionFunctions = mock<IExecuteFunctions>();
+
+		const result = prepareEmailsInput.call(
+			executionFunctions,
+			['alice@example.com', 'bob@example.com'] as unknown as string,
+			'To',
+			0,
+		);
+
+		expect(result).toBe('<alice@example.com>, <bob@example.com>, ');
+	});
+
+	it('should convert message body to a string before trimming', () => {
+		const executionFunctions = mock<IExecuteFunctions>({
+			getNodeParameter: vi.fn((parameterName) => {
+				if (parameterName === 'emailType') return 'text';
+				return 123;
+			}),
+		});
+
+		expect(prepareEmailBody.call(executionFunctions, 0)).toEqual({
+			body: '123',
+			htmlBody: '',
+		});
+	});
+
+	it('should convert attachment property names to strings before splitting', async () => {
+		const binaryData = Buffer.from('file contents');
+		const executionFunctions = mock<IExecuteFunctions>({
+			helpers: mock<IExecuteFunctions['helpers']>({
+				assertBinaryData: vi.fn(() => ({ fileName: 'test.txt', mimeType: 'text/plain' })),
+				getBinaryDataBuffer: vi.fn(async () => binaryData),
+			}),
+		});
+
+		const result = await prepareEmailAttachments.call(
+			executionFunctions,
+			{ attachmentsBinary: [{ property: 123 }] },
+			0,
+		);
+
+		expect(executionFunctions.helpers.assertBinaryData).toHaveBeenCalledWith(0, '123');
+		expect(executionFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, '123');
+		expect(result).toEqual([{ name: 'test.txt', content: binaryData, type: 'text/plain' }]);
 	});
 });
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

Gmail node has some parameters that should be strings, but if an expression that returns something other than string (like a number) is used - the node breaks. This PR updates the code in multiple places to defensively stringify such parameters.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

Use this workflow:
```json
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        960,
        128
      ],
      "id": "1fa06c5f-ddb8-471a-b736-e48281ccecf3",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "sendTo": "// your email",
        "subject": "test",
        "message": "={{ $('When clicking ‘Execute workflow’').item.json.code }}",
        "options": {}
      },
      "type": "n8n-nodes-base.gmail",
      "typeVersion": 2.2,
      "position": [
        1168,
        128
      ],
      "id": "802804c3-3f74-432e-a73d-6b0998f85235",
      "name": "Send a message",
      "webhookId": "0cf120f0-ca62-4562-acd2-27f0389b1664",
      "credentials": {
        "gmailOAuth2": {
          "id": "7t9xBjmGQZlhfE3M",
          "name": "Gmail account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Send a message",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {
    "When clicking ‘Execute workflow’": [
      {
        "name": "First item",
        "code": 1
      }
    ]
  },
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "84159bd40ee0872ba94e582fafd3c88060461d6a703f20e5d4fdbd94e3bc35eb"
  }
}
```
1. Set up Gmail credentials
2. Specify your email in "To" parameter
3. Run the workflow
4. It should successfully send an email, even though the content is an expression that's evaluated to a number

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-4122/community-issue-cannot-send-email-using-gmail-node
Closes #22614

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

