### PR TITLE
fix(core): Update error message on file write

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -310,21 +310,25 @@ describe('getFileSystemHelperFunctions', () => {
 			).rejects.toThrow(`The file "${filePath}" could not be accessed.`);
 		});
 
-		it('should throw when file access is blocked', async () => {
+		it('should explain that a blocked file is outside the allowed paths', async () => {
 			securityConfig.restrictFileAccessTo = '/allowed/path';
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
+			).rejects.toThrow(
+				'Access to the file is not allowed. The file is outside of the allowed paths.',
+			);
 		});
 
-		it('should not reveal if file exists if it is within restricted path', async () => {
+		it('should not reveal if a blocked file exists', async () => {
 			securityConfig.restrictFileAccessTo = '/allowed/path';
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
+			).rejects.toThrow(
+				'Access to the file is not allowed. The file is outside of the allowed paths.',
+			);
 		});
 
 		it('should omit allowed paths from blocked access errors when none are configured', async () => {
@@ -409,7 +413,7 @@ describe('getFileSystemHelperFunctions', () => {
 			).rejects.toThrow('Access to the file is not allowed.');
 		});
 
-		it('should include allowed paths when writing outside configured allowed paths', async () => {
+		it('should explain that a blocked file is outside the allowed paths', async () => {
 			securityConfig.restrictFileAccessTo = '/allowed/path';
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 
@@ -419,7 +423,9 @@ describe('getFileSystemHelperFunctions', () => {
 					'content',
 					constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
 				),
-			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
+			).rejects.toThrow(
+				'Access to the file is not allowed. The file is outside of the allowed paths.',
+			);
 		});
 
 		it('should reject symlinks with ELOOP error', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -335,7 +335,7 @@ describe('getFileSystemHelperFunctions', () => {
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 
 			await expect(helperFunctions.createReadStream(blockedPath)).rejects.toThrow(
-				`Access to the file "${blockedPath}" is not allowed.`,
+				'Access to the file is not allowed.',
 			);
 		});
 
@@ -398,6 +398,18 @@ describe('getFileSystemHelperFunctions', () => {
 		const mockFileStats = { dev: 123, ino: 456, isFile: () => true };
 
 		it('should throw error for blocked file path', async () => {
+			process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+
+			await expect(
+				helperFunctions.writeContentToFile(
+					await helperFunctions.resolvePath(instanceSettings.n8nFolder + '/test.txt'),
+					'content',
+					constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
+				),
+			).rejects.toThrow('Access to the file is not allowed.');
+		});
+
+		it('should include allowed paths when writing outside configured allowed paths', async () => {
 			securityConfig.restrictFileAccessTo = '/allowed/path';
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -315,9 +315,7 @@ describe('getFileSystemHelperFunctions', () => {
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow(
-				'Access to the file is not allowed. The file is outside of the allowed paths.',
-			);
+			).rejects.toThrow('Access to the file is not allowed.');
 		});
 
 		it('should not reveal if a blocked file exists', async () => {
@@ -326,9 +324,7 @@ describe('getFileSystemHelperFunctions', () => {
 
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow(
-				'Access to the file is not allowed. The file is outside of the allowed paths.',
-			);
+			).rejects.toThrow('Access to the file is not allowed.');
 		});
 
 		it('should omit allowed paths from blocked access errors when none are configured', async () => {
@@ -423,9 +419,7 @@ describe('getFileSystemHelperFunctions', () => {
 					'content',
 					constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
 				),
-			).rejects.toThrow(
-				'Access to the file is not allowed. The file is outside of the allowed paths.',
-			);
+			).rejects.toThrow('Access to the file is not allowed.');
 		});
 
 		it('should reject symlinks with ELOOP error', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -626,7 +626,8 @@ describe('getFileSystemHelperFunctions', () => {
 				),
 			).resolves.toBeUndefined();
 
-			expect(fsMkdir).toHaveBeenLastCalledWith(join('/allowed', 'dir'));
+			expect(fsMkdir).toHaveBeenCalledWith('/allowed');
+			expect(fsMkdir).toHaveBeenCalledWith('/allowed/dir');
 		});
 
 		it('rejects when a parent component is a symlink', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/file-system-helper-functions.test.ts
@@ -315,7 +315,7 @@ describe('getFileSystemHelperFunctions', () => {
 			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow('Access to the file is not allowed');
+			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
 		});
 
 		it('should not reveal if file exists if it is within restricted path', async () => {
@@ -324,7 +324,19 @@ describe('getFileSystemHelperFunctions', () => {
 
 			await expect(
 				helperFunctions.createReadStream(await helperFunctions.resolvePath('/blocked/path')),
-			).rejects.toThrow('Access to the file is not allowed');
+			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
+		});
+
+		it('should omit allowed paths from blocked access errors when none are configured', async () => {
+			process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+			const blockedPath = await helperFunctions.resolvePath(
+				join(instanceSettings.n8nFolder, 'config'),
+			);
+			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
+
+			await expect(helperFunctions.createReadStream(blockedPath)).rejects.toThrow(
+				`Access to the file "${blockedPath}" is not allowed.`,
+			);
 		});
 
 		it('should create a read stream if file access is permitted', async () => {
@@ -386,15 +398,16 @@ describe('getFileSystemHelperFunctions', () => {
 		const mockFileStats = { dev: 123, ino: 456, isFile: () => true };
 
 		it('should throw error for blocked file path', async () => {
-			process.env[BLOCK_FILE_ACCESS_TO_N8N_FILES] = 'true';
+			securityConfig.restrictFileAccessTo = '/allowed/path';
+			(fsStat as Mock).mockResolvedValueOnce(mockFileStats);
 
 			await expect(
 				helperFunctions.writeContentToFile(
-					await helperFunctions.resolvePath(instanceSettings.n8nFolder + '/test.txt'),
+					await helperFunctions.resolvePath('/blocked/path'),
 					'content',
 					constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC,
 				),
-			).rejects.toThrow('not writable');
+			).rejects.toThrow('Access to the file is not allowed. Allowed paths: /allowed/path');
 		});
 
 		it('should reject symlinks with ELOOP error', async () => {
@@ -601,8 +614,7 @@ describe('getFileSystemHelperFunctions', () => {
 				),
 			).resolves.toBeUndefined();
 
-			expect(fsMkdir).toHaveBeenCalledWith('/allowed');
-			expect(fsMkdir).toHaveBeenCalledWith('/allowed/dir');
+			expect(fsMkdir).toHaveBeenLastCalledWith(join('/allowed', 'dir'));
 		});
 
 		it('rejects when a parent component is a symlink', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -51,6 +51,14 @@ const getAllowedPaths = () => {
 	return allowedPaths;
 };
 
+function createBlockedPathError(node: INode): NodeOperationError {
+	const allowedPaths = getAllowedPaths();
+	const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
+	return new NodeOperationError(node, `Access to the file is not allowed.${message}`, {
+		level: 'warning',
+	});
+}
+
 async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {
 	const pathStr = path.toString();
 
@@ -275,11 +283,7 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 		const pathIdentity = await fsStat(resolvedFilePath);
 		// Check that the path is allowed.
 		if (isFilePathBlocked(resolvedFilePath)) {
-			const allowedPaths = getAllowedPaths();
-			const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
-			throw new NodeOperationError(node, `Access to the file is not allowed.${message}`, {
-				level: 'warning',
-			});
+			throw createBlockedPathError(node);
 		}
 
 		try {
@@ -348,13 +352,7 @@ export const getFileSystemHelperFunctions = (node: INode): FileSystemHelperFunct
 
 		// Check that the path is allowed.
 		if (isFilePathBlocked(resolvedFilePath)) {
-			throw new NodeOperationError(
-				node,
-				`The file "${String(resolvedFilePath)}" is not writable.`,
-				{
-					level: 'warning',
-				},
-			);
+			throw createBlockedPathError(node);
 		}
 
 		const shouldTruncate = flag === undefined || (flag & constants.O_TRUNC) === constants.O_TRUNC;

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -52,13 +52,9 @@ const getAllowedPaths = () => {
 };
 
 function createBlockedPathError(node: INode): NodeOperationError {
-	return new NodeOperationError(
-		node,
-		'Access to the file is not allowed. The file is outside of the allowed paths.',
-		{
-			level: 'warning',
-		},
-	);
+	return new NodeOperationError(node, 'Access to the file is not allowed.', {
+		level: 'warning',
+	});
 }
 
 async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {

--- a/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/file-system-helper-functions.ts
@@ -52,11 +52,13 @@ const getAllowedPaths = () => {
 };
 
 function createBlockedPathError(node: INode): NodeOperationError {
-	const allowedPaths = getAllowedPaths();
-	const message = allowedPaths.length ? ` Allowed paths: ${allowedPaths.join(', ')}` : '';
-	return new NodeOperationError(node, `Access to the file is not allowed.${message}`, {
-		level: 'warning',
-	});
+	return new NodeOperationError(
+		node,
+		'Access to the file is not allowed. The file is outside of the allowed paths.',
+		{
+			level: 'warning',
+		},
+	);
 }
 
 async function resolvePath(path: PathLike): Promise<ResolvedFilePath> {


### PR DESCRIPTION
## Summary

Updates errors thrown when path is blocked to be same for different branches and don't include list of paths(see discussion below)

## How to test

Try this workflow, the error message should be updated

<details>
<summary>Workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {
        "operation": "toText",
        "sourceProperty": "test",
        "options": {}
      },
      "type": "n8n-nodes-base.convertToFile",
      "typeVersion": 1.1,
      "position": [
        448,
        64
      ],
      "id": "4683aa21-bab9-4e8f-aadc-611a8d61f0e2",
      "name": "Convert to File"
    },
    {
      "parameters": {
        "assignments": {
          "assignments": [
            {
              "id": "a64c9711-ecc0-45c7-83f2-d27ade27b2b9",
              "name": "test",
              "value": "a",
              "type": "string"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.set",
      "typeVersion": 3.4,
      "position": [
        240,
        64
      ],
      "id": "605be448-9034-4ffc-aee6-812f8c618944",
      "name": "Edit Fields"
    },
    {
      "parameters": {
        "operation": "write",
        "fileName": "enter-path-here",
        "options": {}
      },
      "type": "n8n-nodes-base.readWriteFile",
      "typeVersion": 1.1,
      "position": [
        656,
        64
      ],
      "id": "9c8eab67-ef04-48b1-a266-541559ede54d",
      "name": "Read/Write Files from Disk1"
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        64
      ],
      "id": "85edf475-ed9e-4fff-8768-2b30883ec038",
      "name": "When clicking ‘Execute workflow’"
    }
  ],
  "connections": {
    "Convert to File": {
      "main": [
        [
          {
            "node": "Read/Write Files from Disk1",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Edit Fields": {
      "main": [
        [
          {
            "node": "Convert to File",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "Edit Fields",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5113/improve-readwrite-files-error-message-on-cloud


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

