### PR TITLE
fix(core): Isolate sub-node supplyData failures so one bad tool doesn't disable all connected tools

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -541,20 +541,68 @@ describe('getInputConnectionData', () => {
 			expect(supplyData).toHaveBeenCalled();
 		});
 
-		it('should return the tool when there are no issues', async () => {
+		it('should isolate a failing tool and still return healthy tools (graceful degradation)', async () => {
 			agentNodeType.description.inputs = [
 				{
 					type: NodeConnectionTypes.AiTool,
 					required: true,
 				},
 			];
+
+			nodeTypes.getByNameAndVersion
+				.calledWith(secondToolNode.type, expect.anything())
+				.mockReturnValue(secondToolNodeType);
+
+			workflow.getParentNodes
+				.calledWith(agentNode.name, NodeConnectionTypes.AiTool)
+				.mockReturnValue([toolNode.name, secondToolNode.name]);
 			vi.spyOn(executeContext, 'getConnections').mockReturnValueOnce([
 				[{ node: toolNode.name, type: NodeConnectionTypes.AiTool, index: 0 }],
+				[{ node: secondToolNode.name, type: NodeConnectionTypes.AiTool, index: 0 }],
 			]);
 
+			// First tool fails to construct
+			supplyData.mockRejectedValueOnce(new Error('failed to resolve dependency'));
+
 			const result = await executeContext.getInputConnectionData(NodeConnectionTypes.AiTool, 0);
-			expect(result).toEqual([mockTool]);
+
+			// The healthy second tool is still returned, even though the first one failed
+			expect(result).toEqual([secondMockTool]);
 			expect(supplyData).toHaveBeenCalled();
+			expect(secondToolNodeType.supplyData).toHaveBeenCalled();
+
+			// The failure was recorded as a non-fatal hint instead of rejecting the whole call
+			expect(executeContext.hints).toHaveLength(1);
+			expect(executeContext.hints[0].message).toContain(`Error in sub-node ${toolNode.name}`);
+		});
+
+		it('should throw when every connected tool fails to construct', async () => {
+			agentNodeType.description.inputs = [
+				{
+					type: NodeConnectionTypes.AiTool,
+					required: true,
+				},
+			];
+
+			nodeTypes.getByNameAndVersion
+				.calledWith(secondToolNode.type, expect.anything())
+				.mockReturnValue(secondToolNodeType);
+
+			workflow.getParentNodes
+				.calledWith(agentNode.name, NodeConnectionTypes.AiTool)
+				.mockReturnValue([toolNode.name, secondToolNode.name]);
+			vi.spyOn(executeContext, 'getConnections').mockReturnValueOnce([
+				[{ node: toolNode.name, type: NodeConnectionTypes.AiTool, index: 0 }],
+				[{ node: secondToolNode.name, type: NodeConnectionTypes.AiTool, index: 0 }],
+			]);
+
+			supplyData.mockRejectedValueOnce(new Error('failed #1'));
+			(secondToolNodeType.supplyData as Mock).mockRejectedValueOnce(new Error('failed #2'));
+
+			// Nothing healthy is left, so the original error still propagates
+			await expect(
+				executeContext.getInputConnectionData(NodeConnectionTypes.AiTool, 0),
+			).rejects.toThrow(`Error in sub-node ${toolNode.name}`);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -17,6 +17,7 @@ import type {
 	ITaskDataConnections,
 	IWorkflowExecuteAdditionalData,
 	NodeConnectionType,
+	NodeExecutionHint,
 	NodeOutput,
 	SupplyData,
 	Workflow,
@@ -428,6 +429,8 @@ export async function getInputConnectionData(
 	}
 
 	const nodes: SupplyData[] = [];
+	const subNodeErrors: NodeOperationError[] = [];
+
 	for (const connectedNode of connectedNodes) {
 		// Check if this is an HITL (Human-in-the-Loop) tool node
 		// HITL tools need special handling to create the middleware tool
@@ -544,15 +547,43 @@ export async function getInputConnectionData(
 					currentNodeRunIndex,
 				);
 
-				// Display on the calling node which node has the error
-				throw new NodeOperationError(connectedNode, `Error in sub-node ${connectedNode.name}`, {
-					itemIndex,
-					functionality: 'configuration-node',
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-					description: error.message,
+				const subNodeError = new NodeOperationError(
+					connectedNode,
+					`Error in sub-node ${connectedNode.name}`,
+					{
+						itemIndex,
+						functionality: 'configuration-node',
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+						description: error.message,
+					},
+				);
+
+				if (maxConnections === 1) {
+					throw subNodeError;
+				}
+
+				this.logger.warn(subNodeError.message, {
+					node: connectedNode.name,
+					description: subNodeError.description,
 				});
+				subNodeErrors.push(subNodeError);
+				continue;
 			}
 		}
+	}
+
+	if (nodes.length === 0 && subNodeErrors.length > 0) {
+		throw subNodeErrors[0];
+	}
+
+	const hintableContext = this as { addExecutionHints?: (...hints: NodeExecutionHint[]) => void };
+	if (subNodeErrors.length > 0 && typeof hintableContext.addExecutionHints === 'function') {
+		hintableContext.addExecutionHints(
+			...subNodeErrors.map((subNodeError) => ({
+				message: `${subNodeError.message}: ${subNodeError.description ?? ''}`.trim(),
+				location: 'outputPane' as const,
+			})),
+		);
 	}
 
 	return maxConnections === 1 ? (nodes || [])[0]?.response : nodes.map((node) => node.response);


### PR DESCRIPTION
## Summary

Fixes a bug where a single connected sub-node failing during `supplyData()`
construction takes down *every* other sub-node connected to the same input —
even perfectly healthy ones.

This most visibly affects the **MCP Server Trigger** node: if one connected
AI Tool fails to construct (e.g. a community tool node that throws while
resolving a dependency), the entire webhook request returns HTTP 500 and
none of the connected tools are usable, regardless of their own health. The
**AI Agent** node is affected by the same underlying mechanism, since both
go through `getInputConnectionData()` in `n8n-core`.

## Root cause

`getInputConnectionData()` already has a per-sub-node `try/catch` around each
`supplyData()` call, but on failure it only enriches the error and re-throws
it — aborting the whole loop. The sub-nodes that had already constructed
successfully are discarded, and the ones after the failing node are never
even attempted.

## Fix

- For **fan-out inputs** (`maxConnections !== 1`, e.g. AI Tool, where many
  sub-nodes can be connected), a construction failure is now recorded and
  the loop **continues**, so the remaining healthy sub-nodes are still
  assembled and returned.
- For **single, required inputs** (`maxConnections === 1`, e.g. Chat Model,
  Memory), there is no fallback to degrade into, so behavior is **unchanged**
  — these still fail fast, exactly as before.
- If **every** sub-node on a fan-out input fails to construct, there's
  nothing healthy left to serve, so the original error still propagates
  (no silent empty result).
- When some (but not all) sub-nodes fail, the failure is surfaced as a
  non-fatal execution hint on the parent node instead of disappearing
  silently.

The existing diagnostics (`context.addExecutionDataFunctions` for input/
output, and the `Error in sub-node <name>` message) are preserved exactly
as before — this change only affects whether the error aborts the whole
call or is isolated to the one failing sub-node.

## Tests

- Added: healthy AI Tool sub-node is still returned when a sibling tool
  throws in `supplyData()`.
- Added: the call still rejects when **all** connected tools fail to
  construct.
- Verified: all existing tests in `get-input-connection-data.test.ts` pass
  unchanged, including the `maxConnections === 1` fail-fast cases.

## Impact

- Removes the whole-request blast radius from a single misbehaving sub-node.
- MCP Server Trigger's `tools/list` (and equivalent SSE/streamable-HTTP
  handlers) will now return the tools that did resolve, instead of an
  opaque HTTP 500.
- No behavior change for single-required connections (Chat Model, Memory,
  etc.) — those still fail fast, matching current behavior.

Fixes #33792

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33813">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

