### PR TITLE
ci: Raise Instance AI eval workflow timeout for full-suite baseline runs (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -93,7 +93,9 @@ jobs:
   run-evals:
     name: 'Run Evals'
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    timeout-minutes: 90
+    # Full-suite baseline refreshes (~140 dataset rows × 10 iterations) outgrew
+    # 90 minutes as cases were added — runs were getting killed at the cap.
+    timeout-minutes: 240
     env:
       # Each port hosts an independent n8n container. The eval CLI's
       # work-stealing allocator dispatches builds across them, capped per-lane.

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -92,7 +92,11 @@ on:
 jobs:
   run-evals:
     name: 'Run Evals'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    # 8vcpu for the memory headroom, not the cores: 11 lane containers plus the
+    # eval CLI (which holds every run result until the final reshape) exceed the
+    # 4vcpu host's RAM on full-suite N=10 runs — the host OOM killed the runner
+    # mid-eval with no error in the job log.
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     # Full-suite baseline refreshes (~140 dataset rows × 10 iterations) outgrew
     # 90 minutes as cases were added — runs were getting killed at the cap.
     timeout-minutes: 240


### PR DESCRIPTION
## Summary

Full-suite baseline refreshes (~140 dataset rows × 10 iterations after recent case additions) outgrew the 90-minute job timeout — several full-scale runs on Jul 6 were cancelled at 92–93 min by the cap. Raises `run-evals` `timeout-minutes` 90 → 240.

Needed now: the TRUST-158 baseline refresh (#33788 / #33789) dispatches point at this branch as the workflow ref.

## How to test

Dispatch `test-evals-instance-ai.yml` with `--ref` this branch and baseline-scale inputs; the job no longer gets cancelled at 90 min.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-158

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33817">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

