### PR TITLE
fix(ai-builder): Sync execution scenarios on lang-tracer push updates (no-changelog)

### DIFF
--- a/.agents/skills/create-instance-ai-eval/SKILL.md
+++ b/.agents/skills/create-instance-ai-eval/SKILL.md
@@ -451,9 +451,11 @@ dotenvx run -f .env.eval -- pnpm eval:langtracer-push --suite workflow-building 
   for MCP + REST) — put them in `.env.eval` and run under `dotenvx`.
 - **Options:** `--set-kind regression|capability_gap` (default `regression`, must
   match the suite's kind), `--contains-user-data` (default is `synthetic`).
-- **Limitation:** `executionScenarios` are written on **create** only — the update
-  path patches case-level fields but not scenario rows (so scenario-only edits to
-  an existing case aren't re-synced; remove+re-push or edit in the lang-tracer UI).
+- **Scenarios sync on update too:** `PATCH /cases/:id` reconciles
+  `executionScenarios` by name (update in place, insert new, delete missing —
+  lang-tracer #48), so scenario edits re-push like any other field. A lang-tracer
+  deployment predating that change silently ignores the key; if a pushed scenario
+  edit doesn't land, update the scenario in the lang-tracer UI.
 - **Seeded cases can't be pushed:** the case-write API rejects every seeding mode
   (`seedThread` / `seedFile` / `priorConversation`), so the push lists them under
   `skipped:` and they never reach the suite. A `seedThread` case shouldn't be

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
@@ -61,7 +61,7 @@ describe('planPush', () => {
 		expect(plan.toCreate).toEqual([]);
 	});
 
-	it('treats a scenario-only difference as unchanged so re-runs converge', () => {
+	it('treats a scenario-only difference as an update (PATCH reconciles scenarios by name)', () => {
 		const plan = planPush(
 			[
 				item('c', {
@@ -77,6 +77,18 @@ describe('planPush', () => {
 					],
 				}),
 			},
+			{ c: 5 },
+		);
+		expect(plan.toUpdate).toHaveLength(1);
+		expect(plan.toUpdate[0].id).toBe(5);
+		expect(plan.unchanged).toEqual([]);
+	});
+
+	it('treats identical scenarios as unchanged so re-pushes converge', () => {
+		const scenarios = [{ name: 'a', description: 'd', dataSetup: 's', successCriteria: 'ok' }];
+		const plan = planPush(
+			[item('c', { executionScenarios: scenarios })],
+			{ 'c.json': body({ executionScenarios: scenarios }) },
 			{ c: 5 },
 		);
 		expect(plan.unchanged.map((c) => c.fileSlug)).toEqual(['c']);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/langtracer-push.test.ts
@@ -1,5 +1,6 @@
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
-import { planPush } from '../langtracer/push';
+import { planPush, toUpdatePatch } from '../langtracer/push';
+import type { LangTracerCreateCaseBody } from '../langtracer/to-exported';
 
 function item(fileSlug: string, overrides: Record<string, unknown> = {}): WorkflowTestCaseWithFile {
 	return {
@@ -84,6 +85,20 @@ describe('planPush', () => {
 		expect(plan.unchanged).toEqual([]);
 	});
 
+	it('treats removed scenarios as an update (disk case went process/outcome-only)', () => {
+		const plan = planPush(
+			[item('c')],
+			{
+				'c.json': body({
+					executionScenarios: [{ name: 'a', dataSetup: 's', successCriteria: 'ok' }],
+				}),
+			},
+			{ c: 5 },
+		);
+		expect(plan.toUpdate).toHaveLength(1);
+		expect(plan.unchanged).toEqual([]);
+	});
+
 	it('treats identical scenarios as unchanged so re-pushes converge', () => {
 		const scenarios = [{ name: 'a', description: 'd', dataSetup: 's', successCriteria: 'ok' }];
 		const plan = planPush(
@@ -145,5 +160,40 @@ describe('planPush', () => {
 		);
 		expect(plan.unchanged.map((c) => c.fileSlug)).toEqual(['c']);
 		expect(plan.toUpdate).toEqual([]);
+	});
+});
+
+describe('toUpdatePatch', () => {
+	function createBody(overrides: Partial<LangTracerCreateCaseBody> = {}): LangTracerCreateCaseBody {
+		return {
+			name: 'c',
+			setKind: 'regression',
+			synthetic: true,
+			suiteId: 7,
+			evalComplexity: 'simple',
+			evalTags: ['build'],
+			...overrides,
+		};
+	}
+
+	it('drops the create-only fields', () => {
+		const patch = toUpdatePatch(createBody());
+		expect(patch).not.toHaveProperty('suiteId');
+		expect(patch).not.toHaveProperty('synthetic');
+		expect(patch.name).toBe('c');
+	});
+
+	it('sends an explicit empty scenarios list when the case has none, so a PATCH deletes stale rows', () => {
+		// A case converted to process/outcome-only has no scenarios key; a partial
+		// PATCH without it would leave the server's old scenario rows in place and
+		// every later push would re-detect the same drift.
+		const patch = toUpdatePatch(createBody());
+		expect(patch.scenarios).toEqual([]);
+	});
+
+	it('keeps the mapped scenarios when the case has them', () => {
+		const scenarios = [{ name: 'a', successCriteria: 'ok' }];
+		const patch = toUpdatePatch(createBody({ scenarios }));
+		expect(patch.scenarios).toEqual(scenarios);
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
@@ -11,13 +11,10 @@ import { execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
 
 import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
-import { LangTracerClient, type LangTracerUpdateCaseBody } from '../langtracer/client';
+import { LangTracerClient } from '../langtracer/client';
 import { resolveLangTracerConfig } from '../langtracer/config';
-import { planPush } from '../langtracer/push';
-import {
-	diskCaseToLangTracerCreate,
-	type LangTracerCreateCaseBody,
-} from '../langtracer/to-exported';
+import { planPush, toUpdatePatch } from '../langtracer/push';
+import { diskCaseToLangTracerCreate } from '../langtracer/to-exported';
 
 interface CliArgs {
 	suite: string;
@@ -152,16 +149,6 @@ function gitChangedSlugs(): string[] {
 		}
 	}
 	return slugs;
-}
-
-/** Drop the create-only fields, leaving the patchable set (`scenarios` included —
- *  `PATCH /cases/:id` reconciles them by name since lang-tracer #48). */
-function toUpdatePatch({
-	suiteId,
-	synthetic,
-	...patch
-}: LangTracerCreateCaseBody): LangTracerUpdateCaseBody {
-	return patch;
 }
 
 async function main() {

--- a/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
@@ -154,11 +154,11 @@ function gitChangedSlugs(): string[] {
 	return slugs;
 }
 
-/** Drop the create-only fields `PATCH /cases/:id` rejects, leaving the patchable set. */
+/** Drop the create-only fields, leaving the patchable set (`scenarios` included —
+ *  `PATCH /cases/:id` reconciles them by name since lang-tracer #48). */
 function toUpdatePatch({
 	suiteId,
 	synthetic,
-	scenarios,
 	...patch
 }: LangTracerCreateCaseBody): LangTracerUpdateCaseBody {
 	return patch;

--- a/packages/@n8n/instance-ai/evaluations/langtracer/client.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/client.ts
@@ -32,10 +32,12 @@ export type LangTracerSuiteSummary = z.infer<typeof suiteSummarySchema>;
 export type ExportedSuite = z.infer<typeof exportedSuiteSchema>;
 export type LangTracerCaseRef = z.infer<typeof caseRefSchema>;
 
-/** Fields patchable via `PATCH /cases/:id` — a create body minus what that route
- *  rejects (`suiteId`/`synthetic` handled elsewhere, `scenarios` are sidecar rows). */
+/** Fields patchable via `PATCH /cases/:id` — a create body minus the create-only
+ *  keys (`suiteId`/`synthetic`). `scenarios` are sidecar rows the server reconciles
+ *  by name on PATCH (upsert + delete missing); a server predating lang-tracer #48
+ *  strips the key silently, leaving the old scenarios in place. */
 export type LangTracerUpdateCaseBody = Partial<
-	Omit<LangTracerCreateCaseBody, 'suiteId' | 'synthetic' | 'scenarios'>
+	Omit<LangTracerCreateCaseBody, 'suiteId' | 'synthetic'>
 >;
 
 export class LangTracerClient {

--- a/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
@@ -3,8 +3,9 @@
 // seeding). Pure — no network — so the create/update/unchanged partitioning is
 // unit-testable against in-memory suite state.
 
+import type { LangTracerUpdateCaseBody } from './client';
 import { normalizeExportedCase } from './normalize';
-import { unsupportedPushReason } from './to-exported';
+import { unsupportedPushReason, type LangTracerCreateCaseBody } from './to-exported';
 import type { WorkflowTestCaseWithFile } from '../data/workflows';
 
 export interface PushPlan {
@@ -33,6 +34,19 @@ const COMPARED_KEYS = [
 	// (lang-tracer #48) and the export emits them back in disk shape.
 	'executionScenarios',
 ] as const;
+
+/** Drop the create-only fields, leaving the patchable set (`scenarios` included —
+ *  `PATCH /cases/:id` reconciles them by name since lang-tracer #48). An absent
+ *  `scenarios` is sent as an explicit `[]`: a partial PATCH leaves missing keys
+ *  untouched, so omitting it would keep the server's old scenario rows alive
+ *  forever after a disk case drops its `executionScenarios`. */
+export function toUpdatePatch({
+	suiteId,
+	synthetic,
+	...patch
+}: LangTracerCreateCaseBody): LangTracerUpdateCaseBody {
+	return { scenarios: [], ...patch };
+}
 
 /** `existingBodies`: `<name>.json` → exported (disk-shape) body from `GET /suites/:id/export`.
  *  `existingIdsByName`: case name → id from `GET /suites/:id` (authoritative membership). */

--- a/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
+++ b/packages/@n8n/instance-ai/evaluations/langtracer/push.ts
@@ -14,9 +14,8 @@ export interface PushPlan {
 	skipped: Array<{ fileSlug: string; reason: string }>;
 }
 
-/** Disk fields compared to decide create-vs-update. Deliberately EXCLUDES three
+/** Disk fields compared to decide create-vs-update. Deliberately EXCLUDES two
  *  fields that would make a re-push never converge (always "update"):
- *  - `executionScenarios`: sidecar rows `PATCH /cases/:id` can't update — written on create only.
  *  - `tags` and `datasets`: the lang-tracer suite export does not round-trip these
  *    (tags come back empty, default `datasets` comes back null/omitted), so a diff
  *    on them always fires. They're still SENT on create so new cases carry them;
@@ -30,6 +29,9 @@ const COMPARED_KEYS = [
 	'outcomeExpectations',
 	'messageBudget',
 	'credentials',
+	// Round-trips faithfully: PATCH /cases/:id reconciles scenario rows by name
+	// (lang-tracer #48) and the export emits them back in disk shape.
+	'executionScenarios',
 ] as const;
 
 /** `existingBodies`: `<name>.json` → exported (disk-shape) body from `GET /suites/:id/export`.


### PR DESCRIPTION
## Summary

`eval:langtracer-push` could create a case's `executionScenarios` but never update them: the update path stripped `scenarios` from PATCH payloads (the lang-tracer case-update endpoint didn't take them), and the planner deliberately excluded `executionScenarios` from its update-vs-unchanged comparison. Net effect: pushing a new revision of an existing case silently kept its old scenarios (hit in practice on `code-node-syntax-survives-formatting-edit`, case #235 — conversation/expectations synced, scenario stayed stale).

lang-tracer now reconciles scenario rows by name on `PATCH /cases/:id` (https://github.com/n8n-io/lang-tracer/pull/48), so this PR:

- stops stripping `scenarios` in `toUpdatePatch` and widens `LangTracerUpdateCaseBody`
- adds `executionScenarios` to the planner's compared keys — a scenario-only edit now classifies as an update; re-pushes still converge because the suite export emits scenarios back in disk shape
- updates the `create-instance-ai-eval` skill doc (drops the create-only caveat, notes the old-deployment behavior)

**Deploy ordering:** a lang-tracer deployment predating #48 silently ignores the `scenarios` key on PATCH (zod strips unknown keys), so merging this first is safe but scenario edits won't land until lang-tracer #48 deploys (it auto-deploys on merge).

## How to test

```bash
cd packages/@n8n/instance-ai
pnpm vitest run evaluations/__tests__/langtracer-push.test.ts   # 10/10
```

End to end (needs lang-tracer #48 deployed): edit only a scenario's `successCriteria` in an already-pushed case, run `eval:langtracer-push --suite <slug> <case-slug> --dry-run` → the case classifies as `update`; push, re-run dry-run → `unchanged`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-256
Server side: https://github.com/n8n-io/lang-tracer/pull/48

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated (create-instance-ai-eval skill).
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33841">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

