### PR TITLE
feat(core): Add Durable Scheduler metrics and instrumentation (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -60,6 +60,14 @@ export class PrometheusMetricsConfig {
 	@Env('N8N_METRICS_QUEUE_METRICS_INTERVAL')
 	queueMetricsInterval: number = 20;
 
+	/** Whether to include Durable Scheduler metrics (queue depth, scheduling lag, dispatches, retries, dead-letters). */
+	@Env('N8N_METRICS_INCLUDE_SCHEDULER_METRICS')
+	includeSchedulerMetrics: boolean = false;
+
+	/** How often (in seconds) the scheduler gauge queries are refreshed (cache TTL). */
+	@Env('N8N_METRICS_SCHEDULER_INTERVAL')
+	schedulerMetricsInterval: number = 20;
+
 	/** How often (in seconds) to update active workflow metric */
 	@Env('N8N_METRICS_ACTIVE_WORKFLOW_METRIC_INTERVAL')
 	activeWorkflowCountInterval: number = 60;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -250,6 +250,8 @@ describe('GlobalConfig', () => {
 				includeQueueMetrics: false,
 				includeWorkflowExecutionDuration: true,
 				queueMetricsInterval: 20,
+				includeSchedulerMetrics: false,
+				schedulerMetricsInterval: 20,
 				activeWorkflowCountInterval: 60,
 				includeWorkflowStatistics: false,
 				workflowStatisticsInterval: 300,

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -42,7 +42,7 @@ export type {
 	ClaimedRef,
 	HostedClaimedRef,
 	DeleteFinishedTasksOptions,
-	MetricSnapshot,
+	ScheduledTaskMetricSnapshot,
 } from './scheduled-task.repository';
 export { ProcessedDataRepository } from './processed-data.repository';
 export { SettingsRepository } from './settings.repository';

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -42,6 +42,7 @@ export type {
 	ClaimedRef,
 	HostedClaimedRef,
 	DeleteFinishedTasksOptions,
+	MetricSnapshot,
 } from './scheduled-task.repository';
 export { ProcessedDataRepository } from './processed-data.repository';
 export { SettingsRepository } from './settings.repository';

--- a/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
@@ -77,11 +77,11 @@ export interface NewOccurrence {
  * constraints (e.g. cli's `CachedMetricQuery`) without a duplicate local alias.
  */
 export type MetricSnapshot = {
-	/** Rows awaiting a worker, whether or not they are due yet. */
+	/** Rows awaiting dispatch, whether or not they are due yet. */
 	pending: number;
 	/** Pending rows already due (`runAt <= now`): the actionable queue depth. */
 	due: number;
-	/** Rows a worker currently holds. */
+	/** Rows currently claimed and in flight (leased to an instance). */
 	running: number;
 	/** How far the oldest due pending row has waited, in ms; `null` when none is due. */
 	oldestPendingAgeMs: number | null;
@@ -337,6 +337,12 @@ export class ScheduledTaskRepository extends Repository<ScheduledTask> {
 	 * The oldest-row lookup is skipped when nothing is due.
 	 */
 	async getMetricSnapshot(now: Date): Promise<MetricSnapshot> {
+		// Each query filters on `status` and is served by the partial indexes on
+		// `scheduled_task` (`runAt WHERE status='pending'`, `leaseExpiresAt WHERE
+		// status='running'`), so they scan only the live pending/running working
+		// set, never the terminal rows that make the table grow (and that retention
+		// prunes). Cost scales with the backlog, not with total history; the caller
+		// runs this behind a short scrape cache.
 		const [pending, due, running] = await Promise.all([
 			this.countBy({ status: ScheduledTaskStatus.Pending }),
 			this.countBy({ status: ScheduledTaskStatus.Pending, runAt: LessThanOrEqual(now) }),

--- a/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
@@ -1,6 +1,6 @@
 import { DatabaseConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { DataSource, type EntityManager, In, Repository } from '@n8n/typeorm';
+import { DataSource, type EntityManager, In, LessThanOrEqual, Repository } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -68,6 +68,24 @@ export interface NewOccurrence {
 	runAt: Date;
 	maxAttempts: number;
 }
+
+/**
+ * Point-in-time queue health, read at Prometheus scrape time
+ * (see {@link ScheduledTaskRepository.getMetricSnapshot}).
+ *
+ * Declared as a `type` (not `interface`) so it satisfies structural `JsonObject`
+ * constraints (e.g. cli's `CachedMetricQuery`) without a duplicate local alias.
+ */
+export type MetricSnapshot = {
+	/** Rows awaiting a worker, whether or not they are due yet. */
+	pending: number;
+	/** Pending rows already due (`runAt <= now`): the actionable queue depth. */
+	due: number;
+	/** Rows a worker currently holds. */
+	running: number;
+	/** How far the oldest due pending row has waited, in ms; `null` when none is due. */
+	oldestPendingAgeMs: number | null;
+};
 
 @Service()
 export class ScheduledTaskRepository extends Repository<ScheduledTask> {
@@ -304,6 +322,43 @@ export class ScheduledTaskRepository extends Repository<ScheduledTask> {
 			.orderBy('t.leaseExpiresAt', 'ASC')
 			.limit(limit)
 			.getMany();
+	}
+
+	/**
+	 * Read queue health at Prometheus scrape time: the counts behind the queue-depth
+	 * gauges (`pending`, `due`, `running`) and the scheduling-lag gauge
+	 * (`oldestPendingAgeMs`). `now` is the caller's scrape instant, so the gauges reflect
+	 * a single consistent moment; `due`-ness is judged against it rather than the DB clock.
+	 *
+	 * Portability over query count: the counts are three `getCount()` calls and the oldest
+	 * due row is one `findOne`, all via find options, so no dialect-specific conditional
+	 * aggregation is needed and both SQLite and Postgres take the same path. The caller
+	 * caches the whole snapshot between scrapes, so the extra round-trips don't matter.
+	 * The oldest-row lookup is skipped when nothing is due.
+	 */
+	async getMetricSnapshot(now: Date): Promise<MetricSnapshot> {
+		const [pending, due, running] = await Promise.all([
+			this.countBy({ status: ScheduledTaskStatus.Pending }),
+			this.countBy({ status: ScheduledTaskStatus.Pending, runAt: LessThanOrEqual(now) }),
+			this.countBy({ status: ScheduledTaskStatus.Running }),
+		]);
+
+		let oldestPendingAgeMs: number | null = null;
+		if (due > 0) {
+			// TypeORM maps the datetime column to a `Date` on both drivers, so reading the
+			// oldest due row's `runAt` back avoids parsing a raw MIN() that each driver types
+			// differently (Postgres Date vs SQLite string).
+			const oldest = await this.findOne({
+				select: { runAt: true },
+				where: { status: ScheduledTaskStatus.Pending, runAt: LessThanOrEqual(now) },
+				order: { runAt: 'ASC' },
+			});
+			if (oldest !== null) {
+				oldestPendingAgeMs = now.getTime() - oldest.runAt.getTime();
+			}
+		}
+
+		return { pending, due, running, oldestPendingAgeMs };
 	}
 
 	/**

--- a/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
@@ -1,6 +1,6 @@
 import { DatabaseConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
-import { DataSource, type EntityManager, In, LessThanOrEqual, Repository } from '@n8n/typeorm';
+import { DataSource, type EntityManager, In, Repository } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError } from 'n8n-workflow';
 
@@ -10,7 +10,7 @@ import {
 	type TerminalTaskStatus,
 	TerminalTaskStatusList,
 } from '../entities/scheduled-task';
-import { dbNowLiteral, dbNowPlusMsLiteral } from '../utils/dialect-time';
+import { dbNowLiteral, dbNowPlusMsLiteral, parseDbTime } from '../utils/dialect-time';
 
 /** Inputs to a claim (see {@link ScheduledTaskRepository.claimDueTasks}). */
 export interface ClaimDueTasksOptions {
@@ -76,14 +76,14 @@ export interface NewOccurrence {
  * Declared as a `type` (not `interface`) so it satisfies structural `JsonObject`
  * constraints (e.g. cli's `CachedMetricQuery`) without a duplicate local alias.
  */
-export type MetricSnapshot = {
+export type ScheduledTaskMetricSnapshot = {
 	/** Rows awaiting dispatch, whether or not they are due yet. */
 	pending: number;
-	/** Pending rows already due (`runAt <= now`): the actionable queue depth. */
+	/** Pending rows already due (`runAt <= DB-now`): the actionable queue depth. */
 	due: number;
 	/** Rows currently claimed and in flight (leased to an instance). */
 	running: number;
-	/** How far the oldest due pending row has waited, in ms; `null` when none is due. */
+	/** How far the oldest due pending row has waited (against DB-now), in ms; `null` when none is due. */
 	oldestPendingAgeMs: number | null;
 };
 
@@ -325,46 +325,53 @@ export class ScheduledTaskRepository extends Repository<ScheduledTask> {
 	}
 
 	/**
-	 * Read queue health at Prometheus scrape time: the counts behind the queue-depth
+	 * Read queue health for the Prometheus scrape: the counts behind the queue-depth
 	 * gauges (`pending`, `due`, `running`) and the scheduling-lag gauge
-	 * (`oldestPendingAgeMs`). `now` is the caller's scrape instant, so the gauges reflect
-	 * a single consistent moment; `due`-ness is judged against it rather than the DB clock.
+	 * (`oldestPendingAgeMs`). Everything reads the DB clock, so `due`-ness and the
+	 * oldest-age reference are consistent regardless of any instance clock skew.
 	 *
-	 * Portability over query count: the counts are three `getCount()` calls and the oldest
-	 * due row is one `findOne`, all via find options, so no dialect-specific conditional
-	 * aggregation is needed and both SQLite and Postgres take the same path. The caller
-	 * caches the whole snapshot between scrapes, so the extra round-trips don't matter.
-	 * The oldest-row lookup is skipped when nothing is due.
+	 * One conditional-aggregation pass (`COUNT(*) FILTER`) over the live working set,
+	 * rather than several round-trips: `status IN ('pending','running')` keeps the scan
+	 * off the terminal rows that grow the table (and that retention prunes), so cost
+	 * scales with the backlog, not total history. The caller runs this behind a short
+	 * scrape cache.
 	 */
-	async getMetricSnapshot(now: Date): Promise<MetricSnapshot> {
-		// Each query filters on `status` and is served by the partial indexes on
-		// `scheduled_task` (`runAt WHERE status='pending'`, `leaseExpiresAt WHERE
-		// status='running'`), so they scan only the live pending/running working
-		// set, never the terminal rows that make the table grow (and that retention
-		// prunes). Cost scales with the backlog, not with total history; the caller
-		// runs this behind a short scrape cache.
-		const [pending, due, running] = await Promise.all([
-			this.countBy({ status: ScheduledTaskStatus.Pending }),
-			this.countBy({ status: ScheduledTaskStatus.Pending, runAt: LessThanOrEqual(now) }),
-			this.countBy({ status: ScheduledTaskStatus.Running }),
-		]);
+	async getMetricSnapshot(): Promise<ScheduledTaskMetricSnapshot> {
+		const now = dbNowLiteral(this.isPostgres);
+		// Double-quoted identifiers and `FILTER` are accepted by both dialects; the only
+		// per-dialect bit is the DB-now literal. `oldestDueRunAt` is NULL when nothing is
+		// due, and `dbNow` is selected so the age is measured against the same instant the
+		// `due` filter used.
+		const [row]: [
+			{
+				pending: number | string;
+				due: number | string;
+				running: number | string;
+				oldestDueRunAt: Date | string | null;
+				dbNow: Date | string;
+			},
+		] = await this.query(
+			`SELECT
+			   COUNT(*) FILTER (WHERE "status" = '${ScheduledTaskStatus.Pending}') AS "pending",
+			   COUNT(*) FILTER (WHERE "status" = '${ScheduledTaskStatus.Pending}' AND "runAt" <= ${now}) AS "due",
+			   COUNT(*) FILTER (WHERE "status" = '${ScheduledTaskStatus.Running}') AS "running",
+			   MIN("runAt") FILTER (WHERE "status" = '${ScheduledTaskStatus.Pending}' AND "runAt" <= ${now}) AS "oldestDueRunAt",
+			   ${now} AS "dbNow"
+			 FROM ${this.tableName}
+			 WHERE "status" IN ('${ScheduledTaskStatus.Pending}', '${ScheduledTaskStatus.Running}')`,
+		);
 
-		let oldestPendingAgeMs: number | null = null;
-		if (due > 0) {
-			// TypeORM maps the datetime column to a `Date` on both drivers, so reading the
-			// oldest due row's `runAt` back avoids parsing a raw MIN() that each driver types
-			// differently (Postgres Date vs SQLite string).
-			const oldest = await this.findOne({
-				select: { runAt: true },
-				where: { status: ScheduledTaskStatus.Pending, runAt: LessThanOrEqual(now) },
-				order: { runAt: 'ASC' },
-			});
-			if (oldest !== null) {
-				oldestPendingAgeMs = now.getTime() - oldest.runAt.getTime();
-			}
-		}
+		const oldestPendingAgeMs =
+			row.oldestDueRunAt !== null
+				? parseDbTime(row.dbNow).getTime() - parseDbTime(row.oldestDueRunAt).getTime()
+				: null;
 
-		return { pending, due, running, oldestPendingAgeMs };
+		return {
+			pending: Number(row.pending),
+			due: Number(row.due),
+			running: Number(row.running),
+			oldestPendingAgeMs,
+		};
 	}
 
 	/**

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -883,4 +883,37 @@ describe('createScheduler metrics', () => {
 		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
 		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
 	});
+
+	it('does not let a throwing metrics sink break a pass', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		metrics.recordPruned.mockImplementation(() => {
+			throw new Error('exporter down');
+		});
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		taskStore.deleteFinishedOlderThan.mockResolvedValueOnce(5).mockResolvedValue(0);
+
+		// The pass completes normally even though recording its outcome threw.
+		await expect(scheduler.prune()).resolves.toEqual({ deleted: 5, drained: true });
+	});
+
+	it('does not let a throwing metrics sink break a fire', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		metrics.recordDispatch.mockImplementation(() => {
+			throw new Error('exporter down');
+		});
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		const execute = vi.fn().mockResolvedValue(undefined);
+		scheduler.registerTaskHandler('test-task', { execute });
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask()]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.completeTask.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		// The handler still runs and the task still completes despite the sink throwing.
+		await vi.waitFor(() => {
+			expect(taskStore.completeTask).toHaveBeenCalledTimes(1);
+		});
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -1,8 +1,8 @@
 import { ScheduledTaskStatus } from '@n8n/constants';
 import { mock } from 'vitest-mock-extended';
 
-import { InvalidLifecycleOptionsError } from '../errors';
 import type { SchedulerMetrics } from '../../observability/metrics';
+import { InvalidLifecycleOptionsError } from '../errors';
 import { createScheduler } from '../factory';
 import type { SchedulerDeps, SchedulerTaskStore } from '../factory';
 import type { MaterializerTransaction, RunInTransaction } from '../materializer';

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -823,4 +823,64 @@ describe('createScheduler metrics', () => {
 		// No metrics dep: the defaulted no-op must not throw.
 		await expect(scheduler.prune()).resolves.toEqual({ deleted: 0, drained: true });
 	});
+
+	it('maps a successful fire onto dispatch and success metrics', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		scheduler.registerTaskHandler('test-task', { execute: vi.fn().mockResolvedValue(undefined) });
+		// A task due in the past fires on the next timer tick.
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask()]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.completeTask.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		// The fire is detached from the claim: wait for the timer to deliver it.
+		await vi.waitFor(() => {
+			expect(metrics.recordFireOutcome).toHaveBeenCalledWith('test-task', 'success');
+		});
+		expect(metrics.recordDispatch).toHaveBeenCalledWith('test-task');
+		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith('test-task', expect.any(Number));
+		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
+	});
+
+	it('maps a terminal failure onto a failure outcome and a dead-letter', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		scheduler.registerTaskHandler('test-task', {
+			execute: vi.fn().mockRejectedValue(new Error('boom')),
+		});
+		// Single attempt: the first failure exhausts it.
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask({ attempts: 0, maxAttempts: 1 })]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.failTaskTerminal.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		await vi.waitFor(() => {
+			expect(metrics.recordFireOutcome).toHaveBeenCalledWith('test-task', 'failure');
+		});
+		expect(metrics.recordDeadLettered).toHaveBeenCalledTimes(1);
+		expect(metrics.recordRetry).not.toHaveBeenCalled();
+	});
+
+	it('maps a failure with attempts remaining onto a retry', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		scheduler.registerTaskHandler('test-task', {
+			execute: vi.fn().mockRejectedValue(new Error('boom')),
+		});
+		// Attempts remain, so the failure reschedules rather than fails terminally.
+		taskStore.claimDueTasks.mockResolvedValue([claimedTask({ attempts: 0, maxAttempts: 3 })]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.rescheduleTask.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		await vi.waitFor(() => {
+			expect(metrics.recordRetry).toHaveBeenCalledWith('test-task');
+		});
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
+	});
 });

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -2,6 +2,7 @@ import { ScheduledTaskStatus } from '@n8n/constants';
 import { mock } from 'vitest-mock-extended';
 
 import { InvalidLifecycleOptionsError } from '../errors';
+import type { SchedulerMetrics } from '../../observability/metrics';
 import { createScheduler } from '../factory';
 import type { SchedulerDeps, SchedulerTaskStore } from '../factory';
 import type { MaterializerTransaction, RunInTransaction } from '../materializer';
@@ -758,5 +759,68 @@ describe('createScheduler reap', () => {
 			message: 'Scheduler dead-lettered a task; its last attempt lost its lease',
 			context: { taskId: '7', attempts: 3, maxAttempts: 3 },
 		});
+	});
+});
+
+describe('createScheduler metrics', () => {
+	it('records the materialization outcome from the pass summary', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const corrupt: ScheduledJob = {
+			id: 7,
+			taskType: 'test-task',
+			payload: {},
+			kind: 'cron',
+			cronExpression: null,
+			timezone: null,
+			intervalSeconds: null,
+			fireAt: null,
+			nextRunAt: new Date('2026-01-01T00:00:00.000Z'),
+			lastFiredAt: null,
+			maxAttempts: 3,
+		};
+		const tx = mock<MaterializerTransaction>();
+		tx.claimDueJobs.mockResolvedValue({
+			now: new Date('2026-01-01T00:00:00.000Z'),
+			jobs: [corrupt],
+		});
+		tx.recordOccurrences.mockResolvedValue(0);
+		const materializerTransaction: RunInTransaction = async (work) => await work(tx);
+		const { scheduler } = makeScheduler({ materializerTransaction, metrics });
+
+		await scheduler.materialize();
+
+		// One corrupt job deferred, no occurrences recorded.
+		expect(metrics.recordMaterialized).toHaveBeenCalledWith(0, 1);
+	});
+
+	it('records the reaper outcome from the sweep result', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		taskStore.findExpiredLeases.mockResolvedValue([
+			{ id: '7', attempts: 2, maxAttempts: 3, leaseEpoch: 1 },
+		]);
+		taskStore.deadLetterExpired.mockResolvedValue(1);
+
+		await scheduler.reap();
+
+		expect(metrics.recordReaped).toHaveBeenCalledWith(0, 1);
+	});
+
+	it('records the retention outcome from the pass summary', async () => {
+		const metrics = mock<SchedulerMetrics>();
+		const { scheduler, taskStore } = makeScheduler({ metrics });
+		taskStore.deleteFinishedOlderThan.mockResolvedValueOnce(5).mockResolvedValue(0);
+
+		await scheduler.prune();
+
+		expect(metrics.recordPruned).toHaveBeenCalledWith(5);
+	});
+
+	it('defaults to a safe no-op when no metrics port is supplied', async () => {
+		const { scheduler, taskStore } = makeScheduler();
+		taskStore.deleteFinishedOlderThan.mockResolvedValue(0);
+
+		// No metrics dep: the defaulted no-op must not throw.
+		await expect(scheduler.prune()).resolves.toEqual({ deleted: 0, drained: true });
 	});
 });

--- a/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
+++ b/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
@@ -1,5 +1,6 @@
 import { mock } from 'vitest-mock-extended';
 
+import type { SchedulerMetrics } from '../../../observability/metrics';
 import type { ClaimedTask } from '../../types';
 import { backoff } from '../backoff';
 import { Executor, type ExecutorHooks } from '../executor';
@@ -28,6 +29,7 @@ const setup = (options?: Partial<ExecutorOptions>) => {
 	const store = mock<ExecutorTaskStore>();
 	const registry = mock<TaskHandlerRegistry>();
 	const timer = mock<PrecisionTimer>();
+	const metrics = mock<SchedulerMetrics>();
 	const hooks = {
 		onLeaseShorterThanLookahead: vi.fn(),
 		onMissingHandler: vi.fn(),
@@ -40,8 +42,9 @@ const setup = (options?: Partial<ExecutorOptions>) => {
 		timer,
 		{ leaseSeconds: 60, lookaheadSeconds: 5, batchSize: 100, ...options },
 		hooks,
+		metrics,
 	);
-	return { store, registry, timer, hooks, executor };
+	return { store, registry, timer, metrics, hooks, executor };
 };
 
 describe('Executor construction', () => {
@@ -340,6 +343,152 @@ describe('Executor.fire', () => {
 		await expect(executor.fire(HOST, task)).resolves.toBeUndefined();
 
 		expect(hooks.onReleaseError).toHaveBeenCalledWith(task.id, failure);
+	});
+});
+
+describe('Executor.fire metrics', () => {
+	it('records a dispatch and the lag against the timer clock when a task fires', async () => {
+		const { store, registry, timer, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.completeTask.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		const task = claimedTask({ runAt: new Date('2026-07-01T00:00:00.000Z') });
+		// Fired 3s after runAt.
+		timer.now.mockReturnValue(new Date('2026-07-01T00:00:03.000Z').getTime());
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.recordDispatch).toHaveBeenCalledWith(task.taskType);
+		expect(metrics.recordDispatch).toHaveBeenCalledTimes(1);
+		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 3);
+		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledTimes(1);
+	});
+
+	it('measures dispatch lag from runAt, not the fixed scheduledFor slot', async () => {
+		const { store, registry, timer, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.completeTask.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		// A retried task: runAt was pushed 60s past the original slot by backoff.
+		const task = claimedTask({
+			scheduledFor: new Date('2026-07-01T00:00:00.000Z'),
+			runAt: new Date('2026-07-01T00:01:00.000Z'),
+		});
+		// Fired 2s after runAt (62s after scheduledFor); lag is measured from runAt.
+		timer.now.mockReturnValue(new Date('2026-07-01T00:01:02.000Z').getTime());
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 2);
+	});
+
+	it('clamps dispatch lag to zero when the timer fires before runAt', async () => {
+		const { store, registry, timer, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.completeTask.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		const task = claimedTask({ runAt: new Date('2026-07-01T00:00:05.000Z') });
+		// Timer fires 1s before runAt; a negative sample must be clamped to 0.
+		timer.now.mockReturnValue(new Date('2026-07-01T00:00:04.000Z').getTime());
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 0);
+	});
+
+	it('records nothing when the row is gone or reclaimed', async () => {
+		const { store, registry, metrics, executor } = setup();
+		registry.resolve.mockReturnValue({ execute: vi.fn() });
+		store.markStarted.mockResolvedValue(0);
+
+		await executor.fire(HOST, claimedTask());
+
+		expect(metrics.recordDispatch).not.toHaveBeenCalled();
+		expect(metrics.observeDispatchLagSeconds).not.toHaveBeenCalled();
+	});
+
+	it('records a success outcome when the handler completes', async () => {
+		const { store, registry, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.completeTask.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		const task = claimedTask();
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.recordFireOutcome).toHaveBeenCalledWith(task.taskType, 'success');
+		expect(metrics.recordFireOutcome).toHaveBeenCalledTimes(1);
+		expect(metrics.recordRetry).not.toHaveBeenCalled();
+	});
+
+	it('records a retry when the handler fails and attempts remain', async () => {
+		const { store, registry, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.rescheduleTask.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+		const task = claimedTask({ attempts: 0, maxAttempts: 3 });
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.recordRetry).toHaveBeenCalledWith(task.taskType);
+		expect(metrics.recordRetry).toHaveBeenCalledTimes(1);
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+	});
+
+	it('records a failure outcome and a dead-letter when the handler fails terminally', async () => {
+		const { store, registry, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		store.failTaskTerminal.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+		const task = claimedTask({ attempts: 0, maxAttempts: 1 });
+
+		await executor.fire(HOST, task);
+
+		expect(metrics.recordFireOutcome).toHaveBeenCalledWith(task.taskType, 'failure');
+		expect(metrics.recordFireOutcome).toHaveBeenCalledTimes(1);
+		// A terminal failure is a permanent failure, so it is also a dead-letter.
+		expect(metrics.recordDeadLettered).toHaveBeenCalledTimes(1);
+		expect(metrics.recordRetry).not.toHaveBeenCalled();
+	});
+
+	it('records no outcome when a terminal write affects no row (reclaimed on lease overrun)', async () => {
+		const { store, registry, metrics, executor } = setup();
+		store.markStarted.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		// Every terminal write resolves 0: the row was reclaimed, so nothing is ours to count.
+		store.completeTask.mockResolvedValue(0);
+		store.failTaskTerminal.mockResolvedValue(0);
+		store.rescheduleTask.mockResolvedValue(0);
+
+		// Success path with a 0-row complete.
+		await executor.fire(HOST, claimedTask());
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+
+		// Retry path with a 0-row reschedule.
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
+		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 3 }));
+		expect(metrics.recordRetry).not.toHaveBeenCalled();
+
+		// Terminal-failure path with a 0-row failTaskTerminal.
+		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 1 }));
+		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
+	});
+
+	it('defaults to a safe no-op when no metrics port is supplied', async () => {
+		const store = mock<ExecutorTaskStore>();
+		const registry = mock<TaskHandlerRegistry>();
+		const timer = mock<PrecisionTimer>();
+		store.markStarted.mockResolvedValue(1);
+		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
+		// No hooks, no metrics: the defaulted no-op must not throw.
+		const executor = new Executor(store, registry, timer, {
+			leaseSeconds: 60,
+			lookaheadSeconds: 5,
+			batchSize: 100,
+		});
+
+		await expect(executor.fire(HOST, claimedTask())).resolves.toBeUndefined();
 	});
 });
 

--- a/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
+++ b/packages/@n8n/scheduler/src/core/executor/__tests__/executor.test.ts
@@ -1,6 +1,5 @@
 import { mock } from 'vitest-mock-extended';
 
-import type { SchedulerMetrics } from '../../../observability/metrics';
 import type { ClaimedTask } from '../../types';
 import { backoff } from '../backoff';
 import { Executor, type ExecutorHooks } from '../executor';
@@ -29,12 +28,14 @@ const setup = (options?: Partial<ExecutorOptions>) => {
 	const store = mock<ExecutorTaskStore>();
 	const registry = mock<TaskHandlerRegistry>();
 	const timer = mock<PrecisionTimer>();
-	const metrics = mock<SchedulerMetrics>();
 	const hooks = {
 		onLeaseShorterThanLookahead: vi.fn(),
 		onMissingHandler: vi.fn(),
 		onFireError: vi.fn(),
 		onReleaseError: vi.fn(),
+		onDispatch: vi.fn(),
+		onFire: vi.fn(),
+		onRetry: vi.fn(),
 	} satisfies ExecutorHooks;
 	const executor = new Executor(
 		store,
@@ -42,9 +43,8 @@ const setup = (options?: Partial<ExecutorOptions>) => {
 		timer,
 		{ leaseSeconds: 60, lookaheadSeconds: 5, batchSize: 100, ...options },
 		hooks,
-		metrics,
 	);
-	return { store, registry, timer, metrics, hooks, executor };
+	return { store, registry, timer, hooks, executor };
 };
 
 describe('Executor construction', () => {
@@ -346,9 +346,9 @@ describe('Executor.fire', () => {
 	});
 });
 
-describe('Executor.fire metrics', () => {
-	it('records a dispatch and the lag against the timer clock when a task fires', async () => {
-		const { store, registry, timer, metrics, executor } = setup();
+describe('Executor.fire metrics hooks', () => {
+	it('calls onDispatch with the lag against the timer clock when a task fires', async () => {
+		const { store, registry, timer, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.completeTask.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
@@ -358,14 +358,12 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.recordDispatch).toHaveBeenCalledWith(task.taskType);
-		expect(metrics.recordDispatch).toHaveBeenCalledTimes(1);
-		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 3);
-		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledTimes(1);
+		expect(hooks.onDispatch).toHaveBeenCalledWith(task.taskType, 3);
+		expect(hooks.onDispatch).toHaveBeenCalledTimes(1);
 	});
 
 	it('measures dispatch lag from runAt, not the fixed scheduledFor slot', async () => {
-		const { store, registry, timer, metrics, executor } = setup();
+		const { store, registry, timer, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.completeTask.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
@@ -379,11 +377,11 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 2);
+		expect(hooks.onDispatch).toHaveBeenCalledWith(task.taskType, 2);
 	});
 
 	it('clamps dispatch lag to zero when the timer fires before runAt', async () => {
-		const { store, registry, timer, metrics, executor } = setup();
+		const { store, registry, timer, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.completeTask.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
@@ -393,22 +391,22 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.observeDispatchLagSeconds).toHaveBeenCalledWith(task.taskType, 0);
+		expect(hooks.onDispatch).toHaveBeenCalledWith(task.taskType, 0);
 	});
 
-	it('records nothing when the row is gone or reclaimed', async () => {
-		const { store, registry, metrics, executor } = setup();
+	it('calls no hooks when the row is gone or reclaimed', async () => {
+		const { store, registry, hooks, executor } = setup();
 		registry.resolve.mockReturnValue({ execute: vi.fn() });
 		store.markStarted.mockResolvedValue(0);
 
 		await executor.fire(HOST, claimedTask());
 
-		expect(metrics.recordDispatch).not.toHaveBeenCalled();
-		expect(metrics.observeDispatchLagSeconds).not.toHaveBeenCalled();
+		expect(hooks.onDispatch).not.toHaveBeenCalled();
+		expect(hooks.onFire).not.toHaveBeenCalled();
 	});
 
-	it('records a success outcome when the handler completes', async () => {
-		const { store, registry, metrics, executor } = setup();
+	it('calls onFire with success when the handler completes', async () => {
+		const { store, registry, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.completeTask.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
@@ -416,13 +414,13 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.recordFireOutcome).toHaveBeenCalledWith(task.taskType, 'success');
-		expect(metrics.recordFireOutcome).toHaveBeenCalledTimes(1);
-		expect(metrics.recordRetry).not.toHaveBeenCalled();
+		expect(hooks.onFire).toHaveBeenCalledWith(task.taskType, 'success');
+		expect(hooks.onFire).toHaveBeenCalledTimes(1);
+		expect(hooks.onRetry).not.toHaveBeenCalled();
 	});
 
-	it('records a retry when the handler fails and attempts remain', async () => {
-		const { store, registry, metrics, executor } = setup();
+	it('calls onRetry when the handler fails and attempts remain', async () => {
+		const { store, registry, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.rescheduleTask.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
@@ -430,13 +428,13 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.recordRetry).toHaveBeenCalledWith(task.taskType);
-		expect(metrics.recordRetry).toHaveBeenCalledTimes(1);
-		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+		expect(hooks.onRetry).toHaveBeenCalledWith(task.taskType);
+		expect(hooks.onRetry).toHaveBeenCalledTimes(1);
+		expect(hooks.onFire).not.toHaveBeenCalled();
 	});
 
-	it('records a failure outcome and a dead-letter when the handler fails terminally', async () => {
-		const { store, registry, metrics, executor } = setup();
+	it('calls onFire with failure when the handler fails terminally', async () => {
+		const { store, registry, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		store.failTaskTerminal.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
@@ -444,15 +442,13 @@ describe('Executor.fire metrics', () => {
 
 		await executor.fire(HOST, task);
 
-		expect(metrics.recordFireOutcome).toHaveBeenCalledWith(task.taskType, 'failure');
-		expect(metrics.recordFireOutcome).toHaveBeenCalledTimes(1);
-		// A terminal failure is a permanent failure, so it is also a dead-letter.
-		expect(metrics.recordDeadLettered).toHaveBeenCalledTimes(1);
-		expect(metrics.recordRetry).not.toHaveBeenCalled();
+		expect(hooks.onFire).toHaveBeenCalledWith(task.taskType, 'failure');
+		expect(hooks.onFire).toHaveBeenCalledTimes(1);
+		expect(hooks.onRetry).not.toHaveBeenCalled();
 	});
 
-	it('records no outcome when a terminal write affects no row (reclaimed on lease overrun)', async () => {
-		const { store, registry, metrics, executor } = setup();
+	it('calls no outcome hook when a terminal write affects no row (reclaimed on lease overrun)', async () => {
+		const { store, registry, hooks, executor } = setup();
 		store.markStarted.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
 		// Every terminal write resolves 0: the row was reclaimed, so nothing is ours to count.
@@ -462,26 +458,25 @@ describe('Executor.fire metrics', () => {
 
 		// Success path with a 0-row complete.
 		await executor.fire(HOST, claimedTask());
-		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
+		expect(hooks.onFire).not.toHaveBeenCalled();
 
 		// Retry path with a 0-row reschedule.
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockRejectedValue(new Error('boom')) });
 		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 3 }));
-		expect(metrics.recordRetry).not.toHaveBeenCalled();
+		expect(hooks.onRetry).not.toHaveBeenCalled();
 
 		// Terminal-failure path with a 0-row failTaskTerminal.
 		await executor.fire(HOST, claimedTask({ attempts: 0, maxAttempts: 1 }));
-		expect(metrics.recordFireOutcome).not.toHaveBeenCalled();
-		expect(metrics.recordDeadLettered).not.toHaveBeenCalled();
+		expect(hooks.onFire).not.toHaveBeenCalled();
 	});
 
-	it('defaults to a safe no-op when no metrics port is supplied', async () => {
+	it('defaults to a safe no-op when no hooks are supplied', async () => {
 		const store = mock<ExecutorTaskStore>();
 		const registry = mock<TaskHandlerRegistry>();
 		const timer = mock<PrecisionTimer>();
 		store.markStarted.mockResolvedValue(1);
 		registry.resolve.mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) });
-		// No hooks, no metrics: the defaulted no-op must not throw.
+		// No hooks: the optional calls must not throw.
 		const executor = new Executor(store, registry, timer, {
 			leaseSeconds: 60,
 			lookaheadSeconds: 5,

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -225,17 +225,17 @@ export class Executor {
 			if (nextAttempts >= task.maxAttempts) {
 				// Guard the metric on rows affected: the write resolves 0 (not rejects) when the
 				// row was reclaimed by the reaper on lease overrun, so don't count that as ours.
-				const n = await this.store.failTaskTerminal(claim, message);
-				if (n > 0) this.hooks.onFire?.(task.taskType, 'failure');
+				const rowsAffected = await this.store.failTaskTerminal(claim, message);
+				if (rowsAffected > 0) this.hooks.onFire?.(task.taskType, 'failure');
 			} else {
-				const n = await this.store.rescheduleTask(claim, backoff(nextAttempts), message);
-				if (n > 0) this.hooks.onRetry?.(task.taskType);
+				const rowsAffected = await this.store.rescheduleTask(claim, backoff(nextAttempts), message);
+				if (rowsAffected > 0) this.hooks.onRetry?.(task.taskType);
 			}
 			return;
 		}
 
-		const n = await this.store.completeTask(claim);
-		if (n > 0) this.hooks.onFire?.(task.taskType, 'success');
+		const rowsAffected = await this.store.completeTask(claim);
+		if (rowsAffected > 0) this.hooks.onFire?.(task.taskType, 'success');
 	}
 
 	/** Release a claim, reporting but swallowing failures: the reaper still recovers the row. */

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -203,10 +203,14 @@ export class Executor {
 		// The timer's clock (the one scheduling used) is used, not a fresh wall clock, so a
 		// skewed instance doesn't bias the lag it also scheduled against; clamp non-negative
 		// since a timer can fire marginally early.
-		this.metrics.recordDispatch(task.taskType);
-		const lagMs = this.timer.now() - task.runAt.getTime();
-		const lagSeconds = Math.max(0, lagMs) / Time.seconds.toMilliseconds;
-		this.metrics.observeDispatchLagSeconds(task.taskType, lagSeconds);
+		try {
+			this.metrics.recordDispatch(task.taskType);
+			const lagMs = this.timer.now() - task.runAt.getTime();
+			const lagSeconds = Math.max(0, lagMs) / Time.seconds.toMilliseconds;
+			this.metrics.observeDispatchLagSeconds(task.taskType, lagSeconds);
+		} catch {
+			// Metrics are best-effort observability and must not prevent task dispatch.
+		}
 
 		// Record success only after the try, so a failure to record it isn't taken for a
 		// handler failure. Such a failure propagates out (caught by the detached `.catch`

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -6,6 +6,7 @@ import { DEFAULT_EXECUTOR_OPTIONS, type ExecutorOptions } from './options';
 import type { PrecisionTimer } from './precision-timer';
 import type { ClaimedTaskRef, ClaimDueTasksBatch, ExecutorTaskStore } from './store';
 import type { TaskHandlerRegistry } from './task-handler';
+import { noopMetrics, type SchedulerMetrics } from '../../observability/metrics';
 import type { ClaimedTask } from '../types';
 
 type ClaimedEntry = { host: string; task: ClaimedTask };
@@ -81,6 +82,7 @@ export class Executor {
 		private readonly timer: PrecisionTimer,
 		private readonly options: ExecutorOptions = DEFAULT_EXECUTOR_OPTIONS,
 		private readonly hooks: ExecutorHooks = {},
+		private readonly metrics: SchedulerMetrics = noopMetrics,
 	) {
 		this.leaseMs = options.leaseSeconds * Time.seconds.toMilliseconds;
 		// Claim one driver tick ahead so a task due before the next tick fires precisely
@@ -195,6 +197,17 @@ export class Executor {
 		const started = await this.store.markStarted(claim);
 		if (started === 0) return;
 
+		// Now that the task is confirmed ours and started, it is genuinely being dispatched.
+		// Lag is measured against `runAt` (the effective fire time, pushed forward by retry
+		// backoff), not the fixed original slot, so a retry's backoff wait isn't logged as lag.
+		// The timer's clock (the one scheduling used) is used, not a fresh wall clock, so a
+		// skewed instance doesn't bias the lag it also scheduled against; clamp non-negative
+		// since a timer can fire marginally early.
+		this.metrics.recordDispatch(task.taskType);
+		const lagMs = this.timer.now() - task.runAt.getTime();
+		const lagSeconds = Math.max(0, lagMs) / Time.seconds.toMilliseconds;
+		this.metrics.observeDispatchLagSeconds(task.taskType, lagSeconds);
+
 		// Record success only after the try, so a failure to record it isn't taken for a
 		// handler failure. Such a failure propagates out (caught by the detached `.catch`
 		// in claimAndSchedule) and leaves the row `running` for the reaper.
@@ -204,14 +217,23 @@ export class Executor {
 			const message = ensureError(error).message;
 			const nextAttempts = task.attempts + 1;
 			if (nextAttempts >= task.maxAttempts) {
-				await this.store.failTaskTerminal(claim, message);
+				// Guard the metric on rows affected: the write resolves 0 (not rejects) when the
+				// row was reclaimed by the reaper on lease overrun, so don't count that as ours.
+				const n = await this.store.failTaskTerminal(claim, message);
+				if (n > 0) {
+					this.metrics.recordFireOutcome(task.taskType, 'failure');
+					// Attempts exhausted, handler kept throwing: a permanent failure is a dead-letter.
+					this.metrics.recordDeadLettered();
+				}
 			} else {
-				await this.store.rescheduleTask(claim, backoff(nextAttempts), message);
+				const n = await this.store.rescheduleTask(claim, backoff(nextAttempts), message);
+				if (n > 0) this.metrics.recordRetry(task.taskType);
 			}
 			return;
 		}
 
-		await this.store.completeTask(claim);
+		const n = await this.store.completeTask(claim);
+		if (n > 0) this.metrics.recordFireOutcome(task.taskType, 'success');
 	}
 
 	/** Release a claim, reporting but swallowing failures: the reaper still recovers the row. */

--- a/packages/@n8n/scheduler/src/core/executor/executor.ts
+++ b/packages/@n8n/scheduler/src/core/executor/executor.ts
@@ -6,7 +6,6 @@ import { DEFAULT_EXECUTOR_OPTIONS, type ExecutorOptions } from './options';
 import type { PrecisionTimer } from './precision-timer';
 import type { ClaimedTaskRef, ClaimDueTasksBatch, ExecutorTaskStore } from './store';
 import type { TaskHandlerRegistry } from './task-handler';
-import { noopMetrics, type SchedulerMetrics } from '../../observability/metrics';
 import type { ClaimedTask } from '../types';
 
 type ClaimedEntry = { host: string; task: ClaimedTask };
@@ -38,6 +37,15 @@ export interface ExecutorHooks {
 
 	/** A best-effort claim release failed; the reaper still recovers the row. */
 	onReleaseError?: (taskId: string, error: unknown) => void;
+
+	// Fire-path metrics hooks (the normal path), distinct from the incident hooks above.
+
+	/** A claimed task was dispatched to its handler; `lagSeconds` is fire time minus its effective `runAt` (clamped >= 0). */
+	onDispatch?: (taskType: string, lagSeconds: number) => void;
+	/** A fire reached a terminal outcome: the handler completed ('success') or exhausted its attempts ('failure'). */
+	onFire?: (taskType: string, result: 'success' | 'failure') => void;
+	/** A fire failed but has attempts left; it was rescheduled with backoff. */
+	onRetry?: (taskType: string) => void;
 }
 
 /**
@@ -82,7 +90,6 @@ export class Executor {
 		private readonly timer: PrecisionTimer,
 		private readonly options: ExecutorOptions = DEFAULT_EXECUTOR_OPTIONS,
 		private readonly hooks: ExecutorHooks = {},
-		private readonly metrics: SchedulerMetrics = noopMetrics,
 	) {
 		this.leaseMs = options.leaseSeconds * Time.seconds.toMilliseconds;
 		// Claim one driver tick ahead so a task due before the next tick fires precisely
@@ -203,14 +210,9 @@ export class Executor {
 		// The timer's clock (the one scheduling used) is used, not a fresh wall clock, so a
 		// skewed instance doesn't bias the lag it also scheduled against; clamp non-negative
 		// since a timer can fire marginally early.
-		try {
-			this.metrics.recordDispatch(task.taskType);
-			const lagMs = this.timer.now() - task.runAt.getTime();
-			const lagSeconds = Math.max(0, lagMs) / Time.seconds.toMilliseconds;
-			this.metrics.observeDispatchLagSeconds(task.taskType, lagSeconds);
-		} catch {
-			// Metrics are best-effort observability and must not prevent task dispatch.
-		}
+		const lagMs = this.timer.now() - task.runAt.getTime();
+		const lagSeconds = Math.max(0, lagMs) / Time.seconds.toMilliseconds;
+		this.hooks.onDispatch?.(task.taskType, lagSeconds);
 
 		// Record success only after the try, so a failure to record it isn't taken for a
 		// handler failure. Such a failure propagates out (caught by the detached `.catch`
@@ -224,20 +226,16 @@ export class Executor {
 				// Guard the metric on rows affected: the write resolves 0 (not rejects) when the
 				// row was reclaimed by the reaper on lease overrun, so don't count that as ours.
 				const n = await this.store.failTaskTerminal(claim, message);
-				if (n > 0) {
-					this.metrics.recordFireOutcome(task.taskType, 'failure');
-					// Attempts exhausted, handler kept throwing: a permanent failure is a dead-letter.
-					this.metrics.recordDeadLettered();
-				}
+				if (n > 0) this.hooks.onFire?.(task.taskType, 'failure');
 			} else {
 				const n = await this.store.rescheduleTask(claim, backoff(nextAttempts), message);
-				if (n > 0) this.metrics.recordRetry(task.taskType);
+				if (n > 0) this.hooks.onRetry?.(task.taskType);
 			}
 			return;
 		}
 
 		const n = await this.store.completeTask(claim);
-		if (n > 0) this.metrics.recordFireOutcome(task.taskType, 'success');
+		if (n > 0) this.hooks.onFire?.(task.taskType, 'success');
 	}
 
 	/** Release a claim, reporting but swallowing failures: the reaper still recovers the row. */

--- a/packages/@n8n/scheduler/src/core/executor/precision-timer.ts
+++ b/packages/@n8n/scheduler/src/core/executor/precision-timer.ts
@@ -34,6 +34,11 @@ export class PrecisionTimer {
 
 	constructor(private readonly backend: TimerBackend = defaultBackend) {}
 
+	/** The clock scheduling is measured against; callers timing against `runAt` must use it. */
+	now(): number {
+		return this.backend.now();
+	}
+
 	/** Fire `fn` at `runAt` (or immediately if that instant has passed). */
 	schedule(runAt: Date, fn: () => void): void {
 		// The delay is measured against the instance wall clock, whereas due-ness and

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -153,6 +153,17 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 	};
 	const described = (error: unknown) => ensureError(error).message;
 
+	// Metrics are best-effort observability: a throwing sink (e.g. a broken
+	// exporter) must never break the pass that emitted, so every record is
+	// wrapped and its failure swallowed.
+	const recordMetric = (record: () => void) => {
+		try {
+			record();
+		} catch {
+			// Deliberately swallowed; see above.
+		}
+	};
+
 	const registry = new TaskHandlerRegistry();
 	const executor = new Executor(taskStore, registry, new PrecisionTimer(), executorOptions, {
 		onLeaseShorterThanLookahead: (context) => {
@@ -180,16 +191,18 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 				error: described(error),
 			});
 		},
-		onDispatch: (taskType, lagSeconds) => {
-			metrics.recordDispatch(taskType);
-			metrics.observeDispatchLagSeconds(taskType, lagSeconds);
-		},
-		onFire: (taskType, result) => {
-			metrics.recordFireOutcome(taskType, result);
-			// An executor terminal failure (attempts exhausted) is a permanent failure = a dead-letter.
-			if (result === 'failure') metrics.recordDeadLettered();
-		},
-		onRetry: (taskType) => metrics.recordRetry(taskType),
+		onDispatch: (taskType, lagSeconds) =>
+			recordMetric(() => {
+				metrics.recordDispatch(taskType);
+				metrics.observeDispatchLagSeconds(taskType, lagSeconds);
+			}),
+		onFire: (taskType, result) =>
+			recordMetric(() => {
+				metrics.recordFireOutcome(taskType, result);
+				// An executor terminal failure (attempts exhausted) is a permanent failure = a dead-letter.
+				if (result === 'failure') metrics.recordDeadLettered();
+			}),
+		onRetry: (taskType) => recordMetric(() => metrics.recordRetry(taskType)),
 	});
 
 	if (retentionOptions.failedRetentionSeconds < retentionOptions.retentionSeconds) {
@@ -222,7 +235,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 			},
 			signal,
 		);
-		metrics.recordMaterialized(summary.occurrences, summary.deferredJobs);
+		recordMetric(() => metrics.recordMaterialized(summary.occurrences, summary.deferredJobs));
 		return summary;
 	};
 
@@ -252,7 +265,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 			},
 			signal,
 		);
-		metrics.recordReaped(result.reclaimed, result.deadLettered);
+		recordMetric(() => metrics.recordReaped(result.reclaimed, result.deadLettered));
 		return result;
 	};
 
@@ -265,7 +278,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 		} else if (summary.drained && summary.deleted > 0) {
 			emit('debug', 'Scheduler retention deleted finished tasks', { ...summary });
 		}
-		metrics.recordPruned(summary.deleted);
+		recordMetric(() => metrics.recordPruned(summary.deleted));
 		return summary;
 	};
 

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -18,6 +18,7 @@ import type { ReaperOptions, ReaperTaskStore } from './reaper';
 import { DEFAULT_RETENTION_OPTIONS, prune } from './retention';
 import type { RetentionOptions, RetentionStore } from './retention';
 import type { Scheduler, SchedulerPasses } from './scheduler';
+import { noopMetrics, type SchedulerMetrics } from '../observability/metrics';
 
 export type SchedulerEventLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -59,6 +60,9 @@ export interface SchedulerDeps {
 	lifecycle?: Partial<LifecycleOptions>;
 
 	onEvent?: (event: SchedulerEvent) => void;
+
+	/** Host metrics; defaults to a no-op. */
+	metrics?: SchedulerMetrics;
 }
 
 /**
@@ -86,6 +90,7 @@ function withDefaults<T extends object>(defaults: T, overrides: Partial<T> = {})
  */
 export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasses {
 	const { hostId, materializerTransaction, taskStore, onEvent } = deps;
+	const metrics = deps.metrics ?? noopMetrics;
 	const materializerOptions = withDefaults(DEFAULT_MATERIALIZER_OPTIONS, deps.materializer);
 	const executorOptions = withDefaults(DEFAULT_EXECUTOR_OPTIONS, deps.executor);
 	const reaperOptions = withDefaults(DEFAULT_REAPER_OPTIONS, deps.reaper);
@@ -149,33 +154,40 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 	const described = (error: unknown) => ensureError(error).message;
 
 	const registry = new TaskHandlerRegistry();
-	const executor = new Executor(taskStore, registry, new PrecisionTimer(), executorOptions, {
-		onLeaseShorterThanLookahead: (context) => {
-			emit(
-				'warn',
-				'Scheduler executor lookahead reaches or exceeds the lease; claimed tasks may lose their lease before firing',
-				{ ...context },
-			);
+	const executor = new Executor(
+		taskStore,
+		registry,
+		new PrecisionTimer(),
+		executorOptions,
+		{
+			onLeaseShorterThanLookahead: (context) => {
+				emit(
+					'warn',
+					'Scheduler executor lookahead reaches or exceeds the lease; claimed tasks may lose their lease before firing',
+					{ ...context },
+				);
+			},
+			onMissingHandler: (task) => {
+				emit('warn', 'Scheduler claimed a task with no registered handler; claim released', {
+					taskId: task.id,
+					taskType: task.taskType,
+				});
+			},
+			onFireError: (task, error) => {
+				emit('error', 'Scheduler could not record a task outcome; left for the reaper', {
+					taskId: task.id,
+					error: described(error),
+				});
+			},
+			onReleaseError: (taskId, error) => {
+				emit('error', 'Scheduler failed to release a claimed task; left for the reaper', {
+					taskId,
+					error: described(error),
+				});
+			},
 		},
-		onMissingHandler: (task) => {
-			emit('warn', 'Scheduler claimed a task with no registered handler; claim released', {
-				taskId: task.id,
-				taskType: task.taskType,
-			});
-		},
-		onFireError: (task, error) => {
-			emit('error', 'Scheduler could not record a task outcome; left for the reaper', {
-				taskId: task.id,
-				error: described(error),
-			});
-		},
-		onReleaseError: (taskId, error) => {
-			emit('error', 'Scheduler failed to release a claimed task; left for the reaper', {
-				taskId,
-				error: described(error),
-			});
-		},
-	});
+		metrics,
+	);
 
 	if (retentionOptions.failedRetentionSeconds < retentionOptions.retentionSeconds) {
 		emit(
@@ -188,8 +200,8 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 		);
 	}
 
-	const runMaterialize = async (signal?: AbortSignal) =>
-		await materialize(
+	const runMaterialize = async (signal?: AbortSignal) => {
+		const summary = await materialize(
 			materializerTransaction,
 			materializerOptions,
 			{
@@ -207,12 +219,15 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 			},
 			signal,
 		);
+		metrics.recordMaterialized(summary.occurrences, summary.deferredJobs);
+		return summary;
+	};
 
 	const runExecute = async (signal?: AbortSignal) =>
 		await executor.claimAndSchedule(hostId, signal);
 
-	const runReap = async (signal?: AbortSignal) =>
-		await reap(
+	const runReap = async (signal?: AbortSignal) => {
+		const result = await reap(
 			taskStore,
 			reaperOptions,
 			{
@@ -234,6 +249,9 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 			},
 			signal,
 		);
+		metrics.recordReaped(result.reclaimed, result.deadLettered);
+		return result;
+	};
 
 	const runPrune = async (signal?: AbortSignal) => {
 		const summary = await prune(taskStore, retentionOptions, signal);
@@ -244,6 +262,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 		} else if (summary.drained && summary.deleted > 0) {
 			emit('debug', 'Scheduler retention deleted finished tasks', { ...summary });
 		}
+		metrics.recordPruned(summary.deleted);
 		return summary;
 	};
 

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -154,40 +154,43 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 	const described = (error: unknown) => ensureError(error).message;
 
 	const registry = new TaskHandlerRegistry();
-	const executor = new Executor(
-		taskStore,
-		registry,
-		new PrecisionTimer(),
-		executorOptions,
-		{
-			onLeaseShorterThanLookahead: (context) => {
-				emit(
-					'warn',
-					'Scheduler executor lookahead reaches or exceeds the lease; claimed tasks may lose their lease before firing',
-					{ ...context },
-				);
-			},
-			onMissingHandler: (task) => {
-				emit('warn', 'Scheduler claimed a task with no registered handler; claim released', {
-					taskId: task.id,
-					taskType: task.taskType,
-				});
-			},
-			onFireError: (task, error) => {
-				emit('error', 'Scheduler could not record a task outcome; left for the reaper', {
-					taskId: task.id,
-					error: described(error),
-				});
-			},
-			onReleaseError: (taskId, error) => {
-				emit('error', 'Scheduler failed to release a claimed task; left for the reaper', {
-					taskId,
-					error: described(error),
-				});
-			},
+	const executor = new Executor(taskStore, registry, new PrecisionTimer(), executorOptions, {
+		onLeaseShorterThanLookahead: (context) => {
+			emit(
+				'warn',
+				'Scheduler executor lookahead reaches or exceeds the lease; claimed tasks may lose their lease before firing',
+				{ ...context },
+			);
 		},
-		metrics,
-	);
+		onMissingHandler: (task) => {
+			emit('warn', 'Scheduler claimed a task with no registered handler; claim released', {
+				taskId: task.id,
+				taskType: task.taskType,
+			});
+		},
+		onFireError: (task, error) => {
+			emit('error', 'Scheduler could not record a task outcome; left for the reaper', {
+				taskId: task.id,
+				error: described(error),
+			});
+		},
+		onReleaseError: (taskId, error) => {
+			emit('error', 'Scheduler failed to release a claimed task; left for the reaper', {
+				taskId,
+				error: described(error),
+			});
+		},
+		onDispatch: (taskType, lagSeconds) => {
+			metrics.recordDispatch(taskType);
+			metrics.observeDispatchLagSeconds(taskType, lagSeconds);
+		},
+		onFire: (taskType, result) => {
+			metrics.recordFireOutcome(taskType, result);
+			// An executor terminal failure (attempts exhausted) is a permanent failure = a dead-letter.
+			if (result === 'failure') metrics.recordDeadLettered();
+		},
+		onRetry: (taskType) => metrics.recordRetry(taskType),
+	});
 
 	if (retentionOptions.failedRetentionSeconds < retentionOptions.retentionSeconds) {
 		emit(

--- a/packages/@n8n/scheduler/src/core/index.ts
+++ b/packages/@n8n/scheduler/src/core/index.ts
@@ -19,3 +19,6 @@ export { executorLookaheadSeconds } from './lifecycle';
 export type { ConcurrencyMode, LifecycleOptions } from './lifecycle';
 export type { ReaperOptions, ReapResult } from './reaper';
 export type { RetentionOptions, RetentionSummary } from './retention';
+
+export { noopMetrics } from '../observability/metrics';
+export type { SchedulerMetrics } from '../observability/metrics';

--- a/packages/@n8n/scheduler/src/observability/metrics.ts
+++ b/packages/@n8n/scheduler/src/observability/metrics.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal metrics port. The scheduler stays dependency-light: it depends on this
+ * interface and records counts and timings through it, while the host adapts its
+ * concrete (Prometheus-backed) metrics to it. Push-based: the scheduler calls a
+ * method per event, so the port carries no reader/registry surface.
+ */
+export interface SchedulerMetrics {
+	/** A claimed task is about to be dispatched to its handler. */
+	recordDispatch(taskType: string): void;
+	/** A dispatch reached a terminal outcome (completed, or failed with no attempts left). */
+	recordFireOutcome(taskType: string, result: 'success' | 'failure'): void;
+	/** A failed dispatch was rescheduled for another attempt. */
+	recordRetry(taskType: string): void;
+	/** Delay between when a task was due (`scheduledFor`) and when it actually fired. */
+	observeDispatchLagSeconds(taskType: string, seconds: number): void;
+
+	/** Outcome of one materialization pass. */
+	recordMaterialized(occurrences: number, deferredJobs: number): void;
+	/** Outcome of one reaper sweep. */
+	recordReaped(reclaimed: number, deadLettered: number): void;
+	/**
+	 * A task became a dead-letter on the executor's terminal-failure path (attempts
+	 * exhausted). Complements the reaper's `recordReaped`, which counts the ones it
+	 * dead-letters.
+	 */
+	recordDeadLettered(): void;
+	/** Outcome of one retention pass. */
+	recordPruned(deleted: number): void;
+}
+
+/** Default metrics: records nothing. */
+export const noopMetrics: SchedulerMetrics = {
+	recordDispatch() {},
+	recordFireOutcome() {},
+	recordRetry() {},
+	observeDispatchLagSeconds() {},
+	recordMaterialized() {},
+	recordReaped() {},
+	recordDeadLettered() {},
+	recordPruned() {},
+};

--- a/packages/@n8n/scheduler/src/observability/metrics.ts
+++ b/packages/@n8n/scheduler/src/observability/metrics.ts
@@ -2,7 +2,7 @@
  * Minimal metrics port. The scheduler stays dependency-light: it depends on this
  * interface and records counts and timings through it, while the host adapts its
  * concrete (Prometheus-backed) metrics to it. Push-based: the scheduler calls a
- * method per event, so the port carries no reader/registry surface.
+ * method per event, so the port exposes no reader or registry API.
  */
 export interface SchedulerMetrics {
 	/** A claimed task is about to be dispatched to its handler. */

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -18,6 +18,7 @@ import { PrometheusMetricsService } from '../prometheus/prometheus.service';
 import type { PrometheusPssMetricsService } from '../prometheus/pss-metrics.service';
 import type { PrometheusQueueMetricsService } from '../prometheus/queue-metrics.service';
 import type { PrometheusRouteMetricsService } from '../prometheus/route-metrics.service';
+import type { PrometheusSchedulerMetricsService } from '../prometheus/scheduler-metrics.service';
 import type { PrometheusSsrfMetricsService } from '../prometheus/ssrf-metrics.service';
 import type { PrometheusTokenExchangeMetricsService } from '../prometheus/token-exchange-metrics.service';
 import type { PrometheusVersionMetricsService } from '../prometheus/version-metrics.service';
@@ -53,6 +54,7 @@ describe('PrometheusMetricsService', () => {
 	let instanceAi: Mocked<PrometheusInstanceAiMetricsService>;
 	let dbPool: Mocked<PrometheusDbPoolMetricsService>;
 	let workflowPublication: Mocked<PrometheusWorkflowPublicationMetricsService>;
+	let scheduler: Mocked<PrometheusSchedulerMetricsService>;
 
 	let service: PrometheusMetricsService;
 
@@ -79,6 +81,7 @@ describe('PrometheusMetricsService', () => {
 			instanceAi,
 			dbPool,
 			workflowPublication,
+			scheduler,
 		);
 
 	beforeEach(() => {
@@ -112,6 +115,7 @@ describe('PrometheusMetricsService', () => {
 		instanceAi = mock<PrometheusInstanceAiMetricsService>({ enabled: true });
 		dbPool = mock<PrometheusDbPoolMetricsService>({ enabled: true });
 		workflowPublication = mock<PrometheusWorkflowPublicationMetricsService>({ enabled: true });
+		scheduler = mock<PrometheusSchedulerMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -144,6 +148,7 @@ describe('PrometheusMetricsService', () => {
 			expect(instanceAi.init).toHaveBeenCalledWith(app);
 			expect(dbPool.init).toHaveBeenCalledWith(app);
 			expect(workflowPublication.init).toHaveBeenCalledWith(app);
+			expect(scheduler.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
@@ -1,0 +1,314 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import type { MetricSnapshot, ScheduledTaskRepository } from '@n8n/db';
+import type { InstanceSettings } from 'n8n-core';
+import promClient from 'prom-client';
+import type { Mock } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { PrometheusSchedulerMetricsService } from '../scheduler-metrics.service';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+vi.mock('prom-client');
+
+describe('PrometheusSchedulerMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+		includeSchedulerMetrics: true,
+		schedulerMetricsInterval: 20,
+	});
+	const instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
+	const cacheService = mock<CacheService>();
+	const taskRepository = mock<ScheduledTaskRepository>();
+
+	let service: PrometheusSchedulerMetricsService;
+	let sharedCounterInc: Mock;
+	let mockHistogramObserve: Mock;
+	// Records the options each Counter is constructed with (a vitest constructor
+	// mock returns a shared instance, so we track construction and per-instance
+	// `inc` mocks ourselves via a real fake class below).
+	let counterCtor: Mock;
+	const counterIncByName = new Map<string, Mock>();
+
+	const snapshot: MetricSnapshot = {
+		pending: 4,
+		due: 2,
+		running: 1,
+		oldestPendingAgeMs: 10_000,
+	};
+
+	beforeEach(() => {
+		Object.assign(config, {
+			prefix: 'n8n_',
+			includeSchedulerMetrics: true,
+			schedulerMetricsInterval: 20,
+		});
+		Object.assign(instanceSettings, { instanceType: 'main' });
+
+		service = new PrometheusSchedulerMetricsService(
+			config,
+			instanceSettings,
+			cacheService,
+			taskRepository,
+		);
+
+		sharedCounterInc = vi.fn();
+		mockHistogramObserve = vi.fn();
+		counterCtor = vi.fn();
+		counterIncByName.clear();
+		// Replace the auto-mocked Counter class (whose instances share one prototype
+		// `inc`) with a real class, so each construction yields its own `inc`. This
+		// lets a test assert the right counter received the right value (an arg-swap
+		// would otherwise pass). `inc` also forwards to `sharedCounterInc`, letting
+		// the before-init test assert no counter was touched at all.
+		class FakeCounter {
+			// A fresh arrow wrapper per instance (passing `sharedCounterInc` directly
+			// would hit vitest's `vi.fn` memoisation and share one mock across instances).
+			inc = vi.fn((...args: unknown[]) => sharedCounterInc(...args));
+
+			constructor(opts: { name: string }) {
+				counterCtor(opts);
+				counterIncByName.set(opts.name, this.inc);
+			}
+		}
+		(promClient as unknown as { Counter: unknown }).Counter = FakeCounter;
+		promClient.Histogram.prototype.observe = mockHistogramObserve;
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	const gaugeOptsFor = (name: string) =>
+		(promClient.Gauge as unknown as Mock).mock.calls.find((call) => call[0].name === name)?.[0];
+
+	// Resolves the per-instance `inc` mock for the counter registered under `name`.
+	const counterIncFor = (name: string): Mock => counterIncByName.get(name)!;
+
+	// Clears the init-time `.inc(0)` seeding so behavioural tests see only their own
+	// call.
+	const clearCounterIncs = () => {
+		for (const inc of counterIncByName.values()) inc.mockClear();
+	};
+
+	describe('enabled', () => {
+		it('is true when opted in and the instance is main', () => {
+			expect(service.enabled).toBe(true);
+		});
+
+		it('is false when not opted in', () => {
+			config.includeSchedulerMetrics = false;
+			expect(service.enabled).toBe(false);
+		});
+
+		it('is false on a non-main instance', () => {
+			Object.assign(instanceSettings, { instanceType: 'worker' });
+			expect(service.enabled).toBe(false);
+		});
+	});
+
+	describe('init', () => {
+		it('registers the counters, lag histogram and snapshot gauges', () => {
+			service.init();
+
+			const counterNames = counterCtor.mock.calls.map((c) => c[0].name);
+			expect(counterNames).toEqual(
+				expect.arrayContaining([
+					'n8n_scheduler_tasks_dispatched_total',
+					'n8n_scheduler_tasks_completed_total',
+					'n8n_scheduler_task_retries_total',
+					'n8n_scheduler_occurrences_materialized_total',
+					'n8n_scheduler_jobs_deferred_total',
+					'n8n_scheduler_tasks_reclaimed_total',
+					'n8n_scheduler_tasks_dead_lettered_total',
+					'n8n_scheduler_tasks_pruned_total',
+				]),
+			);
+
+			const histogramNames = (promClient.Histogram as unknown as Mock).mock.calls.map(
+				(c) => c[0].name,
+			);
+			expect(histogramNames).toContain('n8n_scheduler_dispatch_lag_seconds');
+
+			const gaugeNames = (promClient.Gauge as unknown as Mock).mock.calls.map((c) => c[0].name);
+			expect(gaugeNames).toEqual(
+				expect.arrayContaining([
+					'n8n_scheduler_tasks_pending',
+					'n8n_scheduler_tasks_due',
+					'n8n_scheduler_tasks_running',
+					'n8n_scheduler_oldest_pending_age_seconds',
+				]),
+			);
+		});
+
+		it('applies a custom prefix to metric names', () => {
+			config.prefix = 'myapp_';
+			service.init();
+
+			const gaugeNames = (promClient.Gauge as unknown as Mock).mock.calls.map((c) => c[0].name);
+			expect(gaugeNames).toContain('myapp_scheduler_tasks_pending');
+		});
+
+		it('pre-seeds the label-free counters with an initial zero', () => {
+			service.init();
+
+			for (const name of [
+				'n8n_scheduler_occurrences_materialized_total',
+				'n8n_scheduler_jobs_deferred_total',
+				'n8n_scheduler_tasks_reclaimed_total',
+				'n8n_scheduler_tasks_dead_lettered_total',
+				'n8n_scheduler_tasks_pruned_total',
+			]) {
+				expect(counterIncFor(name)).toHaveBeenCalledWith(0);
+			}
+		});
+	});
+
+	describe('gauge collection', () => {
+		beforeEach(() => {
+			taskRepository.getMetricSnapshot.mockResolvedValue(snapshot);
+			service.init();
+		});
+
+		it('reports the pending, due and running counts from the snapshot', async () => {
+			for (const [name, expected] of [
+				['n8n_scheduler_tasks_pending', 4],
+				['n8n_scheduler_tasks_due', 2],
+				['n8n_scheduler_tasks_running', 1],
+			] as const) {
+				const set = vi.fn();
+				await gaugeOptsFor(name).collect.call({ set });
+				expect(set).toHaveBeenCalledWith(expected);
+			}
+		});
+
+		it('reports the oldest pending age in seconds', async () => {
+			const set = vi.fn();
+			await gaugeOptsFor('n8n_scheduler_oldest_pending_age_seconds').collect.call({ set });
+			expect(set).toHaveBeenCalledWith(10);
+		});
+
+		it('reports 0 for the oldest pending age when none is due', async () => {
+			cacheService.get.mockResolvedValueOnce({ ...snapshot, oldestPendingAgeMs: null });
+
+			const set = vi.fn();
+			await gaugeOptsFor('n8n_scheduler_oldest_pending_age_seconds').collect.call({ set });
+			expect(set).toHaveBeenCalledWith(0);
+		});
+
+		it('caches the snapshot query with the configured interval as TTL', async () => {
+			await gaugeOptsFor('n8n_scheduler_tasks_pending').collect.call({ set: vi.fn() });
+
+			// 20s interval → 20_000ms TTL.
+			expect(cacheService.set).toHaveBeenCalledWith(
+				'metrics:scheduler:snapshot:v1',
+				snapshot,
+				20_000,
+			);
+		});
+
+		it('serves the gauges from cache without querying the database', async () => {
+			cacheService.get.mockResolvedValueOnce({ ...snapshot, pending: 99 });
+
+			const set = vi.fn();
+			await gaugeOptsFor('n8n_scheduler_tasks_pending').collect.call({ set });
+
+			expect(taskRepository.getMetricSnapshot).not.toHaveBeenCalled();
+			expect(set).toHaveBeenCalledWith(99);
+		});
+	});
+
+	describe('push metrics', () => {
+		beforeEach(() => {
+			service.init();
+			// Drop the init-time `.inc(0)` seeding so each test sees only its own call.
+			clearCounterIncs();
+			mockHistogramObserve.mockClear();
+		});
+
+		it('increments the dispatched counter by task type', () => {
+			service.recordDispatch('workflow');
+
+			const inc = counterIncFor('n8n_scheduler_tasks_dispatched_total');
+			expect(inc).toHaveBeenCalledWith({ task_type: 'workflow' }, 1);
+			expect(inc).toHaveBeenCalledTimes(1);
+		});
+
+		it('increments the completed counter by task type and result', () => {
+			service.recordFireOutcome('workflow', 'failure');
+
+			const inc = counterIncFor('n8n_scheduler_tasks_completed_total');
+			expect(inc).toHaveBeenCalledWith({ task_type: 'workflow', result: 'failure' }, 1);
+			expect(inc).toHaveBeenCalledTimes(1);
+		});
+
+		it('increments the retries counter by task type', () => {
+			service.recordRetry('workflow');
+
+			const inc = counterIncFor('n8n_scheduler_task_retries_total');
+			expect(inc).toHaveBeenCalledWith({ task_type: 'workflow' }, 1);
+			expect(inc).toHaveBeenCalledTimes(1);
+		});
+
+		it('observes dispatch lag by task type', () => {
+			service.observeDispatchLagSeconds('workflow', 1.5);
+			expect(mockHistogramObserve).toHaveBeenCalledWith({ task_type: 'workflow' }, 1.5);
+		});
+
+		it('increments materialized occurrences and deferred jobs into their own counters', () => {
+			service.recordMaterialized(7, 2);
+
+			const materialized = counterIncFor('n8n_scheduler_occurrences_materialized_total');
+			const deferred = counterIncFor('n8n_scheduler_jobs_deferred_total');
+			expect(materialized).toHaveBeenCalledWith(7);
+			expect(materialized).toHaveBeenCalledTimes(1);
+			expect(deferred).toHaveBeenCalledWith(2);
+			expect(deferred).toHaveBeenCalledTimes(1);
+		});
+
+		it('increments reclaimed and dead-lettered into their own counters', () => {
+			service.recordReaped(3, 1);
+
+			const reclaimed = counterIncFor('n8n_scheduler_tasks_reclaimed_total');
+			const deadLettered = counterIncFor('n8n_scheduler_tasks_dead_lettered_total');
+			expect(reclaimed).toHaveBeenCalledWith(3);
+			expect(reclaimed).toHaveBeenCalledTimes(1);
+			expect(deadLettered).toHaveBeenCalledWith(1);
+			expect(deadLettered).toHaveBeenCalledTimes(1);
+		});
+
+		it('increments the dead-lettered counter by one on the executor terminal-failure path', () => {
+			service.recordDeadLettered();
+
+			const deadLettered = counterIncFor('n8n_scheduler_tasks_dead_lettered_total');
+			expect(deadLettered).toHaveBeenCalledWith(1);
+			expect(deadLettered).toHaveBeenCalledTimes(1);
+		});
+
+		it('increments the pruned counter', () => {
+			service.recordPruned(5);
+
+			const inc = counterIncFor('n8n_scheduler_tasks_pruned_total');
+			expect(inc).toHaveBeenCalledWith(5);
+			expect(inc).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('push metrics before init', () => {
+		it('are no-ops when the collector was never initialized', () => {
+			// Fresh, uninitialized instance (metrics disabled or not a main).
+			service.recordDispatch('workflow');
+			service.recordFireOutcome('workflow', 'success');
+			service.recordRetry('workflow');
+			service.observeDispatchLagSeconds('workflow', 1);
+			service.recordMaterialized(1, 1);
+			service.recordReaped(1, 1);
+			service.recordDeadLettered();
+			service.recordPruned(1);
+
+			expect(sharedCounterInc).not.toHaveBeenCalled();
+			expect(mockHistogramObserve).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
@@ -1,6 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { PrometheusMetricsConfig } from '@n8n/config';
-import type { MetricSnapshot, ScheduledTaskRepository } from '@n8n/db';
+import type { ScheduledTaskMetricSnapshot, ScheduledTaskRepository } from '@n8n/db';
 import type { InstanceSettings } from 'n8n-core';
 import promClient from 'prom-client';
 import type { Mock } from 'vitest';
@@ -31,7 +31,7 @@ describe('PrometheusSchedulerMetricsService', () => {
 	let counterCtor: Mock;
 	const counterIncByName = new Map<string, Mock>();
 
-	const snapshot: MetricSnapshot = {
+	const snapshot: ScheduledTaskMetricSnapshot = {
 		pending: 4,
 		due: 2,
 		running: 1,

--- a/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/scheduler-metrics.service.test.ts
@@ -200,7 +200,7 @@ describe('PrometheusSchedulerMetricsService', () => {
 		it('caches the snapshot query with the configured interval as TTL', async () => {
 			await gaugeOptsFor('n8n_scheduler_tasks_pending').collect.call({ set: vi.fn() });
 
-			// 20s interval → 20_000ms TTL.
+			// 20s interval means a 20_000ms TTL.
 			expect(cacheService.set).toHaveBeenCalledWith(
 				'metrics:scheduler:snapshot:v1',
 				snapshot,

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -16,6 +16,7 @@ import { PrometheusInstanceRoleMetricsService } from './instance-role-metrics.se
 import { PrometheusPssMetricsService } from './pss-metrics.service';
 import { PrometheusQueueMetricsService } from './queue-metrics.service';
 import { PrometheusRouteMetricsService } from './route-metrics.service';
+import { PrometheusSchedulerMetricsService } from './scheduler-metrics.service';
 import { PrometheusSsrfMetricsService } from './ssrf-metrics.service';
 import { PrometheusTokenExchangeMetricsService } from './token-exchange-metrics.service';
 import { PrometheusVersionMetricsService } from './version-metrics.service';
@@ -53,6 +54,7 @@ export class PrometheusMetricsService {
 		instanceAi: PrometheusInstanceAiMetricsService,
 		dbPool: PrometheusDbPoolMetricsService,
 		workflowPublication: PrometheusWorkflowPublicationMetricsService,
+		scheduler: PrometheusSchedulerMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -76,6 +78,7 @@ export class PrometheusMetricsService {
 			instanceAi,
 			dbPool,
 			workflowPublication,
+			scheduler,
 		];
 	}
 

--- a/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
@@ -93,7 +93,7 @@ export class PrometheusSchedulerMetricsService
 
 		this.tasksDeadLettered = new promClient.Counter({
 			name: `${prefix}scheduler_tasks_dead_lettered_total`,
-			help: 'Total number of scheduler tasks dead-lettered by the reaper.',
+			help: 'Total number of scheduler tasks dead-lettered after exhausting their attempts, from either path: a terminal handler failure or the reaper recovering an expired lease.',
 		});
 
 		this.tasksPruned = new promClient.Counter({
@@ -134,7 +134,7 @@ export class PrometheusSchedulerMetricsService
 
 		new promClient.Gauge({
 			name: `${prefix}scheduler_tasks_pending`,
-			help: 'Number of pending scheduler tasks awaiting a worker. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			help: 'Number of pending scheduler tasks awaiting dispatch. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
 			async collect() {
 				const snapshot = await query.get();
 				this.set(snapshot.pending);
@@ -152,7 +152,7 @@ export class PrometheusSchedulerMetricsService
 
 		new promClient.Gauge({
 			name: `${prefix}scheduler_tasks_running`,
-			help: 'Number of scheduler tasks currently held by a worker. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			help: 'Number of scheduler tasks currently claimed and in flight. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
 			async collect() {
 				const snapshot = await query.get();
 				this.set(snapshot.running);

--- a/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
@@ -1,0 +1,223 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Time } from '@n8n/constants';
+import { ScheduledTaskRepository, type MetricSnapshot } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { SchedulerMetrics } from '@n8n/scheduler';
+import { InstanceSettings } from 'n8n-core';
+import promClient from 'prom-client';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import type { PrometheusMetricsCollector } from './base';
+import { CachedMetricQuery } from './cached-metric-query';
+import { DURATION_BUCKETS_SECONDS } from './constant';
+
+const SNAPSHOT_CACHE_KEY = 'metrics:scheduler:snapshot:v1';
+
+/**
+ * Collects Prometheus metrics for the Durable Scheduler. Opt-in via
+ * `includeSchedulerMetrics` and only active on a main instance. Counters and the
+ * lag histogram are driven directly through the {@link SchedulerMetrics} contract
+ * (this collector is the scheduler's metrics sink); queue-health gauges are read
+ * lazily from the task repository on each scrape. It is the only place that
+ * touches `prom-client` for scheduler metrics.
+ */
+@Service()
+export class PrometheusSchedulerMetricsService
+	implements PrometheusMetricsCollector, SchedulerMetrics
+{
+	private initialized = false;
+
+	private tasksDispatched!: promClient.Counter<'task_type'>;
+	private tasksCompleted!: promClient.Counter<'task_type' | 'result'>;
+	private taskRetries!: promClient.Counter<'task_type'>;
+	private occurrencesMaterialized!: promClient.Counter;
+	private jobsDeferred!: promClient.Counter;
+	private tasksReclaimed!: promClient.Counter;
+	private tasksDeadLettered!: promClient.Counter;
+	private tasksPruned!: promClient.Counter;
+	private dispatchLagSeconds!: promClient.Histogram<'task_type'>;
+
+	constructor(
+		private readonly config: PrometheusMetricsConfig,
+		private readonly instanceSettings: InstanceSettings,
+		private readonly cacheService: CacheService,
+		private readonly taskRepository: ScheduledTaskRepository,
+	) {}
+
+	get enabled(): boolean {
+		return this.config.includeSchedulerMetrics && this.instanceSettings.instanceType === 'main';
+	}
+
+	init() {
+		this.initPushMetrics();
+		this.initSnapshotGauges();
+		this.initialized = true;
+	}
+
+	private initPushMetrics() {
+		const prefix = this.config.prefix;
+
+		this.tasksDispatched = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_dispatched_total`,
+			help: 'Total number of scheduler tasks dispatched to a handler by task type.',
+			labelNames: ['task_type'],
+		});
+
+		this.tasksCompleted = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_completed_total`,
+			help: 'Total number of scheduler tasks that finished firing by task type and result.',
+			labelNames: ['task_type', 'result'],
+		});
+
+		this.taskRetries = new promClient.Counter({
+			name: `${prefix}scheduler_task_retries_total`,
+			help: 'Total number of scheduler task retries by task type.',
+			labelNames: ['task_type'],
+		});
+
+		this.occurrencesMaterialized = new promClient.Counter({
+			name: `${prefix}scheduler_occurrences_materialized_total`,
+			help: 'Total number of occurrences materialized from job schedules.',
+		});
+
+		this.jobsDeferred = new promClient.Counter({
+			name: `${prefix}scheduler_jobs_deferred_total`,
+			help: 'Total number of jobs deferred for retry during materialization.',
+		});
+
+		this.tasksReclaimed = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_reclaimed_total`,
+			help: 'Total number of expired scheduler tasks reclaimed by the reaper.',
+		});
+
+		this.tasksDeadLettered = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_dead_lettered_total`,
+			help: 'Total number of scheduler tasks dead-lettered by the reaper.',
+		});
+
+		this.tasksPruned = new promClient.Counter({
+			name: `${prefix}scheduler_tasks_pruned_total`,
+			help: 'Total number of finished scheduler tasks deleted by retention.',
+		});
+
+		this.dispatchLagSeconds = new promClient.Histogram({
+			name: `${prefix}scheduler_dispatch_lag_seconds`,
+			help: 'Delay in seconds between a task becoming due and being dispatched, by task type.',
+			labelNames: ['task_type'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		// Only the label-free counters can be pre-seeded; the `task_type`-labelled
+		// series are created lazily as task types are discovered at runtime.
+		this.occurrencesMaterialized.inc(0);
+		this.jobsDeferred.inc(0);
+		this.tasksReclaimed.inc(0);
+		this.tasksDeadLettered.inc(0);
+		this.tasksPruned.inc(0);
+	}
+
+	private initSnapshotGauges() {
+		const repository = this.taskRepository;
+		const prefix = this.config.prefix;
+		// One snapshot query feeds all four gauges; cache it so a tight scrape
+		// interval doesn't hammer the tasks table. Within a scrape, coalescing
+		// collapses the gauges' collects to a single query.
+		const ttlMs = this.config.schedulerMetricsInterval * Time.seconds.toMilliseconds;
+
+		const query = new CachedMetricQuery<MetricSnapshot>({
+			cacheService: this.cacheService,
+			cacheKey: SNAPSHOT_CACHE_KEY,
+			ttlMs,
+			query: async () => await repository.getMetricSnapshot(new Date()),
+		});
+
+		new promClient.Gauge({
+			name: `${prefix}scheduler_tasks_pending`,
+			help: 'Number of pending scheduler tasks awaiting a worker. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			async collect() {
+				const snapshot = await query.get();
+				this.set(snapshot.pending);
+			},
+		});
+
+		new promClient.Gauge({
+			name: `${prefix}scheduler_tasks_due`,
+			help: 'Number of pending scheduler tasks already due for dispatch. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			async collect() {
+				const snapshot = await query.get();
+				this.set(snapshot.due);
+			},
+		});
+
+		new promClient.Gauge({
+			name: `${prefix}scheduler_tasks_running`,
+			help: 'Number of scheduler tasks currently held by a worker. Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			async collect() {
+				const snapshot = await query.get();
+				this.set(snapshot.running);
+			},
+		});
+
+		new promClient.Gauge({
+			name: `${prefix}scheduler_oldest_pending_age_seconds`,
+			help: 'Age in seconds of the oldest due pending scheduler task; 0 means no due backlog (not a task 0s late). Cluster-wide snapshot, identical on every main; aggregate with max/avg, not sum.',
+			async collect() {
+				const snapshot = await query.get();
+				this.set(
+					snapshot.oldestPendingAgeMs !== null
+						? snapshot.oldestPendingAgeMs * Time.milliseconds.toSeconds
+						: 0,
+				);
+			},
+		});
+	}
+
+	// SchedulerMetrics sink. Each guard makes the method a no-op when the collector
+	// was never initialized (metrics disabled or not a main), so the scheduler can
+	// hold this instance as its metrics dependency unconditionally.
+
+	recordDispatch(taskType: string) {
+		if (!this.initialized) return;
+		this.tasksDispatched.inc({ task_type: taskType }, 1);
+	}
+
+	recordFireOutcome(taskType: string, result: 'success' | 'failure') {
+		if (!this.initialized) return;
+		this.tasksCompleted.inc({ task_type: taskType, result }, 1);
+	}
+
+	recordRetry(taskType: string) {
+		if (!this.initialized) return;
+		this.taskRetries.inc({ task_type: taskType }, 1);
+	}
+
+	observeDispatchLagSeconds(taskType: string, seconds: number) {
+		if (!this.initialized) return;
+		this.dispatchLagSeconds.observe({ task_type: taskType }, seconds);
+	}
+
+	recordMaterialized(occurrences: number, deferredJobs: number) {
+		if (!this.initialized) return;
+		this.occurrencesMaterialized.inc(occurrences);
+		this.jobsDeferred.inc(deferredJobs);
+	}
+
+	recordReaped(reclaimed: number, deadLettered: number) {
+		if (!this.initialized) return;
+		this.tasksReclaimed.inc(reclaimed);
+		this.tasksDeadLettered.inc(deadLettered);
+	}
+
+	// Executor terminal-failure path. Feeds the same counter as `recordReaped`'s
+	// deadLettered arg, so the total counts all permanent failures from either path.
+	recordDeadLettered() {
+		if (!this.initialized) return;
+		this.tasksDeadLettered.inc(1);
+	}
+
+	recordPruned(deleted: number) {
+		if (!this.initialized) return;
+		this.tasksPruned.inc(deleted);
+	}
+}

--- a/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/scheduler-metrics.service.ts
@@ -1,6 +1,6 @@
 import { PrometheusMetricsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import { ScheduledTaskRepository, type MetricSnapshot } from '@n8n/db';
+import { ScheduledTaskRepository, type ScheduledTaskMetricSnapshot } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { SchedulerMetrics } from '@n8n/scheduler';
 import { InstanceSettings } from 'n8n-core';
@@ -125,11 +125,11 @@ export class PrometheusSchedulerMetricsService
 		// collapses the gauges' collects to a single query.
 		const ttlMs = this.config.schedulerMetricsInterval * Time.seconds.toMilliseconds;
 
-		const query = new CachedMetricQuery<MetricSnapshot>({
+		const query = new CachedMetricQuery<ScheduledTaskMetricSnapshot>({
 			cacheService: this.cacheService,
 			cacheKey: SNAPSHOT_CACHE_KEY,
 			ttlMs,
-			query: async () => await repository.getMetricSnapshot(new Date()),
+			query: async () => await repository.getMetricSnapshot(),
 		});
 
 		new promClient.Gauge({
@@ -178,46 +178,54 @@ export class PrometheusSchedulerMetricsService
 	// hold this instance as its metrics dependency unconditionally.
 
 	recordDispatch(taskType: string) {
-		if (!this.initialized) return;
-		this.tasksDispatched.inc({ task_type: taskType }, 1);
+		if (this.initialized) {
+			this.tasksDispatched.inc({ task_type: taskType }, 1);
+		}
 	}
 
 	recordFireOutcome(taskType: string, result: 'success' | 'failure') {
-		if (!this.initialized) return;
-		this.tasksCompleted.inc({ task_type: taskType, result }, 1);
+		if (this.initialized) {
+			this.tasksCompleted.inc({ task_type: taskType, result }, 1);
+		}
 	}
 
 	recordRetry(taskType: string) {
-		if (!this.initialized) return;
-		this.taskRetries.inc({ task_type: taskType }, 1);
+		if (this.initialized) {
+			this.taskRetries.inc({ task_type: taskType }, 1);
+		}
 	}
 
 	observeDispatchLagSeconds(taskType: string, seconds: number) {
-		if (!this.initialized) return;
-		this.dispatchLagSeconds.observe({ task_type: taskType }, seconds);
+		if (this.initialized) {
+			this.dispatchLagSeconds.observe({ task_type: taskType }, seconds);
+		}
 	}
 
 	recordMaterialized(occurrences: number, deferredJobs: number) {
-		if (!this.initialized) return;
-		this.occurrencesMaterialized.inc(occurrences);
-		this.jobsDeferred.inc(deferredJobs);
+		if (this.initialized) {
+			this.occurrencesMaterialized.inc(occurrences);
+			this.jobsDeferred.inc(deferredJobs);
+		}
 	}
 
 	recordReaped(reclaimed: number, deadLettered: number) {
-		if (!this.initialized) return;
-		this.tasksReclaimed.inc(reclaimed);
-		this.tasksDeadLettered.inc(deadLettered);
+		if (this.initialized) {
+			this.tasksReclaimed.inc(reclaimed);
+			this.tasksDeadLettered.inc(deadLettered);
+		}
 	}
 
 	// Executor terminal-failure path. Feeds the same counter as `recordReaped`'s
 	// deadLettered arg, so the total counts all permanent failures from either path.
 	recordDeadLettered() {
-		if (!this.initialized) return;
-		this.tasksDeadLettered.inc(1);
+		if (this.initialized) {
+			this.tasksDeadLettered.inc(1);
+		}
 	}
 
 	recordPruned(deleted: number) {
-		if (!this.initialized) return;
-		this.tasksPruned.inc(deleted);
+		if (this.initialized) {
+			this.tasksPruned.inc(deleted);
+		}
 	}
 }

--- a/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
@@ -6,6 +6,8 @@ import { createScheduler } from '@n8n/scheduler';
 import type { InstanceSettings } from 'n8n-core';
 import { mock } from 'vitest-mock-extended';
 
+import type { PrometheusSchedulerMetricsService } from '@/metrics/prometheus/scheduler-metrics.service';
+
 import { DurableScheduler } from '../durable-scheduler';
 import { SCHEDULE_TRIGGER_TASK_TYPE } from '../schedule-trigger-node/schedule-trigger-task';
 import type { ScheduleTriggerTaskHandler } from '../schedule-trigger-node/schedule-trigger-task-handler';
@@ -37,6 +39,7 @@ describe('DurableScheduler', () => {
 				scheduler: { enabled, executorIntervalSeconds: 5, jitterRatio: 0.1 },
 			}),
 			scheduleTriggerTaskHandler,
+			mock<PrometheusSchedulerMetricsService>(),
 		);
 		return { scheduler, inner, logger };
 	}

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -38,7 +38,7 @@ export class DurableScheduler implements Scheduler {
 					hostId: instanceSettings.hostId,
 					materializerTransaction: buildMaterializerTransaction(dataSource, jobs, tasks),
 					taskStore: tasks,
-					// The collector implements SchedulerMetrics; it stays a no-op sink
+					// The collector implements `SchedulerMetrics`; it stays a no-op sink
 					// until its `init()` runs when metrics are enabled on a main instance.
 					metrics,
 					materializer: {

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -7,6 +7,8 @@ import type { RunInTransaction, Scheduler, TaskHandler } from '@n8n/scheduler';
 import { createScheduler, executorLookaheadSeconds } from '@n8n/scheduler';
 import { InstanceSettings } from 'n8n-core';
 
+import { PrometheusSchedulerMetricsService } from '@/metrics/prometheus/scheduler-metrics.service';
+
 import { ScheduleTriggerTaskHandler } from './schedule-trigger-node/schedule-trigger-task-handler';
 
 /**
@@ -27,6 +29,7 @@ export class DurableScheduler implements Scheduler {
 		instanceSettings: InstanceSettings,
 		globalConfig: GlobalConfig,
 		scheduleTriggerTaskHandler: ScheduleTriggerTaskHandler,
+		metrics: PrometheusSchedulerMetricsService,
 	) {
 		const config = globalConfig.scheduler;
 		const enabled = config.enabled && instanceSettings.instanceType === 'main';
@@ -35,6 +38,9 @@ export class DurableScheduler implements Scheduler {
 					hostId: instanceSettings.hostId,
 					materializerTransaction: buildMaterializerTransaction(dataSource, jobs, tasks),
 					taskStore: tasks,
+					// The collector implements SchedulerMetrics; it stays a no-op sink
+					// until its `init()` runs when metrics are enabled on a main instance.
+					metrics,
 					materializer: {
 						windowSeconds: config.materializationWindowSeconds,
 						defaultTimezone: globalConfig.generic.timezone,

--- a/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
@@ -635,4 +635,60 @@ describe('scheduled repositories', () => {
 			},
 		);
 	});
+
+	describe('ScheduledTaskRepository.getMetricSnapshot', () => {
+		it('reports queue depth counts and the oldest due pending age', async () => {
+			const job = await createJob();
+			const now = new Date();
+
+			// Two due pending rows (runAt in the past) and one not-yet-due pending row.
+			const dueOld = await createTask(job.id, {
+				status: 'pending',
+				runAt: new Date(now.getTime() - 120_000),
+			});
+			await createTask(job.id, { status: 'pending', runAt: new Date(now.getTime() - 30_000) });
+			await createTask(job.id, { status: 'pending', runAt: new Date(now.getTime() + 3_600_000) });
+			// A running row, plus terminal rows that must not be counted.
+			await createTask(job.id, {
+				status: 'running',
+				claimedBy: 'main-1',
+				leaseExpiresAt: new Date(now.getTime() + 60_000),
+			});
+			await createTask(job.id, { status: 'succeeded', finishedAt: secondsFromNow(-60) });
+			await createTask(job.id, { status: 'failed', finishedAt: secondsFromNow(-60) });
+
+			const snapshot = await taskRepository.getMetricSnapshot(now);
+
+			expect(snapshot.pending).toBe(3); // both due rows plus the future one
+			expect(snapshot.due).toBe(2); // only the two past-runAt rows are actionable
+			expect(snapshot.running).toBe(1);
+			// Lag tracks the oldest DUE pending row, not the future one.
+			expect(snapshot.oldestPendingAgeMs).toBe(now.getTime() - dueOld.runAt.getTime());
+		});
+
+		it('returns a null oldest age when no pending row is due', async () => {
+			const job = await createJob();
+			const now = new Date();
+
+			await createTask(job.id, { status: 'pending', runAt: new Date(now.getTime() + 3_600_000) });
+			await createTask(job.id, {
+				status: 'running',
+				claimedBy: 'main-1',
+				leaseExpiresAt: new Date(now.getTime() + 60_000),
+			});
+
+			const snapshot = await taskRepository.getMetricSnapshot(now);
+
+			expect(snapshot.pending).toBe(1);
+			expect(snapshot.due).toBe(0);
+			expect(snapshot.running).toBe(1);
+			expect(snapshot.oldestPendingAgeMs).toBeNull();
+		});
+
+		it('reports all-zero counts and a null age on an empty queue', async () => {
+			const snapshot = await taskRepository.getMetricSnapshot(new Date());
+
+			expect(snapshot).toEqual({ pending: 0, due: 0, running: 0, oldestPendingAgeMs: null });
+		});
+	});
 });

--- a/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
+++ b/packages/cli/test/integration/scheduling/scheduled-repositories.test.ts
@@ -657,13 +657,17 @@ describe('scheduled repositories', () => {
 			await createTask(job.id, { status: 'succeeded', finishedAt: secondsFromNow(-60) });
 			await createTask(job.id, { status: 'failed', finishedAt: secondsFromNow(-60) });
 
-			const snapshot = await taskRepository.getMetricSnapshot(now);
+			const snapshot = await taskRepository.getMetricSnapshot();
 
 			expect(snapshot.pending).toBe(3); // both due rows plus the future one
 			expect(snapshot.due).toBe(2); // only the two past-runAt rows are actionable
 			expect(snapshot.running).toBe(1);
-			// Lag tracks the oldest DUE pending row, not the future one.
-			expect(snapshot.oldestPendingAgeMs).toBe(now.getTime() - dueOld.runAt.getTime());
+			// Lag tracks the oldest DUE pending row, not the future one. Measured against
+			// DB-now, so it's at least the row's age at seed time, plus the small elapsed
+			// time until the query ran.
+			const seededAgeMs = now.getTime() - dueOld.runAt.getTime();
+			expect(snapshot.oldestPendingAgeMs).toBeGreaterThanOrEqual(seededAgeMs);
+			expect(snapshot.oldestPendingAgeMs).toBeLessThan(seededAgeMs + 60_000);
 		});
 
 		it('returns a null oldest age when no pending row is due', async () => {
@@ -677,7 +681,7 @@ describe('scheduled repositories', () => {
 				leaseExpiresAt: new Date(now.getTime() + 60_000),
 			});
 
-			const snapshot = await taskRepository.getMetricSnapshot(now);
+			const snapshot = await taskRepository.getMetricSnapshot();
 
 			expect(snapshot.pending).toBe(1);
 			expect(snapshot.due).toBe(0);
@@ -686,7 +690,7 @@ describe('scheduled repositories', () => {
 		});
 
 		it('reports all-zero counts and a null age on an empty queue', async () => {
-			const snapshot = await taskRepository.getMetricSnapshot(new Date());
+			const snapshot = await taskRepository.getMetricSnapshot();
 
 			expect(snapshot).toEqual({ pending: 0, due: 0, running: 0, oldestPendingAgeMs: null });
 		});


### PR DESCRIPTION
## Summary

Adds Prometheus metrics for the Durable Scheduler, following the E3 distributed-tracing observability pattern (CAT-3628).

`@n8n/scheduler` gains a dependency-light `SchedulerMetrics` port (interface + `noopMetrics`), but the subcomponents stay independent of it: the `Executor` exposes metric **hooks** (`onDispatch` / `onFire` / `onRetry`) on its existing hook set, and `createScheduler` maps those (plus the materializer/reaper/retention pass summaries) onto the `SchedulerMetrics` it is given. The service is passed in but never goes deeper than the factory. Metric recording is best-effort: a throwing sink can't break a fire or a pass. The concrete prom-client implementation lives in `cli` as a single collector that also serves scrape-time cached gauges via `CachedMetricQuery`, so the scheduler package stays free of prom-client.

**Metrics**
- Counters: tasks dispatched / completed`{result}` / retries, occurrences materialised, jobs deferred, tasks reclaimed / dead-lettered / pruned. Dead-letters accumulate from both the reaper and executor terminal-failure paths, giving one true total.
- Histogram: `scheduler_dispatch_lag_seconds` (measured from `runAt`, so retry backoff is not counted as lag).
- Cached gauges: pending / due / running task counts and oldest-pending age, backed by a new `ScheduledTaskRepository.getMetricSnapshot` aggregate behind a short TTL cache.

**Design notes**
- Labels bounded to `task_type` and `result`; no per-instance / workflow labels (Prometheus adds `instance` at scrape). Cardinality stays bounded.
- The scheduler is leaderless (claim-based, all mains): counters are per-instance; the pull gauges are a whole-table cluster-wide snapshot identical on every main, so their help text notes they should be aggregated with `max`/`avg`, not `sum`.
- Gated behind `N8N_METRICS_INCLUDE_SCHEDULER_METRICS` with a configurable gauge cache TTL (`N8N_METRICS_SCHEDULER_INTERVAL`, default 20s).
- Misfires are intentionally out of scope: no producer exists yet (the `Missed` status is never written). To follow up once reaper misfire/supersede policy lands.

## Related

https://linear.app/n8n/issue/CAT-3621/e1-metrics-and-instrumentation

Part of the Durable Scheduler M3 Observability milestone; unblocks E2 dashboards (CAT-3622), R1 benchmarks (CAT-3623), R2 chaos/failover (CAT-3624).

## How to test

- `N8N_METRICS=true N8N_METRICS_INCLUDE_SCHEDULER_METRICS=true`, run a main with the durable scheduler enabled, hit `/metrics`, confirm the `n8n_scheduler_*` series appear and move as tasks fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
