### PR TITLE
chore: Remove dead submit-workflow tool code

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/event-parser.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/event-parser.test.ts
@@ -87,7 +87,7 @@ describe('extractOutcomeFromEvents', () => {
 				type: 'tool-call',
 				data: {
 					type: 'tool-call',
-					payload: { toolCallId: 'tc-1', toolName: 'submit-workflow', args: {} },
+					payload: { toolCallId: 'tc-1', toolName: 'build-workflow', args: {} },
 				},
 			},
 			{

--- a/packages/@n8n/instance-ai/evaluations/cli/compare-pairwise.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/compare-pairwise.ts
@@ -46,7 +46,7 @@ export interface BuilderRecord {
 	feedback: FeedbackEntry[];
 	tokenInput?: number;
 	tokenOutput?: number;
-	/** Number of `submit-workflow` calls during the build. IA-only — EE
+	/** Number of `build-workflow` calls during the build. IA-only — EE
 	 *  doesn't capture a tool-call timeline in the comparable shape. */
 	submitCalls?: number;
 	/** Number of tool calls that errored or returned a failed result. */
@@ -71,10 +71,10 @@ interface BuilderSummary {
 		primaryPassRate: number;
 		avgDiagnostic: number;
 		avgDurationMs: number;
-		/** Total `submit-workflow` calls aggregated across IA records. Undefined
+		/** Total `build-workflow` calls aggregated across IA records. Undefined
 		 *  for EE (which doesn't capture a comparable tool-call timeline). */
 		submitCallsTotal?: number;
-		/** Mean `submit-workflow` calls per record (IA only). */
+		/** Mean `build-workflow` calls per record (IA only). */
 		avgSubmitCalls?: number;
 		/** Total tool calls observed across IA records. */
 		toolCallsTotal?: number;
@@ -192,7 +192,7 @@ async function loadInstanceAiRun(dir: string): Promise<BuilderRun> {
 			feedback: r.feedback,
 			tokenInput: r.build.tokenUsage?.input,
 			tokenOutput: r.build.tokenUsage?.output,
-			submitCalls: tcs.filter((tc) => tc.toolName === 'submit-workflow').length,
+			submitCalls: tcs.filter((tc) => tc.toolName === 'build-workflow').length,
 			toolCallErrors: tcs.filter(isErroredIAToolCall).length,
 			toolCallsTotal: tcs.length,
 			toolCalls: tcs,
@@ -698,7 +698,7 @@ function summarizeToolCallArgs(toolName: string, args: unknown): string {
 		}
 		case 'workspace_mkdir':
 			return trunc(str(a.path));
-		case 'submit-workflow':
+		case 'build-workflow':
 			return trunc(`${str(a.name)} ${str(a.filePath)}`);
 		case 'verify-built-workflow':
 			return trunc(str(a.workflowId) || str(a.workItemId));
@@ -887,8 +887,8 @@ function renderMetricsNote(): string {
   <span><b>Primary pass</b> — workflow passes only if a majority of LLM judges (2 of 3) find zero "don't" violations. Computed over all prompt attempts; build failures count as fail.</span>
   <span><b>Average diagnostic</b> — mean fraction of criteria (dos + don'ts) satisfied across the dataset, averaged across judges. Range 0–1; gives partial credit.</span>
   <span><b>Average build time</b> — averaged across all attempts including failures, so build timeouts (20-min cap) inflate this number.</span>
-  <span><b>Tool error rate</b> — fraction of tool calls that errored or returned a failed result (e.g. <code>tsc</code> non-zero exit, <code>submit-workflow</code> rejection). Captures build-path roughness even on builds that eventually succeeded. <i>IA-only.</i></span>
-  <span><b>Avg submit calls</b> — mean <code>submit-workflow</code> invocations per build. 1.0 = clean first-try submit. <i>IA-only.</i></span>
+  <span><b>Tool error rate</b> — fraction of tool calls that errored or returned a failed result (e.g. <code>tsc</code> non-zero exit, <code>build-workflow</code> rejection). Captures build-path roughness even on builds that eventually succeeded. <i>IA-only.</i></span>
+  <span><b>Avg submit calls</b> — mean <code>build-workflow</code> invocations per build. 1.0 = clean first-try build. <i>IA-only.</i></span>
   <span><b>Verdicts</b> compare per-prompt primary pass between the two builders.</span>
 </aside>`;
 }

--- a/packages/@n8n/instance-ai/evaluations/cli/pairwise.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/pairwise.ts
@@ -404,10 +404,10 @@ interface Summary {
 		buildFailures: Record<string, number>;
 		primaryPassRate: number;
 		avgDiagnostic: number;
-		/** Total `submit-workflow` tool invocations across all records. */
+		/** Total `build-workflow` tool invocations across all records. */
 		submitCallsTotal: number;
-		/** Mean `submit-workflow` invocations per build. 1.0 = every build called
-		 *  submit exactly once; >1.0 = builds had to fix and re-submit. */
+		/** Mean `build-workflow` invocations per build. 1.0 = every build called
+		 *  build-workflow exactly once; >1.0 = builds had to fix and rebuild. */
 		avgSubmitCalls: number;
 		/** (errored tool calls) / (total tool calls) micro-averaged across all
 		 *  runs. Captures how rough the build path was even on builds that
@@ -478,7 +478,7 @@ async function writeOutputs(
 	].join(',');
 	const csvRows = records.map((r) => {
 		const find = (m: string) => r.feedback.find((f) => f.metric === m)?.score ?? '';
-		const submits = r.toolCalls.filter((tc) => tc.toolName === 'submit-workflow').length;
+		const submits = r.toolCalls.filter((tc) => tc.toolName === 'build-workflow').length;
 		const errors = r.toolCalls.filter(isErroredToolCall).length;
 		return [
 			r.exampleId,
@@ -529,14 +529,14 @@ async function writeOutputs(
 
 		// `toolCalls` is the ordered timeline captured by the trace collector.
 		// We count any tool call that errored OR returned a failed result —
-		// hard native agent tool failures are rare, but `submit-workflow` rejections
+		// hard native agent tool failures are rare, but `build-workflow` rejections
 		// and `execute_command` returning a non-zero `tsc` exit are common and
 		// dominate the "rough path" signal we care about. Suspensions are
 		// benign (auto-approved or surfaced via `errorClass` separately).
 		for (const tc of record.toolCalls) {
 			toolCallsTotal++;
 			if (isErroredToolCall(tc)) toolCallErrors++;
-			if (tc.toolName === 'submit-workflow') submitCallsTotal++;
+			if (tc.toolName === 'build-workflow') submitCallsTotal++;
 		}
 
 		const primary = record.feedback.find((f) => f.metric === 'pairwise_primary')?.score;
@@ -753,7 +753,7 @@ function safeFilename(s: string): string {
  *
  * Catches three flavours:
  * 1. **Hard native agent failure** (`trace.error` set) — tool threw / rejected.
- * 2. **Tool returned a failed result object** — e.g. `submit-workflow`
+ * 2. **Tool returned a failed result object** — e.g. `build-workflow`
  *    returning `{ success: false, errors: [...] }`. Looks at top-level
  *    `success === false` or non-empty `errors` array, plus a string
  *    `error` field.

--- a/packages/@n8n/instance-ai/evaluations/cli/report.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/report.ts
@@ -195,7 +195,7 @@ function isErroredToolCall(trace: ToolCallTrace): boolean {
 
 function countSubmitCalls(traces: ToolCallTrace[] | undefined): number {
 	if (!traces) return 0;
-	return traces.filter((t) => t.toolName === 'submit-workflow').length;
+	return traces.filter((t) => t.toolName === 'build-workflow').length;
 }
 
 function countToolCallErrors(traces: ToolCallTrace[] | undefined): number {

--- a/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/langsmith-seed.ts
@@ -17,12 +17,8 @@ import { COMPILED_WORKFLOW_TRACE_RUN_NAME, DOMAIN_TOOL_IDS } from '../../src/too
 const DEFAULT_SOURCE_PROJECT = 'instance-ai';
 
 // Reference the live tool-id so a rename there follows here (or breaks the import).
-// patch/submit-workflow were removed in #32545 but stay for older traces.
-const WORKFLOW_BUILD_TOOLS = new Set<string>([
-	DOMAIN_TOOL_IDS.BUILD_WORKFLOW,
-	'patch-workflow',
-	'submit-workflow',
-]);
+// patch-workflow was removed in #32545 but stays for older traces.
+const WORKFLOW_BUILD_TOOLS = new Set<string>([DOMAIN_TOOL_IDS.BUILD_WORKFLOW, 'patch-workflow']);
 
 // Workspace tools (@n8n/agents) whose ops mutate file content we replay. The names
 // live here only; a contract test pins them — and the arg keys below — against the

--- a/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
@@ -21,7 +21,7 @@ import { getNestedRecord as getRecord, getString } from '../utils/safe-extract';
 // Tool names whose results contain resource IDs we need to track
 // ---------------------------------------------------------------------------
 
-const WORKFLOW_TOOLS = new Set(['build-workflow', 'submit-workflow', 'patch-workflow']);
+const WORKFLOW_TOOLS = new Set(['build-workflow', 'patch-workflow']);
 
 // Retired standalone tool names, kept so captures from older backends still parse.
 const EXECUTION_TOOL_LEGACY = 'run-workflow';

--- a/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/workflow-discovery.ts
@@ -12,7 +12,7 @@ import type { AgentOutcome, EventOutcome, ExecutionSummary, WorkflowSummary } fr
 // Tool names whose results contain workflow IDs
 // ---------------------------------------------------------------------------
 
-const WORKFLOW_TOOLS = new Set(['build-workflow', 'submit-workflow', 'patch-workflow']);
+const WORKFLOW_TOOLS = new Set(['build-workflow', 'patch-workflow']);
 
 // ---------------------------------------------------------------------------
 // snapshotWorkflowIds -- call before the run to know what existed prior
@@ -144,7 +144,7 @@ export async function buildAgentOutcome(
 // extractWorkflowIdsFromMessages
 //
 // Extracts workflow IDs from agent tree targetResource fields AND from
-// tool call results (build-workflow, submit-workflow, etc.).
+// tool call results (build-workflow, patch-workflow, etc.).
 // Thread-scoped -- avoids cross-run workflow attribution.
 // ---------------------------------------------------------------------------
 

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -389,7 +389,7 @@ function summarizeToolCalls(result: WorkflowTestCaseResult): string[] {
 	const toolCalls = result.buildTrace?.toolCalls ?? [];
 	const count = (toolName: string): number =>
 		toolCalls.filter((call) => call.toolName === toolName).length;
-	const submitCalls = toolCalls.filter((call) => call.toolName === 'submit-workflow');
+	const submitCalls = toolCalls.filter((call) => call.toolName === 'build-workflow');
 	const verifyCalls = toolCalls.filter((call) => call.toolName === 'verify-built-workflow');
 
 	const summaries = [
@@ -1135,10 +1135,7 @@ function renderWorkflowSummary(result: WorkflowTestCaseResult): string {
 			(call) => call.toolName === 'nodes',
 		);
 		const workflowWriteCalls = result.buildTrace.toolCalls.filter((call) =>
-			['build-workflow', 'submit-workflow', 'build-workflow-with-agent'].includes(call.toolName),
-		);
-		const validationCalls = result.buildTrace.toolCalls.filter(
-			(call) => call.toolName === 'submit-workflow',
+			['build-workflow', 'build-workflow-with-agent'].includes(call.toolName),
 		);
 		const credentialCalls = result.buildTrace.toolCalls.filter(
 			(call) => call.toolName === 'credentials',
@@ -1154,11 +1151,6 @@ function renderWorkflowSummary(result: WorkflowTestCaseResult): string {
 			nodeResearchCalls: nodeResearchCalls.map((call) => call.args),
 			workflowWriteCalls: workflowWriteCalls.map((call) => ({
 				toolName: call.toolName,
-				args: call.args,
-				result: call.result,
-				error: call.error,
-			})),
-			validationCalls: validationCalls.map((call) => ({
 				args: call.args,
 				result: call.result,
 				error: call.error,

--- a/packages/@n8n/instance-ai/evaluations/subagent/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/subagent/types.ts
@@ -35,9 +35,9 @@ export interface WorkflowBuildEvalCase {
 export interface CapturedWorkflow {
 	/** The WorkflowJSON the agent produced */
 	json: WorkflowJSON;
-	/** Whether the submit-workflow tool reported success */
+	/** Whether the build-workflow tool reported success */
 	success: boolean;
-	/** Errors reported by the submit-workflow tool */
+	/** Errors reported by the build-workflow tool */
 	errors?: string[];
 }
 
@@ -49,7 +49,7 @@ export interface WorkflowBuildEvalResult {
 	testCase: WorkflowBuildEvalCase;
 	/** The agent's final text output */
 	text: string;
-	/** Workflows captured from submit-workflow tool calls */
+	/** Workflows captured from build-workflow tool calls */
 	capturedWorkflows: CapturedWorkflow[];
 	/** Evaluation feedback (binary checks on captured workflows, etc.) */
 	feedback: Feedback[];

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/agentTimeline.utils.test.ts
@@ -110,18 +110,6 @@ describe('extractArtifacts', () => {
 		]);
 	});
 
-	test('returns workflow artifact from submit-workflow tool call', () => {
-		const node = makeAgentNode({
-			toolCalls: [
-				makeToolCall({
-					toolName: 'submit-workflow',
-					result: { workflowId: 'wf-3', workflowName: 'Submitted WF' },
-				}),
-			],
-		});
-		expect(extractArtifacts(node)[0].resourceId).toBe('wf-3');
-	});
-
 	test('falls back to args.name when result.workflowName is missing', () => {
 		const node = makeAgentNode({
 			toolCalls: [

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/canvasPreview.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/canvasPreview.utils.test.ts
@@ -87,22 +87,6 @@ describe('getLatestBuildResult', () => {
 		});
 	});
 
-	test('returns workflowId from successful submit-workflow call', () => {
-		const node = makeAgentNode({
-			toolCalls: [
-				makeToolCall({
-					toolCallId: 'tc-submit-1',
-					toolName: 'submit-workflow',
-					result: { success: true, workflowId: 'wf-456' },
-				}),
-			],
-		});
-		expect(getLatestBuildResult(node)).toEqual({
-			workflowId: 'wf-456',
-			toolCallId: 'tc-submit-1',
-		});
-	});
-
 	test('returns the latest result when multiple builds exist', () => {
 		const node = makeAgentNode({
 			toolCalls: [

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -1404,30 +1404,6 @@ describe('createThreadRuntime - session always-allow', () => {
 		expect(mockPostConfirmation).not.toHaveBeenCalled();
 	});
 
-	it('distinguishes submit-workflow create vs update grants by workflowId presence', async () => {
-		const runtime = registry.getOrCreateRuntime(activeThreadId);
-		runtime.addAlwaysAllowKey('submit-workflow', {});
-
-		pushPendingApproval(runtime, {
-			messageId: 'msg-create',
-			requestId: 'req-create',
-			toolName: 'submit-workflow',
-			args: {},
-		});
-		await vi.waitFor(() => {
-			expect(runtime.resolvedConfirmationIds.get('req-create')).toBe('approved');
-		});
-
-		pushPendingApproval(runtime, {
-			messageId: 'msg-update',
-			requestId: 'req-update',
-			toolName: 'submit-workflow',
-			args: { workflowId: 'wf-1' },
-		});
-		await new Promise((resolve) => setTimeout(resolve, 10));
-		expect(runtime.resolvedConfirmationIds.has('req-update')).toBe(false);
-	});
-
 	it('scopes executions run grants per workflow', async () => {
 		const runtime = registry.getOrCreateRuntime(activeThreadId);
 		runtime.addAlwaysAllowKey('executions', { action: 'run', workflowId: 'wf-1' });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/toolLabels.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/toolLabels.test.ts
@@ -70,7 +70,7 @@ describe('getToolIcon', () => {
 		expect(getToolIcon('executions')).toBe('workflow');
 		expect(getToolIcon('nodes')).toBe('workflow');
 		expect(getToolIcon('templates')).toBe('workflow');
-		expect(getToolIcon('submit-workflow')).toBe('workflow');
+		expect(getToolIcon('build-workflow')).toBe('workflow');
 		expect(getToolIcon('materialize-node-type')).toBe('workflow');
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/useResourceRegistry.test.ts
@@ -331,7 +331,7 @@ describe('useResourceRegistry', () => {
 								targetResource: { type: 'workflow', id: 'wf-edit' },
 								toolCalls: [
 									makeToolCall({
-										toolName: 'submit-workflow',
+										toolName: 'build-workflow',
 										result: { workflowId: 'wf-edit', workflowName: 'Renamed' },
 									}),
 								],
@@ -363,7 +363,7 @@ describe('useResourceRegistry', () => {
 							}),
 							makeToolCall({
 								toolCallId: 'tc-2',
-								toolName: 'submit-workflow',
+								toolName: 'build-workflow',
 								result: { workflowId: 'wf-1', workflowName: 'Renamed' },
 							}),
 						],

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/agentTimeline.utils.ts
@@ -93,9 +93,9 @@ export function extractArtifacts(node: InstanceAiAgentNode): ArtifactInfo[] {
 		if (!tc.result || typeof tc.result !== 'object') continue;
 		const result = tc.result as Record<string, unknown>;
 
-		// Workflow artifacts from build-workflow / submit-workflow
+		// Workflow artifacts from build-workflow
 		if (
-			(tc.toolName === 'build-workflow' || tc.toolName === 'submit-workflow') &&
+			tc.toolName === 'build-workflow' &&
 			typeof result.workflowId === 'string' &&
 			!seenIds.has(result.workflowId)
 		) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/canvasPreview.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/canvasPreview.utils.ts
@@ -43,7 +43,7 @@ export interface DataTableResult {
 
 /**
  * Walks an agent tree depth-first (most recent last) and returns the workflowId
- * and toolCallId from the latest successful build-workflow / submit-workflow tool result.
+ * and toolCallId from the latest successful build-workflow tool result.
  */
 export function getLatestBuildResult(node: InstanceAiAgentNode): BuildResult | undefined {
 	for (let i = node.children.length - 1; i >= 0; i--) {
@@ -53,7 +53,7 @@ export function getLatestBuildResult(node: InstanceAiAgentNode): BuildResult | u
 	for (let i = node.toolCalls.length - 1; i >= 0; i--) {
 		const tc = node.toolCalls[i];
 		if (
-			(tc.toolName === 'build-workflow' || tc.toolName === 'submit-workflow') &&
+			tc.toolName === 'build-workflow' &&
 			!tc.isLoading &&
 			tc.result &&
 			typeof tc.result === 'object'
@@ -186,7 +186,7 @@ const WORKFLOW_LOCKING_TOOLS = new Set([
  *      This covers short gaps between tool calls while the agent run is still
  *      ongoing.
  *   2. An active workflow-builder sub-agent targeting the workflow (covers the
- *      whole build window: read file → edit → submit-workflow → verify).
+ *      whole build window: read file → edit → build-workflow → verify).
  *   3. An in-flight workflow-affecting tool call targeting the workflow — the
  *      build/setup/verify tools, `executions.run`, or a `workflows` update /
  *      restore-version / setup action. Read-only `workflows` actions (get-json,

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -451,17 +451,10 @@ export function createThreadRuntime(
 
 	// --- Session "Always allow" ---
 	// Thread-scoped: cleared by `resetState()` so grants don't leak when the
-	// runtime is disposed and recreated. Key: `${toolName}:${args.action ?? ''}`
-	// for most tools; `submit-workflow` is keyed on `workflowId` presence so a
-	// create grant doesn't silently auto-approve later updates (the backend
-	// distinguishes createWorkflow vs updateWorkflow by that field).
+	// runtime is disposed and recreated. Key: `${toolName}:${args.action ?? ''}`.
 	const sessionAlwaysAllowKeys = ref<Set<string>>(new Set());
 
 	function buildAlwaysAllowKey(toolName: string, args: Record<string, unknown>): string {
-		if (toolName === 'submit-workflow') {
-			const isUpdate = typeof args.workflowId === 'string' && args.workflowId.length > 0;
-			return `submit-workflow:${isUpdate ? 'update' : 'create'}`;
-		}
 		const action = typeof args.action === 'string' ? args.action : '';
 		// Running a workflow grants "always allow" per workflow, so the grant applies only to the
 		// workflow the user approved.

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/toolLabels.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/toolLabels.ts
@@ -114,11 +114,7 @@ export function getToolIcon(toolName: string): IconName {
 	if (toolName === 'filesystem') return 'file-text';
 	if (toolName === 'workspace' || toolName.startsWith('workspace_')) return 'folder';
 	if (toolName.includes('data-table')) return 'table';
-	if (
-		toolName.includes('workflow') ||
-		toolName === 'submit-workflow' ||
-		toolName === 'materialize-node-type'
-	) {
+	if (toolName.includes('workflow') || toolName === 'materialize-node-type') {
 		return 'workflow';
 	}
 	if (toolName.includes('credential')) return 'key-round';

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/useResourceRegistry.ts
@@ -102,7 +102,6 @@ function entryFromListItem(
 const ARTIFACT_TOOLS = new Set([
 	'build-workflow',
 	'build-workflow-with-agent',
-	'submit-workflow',
 	'apply-workflow-credentials',
 	'workflows',
 	'credentials',
@@ -127,7 +126,7 @@ function extractFromToolCall(tc: InstanceAiToolCallState, col: Collections): voi
 		}
 	}
 
-	// build-workflow / build-workflow-with-agent / submit-workflow:
+	// build-workflow / build-workflow-with-agent:
 	// { workflowId, workflowName? } — produced. Patch calls may omit the name,
 	// so fall back to the existing entry before regressing to 'Untitled'.
 	if (typeof result.workflowId === 'string') {


### PR DESCRIPTION
## Summary

Removing the remains of submit-workflow tool that we no longer have/use.

This breaks old threads rendering that had submit-workflow tool calls, but those are legacy that we don't really care about(?).

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->