### PR TITLE
fix(core): Use correct Gmail OAuth2 credential type in eval credential seeder (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/case-shapes.md
+++ b/.agents/skills/create-instance-ai-eval/case-shapes.md
@@ -123,7 +123,7 @@ of mocked) set the type's `EVAL_*` env var — e.g. `EVAL_SLACK_ACCESS_TOKEN`,
 Only a closed set of types is valid — declaring anything else fails at case-load
 with a pointer to add a template. From
 [`credentials/seeder.ts`](../../../packages/@n8n/instance-ai/evaluations/credentials/seeder.ts):
-`slackApi`, `notionApi`, `githubApi`, `gmailOAuth2Api`,
+`slackApi`, `notionApi`, `githubApi`, `gmailOAuth2`,
 `microsoftTeamsOAuth2Api`, `whatsAppTriggerApi`, `httpHeaderAuth`,
 `httpBasicAuth`. Need another? Add a `CredentialTemplate` to `seeder.ts` (a
 `defaultName`, optional `envVar`, and `buildData(token)`); that extends

--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -39,7 +39,7 @@ const CREDENTIAL_TEMPLATES: Record<string, CredentialTemplate> = {
 		envVar: 'EVAL_GITHUB_ACCESS_TOKEN',
 		buildData: (token) => ({ accessToken: token }),
 	},
-	gmailOAuth2Api: {
+	gmailOAuth2: {
 		defaultName: '[eval] Gmail',
 		envVar: 'EVAL_GMAIL_ACCESS_TOKEN',
 		buildData: (token) => ({ oauthTokenData: { access_token: token } }),


### PR DESCRIPTION
## Summary

The Instance AI eval credential seeder (`evaluations/credentials/seeder.ts`) registered its Gmail template under the credential type `gmailOAuth2Api`. The actual n8n credential type is `gmailOAuth2` (see `packages/nodes-base/credentials/GmailOAuth2Api.credentials.ts`, the class is named `GmailOAuth2Api` but its type name is `gmailOAuth2`).

Because the case schema validates against the seeder's template keys, an eval case could only declare the wrong name, and the run then failed before the build started: `POST /rest/credentials` returns 400 with "Unrecognized credential type: gmailOAuth2Api". No committed case had declared a Gmail credential yet, so this was never hit until now.

This PR renames the template key to `gmailOAuth2` and updates the skill doc that lists the supported credential types.

## How to test

1. Add `"credentials": [{ "type": "gmailOAuth2" }]` to any workflow eval case in `packages/@n8n/instance-ai/evaluations/data/workflows/`.
2. Run it against a dev instance: `pnpm eval:instance-ai --filter <case-slug> --base-url <instance>`.
3. The credential is created and the build starts. On master the same case can only declare `gmailOAuth2Api`, and the run fails at credential creation with the 400 error above.

## Related Linear tickets, Github issues, and Community forum posts

Found while authoring a new eval case that declares a Gmail credential. No ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

