### PR TITLE
refactor(core): Use a `bindings` object instead of `credentialBindings` on import (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -138,6 +138,12 @@ describe('ImportPackageRequestDto', () => {
 		{ name: 'non-string target id', bindings: '{"credentials":{"source":1}}' },
 		{ name: 'empty source id', bindings: '{"credentials":{"":"target"}}' },
 		{ name: 'empty target id', bindings: '{"credentials":{"source":""}}' },
+		{ name: 'a misspelled credentials key', bindings: '{"credential":{"source":"target"}}' },
+		{ name: 'an unsupported workflows key', bindings: '{"workflows":{"source":"target"}}' },
+		{
+			name: 'a mix of known and unknown keys',
+			bindings: '{"credentials":{"source":"target"},"nope":{"a":"b"}}',
+		},
 	])('rejects bindings with $name', ({ bindings }) => {
 		expect(
 			ImportPackageRequestDto.safeParse({
@@ -145,6 +151,22 @@ describe('ImportPackageRequestDto', () => {
 				workflowConflictPolicy: 'fail',
 			}).success,
 		).toBe(false);
+	});
+
+	it('names the offending key when bindings use an unknown entity type', () => {
+		const result = ImportPackageRequestDto.safeParse({
+			bindings: '{"credential":{"source":"target"}}',
+			workflowConflictPolicy: 'fail',
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			// The diagnostic must name the typo, not fall back to the generic message —
+			// only the unknown-key path says "unsupported entity type".
+			const message = result.error.errors.map((issue) => issue.message).join('; ');
+			expect(message).toContain('unsupported entity type');
+			expect(message).toContain('"credential"');
+		}
 	});
 
 	it('rejects omitted workflowConflictPolicy', () => {

--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -161,11 +161,11 @@ describe('ImportPackageRequestDto', () => {
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			// The diagnostic must name the typo, not fall back to the generic message —
-			// only the unknown-key path says "unsupported entity type".
+			// The strict schema names the offending key, so the typo is discoverable
+			// rather than being silently stripped and ignored.
 			const message = result.error.errors.map((issue) => issue.message).join('; ');
-			expect(message).toContain('unsupported entity type');
-			expect(message).toContain('"credential"');
+			expect(message).toContain('Unrecognized key');
+			expect(message).toContain('credential');
 		}
 	});
 

--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -8,7 +8,7 @@ describe('ImportPackageRequestDto', () => {
 			expect(result.data).toEqual({
 				credentialMatchingMode: 'id-only',
 				credentialMissingMode: 'create-stub',
-				credentialBindings: {},
+				bindings: {},
 				workflowConflictPolicy: 'fail',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
@@ -27,7 +27,7 @@ describe('ImportPackageRequestDto', () => {
 			expect(result.data).toEqual({
 				credentialMatchingMode: 'id-only',
 				credentialMissingMode: 'create-stub',
-				credentialBindings: {},
+				bindings: {},
 				workflowConflictPolicy: 'fail',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
@@ -48,7 +48,7 @@ describe('ImportPackageRequestDto', () => {
 				folderId: 'fld-1',
 				credentialMatchingMode: 'id-only',
 				credentialMissingMode: 'create-stub',
-				credentialBindings: {},
+				bindings: {},
 				workflowConflictPolicy: 'new-version',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
@@ -68,7 +68,7 @@ describe('ImportPackageRequestDto', () => {
 				projectId: 'proj-1',
 				credentialMatchingMode: 'id-only',
 				credentialMissingMode: 'create-stub',
-				credentialBindings: {},
+				bindings: {},
 				workflowConflictPolicy: 'skip',
 				workflowPublishingPolicy: 'preserve-published-state',
 				workflowIdPolicy: 'new',
@@ -119,28 +119,29 @@ describe('ImportPackageRequestDto', () => {
 		}
 	});
 
-	it('parses credentialBindings from a JSON object string', () => {
+	it('parses bindings from a JSON object string keyed by entity type', () => {
 		const result = ImportPackageRequestDto.safeParse({
-			credentialBindings: '{"source-cred":"target-cred"}',
+			bindings: '{"credentials":{"source-cred":"target-cred"}}',
 			workflowConflictPolicy: 'fail',
 		});
 
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.credentialBindings).toEqual({ 'source-cred': 'target-cred' });
+			expect(result.data.bindings).toEqual({ credentials: { 'source-cred': 'target-cred' } });
 		}
 	});
 
 	it.each([
-		{ name: 'invalid JSON', credentialBindings: 'not json' },
-		{ name: 'array JSON', credentialBindings: '[]' },
-		{ name: 'non-string target id', credentialBindings: '{"source":1}' },
-		{ name: 'empty source id', credentialBindings: '{"":"target"}' },
-		{ name: 'empty target id', credentialBindings: '{"source":""}' },
-	])('rejects credentialBindings with $name', ({ credentialBindings }) => {
+		{ name: 'invalid JSON', bindings: 'not json' },
+		{ name: 'array JSON', bindings: '[]' },
+		{ name: 'non-object credentials map', bindings: '{"credentials":"nope"}' },
+		{ name: 'non-string target id', bindings: '{"credentials":{"source":1}}' },
+		{ name: 'empty source id', bindings: '{"credentials":{"":"target"}}' },
+		{ name: 'empty target id', bindings: '{"credentials":{"source":""}}' },
+	])('rejects bindings with $name', ({ bindings }) => {
 		expect(
 			ImportPackageRequestDto.safeParse({
-				credentialBindings,
+				bindings,
 				workflowConflictPolicy: 'fail',
 			}).success,
 		).toBe(false);

--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -161,8 +161,6 @@ describe('ImportPackageRequestDto', () => {
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			// The strict schema names the offending key, so the typo is discoverable
-			// rather than being silently stripped and ignored.
 			const message = result.error.errors.map((issue) => issue.message).join('; ');
 			expect(message).toContain('Unrecognized key');
 			expect(message).toContain('credential');

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -8,7 +8,7 @@ export const IMPORT_PACKAGE_REQUEST_FORM_FIELDS = [
 	'folderId',
 	'credentialMatchingMode',
 	'credentialMissingMode',
-	'credentialBindings',
+	'bindings',
 	'workflowConflictPolicy',
 	'workflowPublishingPolicy',
 	'workflowIdPolicy',
@@ -32,30 +32,31 @@ function isStringRecord(value: unknown): value is Record<string, string> {
 	);
 }
 
-const credentialBindingsSchema = z
+/** A `bindings` object keyed by entity type; each value maps source ids to target ids. */
+function isBindingsObject(value: unknown): value is { credentials?: Record<string, string> } {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+	return Object.values(value).every((entry) => isStringRecord(entry));
+}
+
+const BINDINGS_ERROR_MESSAGE =
+	'bindings must be a JSON object keyed by entity type, e.g. {"credentials":{"<sourceId>":"<targetId>"}}';
+
+const bindingsSchema = z
 	.string()
 	.optional()
-	.transform((value, ctx) => {
+	.transform((value, ctx): { credentials?: Record<string, string> } => {
 		if (value === undefined || value.trim().length === 0) return {};
 
 		let parsed: unknown;
 		try {
 			parsed = JSON.parse(value);
 		} catch {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				message:
-					'credentialBindings must be a JSON object mapping source credential ids to target credential ids',
-			});
+			ctx.addIssue({ code: z.ZodIssueCode.custom, message: BINDINGS_ERROR_MESSAGE });
 			return z.NEVER;
 		}
 
-		if (!isStringRecord(parsed)) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				message:
-					'credentialBindings must be a JSON object mapping source credential ids to target credential ids',
-			});
+		if (!isBindingsObject(parsed)) {
+			ctx.addIssue({ code: z.ZodIssueCode.custom, message: BINDINGS_ERROR_MESSAGE });
 			return z.NEVER;
 		}
 
@@ -70,7 +71,7 @@ export class ImportPackageRequestDto extends Z.class({
 		.optional()
 		.default('id-only'),
 	credentialMissingMode: z.enum(['must-preexist', 'create-stub']).optional().default('create-stub'),
-	credentialBindings: credentialBindingsSchema,
+	bindings: bindingsSchema,
 	workflowConflictPolicy: z.enum(['new-version', 'fail', 'skip']),
 	workflowPublishingPolicy: z
 		.enum(['preserve-published-state', 'match-source', 'publish-all', 'unpublish-all'])

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -24,37 +24,23 @@ const optionalFormId = z
 		return trimmed.length > 0 ? trimmed : undefined;
 	});
 
-function isStringRecord(value: unknown): value is Record<string, string> {
-	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-	return Object.entries(value).every(
-		([sourceId, targetId]) =>
-			sourceId.length > 0 && typeof targetId === 'string' && targetId.length > 0,
-	);
-}
+const BINDINGS_ERROR_MESSAGE =
+	'bindings must be a JSON object, e.g. {"credentials":{"<sourceId>":"<targetId>"}}';
 
-/** Entity types accepted in an import `bindings` object; only these are honoured today. */
-const KNOWN_BINDING_ENTITY_TYPES = ['credentials'] as const;
-type KnownBindingEntityType = (typeof KNOWN_BINDING_ENTITY_TYPES)[number];
+/** Source id → target id map; both ids are non-empty strings. */
+const bindingMapSchema = z.record(z.string().min(1), z.string().min(1));
 
-/** An import `bindings` object: known entity type → (source id → target id). */
-type BindingsInput = Partial<Record<KnownBindingEntityType, Record<string, string>>>;
+/**
+ * A `bindings` object keyed exclusively by known entity types. `.strict()` rejects
+ * unknown keys (e.g. a misspelled `credential`) with a naming error rather than
+ * silently ignoring them. Only `credentials` is honoured today; other entity types
+ * (`dataTables`/`variables`) are RFC seams — add a field here once honoured.
+ */
+const bindingsObjectSchema = z.object({ credentials: bindingMapSchema }).partial().strict();
 
-function isKnownBindingEntityType(key: string): key is KnownBindingEntityType {
-	return KNOWN_BINDING_ENTITY_TYPES.some((known) => known === key);
-}
+type BindingsInput = z.infer<typeof bindingsObjectSchema>;
 
-/** A `bindings` object keyed exclusively by known entity types, each a source→target id map. */
-function isBindingsObject(value: unknown): value is BindingsInput {
-	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-	return Object.entries(value).every(
-		([key, entry]) => isKnownBindingEntityType(key) && isStringRecord(entry),
-	);
-}
-
-const BINDINGS_ERROR_MESSAGE = `bindings must be a JSON object keyed by a supported entity type (${KNOWN_BINDING_ENTITY_TYPES.join(
-	', ',
-)}), e.g. {"credentials":{"<sourceId>":"<targetId>"}}`;
-
+/** Multipart text field: a JSON string parsed then validated against {@link bindingsObjectSchema}. */
 const bindingsSchema = z
 	.string()
 	.optional()
@@ -69,27 +55,15 @@ const bindingsSchema = z
 			return z.NEVER;
 		}
 
-		// Reject unknown keys explicitly — a typo like "credential" would otherwise
-		// pass validation and then be silently ignored during import.
-		if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-			const unknownKeys = Object.keys(parsed).filter((key) => !isKnownBindingEntityType(key));
-			if (unknownKeys.length > 0) {
-				const offending = unknownKeys.map((key) => `"${key}"`).join(', ');
-				const supported = KNOWN_BINDING_ENTITY_TYPES.join(', ');
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: `bindings contains unsupported entity type(s) ${offending}; supported: ${supported}`,
-				});
-				return z.NEVER;
+		const result = bindingsObjectSchema.safeParse(parsed);
+		if (!result.success) {
+			for (const issue of result.error.issues) {
+				ctx.addIssue({ code: z.ZodIssueCode.custom, message: issue.message, path: issue.path });
 			}
-		}
-
-		if (!isBindingsObject(parsed)) {
-			ctx.addIssue({ code: z.ZodIssueCode.custom, message: BINDINGS_ERROR_MESSAGE });
 			return z.NEVER;
 		}
 
-		return parsed;
+		return result.data;
 	});
 
 export class ImportPackageRequestDto extends Z.class({

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -32,19 +32,33 @@ function isStringRecord(value: unknown): value is Record<string, string> {
 	);
 }
 
-/** A `bindings` object keyed by entity type; each value maps source ids to target ids. */
-function isBindingsObject(value: unknown): value is { credentials?: Record<string, string> } {
-	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
-	return Object.values(value).every((entry) => isStringRecord(entry));
+/** Entity types accepted in an import `bindings` object; only these are honoured today. */
+const KNOWN_BINDING_ENTITY_TYPES = ['credentials'] as const;
+type KnownBindingEntityType = (typeof KNOWN_BINDING_ENTITY_TYPES)[number];
+
+/** An import `bindings` object: known entity type → (source id → target id). */
+type BindingsInput = Partial<Record<KnownBindingEntityType, Record<string, string>>>;
+
+function isKnownBindingEntityType(key: string): key is KnownBindingEntityType {
+	return KNOWN_BINDING_ENTITY_TYPES.some((known) => known === key);
 }
 
-const BINDINGS_ERROR_MESSAGE =
-	'bindings must be a JSON object keyed by entity type, e.g. {"credentials":{"<sourceId>":"<targetId>"}}';
+/** A `bindings` object keyed exclusively by known entity types, each a source→target id map. */
+function isBindingsObject(value: unknown): value is BindingsInput {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+	return Object.entries(value).every(
+		([key, entry]) => isKnownBindingEntityType(key) && isStringRecord(entry),
+	);
+}
+
+const BINDINGS_ERROR_MESSAGE = `bindings must be a JSON object keyed by a supported entity type (${KNOWN_BINDING_ENTITY_TYPES.join(
+	', ',
+)}), e.g. {"credentials":{"<sourceId>":"<targetId>"}}`;
 
 const bindingsSchema = z
 	.string()
 	.optional()
-	.transform((value, ctx): { credentials?: Record<string, string> } => {
+	.transform((value, ctx): BindingsInput => {
 		if (value === undefined || value.trim().length === 0) return {};
 
 		let parsed: unknown;
@@ -53,6 +67,21 @@ const bindingsSchema = z
 		} catch {
 			ctx.addIssue({ code: z.ZodIssueCode.custom, message: BINDINGS_ERROR_MESSAGE });
 			return z.NEVER;
+		}
+
+		// Reject unknown keys explicitly — a typo like "credential" would otherwise
+		// pass validation and then be silently ignored during import.
+		if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+			const unknownKeys = Object.keys(parsed).filter((key) => !isKnownBindingEntityType(key));
+			if (unknownKeys.length > 0) {
+				const offending = unknownKeys.map((key) => `"${key}"`).join(', ');
+				const supported = KNOWN_BINDING_ENTITY_TYPES.join(', ');
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: `bindings contains unsupported entity type(s) ${offending}; supported: ${supported}`,
+				});
+				return z.NEVER;
+			}
 		}
 
 		if (!isBindingsObject(parsed)) {

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -27,20 +27,11 @@ const optionalFormId = z
 const BINDINGS_ERROR_MESSAGE =
 	'bindings must be a JSON object, e.g. {"credentials":{"<sourceId>":"<targetId>"}}';
 
-/** Source id → target id map; both ids are non-empty strings. */
 const bindingMapSchema = z.record(z.string().min(1), z.string().min(1));
-
-/**
- * A `bindings` object keyed exclusively by known entity types. `.strict()` rejects
- * unknown keys (e.g. a misspelled `credential`) with a naming error rather than
- * silently ignoring them. Only `credentials` is honoured today; other entity types
- * (`dataTables`/`variables`) are RFC seams — add a field here once honoured.
- */
 const bindingsObjectSchema = z.object({ credentials: bindingMapSchema }).partial().strict();
 
 type BindingsInput = z.infer<typeof bindingsObjectSchema>;
 
-/** Multipart text field: a JSON string parsed then validated against {@link bindingsObjectSchema}. */
 const bindingsSchema = z
 	.string()
 	.optional()

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -37,6 +37,7 @@ Import a `.n8np` archive into a project.
 n8n-cli package import --file=export.n8np --conflict-policy=fail
 n8n-cli package import --file=export.n8np --project=<id> --conflict-policy=new-version
 n8n-cli package import --file=export.n8np --conflict-policy=fail --credential-missing-mode=must-preexist
+n8n-cli package import --file=export.n8np --conflict-policy=fail --bindings='{"credentials":{"<sourceId>":"<targetId>"}}'
 ```
 
 | Flag | Description |
@@ -48,6 +49,7 @@ n8n-cli package import --file=export.n8np --conflict-policy=fail --credential-mi
 | `--workflow-id-policy` | Whether imported workflows keep their source ID (`source`) or receive a new one (`new`). |
 | `--credential-matching-mode` | How credential references are matched on the target instance: `id-only` (default, match by id), `name-and-type` (match by exact name and type), or `type-only` (match by type). For `name-and-type` and `type-only`, candidates are ranked by scope — owned by the target project, then shared into it, then global — and ties within a scope use the most recently updated credential. |
 | `--credential-missing-mode` | What to do when a referenced credential cannot be resolved. `create-stub` (instance default) creates empty placeholder credentials in the target project; `must-preexist` requires every referenced credential to already exist. |
+| `--bindings` | Explicit source→target id bindings as a JSON object keyed by entity type, e.g. `{"credentials":{"<sourceId>":"<targetId>"}}`. Only `credentials` is honoured today; these bindings are applied before `--credential-matching-mode` resolution runs. |
 
 Requires the API key to hold the `workflow:import` scope. When the import is
 blocked — for example by a workflow conflict under `--conflict-policy=fail`, or

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -145,6 +145,25 @@ describe('N8nClient packages', () => {
 			expect(form.get('credentialMissingMode')).toBe('create-stub');
 		});
 
+		it('forwards bindings verbatim as a form field', async () => {
+			fetchMock.mockResolvedValue(
+				jsonResponse(200, {
+					workflows: [],
+					bindings: {},
+					credentials: { matched: [], stubbed: [] },
+				}),
+			);
+
+			const bindings = '{"credentials":{"source-cred":"target-cred"}}';
+			await client.importPackage(
+				{ buffer: Buffer.from('package-bytes'), filename: 'export.n8np' },
+				{ workflowConflictPolicy: 'fail', bindings },
+			);
+
+			const form = (fetchMock.mock.calls[0] as [string, RequestInit])[1].body as FormData;
+			expect(form.get('bindings')).toBe(bindings);
+		});
+
 		it('omits credentialMissingMode so the instance default applies', async () => {
 			fetchMock.mockResolvedValue(
 				jsonResponse(200, {

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -14,7 +14,6 @@ export interface ImportPackageFields {
 	folderId?: string;
 	credentialMatchingMode?: string;
 	credentialMissingMode?: string;
-	/** JSON object of explicit source→target id bindings, keyed by entity type. Sent verbatim; the server validates it. */
 	bindings?: string;
 	workflowConflictPolicy: string;
 	workflowIdPolicy?: string;

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -14,6 +14,8 @@ export interface ImportPackageFields {
 	folderId?: string;
 	credentialMatchingMode?: string;
 	credentialMissingMode?: string;
+	/** JSON object of explicit source→target id bindings, keyed by entity type. Sent verbatim; the server validates it. */
+	bindings?: string;
 	workflowConflictPolicy: string;
 	workflowIdPolicy?: string;
 }

--- a/packages/@n8n/cli/src/commands/package/import.ts
+++ b/packages/@n8n/cli/src/commands/package/import.ts
@@ -12,6 +12,7 @@ export default class PackageImport extends BaseCommand {
 		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail',
 		'<%= config.bin %> package import --file=export.n8np --project=<id> --conflict-policy=new-version',
 		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail --credential-missing-mode=must-preexist',
+		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail --bindings=\'{"credentials":{"<sourceId>":"<targetId>"}}\'',
 	];
 
 	static override flags = {
@@ -45,6 +46,10 @@ export default class PackageImport extends BaseCommand {
 			options: ['must-preexist', 'create-stub'],
 			aliases: ['credential-missing-mode'],
 		}),
+		bindings: Flags.string({
+			description:
+				'Explicit source→target id bindings as a JSON object keyed by entity type, e.g. \'{"credentials":{"<sourceId>":"<targetId>"}}\'. Applied before credential-matching-mode resolution.',
+		}),
 	};
 
 	async run(): Promise<void> {
@@ -68,6 +73,7 @@ export default class PackageImport extends BaseCommand {
 						workflowIdPolicy: flags.workflowIdPolicy,
 						credentialMatchingMode: flags.credentialMatchingMode,
 						credentialMissingMode: flags.credentialMissingMode,
+						bindings: flags.bindings,
 					},
 				);
 			} catch (error) {

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -53,7 +53,7 @@ type ImportPackageParams = Omit<
 	ImportPackageRequest,
 	| 'credentialMatchingMode'
 	| 'credentialMissingMode'
-	| 'credentialBindings'
+	| 'bindings'
 	| 'workflowConflictPolicy'
 	| 'workflowPublishingPolicy'
 	| 'workflowIdPolicy'
@@ -63,7 +63,7 @@ type ImportPackageParams = Omit<
 			ImportPackageRequest,
 			| 'credentialMatchingMode'
 			| 'credentialMissingMode'
-			| 'credentialBindings'
+			| 'bindings'
 			| 'workflowConflictPolicy'
 			| 'workflowPublishingPolicy'
 			| 'workflowIdPolicy'
@@ -1454,7 +1454,7 @@ describe('ImportPipeline credential resolution', () => {
 
 		const result = await importPackage({
 			user: owner,
-			credentialBindings: new Map([['source-credential', targetCredential.id]]),
+			bindings: { credentials: new Map([['source-credential', targetCredential.id]]) },
 			packageBuffer: await buildImportPackageBuffer(
 				[
 					serializedWorkflowWithCredential({
@@ -1495,7 +1495,7 @@ describe('ImportPipeline credential resolution', () => {
 		await expect(
 			importPackage({
 				user: owner,
-				credentialBindings: new Map([['source-credential', mismatchedCredential.id]]),
+				bindings: { credentials: new Map([['source-credential', mismatchedCredential.id]]) },
 				packageBuffer: await buildImportPackageBuffer(
 					[
 						serializedWorkflowWithCredential({

--- a/packages/cli/src/modules/n8n-packages/__tests__/utils/import-package-upload.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/utils/import-package-upload.test.ts
@@ -105,7 +105,7 @@ describe('resolveImportPackageUpload', () => {
 				files: [makeFile('package', packageBuffer)],
 				body: {
 					folderId: 'fld-1',
-					credentialBindings: '{"source":"target"}',
+					bindings: '{"credentials":{"source":"target"}}',
 					workflowConflictPolicy: 'skip',
 					package: '',
 				},

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -69,7 +69,7 @@ export class ImportPipeline {
 			requirements: manifest.requirements?.credentials,
 			matchingMode: request.credentialMatchingMode,
 			missingMode: request.credentialMissingMode,
-			credentialBindings: request.credentialBindings,
+			credentialBindings: request.bindings?.credentials,
 		};
 
 		const credentialPlan = await this.credentialImporter.plan(context, credentialRequest);

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -47,7 +47,12 @@ export type ImportPackageRequest = {
 	projectId?: string;
 	folderId?: string;
 	packageBuffer: Buffer;
-	bindings?: ImportBindingsInput;
+	/**
+	 * Explicit source→target id overrides supplied with the request, mirroring the
+	 * {@link PackageImportBindings} result shape. Only `credentials` is consumed
+	 * today (and accepted by the request DTO); the remaining keys are RFC seams.
+	 */
+	bindings?: Partial<PackageImportBindings>;
 } & ImportCredentialProperties &
 	ImportWorkflowProperties;
 
@@ -55,15 +60,6 @@ export type ImportCredentialProperties = {
 	credentialMatchingMode: CredentialMatchingMode;
 	credentialMissingMode: CredentialMissingMode;
 };
-
-/**
- * Explicit source→target id overrides supplied with an import request, keyed by
- * entity type and mirroring the {@link SerializedBindings} result shape. Only
- * `credentials` is honoured today; `dataTables`/`variables` are RFC seams.
- */
-export interface ImportBindingsInput {
-	credentials?: ImportBindingMap;
-}
 
 export type ImportWorkflowProperties = {
 	workflowConflictPolicy: WorkflowConflictPolicy;

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -47,11 +47,6 @@ export type ImportPackageRequest = {
 	projectId?: string;
 	folderId?: string;
 	packageBuffer: Buffer;
-	/**
-	 * Explicit source→target id overrides supplied with the request, mirroring the
-	 * {@link PackageImportBindings} result shape. Only `credentials` is consumed
-	 * today (and accepted by the request DTO); the remaining keys are RFC seams.
-	 */
 	bindings?: Partial<PackageImportBindings>;
 } & ImportCredentialProperties &
 	ImportWorkflowProperties;

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -47,14 +47,23 @@ export type ImportPackageRequest = {
 	projectId?: string;
 	folderId?: string;
 	packageBuffer: Buffer;
+	bindings?: ImportBindingsInput;
 } & ImportCredentialProperties &
 	ImportWorkflowProperties;
 
 export type ImportCredentialProperties = {
 	credentialMatchingMode: CredentialMatchingMode;
 	credentialMissingMode: CredentialMissingMode;
-	credentialBindings?: ImportBindingMap;
 };
+
+/**
+ * Explicit source→target id overrides supplied with an import request, keyed by
+ * entity type and mirroring the {@link SerializedBindings} result shape. Only
+ * `credentials` is honoured today; `dataTables`/`variables` are RFC seams.
+ */
+export interface ImportBindingsInput {
+	credentials?: ImportBindingMap;
+}
 
 export type ImportWorkflowProperties = {
 	workflowConflictPolicy: WorkflowConflictPolicy;
@@ -75,8 +84,7 @@ export interface ImportContext {
 	folderId: string | null;
 }
 
-export type ImportPackageEventOptions = Omit<ImportCredentialProperties, 'credentialBindings'> &
-	ImportWorkflowProperties;
+export type ImportPackageEventOptions = ImportCredentialProperties & ImportWorkflowProperties;
 
 /** Credential ids involved in a package import, shaped for forward-compatible audit events. */
 export type ImportAuditCredentialIds = {

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -126,7 +126,9 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 				folderId: payload.data.folderId,
 				credentialMatchingMode: payload.data.credentialMatchingMode,
 				credentialMissingMode: payload.data.credentialMissingMode,
-				credentialBindings: new Map(Object.entries(payload.data.credentialBindings)),
+				bindings: {
+					credentials: new Map(Object.entries(payload.data.bindings.credentials ?? {})),
+				},
 				workflowConflictPolicy: payload.data.workflowConflictPolicy,
 				workflowPublishingPolicy: payload.data.workflowPublishingPolicy,
 				workflowIdPolicy: payload.data.workflowIdPolicy,

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -81,10 +81,12 @@ post:
               default: '{}'
               description: >
                 Optional JSON object of explicit source→target id bindings, keyed
-                by entity type. Today only `credentials` is honoured: send
+                by entity type. Only `credentials` is supported today: send
                 `{"credentials":{"<packageCredentialId>":"<targetCredentialId>"}}`
                 to map credential ids from the package manifest to credential ids
-                on the target instance. These explicit bindings are validated and
+                on the target instance. Any other top-level key (including a
+                misspelled `credentials`) is rejected with `400` rather than
+                silently ignored. These explicit bindings are validated and
                 applied before `credentialMatchingMode` resolution runs.
             workflowConflictPolicy:
               type: string

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -11,7 +11,7 @@ post:
     Imports a gzip-compressed tar package (`.n8np`) into the target project. Send the
     archive as the multipart field `package`. Optional routing uses form fields
     `projectId` and `folderId` (omit or send empty for defaults). The optional
-    `credentialMatchingMode`, `credentialMissingMode`, `credentialBindings`,
+    `credentialMatchingMode`, `credentialMissingMode`, `bindings`,
     `workflowIdPolicy`, and `workflowPublishingPolicy` fields take their defaults when omitted. The required
     `workflowConflictPolicy` field controls what happens when a package workflow
     matches an existing workflow by source id in the target project. Maximum upload
@@ -76,14 +76,16 @@ post:
                 `create-stub` (default) creates empty credential placeholders in
                 the target project for missing references. `must-preexist`
                 requires every referenced credential to already exist.
-            credentialBindings:
+            bindings:
               type: string
               default: '{}'
               description: >
-                Optional JSON object mapping credential ids from the package
-                manifest to credential ids on the target instance. These explicit
-                bindings are validated and applied before `credentialMatchingMode`
-                resolution runs.
+                Optional JSON object of explicit source→target id bindings, keyed
+                by entity type. Today only `credentials` is honoured: send
+                `{"credentials":{"<packageCredentialId>":"<targetCredentialId>"}}`
+                to map credential ids from the package manifest to credential ids
+                on the target instance. These explicit bindings are validated and
+                applied before `credentialMatchingMode` resolution runs.
             workflowConflictPolicy:
               type: string
               enum:

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -83,10 +83,8 @@ post:
                 Optional JSON object of explicit source→target id bindings, keyed
                 by entity type. Only `credentials` is supported today: send
                 `{"credentials":{"<packageCredentialId>":"<targetCredentialId>"}}`
-                to map credential ids from the package manifest to credential ids
-                on the target instance. Any other top-level key (including a
-                misspelled `credentials`) is rejected with `400` rather than
-                silently ignored. These explicit bindings are validated and
+                to map credential ids from the package to credential ids
+                on the target instance. These explicit bindings are validated on type and
                 applied before `credentialMatchingMode` resolution runs.
             workflowConflictPolicy:
               type: string

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -130,8 +130,6 @@ describe('POST /n8n-packages/import', () => {
 			.attach('package', tarBuffer, 'import.n8np');
 
 		expect(response.statusCode).toBe(400);
-		// The strict schema names the offending key; assert that specific diagnostic so a
-		// regression to silently stripping unknown keys would fail here.
 		expect(response.body.message).toContain('Unrecognized key');
 		expect(response.body.message).toContain('credential');
 	});

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -119,6 +119,24 @@ describe('POST /n8n-packages/import', () => {
 		expect(response.statusCode).toBe(400);
 	});
 
+	test('rejects bindings keyed by an unsupported entity type', async () => {
+		const tarBuffer = await buildImportPackage();
+
+		const response = await authOwnerAgent
+			.post('/n8n-packages/import')
+			.field('workflowConflictPolicy', 'fail')
+			// "credential" (no trailing s) is a plausible typo that must error, not silently no-op.
+			.field('bindings', '{"credential":{"source":"target"}}')
+			.attach('package', tarBuffer, 'import.n8np');
+
+		expect(response.statusCode).toBe(400);
+		// Match the unique diagnostic phrase, not just "credential" — the generic binding
+		// error also contains that substring (inside "credentials"), so it would give false
+		// confidence that the offending key was named.
+		expect(response.body.message).toContain('unsupported entity type');
+		expect(response.body.message).toContain('credential');
+	});
+
 	test('imports a package and returns the rich ImportResult', async () => {
 		const tarBuffer = await buildImportPackage();
 

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -168,7 +168,7 @@ describe('POST /n8n-packages/import', () => {
 			.field('folderId', '')
 			.field('credentialMatchingMode', 'id-only')
 			.field('credentialMissingMode', 'must-preexist')
-			.field('credentialBindings', '{}')
+			.field('bindings', '{}')
 			.field('workflowConflictPolicy', 'fail')
 			.field('workflowIdPolicy', 'new')
 			.attach('package', tarBuffer, 'import.n8np');

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -130,10 +130,9 @@ describe('POST /n8n-packages/import', () => {
 			.attach('package', tarBuffer, 'import.n8np');
 
 		expect(response.statusCode).toBe(400);
-		// Match the unique diagnostic phrase, not just "credential" — the generic binding
-		// error also contains that substring (inside "credentials"), so it would give false
-		// confidence that the offending key was named.
-		expect(response.body.message).toContain('unsupported entity type');
+		// The strict schema names the offending key; assert that specific diagnostic so a
+		// regression to silently stripping unknown keys would fail here.
+		expect(response.body.message).toContain('Unrecognized key');
 		expect(response.body.message).toContain('credential');
 	});
 


### PR DESCRIPTION
## Summary

Reshapes the **manual bindings map** supplied with a package (`.n8np`) import so it is keyed by entity type:

```jsonc
// before
credentialBindings: { "<sourceId>": "<targetId>" }
// after
bindings: { "credentials": { "<sourceId>": "<targetId>" } }
```

This mirrors the keyed result shape already returned in `ImportResult.bindings` (`SerializedBindings`) and leaves seams for future `dataTables`/`variables` bindings as the package RFC lands — without adding those keys prematurely. Only `credentials` is honoured today.

The change is threaded through every layer of the import path:

- **`@n8n/api-types` DTO** — the multipart form field is renamed `credentialBindings` → `bindings`, and zod now validates a JSON object keyed by entity type (each value a `{ sourceId: targetId }` string record).
- **Public API** — the handler builds `bindings.credentials` from the parsed payload; the hand-written OpenAPI spec (`n8n-packages.import.yml`) documents the new field and shape.
- **Module request types** — `ImportPackageRequest` gains a typed `bindings?: ImportBindingsInput`; `credentialBindings` is removed from `ImportCredentialProperties`.
- **CLI (`@n8n/cli`)** — `n8n-cli package import` gains a `--bindings` flag that accepts the entity-keyed map as a JSON string (e.g. `--bindings='{"credentials":{"<sourceId>":"<targetId>"}}'`), forwarded verbatim as the `bindings` multipart field for the server to validate.

The internal, credential-scoped `credentialBindings` name (on `CredentialBindingRequest` / `CredentialMatcherContext` and the credential matcher/importer) is deliberately **kept** — downstream of the supply boundary it is accurately credential-specific, so renaming it would be churn without benefit.

This lands the "generalize the credential-only import input to keyed bindings" follow-up flagged during the export-side alignment work.

## How to test

The package import/export feature is beta and licensed behind `feat:n8nPackages`.

Automated coverage (all green):

```bash
# DTO validation
pnpm --filter @n8n/api-types vitest run src/dto/packages/__tests__/import-package-request.dto.test.ts
# module unit + integration (from packages/cli)
pnpm --filter n8n test:integration src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
pnpm --filter n8n test:integration test/integration/public-api/n8n-packages-import.test.ts
# CLI client
pnpm --filter @n8n/cli vitest run src/__tests__/client.test.ts
```

Manual (public API): `POST /n8n-packages/import` as multipart form-data with a `bindings` field, e.g. `bindings={"credentials":{"<packageCredentialId>":"<targetCredentialId>"}}`.

Manual (CLI): `n8n-cli package import --file=export.n8np --conflict-policy=fail --bindings='{"credentials":{"<sourceId>":"<targetId>"}}'`.

In both cases the explicit binding is validated and applied before `credentialMatchingMode` resolution; the response `bindings.credentials` reflects the resolved source→target map.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Part of the n8n-packages import work; no dedicated ticket. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

🤖 PR Summary generated by AI