### PR TITLE
test: Stabilize NDV run selector interactions in vector stores e2e test (no-changelog)

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -15,6 +15,8 @@ import { ResourceLocator } from './components/ResourceLocator';
 import { RunDataPanel } from './components/RunDataPanel';
 import { locatorByIndex } from '../utils/index-helper';
 
+const containsValue = (value: string) => new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
 export class NodeDetailsViewPage extends BasePage {
 	readonly setupHelper: NodeParameterHelper;
 	readonly editFields: EditFieldsNode;
@@ -596,12 +598,14 @@ export class NodeDetailsViewPage extends BasePage {
 		const selector = this.inputPanel.getRunSelector();
 		await selector.click();
 		await this.getVisiblePopoverOption(value).click();
+		await expect(this.inputPanel.getRunSelectorInput()).toHaveValue(containsValue(value));
 	}
 
 	async changeOutputRunSelector(value: string) {
 		const selector = this.outputPanel.getRunSelector();
 		await selector.click();
 		await this.getVisiblePopoverOption(value).click();
+		await expect(this.outputPanel.getRunSelectorInput()).toHaveValue(containsValue(value));
 	}
 
 	async getInputRunSelectorValue() {

--- a/packages/testing/playwright/tests/e2e/ai/langchain-vectorstores.spec.ts
+++ b/packages/testing/playwright/tests/e2e/ai/langchain-vectorstores.spec.ts
@@ -1,12 +1,4 @@
 import { test, expect } from '../../../fixtures/base';
-import type { n8nPage } from '../../../pages/n8nPage';
-
-// Helper functions for common operations
-async function waitForWorkflowSuccess(n8n: n8nPage, timeout = 10000) {
-	await n8n.notifications.waitForNotificationAndClose('Workflow executed successfully', {
-		timeout,
-	});
-}
 
 test.use({ capability: 'proxy' });
 test.describe(
@@ -30,7 +22,10 @@ test.describe(
 				await n8n.canvas.deselectAll();
 
 				await n8n.canvas.executeNode('Populate VS');
-				await waitForWorkflowSuccess(n8n);
+				await expect(n8n.canvas.getNodeSuccessStatusIndicator('Populate VS')).toBeVisible({
+					timeout: 30_000,
+				});
+				await n8n.notifications.quickCloseAll();
 
 				const assertInputOutputTextExists = async (text: string) => {
 					await expect(n8n.ndv.getOutputPanel()).toContainText(text);


### PR DESCRIPTION
## Summary

Fixes the auto-quarantined flaky e2e test `should render runItems for sub-nodes and allow switching between them` in `tests/e2e/ai/langchain-vectorstores.spec.ts`. Two flakiness sources are addressed:

1. **Silent, hard-capped 10s wait for execution success.** The spec's local `waitForWorkflowSuccess` helper relied on `waitForNotificationAndClose`, which swallows timeouts and returns a boolean instead of throwing. On slow CI runs the test continued with an unfinished execution and failed later at the run-selector value / panel text assertions. The spec now waits on the stable canvas node success indicator (`canvas-node-status-success` on `Populate VS`) with a throwing 30s assertion, then closes any toasts.
2. **Unverified N8nSelect dropdown clicks.** `NodeDetailsViewPage.changeInputRunSelector` / `changeOutputRunSelector` clicked the run-selector option without verifying the selection took effect, so a click swallowed by the Element Plus dropdown animation/re-render surfaced as a confusing downstream `not.toContainText` failure. Both methods now assert the run-selector input reflects the chosen value right after clicking (regex-escaped substring match, since some callers pass partial labels like `(2 items)`).

## How to test

- CI runs the affected spec (`@capability:proxy`).
- Locally, the shared page-object change is exercised by the NDV specs that use the run-selector helpers; both pass (17/17):

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts tests/e2e/workflows/editor/ndv/paired-item.spec.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2615

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33849">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

