### PR TITLE
fix(core): Skip webhook auth for editor test executions and scope basic auth realm per webhook

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/ChatTrigger.node.ts
@@ -861,11 +861,19 @@ export class ChatTrigger extends Node {
 		const bodyData = ctx.getBodyData() ?? {};
 
 		try {
-			await validateAuth(ctx);
+			// The editor's canvas chat can't supply webhook credentials, and test webhooks
+			// are only ever registered through an authenticated editor session, so auth is
+			// only enforced for production executions.
+			if (mode !== 'test') {
+				await validateAuth(ctx);
+			}
 		} catch (error) {
 			if (error) {
+				// Realm is scoped per webhook so browsers don't reuse cached credentials across chats sharing an origin
+				const webhookId = ctx.getNode().webhookId;
+				const realm = webhookId ? `Webhook ${webhookId}` : 'Webhook';
 				res.writeHead((error as IDataObject).responseCode as number, {
-					'www-authenticate': 'Basic realm="Webhook"',
+					'www-authenticate': `Basic realm="${realm}"`,
 				});
 				res.end((error as IDataObject).message as string);
 				return { noWebhookResponse: true };

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/ChatTrigger.node.test.ts
@@ -5,6 +5,8 @@ import type { INode, IWebhookFunctions } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { ChatTrigger } from '../ChatTrigger.node';
+import { ChatTriggerAuthorizationError } from '../error';
+import { validateAuth } from '../GenericFunctions';
 import type { LoadPreviousSessionChatOption } from '../types';
 
 vi.mock('../GenericFunctions', () => ({
@@ -295,6 +297,95 @@ describe('ChatTrigger Node', () => {
 				workflowData: expect.any(Array),
 				noWebhookResponse: true,
 			});
+		});
+
+		it('skips auth validation for manual (test) executions', async () => {
+			mockContext.getMode.mockReturnValue('manual');
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return 'basicAuth';
+					return defaultValue;
+				},
+			);
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(validateAuth).not.toHaveBeenCalled();
+			expect(mockResponse.writeHead).not.toHaveBeenCalledWith(401, expect.anything());
+			expect(result).toEqual({
+				webhookResponse: { status: 200 },
+				workflowData: expect.any(Array),
+			});
+		});
+
+		it('still enforces auth validation for production executions', async () => {
+			mockContext.getMode.mockReturnValue('webhook');
+			mockContext.getNode.mockReturnValue({
+				name: 'Chat Trigger',
+				type: 'n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1,
+				webhookId: 'abc123',
+			} as INode);
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return 'basicAuth';
+					return defaultValue;
+				},
+			);
+			vi.mocked(validateAuth).mockRejectedValueOnce(new ChatTriggerAuthorizationError(401));
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(validateAuth).toHaveBeenCalledWith(mockContext);
+			expect(mockResponse.writeHead).toHaveBeenCalledWith(401, {
+				'www-authenticate': 'Basic realm="Webhook abc123"',
+			});
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('falls back to the plain realm when the node has no webhookId', async () => {
+			mockContext.getMode.mockReturnValue('webhook');
+			mockContext.getNode.mockReturnValue({
+				name: 'Chat Trigger',
+				type: 'n8n-nodes-langchain.chatTrigger',
+				typeVersion: 1,
+			} as INode);
+			mockContext.getNodeParameter.mockImplementation(
+				(
+					paramName: string,
+					defaultValue?: boolean | string | object,
+				): boolean | string | object | undefined => {
+					if (paramName === 'public') return true;
+					if (paramName === 'mode') return 'hostedChat';
+					if (paramName === 'options') return {};
+					if (paramName === 'availableInChat') return false;
+					if (paramName === 'authentication') return 'basicAuth';
+					return defaultValue;
+				},
+			);
+			vi.mocked(validateAuth).mockRejectedValueOnce(new ChatTriggerAuthorizationError(401));
+
+			const result = await chatTrigger.webhook(mockContext);
+
+			expect(validateAuth).toHaveBeenCalledWith(mockContext);
+			expect(mockResponse.writeHead).toHaveBeenCalledWith(401, {
+				'www-authenticate': 'Basic realm="Webhook"',
+			});
+			expect(result).toEqual({ noWebhookResponse: true });
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes two related problems with basic-auth-protected Chat Triggers (`public: true` + Basic Auth):

1. **Basic auth dialog in the editor's chat panel.** Since #20991, the canvas chat posts messages directly to the `webhook-test` endpoint instead of running through the authenticated REST API, so the trigger's auth check started running for editor test executions. The editor cannot supply the webhook credentials (they are stored encrypted and the tester may not know them), so the browser's native basic auth dialog appeared. `validateAuth` is now skipped for manual (test) executions — test webhooks can only be registered through an authenticated editor session, and this restores the pre-#20991 behavior. Production executions (`/webhook/...`) are unchanged.

2. **Credentials leaking between chats via the browser cache.** All Chat Triggers shared the hardcoded realm `Basic realm="Webhook"`. Browsers cache basic auth credentials per origin + realm, so credentials entered for one public hosted chat were silently replayed against other chats on the same instance and rejected with 403 "Authorization data is wrong!" (with no way to re-prompt, since browsers only show the dialog on 401). The realm is now scoped per webhook (`Basic realm="Webhook <webhookId>"`), so each public chat prompts and caches its own credentials.

## How to test

1. Create two workflows, each with only a Chat Trigger set to **Make chat publicly available** + **Authentication: Basic Auth**, using two different basic auth credentials.
2. Open the first workflow in the editor, open the chat panel, and send a message → no basic auth dialog appears and the workflow executes (previously the dialog popped up).
3. Repeat in the second workflow → also works, no dialog, no 403.
4. Activate both workflows and open their public chat URLs in the same browser session. Authenticate on the first chat, then open the second → the browser prompts for the second chat's credentials instead of silently sending the first chat's credentials and failing with 403.
5. Wrong/missing credentials on a public chat URL still return 401/403 as before.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes https://github.com/n8n-io/n8n/issues/27464
- https://linear.app/n8n/issue/GHC-7432

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

