### PR TITLE
fix(core): Report auto-bound credentials from AI Assistant workflow builds

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/binds-existing-credential-without-reasking.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/binds-existing-credential-without-reasking.json
@@ -1,0 +1,32 @@
+{
+	"description": "INS-770 regression: with exactly one matching Slack credential in the space, the build must bind that existing credential and the assistant must NOT ask the user to connect or create one. In the original incident the builder wrote an unresolved newCredential(), the build auto-bound the sole existing credential silently, and the completion still asked the user to connect the service and offered the credential setup card. Sibling of mocks-node-with-one-credential (same seeded setup, different guarded behaviour: messaging/binding instead of verification mocking).",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Every Friday at 4pm, post the message \"Weekly wrap-up time! Share your highlights in the thread.\" to the Slack channel #general."
+		}
+	],
+	"complexity": "simple",
+	"tags": ["behaviour", "credentials", "slack", "setup"],
+	"credentials": [{ "type": "slackApi", "name": "Team Slack" }],
+	"triggerType": "schedule",
+	"datasets": ["behaviour", "full"],
+	"processExpectations": [
+		"Exactly one Slack credential ('Team Slack') was available to the agent during the build — confirming the sole-candidate precondition.",
+		"The agent never asked the user to connect, create, or set up a Slack credential — not as a question, not as an offer to open a credential setup card, and not as a 'one setup step' item in the completion message. Mentioning that the existing Slack credential is being used is fine.",
+		"The completion message did not describe the Slack credential as missing, unresolved, or pending setup."
+	],
+	"outcomeExpectations": [
+		"A Schedule Trigger runs the workflow weekly on Friday afternoon.",
+		"A Slack node posts the given message to the #general channel.",
+		"The Slack node is bound to the existing 'Team Slack' credential — its slackApi credential reference carries a real id, it is not left without a credential."
+	],
+	"executionScenarios": [
+		{
+			"name": "happy-path",
+			"description": "The scheduled run posts the wrap-up message to Slack",
+			"dataSetup": "The Slack chat.postMessage call returns { \"ok\": true, \"ts\": \"1700000000.000200\", \"channel\": \"C0GENERAL\" }.",
+			"successCriteria": "The workflow executes without errors and posts the message \"Weekly wrap-up time! Share your highlights in the thread.\" to Slack #general."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/post-build-flow/SKILL.md
@@ -257,6 +257,15 @@ default path. Workflow verification is automatic from the build outcome; the
 orchestrator handles workflow setup after verification when the saved workflow
 still has mocked credentials or placeholders.
 
+**Trust the build outcome over your own source file.** When `build-workflow`
+returns `resolvedCredentialsByNode` (or `setupRequirement.status ===
+"not_required"`), the saved workflow is already connected to existing
+credentials — even if your source used an unresolved `newCredential()` call.
+Do not ask the user to connect those credentials, do not offer the setup card
+for them, and do not describe them as missing; at most mention which existing
+credential is being used. Route credential setup only when the build outcome
+reports mocked credentials or `setupRequirement.status === "required"`.
+
 **Ask once when a service has multiple credentials of the same type.** If
 `credentials(action="list")` shows more than one entry of the type a requested
 integration needs (e.g. two `openAiApi` accounts, three Google Calendar

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -257,6 +257,11 @@ decision after testing.
   workflow already had it. Otherwise use `newCredential('Suggested Credential
   Name')` — build tools mock unresolved credentials for verification and setup
   collects real ones later.
+- When `build-workflow` returns `resolvedCredentialsByNode`, the build already
+  attached existing credentials to those nodes. Treat them as connected: do not
+  ask the user to connect or create those credentials, do not route them to
+  credential setup, and mention at most that the existing credential is being
+  used.
 - Never use raw credential objects like `{ id: '...', name: '...' }` in SDK
   code; replace them with `newCredential()` when editing roundtripped code.
 - If a required credential type is not listed, call

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -50,12 +50,14 @@ vi.mock('../workflow-source-compiler', () => ({
 
 vi.mock('../resolve-credentials', () => ({
 	buildCredentialMap: vi.fn(async () => await Promise.resolve(new Map())),
+	buildCredentialResolutionNote: vi.fn(() => undefined),
 	resolveCredentials: vi.fn(
 		async () =>
 			await Promise.resolve({
 				mockedNodeNames: [],
 				mockedCredentialTypes: [],
 				mockedCredentialsByNode: {},
+				resolvedCredentialsByNode: {},
 			}),
 	),
 }));

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/resolve-credentials.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from 'vitest';
 import type { InstanceAiContext } from '../../../types';
 import {
 	buildCredentialMap,
+	buildCredentialResolutionNote,
 	resolveCredentials,
 	type CredentialEntry,
 	type CredentialMap,
@@ -599,5 +600,127 @@ describe('resolveCredentials', () => {
 			// Gmail credential should be removed
 			expect(json.nodes[1].credentials).toEqual({});
 		});
+	});
+
+	describe('resolved credential reporting', () => {
+		it('auto-binds the sole candidate and reports it in resolvedCredentialsByNode', async () => {
+			const json = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'OpenAI Chat Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.2,
+						position: [0, 0],
+						credentials: { openAiApi: null as unknown as { id: string; name: string } },
+					},
+				],
+			});
+			const map = makeCredentialMap([{ id: 'cred-1', name: 'OpenAI account', type: 'openAiApi' }]);
+
+			const result = await resolveCredentials(json, undefined, createMockContext(), map);
+
+			expect(result.mockedNodeNames).toEqual([]);
+			expect(result.resolvedCredentialsByNode).toEqual({
+				'OpenAI Chat Model': [{ type: 'openAiApi', id: 'cred-1', name: 'OpenAI account' }],
+			});
+			expect(json.nodes[0].credentials).toEqual({
+				openAiApi: { id: 'cred-1', name: 'OpenAI account' },
+			});
+		});
+
+		it('reports credentials restored from the existing workflow', async () => {
+			const json = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'Slack',
+						type: 'n8n-nodes-base.slack',
+						typeVersion: 2,
+						position: [0, 0],
+						credentials: { slackApi: undefined as unknown as { id: string; name: string } },
+					},
+				],
+			});
+			const existingWorkflow = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'Slack',
+						type: 'n8n-nodes-base.slack',
+						typeVersion: 2,
+						position: [0, 0],
+						credentials: { slackApi: { id: 'existing-id', name: 'Existing Slack' } },
+					},
+				],
+			});
+
+			const result = await resolveCredentials(json, 'wf-123', createMockContext(existingWorkflow));
+
+			expect(result.resolvedCredentialsByNode).toEqual({
+				Slack: [{ type: 'slackApi', id: 'existing-id', name: 'Existing Slack' }],
+			});
+		});
+
+		it('does not report mocked credentials as resolved', async () => {
+			const json = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'OpenAI Chat Model',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						typeVersion: 1.2,
+						position: [0, 0],
+						credentials: { openAiApi: null as unknown as { id: string; name: string } },
+					},
+				],
+			});
+			// Two candidates — ambiguous, so the credential is mocked, not bound.
+			const map = makeCredentialMap([
+				{ id: 'cred-1', name: 'OpenAI A', type: 'openAiApi' },
+				{ id: 'cred-2', name: 'OpenAI B', type: 'openAiApi' },
+			]);
+
+			const result = await resolveCredentials(json, undefined, createMockContext(), map);
+
+			expect(result.mockedNodeNames).toEqual(['OpenAI Chat Model']);
+			expect(result.resolvedCredentialsByNode).toEqual({});
+		});
+
+		it('does not report explicit valid credential ids as resolved', async () => {
+			const json = makeWorkflow({
+				nodes: [
+					{
+						id: '1',
+						name: 'Slack',
+						type: 'n8n-nodes-base.slack',
+						typeVersion: 2,
+						position: [0, 0],
+						credentials: { slackApi: { id: 'cred-1', name: 'My Slack' } },
+					},
+				],
+			});
+			const map = makeCredentialMap([{ id: 'cred-1', name: 'My Slack', type: 'slackApi' }]);
+
+			const result = await resolveCredentials(json, undefined, createMockContext(), map);
+
+			expect(result.mockedNodeNames).toEqual([]);
+			expect(result.resolvedCredentialsByNode).toEqual({});
+		});
+	});
+});
+
+describe('buildCredentialResolutionNote', () => {
+	it('returns undefined when nothing was resolved', () => {
+		expect(buildCredentialResolutionNote({})).toBeUndefined();
+	});
+
+	it('names each resolved credential and instructs not to re-ask', () => {
+		const note = buildCredentialResolutionNote({
+			'OpenAI Chat Model': [{ type: 'openAiApi', id: 'cred-1', name: 'OpenAI account' }],
+		});
+
+		expect(note).toContain('"OpenAI account" (openAiApi) on node "OpenAI Chat Model"');
+		expect(note).toContain('do not ask the user to connect or create them');
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -289,6 +289,10 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				mockedNodeNames: z.array(z.string()).optional(),
 				mockedCredentialTypes: z.array(z.string()).optional(),
 				mockedCredentialsByNode: z.record(z.array(z.string())).optional(),
+				resolvedCredentialsByNode: z
+					.record(z.array(z.object({ type: z.string(), id: z.string(), name: z.string() })))
+					.optional(),
+				credentialResolutionNote: z.string().optional(),
 				referencedWorkflowIds: z.array(z.string()).optional(),
 				hasUnresolvedPlaceholders: z.boolean().optional(),
 				denied: z.boolean().optional(),

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -8,7 +8,11 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 import { planVerificationSimulation } from './plan-verification-simulation';
-import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
+import {
+	buildCredentialMap,
+	buildCredentialResolutionNote,
+	resolveCredentials,
+} from './resolve-credentials';
 import { analyzeWorkflow, stripStaleCredentialsFromWorkflow } from './setup-workflow.service';
 import {
 	combineWarnings,
@@ -713,6 +717,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				await preserveExistingNodeGroupIds(json, targetWorkflowId, context);
 
 				const hasMockedCredentialNodes = mockResult.mockedNodeNames.length > 0;
+				const hasResolvedCredentials = Object.keys(mockResult.resolvedCredentialsByNode).length > 0;
 				const referencedWorkflowIds = getReferencedWorkflowIds(json);
 				const triggerNodes = (json.nodes ?? [])
 					.filter((n) => isTriggerNodeType(n.type))
@@ -793,6 +798,9 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 						mockedCredentialsByNode: hasMockedCredentialNodes
 							? mockResult.mockedCredentialsByNode
 							: undefined,
+						resolvedCredentialsByNode: hasResolvedCredentials
+							? mockResult.resolvedCredentialsByNode
+							: undefined,
 						workflowNeedsSetup,
 						nodeSimulationPlan,
 						simulationFixtures,
@@ -840,6 +848,12 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 							: undefined,
 						mockedCredentialsByNode: hasMockedCredentialNodes
 							? mockResult.mockedCredentialsByNode
+							: undefined,
+						resolvedCredentialsByNode: hasResolvedCredentials
+							? mockResult.resolvedCredentialsByNode
+							: undefined,
+						credentialResolutionNote: hasResolvedCredentials
+							? buildCredentialResolutionNote(mockResult.resolvedCredentialsByNode)
 							: undefined,
 						referencedWorkflowIds:
 							referencedWorkflowIds.length > 0 ? referencedWorkflowIds : undefined,

--- a/packages/@n8n/instance-ai/src/tools/workflows/resolve-credentials.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/resolve-credentials.ts
@@ -45,6 +45,14 @@ export async function buildCredentialMap(
 	return map;
 }
 
+/** A credential the resolver attached to a node without an explicit id in the source. */
+export interface ResolvedCredential {
+	/** Credential type key on the node, e.g. "openAiApi". */
+	type: string;
+	id: string;
+	name: string;
+}
+
 /** Result of credential resolution — mock metadata for the simulation plan. */
 export interface CredentialResolutionResult {
 	/** Node names whose credentials were mocked. */
@@ -53,6 +61,30 @@ export interface CredentialResolutionResult {
 	mockedCredentialTypes: string[];
 	/** Map of node name → credential types that were mocked on that node. */
 	mockedCredentialsByNode: Record<string, string[]>;
+	/**
+	 * Map of node name → credentials the resolver attached automatically
+	 * (restored from the saved workflow or auto-bound to the sole existing
+	 * candidate). These nodes are already connected — the agent must not ask
+	 * the user to connect or create them.
+	 */
+	resolvedCredentialsByNode: Record<string, ResolvedCredential[]>;
+}
+
+/**
+ * Human-readable summary of automatically attached credentials, meant to be
+ * relayed on the build result so the agent knows setup is not needed for them.
+ */
+export function buildCredentialResolutionNote(
+	resolvedCredentialsByNode: Record<string, ResolvedCredential[]>,
+): string | undefined {
+	const parts: string[] = [];
+	for (const [nodeName, resolved] of Object.entries(resolvedCredentialsByNode)) {
+		for (const credential of resolved) {
+			parts.push(`"${credential.name}" (${credential.type}) on node "${nodeName}"`);
+		}
+	}
+	if (parts.length === 0) return undefined;
+	return `Connected existing credential(s) automatically: ${parts.join('; ')}. These are already set up — do not ask the user to connect or create them, and do not route them to credential setup.`;
 }
 
 /**
@@ -75,6 +107,7 @@ export async function resolveCredentials(
 	const mockedNodeNames: string[] = [];
 	const mockedCredentialTypesSet = new Set<string>();
 	const mockedCredentialsByNode: Record<string, string[]> = {};
+	const resolvedCredentialsByNode: Record<string, ResolvedCredential[]> = {};
 
 	// Build a map of existing credentials by node name (for updates)
 	const existingCredsByNode = new Map<string, Record<string, unknown>>();
@@ -104,9 +137,21 @@ export async function resolveCredentials(
 			// when the LLM drops the id during an edit — e.g., emits newCredential('name')
 			// without the id, which serializes to undefined).
 			const existingCreds = node.name ? existingCredsByNode.get(node.name) : undefined;
+
+			const recordResolvedCredential = (id: string, name: string) => {
+				if (!node.name) return;
+				resolvedCredentialsByNode[node.name] ??= [];
+				resolvedCredentialsByNode[node.name].push({ type: key, id, name });
+			};
+
 			const restoreExistingCredential = () => {
-				if (!existingCreds?.[key]) return false;
-				creds[key] = existingCreds[key];
+				const restored = existingCreds?.[key];
+				if (!restored) return false;
+				creds[key] = restored;
+				const restoredId = getCredentialId(restored);
+				if (restoredId) {
+					recordResolvedCredential(restoredId, getCredentialName(restored) ?? restoredId);
+				}
 				cleanupMockPinData(json, node.name);
 				return true;
 			};
@@ -146,6 +191,7 @@ export async function resolveCredentials(
 			if (credentialsForType?.length === 1) {
 				const [credential] = credentialsForType;
 				creds[key] = { id: credential.id, name: credential.name };
+				recordResolvedCredential(credential.id, credential.name);
 				cleanupMockPinData(json, node.name);
 				continue;
 			}
@@ -166,6 +212,7 @@ export async function resolveCredentials(
 		mockedNodeNames,
 		mockedCredentialTypes: [...mockedCredentialTypesSet],
 		mockedCredentialsByNode,
+		resolvedCredentialsByNode,
 	};
 }
 
@@ -176,6 +223,15 @@ function getCredentialId(value: unknown): string | undefined {
 	if (typeof id !== 'string' || id.trim() === '') return undefined;
 
 	return id;
+}
+
+function getCredentialName(value: unknown): string | undefined {
+	if (typeof value !== 'object' || value === null || !('name' in value)) return undefined;
+
+	const { name } = value;
+	if (typeof name !== 'string' || name.trim() === '') return undefined;
+
+	return name;
 }
 
 function isKnownCredentialForType(

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-state.ts
@@ -265,6 +265,14 @@ export const workflowBuildOutcomeSchema = z.object({
 	/** Map of node name → credential types that were mocked on that node. */
 	mockedCredentialsByNode: z.record(z.array(z.string())).optional(),
 	/**
+	 * Map of node name → credentials the build attached automatically (restored
+	 * from the saved workflow or auto-bound to the sole existing candidate).
+	 * These nodes are already connected — no credential setup is needed for them.
+	 */
+	resolvedCredentialsByNode: z
+		.record(z.array(z.object({ type: z.string(), id: z.string(), name: z.string() })))
+		.optional(),
+	/**
 	 * @deprecated Legacy `{_mockedCredential}` marker channel. No longer
 	 * written — `nodeSimulationPlan` + `simulationFixtures` replaced it. Kept
 	 * in the schema so build outcomes stored before the change still parse and


### PR DESCRIPTION
## Summary

Fixes the "assistant asks you to connect a credential you already have" bug (INS-770).

What was happening: when the builder writes an unresolved `newCredential('OpenAI account')` (no id), `build-workflow` silently auto-binds the sole existing credential of that type — the saved workflow is actually fine. But the tool result never said so. The model's last mental note was "I left this credential unresolved, setup collects it later", so it finished with *"One setup step: connect your OpenAI credential"* — for a credential that was already attached. Whether this bit you was pure prompt-adherence luck: runs that called `credentials(action="list")` and bound the id explicitly were fine, runs that skipped it re-asked. Same space, same credential, different answer.

The fix closes the feedback loop instead of trying to force the lookup:

- `resolveCredentials` now records what it attached automatically (auto-bind + restore-from-saved-workflow) in `resolvedCredentialsByNode`.
- `build-workflow` surfaces that on the tool result and the stored build outcome, plus a plain-language `credentialResolutionNote`: *"Connected existing credential(s) automatically: … do not ask the user to connect or create them."*
- The `workflow-builder` and `post-build-flow` skills tell the agent to trust the build outcome over its own source file — if the outcome says the credential is bound (or `setupRequirement` is `not_required`), don't offer the setup card, don't call it missing.

Also adds an eval (`binds-existing-credential-without-reasking`) that seeds exactly one Slack credential and turns red if the assistant re-asks for it or leaves the node unbound.

## How to test

1. Create exactly one credential of some type (e.g. Slack).
2. Ask the AI Assistant to build a workflow using that service, without mentioning the credential.
3. The completion should mention it's using your existing credential — no "connect Slack" ask, no credential setup card.
4. `build-workflow`'s result now carries `resolvedCredentialsByNode` + `credentialResolutionNote` when this happens.

Unit tests: `pnpm vitest run src/tools/workflows/__tests__/resolve-credentials.test.ts` in `packages/@n8n/instance-ai`.
Eval: `pnpm eval:instance-ai --filter binds-existing`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-770

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33802">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

