### PR TITLE
fix(core): Support custom OpenAI-compatible model endpoints in AI Assistant

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -36,6 +36,16 @@ vi.mock('@ai-sdk/openai', () => ({
 				specificationVersion: 'v3',
 			}),
 			{
+				chat: (model: string) => ({
+					provider: 'openai',
+					modelId: model,
+					api: 'chat-completions',
+					apiKey: opts?.apiKey,
+					baseURL: opts?.baseURL,
+					fetch: opts?.fetch,
+					headers: opts?.headers,
+					specificationVersion: 'v3',
+				}),
 				embeddingModel: (model: string) => ({
 					provider: 'openai',
 					modelId: model,
@@ -205,6 +215,39 @@ describe('createModel', () => {
 		}) as unknown as Record<string, unknown>;
 		expect(model.provider).toBe('openai');
 		expect(model.baseURL).toBe('https://custom.endpoint.com/v1');
+		// Custom endpoints are OpenAI-COMPATIBLE servers: they speak
+		// /chat/completions, not OpenAI's Responses API.
+		expect(model.api).toBe('chat-completions');
+	});
+
+	it('accepts `url` as an alias for baseURL (host configs like Instance AI)', () => {
+		const model = createModel({
+			id: 'openai/mock-model',
+			apiKey: 'sk-test',
+			url: 'http://127.0.0.1:1234/v1',
+		}) as unknown as Record<string, unknown>;
+		expect(model.baseURL).toBe('http://127.0.0.1:1234/v1');
+		expect(model.api).toBe('chat-completions');
+	});
+
+	it('treats an empty url as no custom endpoint (api-key-only host config)', () => {
+		// Instance AI emits { id, url: '', apiKey } when only the API key is set;
+		// the provider default endpoint and default model must be preserved.
+		const model = createModel({
+			id: 'anthropic/claude-sonnet-4-6',
+			apiKey: 'sk-ant-test',
+			url: '',
+		}) as unknown as Record<string, unknown>;
+		expect(model.baseURL).toBeUndefined();
+		expect(model.apiKey).toBe('sk-ant-test');
+	});
+
+	it('keeps the default Responses API model for plain OpenAI (no baseURL)', () => {
+		const model = createModel({
+			id: 'openai/gpt-4o',
+			apiKey: 'sk-test',
+		}) as unknown as Record<string, unknown>;
+		expect(model.api).toBeUndefined();
 	});
 
 	it('should pass through a prebuilt LanguageModel', () => {

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -74,7 +74,12 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 	openai: {
 		build: (creds, model, fetch) => {
 			const { createOpenAI } = require('@ai-sdk/openai') as typeof import('@ai-sdk/openai');
-			return createOpenAI({ ...creds, fetch })(model);
+			const provider = createOpenAI({ ...creds, fetch });
+			// A custom baseURL means an OpenAI-COMPATIBLE server (LM Studio, vLLM,
+			// Ollama, gateways), which speaks /chat/completions; the provider's
+			// default model targets OpenAI's own Responses API (/responses) that
+			// those servers do not implement.
+			return creds.baseURL ? provider.chat(model) : provider(model);
 		},
 	},
 	anthropic: {
@@ -215,6 +220,15 @@ export function createModel(config: ModelConfig, fetch?: FetchFn): LanguageModel
 	if (typeof config !== 'string') {
 		const { id: _id, ...rest } = config as { id: string; [k: string]: unknown };
 		credFields = rest;
+	}
+	// Host configs (e.g. Instance AI's `{ id, url }` for OpenAI-compatible
+	// endpoints) spell the base URL as `url`; the provider schemas only know
+	// `baseURL`, and Zod strips unknown keys, so normalize before validation.
+	// An EMPTY url means "no custom endpoint" (Instance AI emits `url: ''` for
+	// the api-key-only config) and must keep the provider default.
+	if (typeof credFields.url === 'string' && credFields.baseURL === undefined) {
+		const { url, ...restCreds } = credFields;
+		credFields = url ? { ...restCreds, baseURL: url } : restCreds;
 	}
 
 	const schema = PROVIDER_CREDENTIAL_SCHEMAS[provider];


### PR DESCRIPTION
## Summary

The documented custom model endpoint path for the AI Assistant (`N8N_INSTANCE_AI_MODEL_URL`, e.g. LM Studio) failed twice in the `@n8n/agents` model factory:

1. **`url` was not accepted as a `baseURL` alias.** Host configs (Instance AI) spell the base URL as `url`, but the provider credential schemas only know `baseURL` and Zod strips unknown keys, so the custom endpoint was silently dropped. `url` is now normalized to `baseURL` before validation, and an **empty** `url` (the api-key-only config Instance AI emits) means "no custom endpoint" and keeps the provider default.
2. **Custom endpoints were routed to OpenAI's Responses API.** A custom `baseURL` means an OpenAI-compatible server (LM Studio, vLLM, Ollama, gateways) that speaks `/chat/completions`, not `/responses`. With a custom `baseURL`, the factory now builds the model via `provider.chat(model)`; plain OpenAI (no `baseURL`) keeps the default Responses API model.

## How to test

Unit tests cover both fixes plus the empty-url and plain-OpenAI defaults:

```bash
cd packages/@n8n/agents
pnpm vitest run src/runtime/__tests__/model-factory.test.ts
```

Manual: point `N8N_INSTANCE_AI_MODEL_URL` at a local LM Studio server (e.g. `http://127.0.0.1:1234/v1`) with `N8N_INSTANCE_AI_MODEL=openai/<model>`, start n8n, and chat with the AI Assistant; requests now reach the server's `/chat/completions` endpoint.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-839

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


