### PR TITLE
fix(editor): Preserve valid model selection when switching credentials

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -7,6 +7,7 @@ import type { CompletionResult } from '@codemirror/autocomplete';
 import { createTestingPinia } from '@pinia/testing';
 import { faker } from '@faker-js/faker';
 import { fireEvent, waitFor, within } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
 import userEvent from '@testing-library/user-event';
 import type { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -1086,13 +1087,12 @@ describe('ParameterInput.vue', () => {
 		});
 	});
 
-	describe('credential change resets options value', () => {
-		test('should reset options value when credentials change', async () => {
-			mockNodeTypesState.getNodeParameterOptions = vi.fn(async () => [
-				{ name: 'GPT-4', value: 'gpt-4' },
-				{ name: 'GPT-3.5', value: 'gpt-3.5-turbo' },
-			]);
-
+	describe('credential change validates options value', () => {
+		function renderModelParam(
+			getModels: () => Promise<Array<{ name: string; value: string }>>,
+			modelValue: string = 'gpt-3.5-turbo',
+		) {
+			mockNodeTypesState.getNodeParameterOptions = vi.fn(getModels);
 			const activeNode = reactive({
 				id: faker.string.uuid(),
 				name: 'Test Node',
@@ -1100,16 +1100,12 @@ describe('ParameterInput.vue', () => {
 				position: [0, 0] as [number, number],
 				type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
 				typeVersion: 1,
-				credentials: {
-					openAiApi: { id: '1', name: 'OpenAI Account 1' },
-				},
+				credentials: { openAiApi: { id: '1', name: 'OpenAI Account 1' } } as Record<
+					string,
+					{ id: string; name: string }
+				>,
 			});
-
-			mockNdvState = {
-				...getNdvStateMock(),
-				activeNode,
-			};
-
+			mockNdvState = { ...getNdvStateMock(), activeNode };
 			const { emitted } = renderComponent({
 				props: {
 					path: 'model',
@@ -1120,25 +1116,106 @@ describe('ParameterInput.vue', () => {
 						default: 'gpt-4',
 						typeOptions: { loadOptionsMethod: 'getModels' },
 					}),
-					modelValue: 'gpt-3.5-turbo',
+					modelValue,
 				},
 			});
+			return { emitted, activeNode };
+		}
 
-			await waitFor(() => {
-				expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalled();
-			});
-
-			// Change credentials — the previously selected model should be reset to the default
-			activeNode.credentials = {
-				openAiApi: { id: '2', name: 'OpenAI Account 2' },
-			};
+		async function switchCredentialsAndReload(activeNode: {
+			credentials: Record<string, { id: string; name: string }>;
+		}) {
+			await waitFor(() => expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalled());
+			activeNode.credentials = { openAiApi: { id: '2', name: 'OpenAI Account 2' } };
 			await nextTick();
+			await waitFor(() =>
+				expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalledTimes(2),
+			);
+			await flushPromises();
+		}
 
+		async function expectModelResetToDefault(
+			emitted: ReturnType<typeof renderComponent>['emitted'],
+		) {
 			await waitFor(() => {
 				expect(emitted('update')).toContainEqual([
 					expect.objectContaining({ name: 'model', value: 'gpt-4' }),
 				]);
 			});
+		}
+
+		test('should preserve options value when it is still valid for the new credentials', async () => {
+			const { emitted, activeNode } = renderModelParam(async () => [
+				{ name: 'GPT-4', value: 'gpt-4' },
+				{ name: 'GPT-3.5', value: 'gpt-3.5-turbo' },
+			]);
+			await switchCredentialsAndReload(activeNode);
+			expect(emitted('update') ?? []).not.toContainEqual([
+				expect.objectContaining({ name: 'model' }),
+			]);
+		});
+
+		test('should not reset an expression value on credential change', async () => {
+			const { emitted, activeNode } = renderModelParam(
+				async () => [{ name: 'GPT-4', value: 'gpt-4' }],
+				'={{ $json.model }}',
+			);
+			await switchCredentialsAndReload(activeNode);
+			expect(emitted('update') ?? []).not.toContainEqual([
+				expect.objectContaining({ name: 'model' }),
+			]);
+		});
+
+		test('should reset options value to default when it is no longer valid for the new credentials', async () => {
+			const { emitted, activeNode } = renderModelParam(async () => [
+				{ name: 'GPT-4', value: 'gpt-4' },
+			]);
+			await switchCredentialsAndReload(activeNode);
+			await expectModelResetToDefault(emitted);
+		});
+
+		test('should reset options value to default when the reloaded options fail to load', async () => {
+			const { emitted, activeNode } = renderModelParam(async () => {
+				throw new Error('Failed to load options');
+			});
+			await switchCredentialsAndReload(activeNode);
+			await expectModelResetToDefault(emitted);
+		});
+
+		test('should reset options value to default when the reloaded list is empty', async () => {
+			const { emitted, activeNode } = renderModelParam(async () => []);
+			await switchCredentialsAndReload(activeNode);
+			await expectModelResetToDefault(emitted);
+		});
+
+		test('should not apply a stale reload when credentials change again mid-load', async () => {
+			let resolveLoad!: (options: Array<{ name: string; value: string }>) => void;
+			const pendingLoad = new Promise<Array<{ name: string; value: string }>>((resolve) => {
+				resolveLoad = resolve;
+			});
+			let call = 0;
+			const { emitted, activeNode } = renderModelParam(async () => {
+				call += 1;
+				return call === 1 ? [{ name: 'GPT-3.5', value: 'gpt-3.5-turbo' }] : await pendingLoad;
+			});
+
+			await waitFor(() => expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalled());
+
+			activeNode.credentials = { openAiApi: { id: '2', name: 'OpenAI Account 2' } };
+			await nextTick();
+			await waitFor(() =>
+				expect(mockNodeTypesState.getNodeParameterOptions).toHaveBeenCalledTimes(2),
+			);
+
+			// Swap again before the first reload resolves, then resolve it stale.
+			activeNode.credentials = { openAiApi: { id: '3', name: 'OpenAI Account 3' } };
+			await nextTick();
+			resolveLoad([{ name: 'GPT-4', value: 'gpt-4' }]);
+			await flushPromises();
+
+			expect(emitted('update') ?? []).not.toContainEqual([
+				expect.objectContaining({ name: 'model' }),
+			]);
 		});
 
 		test('should not reset non-options parameter when credentials change', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -1366,18 +1366,29 @@ onBeforeUnmount(() => {
 
 watch(
 	() => node.value?.credentials,
-	(_newCredentials, oldCredentials) => {
-		if (hasRemoteMethod.value && node.value) {
-			void loadRemoteParameterOptions();
-			// Reset options value when credentials change (not on initial load or first assignment)
-			const hadCredentials = oldCredentials !== undefined && Object.keys(oldCredentials).length > 0;
-			if (hadCredentials && props.parameter.type === 'options') {
-				emit('update', {
-					node: node.value.name,
-					name: props.path,
-					value: props.parameter.default ?? '',
-				});
-			}
+	async (newCredentials, oldCredentials) => {
+		if (!hasRemoteMethod.value || !node.value) return;
+		await loadRemoteParameterOptions();
+		// Credentials changed again while loading — a newer run will validate the fresh results.
+		if (!node.value || node.value.credentials !== newCredentials) return;
+		const hadCredentials = oldCredentials !== undefined && Object.keys(oldCredentials).length > 0;
+		if (
+			!hadCredentials ||
+			props.parameter.type !== 'options' ||
+			isModelValueExpression.value ||
+			remoteParameterOptionsLoading.value
+		) {
+			return;
+		}
+		const stillValid = remoteParameterOptions.value.some(
+			(option) => option.value === props.modelValue,
+		);
+		if (!stillValid) {
+			emit('update', {
+				node: node.value.name,
+				name: props.path,
+				value: props.parameter.default ?? '',
+			});
 		}
 	},
 	{ immediate: true },

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -929,6 +929,34 @@ describe('ResourceLocator', () => {
 			});
 		});
 
+		it('should ignore a stale search filter and validate against the full list', async () => {
+			// A non-empty filter hides the selected value; the full (unfiltered) list contains it.
+			nodeTypesStore.getResourceLocatorResults.mockImplementation(async (params) => {
+				if (params.filter) {
+					return {
+						results: [{ name: 'Other', value: 'other-model', url: 'https://new.com/other' }],
+						paginationToken: undefined,
+					};
+				}
+				return {
+					results: [{ name: 'GPT-4', value: 'selected-model', url: 'https://new.com/gpt-4' }],
+					paginationToken: undefined,
+				};
+			});
+
+			const { emitted, rerender, getByTestId } = renderWithValue(SELECTED_MODEL);
+
+			// Leave a stale search filter that excludes the selected value.
+			await fireEvent.focus(getByTestId('rlc-input'));
+			await userEvent.type(getByTestId('rlc-search'), 'zzz');
+
+			await switchCredentials(rerender);
+			await flushPromises();
+
+			const updates = (emitted('update:modelValue') ?? []) as Array<[typeof SELECTED_MODEL]>;
+			expect(updates.every(([value]) => value.value === 'selected-model')).toBe(true);
+		});
+
 		it('should not reset value in manual (id) mode', async () => {
 			const { emitted, rerender } = renderWithValue({
 				...TEST_MODEL_VALUE,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.test.ts
@@ -9,6 +9,7 @@ import ResourceLocator from './ResourceLocator.vue';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
 import { computed, shallowRef } from 'vue';
 import { mockedStore } from '@/__tests__/utils';
 import { vi } from 'vitest';
@@ -789,52 +790,198 @@ describe('ResourceLocator', () => {
 		});
 	});
 
-	describe('credential change resets value', () => {
-		it('should reset value when node credentials change', async () => {
-			const modelValue: typeof TEST_MODEL_VALUE = {
-				...TEST_MODEL_VALUE,
-				value: 'selected-model',
-				cachedResultName: 'GPT-4',
-				cachedResultUrl: 'https://test.com/gpt-4',
-			};
+	describe('credential change validates value', () => {
+		const SELECTED_MODEL: typeof TEST_MODEL_VALUE = {
+			...TEST_MODEL_VALUE,
+			value: 'selected-model',
+			cachedResultName: 'GPT-4',
+			cachedResultUrl: 'https://test.com/gpt-4',
+		};
 
-			const node = { ...TEST_NODE_MULTI_MODE };
-
-			const { emitted, rerender } = renderComponent({
+		function renderWithValue(modelValue: typeof TEST_MODEL_VALUE) {
+			return renderComponent({
 				props: {
 					modelValue,
 					parameter: TEST_PARAMETER_MULTI_MODE,
 					path: `parameters.${TEST_PARAMETER_MULTI_MODE.name}`,
-					node,
+					node: { ...TEST_NODE_MULTI_MODE },
 					displayTitle: 'Test Resource Locator',
 					expressionComputedValue: '',
 					isValueExpression: false,
 				},
 			});
+		}
 
-			// Change credentials on the node
+		async function switchCredentials(rerender: ReturnType<typeof renderComponent>['rerender']) {
 			await rerender({
 				node: {
-					...node,
-					credentials: {
-						testAuth: {
-							id: '5678',
-							name: 'Different Account',
-						},
-					},
+					...TEST_NODE_MULTI_MODE,
+					credentials: { testAuth: { id: '5678', name: 'Different Account' } },
 				},
 			});
+		}
 
-			expect(emitted('update:modelValue')).toEqual([
-				[
+		it('should preserve value and refresh cached label when it is still valid for the new credentials', async () => {
+			nodeTypesStore.getResourceLocatorResults.mockResolvedValue({
+				results: [
+					{ name: 'GPT-4 (renamed)', value: 'selected-model', url: 'https://new.com/gpt-4' },
+					{ name: 'Other', value: 'other-model', url: 'https://new.com/other' },
+				],
+				paginationToken: undefined,
+			});
+
+			const { emitted, rerender } = renderWithValue(SELECTED_MODEL);
+			await switchCredentials(rerender);
+
+			await waitFor(() => {
+				expect(emitted('update:modelValue')).toEqual([
+					[
+						{
+							...SELECTED_MODEL,
+							cachedResultName: 'GPT-4 (renamed)',
+							cachedResultUrl: 'https://new.com/gpt-4',
+						},
+					],
+				]);
+			});
+		});
+
+		it('should reset value when it is no longer valid for the new credentials', async () => {
+			nodeTypesStore.getResourceLocatorResults.mockResolvedValue({
+				results: [{ name: 'Other', value: 'other-model', url: 'https://new.com/other' }],
+				paginationToken: undefined,
+			});
+
+			const { emitted, rerender } = renderWithValue(SELECTED_MODEL);
+			await switchCredentials(rerender);
+
+			await waitFor(() => {
+				expect(emitted('update:modelValue')).toEqual([
+					[{ ...SELECTED_MODEL, cachedResultName: '', cachedResultUrl: '', value: '' }],
+				]);
+			});
+		});
+
+		it('should reset value when the reloaded list fails to load', async () => {
+			nodeTypesStore.getResourceLocatorResults.mockRejectedValue(new Error('Failed to load'));
+
+			const { emitted, rerender } = renderWithValue(SELECTED_MODEL);
+			await switchCredentials(rerender);
+
+			await waitFor(() => {
+				expect(emitted('update:modelValue')).toEqual([
+					[{ ...SELECTED_MODEL, cachedResultName: '', cachedResultUrl: '', value: '' }],
+				]);
+			});
+		});
+
+		it('should preserve value but clear cached label when the list cannot be confirmed complete', async () => {
+			nodeTypesStore.getResourceLocatorResults.mockResolvedValue({
+				results: [{ name: 'Other', value: 'other-model', url: 'https://new.com/other' }],
+				paginationToken: 'next-page',
+			});
+
+			const { emitted, rerender } = renderWithValue(SELECTED_MODEL);
+			await switchCredentials(rerender);
+
+			await waitFor(() => {
+				expect(emitted('update:modelValue')).toEqual([
+					[{ ...SELECTED_MODEL, cachedResultName: '', cachedResultUrl: '' }],
+				]);
+			});
+		});
+
+		it('should preserve value but clear cached label when the list requires a search filter', async () => {
+			const searchRequiredParam: typeof TEST_PARAMETER_MULTI_MODE = {
+				...TEST_PARAMETER_MULTI_MODE,
+				name: 'searchRequiredParam',
+				modes: [
 					{
-						...modelValue,
-						cachedResultName: '',
-						cachedResultUrl: '',
-						value: '',
+						displayName: 'From List',
+						name: 'list',
+						type: 'list',
+						typeOptions: {
+							searchListMethod: 'testSearch',
+							searchable: true,
+							searchFilterRequired: true,
+						},
 					},
 				],
-			]);
+			};
+
+			const { emitted, rerender } = renderComponent({
+				props: {
+					modelValue: SELECTED_MODEL,
+					parameter: searchRequiredParam,
+					path: `parameters.${searchRequiredParam.name}`,
+					node: { ...TEST_NODE_MULTI_MODE },
+					displayTitle: 'Test Resource Locator',
+					expressionComputedValue: '',
+					isValueExpression: false,
+				},
+			});
+			await switchCredentials(rerender);
+
+			await waitFor(() => {
+				expect(emitted('update:modelValue')).toEqual([
+					[{ ...SELECTED_MODEL, cachedResultName: '', cachedResultUrl: '' }],
+				]);
+			});
+		});
+
+		it('should not reset value in manual (id) mode', async () => {
+			const { emitted, rerender } = renderWithValue({
+				...TEST_MODEL_VALUE,
+				mode: 'id',
+				value: 'manual-id',
+			});
+			await switchCredentials(rerender);
+
+			expect(emitted('update:modelValue')).toBeUndefined();
+		});
+
+		it('should not apply a stale reloaded list after credentials change again mid-load', async () => {
+			let resolveStale!: (result: INodeListSearchResult) => void;
+			const staleLoad = new Promise<INodeListSearchResult>((resolve) => {
+				resolveStale = resolve;
+			});
+			let resolveCurrent!: (result: INodeListSearchResult) => void;
+			const currentLoad = new Promise<INodeListSearchResult>((resolve) => {
+				resolveCurrent = resolve;
+			});
+			const validList = {
+				results: [{ name: 'GPT-4', value: 'selected-model', url: 'https://new.com/gpt-4' }],
+				paginationToken: undefined,
+			};
+			nodeTypesStore.getResourceLocatorResults
+				.mockReturnValueOnce(staleLoad)
+				.mockReturnValueOnce(currentLoad)
+				.mockResolvedValue(validList);
+
+			const { emitted, rerender } = renderWithValue(SELECTED_MODEL);
+			await rerender({
+				node: {
+					...TEST_NODE_MULTI_MODE,
+					credentials: { testAuth: { id: '5678', name: 'Second' } },
+				},
+			});
+			await rerender({
+				node: { ...TEST_NODE_MULTI_MODE, credentials: { testAuth: { id: '9999', name: 'Third' } } },
+			});
+
+			// Resolve the stale reload while the current one is still pending; the guard must drop it.
+			resolveStale({
+				results: [{ name: 'Other', value: 'other-model' }],
+				paginationToken: undefined,
+			});
+			await flushPromises();
+
+			resolveCurrent(validList);
+			await flushPromises();
+
+			const updates = (emitted('update:modelValue') ?? []) as Array<[typeof SELECTED_MODEL]>;
+			expect(updates.length).toBeGreaterThan(0);
+			expect(updates.every(([value]) => value.value === 'selected-model')).toBe(true);
 		});
 
 		it('should not reset value when credentials have not changed', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -543,23 +543,46 @@ watch(
 
 watch(
 	() => stringify(props.node?.credentials ?? {}),
-	(currentValue, oldValue) => {
+	async (currentValue, oldValue) => {
 		const emptyCredentials = stringify({});
 		const isUpdated =
 			oldValue !== undefined && oldValue !== emptyCredentials && currentValue !== oldValue;
 		if (
-			isUpdated &&
-			props.modelValue &&
-			isResourceLocatorValue(props.modelValue) &&
-			props.modelValue.value !== ''
+			!isUpdated ||
+			!props.modelValue ||
+			!isResourceLocatorValue(props.modelValue) ||
+			props.modelValue.value === '' ||
+			// Manual (id/url) mode: keep the user-entered value.
+			!isListMode.value
 		) {
+			return;
+		}
+
+		// Clear the cache directly rather than refreshList() to avoid its "user refreshed" telemetry.
+		cachedResponses.value = {};
+		await loadResources();
+
+		// Credentials changed again while loading — a newer run will validate the fresh results.
+		if (stringify(props.node?.credentials ?? {}) !== currentValue) return;
+
+		const selected = props.modelValue.value;
+		const match = currentQueryResults.value.find((result) => result.value === selected);
+		if (match) {
 			emit('update:modelValue', {
 				...props.modelValue,
-				cachedResultName: '',
-				cachedResultUrl: '',
-				value: '',
+				cachedResultName: match.name ?? '',
+				cachedResultUrl: match.url ?? '',
 			});
+			return;
 		}
+
+		const mayExistElsewhere = currentQueryHasMore.value || requiresSearchFilter.value;
+		emit('update:modelValue', {
+			...props.modelValue,
+			cachedResultName: '',
+			cachedResultUrl: '',
+			...(mayExistElsewhere ? {} : { value: '' }),
+		});
 	},
 );
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -558,7 +558,9 @@ watch(
 			return;
 		}
 
-		// Clear the cache directly rather than refreshList() to avoid its "user refreshed" telemetry.
+		// Validate against the full current list: reset any stale search filter and clear the cache
+		// directly (skipping refreshList()'s "user refreshed" telemetry).
+		searchFilter.value = '';
 		cachedResponses.value = {};
 		await loadResources();
 


### PR DESCRIPTION
## Summary

Switching the credential on an AI chat-model node (Anthropic / OpenAI / Google Gemini) — from *n8n Connect* to *My own credential*, or between two own credentials — silently reset the selected model to "Choose…", losing the user's selection.

This was a side effect of the previous fix (ADO-4850, #26282), which reset the model on **any** credential change to avoid stale/invalid models causing silent execution failures. Because a node's credential type is fixed, a credential change is almost always same-provider, where the model list is unchanged and the selection is still valid — so the blanket reset was too aggressive.

This PR replaces "always reset" with **validate-on-reload**: on a credential change we re-fetch the model list and reset the value **only when it can't be confirmed valid**. This fixes the silent reset without reopening ADO-4850's stale-model problem.

Two watchers are affected:
- `ParameterInput.vue` — `options` + `loadOptions` params (Gemini).
- `ResourceLocator.vue` — `resourceLocator` + `searchListMethod` params (Anthropic v1.3+, OpenAI v1.2+).

### Behaviour matrix (both watchers)

| Reload result on credential change | Behaviour |
|---|---|
| Value present in the reloaded list | **Preserve** (+ refresh cached label) |
| Complete list without the value | **Reset** |
| Empty list, or list failed to load | **Reset** |
| List can't be enumerated — paginated, or a search term is required | **Preserve** (keep value, drop stale label) |
| Manual `id`/`url` mode, or an expression value | **Never reset** |

> **Two product/UX calls worth a reviewer's eye** (consistent with ADO-4850's "err toward reset", but flagging explicitly):
> 1. **Reset on failed reload** — if the new credential's list fails to load, we clear the value rather than keep an unconfirmable one. This only fires as a consequence of a credential change (never on a standalone network blip while just viewing the node).
> 2. **Preserve on un-enumerable lists** (paginated / search-required) — we keep the value since it can't be disproven; resetting here would wipe valid selections for generic pickers (Slack channels, Drive files, …) on every credential change.

## How to test

**Test Instance** Everything is set up there. Ping me for Login info: https://test-pr-33820.stage-app.n8n.cloud/workflow/ZR0d8BZAyWCQIHUe

**Setup:** an AI Agent with an **Anthropic Chat Model** sub-node, and 3 Anthropic credentials — 2 with valid API keys, 1 with an invalid key (so its model-list fetch fails). Open the node and pick a model.

| Action | Expected |
|---|---|
| Switch credential **valid A → valid B** (and back) | Model **stays** |
| Switch to the **invalid** credential | Model **resets** to "Choose…" |
| Switch the RLC to **By ID** mode, then switch credentials | Value **stays as-is** |

The key regression fix is that switching between valid credentials of the same provider no longer wipes a still-valid model.

Other paths (optional smoke check):
- **Options path:** a **Google Gemini Chat Model** node — same matrix.
- **n8n Connect:** if the AI gateway is enabled, *n8n Connect ↔ My own credential* behaves identically (same code path) — this was the original report.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4896

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33820">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

