### PR TITLE
perf(core): Bound peak memory when computing source control status

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -22,6 +22,7 @@ import {
 	getTrackingInformationFromPullResult,
 	hasOwnerChanged,
 	isWorkflowModified,
+	mapInBatches,
 	mergeRemoteCrendetialDataIntoLocalCredentialData,
 	sanitizeCredentialData,
 	sourceControlFoldersExistCheck,
@@ -242,6 +243,56 @@ describe('Source Control Helper', () => {
 			expect(getRepoType('git@github.com:n8ntest/n8n_testrepo.git')).toBe('github');
 			expect(getRepoType('git@gitlab.com:n8ntest/n8n_testrepo.git')).toBe('gitlab');
 			expect(getRepoType('git@mygitea.io:n8ntest/n8n_testrepo.git')).toBe('other');
+		});
+	});
+
+	describe('mapInBatches', () => {
+		it('should preserve input order and length', async () => {
+			const items = Array.from({ length: 45 }, (_, i) => i);
+
+			// Resolve items out of order within each batch to prove order is preserved
+			const result = await mapInBatches(items, 20, async (item) => {
+				await new Promise((resolve) => setTimeout(resolve, item % 3));
+				return item * 2;
+			});
+
+			expect(result).toEqual(items.map((item) => item * 2));
+		});
+
+		it('should never run more than batchSize items concurrently', async () => {
+			let inFlight = 0;
+			let maxInFlight = 0;
+
+			await mapInBatches(
+				Array.from({ length: 45 }, (_, i) => i),
+				20,
+				async (item) => {
+					inFlight++;
+					maxInFlight = Math.max(maxInFlight, inFlight);
+					await new Promise((resolve) => setImmediate(resolve));
+					inFlight--;
+					return item;
+				},
+			);
+
+			expect(maxInFlight).toBeLessThanOrEqual(20);
+			expect(maxInFlight).toBeGreaterThan(1);
+		});
+
+		it('should reject when an item fails', async () => {
+			await expect(
+				mapInBatches([1, 2, 3], 2, async (item) => {
+					await Promise.resolve();
+					if (item === 2) throw new Error('boom');
+					return item;
+				}),
+			).rejects.toThrow('boom');
+		});
+
+		it('should return an empty array for empty input', async () => {
+			const fn = vi.fn();
+			await expect(mapInBatches([], 20, fn)).resolves.toEqual([]);
+			expect(fn).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1375,6 +1375,31 @@ describe('SourceControlImportService', () => {
 			expect(result).toHaveLength(0);
 		});
 
+		it('should read files in bounded batches and preserve order', async () => {
+			const fileCount = 45;
+			const files = Array.from({ length: fileCount }, (_, i) => `/mock/credential${i}.json`);
+			globMock.mockResolvedValue(files);
+
+			// All reads of a batch start synchronously before any completes (the mock
+			// yields a microtask), so an unbounded implementation would reach 45 in flight
+			let inFlight = 0;
+			let maxInFlight = 0;
+			fsReadFile.mockImplementation(async (file) => {
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await Promise.resolve();
+				inFlight--;
+				const index = /credential(\d+)\.json$/.exec(file as string)?.[1];
+				return JSON.stringify({ id: `cred${index}`, name: `Credential ${index}`, type: 'oauth2' });
+			});
+
+			const result = await service.getRemoteCredentialsFromFiles(globalAdminContext);
+
+			expect(maxInFlight).toBe(20);
+			expect(result).toHaveLength(fileCount);
+			expect(result.map((credential) => credential.id)).toEqual(files.map((_, i) => `cred${i}`));
+		});
+
 		it('should parse global credentials with isGlobal flag set to true', async () => {
 			globMock.mockResolvedValue(['/mock/global-credential.json']);
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -173,6 +173,31 @@ describe('SourceControlImportService', () => {
 
 			expect(result).toHaveLength(0);
 		});
+
+		it('should read files in bounded batches and preserve order', async () => {
+			const fileCount = 45;
+			const files = Array.from({ length: fileCount }, (_, i) => `/mock/workflow${i}.json`);
+			globMock.mockResolvedValue(files);
+
+			// All reads of a batch start synchronously before any completes (the mock
+			// yields a microtask), so an unbounded implementation would reach 45 in flight
+			let inFlight = 0;
+			let maxInFlight = 0;
+			fsReadFile.mockImplementation(async (file) => {
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await Promise.resolve();
+				inFlight--;
+				const index = /workflow(\d+)\.json$/.exec(file as string)?.[1];
+				return JSON.stringify({ id: `workflow${index}`, versionId: `v${index}` });
+			});
+
+			const result = await service.getRemoteVersionIdsFromFiles(globalAdminContext);
+
+			expect(maxInFlight).toBe(20);
+			expect(result).toHaveLength(fileCount);
+			expect(result.map((workflow) => workflow.id)).toEqual(files.map((_, i) => `workflow${i}`));
+		});
 	});
 
 	describe('importWorkflowFromWorkFolder', () => {

--- a/packages/cli/src/modules/source-control.ee/constants.ts
+++ b/packages/cli/src/modules/source-control.ee/constants.ts
@@ -20,3 +20,4 @@ export const SOURCE_CONTROL_README = `
 export const SOURCE_CONTROL_DEFAULT_NAME = 'n8n user';
 export const SOURCE_CONTROL_DEFAULT_EMAIL = 'n8n@example.com';
 export const SOURCE_CONTROL_WRITE_FILE_BATCH_SIZE = 20;
+export const SOURCE_CONTROL_READ_FILE_BATCH_SIZE = 20;

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -4,6 +4,7 @@ import type { TagEntity, WorkflowTagMapping } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { generateKeyPairSync } from 'crypto';
 import { accessSync, constants as fsConstants, mkdirSync } from 'fs';
+import chunk from 'lodash/chunk';
 import isEqual from 'lodash/isEqual';
 import {
 	deepCopy,
@@ -234,6 +235,23 @@ export async function readDataTablesFromSourceControlFile(
 		}
 		throw error;
 	}
+}
+
+/**
+ * Maps items in fixed-size batches (concurrency within a batch, batches sequential)
+ * to bound the peak memory of per-item work. Preserves input order; rejects on the
+ * first failing item, like `Promise.all`.
+ */
+export async function mapInBatches<T, R>(
+	items: T[],
+	batchSize: number,
+	fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+	const results: R[] = [];
+	for (const batch of chunk(items, batchSize)) {
+		results.push(...(await Promise.all(batch.map(fn))));
+	}
+	return results;
 }
 
 export function sourceControlFoldersExistCheck(

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -299,14 +299,16 @@ export class SourceControlImportService {
 			absolute: true,
 		});
 
-		const remoteCredentialFilesRead = await Promise.all(
-			remoteCredentialFiles.map(async (file) => {
+		const remoteCredentialFilesRead = await mapInBatches(
+			remoteCredentialFiles,
+			SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
+			async (file) => {
 				this.logger.debug(`Parsing credential file ${file}`);
 				const remote = jsonParse<ExportableCredential>(
 					await fsReadFile(file, { encoding: 'utf8' }),
 				);
 				return remote;
-			}),
+			},
 		);
 
 		const remoteCredentialFilesParsed = remoteCredentialFilesRead
@@ -371,8 +373,11 @@ export class SourceControlImportService {
 				this.sourceControlScopedService.getCredentialsInAdminProjectsFromContextFilter(context),
 		});
 
-		return (await Promise.all(
-			localCredentials.map(async (local) => {
+		// Batched to bound the transient decryption allocations (plaintext + parsed object)
+		return (await mapInBatches(
+			localCredentials,
+			SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
+			async (local) => {
 				const ownerProject = local.shared?.find((s) => s.role === 'credential:owner')?.project;
 
 				let data: Record<string, unknown> = {};
@@ -398,7 +403,7 @@ export class SourceControlImportService {
 					isResolvable: local.isResolvable,
 					resolvableAllowFallback: local.resolvableAllowFallback,
 				};
-			}),
+			},
 		)) as StatusExportableCredential[];
 	}
 
@@ -435,8 +440,10 @@ export class SourceControlImportService {
 			return [];
 		}
 
-		const remoteTables = await Promise.all(
-			dataTableFiles.map(async (file): Promise<ExportableDataTable | undefined> => {
+		const remoteTables = await mapInBatches(
+			dataTableFiles,
+			SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
+			async (file): Promise<ExportableDataTable | undefined> => {
 				this.logger.debug(`Parsing data table file ${file}`);
 				const fileContent = await fsReadFile(file, { encoding: 'utf8' });
 				try {
@@ -445,7 +452,7 @@ export class SourceControlImportService {
 					this.logger.warn(`Failed to parse data table from file ${file}: invalid JSON format`);
 					return undefined;
 				}
-			}),
+			},
 		);
 
 		return remoteTables.filter((table): table is ExportableDataTable => {
@@ -630,8 +637,10 @@ export class SourceControlImportService {
 			absolute: true,
 		});
 
-		const remoteProjects = await Promise.all(
-			remoteProjectFiles.map(async (file) => {
+		const remoteProjects = await mapInBatches(
+			remoteProjectFiles,
+			SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
+			async (file) => {
 				this.logger.debug(`Parsing project file ${file}`);
 				const fileContent = await fsReadFile(file, { encoding: 'utf8' });
 				const parsedProject = jsonParse<ExportableProject>(fileContent);
@@ -640,7 +649,7 @@ export class SourceControlImportService {
 					...parsedProject,
 					filename: getProjectExportPath(parsedProject.id, this.projectExportFolder),
 				};
-			}),
+			},
 		);
 
 		if (context.hasAccessToAllProjects()) {

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -57,6 +57,7 @@ import {
 	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
 	SOURCE_CONTROL_GIT_FOLDER,
 	SOURCE_CONTROL_PROJECT_EXPORT_FOLDER,
+	SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
 	SOURCE_CONTROL_TAGS_EXPORT_FILE,
 	SOURCE_CONTROL_VARIABLES_EXPORT_FILE,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
@@ -68,6 +69,7 @@ import {
 	getProjectExportPath,
 	getWorkflowExportPath,
 	isValidDataTableColumnType,
+	mapInBatches,
 	mergeRemoteCrendetialDataIntoLocalCredentialData,
 	sanitizeCredentialData,
 } from './source-control-helper.ee';
@@ -154,24 +156,26 @@ export class SourceControlImportService {
 			absolute: true,
 		});
 
-		const remoteWorkflowsRead = await Promise.all(
-			remoteWorkflowFiles.map(async (file) => await this.parseWorkflowFromFile(file)),
-		);
+		// Parse in bounded batches and project each workflow to its slim status shape
+		// right away, so at most one batch of full workflow graphs is in memory at a time
+		const remoteWorkflowFilesParsed = await mapInBatches(
+			remoteWorkflowFiles,
+			SOURCE_CONTROL_READ_FILE_BATCH_SIZE,
+			async (file): Promise<SourceControlWorkflowVersionId | undefined> => {
+				const remote = await this.parseWorkflowFromFile(file);
 
-		const remoteWorkflowFilesParsed = remoteWorkflowsRead
-			.filter((remote) => {
 				if (!remote?.id) {
-					return false;
+					return undefined;
 				}
-				return (
-					context.hasAccessToAllProjects() ||
-					(remote.owner && context.findAuthorizedProjectByOwner(remote.owner))
-				);
-			})
-			.map((remote) => {
+
 				const project = remote.owner
 					? context.findAuthorizedProjectByOwner(remote.owner)
 					: undefined;
+
+				if (!context.hasAccessToAllProjects() && !project) {
+					return undefined;
+				}
+
 				return {
 					id: remote.id,
 					versionId: remote.versionId ?? '',
@@ -179,12 +183,15 @@ export class SourceControlImportService {
 					parentFolderId: remote.parentFolderId,
 					remoteId: remote.id,
 					filename: getWorkflowExportPath(remote.id, this.workflowExportFolder),
-					owner: toStatusOwner(project ?? undefined),
+					owner: toStatusOwner(project),
 					isRemoteArchived: remote.isArchived,
 				};
-			});
+			},
+		);
 
-		return remoteWorkflowFilesParsed;
+		return remoteWorkflowFilesParsed.filter(
+			(workflow): workflow is SourceControlWorkflowVersionId => workflow !== undefined,
+		);
 	}
 
 	async getAllLocalVersionIdsFromDb(): Promise<SourceControlWorkflowVersionId[]> {


### PR DESCRIPTION
## Summary

Opening the source control push/pull modal computes the diff via `getStatus`, whose workflow loader (`getRemoteVersionIdsFromFiles`) read and parsed **every** workflow JSON in the work folder with one unbounded `Promise.all`, holding every fully parsed workflow graph (nodes + connections) in memory simultaneously before slimming them down. On instances with thousands of workflows this transient peak grows linearly with the total corpus size and crashes the main process with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`.

This PR introduces a `mapInBatches` helper (+ `SOURCE_CONTROL_READ_FILE_BATCH_SIZE = 20`, mirroring the existing write-side batching) and applies it to every loader in the `getStatus` fan-out that previously processed its whole corpus concurrently:

- **Workflows** (`getRemoteVersionIdsFromFiles`) — batched, and the slim status projection now happens inside the per-file callback, so at most one batch of full workflow graphs is in memory at a time (this was the dominant allocation).
- **Credentials** (`getRemoteCredentialsFromFiles`), **data tables** (`getRemoteDataTablesFromFiles`), **projects** (`getRemoteProjectsFromFiles`) — file reads/parses batched, callbacks unchanged.
- **Local credential decryption** (`getLocalCredentialsFromDb`) — decryption transients (plaintext + parsed object per credential) bounded to one batch at a time.

Results, filtering semantics, ordering, and error behavior are unchanged everywhere.

Benchmark of the workflow loader (2000 workflow files × ~166KB = 324MB corpus, Node v24):

| | before | after |
|---|---|---|
| Peak heap | 535 MB | 59 MB |
| Peak RSS | 1,028 MB | 227 MB |
| Duration | 675 ms | 300 ms |
| `--max-old-space-size=256` | OOM crash | completes (102 MB peak) |

## How to test

Unit tests cover order preservation, the concurrency cap (max 20 reads in flight across 45 files, for both the workflow and credential loaders), rejection behavior, and result equivalence:

```bash
cd packages/cli
pnpm test src/modules/source-control.ee
```

For a manual check, connect source control (Environments feature, enterprise license) on an instance with many/large workflows and open the push modal — status results are identical to before, with a flat memory profile instead of a spike proportional to the number of workflow files.

## Related Linear tickets, Github issues, and Community forum posts

Internal reports of OOM crashes while loading the push modal diff on large instances.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)