### PR TITLE
fix(core): Reconcile stale AI Assistant mocked-credential simulation plan before workflow verification

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/reverify-reflects-applied-credential.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/reverify-reflects-applied-credential.json
@@ -1,0 +1,49 @@
+{
+	"description": "INS-789 regression. With two matching Slack credentials no auto-attach is possible, so the build mocks the Slack node and freezes that mock into the verification plan. When the user then tells the agent which credential to use and asks for a re-test only (no workflow change), the follow-up verification must reflect the applied credential instead of replaying the stale build-time mocked-credential plan — the historical bug kept reporting the Slack node's credentials as 'not configured' on every re-verify until an unrelated edit forced a rebuild. The form trigger is deliberate: form nodes are always simulated, so the workflow always takes the pin-data replay path where the stale plan was reused.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Create a feedback form with fields for name and comments. When someone submits it, post their feedback to our Slack channel #feedback."
+		},
+		{
+			"role": "assistant",
+			"text": "Built and tested the workflow. There are two Slack credentials on this instance — which one should the Slack step use?"
+		},
+		{
+			"role": "user",
+			"text": [
+				"[After the agent finishes its initial build and test, tell it to use the Slack credential named 'Slack — Engineering' for the Slack step.",
+				"Once it confirms the credential is applied, ask it to run its test again to double-check that the workflow works with that credential.",
+				"Do not ask for any other change — if the agent proposes rebuilding or modifying the workflow's steps, decline and repeat that you only want the credential applied and the test re-run.]"
+			]
+		}
+	],
+	"messageBudget": 10,
+	"complexity": "medium",
+	"tags": ["behaviour", "credentials", "verification", "slack", "form"],
+	"credentials": [
+		{ "type": "slackApi", "name": "Slack — Engineering" },
+		{ "type": "slackApi", "name": "Slack — Marketing" }
+	],
+	"triggerType": "form",
+	"datasets": ["behaviour", "full"],
+	"processExpectations": [
+		"Precondition: during the initial build no Slack credential was auto-attached (two matching credentials existed), and the first verification treated the Slack node as mocked because its credentials were not configured.",
+		"After the user chose 'Slack — Engineering', the agent applied that credential to the workflow itself rather than telling the user to assign it manually in the editor.",
+		"The verification re-run after the credential was applied no longer reported the Slack node's credentials as missing or not configured — neither the verification result nor the agent's reply claimed Slack credentials still needed setup. (Slack may still be simulated in that run, but only because posting is a real external write, not for credential reasons.)",
+		"The agent satisfied the re-test by re-running verification on the existing workflow; it did not modify the workflow's nodes or rebuild it to make verification reflect the applied credential."
+	],
+	"outcomeExpectations": [
+		"The workflow starts from a form trigger whose form collects a name and a comments/feedback field.",
+		"The submitted feedback is posted to the #feedback Slack channel.",
+		"The Slack node ends up with the 'Slack — Engineering' credential assigned, not left credential-less."
+	],
+	"executionScenarios": [
+		{
+			"name": "form-submission-posts-feedback",
+			"description": "A form submission flows through to a Slack post in #feedback",
+			"dataSetup": "The form submission carries name 'Alice' and comments 'Love the new dashboard'. The Slack chat.postMessage call returns { \"ok\": true, \"ts\": \"1700000000.000200\", \"channel\": \"C0FEEDBACK\" }.",
+			"successCriteria": "The workflow executes without errors: the form trigger emits the submission and one Slack message containing the submitted feedback is posted to #feedback."
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/verify-built-workflow.tool.test.ts
@@ -455,6 +455,7 @@ interface VerifyToolContext {
 		};
 		workflowService?: InstanceAiWorkflowService;
 		dataTableService?: InstanceAiDataTableService;
+		credentialService?: { list: Mock };
 	};
 	logger: { debug: Mock; info: Mock; warn: Mock; error: Mock };
 }
@@ -481,8 +482,15 @@ function makeContext(
 	outcome: WorkflowBuildOutcome | undefined,
 	runResult: ExecutionRunResult,
 	overrides: {
-		workflowNodes?: Array<{ name?: string; type: string; parameters?: Record<string, unknown> }>;
+		workflowNodes?: Array<{
+			name?: string;
+			type: string;
+			parameters?: Record<string, unknown>;
+			credentials?: Record<string, unknown>;
+		}>;
+		workflowConnections?: Record<string, unknown>;
 		tableRows?: Record<string, Array<Record<string, unknown>>>;
+		availableCredentials?: Array<{ id: string; name: string; type: string }>;
 	} = {},
 ) {
 	const updateBuildOutcome = vi.fn(
@@ -530,9 +538,19 @@ function makeContext(
 	const workflowService = {
 		getAsWorkflowJSON: vi.fn(async () => {
 			await Promise.resolve();
-			return { nodes: overrides.workflowNodes ?? [] };
+			return {
+				nodes: overrides.workflowNodes ?? [],
+				connections: overrides.workflowConnections ?? {},
+			};
 		}),
 	} as unknown as InstanceAiWorkflowService;
+
+	const credentialService = {
+		list: vi.fn(async () => {
+			await Promise.resolve();
+			return overrides.availableCredentials ?? [];
+		}),
+	};
 
 	const dataTableService = {
 		queryRows,
@@ -565,6 +583,7 @@ function makeContext(
 			executionService: { run },
 			workflowService,
 			dataTableService,
+			credentialService,
 		},
 		logger,
 	};
@@ -1374,5 +1393,106 @@ describe('verify-built-workflow tool — node simulation plan', () => {
 
 		expect(result.success).toBe(true);
 		expect(deleteRows).not.toHaveBeenCalled();
+	});
+});
+
+describe('verify-built-workflow tool — stale mocked-credential plan', () => {
+	const mockedCredentialVerdict = {
+		nodeName: 'Notion',
+		verdict: 'simulate' as const,
+		reason: 'Credentials are not configured for this node',
+		confidence: 'high' as const,
+		source: 'deterministic' as const,
+	};
+	const staleOutcome = () =>
+		makeBuildOutcome({
+			mockedNodeNames: ['Notion'],
+			mockedCredentialTypes: ['notionApi'],
+			mockedCredentialsByNode: { Notion: ['notionApi'] },
+			nodeSimulationPlan: [mockedCredentialVerdict],
+			simulationFixtures: { Notion: [{ page: 'mock' }] },
+		});
+	const notionConnections = {
+		Trigger: { main: [[{ node: 'Notion', type: 'main', index: 0 }]] },
+	};
+
+	it('executes a node for real once its mocked credential was assigned after the build', async () => {
+		const { ctx, updateBuildOutcome } = makeContext(
+			staleOutcome(),
+			{ executionId: 'exec-1', status: 'success', data: {} },
+			{
+				workflowNodes: [
+					{
+						name: 'Notion',
+						type: 'n8n-nodes-base.notion',
+						parameters: { operation: 'get' },
+						credentials: { notionApi: { id: 'cred-1', name: 'Notion' } },
+					},
+				],
+				workflowConnections: notionConnections,
+				availableCredentials: [{ id: 'cred-1', name: 'Notion', type: 'notionApi' }],
+			},
+		);
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.success).toBe(true);
+		expect(result.simulatedNodes).toBeUndefined();
+		const run = vi.mocked(ctx.domainContext.executionService.run);
+		expect(run.mock.calls[0][2]).toMatchObject({ verificationPinData: undefined });
+		expect(updateBuildOutcome).toHaveBeenCalledWith(
+			'wi-1',
+			expect.objectContaining({
+				mockedNodeNames: undefined,
+				mockedCredentialTypes: undefined,
+				mockedCredentialsByNode: undefined,
+				nodeSimulationPlan: [expect.objectContaining({ nodeName: 'Notion', verdict: 'execute' })],
+				simulationFixtures: undefined,
+			}),
+		);
+	});
+
+	it('keeps replaying the stored plan while the credential is still missing', async () => {
+		const { ctx } = makeContext(
+			staleOutcome(),
+			{ executionId: 'exec-1', status: 'success', data: {} },
+			{
+				workflowNodes: [
+					{ name: 'Notion', type: 'n8n-nodes-base.notion', parameters: { operation: 'get' } },
+				],
+				workflowConnections: notionConnections,
+			},
+		);
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.simulatedNodes).toBeUndefined(); // node not reached in this run result
+		const run = vi.mocked(ctx.domainContext.executionService.run);
+		expect(run.mock.calls[0][2]).toMatchObject({
+			verificationPinData: { Notion: [{ page: 'mock' }] },
+		});
+	});
+
+	it('proceeds with the stored plan when the live workflow cannot be loaded', async () => {
+		const { ctx } = makeContext(staleOutcome(), {
+			executionId: 'exec-1',
+			status: 'success',
+			data: {},
+		});
+		vi.mocked(ctx.domainContext.workflowService!.getAsWorkflowJSON).mockRejectedValue(
+			new Error('boom'),
+		);
+
+		const result = await runTool(ctx, { workItemId: 'wi-1', workflowId: 'wf-1' });
+
+		expect(result.success).toBe(true);
+		const run = vi.mocked(ctx.domainContext.executionService.run);
+		expect(run.mock.calls[0][2]).toMatchObject({
+			verificationPinData: { Notion: [{ page: 'mock' }] },
+		});
+		expect(ctx.logger.warn).toHaveBeenCalledWith(
+			'verify-built-workflow: could not reconcile mocked-credential plan',
+			expect.objectContaining({ workItemId: 'wi-1' }),
+		);
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verification/reconcile-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verification/reconcile-plan.ts
@@ -1,0 +1,48 @@
+import type { WorkflowTaskService } from './types';
+import type { OrchestrationContext } from '../../../types';
+import type { WorkflowBuildOutcome } from '../../../workflow-loop/workflow-loop-state';
+import { reconcileSimulationPlan } from '../../workflows/reconcile-simulation-plan';
+import { buildCredentialMap } from '../../workflows/resolve-credentials';
+
+/**
+ * Refresh the build outcome's mocked-credential plan against the live
+ * workflow before a verification run. Credentials assigned after the build
+ * (setup flow, apply-workflow-credentials, manual selection in the editor)
+ * never trigger a rebuild, so without this step every verify replays the
+ * build-time mock. Best-effort: on any failure the stored plan is used as-is.
+ */
+export async function reconcileStaleCredentialPlan(args: {
+	buildOutcome: WorkflowBuildOutcome;
+	workflowId: string;
+	domainContext: NonNullable<OrchestrationContext['domainContext']>;
+	workflowTaskService: WorkflowTaskService;
+	logger: OrchestrationContext['logger'];
+}): Promise<WorkflowBuildOutcome> {
+	const { buildOutcome, workflowId, domainContext, workflowTaskService, logger } = args;
+	if (Object.keys(buildOutcome.mockedCredentialsByNode ?? {}).length === 0) return buildOutcome;
+
+	try {
+		const workflow = await domainContext.workflowService.getAsWorkflowJSON(workflowId);
+		const availableCredentials = await buildCredentialMap(domainContext.credentialService);
+		const patch = await reconcileSimulationPlan({ buildOutcome, workflow, availableCredentials });
+		if (!patch) return buildOutcome;
+
+		await workflowTaskService.updateBuildOutcome(buildOutcome.workItemId, patch);
+		logger.info(
+			'verify-built-workflow: refreshed stale mocked-credential plan from the live workflow',
+			{
+				workItemId: buildOutcome.workItemId,
+				workflowId,
+				remainingMockedNodes: patch.mockedNodeNames ?? [],
+			},
+		);
+		return { ...buildOutcome, ...patch };
+	} catch (error) {
+		logger.warn('verify-built-workflow: could not reconcile mocked-credential plan', {
+			workItemId: buildOutcome.workItemId,
+			workflowId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return buildOutcome;
+	}
+}

--- a/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/verify-built-workflow.tool.ts
@@ -16,6 +16,7 @@ import {
 	persistVerificationOutcome,
 } from './verification/finalize-result';
 import { prepareVerificationRun } from './verification/prepare-run';
+import { reconcileStaleCredentialPlan } from './verification/reconcile-plan';
 import { resolveVerificationTarget } from './verification/resolve-target';
 import { executionNodeErrorSchema } from '../../workflow-loop/workflow-loop-state';
 
@@ -125,7 +126,17 @@ export function createVerifyBuiltWorkflowTool(context: OrchestrationContext) {
 			const targetResult = await resolveVerificationTarget(input, context);
 			if (targetResult.kind === 'blocked') return targetResult.result;
 			const { target } = targetResult;
-			const { input: resolvedInput, buildOutcome, workflowId, workflowTaskService } = target;
+			const { input: resolvedInput, workflowId, workflowTaskService } = target;
+
+			// Credentials assigned after the build never rebuild the plan, so
+			// refresh stale mocked-credential verdicts before pinning.
+			const buildOutcome = await reconcileStaleCredentialPlan({
+				buildOutcome: target.buildOutcome,
+				workflowId,
+				domainContext: target.domainContext,
+				workflowTaskService,
+				logger: context.logger,
+			});
 
 			if (buildOutcome.nodeSimulationPlan === undefined) {
 				return await handleMissingSimulationPlan({

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/apply-workflow-credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/apply-workflow-credentials.tool.test.ts
@@ -4,8 +4,14 @@ import { executeTool } from '../../../__tests__/tool-test-utils';
 import type { InstanceAiContext, OrchestrationContext } from '../../../types';
 import { createApplyWorkflowCredentialsTool } from '../apply-workflow-credentials.tool';
 
-function makeContext(): OrchestrationContext {
-	const workflowJson = {
+interface MakeContextOptions {
+	buildOutcome?: Record<string, unknown>;
+	workflowJson?: Record<string, unknown>;
+	availableCredentials?: Array<{ id: string; name: string; type: string }>;
+}
+
+function makeContext(options: MakeContextOptions = {}): OrchestrationContext {
+	const workflowJson = options.workflowJson ?? {
 		nodes: [
 			{
 				id: 'node-1',
@@ -27,6 +33,7 @@ function makeContext(): OrchestrationContext {
 		} as never,
 		credentialService: {
 			get: vi.fn().mockResolvedValue({ id: 'cred-1', name: 'My Key' }),
+			list: vi.fn().mockResolvedValue(options.availableCredentials ?? []),
 		} as never,
 		executionService: {} as never,
 		nodeService: {} as never,
@@ -36,9 +43,11 @@ function makeContext(): OrchestrationContext {
 
 	return {
 		workflowTaskService: {
-			getBuildOutcome: vi.fn().mockResolvedValue({
-				mockedCredentialsByNode: { Gemini: ['googlePalmApi'] },
-			}),
+			getBuildOutcome: vi.fn().mockResolvedValue(
+				options.buildOutcome ?? {
+					mockedCredentialsByNode: { Gemini: ['googlePalmApi'] },
+				},
+			),
 			updateBuildOutcome: vi.fn().mockResolvedValue(undefined),
 		},
 		domainContext,
@@ -68,6 +77,62 @@ describe('createApplyWorkflowCredentialsTool', () => {
 						},
 					}),
 				],
+			}),
+		);
+	});
+
+	it('refreshes the stale simulation plan instead of stranding the mocked verdict', async () => {
+		const context = makeContext({
+			buildOutcome: {
+				mockedNodeNames: ['Notion'],
+				mockedCredentialTypes: ['notionApi'],
+				mockedCredentialsByNode: { Notion: ['notionApi'] },
+				nodeSimulationPlan: [
+					{
+						nodeName: 'Notion',
+						verdict: 'simulate',
+						reason: 'Credentials are not configured for this node',
+						confidence: 'high',
+						source: 'deterministic',
+					},
+				],
+				simulationFixtures: { Notion: [{ page: 'mock' }] },
+			},
+			workflowJson: {
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Notion',
+						type: 'n8n-nodes-base.notion',
+						typeVersion: 1,
+						position: [0, 0] as [number, number],
+						parameters: { operation: 'get' },
+					},
+				],
+				connections: {
+					Trigger: { main: [[{ node: 'Notion', type: 'main', index: 0 }]] },
+				},
+			},
+			availableCredentials: [{ id: 'cred-1', name: 'My Key', type: 'notionApi' }],
+		});
+		const tool = createApplyWorkflowCredentialsTool(context);
+
+		const result = await executeTool(tool, {
+			workItemId: 'wi_test',
+			workflowId: 'wf-1',
+			credentials: { notionApi: 'cred-1' },
+		});
+
+		expect(result).toEqual({ success: true, appliedNodes: ['Notion'] });
+		expect(context.workflowTaskService!.updateBuildOutcome).toHaveBeenCalledWith(
+			'wi_test',
+			expect.objectContaining({
+				mockedNodeNames: undefined,
+				mockedCredentialTypes: undefined,
+				mockedCredentialsByNode: undefined,
+				verificationPinData: undefined,
+				nodeSimulationPlan: [expect.objectContaining({ nodeName: 'Notion', verdict: 'execute' })],
+				simulationFixtures: undefined,
 			}),
 		);
 	});

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/reconcile-simulation-plan.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/reconcile-simulation-plan.test.ts
@@ -1,0 +1,260 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import type {
+	NodeSimulationVerdict,
+	WorkflowBuildOutcome,
+} from '../../../workflow-loop/workflow-loop-state';
+import { reconcileSimulationPlan } from '../reconcile-simulation-plan';
+import { type CredentialEntry, type CredentialMap } from '../resolve-credentials';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MOCKED_CREDENTIAL_REASON = 'Credentials are not configured for this node';
+
+function makeCredentialMap(credentials: CredentialEntry[]): CredentialMap {
+	const map: CredentialMap = new Map();
+	for (const credential of credentials) {
+		const entries = map.get(credential.type) ?? [];
+		entries.push(credential);
+		map.set(credential.type, entries);
+	}
+	return map;
+}
+
+function mockedVerdict(nodeName: string): NodeSimulationVerdict {
+	return {
+		nodeName,
+		verdict: 'simulate',
+		reason: MOCKED_CREDENTIAL_REASON,
+		confidence: 'high',
+		source: 'deterministic',
+	};
+}
+
+function makeBuildOutcome(overrides: Partial<WorkflowBuildOutcome> = {}): WorkflowBuildOutcome {
+	return {
+		workItemId: 'wi_1',
+		taskId: 'task_1',
+		workflowId: 'wf_1',
+		submitted: true,
+		triggerType: 'manual_or_testable',
+		needsUserInput: false,
+		summary: 'Built',
+		...overrides,
+	};
+}
+
+interface TestNode {
+	name: string;
+	type: string;
+	parameters?: Record<string, unknown>;
+	credentials?: Record<string, unknown>;
+}
+
+function makeWorkflow(nodes: TestNode[]): WorkflowJSON {
+	// Wire every node as a main-flow destination so classification considers it.
+	const connections = Object.fromEntries(
+		nodes.map((node, index) => [
+			index === 0 ? 'Trigger' : nodes[index - 1].name,
+			{ main: [[{ node: node.name, type: 'main', index: 0 }]] },
+		]),
+	);
+	return { name: 'Test Workflow', nodes, connections } as unknown as WorkflowJSON;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('reconcileSimulationPlan', () => {
+	it('returns undefined when the outcome has no mocked credentials', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome(),
+			workflow: makeWorkflow([]),
+			availableCredentials: makeCredentialMap([]),
+		});
+
+		expect(patch).toBeUndefined();
+	});
+
+	it('returns undefined while the mocked node still has no credential', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Notion'],
+				mockedCredentialTypes: ['notionApi'],
+				mockedCredentialsByNode: { Notion: ['notionApi'] },
+				nodeSimulationPlan: [mockedVerdict('Notion')],
+			}),
+			workflow: makeWorkflow([
+				{ name: 'Notion', type: 'n8n-nodes-base.notion', parameters: { operation: 'get' } },
+			]),
+			availableCredentials: makeCredentialMap([]),
+		});
+
+		expect(patch).toBeUndefined();
+	});
+
+	it('returns undefined when the assigned credential id is unknown', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Notion'],
+				mockedCredentialsByNode: { Notion: ['notionApi'] },
+				nodeSimulationPlan: [mockedVerdict('Notion')],
+			}),
+			workflow: makeWorkflow([
+				{
+					name: 'Notion',
+					type: 'n8n-nodes-base.notion',
+					parameters: { operation: 'get' },
+					credentials: { notionApi: { id: 'deleted-cred', name: 'Gone' } },
+				},
+			]),
+			availableCredentials: makeCredentialMap([
+				{ id: 'other-cred', name: 'Other', type: 'notionApi' },
+			]),
+		});
+
+		expect(patch).toBeUndefined();
+	});
+
+	it('flips a safe node to execute and clears its mock bookkeeping once credentials are configured', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Notion'],
+				mockedCredentialTypes: ['notionApi'],
+				mockedCredentialsByNode: { Notion: ['notionApi'] },
+				nodeSimulationPlan: [mockedVerdict('Notion')],
+				simulationFixtures: { Notion: [{ page: 'mock' }] },
+				setupRequirement: {
+					status: 'required',
+					reason: 'mocked-credentials',
+					guidance: 'Route the workflow through setup so the user can add real credentials.',
+				},
+			}),
+			workflow: makeWorkflow([
+				{
+					name: 'Notion',
+					type: 'n8n-nodes-base.notion',
+					parameters: { operation: 'get' },
+					credentials: { notionApi: { id: 'cred-1', name: 'Notion' } },
+				},
+			]),
+			availableCredentials: makeCredentialMap([
+				{ id: 'cred-1', name: 'Notion', type: 'notionApi' },
+			]),
+		});
+
+		expect(patch).toBeDefined();
+		expect(patch?.nodeSimulationPlan).toEqual([
+			expect.objectContaining({ nodeName: 'Notion', verdict: 'execute' }),
+		]);
+		expect(patch?.simulationFixtures).toBeUndefined();
+		expect(patch?.mockedNodeNames).toBeUndefined();
+		expect(patch?.mockedCredentialTypes).toBeUndefined();
+		expect(patch?.mockedCredentialsByNode).toBeUndefined();
+		expect(patch?.setupRequirement).toEqual({ status: 'not_required' });
+	});
+
+	it('keeps a destructive node simulated with an honest reason and keeps its fixture', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Gmail'],
+				mockedCredentialsByNode: { Gmail: ['gmailOAuth2'] },
+				nodeSimulationPlan: [mockedVerdict('Gmail')],
+				simulationFixtures: { Gmail: [{ messageId: 'mock' }] },
+			}),
+			workflow: makeWorkflow([
+				{
+					name: 'Gmail',
+					type: 'n8n-nodes-base.gmail',
+					parameters: { operation: 'send' },
+					credentials: { gmailOAuth2: { id: 'cred-1', name: 'Gmail' } },
+				},
+			]),
+			availableCredentials: makeCredentialMap([
+				{ id: 'cred-1', name: 'Gmail', type: 'gmailOAuth2' },
+			]),
+		});
+
+		expect(patch?.nodeSimulationPlan).toEqual([
+			expect.objectContaining({ nodeName: 'Gmail', verdict: 'simulate' }),
+		]);
+		expect(patch?.nodeSimulationPlan?.[0]?.reason).not.toBe(MOCKED_CREDENTIAL_REASON);
+		expect(patch?.simulationFixtures).toEqual({ Gmail: [{ messageId: 'mock' }] });
+		expect(patch?.mockedNodeNames).toBeUndefined();
+	});
+
+	it('treats an AI Gateway-managed credential as configured', async () => {
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Notion'],
+				mockedCredentialsByNode: { Notion: ['notionApi'] },
+				nodeSimulationPlan: [mockedVerdict('Notion')],
+			}),
+			workflow: makeWorkflow([
+				{
+					name: 'Notion',
+					type: 'n8n-nodes-base.notion',
+					parameters: { operation: 'get' },
+					credentials: { notionApi: { id: null, name: '', __aiGatewayManaged: true } },
+				},
+			]),
+			availableCredentials: makeCredentialMap([]),
+		});
+
+		expect(patch?.nodeSimulationPlan).toEqual([
+			expect.objectContaining({ nodeName: 'Notion', verdict: 'execute' }),
+		]);
+		expect(patch?.mockedCredentialsByNode).toBeUndefined();
+	});
+
+	it('only clears the satisfied node and preserves unrelated verdicts', async () => {
+		const formVerdict: NodeSimulationVerdict = {
+			nodeName: 'Form',
+			verdict: 'simulate',
+			reason: 'Displays a form page and waits for a user submission',
+			confidence: 'high',
+			source: 'deterministic',
+		};
+		const patch = await reconcileSimulationPlan({
+			buildOutcome: makeBuildOutcome({
+				mockedNodeNames: ['Notion', 'Slack'],
+				mockedCredentialTypes: ['notionApi', 'slackApi'],
+				mockedCredentialsByNode: { Notion: ['notionApi'], Slack: ['slackApi'] },
+				nodeSimulationPlan: [formVerdict, mockedVerdict('Notion'), mockedVerdict('Slack')],
+				simulationFixtures: { Form: [{ field: 'x' }], Notion: [{ page: 'mock' }] },
+				setupRequirement: {
+					status: 'required',
+					reason: 'mocked-credentials',
+					guidance: 'Route the workflow through setup so the user can add real credentials.',
+				},
+			}),
+			workflow: makeWorkflow([
+				{ name: 'Form', type: 'n8n-nodes-base.form', parameters: {} },
+				{
+					name: 'Notion',
+					type: 'n8n-nodes-base.notion',
+					parameters: { operation: 'get' },
+					credentials: { notionApi: { id: 'cred-1', name: 'Notion' } },
+				},
+				{ name: 'Slack', type: 'n8n-nodes-base.slack', parameters: { operation: 'send' } },
+			]),
+			availableCredentials: makeCredentialMap([
+				{ id: 'cred-1', name: 'Notion', type: 'notionApi' },
+			]),
+		});
+
+		expect(patch?.nodeSimulationPlan).toEqual([
+			formVerdict,
+			expect.objectContaining({ nodeName: 'Notion', verdict: 'execute' }),
+			mockedVerdict('Slack'),
+		]);
+		expect(patch?.simulationFixtures).toEqual({ Form: [{ field: 'x' }] });
+		expect(patch?.mockedNodeNames).toEqual(['Slack']);
+		expect(patch?.mockedCredentialTypes).toEqual(['slackApi']);
+		expect(patch?.mockedCredentialsByNode).toEqual({ Slack: ['slackApi'] });
+		expect(patch?.setupRequirement).toBeUndefined();
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/workflows/apply-workflow-credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/apply-workflow-credentials.tool.ts
@@ -10,6 +10,8 @@ import { Tool } from '@n8n/agents';
 import { z } from 'zod';
 
 import { assignCredentialToNode, resolveCredentialForApply } from './credential-utils';
+import { reconcileSimulationPlan } from './reconcile-simulation-plan';
+import { buildCredentialMap } from './resolve-credentials';
 import type { OrchestrationContext } from '../../types';
 
 export const applyWorkflowCredentialsInputSchema = z.object({
@@ -90,13 +92,27 @@ export function createApplyWorkflowCredentialsTool(context: OrchestrationContext
 				};
 			}
 
-			// Clear verification context from the build outcome
-			await context.workflowTaskService.updateBuildOutcome(input.workItemId, {
-				mockedCredentialsByNode: undefined,
-				verificationPinData: undefined,
-				mockedNodeNames: undefined,
-				mockedCredentialTypes: undefined,
-			});
+			// Refresh the simulation plan so the next verification executes the
+			// now-credentialed nodes instead of replaying the build-time mock.
+			// Best-effort: verify-built-workflow reconciles again on its own.
+			try {
+				const availableCredentials = await buildCredentialMap(
+					context.domainContext.credentialService,
+				);
+				const patch = await reconcileSimulationPlan({
+					buildOutcome,
+					workflow: json,
+					availableCredentials,
+				});
+				if (patch) {
+					await context.workflowTaskService.updateBuildOutcome(input.workItemId, {
+						...patch,
+						verificationPinData: undefined,
+					});
+				}
+			} catch {
+				// intentional: plan refresh is advisory
+			}
 
 			return { success: true, appliedNodes };
 		})

--- a/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/reconcile-simulation-plan.ts
@@ -1,0 +1,146 @@
+/**
+ * Simulation Plan Reconciliation
+ *
+ * A build outcome freezes the execute-vs-simulate plan at build time. A node
+ * that was simulated only because its credentials were mocked goes stale the
+ * moment a real credential is assigned — via the setup flow, the
+ * apply-workflow-credentials tool, or a manual selection in the editor — since
+ * none of those paths rebuild the workflow. This module re-derives the plan
+ * for exactly those nodes from the live workflow so verification stops
+ * replaying the build-time mock.
+ */
+
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import { classifyNodesForSimulation } from './classify-node-destructiveness.service';
+import { isAiGatewayManagedCredential } from './credential-utils';
+import type { CredentialMap } from './resolve-credentials';
+import type { WorkflowBuildOutcome } from '../../workflow-loop/workflow-loop-state';
+
+export type SimulationPlanPatch = Pick<
+	WorkflowBuildOutcome,
+	| 'mockedNodeNames'
+	| 'mockedCredentialTypes'
+	| 'mockedCredentialsByNode'
+	| 'nodeSimulationPlan'
+	| 'simulationFixtures'
+	| 'setupRequirement'
+>;
+
+function isConfiguredCredential(
+	value: unknown,
+	credentialType: string,
+	availableCredentials: CredentialMap,
+): boolean {
+	if (isAiGatewayManagedCredential(value)) return true;
+	if (typeof value !== 'object' || value === null || !('id' in value)) return false;
+	const { id } = value;
+	if (typeof id !== 'string' || id.trim() === '') return false;
+	return (
+		availableCredentials.get(credentialType)?.some((credential) => credential.id === id) ?? false
+	);
+}
+
+function nodeCredentials(
+	workflow: WorkflowJSON,
+	nodeName: string,
+): Record<string, unknown> | undefined {
+	const node = (workflow.nodes ?? []).find((candidate) => candidate.name === nodeName);
+	return node?.credentials ? (node.credentials as Record<string, unknown>) : undefined;
+}
+
+/**
+ * Compare the outcome's mocked-credential bookkeeping with the live workflow
+ * and return a build-outcome patch when any mocked node now has real
+ * credentials, or `undefined` when nothing changed.
+ *
+ * Satisfied nodes are re-classified with the same policy as a rebuild
+ * (deterministic floor, LLM middle, fail-destructive fallback), so a node that
+ * is destructive stays simulated with an honest reason while safe nodes run
+ * for real. Verdicts of untouched nodes — including build-time LLM decisions
+ * and declared-output overrides — are preserved as-is.
+ */
+export async function reconcileSimulationPlan(args: {
+	buildOutcome: WorkflowBuildOutcome;
+	workflow: WorkflowJSON;
+	availableCredentials: CredentialMap;
+}): Promise<SimulationPlanPatch | undefined> {
+	const { buildOutcome, workflow, availableCredentials } = args;
+
+	const mockedEntries = Object.entries(buildOutcome.mockedCredentialsByNode ?? {});
+	if (mockedEntries.length === 0) return undefined;
+
+	const satisfiedNames = new Set(
+		mockedEntries
+			.filter(([nodeName, mockedTypes]) => {
+				const credentials = nodeCredentials(workflow, nodeName);
+				if (!credentials) return false;
+				const types = mockedTypes.length > 0 ? mockedTypes : Object.keys(credentials);
+				return (
+					types.length > 0 &&
+					types.every((type) =>
+						isConfiguredCredential(credentials[type], type, availableCredentials),
+					)
+				);
+			})
+			.map(([nodeName]) => nodeName),
+	);
+	if (satisfiedNames.size === 0) return undefined;
+
+	const remainingEntries = mockedEntries.filter(([nodeName]) => !satisfiedNames.has(nodeName));
+	const remainingMockedNames = (
+		buildOutcome.mockedNodeNames ?? mockedEntries.map(([nodeName]) => nodeName)
+	).filter((nodeName) => !satisfiedNames.has(nodeName));
+
+	// Scope classification to the satisfied nodes so the ambiguous-node LLM
+	// pass never re-judges the rest of the workflow.
+	const scopedWorkflow: WorkflowJSON = {
+		...workflow,
+		nodes: (workflow.nodes ?? []).filter(
+			(node) => typeof node.name === 'string' && satisfiedNames.has(node.name),
+		),
+	};
+	const freshVerdicts = await classifyNodesForSimulation({
+		workflow: scopedWorkflow,
+		mockedNodeNames: remainingMockedNames,
+	});
+	const freshVerdictByName = new Map(freshVerdicts.map((verdict) => [verdict.nodeName, verdict]));
+
+	// A satisfied node without a fresh verdict (e.g. no longer on the main
+	// flow) keeps its stored verdict — losing coverage is worse than an extra
+	// simulation.
+	const nodeSimulationPlan = buildOutcome.nodeSimulationPlan?.map((verdict) =>
+		satisfiedNames.has(verdict.nodeName)
+			? (freshVerdictByName.get(verdict.nodeName) ?? verdict)
+			: verdict,
+	);
+
+	const retainedFixtureEntries = Object.entries(buildOutcome.simulationFixtures ?? {}).filter(
+		([nodeName]) => freshVerdictByName.get(nodeName)?.verdict !== 'execute',
+	);
+
+	const hasRemainingMocks = remainingEntries.length > 0;
+	const patch: SimulationPlanPatch = {
+		mockedNodeNames: hasRemainingMocks ? remainingMockedNames : undefined,
+		mockedCredentialTypes: hasRemainingMocks
+			? [...new Set(remainingEntries.flatMap(([, types]) => types))]
+			: undefined,
+		mockedCredentialsByNode: hasRemainingMocks ? Object.fromEntries(remainingEntries) : undefined,
+		nodeSimulationPlan,
+		simulationFixtures:
+			retainedFixtureEntries.length > 0 ? Object.fromEntries(retainedFixtureEntries) : undefined,
+	};
+
+	// The mocked-credentials requirement is settled; complete-checkpoint
+	// re-analyzes the live workflow, so any other pending setup still blocks.
+	if (
+		!hasRemainingMocks &&
+		!buildOutcome.hasUnresolvedPlaceholders &&
+		buildOutcome.setupRequirement?.status === 'required' &&
+		buildOutcome.setupRequirement.reason === 'mocked-credentials'
+	) {
+		patch.setupRequirement = { status: 'not_required' };
+	}
+
+	return patch;
+}


### PR DESCRIPTION
## Summary

The post-build verifier replayed the simulation plan that was frozen into the build outcome at build time. It never looked at the workflow again. So when a node was simulated only because its credentials were mocked, the plan stayed stale after the user assigned a real credential. None of the credential paths (setup flow, `apply-workflow-credentials`, manual selection in the editor) trigger a rebuild, and the apply tool even made it worse: it cleared the mock metadata but left `nodeSimulationPlan` and `simulationFixtures` in place, which are the only fields the verifier reads.

The result was the behavior from the bug report: every re-verify kept pinning the node with the build-time fixture and reporting "Credentials are not configured", until some unrelated modification forced a full rebuild. Workflows with form nodes always hit this, because form nodes are always simulated, so those workflows always take the pin data replay path.

What changed:

- New `reconcile-simulation-plan.ts`: compares the outcome's `mockedCredentialsByNode` with the live workflow. Nodes that now have a real credential get re-classified with the same policy as a rebuild (deterministic first, LLM for ambiguous, simulate as fallback). Safe nodes flip to `execute`, destructive nodes stay simulated but with an honest reason. Classification is scoped to just those nodes, so the LLM never re-judges the rest of the workflow.
- `verify-built-workflow` runs this reconciliation before preparing pin data and persists the refreshed outcome. Best effort: if anything fails, it verifies with the stored plan like before.
- `apply-workflow-credentials` uses the same reconciliation instead of blindly clearing the mock metadata.

Also adds an eval case (`reverify-reflects-applied-credential`) that reproduces the exact scenario: two Slack credentials force mocking at build, the user then picks one and asks for a re-test


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-789

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33808">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

