### PR TITLE
feat(editor): Add telemetry event for stalled builder generation (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue';
 import { setActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { describe, test, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
@@ -1664,5 +1665,124 @@ describe('createThreadRuntime - "User viewed new builder workflow" telemetry', (
 			'User viewed new builder workflow',
 			expect.anything(),
 		);
+	});
+});
+
+describe('createThreadRuntime - "Builder generation stalled" telemetry', () => {
+	let registry: RuntimeRegistry;
+
+	const stalledCalls = () =>
+		mockTelemetryTrack.mock.calls.filter(([event]) => event === 'Builder generation stalled');
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		setupRuntimePinia();
+		capturedOnMessage = null;
+		registry = createRuntimeRegistry();
+		activeThreadId = 'thread-active';
+		activeRuntime(registry).connectSSE();
+		// Flush the MockEventSource constructor's setTimeout(0).
+		await vi.advanceTimersByTimeAsync(0);
+		expect(capturedOnMessage).not.toBeNull();
+	});
+
+	afterEach(() => {
+		activeRuntime(registry).closeSSE();
+		vi.useRealTimers();
+		vi.clearAllMocks();
+	});
+
+	test('fires once with thread_id after a minute of stream silence during an active run', async () => {
+		capturedOnMessage!(makeSSEEvent(validRunStartEvent('run-1', 'agent-root')));
+
+		await vi.advanceTimersByTimeAsync(59_000);
+		expect(stalledCalls()).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(stalledCalls()).toHaveLength(1);
+		expect(stalledCalls()[0][1]).toEqual({ thread_id: 'thread-active' });
+
+		// Continued silence does not re-fire — one event per silent stretch.
+		await vi.advanceTimersByTimeAsync(180_000);
+		expect(stalledCalls()).toHaveLength(1);
+	});
+
+	test('every received stream event re-arms the countdown', async () => {
+		capturedOnMessage!(makeSSEEvent(validRunStartEvent('run-1', 'agent-root')));
+
+		await vi.advanceTimersByTimeAsync(50_000);
+		capturedOnMessage!(
+			makeSSEEvent({
+				type: 'text-delta',
+				runId: 'run-1',
+				agentId: 'agent-root',
+				payload: { text: 'hello' },
+			}),
+		);
+
+		// 100s since run start, but only 50s since the last event — not stalled.
+		await vi.advanceTimersByTimeAsync(50_000);
+		expect(stalledCalls()).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(stalledCalls()).toHaveLength(1);
+	});
+
+	test('does not fire when the run finishes within the window', async () => {
+		capturedOnMessage!(makeSSEEvent(validRunStartEvent('run-1', 'agent-root')));
+		await vi.advanceTimersByTimeAsync(30_000);
+		capturedOnMessage!(
+			makeSSEEvent({
+				type: 'run-finish',
+				runId: 'run-1',
+				agentId: 'agent-root',
+				payload: { status: 'completed' },
+			}),
+		);
+
+		await vi.advanceTimersByTimeAsync(180_000);
+		expect(stalledCalls()).toHaveLength(0);
+	});
+
+	test('does not fire while the run waits on a user confirmation', async () => {
+		capturedOnMessage!(makeSSEEvent(validRunStartEvent('run-1', 'agent-root')));
+		capturedOnMessage!(
+			makeSSEEvent({
+				type: 'tool-call',
+				runId: 'run-1',
+				agentId: 'agent-root',
+				payload: { toolCallId: 'tc-1', toolName: 'dangerous-tool', args: {} },
+			}),
+		);
+		capturedOnMessage!(
+			makeSSEEvent({
+				type: 'confirmation-request',
+				runId: 'run-1',
+				agentId: 'agent-root',
+				payload: {
+					requestId: 'req-1',
+					toolCallId: 'tc-1',
+					toolName: 'dangerous-tool',
+					args: {},
+					severity: 'warning',
+					message: 'Are you sure?',
+				},
+			}),
+		);
+
+		await vi.advanceTimersByTimeAsync(180_000);
+		expect(stalledCalls()).toHaveLength(0);
+	});
+
+	test('arms when a message send starts a run while the stream stays silent', async () => {
+		mockPostMessage.mockResolvedValueOnce({ runId: 'run-silent' });
+
+		await activeRuntime(registry).sendMessage('build me a workflow');
+		// Let the isGenerationPending watcher observe the new run id.
+		await nextTick();
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(stalledCalls()).toHaveLength(1);
+		expect(stalledCalls()[0][1]).toEqual({ thread_id: 'thread-active' });
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -76,6 +76,9 @@ export type HistoricalHydrationStatus = 'applied' | 'stale' | 'skipped';
 
 const MAX_DEBUG_EVENTS = 1000;
 
+/** Silence window after which an active run with no stream traffic counts as stalled. */
+const GENERATION_STALL_TIMEOUT_MS = 60_000;
+
 /**
  * Cross-runtime hooks the store wires up at creation time.
  *
@@ -122,6 +125,29 @@ function collectPendingConfirmations(
 	for (const child of node.children) {
 		collectPendingConfirmations(child, messageId, resolved, out);
 	}
+}
+
+/**
+ * Whether any tool call in the tree still waits on user input. Broader than
+ * `collectPendingConfirmations`: plan-review and expired confirmations also
+ * pause the run, so the stall watchdog must not count them as thinking time.
+ */
+function hasUnresolvedConfirmation(
+	node: InstanceAiAgentNode,
+	resolved: Map<string, 'approved' | 'changes-requested' | 'denied' | 'deferred'>,
+): boolean {
+	for (const tc of node.toolCalls) {
+		if (
+			tc.confirmation &&
+			tc.isLoading &&
+			tc.confirmationStatus !== 'approved' &&
+			tc.confirmationStatus !== 'denied' &&
+			!resolved.has(tc.confirmation.requestId)
+		) {
+			return true;
+		}
+	}
+	return node.children.some((child) => hasUnresolvedConfirmation(child, resolved));
 }
 
 function findLatestTasksFromMessages(messages: InstanceAiMessage[]): TaskList | null {
@@ -389,6 +415,47 @@ export function createThreadRuntime(
 		{ flush: 'sync' },
 	);
 
+	// --- Telemetry: 'Builder generation stalled' ---
+	// Fires when the active run has produced nothing on the stream for a minute.
+	// A run paused on user input (confirmation, plan review) isn't stalled, so
+	// the watchdog disarms for those. Every received SSE event re-arms it, so it
+	// fires at most once per silent stretch.
+	let generationStallTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Scoped to the active run's message (not all messages) so a stale
+	// confirmation left on an older message can't suppress stall detection.
+	const isAwaitingUserInput = computed(() => {
+		const runId = activeRunId.value;
+		if (runId === null) return false;
+		const activeMessage = messages.value.find(
+			(m) => m.role === 'assistant' && (m.runId === runId || (m.runIds?.includes(runId) ?? false)),
+		);
+		if (!activeMessage?.agentTree) return false;
+		return hasUnresolvedConfirmation(activeMessage.agentTree, resolvedConfirmationIds);
+	});
+
+	const isGenerationPending = computed(() => isStreaming.value && !isAwaitingUserInput.value);
+
+	function disarmGenerationStallWatchdog(): void {
+		if (generationStallTimer === null) return;
+		clearTimeout(generationStallTimer);
+		generationStallTimer = null;
+	}
+
+	/** (Re)start the silence countdown while generation is pending, stop it otherwise. */
+	function resetGenerationStallWatchdog(): void {
+		disarmGenerationStallWatchdog();
+		if (!isGenerationPending.value) return;
+		generationStallTimer = setTimeout(() => {
+			generationStallTimer = null;
+			telemetry.track('Builder generation stalled', { thread_id: threadId });
+		}, GENERATION_STALL_TIMEOUT_MS);
+	}
+
+	// Covers arm/disarm transitions that happen without stream traffic — e.g.
+	// POST /message sets the run id while SSE stays silent (the primary stall case).
+	watch(isGenerationPending, resetGenerationStallWatchdog);
+
 	/**
 	 * Derive a single contextual follow-up suggestion from the last completed
 	 * assistant message. Shown as the input placeholder + Tab to autocomplete.
@@ -566,6 +633,8 @@ export function createThreadRuntime(
 				},
 				parsed.data,
 			);
+			// Anything received on the stream means generation isn't stalled.
+			resetGenerationStallWatchdog();
 			if (parsed.data.type === 'tasks-update') {
 				latestTasks.value = parsed.data.payload.tasks;
 			}
@@ -757,6 +826,7 @@ export function createThreadRuntime(
 		runStateByGroupId.clear();
 		groupIdByRunId.clear();
 		lastEventId.value = undefined;
+		disarmGenerationStallWatchdog();
 	}
 
 	function dispose(): void {


### PR DESCRIPTION
## Summary

Adds the FE telemetry event `Builder generation stalled`, fired when thinking time exceeds one minute with nothing received on the stream. The payload is only `thread_id`; instance and user identity ride along via the RudderStack `identify` call.

The watchdog lives in the thread runtime, which owns the SSE connection and run state:

- A 60s timer arms while generation is pending (a run is active and not waiting on user input). Every valid SSE event re-arms it, so it fires at most once per silent stretch and never repeats during continued silence.
- A watcher on the pending state covers transitions that happen without stream traffic, most importantly the primary stall case: `POST /chat` returns a run id but the stream never delivers anything.
- Runs paused on human input do not count as stalled. When the backend suspends for input it publishes the confirmation-request but no run-finish, so `activeRunId` stays set while the user reads a confirmation or plan review, and a naive timer would false-fire there. A new `hasUnresolvedConfirmation` walk disarms the watchdog in that state; unlike the confirmation panel logic it also covers plan-review and expired confirmations, and it is scoped to the active run's message so stale confirmations on older messages cannot suppress detection.

## How to test

Five new fake-timer unit tests in `instanceAi.threadRuntime.test.ts` cover the behavior: fires once with only `thread_id` after 60s of stream silence, re-arms on every received event, disarms on run-finish, stays quiet while a confirmation is pending, and arms when a send starts a run on a silent stream.

Manually: send a builder message, then kill the backend (or drop the SSE connection) and wait one minute; the event appears in the network tab / PostHog.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-832

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33829">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

