### PR TITLE
feat(editor): Boost n8n Connect services in nodes and tools panel search

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
@@ -19,6 +19,8 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { useAiGatewayStore } from '@/app/stores/aiGateway.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowDocumentId,
@@ -137,6 +139,30 @@ describe('useNodeCreatorStore', () => {
 			source,
 			nodes_panel_session_id: getSessionId(now),
 			workflow_id,
+		});
+	});
+
+	describe('AI Gateway config warmup', () => {
+		it('fetches the gateway config when AI Gateway is enabled', () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.isAiGatewayEnabled = true;
+			const aiGatewayStore = mockedStore(useAiGatewayStore);
+			aiGatewayStore.fetchConfig = vi.fn();
+
+			nodeCreatorStore.onCreatorOpened({ source, mode, workflow_id });
+
+			expect(aiGatewayStore.fetchConfig).toHaveBeenCalled();
+		});
+
+		it('does not fetch the gateway config when AI Gateway is disabled', () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.isAiGatewayEnabled = false;
+			const aiGatewayStore = mockedStore(useAiGatewayStore);
+			aiGatewayStore.fetchConfig = vi.fn();
+
+			nodeCreatorStore.onCreatorOpened({ source, mode, workflow_id });
+
+			expect(aiGatewayStore.fetchConfig).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -20,7 +20,9 @@ import { defineStore } from 'pinia';
 
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useAiGatewayStore } from '@/app/stores/aiGateway.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useRouteWorkflowId } from '@/app/composables/useWorkflowId';
 import type { TelemetryNdvType } from '@/app/types/telemetry';
@@ -355,6 +357,13 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		workflow_id?: string;
 	}) {
 		resetNodesPanelSession();
+
+		// Warm up the AI Gateway config so the n8n Connect search boost has the
+		// supported-node list by the time the user types. Cached after first load.
+		if (useSettingsStore().isAiGatewayEnabled) {
+			void useAiGatewayStore().fetchConfig();
+		}
+
 		trackNodeCreatorEvent('User opened nodes panel', {
 			source,
 			mode,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -998,6 +998,47 @@ describe('NodeCreator - utils', () => {
 			expect(keys[2]).toBe('plainNode');
 			expect(keys.slice(0, 2)).toEqual(expect.arrayContaining([core.key, community.key]));
 		});
+
+		it('should not boost a supported node that has no alias metadata', () => {
+			mockStores({ supportedNodes: ['connectNoAlias'] });
+			// codex present but without an `alias` array exercises the `?? []` fallback:
+			// with no aliases there is nothing to match, so no boost is applied.
+			const connectNoAlias = mockNodeCreateElement(
+				{ key: 'connectNoAlias' },
+				{
+					name: 'connectNoAlias',
+					displayName: 'Scrape Tool',
+					codex: { categories: [], subcategories: {} },
+				},
+			);
+			const plain = mockNodeCreateElement(
+				{ key: 'plainNode' },
+				{
+					name: 'plainNode',
+					displayName: 'Scrape Tool',
+					codex: { categories: [], subcategories: {} },
+				},
+			);
+
+			const keys = searchNodes('scrape', [plain, connectNoAlias]).map((item) => item.key);
+			expect(keys).toEqual(['plainNode', 'connectNoAlias']);
+		});
+
+		it('should not boost non-node items even when their name is gateway-supported', () => {
+			mockStores({ supportedNodes: ['connectAction'] });
+			const plain = makeNode('plainNode', 'Serp Tool', ['serp']);
+			// An action element that matches by alias and is "supported": the type guard
+			// must skip it, so it is never boosted above the (unboosted) node.
+			const action = mockActionCreateElement(undefined, {
+				name: 'connectAction',
+				displayName: 'Serp Action',
+				codex: { label: 'Serp', categories: [], alias: ['serp'] },
+			} as unknown as Partial<ActionTypeDescription>);
+			action.key = 'connectAction';
+
+			const keys = searchNodes('serp', [plain, action]).map((item) => item.key);
+			expect(keys[0]).toBe('plainNode');
+		});
 	});
 
 	describe('mapToolSubcategoryIcon', () => {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -891,9 +891,8 @@ describe('NodeCreator - utils', () => {
 			expect(matchesAliasForConnectBoost('', ['scrape'])).toBe(false);
 		});
 
-		// Cases drawn from the RLY-160 keyword table. The 3-char threshold exists
-		// specifically so short aliases like `ocr` and `pdf` stay boostable while
-		// 1-2 char partials remain noise-free.
+		// The 3-char threshold exists specifically so short aliases like `ocr` and
+		// `pdf` stay boostable while 1-2 char partials remain noise-free.
 		it.each<[string, string[], boolean]>([
 			['serp', ['serp'], true],
 			['fetch', ['fetch'], true],
@@ -986,8 +985,8 @@ describe('NodeCreator - utils', () => {
 			expect(result[0].key).toEqual('googleSheets');
 		});
 
-		// RLY-160: the boost must apply to both core and community nodes as long as
-		// they are listed as AI Gateway-supported.
+		// The boost must apply to both core and community nodes as long as they are
+		// listed as AI Gateway-supported.
 		it('should boost both core and community Connect nodes above a non-Connect node', () => {
 			const core = makeNode('n8n-nodes-base.brave', 'Brave', ['serp']);
 			const community = makeNode('@mendable/n8n-nodes-firecrawl.firecrawl', 'Firecrawl', ['serp']);

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -17,8 +17,10 @@ import {
 	getHumanInTheLoopCallout,
 	getRootSearchCallouts,
 	getSendAndWaitNodes,
+	matchesAliasForConnectBoost,
 	nodeTypesToCreateElements,
 	mapToolSubcategoryIcon,
+	searchNodes,
 } from './nodeCreator.utils';
 import {
 	mockActionCreateElement,
@@ -850,6 +852,120 @@ describe('NodeCreator - utils', () => {
 
 			const [result] = finalizeItems([makeGatewayNode('unknownTool')]) as NodeCreateElement[];
 			expect(result.properties.tag).toBeUndefined();
+		});
+	});
+
+	describe('matchesAliasForConnectBoost', () => {
+		it('should match an exact alias', () => {
+			expect(matchesAliasForConnectBoost('scrape', ['scrape'])).toBe(true);
+		});
+
+		it('should match an exact alias below 3 characters', () => {
+			expect(matchesAliasForConnectBoost('ai', ['ai'])).toBe(true);
+		});
+
+		it('should match case-insensitively', () => {
+			expect(matchesAliasForConnectBoost('SCRAPE', ['Scrape'])).toBe(true);
+		});
+
+		it('should match a whole-alias prefix of 3+ characters', () => {
+			expect(matchesAliasForConnectBoost('scr', ['scrape'])).toBe(true);
+			expect(matchesAliasForConnectBoost('scra', ['scrape'])).toBe(true);
+		});
+
+		it('should not match a partial prefix below 3 characters', () => {
+			expect(matchesAliasForConnectBoost('sc', ['scrape'])).toBe(false);
+		});
+
+		it('should match an alias-token prefix', () => {
+			expect(matchesAliasForConnectBoost('pdf', ['pdf parser'])).toBe(true);
+			expect(matchesAliasForConnectBoost('pars', ['pdf parser'])).toBe(true);
+		});
+
+		it('should not match a fuzzy subsequence', () => {
+			// 'shee' appears in-order in 'search engine' but no token starts with it
+			expect(matchesAliasForConnectBoost('shee', ['search engine'])).toBe(false);
+		});
+
+		it('should not match an empty query', () => {
+			expect(matchesAliasForConnectBoost('', ['scrape'])).toBe(false);
+		});
+	});
+
+	describe('searchNodes - n8n Connect boost', () => {
+		const makeNode = (name: string, displayName: string, alias: string[] = []) =>
+			mockNodeCreateElement(
+				{ key: name },
+				{ name, displayName, codex: { categories: [], subcategories: {}, alias } },
+			);
+
+		const mockStores = ({
+			gatewayEnabled = true,
+			supportedNodes = [] as string[],
+			versionSupported = true,
+		} = {}) => {
+			vi.mocked(useSettingsStore).mockReturnValue({
+				isAskAiEnabled: true,
+				isAiGatewayEnabled: gatewayEnabled,
+			} as unknown as ReturnType<typeof useSettingsStore>);
+			vi.mocked(useAiGatewayStore).mockReturnValue({
+				isNodeSupported: vi.fn((name: string) => supportedNodes.includes(name)),
+				isNodeTypeVersionSupported: vi.fn(() => versionSupported),
+			} as unknown as ReturnType<typeof useAiGatewayStore>);
+			vi.mocked(useNodeTypesStore).mockReturnValue({
+				getNodeVersions: vi.fn(() => [1]),
+			} as unknown as ReturnType<typeof useNodeTypesStore>);
+		};
+
+		// Two nodes with the same alias: without the boost the earlier item wins
+		// the tie, so connect ranking first proves the boost was applied.
+		const plainNode = makeNode('plainNode', 'Plain Node', ['scrape']);
+		const connectNode = makeNode('connectNode', 'Connect Node', ['scrape']);
+
+		it('should rank a Connect node above an equal non-Connect match on alias prefix', () => {
+			mockStores({ supportedNodes: ['connectNode'] });
+
+			const result = searchNodes('scra', [plainNode, connectNode]);
+			expect(result.map((item) => item.key)).toEqual(['connectNode', 'plainNode']);
+		});
+
+		it('should not boost when the gateway is disabled', () => {
+			mockStores({ gatewayEnabled: false, supportedNodes: ['connectNode'] });
+
+			const result = searchNodes('scra', [plainNode, connectNode]);
+			expect(result.map((item) => item.key)).toEqual(['plainNode', 'connectNode']);
+		});
+
+		it('should not boost a node missing from the gateway config', () => {
+			mockStores({ supportedNodes: [] });
+
+			const result = searchNodes('scra', [plainNode, connectNode]);
+			expect(result.map((item) => item.key)).toEqual(['plainNode', 'connectNode']);
+		});
+
+		it('should not boost a node whose latest version is below the gateway minimum', () => {
+			mockStores({ supportedNodes: ['connectNode'], versionSupported: false });
+
+			const result = searchNodes('scra', [plainNode, connectNode]);
+			expect(result.map((item) => item.key)).toEqual(['plainNode', 'connectNode']);
+		});
+
+		it('should boost a Tool-suffixed node via its base name', () => {
+			mockStores({ supportedNodes: ['connect'] });
+			const plainTool = makeNode('plainTool', 'Plain Tool', ['scrape']);
+			const connectTool = makeNode('connectTool', 'Connect Tool', ['scrape']);
+
+			const result = searchNodes('scra', [plainTool, connectTool]);
+			expect(result.map((item) => item.key)).toEqual(['connectTool', 'plainTool']);
+		});
+
+		it('should not boost on a fuzzy subsequence match and keep the intent match on top', () => {
+			mockStores({ supportedNodes: ['firecrawl'] });
+			const sheets = makeNode('googleSheets', 'Google Sheets');
+			const firecrawl = makeNode('firecrawl', 'Firecrawl', ['search engine']);
+
+			const result = searchNodes('shee', [firecrawl, sheets]);
+			expect(result[0].key).toEqual('googleSheets');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -821,6 +821,7 @@ describe('NodeCreator - utils', () => {
 			const isNodeTypeVersionSupported = vi.fn(() => true);
 			vi.mocked(useNodeTypesStore).mockReturnValue({
 				getNodeVersions: vi.fn(() => []),
+				communityNodeType: vi.fn(() => null),
 			} as unknown as ReturnType<typeof useNodeTypesStore>);
 			vi.mocked(useAiGatewayStore).mockReturnValue({
 				isNodeSupported: vi.fn(() => true),
@@ -829,6 +830,23 @@ describe('NodeCreator - utils', () => {
 
 			finalizeItems([makeGatewayNode('my-node')]);
 			expect(isNodeTypeVersionSupported).toHaveBeenCalledWith('my-node', 1);
+		});
+
+		it('should fall back to the community node description version for a preview node', () => {
+			// Preview community nodes are absent from the core map, so getNodeVersions
+			// is empty; the version must come from the community node description.
+			const isNodeTypeVersionSupported = vi.fn(() => true);
+			vi.mocked(useNodeTypesStore).mockReturnValue({
+				getNodeVersions: vi.fn(() => []),
+				communityNodeType: vi.fn(() => ({ nodeDescription: { version: [1, 2] } })),
+			} as unknown as ReturnType<typeof useNodeTypesStore>);
+			vi.mocked(useAiGatewayStore).mockReturnValue({
+				isNodeSupported: vi.fn(() => true),
+				isNodeTypeVersionSupported,
+			} as unknown as ReturnType<typeof useAiGatewayStore>);
+
+			finalizeItems([makeGatewayNode('my-node')]);
+			expect(isNodeTypeVersionSupported).toHaveBeenCalledWith('my-node', 2);
 		});
 
 		it('should show Free credits badge for a Tool-suffixed node whose base name is in the gateway config', () => {
@@ -840,6 +858,20 @@ describe('NodeCreator - utils', () => {
 
 			const [result] = finalizeItems([
 				makeGatewayNode('llamaParsePlatformTool'),
+			]) as NodeCreateElement[];
+			expect(result.properties.tag).toEqual({ text: expect.any(String), pill: true });
+		});
+
+		it('should show Free credits badge for an uninstalled preview node whose canonical name is in the gateway config', () => {
+			// Preview community nodes carry a `-preview` token; the gateway config
+			// only lists the canonical name, so the token must be stripped.
+			vi.mocked(useAiGatewayStore).mockReturnValue({
+				isNodeSupported: vi.fn((name: string) => name === '@vendor/n8n-nodes-connect.connect'),
+				isNodeTypeVersionSupported: vi.fn(() => true),
+			} as unknown as ReturnType<typeof useAiGatewayStore>);
+
+			const [result] = finalizeItems([
+				makeGatewayNode('@vendor/n8n-nodes-preview-connect.connect'),
 			]) as NodeCreateElement[];
 			expect(result.properties.tag).toEqual({ text: expect.any(String), pill: true });
 		});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -890,6 +890,24 @@ describe('NodeCreator - utils', () => {
 		it('should not match an empty query', () => {
 			expect(matchesAliasForConnectBoost('', ['scrape'])).toBe(false);
 		});
+
+		// Cases drawn from the RLY-160 keyword table. The 3-char threshold exists
+		// specifically so short aliases like `ocr` and `pdf` stay boostable while
+		// 1-2 char partials remain noise-free.
+		it.each<[string, string[], boolean]>([
+			['serp', ['serp'], true],
+			['fetch', ['fetch'], true],
+			['browse', ['browser', 'browse'], true],
+			['ocr', ['ocr'], true],
+			['pdf', ['pdf', 'parse'], true],
+			['scrap', ['scrape'], true],
+			['inv', ['invoice'], true],
+			['invoice', ['pdf', 'extract', 'ocr', 'invoice', 'scan', 'parse'], true],
+			['oc', ['ocr'], false],
+			['pd', ['pdf'], false],
+		])('matches "%s" against %j -> %s', (query, aliases, expected) => {
+			expect(matchesAliasForConnectBoost(query, aliases)).toBe(expected);
+		});
 	});
 
 	describe('searchNodes - n8n Connect boost', () => {
@@ -966,6 +984,20 @@ describe('NodeCreator - utils', () => {
 
 			const result = searchNodes('shee', [firecrawl, sheets]);
 			expect(result[0].key).toEqual('googleSheets');
+		});
+
+		// RLY-160: the boost must apply to both core and community nodes as long as
+		// they are listed as AI Gateway-supported.
+		it('should boost both core and community Connect nodes above a non-Connect node', () => {
+			const core = makeNode('n8n-nodes-base.brave', 'Brave', ['serp']);
+			const community = makeNode('@mendable/n8n-nodes-firecrawl.firecrawl', 'Firecrawl', ['serp']);
+			const plain = makeNode('plainNode', 'Plain Node', ['serp']);
+			mockStores({ supportedNodes: [core.key, community.key] });
+
+			const keys = searchNodes('serp', [plain, core, community]).map((item) => item.key);
+
+			expect(keys[2]).toBe('plainNode');
+			expect(keys.slice(0, 2)).toEqual(expect.arrayContaining([core.key, community.key]));
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
@@ -129,6 +129,66 @@ export function removeTrailingTrigger(searchFilter: string) {
 	return searchFilter;
 }
 
+// Modest on purpose: high-confidence matches on other nodes should still win.
+const AI_GATEWAY_SEARCH_BOOST = 75;
+const AI_GATEWAY_BOOST_MIN_QUERY_LENGTH = 3;
+
+/**
+ * 1. exact alias match (any query length): `scrape` → `scrape`
+ * 2. whole-alias prefix match at 3+ chars: `scra` → `scrape`
+ * 3. alias-token prefix match at 3+ chars: `pdf` → `pdf parser`
+ */
+export function matchesAliasForConnectBoost(query: string, aliases: string[]): boolean {
+	const queryLower = query.toLowerCase();
+
+	return aliases.some((alias) => {
+		const aliasLower = alias.toLowerCase();
+
+		if (aliasLower === queryLower) return true;
+
+		if (queryLower.length < AI_GATEWAY_BOOST_MIN_QUERY_LENGTH) return false;
+
+		if (aliasLower.startsWith(queryLower)) return true;
+
+		return aliasLower.split(/\s+/).some((token) => token.startsWith(queryLower));
+	});
+}
+
+/**
+ * Whether the node is eligible for n8n Connect (AI Gateway)
+ */
+function isAiGatewayEligibleNode(nodeName: string): boolean {
+	if (!useSettingsStore().isAiGatewayEnabled) return false;
+
+	const aiGatewayStore = useAiGatewayStore();
+	const baseName = nodeName.replace(/Tool$/, '');
+	const supportedName = [nodeName, baseName].find((n) => aiGatewayStore.isNodeSupported(n));
+	if (!supportedName) return false;
+
+	const versions = useNodeTypesStore().getNodeVersions(supportedName);
+	const latestVersion = versions.length > 0 ? Math.max(...versions) : 1;
+	return aiGatewayStore.isNodeTypeVersionSupported(supportedName, latestVersion);
+}
+
+function getAiGatewaySearchBoosts(
+	query: string,
+	items: INodeCreateElement[],
+): Record<string, number> {
+	if (query === '' || !useSettingsStore().isAiGatewayEnabled) return {};
+
+	const boosts: Record<string, number> = {};
+	for (const item of items) {
+		if (item.type !== 'node') continue;
+
+		const aliases = item.properties.codex?.alias ?? [];
+		if (!matchesAliasForConnectBoost(query, aliases)) continue;
+		if (!isAiGatewayEligibleNode(item.properties.name)) continue;
+
+		boosts[item.key] = AI_GATEWAY_SEARCH_BOOST;
+	}
+	return boosts;
+}
+
 export function searchNodes(
 	searchFilter: string,
 	items: INodeCreateElement[],
@@ -145,7 +205,17 @@ export function searchNodes(
 	// Please update the snapshots per the README next to the snapshots if you modify items significantly.
 	const searchResults = sublimeSearch<INodeCreateElement>(trimmedFilter, items) || [];
 
-	const reRankedResults = reRankSearchResults(searchResults, additionalFactors);
+	// Any alias-prefix match is also a fuzzy match, so scanning the results
+	// (instead of all items) can never miss a boostable node.
+	const aiGatewayBoost = getAiGatewaySearchBoosts(
+		trimmedFilter,
+		searchResults.map(({ item }) => item),
+	);
+
+	const reRankedResults = reRankSearchResults(searchResults, {
+		...additionalFactors,
+		aiGatewayBoost,
+	});
 
 	return reRankedResults.map(({ item }) => item);
 }
@@ -313,24 +383,11 @@ function applyNodeTags(element: INodeCreateElement): INodeCreateElement {
 			type: 'info',
 			text: i18n.baseText('generic.betaProper'),
 		};
-	} else if (useSettingsStore().isAiGatewayEnabled) {
-		const aiGatewayStore = useAiGatewayStore();
-		// Tool-variant node types carry a "Tool" suffix (e.g. "llamaParsePlatformTool"),
-		// but the gateway config lists the base name ("llamaParsePlatform").
-		const baseName = element.properties.name.replace(/Tool$/, '');
-		const supportedName = [element.properties.name, baseName].find((n) =>
-			aiGatewayStore.isNodeSupported(n),
-		);
-		if (supportedName) {
-			const versions = useNodeTypesStore().getNodeVersions(supportedName);
-			const latestVersion = versions.length > 0 ? Math.max(...versions) : 1;
-			if (aiGatewayStore.isNodeTypeVersionSupported(supportedName, latestVersion)) {
-				element.properties.tag = {
-					text: i18n.baseText('generic.freeCredits'),
-					pill: true,
-				};
-			}
-		}
+	} else if (isAiGatewayEligibleNode(element.properties.name)) {
+		element.properties.tag = {
+			text: i18n.baseText('generic.freeCredits'),
+			pill: true,
+		};
 	}
 
 	return element;

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
@@ -162,12 +162,35 @@ function isAiGatewayEligibleNode(nodeName: string): boolean {
 
 	const aiGatewayStore = useAiGatewayStore();
 	const baseName = nodeName.replace(/Tool$/, '');
-	const supportedName = [nodeName, baseName].find((n) => aiGatewayStore.isNodeSupported(n));
+	const candidates = [
+		nodeName,
+		baseName,
+		removePreviewToken(nodeName),
+		removePreviewToken(baseName),
+	];
+	const supportedName = candidates.find((n) => aiGatewayStore.isNodeSupported(n));
 	if (!supportedName) return false;
 
-	const versions = useNodeTypesStore().getNodeVersions(supportedName);
-	const latestVersion = versions.length > 0 ? Math.max(...versions) : 1;
-	return aiGatewayStore.isNodeTypeVersionSupported(supportedName, latestVersion);
+	return aiGatewayStore.isNodeTypeVersionSupported(
+		supportedName,
+		getLatestKnownVersion(supportedName),
+	);
+}
+
+/**
+ * Latest version we know about for a node. `getNodeVersions` only covers the
+ * core map (built-in + installed community nodes); preview community nodes live
+ * behind `communityNodeType`, so fall back to their description version before
+ * defaulting to 1.
+ */
+function getLatestKnownVersion(nodeName: string): number {
+	const nodeTypesStore = useNodeTypesStore();
+	const versions = nodeTypesStore.getNodeVersions(nodeName);
+	if (versions.length > 0) return Math.max(...versions);
+
+	const communityVersion = nodeTypesStore.communityNodeType(nodeName)?.nodeDescription?.version;
+	if (Array.isArray(communityVersion)) return Math.max(...communityVersion);
+	return communityVersion ?? 1;
 }
 
 function getAiGatewaySearchBoosts(


### PR DESCRIPTION
## Summary

https://www.loom.com/share/d10671b1e0564b36a53579cf9373abe7

Boosts n8n Connect (AI Gateway) services in the **nodes & tools panel search** so eligible Connect services rank higher when the query matches one of their aliases.

- Applies an additive boost (`+75`) inside `searchNodes`, merged into the existing `reRankSearchResults` factors, so it composes with popularity/other factors instead of replacing scores.
- The boost only triggers on **prefix semantics**, kept as three explicit, independently tunable cases (`matchesAliasForConnectBoost`):
  1. exact alias match at any query length (`scrape` → `scrape`)
  2. whole-alias prefix at 3+ chars (`scra` → `scrape`)
  3. alias-token prefix at 3+ chars (`pdf` → `pdf parser`)
  A generic fuzzy subsequence (`shee` in `search engine`) does **not** boost, so a strong intent match on another node (e.g. Google Sheets) still wins.
- Gated on `isAiGatewayEnabled` **and** the gateway config (node is supported and its latest version meets the configured minimum). The config is warmed up when the node creator opens so the list is ready by the time the user types.
- Refactored the Connect-eligibility check out of `applyNodeTags` into a shared `isAiGatewayEligibleNode` helper (handles the `Tool` node-type suffix).

## How to test

> Instance with change -> https://test-pr-33832.stage-app.n8n.cloud/ (ping me for pass)

1. Open the nodes/tools panel and type an alias of a Connect service (e.g. `scrape`, `scra`, `serp`, `pdf`, `ocr`). The eligible Connect service should rank at/near the top.
2. Type a term that strongly matches a non-Connect node (e.g. `shee` → **Google Sheets**) and confirm the Connect node does **not** jump above it.
3. Type a 1–2 char partial (e.g. `sc`) and confirm no partial-prefix boost is applied (exact matches still boost at any length).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-160

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33832">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->