### PR TITLE
fix(editor): Keep credential connect banner below the type selector

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -438,6 +438,29 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 					@click="$emit('retest')"
 				/>
 
+				<!-- Type selection stays above the connection banners: the connect /
+					 connected banner always renders below the selector, so it keeps a
+					 stable position when the credential connects or the type changes. -->
+				<CredentialTypeSelector
+					v-if="
+						isPrivateCredentialsEnabled &&
+						// Only OAuth credentials can be dynamic for now, as they are the only ones with the managed authorize endpoint
+						isOAuthType &&
+						canWrite
+					"
+					:model-value="Boolean(isResolvable)"
+					:info-tip="i18n.baseText('credentialEdit.credentialConfig.dynamicCredentials.infoTip')"
+					@update:model-value="(val) => $emit('update:isResolvable', val)"
+				/>
+
+				<N8nInfoTip
+					v-if="isResolvable"
+					:bold="false"
+					data-test-id="end-user-credential-connect-subtext"
+				>
+					{{ i18n.baseText('credentialEdit.credentialConfig.endUserCredential.connectSubtext') }}
+				</N8nInfoTip>
+
 				<Banner
 					v-show="showOAuthSuccessBanner && !showValidationWarning"
 					theme="success"
@@ -483,18 +506,6 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 					@click="$emit('retest')"
 				/>
 
-				<CredentialTypeSelector
-					v-if="
-						isPrivateCredentialsEnabled &&
-						// Only OAuth credentials can be dynamic for now, as they are the only ones with the managed authorize endpoint
-						isOAuthType &&
-						canWrite
-					"
-					:model-value="Boolean(isResolvable)"
-					:info-tip="i18n.baseText('credentialEdit.credentialConfig.dynamicCredentials.infoTip')"
-					@update:model-value="(val) => $emit('update:isResolvable', val)"
-				/>
-
 				<Banner
 					v-show="showOAuthNotConnectedBanner && !showValidationWarning"
 					theme="warning"
@@ -521,14 +532,6 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 						/>
 					</template>
 				</Banner>
-
-				<N8nInfoTip
-					v-if="isResolvable"
-					:bold="false"
-					data-test-id="end-user-credential-connect-subtext"
-				>
-					{{ i18n.baseText('credentialEdit.credentialConfig.endUserCredential.connectSubtext') }}
-				</N8nInfoTip>
 
 				<template v-if="canWrite">
 					<!-- Instance AI credential setup help (mimics the assistant button) -->


### PR DESCRIPTION
## Summary

In the credentials modal, the OAuth connect/connected banner changed position depending on connection state: the "connected" banner rendered above the credential type selector (per-user vs fixed) while the "not connected" banner rendered below it, so the banner jumped when a credential connected or when the type changed. This moves the type selector (and its subtext) above all the connection banners so the connect banner always stays below the type selection in a stable position.

## How to test

1. Open a credential of an OAuth type that supports end-user (per-user) credentials with private credentials enabled.
2. Toggle between the "fixed" and "per-user" type options and connect/disconnect the account.
3. Verify the connect / connected banner always renders below the type selector and no longer jumps position.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-963

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI