### PR TITLE
fix(editor): Use the show-suffix property to display chevron

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
+++ b/packages/frontend/editor-ui/src/app/components/forms/ResourceFiltersDropdown.vue
@@ -172,6 +172,7 @@ watch(filtersLength, (value) => {
 					<ProjectSharing
 						v-model="selectedProject"
 						:search-fn="searchFn"
+						show-suffix
 						:placeholder="i18n.baseText('forms.resourceFiltersDropdown.owner.placeholder')"
 						:empty-options-text="i18n.baseText('projects.sharing.noMatchingProjects')"
 						@update:model-value="setKeyValue('homeProject', ($event as ProjectSharingData).id)"

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.test.ts
@@ -77,6 +77,31 @@ describe('ProjectSharing', () => {
 		expect(queryByTestId('project-sharing-owner')).not.toBeInTheDocument();
 	});
 
+	it('should hide the dropdown chevron by default (remote + filterable select)', () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				searchFn: createTestSearchFn([]),
+				modelValue: null,
+			},
+		});
+
+		expect(getByTestId('project-sharing-select').querySelector('.el-select__caret')).toBeNull();
+	});
+
+	it('should show the dropdown chevron when showSuffix is set', () => {
+		const { getByTestId } = renderComponent({
+			props: {
+				searchFn: createTestSearchFn([]),
+				modelValue: null,
+				showSuffix: true,
+			},
+		});
+
+		expect(
+			getByTestId('project-sharing-select').querySelector('.el-select__caret'),
+		).toBeInTheDocument();
+	});
+
 	it('should filter, add and remove projects', async () => {
 		const { getByTestId, getAllByTestId, queryAllByTestId, emitted } = renderComponent({
 			props: {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectSharing.vue
@@ -37,6 +37,8 @@ type Props = {
 	isSharedGlobally?: boolean;
 	allUsersLabel?: string;
 	disabledTooltip?: string;
+	// Show the dropdown chevron even in remote+filterable mode (element-plus hides it by default)
+	showSuffix?: boolean;
 };
 
 const props = defineProps<Props>();
@@ -221,6 +223,7 @@ watch(
 				data-test-id="project-sharing-select"
 				filterable
 				remote
+				:remote-show-suffix="props.showSuffix"
 				:remote-method="setFilter"
 				:placeholder="selectPlaceholder"
 				:default-first-option="true"


### PR DESCRIPTION
## Summary

Shows the chevron in the workflow list filter next to the owner drop down
<img width="442" height="457" alt="Screenshot 2026-07-08 at 09 44 47" src="https://github.com/user-attachments/assets/cd4f64e1-3efa-4255-aae0-059626460b66" />

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
Open the filter menu in workflow list
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/ADO-5555
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

