### PR TITLE
fix: Update Supabase credential description to use new secret keys

### DIFF
--- a/packages/nodes-base/credentials/SupabaseApi.credentials.ts
+++ b/packages/nodes-base/credentials/SupabaseApi.credentials.ts
@@ -19,15 +19,19 @@ export class SupabaseApi implements ICredentialType {
 			type: 'string',
 			placeholder: 'https://your_account.supabase.co',
 			default: '',
+			description:
+				'Your Supabase project URL without the <code>/rest/v1</code> path. If you copied the full Data API URL, remove the <code>/rest/v1</code> suffix.',
 		},
 		{
-			displayName: 'Service Role Secret',
+			displayName: 'Secret Key',
 			name: 'serviceRole',
 			type: 'string',
 			default: '',
 			typeOptions: {
 				password: true,
 			},
+			description:
+				'Your Supabase project secret key. You can create one in the <a href="https://supabase.com/dashboard/project/_/settings/api-keys" target="_blank">API Keys settings</a> of your project. Legacy service_role secrets are also supported.',
 		},
 	];
 


### PR DESCRIPTION
## Summary

The old `service_role` secrets are [deprecated and will stop working end of 2026](https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys).

- Updated the naming to be `Secret Key` instead of legacy `Service Role Secret`
- Added tooltip descriptions to secret key and Host fields

No functional changes, Supabase API accepts both the new secret keys and the old service role secrets in the same header format. Related docs changes ([PR](https://github.com/n8n-io/n8n-docs/pull/4996)): https://docs.n8n.io/integrations/~/revisions/TRwTrGeJipAVk7Ym3lrs/builtin/credentials/supabase

<img width="1064" height="594" alt="Bildschirmfoto 2026-07-08 um 10 54 02" src="https://github.com/user-attachments/assets/17384688-e46e-400d-bdd5-a55d42d87068" />

Official documentation refs:
- https://supabase.com/docs/guides/getting-started/api-keys
- https://supabase.com/docs/guides/getting-started/migrating-to-new-api-keys
- https://supabase.com/docs/guides/api

## How to test

1. Create a Supabase credential
2. Observe new naming `Secret Key` and that it has a tooltip description (must hover over the field)
3. Observe that `Host` now also has a tooltip description

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5403/update-supabase-node-and-docs-for-new-supabase-api-keys

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33818">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

