### PR TITLE
refactor(editor): Reorder credential type cards to show Fixed first

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialTypeSelector.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialTypeSelector.vue
@@ -45,31 +45,6 @@ function select(value: boolean): void {
 			<button
 				type="button"
 				role="radio"
-				:aria-checked="modelValue"
-				data-test-id="credential-type-card-end-user"
-				:class="[$style.card, modelValue ? $style.cardSelected : $style.cardIdle]"
-				@click="select(true)"
-			>
-				<span :class="$style.cardTop">
-					<span :class="$style.cardLabel">
-						<N8nIcon icon="user-round" size="small" />
-						<N8nText size="medium" :bold="true">
-							{{ i18n.baseText('credentialEdit.credentialConfig.credentialType.endUser.title') }}
-						</N8nText>
-					</span>
-					<span
-						:class="[$style.radioOuter, modelValue && $style.radioOuterOn]"
-						aria-hidden="true"
-					/>
-				</span>
-				<N8nText size="xsmall" color="text-light" :class="$style.subtitle">
-					{{ i18n.baseText('credentialEdit.credentialConfig.credentialType.endUser.subtitle') }}
-				</N8nText>
-			</button>
-
-			<button
-				type="button"
-				role="radio"
 				:aria-checked="!modelValue"
 				data-test-id="credential-type-card-fixed"
 				:class="[$style.card, !modelValue ? $style.cardSelected : $style.cardIdle]"
@@ -89,6 +64,31 @@ function select(value: boolean): void {
 				</span>
 				<N8nText size="xsmall" color="text-light" :class="$style.subtitle">
 					{{ i18n.baseText('credentialEdit.credentialConfig.credentialType.fixed.subtitle') }}
+				</N8nText>
+			</button>
+
+			<button
+				type="button"
+				role="radio"
+				:aria-checked="modelValue"
+				data-test-id="credential-type-card-end-user"
+				:class="[$style.card, modelValue ? $style.cardSelected : $style.cardIdle]"
+				@click="select(true)"
+			>
+				<span :class="$style.cardTop">
+					<span :class="$style.cardLabel">
+						<N8nIcon icon="user-round" size="small" />
+						<N8nText size="medium" :bold="true">
+							{{ i18n.baseText('credentialEdit.credentialConfig.credentialType.endUser.title') }}
+						</N8nText>
+					</span>
+					<span
+						:class="[$style.radioOuter, modelValue && $style.radioOuterOn]"
+						aria-hidden="true"
+					/>
+				</span>
+				<N8nText size="xsmall" color="text-light" :class="$style.subtitle">
+					{{ i18n.baseText('credentialEdit.credentialConfig.credentialType.endUser.subtitle') }}
 				</N8nText>
 			</button>
 		</div>


### PR DESCRIPTION
## Summary

Reorders the credential type radio cards in the credential config modal so the **Fixed** card (the default selection) renders on the left and the **End-user** card on the right. This is a purely presentational swap — `modelValue` semantics, `data-testid`s, aria roles, and the selection handlers are unchanged.

## How to test

Open the credential config modal for a credential that supports the type selector. Confirm the **Fixed** card now appears on the left (selected by default) and the **End-user** card on the right, and that selecting either still works as before.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33851">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

