### PR TITLE
feat(core): Allow plugin prefix in MCP skillsUsed and unify parameter descriptions

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
@@ -48,13 +48,47 @@ describe('sanitizeSkillsUsed', () => {
 				'workflow-builder',
 				'has spaces',
 				'has/slash',
-				'has:colon',
 				'unicode-‑hyphen',
 				'contains "quote"',
 				'-starts-with-dash',
 				'.starts-with-dot',
 			]),
 		).toEqual(['workflow-builder']);
+	});
+
+	test('keeps plugin-prefixed identifiers', () => {
+		expect(
+			sanitizeSkillsUsed(['n8n-skills:workflow-builder', 'community-plugin:node-selection']),
+		).toEqual(['n8n-skills:workflow-builder', 'community-plugin:node-selection']);
+	});
+
+	test('trims and lowercases plugin-prefixed identifiers', () => {
+		expect(sanitizeSkillsUsed(['  N8N-Skills:Workflow-Builder  '])).toEqual([
+			'n8n-skills:workflow-builder',
+		]);
+	});
+
+	test('keeps prefixed and unprefixed variants of the same skill as distinct entries', () => {
+		expect(sanitizeSkillsUsed(['workflow-builder', 'n8n-skills:workflow-builder'])).toEqual([
+			'workflow-builder',
+			'n8n-skills:workflow-builder',
+		]);
+	});
+
+	test('drops malformed plugin-prefixed identifiers', () => {
+		expect(
+			sanitizeSkillsUsed([
+				'n8n-skills:workflow-builder',
+				':missing-prefix',
+				'missing-name:',
+				'double::colon',
+				'too:many:colons',
+				'n8n-skills:has spaces',
+				'-bad-prefix:workflow-builder',
+				`${'a'.repeat(65)}:workflow-builder`,
+				`n8n-skills:${'a'.repeat(65)}`,
+			]),
+		).toEqual(['n8n-skills:workflow-builder']);
 	});
 
 	test('drops non-string entries', () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -6,7 +6,7 @@ import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from '
 import { validateWorkflowCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials, stripNullCredentialStubs } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
-import { sanitizeSkillsUsed } from './skills-used';
+import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
 import {
 	buildCreateVersionMetadata,
 	resolveVersionMetadata,
@@ -47,12 +47,7 @@ const inputSchema = {
 		.describe(
 			`Full TypeScript/JavaScript workflow code using the n8n Workflow SDK. Must be validated first with ${CODE_BUILDER_VALIDATE_TOOL.toolName}.`,
 		),
-	skillsUsed: z
-		.array(z.string())
-		.optional()
-		.describe(
-			'Names of n8n skills (lowercase kebab-case identifiers) used by the MCP client to produce this workflow create call. Server-side normalization will trim, lowercase, dedupe, and drop entries that are not valid skill identifiers.',
-		),
+	skillsUsed: z.array(z.string()).optional().describe(SKILLS_USED_PARAM_DESCRIPTION),
 	name: z
 		.string()
 		.max(128)

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
@@ -2,6 +2,14 @@ import { RUNTIME_SKILL_NAME_PATTERN } from '@n8n/agents';
 
 const MAX_SKILLS_LOGGED = 50;
 
+// Skill IDs may carry a plugin prefix (e.g. `n8n-skills:workflow-builder`);
+// both the prefix and the skill name follow RUNTIME_SKILL_NAME_PATTERN.
+const skillNameSource = RUNTIME_SKILL_NAME_PATTERN.source.replace(/^\^|\$$/g, '');
+const SKILL_ID_PATTERN = new RegExp(`^(?:${skillNameSource}:)?${skillNameSource}$`);
+
+export const SKILLS_USED_PARAM_DESCRIPTION =
+	'IDs of n8n skills used to prepare this call, e.g. "workflow-builder". An optional plugin prefix is allowed, e.g. "n8n-skills:workflow-builder". Entries are normalized server-side (trimmed, lowercased, deduped); invalid identifiers are dropped.';
+
 export function sanitizeSkillsUsed(input: unknown): string[] | undefined {
 	if (!Array.isArray(input)) return undefined;
 
@@ -11,7 +19,7 @@ export function sanitizeSkillsUsed(input: unknown): string[] | undefined {
 	for (const raw of input) {
 		if (typeof raw !== 'string') continue;
 		const normalized = raw.trim().toLowerCase();
-		if (!RUNTIME_SKILL_NAME_PATTERN.test(normalized)) continue;
+		if (!SKILL_ID_PATTERN.test(normalized)) continue;
 		if (seen.has(normalized)) continue;
 		seen.add(normalized);
 		out.push(normalized);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -12,7 +12,7 @@ import { MCP_UPDATE_WORKFLOW_TOOL } from './constants';
 import { validateCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
-import { sanitizeSkillsUsed } from './skills-used';
+import { sanitizeSkillsUsed, SKILLS_USED_PARAM_DESCRIPTION } from './skills-used';
 import {
 	buildUpdateVersionMetadata,
 	resolveVersionMetadata,
@@ -210,10 +210,7 @@ function collectTouchedNodes(operations: PartialUpdateOperation[]): Map<string, 
 
 const inputSchema: z.ZodRawShape = {
 	workflowId: z.string().describe('The ID of the workflow to update.'),
-	skillsUsed: z
-		.array(z.string())
-		.optional()
-		.describe('n8n skill IDs used for this update; normalized server-side.'),
+	skillsUsed: z.array(z.string()).optional().describe(SKILLS_USED_PARAM_DESCRIPTION),
 	operations: z
 		.array(operationInputSchema)
 		.min(1)


### PR DESCRIPTION
## Summary

The `skillsUsed` telemetry parameter on the MCP `create_workflow_from_code` and `update_workflow` tools previously rejected plugin-prefixed skill identifiers (e.g. `n8n-skills:workflow-builder`), because `sanitizeSkillsUsed` validated entries against `RUNTIME_SKILL_NAME_PATTERN`, which does not allow `:`. MCP clients that install skills via a plugin report them with the plugin prefix, so those entries were silently dropped from telemetry — making it impossible to distinguish official n8n skills from community skills.

Changes:

- `sanitizeSkillsUsed` now accepts an optional plugin prefix (`prefix:skill-name`), where both the prefix and the skill name follow the existing skill-name pattern (derived from `RUNTIME_SKILL_NAME_PATTERN` so they can't drift). The prefix is preserved in the normalized output so telemetry can attribute the skill source.
- The `skillsUsed` parameter description, which previously differed between the create and update tools, is now a shared constant (`SKILLS_USED_PARAM_DESCRIPTION`) that documents the expected format including the optional plugin prefix.
- Added unit tests covering valid prefixed IDs, normalization (trim/lowercase), prefixed vs unprefixed dedupe semantics, and malformed prefix forms (empty prefix/name, double colons, multiple colons, invalid characters, over-length segments).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/MCP-10

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

