### PR TITLE
fix(core): Normalize Anthropic base URL to the versioned API path (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts
@@ -357,6 +357,43 @@ describe('createModel', () => {
 		});
 	});
 
+	describe('anthropic baseURL normalization', () => {
+		it('appends /v1 to a custom baseURL without a version segment (e.g. Azure AI Foundry)', () => {
+			const model = createModel({
+				id: 'anthropic/claude-sonnet-4-6',
+				apiKey: 'sk-ant',
+				baseURL: 'https://internal.example.services.ai.azure.com/anthropic/',
+			}) as unknown as Record<string, unknown>;
+			expect(model.baseURL).toBe('https://internal.example.services.ai.azure.com/anthropic/v1');
+		});
+
+		it('appends /v1 to a bare host baseURL', () => {
+			const model = createModel({
+				id: 'anthropic/claude-sonnet-4-6',
+				apiKey: 'sk-ant',
+				baseURL: 'https://api.anthropic.com',
+			}) as unknown as Record<string, unknown>;
+			expect(model.baseURL).toBe('https://api.anthropic.com/v1');
+		});
+
+		it('leaves a baseURL that already ends in /v1 unchanged', () => {
+			const model = createModel({
+				id: 'anthropic/claude-sonnet-4-6',
+				apiKey: 'sk-ant',
+				baseURL: 'https://proxy.example/api-proxy/anthropic/v1',
+			}) as unknown as Record<string, unknown>;
+			expect(model.baseURL).toBe('https://proxy.example/api-proxy/anthropic/v1');
+		});
+
+		it('leaves baseURL undefined when none is provided', () => {
+			const model = createModel('anthropic/claude-sonnet-4-5') as unknown as Record<
+				string,
+				unknown
+			>;
+			expect(model.baseURL).toBeUndefined();
+		});
+	});
+
 	describe('azure-openai', () => {
 		it('should create model with resourceName', () => {
 			const model = createModel({

--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -86,7 +86,18 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 		build: (creds, model, fetch) => {
 			const { createAnthropic } =
 				require('@ai-sdk/anthropic') as typeof import('@ai-sdk/anthropic');
-			return createAnthropic({ ...creds, fetch })(model);
+			let normalizedBaseURL = creds.baseURL;
+			// The SDK expects the versioned base (default `https://api.anthropic.com/v1`),
+			// but n8n Anthropic credentials store the host without `/v1` — their
+			// consumers append the version segment themselves.
+			if (normalizedBaseURL) {
+				const url = new URL(normalizedBaseURL);
+				if (!url.pathname.replace(/\/$/, '').endsWith('/v1')) {
+					url.pathname = url.pathname.replace(/\/?$/, '/v1');
+					normalizedBaseURL = url.toString();
+				}
+			}
+			return createAnthropic({ ...creds, baseURL: normalizedBaseURL, fetch })(model);
 		},
 	},
 	google: {


### PR DESCRIPTION
## Summary

In the Agents feature, Anthropic credentials with a custom Base URL (e.g. Azure AI Foundry endpoints like `https://<resource>.services.ai.azure.com/anthropic/`) fail silently at chat time, while the same credentials work in the classic AI Agent node and the model dropdown populates fine.

Root cause: the n8n `anthropicApi` credential's `url` field excludes the `/v1` path segment (its consumers append `/v1/...` themselves), but `@ai-sdk/anthropic` expects `baseURL` to include `/v1` (its default is `https://api.anthropic.com/v1`) and builds requests as `${baseURL}/messages`. So chat calls went to `<url>/messages` instead of `<url>/v1/messages` and 404'd. Model discovery was unaffected because it appends `/v1/models` itself — which is why the model picker worked while runs failed.

This PR normalizes the Anthropic base URL in the model factory so its path ends with `/v1` (idempotent — already-versioned URLs like the AI proxy's pass through unchanged), mirroring the existing `azure-openai` `/openai` path normalization in the same registry.

## How to test

1. Create an `anthropicApi` credential with a custom Base URL pointing at an Anthropic-compatible endpoint that serves `/v1/messages` (e.g. an Azure AI Foundry Anthropic resource).
2. Create an agent using that credential, pick a model from the dropdown, and run it in Preview or on the agent page.
3. Before this fix: the run produces an empty session with no output. After: the run completes normally.
4. Also covered by new unit tests in `packages/@n8n/agents/src/runtime/__tests__/model-factory.test.ts` (`pnpm test model-factory` from `packages/@n8n/agents`): Azure-style URL gets `/v1` appended, bare `https://api.anthropic.com` gets `/v1` appended, an already-versioned URL is unchanged, and no base URL keeps the SDK default.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-343

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->