### PR TITLE
fix(core): Add project ID and project name to log stream events

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -2,7 +2,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { WorkflowsConfig } from '@n8n/config';
-import type { WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
+import type { Project, WorkflowEntity, WorkflowHistory, WorkflowRepository } from '@n8n/db';
 import type { UpdateResult } from '@n8n/typeorm';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ErrorReporter, InstanceSettings } from 'n8n-core';
@@ -41,6 +41,7 @@ import type {
 	ScheduleTriggerCollectionSession,
 	ScheduleTriggerJobRegistrar,
 } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
+import type { OwnershipService } from '@/services/ownership.service';
 import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
 import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
@@ -413,6 +414,11 @@ describe('ActiveWorkflowManager', () => {
 			scopedLogger = mock<Logger>();
 			const rootLogger = mock<Logger>({ scoped: vi.fn().mockReturnValue(scopedLogger) });
 
+			const ownershipService = mock<OwnershipService>();
+			ownershipService.getWorkflowProjectCached.mockResolvedValue(
+				mock<Project>({ id: 'project-1', name: 'Test Project' }),
+			);
+
 			factory = new TriggerExecutionContextFactory(
 				rootLogger,
 				mock(), // errorReporter
@@ -424,6 +430,7 @@ describe('ActiveWorkflowManager', () => {
 				mock(), // storageConfig
 				mock(), // workflowPublishedDataService
 				mock(), // scheduleTriggerJobRegistrar
+				ownershipService,
 			);
 
 			activeWorkflowManager = new ActiveWorkflowManager(
@@ -489,6 +496,8 @@ describe('ActiveWorkflowManager', () => {
 					workflowId: workflowData.id,
 					workflowName: workflowData.name,
 					executionId: 'exec-123',
+					projectId: 'project-1',
+					projectName: 'Test Project',
 					source: 'trigger',
 				});
 			});

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -163,8 +163,12 @@ describe('WorkflowExecuteAdditionalData', () => {
 		const runWithData = getMockRun({
 			lastNodeOutput: [[{ json: { test: 1 } }]],
 		});
+		const ownershipService = mockInstance(OwnershipService);
 
 		beforeEach(() => {
+			// Both this and the executeAgent describe call mockInstance(OwnershipService),
+			// which each Container.set a fresh mock. Re-bind ours so the source resolves it.
+			Container.set(OwnershipService, ownershipService);
 			workflowRepository.get.mockResolvedValue(
 				mock<WorkflowEntity>({
 					id: EXECUTION_ID,
@@ -182,6 +186,9 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 			activeExecutions.add.mockResolvedValue(EXECUTION_ID);
 			processRunExecutionData.mockReturnValue(getCancelablePromise(runWithData));
+			ownershipService.getWorkflowProjectCached.mockResolvedValue(
+				mock<Project>({ id: 'project-id-1', name: 'Mock Project' }),
+			);
 		});
 
 		it('should execute workflow, return data and execution id', async () => {
@@ -1241,6 +1248,9 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
+			// Both this and the getBase describe call mockInstance(OwnershipService),
+			// which each Container.set a fresh mock. Re-bind ours so the source resolves it.
+			Container.set(OwnershipService, ownershipService);
 			agentWorkflowExecutionService.executeForWorkflow.mockResolvedValue(
 				mock<Awaited<ReturnType<typeof agentWorkflowExecutionService.executeForWorkflow>>>(),
 			);

--- a/packages/cli/src/commands/__tests__/execute.test.ts
+++ b/packages/cli/src/commands/__tests__/execute.test.ts
@@ -1,14 +1,8 @@
 import { LicenseState } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import type { User, WorkflowEntity } from '@n8n/db';
-import {
-	WorkflowRepository,
-	DbConnection,
-	AuthRolesService,
-	BinaryDataRepository,
-	Project,
-} from '@n8n/db';
+import type { User, WorkflowEntity, Project } from '@n8n/db';
+import { WorkflowRepository, DbConnection, AuthRolesService, BinaryDataRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { IRun } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';

--- a/packages/cli/src/commands/__tests__/execute.test.ts
+++ b/packages/cli/src/commands/__tests__/execute.test.ts
@@ -2,7 +2,13 @@ import { LicenseState } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { User, WorkflowEntity } from '@n8n/db';
-import { WorkflowRepository, DbConnection, AuthRolesService, BinaryDataRepository } from '@n8n/db';
+import {
+	WorkflowRepository,
+	DbConnection,
+	AuthRolesService,
+	BinaryDataRepository,
+	Project,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { IRun } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
@@ -66,6 +72,9 @@ test('should start a task runner', async () => {
 
 	workflowRepository.findOneBy.mockResolvedValue(workflow);
 	ownershipService.getInstanceOwner.mockResolvedValue(mock<User>({ id: '123' }));
+	ownershipService.getWorkflowProjectCached.mockResolvedValue(
+		mock<Project>({ id: 'project-id-1', name: 'Mock Project' }),
+	);
 	workflowRunner.run.mockResolvedValue('123');
 	activeExecutions.getPostExecutePromise.mockResolvedValue(run);
 

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -10,6 +10,7 @@ import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { findCliWorkflowStart, isWorkflowIdValid } from '@/utils';
 import { WorkflowRunner } from '@/workflow-runner';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 
 import { BaseCommand } from './base-command';
 
@@ -79,7 +80,10 @@ export class Execute extends BaseCommand<z.infer<typeof flagsSchema>> {
 		const startingNode = findCliWorkflowStart(workflowData.nodes);
 
 		const user = await Container.get(OwnershipService).getInstanceOwner();
-		const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowData.id);
+		const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+			Container.get(OwnershipService),
+			workflowData.id,
+		);
 		const runData: IWorkflowExecutionDataProcess = {
 			executionMode: 'cli',
 			startNodes: [{ name: startingNode.name, sourceData: null }],
@@ -103,8 +107,8 @@ export class Execute extends BaseCommand<z.infer<typeof flagsSchema>> {
 			workflowId: workflowData.id,
 			workflowName: workflowData.name,
 			executionId,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 			source: 'cli',
 		});
 

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -79,6 +79,7 @@ export class Execute extends BaseCommand<z.infer<typeof flagsSchema>> {
 		const startingNode = findCliWorkflowStart(workflowData.nodes);
 
 		const user = await Container.get(OwnershipService).getInstanceOwner();
+		const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowData.id);
 		const runData: IWorkflowExecutionDataProcess = {
 			executionMode: 'cli',
 			startNodes: [{ name: startingNode.name, sourceData: null }],
@@ -102,6 +103,8 @@ export class Execute extends BaseCommand<z.infer<typeof flagsSchema>> {
 			workflowId: workflowData.id,
 			workflowName: workflowData.name,
 			executionId,
+			projectId: project.id,
+			projectName: project.name,
 			source: 'cli',
 		});
 

--- a/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/__tests__/test-runner.service.ee.test.ts
@@ -4,6 +4,7 @@ import { TestCaseExecutionErrorCode } from '@n8n/db';
 import type {
 	EvaluationCollectionRepository,
 	EvaluationConfigRepository,
+	Project,
 	TestRun,
 	TestCaseExecutionRepository,
 	TestRunRepository,
@@ -28,6 +29,7 @@ import { TestRunError } from '@/evaluation.ee/test-runner/errors.ee';
 import type { License } from '@/license';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { OwnershipService } from '@/services/ownership.service';
 import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -72,6 +74,7 @@ describe('TestRunnerService', () => {
 	const evaluationCollectionRepository = mock<EvaluationCollectionRepository>();
 	const evaluationConfigRepository = mock<EvaluationConfigRepository>();
 	const workflowCompiler = mock<WorkflowCompilerService>();
+	const ownershipService = mock<OwnershipService>();
 	let testRunnerService: TestRunnerService;
 
 	mockInstance(LoadNodesAndCredentials, {
@@ -98,9 +101,13 @@ describe('TestRunnerService', () => {
 			evaluationCollectionRepository,
 			evaluationConfigRepository,
 			workflowCompiler,
+			ownershipService,
 		);
 
 		testRunRepository.createTestRun.mockResolvedValue(mock<TestRun>({ id: 'test-run-id' }));
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Test Project' }),
+		);
 	});
 
 	afterEach(() => {
@@ -546,6 +553,7 @@ describe('TestRunnerService', () => {
 				evaluationCollectionRepository,
 				evaluationConfigRepository,
 				workflowCompiler,
+				ownershipService,
 			);
 			process.env.OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = 'true';
 
@@ -870,6 +878,7 @@ describe('TestRunnerService', () => {
 					evaluationCollectionRepository,
 					evaluationConfigRepository,
 					workflowCompiler,
+					ownershipService,
 				);
 			});
 
@@ -2374,6 +2383,7 @@ describe('TestRunnerService', () => {
 				evaluationCollectionRepository,
 				evaluationConfigRepository,
 				workflowCompiler,
+				ownershipService,
 			);
 			setupHappyPathMocks(2);
 			const originalEnv = process.env.N8N_CONCURRENCY_EVALUATION_LIMIT;
@@ -2453,6 +2463,7 @@ describe('TestRunnerService', () => {
 				evaluationCollectionRepository,
 				evaluationConfigRepository,
 				workflowCompiler,
+				ownershipService,
 			);
 
 			const { inFlightTracker } = setupHappyPathMocks(6);
@@ -2552,6 +2563,7 @@ describe('TestRunnerService', () => {
 				evaluationCollectionRepository,
 				evaluationConfigRepository,
 				workflowCompiler,
+				ownershipService,
 			);
 
 			setupHappyPathMocks(4);
@@ -2791,6 +2803,7 @@ describe('TestRunnerService', () => {
 				evaluationCollectionRepository,
 				evaluationConfigRepository,
 				workflowCompiler,
+				ownershipService,
 			);
 
 			testRunRepository.find.mockResolvedValue([{ id: 'tr-running' } as never]);

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -59,6 +59,7 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 
 import { EvaluationMetrics, type MetricContribution } from './evaluation-metrics.ee';
 import { WorkflowCompilerService } from './workflow-compiler.service';
+import { OwnershipService } from '@/services/ownership.service';
 
 export interface TestRunMetadata {
 	testRunId: string;
@@ -102,6 +103,7 @@ export class TestRunnerService {
 		private readonly evaluationCollectionRepository: EvaluationCollectionRepository,
 		private readonly evaluationConfigRepository: EvaluationConfigRepository,
 		private readonly workflowCompiler: WorkflowCompilerService,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	/**

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -56,6 +56,7 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 
 import { EvaluationMetrics, type MetricContribution } from './evaluation-metrics.ee';
@@ -319,15 +320,18 @@ export class TestRunnerService {
 		const executionId = await this.workflowRunner.run(data);
 		assert(executionId);
 
-		const project = await this.ownershipService.getWorkflowProjectCached(workflow.id);
+		const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+			this.ownershipService,
+			workflow.id,
+		);
 
 		this.eventService.emit('workflow-executed', {
 			user: metadata.userId ? { id: metadata.userId } : undefined,
 			workflowId: workflow.id,
 			workflowName: workflow.name,
 			executionId,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 			source: 'evaluation',
 		});
 

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -59,7 +59,6 @@ import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-hi
 
 import { EvaluationMetrics, type MetricContribution } from './evaluation-metrics.ee';
 import { WorkflowCompilerService } from './workflow-compiler.service';
-import { OwnershipService } from '@/services/ownership.service';
 
 export interface TestRunMetadata {
 	testRunId: string;
@@ -103,7 +102,6 @@ export class TestRunnerService {
 		private readonly evaluationCollectionRepository: EvaluationCollectionRepository,
 		private readonly evaluationConfigRepository: EvaluationConfigRepository,
 		private readonly workflowCompiler: WorkflowCompilerService,
-		private readonly ownershipService: OwnershipService,
 	) {}
 
 	/**

--- a/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runner/test-runner.service.ee.ts
@@ -53,6 +53,7 @@ import {
 import { EventService } from '@/events/event.service';
 import { License } from '@/license';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
+import { OwnershipService } from '@/services/ownership.service';
 import { Telemetry } from '@/telemetry';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
@@ -102,6 +103,7 @@ export class TestRunnerService {
 		private readonly evaluationCollectionRepository: EvaluationCollectionRepository,
 		private readonly evaluationConfigRepository: EvaluationConfigRepository,
 		private readonly workflowCompiler: WorkflowCompilerService,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	/**
@@ -317,11 +319,15 @@ export class TestRunnerService {
 		const executionId = await this.workflowRunner.run(data);
 		assert(executionId);
 
+		const project = await this.ownershipService.getWorkflowProjectCached(workflow.id);
+
 		this.eventService.emit('workflow-executed', {
 			user: metadata.userId ? { id: metadata.userId } : undefined,
 			workflowId: workflow.id,
 			workflowName: workflow.name,
 			executionId,
+			projectId: project.id,
+			projectName: project.name,
 			source: 'evaluation',
 		});
 

--- a/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
+++ b/packages/cli/src/eventbus/event-message-classes/event-message-audit.ts
@@ -20,6 +20,8 @@ export interface EventPayloadAudit extends AbstractEventPayload {
 	credentialId?: string;
 	workflowId?: string;
 	workflowName?: string;
+	projectId?: string;
+	projectName?: string;
 	activeVersionId?: string | null;
 	deactivatedVersionId?: string | null;
 	versionId?: string;

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2083,6 +2083,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-manual',
 				workflowName: 'Manual Test Workflow',
 				executionId: 'exec-manual-123',
+				projectId: 'project-manual',
+				projectName: 'Manual Project',
 				source: 'user-manual',
 			};
 
@@ -2099,6 +2101,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-manual',
 					workflowName: 'Manual Test Workflow',
 					executionId: 'exec-manual-123',
+					projectId: 'project-manual',
+					projectName: 'Manual Project',
 					source: 'user-manual',
 				},
 			});
@@ -2155,6 +2159,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-retry',
 				workflowName: 'Retry Test Workflow',
 				executionId: 'exec-retry-456',
+				projectId: 'project-retry',
+				projectName: 'Retry Project',
 				source: 'user-retry',
 			};
 
@@ -2171,6 +2177,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-retry',
 					workflowName: 'Retry Test Workflow',
 					executionId: 'exec-retry-456',
+					projectId: 'project-retry',
+					projectName: 'Retry Project',
 					source: 'user-retry',
 				},
 			});
@@ -2181,6 +2189,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-webhook',
 				workflowName: 'Webhook Test Workflow',
 				executionId: 'exec-webhook-123',
+				projectId: 'project-webhook',
+				projectName: 'Webhook Project',
 				source: 'webhook',
 			};
 
@@ -2192,6 +2202,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-webhook',
 					workflowName: 'Webhook Test Workflow',
 					executionId: 'exec-webhook-123',
+					projectId: 'project-webhook',
+					projectName: 'Webhook Project',
 					source: 'webhook',
 				},
 			});
@@ -2202,6 +2214,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-trigger',
 				workflowName: 'Trigger Test Workflow',
 				executionId: 'exec-trigger-123',
+				projectId: 'project-trigger',
+				projectName: 'Trigger Project',
 				source: 'trigger',
 			};
 
@@ -2213,6 +2227,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-trigger',
 					workflowName: 'Trigger Test Workflow',
 					executionId: 'exec-trigger-123',
+					projectId: 'project-trigger',
+					projectName: 'Trigger Project',
 					source: 'trigger',
 				},
 			});
@@ -2223,6 +2239,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-error',
 				workflowName: 'Error Test Workflow',
 				executionId: 'exec-error-123',
+				projectId: 'project-error',
+				projectName: 'Error Project',
 				source: 'error',
 			};
 
@@ -2234,6 +2252,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-error',
 					workflowName: 'Error Test Workflow',
 					executionId: 'exec-error-123',
+					projectId: 'project-error',
+					projectName: 'Error Project',
 					source: 'error',
 				},
 			});
@@ -2247,6 +2267,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-cli',
 				workflowName: 'CLI Test Workflow',
 				executionId: 'exec-cli-123',
+				projectId: 'project-cli',
+				projectName: 'CLI Project',
 				source: 'cli',
 			};
 
@@ -2259,6 +2281,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-cli',
 					workflowName: 'CLI Test Workflow',
 					executionId: 'exec-cli-123',
+					projectId: 'project-cli',
+					projectName: 'CLI Project',
 					source: 'cli',
 				},
 			});
@@ -2272,6 +2296,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-integrated',
 				workflowName: 'Integrated Test Workflow',
 				executionId: 'exec-integrated-123',
+				projectId: 'project-integrated',
+				projectName: 'Integrated Project',
 				source: 'integrated',
 			};
 
@@ -2284,6 +2310,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-integrated',
 					workflowName: 'Integrated Test Workflow',
 					executionId: 'exec-integrated-123',
+					projectId: 'project-integrated',
+					projectName: 'Integrated Project',
 					source: 'integrated',
 				},
 			});
@@ -2297,6 +2325,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-evaluation',
 				workflowName: 'Evaluation Test Workflow',
 				executionId: 'exec-evaluation-123',
+				projectId: 'project-evaluation',
+				projectName: 'Evaluation Project',
 				source: 'evaluation',
 			};
 
@@ -2309,6 +2339,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-evaluation',
 					workflowName: 'Evaluation Test Workflow',
 					executionId: 'exec-evaluation-123',
+					projectId: 'project-evaluation',
+					projectName: 'Evaluation Project',
 					source: 'evaluation',
 				},
 			});
@@ -2322,6 +2354,8 @@ describe('LogStreamingEventRelay', () => {
 				workflowId: 'wf-chat',
 				workflowName: 'Chat Test Workflow',
 				executionId: 'exec-chat-123',
+				projectId: 'project-chat',
+				projectName: 'Chat Project',
 				source: 'chat',
 			};
 
@@ -2334,6 +2368,8 @@ describe('LogStreamingEventRelay', () => {
 					workflowId: 'wf-chat',
 					workflowName: 'Chat Test Workflow',
 					executionId: 'exec-chat-123',
+					projectId: 'project-chat',
+					projectName: 'Chat Project',
 					source: 'chat',
 				},
 			});

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -201,6 +201,8 @@ export type RelayEventMap = {
 		workflowId: string;
 		workflowName: string;
 		executionId: string;
+		projectId: string;
+		projectName: string;
 		source:
 			| 'user-manual'
 			| 'user-retry'

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -201,8 +201,6 @@ export type RelayEventMap = {
 		workflowId: string;
 		workflowName: string;
 		executionId: string;
-		projectId: string;
-		projectName: string;
 		source:
 			| 'user-manual'
 			| 'user-retry'

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -386,6 +386,8 @@ export class LogStreamingEventRelay extends EventRelay {
 		workflowId,
 		workflowName,
 		executionId,
+		projectId,
+		projectName,
 		source,
 	}: WorkflowExecutedEventWithUser) {
 		void this.eventBus.sendAuditEvent({
@@ -395,6 +397,8 @@ export class LogStreamingEventRelay extends EventRelay {
 				workflowId,
 				workflowName,
 				executionId,
+				projectId,
+				projectName,
 				source,
 			},
 		});
@@ -404,6 +408,8 @@ export class LogStreamingEventRelay extends EventRelay {
 		workflowId,
 		workflowName,
 		executionId,
+		projectId,
+		projectName,
 		source,
 	}: WorkflowExecutedEvent) {
 		void this.eventBus.sendAuditEvent({
@@ -412,6 +418,8 @@ export class LogStreamingEventRelay extends EventRelay {
 				workflowId,
 				workflowName,
 				executionId,
+				projectId,
+				projectName,
 				source,
 			},
 		});

--- a/packages/cli/src/executions/__tests__/execution.service.test.ts
+++ b/packages/cli/src/executions/__tests__/execution.service.test.ts
@@ -4,6 +4,7 @@ import type {
 	IExecutionDb,
 	IExecutionResponse,
 	ExecutionRepository,
+	Project,
 	User,
 	WorkflowHistoryRepository,
 } from '@n8n/db';
@@ -26,6 +27,7 @@ import type { ExecutionRequest } from '@/executions/execution.types';
 import type { ExecutionStopService } from '@/scaling/execution-stop.service';
 import { ScalingService } from '@/scaling/scaling.service';
 import type { Job } from '@/scaling/scaling.types';
+import type { OwnershipService } from '@/services/ownership.service';
 import type { WaitTracker } from '@/wait-tracker';
 import type { WorkflowRunner } from '@/workflow-runner';
 
@@ -40,6 +42,7 @@ describe('ExecutionService', () => {
 	const globalConfig = Container.get(GlobalConfig);
 	const executionRedactionServiceProxy = mock<ExecutionRedactionServiceProxy>();
 	const executionStopService = mock<ExecutionStopService>();
+	const ownershipService = mock<OwnershipService>();
 
 	const executionService = new ExecutionService(
 		globalConfig,
@@ -61,11 +64,15 @@ describe('ExecutionService', () => {
 		mock(),
 		executionRedactionServiceProxy,
 		executionStopService,
+		ownershipService,
 	);
 
 	beforeEach(() => {
 		globalConfig.executions.mode = 'regular';
 		vi.clearAllMocks();
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Test Project' }),
+		);
 	});
 
 	describe('findOne', () => {
@@ -195,6 +202,7 @@ describe('ExecutionService', () => {
 				mock(),
 				localExecutionRedactionProxy,
 				executionStopService,
+				ownershipService,
 			);
 
 			const mockUser = mock<User>({ id: 'user-1' });
@@ -279,6 +287,7 @@ describe('ExecutionService', () => {
 				mock(),
 				redactionProxy,
 				mock(),
+				ownershipService,
 			);
 
 			workflowRunner.run.mockResolvedValue('retried-123');

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -53,6 +53,7 @@ import type { IExecutionFlattedResponse } from '@/interfaces';
 import { License } from '@/license';
 import { NodeTypes } from '@/node-types';
 import { ExecutionStopService } from '@/scaling/execution-stop.service';
+import { OwnershipService } from '@/services/ownership.service';
 import { RoleService } from '@/services/role.service';
 import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
@@ -130,6 +131,7 @@ export class ExecutionService {
 		private readonly eventService: EventService,
 		private readonly executionRedactionServiceProxy: ExecutionRedactionServiceProxy,
 		private readonly executionStopService: ExecutionStopService,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	/**
@@ -348,6 +350,8 @@ export class ExecutionService {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
+		const project = await this.ownershipService.getWorkflowProjectCached(execution.workflowId);
+
 		this.eventService.emit('workflow-executed', {
 			user: {
 				id: req.user.id,
@@ -359,6 +363,8 @@ export class ExecutionService {
 			workflowId: execution.workflowId,
 			workflowName: execution.workflowData.name,
 			executionId: retriedExecutionId,
+			projectId: project.id,
+			projectName: project.name,
 			source: 'user-retry',
 		});
 

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -18,6 +18,7 @@ import {
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { stringify } from 'flatted';
 import { validate as jsonSchemaValidate } from 'jsonschema';
 import type {
@@ -28,7 +29,6 @@ import type {
 	IWorkflowExecutionDataProcess,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { ensureError } from '@n8n/utils/errors/ensure-error';
 import {
 	ExecutionStatusList,
 	ManualExecutionCancelledError,
@@ -57,6 +57,7 @@ import { OwnershipService } from '@/services/ownership.service';
 import { RoleService } from '@/services/role.service';
 import { WaitTracker } from '@/wait-tracker';
 import { WorkflowRunner } from '@/workflow-runner';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
 import { MissingExecutionDataError } from './execution-data/missing-execution-data.error';
@@ -350,7 +351,10 @@ export class ExecutionService {
 			throw new UnexpectedError('The retry did not start for an unknown reason.');
 		}
 
-		const project = await this.ownershipService.getWorkflowProjectCached(execution.workflowId);
+		const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+			this.ownershipService,
+			execution.workflowId,
+		);
 
 		this.eventService.emit('workflow-executed', {
 			user: {
@@ -363,8 +367,8 @@ export class ExecutionService {
 			workflowId: execution.workflowId,
 			workflowName: execution.workflowData.name,
 			executionId: retriedExecutionId,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 			source: 'user-retry',
 		});
 

--- a/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/__tests__/schedule-trigger-task-handler.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention -- item keys are pinned to the legacy ScheduleTrigger emit shape */
 import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
-import type { ExecutionEntity, ExecutionRepository } from '@n8n/db';
+import type { ExecutionEntity, ExecutionRepository, Project } from '@n8n/db';
 import type { ClaimedTask } from '@n8n/scheduler';
 import type { ErrorReporter } from 'n8n-core';
 import type { INode, IWorkflowBase, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
@@ -11,6 +11,7 @@ import { mock } from 'vitest-mock-extended';
 
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import type { EventService } from '@/events/event.service';
+import type { OwnershipService } from '@/services/ownership.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import type { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
 import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
@@ -24,6 +25,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 	const eventService = mock<EventService>();
 	const triggerExecutionContextFactory = mock<TriggerExecutionContextFactory>();
 	const workflowExecutionService = mock<WorkflowExecutionService>();
+	const ownershipService = mock<OwnershipService>();
 	const globalConfig = mock<GlobalConfig>({ generic: { timezone: 'America/New_York' } });
 	const additionalData = mock<IWorkflowExecuteAdditionalData>();
 
@@ -38,6 +40,7 @@ describe('ScheduleTriggerTaskHandler', () => {
 		eventService,
 		triggerExecutionContextFactory,
 		workflowExecutionService,
+		ownershipService,
 	);
 
 	// The executor's dispatch-marker callback; cleared each test by vi.clearAllMocks().
@@ -81,6 +84,9 @@ describe('ScheduleTriggerTaskHandler', () => {
 		vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(additionalData);
 		triggerExecutionContextFactory.loadPublishedWorkflowData.mockResolvedValue(buildWorkflowData());
 		workflowExecutionService.runWorkflow.mockResolvedValue('exec-1');
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'My Project' }),
+		);
 	});
 
 	describe('task type', () => {
@@ -158,10 +164,13 @@ describe('ScheduleTriggerTaskHandler', () => {
 		test('emits workflow-executed for the new execution', async () => {
 			await handler.execute(buildTask(), onDispatch);
 
+			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
 			expect(eventService.emit).toHaveBeenCalledWith('workflow-executed', {
 				workflowId: 'wf-1',
 				workflowName: 'My Scheduled Workflow',
 				executionId: 'exec-1',
+				projectId: 'project-1',
+				projectName: 'My Project',
 				source: 'trigger',
 			});
 		});

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -12,6 +12,7 @@ import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 
 import {
@@ -80,14 +81,17 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 
 			onDispatch();
 
-			const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+			const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+				this.ownershipService,
+				workflowData.id,
+			);
 
 			this.eventService.emit('workflow-executed', {
 				workflowId,
 				workflowName: workflowData.name,
 				executionId,
-				projectId: project.id,
-				projectName: project.name,
+				projectId,
+				projectName,
 				source: 'trigger',
 			});
 

--- a/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
+++ b/packages/cli/src/scheduling/schedule-trigger-node/schedule-trigger-task-handler.ts
@@ -9,6 +9,7 @@ import { UnexpectedError } from 'n8n-workflow';
 
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import { EventService } from '@/events/event.service';
+import { OwnershipService } from '@/services/ownership.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
@@ -39,6 +40,7 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 		private readonly eventService: EventService,
 		private readonly triggerExecutionContextFactory: TriggerExecutionContextFactory,
 		private readonly workflowExecutionService: WorkflowExecutionService,
+		private readonly ownershipService: OwnershipService,
 	) {
 		this.logger = this.logger.scoped('scheduler');
 	}
@@ -78,10 +80,14 @@ export class ScheduleTriggerTaskHandler implements TaskHandler {
 
 			onDispatch();
 
+			const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+
 			this.eventService.emit('workflow-executed', {
 				workflowId,
 				workflowName: workflowData.name,
 				executionId,
+				projectId: project.id,
+				projectName: project.name,
 				source: 'trigger',
 			});
 

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -462,7 +462,7 @@ export async function executeWebhook(
 		additionalKeys,
 	);
 
-	let project: Project | undefined = undefined;
+	let project: Project;
 	try {
 		project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowData.id);
 	} catch (error) {
@@ -871,6 +871,8 @@ export async function executeWebhook(
 			workflowId: workflowData.id,
 			workflowName: workflowData.name,
 			executionId,
+			projectId: project.id,
+			projectName: project.name,
 			source: 'webhook',
 		});
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -67,6 +67,7 @@ import { TaskRequester } from '@/task-runners/task-managers/task-requester';
 import { findSubworkflowStart } from '@/utils';
 import { objectToError } from '@/utils/object-to-error';
 import * as WorkflowHelpers from '@/workflow-helpers';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 
 import { RuntimeCredentialProxyService } from './services/runtime-credential-proxy.service';
@@ -319,15 +320,18 @@ export async function executeWorkflow(
 	const executionId = await activeExecutions.add(runData);
 
 	const { OwnershipService } = await import('@/services/ownership.service');
-	const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowData.id);
+	const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+		Container.get(OwnershipService),
+		workflowData.id,
+	);
 
 	Container.get(EventService).emit('workflow-executed', {
 		user: additionalData.userId ? { id: additionalData.userId } : undefined,
 		workflowId: workflowData.id,
 		workflowName: workflowData.name,
 		executionId,
-		projectId: project.id,
-		projectName: project.name,
+		projectId,
+		projectName,
 		source: 'integrated',
 	});
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -318,11 +318,16 @@ export async function executeWorkflow(
 
 	const executionId = await activeExecutions.add(runData);
 
+	const { OwnershipService } = await import('@/services/ownership.service');
+	const project = await Container.get(OwnershipService).getWorkflowProjectCached(workflowData.id);
+
 	Container.get(EventService).emit('workflow-executed', {
 		user: additionalData.userId ? { id: additionalData.userId } : undefined,
 		workflowId: workflowData.id,
 		workflowName: workflowData.name,
 		executionId,
+		projectId: project.id,
+		projectName: project.name,
 		source: 'integrated',
 	});
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -319,7 +319,7 @@ export async function executeWorkflow(
 
 	const executionId = await activeExecutions.add(runData);
 
-	const { OwnershipService } = await import('@/services/ownership.service');
+	const { OwnershipService } = await import('@/services/ownership.service.js');
 	const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
 		Container.get(OwnershipService),
 		workflowData.id,

--- a/packages/cli/src/workflows/__tests__/utils.test.ts
+++ b/packages/cli/src/workflows/__tests__/utils.test.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project } from '@n8n/db';
 import { WorkflowEntity } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
@@ -34,6 +36,8 @@ describe('dropRedactionPolicy', () => {
 });
 
 describe('getWorkflowProjectDetailsSafe', () => {
+	const logger = mockInstance(Logger);
+
 	it('returns the project id and name when the lookup succeeds', async () => {
 		const ownershipService = mock<OwnershipService>();
 		ownershipService.getWorkflowProjectCached.mockResolvedValue(
@@ -53,5 +57,6 @@ describe('getWorkflowProjectDetailsSafe', () => {
 		const result = await getWorkflowProjectDetailsSafe(ownershipService, 'workflow-id');
 
 		expect(result).toEqual({ projectId: '', projectName: '' });
+		expect(logger.warn).toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/workflows/__tests__/utils.test.ts
+++ b/packages/cli/src/workflows/__tests__/utils.test.ts
@@ -1,6 +1,9 @@
+import type { Project } from '@n8n/db';
 import { WorkflowEntity } from '@n8n/db';
+import { mock } from 'vitest-mock-extended';
 
-import { dropRedactionPolicy } from '@/workflows/utils';
+import type { OwnershipService } from '@/services/ownership.service';
+import { dropRedactionPolicy, getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 
 describe('dropRedactionPolicy', () => {
 	it('removes redactionPolicy when present', () => {
@@ -27,5 +30,28 @@ describe('dropRedactionPolicy', () => {
 
 		expect(() => dropRedactionPolicy(workflow)).not.toThrow();
 		expect(workflow.settings).toBeUndefined();
+	});
+});
+
+describe('getWorkflowProjectDetailsSafe', () => {
+	it('returns the project id and name when the lookup succeeds', async () => {
+		const ownershipService = mock<OwnershipService>();
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-id', name: 'Project Name' }),
+		);
+
+		const result = await getWorkflowProjectDetailsSafe(ownershipService, 'workflow-id');
+
+		expect(result).toEqual({ projectId: 'project-id', projectName: 'Project Name' });
+		expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('workflow-id');
+	});
+
+	it('falls back to empty strings when the lookup throws', async () => {
+		const ownershipService = mock<OwnershipService>();
+		ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('no project'));
+
+		const result = await getWorkflowProjectDetailsSafe(ownershipService, 'workflow-id');
+
+		expect(result).toEqual({ projectId: '', projectName: '' });
 	});
 });

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -13,6 +13,7 @@ import {
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 
+import type { EventService } from '@/events/event.service';
 import type { IWorkflowErrorData } from '@/interfaces';
 import type { NodeTypes } from '@/node-types';
 import type { OwnershipService } from '@/services/ownership.service';
@@ -1233,6 +1234,50 @@ describe('WorkflowExecutionService', () => {
 			// workflow separately (single query via the publication service).
 			expect(workflowRunnerMock.run).not.toHaveBeenCalled();
 			expect(workflowRepositoryMock.get).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('executeChatWorkflow()', () => {
+		test('should emit empty project fields when the project lookup fails', async () => {
+			const ownershipService = mock<OwnershipService>();
+			ownershipService.getWorkflowProjectCached.mockRejectedValue(new Error('no project'));
+
+			const eventService = mock<EventService>();
+			const workflowRunnerMock = mock<WorkflowRunner>();
+			workflowRunnerMock.run.mockResolvedValue('fake-execution-id');
+
+			const service = new WorkflowExecutionService(
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				nodeTypes,
+				mock(),
+				workflowRunnerMock,
+				mock(),
+				mock(),
+				mock(),
+				eventService,
+				ownershipService,
+				mock(),
+				mock(),
+				mock(),
+			);
+
+			const user = mock<User>({ id: 'user-id' });
+			const workflowData = mock<IWorkflowBase>({ id: 'workflow-id', name: 'Test Workflow' });
+
+			await service.executeChatWorkflow(user, workflowData, createRunExecutionData({}));
+
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-executed',
+				expect.objectContaining({ projectId: '', projectName: '' }),
+			);
+			expect(workflowRunnerMock.run).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: '', projectName: '' }),
+				undefined,
+				true,
+			);
 		});
 	});
 });

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Logger } from '@n8n/backend-common';
-import type { WorkflowEntity } from '@n8n/db';
+import type { Project, WorkflowEntity } from '@n8n/db';
 import { createDeferredPromise } from '@n8n/utils/promise/deferred-promise';
 import type { ErrorReporter, StorageConfig } from 'n8n-core';
 import { sleep, UnexpectedError } from 'n8n-workflow';
@@ -29,6 +29,7 @@ import type {
 	ScheduleTriggerCollectionSession,
 	ScheduleTriggerJobRegistrar,
 } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
+import type { OwnershipService } from '@/services/ownership.service';
 import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import type {
 	PublishedWorkflowDataForExecution,
@@ -53,6 +54,7 @@ describe('TriggerExecutionContextFactory', () => {
 	const storageConfig = mock<StorageConfig>({ modeTag: 'db' }) as unknown as StorageConfig;
 	const scheduleTriggerJobRegistrar = mock<ScheduleTriggerJobRegistrar>();
 	const scheduleCollectionSession = mock<ScheduleTriggerCollectionSession>();
+	const ownershipService = mock<OwnershipService>();
 
 	let factory: TriggerExecutionContextFactory;
 
@@ -61,6 +63,9 @@ describe('TriggerExecutionContextFactory', () => {
 		workflowStaticDataService.saveStaticData.mockResolvedValue(undefined);
 		workflowExecutionService.runWorkflow.mockResolvedValue('exec-123');
 		executionService.createErrorExecution.mockResolvedValue(undefined);
+		ownershipService.getWorkflowProjectCached.mockResolvedValue(
+			mock<Project>({ id: 'project-1', name: 'Test Project' }),
+		);
 
 		scheduleTriggerJobRegistrar.interceptsNode.mockReturnValue(false);
 		const scopedLogger = mock<Logger>();
@@ -77,6 +82,7 @@ describe('TriggerExecutionContextFactory', () => {
 			storageConfig,
 			workflowPublishedDataService,
 			scheduleTriggerJobRegistrar,
+			ownershipService,
 		);
 	});
 
@@ -119,6 +125,8 @@ describe('TriggerExecutionContextFactory', () => {
 					workflowId: workflowData.id,
 					workflowName: workflowData.name,
 					executionId: 'exec-123',
+					projectId: 'project-1',
+					projectName: 'Test Project',
 					source: 'trigger',
 				});
 			});

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -30,6 +30,7 @@ import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workfl
 import { ExecutionService } from '@/executions/execution.service';
 import type { ScheduleTriggerCollectionSession } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
 import { ScheduleTriggerJobRegistrar } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
+import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
@@ -65,6 +66,7 @@ export class TriggerExecutionContextFactory {
 		private readonly storageConfig: StorageConfig,
 		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
 		private readonly scheduleTriggerJobRegistrar: ScheduleTriggerJobRegistrar,
+		private readonly ownershipService: OwnershipService,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
 	}
@@ -129,14 +131,17 @@ export class TriggerExecutionContextFactory {
 						throw error;
 					});
 
-				void executePromise.then((executionId) => {
+				void executePromise.then(async (executionId) => {
 					// `executionId` is undefined when the catch above swallowed a
 					// duplicate scheduled execution; nothing ran, so nothing to emit.
 					if (executionId === undefined) return;
+					const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
 					this.eventService.emit('workflow-executed', {
 						workflowId: workflowData.id,
 						workflowName: workflowData.name,
 						executionId,
+						projectId: project.id,
+						projectName: project.name,
 						source: 'trigger',
 					});
 				});

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -31,6 +31,7 @@ import { ExecutionService } from '@/executions/execution.service';
 import type { ScheduleTriggerCollectionSession } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
 import { ScheduleTriggerJobRegistrar } from '@/scheduling/schedule-trigger-node/schedule-trigger-job-registrar';
 import { OwnershipService } from '@/services/ownership.service';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
@@ -135,13 +136,16 @@ export class TriggerExecutionContextFactory {
 					// `executionId` is undefined when the catch above swallowed a
 					// duplicate scheduled execution; nothing ran, so nothing to emit.
 					if (executionId === undefined) return;
-					const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+					const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+						this.ownershipService,
+						workflowData.id,
+					);
 					this.eventService.emit('workflow-executed', {
 						workflowId: workflowData.id,
 						workflowName: workflowData.name,
 						executionId,
-						projectId: project.id,
-						projectName: project.name,
+						projectId,
+						projectName,
 						source: 'trigger',
 					});
 				});

--- a/packages/cli/src/workflows/utils.ts
+++ b/packages/cli/src/workflows/utils.ts
@@ -1,4 +1,6 @@
+import { Logger } from '@n8n/backend-common';
 import type { WorkflowEntity } from '@n8n/db';
+import { Container } from '@n8n/di';
 import type { Scope } from '@n8n/permissions';
 import { NodeApiError, NodeError, WorkflowActivationError } from 'n8n-workflow';
 import type { WorkflowSettings } from 'n8n-workflow';
@@ -58,7 +60,11 @@ export async function getWorkflowProjectDetailsSafe(
 	try {
 		const project = await ownershipService.getWorkflowProjectCached(workflowId);
 		return { projectId: project.id, projectName: project.name };
-	} catch {
+	} catch (error) {
+		Container.get(Logger).warn('Failed to resolve owning project for workflow', {
+			workflowId,
+			error,
+		});
 		return { projectId: '', projectName: '' };
 	}
 }

--- a/packages/cli/src/workflows/utils.ts
+++ b/packages/cli/src/workflows/utils.ts
@@ -3,6 +3,8 @@ import type { Scope } from '@n8n/permissions';
 import { NodeApiError, NodeError, WorkflowActivationError } from 'n8n-workflow';
 import type { WorkflowSettings } from 'n8n-workflow';
 
+import type { OwnershipService } from '@/services/ownership.service';
+
 type RedactionMode = 'manual' | 'nonManual';
 
 const REDACTED_MODES: Record<WorkflowSettings.RedactionPolicy, ReadonlySet<RedactionMode>> = {
@@ -42,5 +44,21 @@ export function getErrorDescription(error: unknown): string | undefined {
 export function dropRedactionPolicy(newWorkflow: WorkflowEntity): void {
 	if (newWorkflow.settings?.redactionPolicy !== undefined) {
 		delete newWorkflow.settings.redactionPolicy;
+	}
+}
+
+/**
+ * Loads a workflow's owning project for event data purposes, falling back to empty
+ * strings when it can't be resolved. Project lookup must never break execution.
+ */
+export async function getWorkflowProjectDetailsSafe(
+	ownershipService: OwnershipService,
+	workflowId: string,
+): Promise<{ projectId: string; projectName: string }> {
+	try {
+		const project = await ownershipService.getWorkflowProjectCached(workflowId);
+		return { projectId: project.id, projectName: project.name };
+	} catch {
+		return { projectId: '', projectName: '' };
 	}
 }

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -315,6 +315,8 @@ export class WorkflowExecutionService {
 			workflowId: workflowData.id,
 			workflowName: workflowData.name,
 			executionId,
+			projectId: project.id,
+			projectName: project.name,
 			source: 'chat',
 		});
 
@@ -510,6 +512,8 @@ export class WorkflowExecutionService {
 				workflowId,
 				workflowName: workflowData.name,
 				executionId,
+				projectId: runningProject.id,
+				projectName: runningProject.name,
 				source: 'error',
 			});
 		} catch (error) {

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -88,6 +88,8 @@ export class WorkflowExecutionService {
 			},
 		});
 
+		const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+
 		// Start the workflow
 		const runData: IWorkflowExecutionDataProcess = {
 			userId: additionalData.userId,
@@ -95,8 +97,11 @@ export class WorkflowExecutionService {
 			executionData,
 			workflowData,
 			deduplicationKey,
+			projectId: project.id,
+			projectName: project.name,
 		};
 
+		console.log({ runData });
 		return await this.workflowRunner.run(runData, true, undefined, undefined, responsePromise);
 	}
 
@@ -272,6 +277,7 @@ export class WorkflowExecutionService {
 				});
 			}
 
+			console.log({ data });
 			const executionId = await this.workflowRunner.run(data);
 			return { executionId };
 		}
@@ -312,6 +318,8 @@ export class WorkflowExecutionService {
 			workflowName: workflowData.name,
 			executionId,
 			source: 'chat',
+			projectId: project.id,
+			projectName: project.name,
 		});
 
 		return {
@@ -507,6 +515,8 @@ export class WorkflowExecutionService {
 				workflowName: workflowData.name,
 				executionId,
 				source: 'error',
+				projectId: runningProject.id,
+				projectName: runningProject.name,
 			});
 		} catch (error) {
 			this.errorReporter.error(error);

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -101,7 +101,6 @@ export class WorkflowExecutionService {
 			projectName: project.name,
 		};
 
-		console.log({ runData });
 		return await this.workflowRunner.run(runData, true, undefined, undefined, responsePromise);
 	}
 
@@ -277,7 +276,6 @@ export class WorkflowExecutionService {
 				});
 			}
 
-			console.log({ data });
 			const executionId = await this.workflowRunner.run(data);
 			return { executionId };
 		}
@@ -318,8 +316,6 @@ export class WorkflowExecutionService {
 			workflowName: workflowData.name,
 			executionId,
 			source: 'chat',
-			projectId: project.id,
-			projectName: project.name,
 		});
 
 		return {
@@ -515,8 +511,6 @@ export class WorkflowExecutionService {
 				workflowName: workflowData.name,
 				executionId,
 				source: 'error',
-				projectId: runningProject.id,
-				projectName: runningProject.name,
 			});
 		} catch (error) {
 			this.errorReporter.error(error);

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -40,6 +40,7 @@ import { OwnershipService } from '@/services/ownership.service';
 import { TestWebhooks } from '@/webhooks/test-webhooks';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { WorkflowRunner } from '@/workflow-runner';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
 import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import type { WorkflowRequest } from '@/workflows/workflow.request';
 
@@ -88,7 +89,10 @@ export class WorkflowExecutionService {
 			},
 		});
 
-		const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+		const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+			this.ownershipService,
+			workflowData.id,
+		);
 
 		// Start the workflow
 		const runData: IWorkflowExecutionDataProcess = {
@@ -97,8 +101,8 @@ export class WorkflowExecutionService {
 			executionData,
 			workflowData,
 			deduplicationKey,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 		};
 
 		return await this.workflowRunner.run(runData, true, undefined, undefined, responsePromise);
@@ -233,9 +237,12 @@ export class WorkflowExecutionService {
 		}
 
 		if (data) {
-			const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
-			data.projectId = project.id;
-			data.projectName = project.name;
+			const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+				this.ownershipService,
+				workflowData.id,
+			);
+			data.projectId = projectId;
+			data.projectName = projectName;
 
 			data.encryptedRunnerIdentity = n8nAuthCookie
 				? await this.executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
@@ -294,7 +301,10 @@ export class WorkflowExecutionService {
 		executionMode: WorkflowExecuteMode = 'chat',
 		pushRef?: string,
 	) {
-		const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
+		const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+			this.ownershipService,
+			workflowData.id,
+		);
 
 		const data: IWorkflowExecutionDataProcess = {
 			userId: user.id,
@@ -304,8 +314,8 @@ export class WorkflowExecutionService {
 			streamingEnabled,
 			httpResponse,
 			pushRef,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 		};
 
 		const executionId = await this.workflowRunner.run(data, undefined, true);
@@ -315,8 +325,8 @@ export class WorkflowExecutionService {
 			workflowId: workflowData.id,
 			workflowName: workflowData.name,
 			executionId,
-			projectId: project.id,
-			projectName: project.name,
+			projectId,
+			projectName,
 			source: 'chat',
 		});
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -63,6 +63,7 @@ import { listQueryMiddleware } from '@/middlewares';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import * as ResponseHelper from '@/response-helper';
 import { NamingService } from '@/services/naming.service';
+import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
@@ -92,6 +93,7 @@ export class WorkflowsController {
 		private readonly ssrfProtectionService: SsrfProtectionService,
 		private readonly outboundHttp: OutboundHttp,
 		private readonly workflowPublicationStatusService: WorkflowPublicationStatusService,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	@Post('/')
@@ -532,6 +534,7 @@ export class WorkflowsController {
 		);
 
 		if ('executionId' in result) {
+			const project = await this.ownershipService.getWorkflowProjectCached(dbWorkflow.id);
 			this.eventService.emit('workflow-executed', {
 				user: {
 					id: req.user.id,
@@ -543,6 +546,8 @@ export class WorkflowsController {
 				workflowId: dbWorkflow.id,
 				workflowName: dbWorkflow.name,
 				executionId: result.executionId,
+				projectId: project.id,
+				projectName: project.name,
 				source: 'user-manual',
 			});
 		}

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -37,19 +37,9 @@ import {
 import { hasGlobalScope, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In, type FindOptionsRelations } from '@n8n/typeorm';
-import express from 'express';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
+import express from 'express';
 import { calculateWorkflowChecksum } from 'n8n-workflow';
-
-import { CollaborationService } from '../collaboration/collaboration.service';
-import { WorkflowPublicationStatusService } from './publication/workflow-publication-status.service';
-import { WorkflowCreationService } from './workflow-creation.service';
-import { createWorkflowEntityFromPayload } from './workflow-entity-mapper';
-import { WorkflowExecutionService } from './workflow-execution.service';
-import { WorkflowFinderService } from './workflow-finder.service';
-import { WorkflowRequest } from './workflow.request';
-import { WorkflowService } from './workflow.service';
-import { EnterpriseWorkflowService } from './workflow.service.ee';
 
 import { AuthService } from '@/auth/auth.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
@@ -67,6 +57,17 @@ import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
+import { getWorkflowProjectDetailsSafe } from '@/workflows/utils';
+
+import { CollaborationService } from '../collaboration/collaboration.service';
+import { WorkflowPublicationStatusService } from './publication/workflow-publication-status.service';
+import { WorkflowCreationService } from './workflow-creation.service';
+import { createWorkflowEntityFromPayload } from './workflow-entity-mapper';
+import { WorkflowExecutionService } from './workflow-execution.service';
+import { WorkflowFinderService } from './workflow-finder.service';
+import { WorkflowRequest } from './workflow.request';
+import { WorkflowService } from './workflow.service';
+import { EnterpriseWorkflowService } from './workflow.service.ee';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -534,7 +535,10 @@ export class WorkflowsController {
 		);
 
 		if ('executionId' in result) {
-			const project = await this.ownershipService.getWorkflowProjectCached(dbWorkflow.id);
+			const { projectId, projectName } = await getWorkflowProjectDetailsSafe(
+				this.ownershipService,
+				dbWorkflow.id,
+			);
 			this.eventService.emit('workflow-executed', {
 				user: {
 					id: req.user.id,
@@ -546,8 +550,8 @@ export class WorkflowsController {
 				workflowId: dbWorkflow.id,
 				workflowName: dbWorkflow.name,
 				executionId: result.executionId,
-				projectId: project.id,
-				projectName: project.name,
+				projectId,
+				projectName,
 				source: 'user-manual',
 			});
 		}

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -66,6 +66,7 @@ import { NamingService } from '@/services/naming.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
+import { OwnershipService } from '@/services/ownership.service';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -92,6 +93,7 @@ export class WorkflowsController {
 		private readonly ssrfProtectionService: SsrfProtectionService,
 		private readonly outboundHttp: OutboundHttp,
 		private readonly workflowPublicationStatusService: WorkflowPublicationStatusService,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	@Post('/')
@@ -531,6 +533,8 @@ export class WorkflowsController {
 			n8nAuthCookie,
 		);
 
+		const project = await this.ownershipService.getWorkflowProjectCached(dbWorkflow.id);
+
 		if ('executionId' in result) {
 			this.eventService.emit('workflow-executed', {
 				user: {
@@ -544,6 +548,8 @@ export class WorkflowsController {
 				workflowName: dbWorkflow.name,
 				executionId: result.executionId,
 				source: 'user-manual',
+				projectId: project.id,
+				projectName: project.name,
 			});
 		}
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -66,7 +66,6 @@ import { NamingService } from '@/services/naming.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { UserManagementMailer } from '@/user-management/email';
 import * as utils from '@/utils';
-import { OwnershipService } from '@/services/ownership.service';
 
 @RestController('/workflows')
 export class WorkflowsController {
@@ -93,7 +92,6 @@ export class WorkflowsController {
 		private readonly ssrfProtectionService: SsrfProtectionService,
 		private readonly outboundHttp: OutboundHttp,
 		private readonly workflowPublicationStatusService: WorkflowPublicationStatusService,
-		private readonly ownershipService: OwnershipService,
 	) {}
 
 	@Post('/')
@@ -533,8 +531,6 @@ export class WorkflowsController {
 			n8nAuthCookie,
 		);
 
-		const project = await this.ownershipService.getWorkflowProjectCached(dbWorkflow.id);
-
 		if ('executionId' in result) {
 			this.eventService.emit('workflow-executed', {
 				user: {
@@ -548,8 +544,6 @@ export class WorkflowsController {
 				workflowName: dbWorkflow.name,
 				executionId: result.executionId,
 				source: 'user-manual',
-				projectId: project.id,
-				projectName: project.name,
 			});
 		}
 

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -47,6 +47,8 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
+			mock(),
+			mock(),
 		);
 
 		owner = await createOwner();

--- a/packages/cli/test/integration/execution.service.integration.test.ts
+++ b/packages/cli/test/integration/execution.service.integration.test.ts
@@ -48,7 +48,6 @@ describe('ExecutionService', () => {
 			mock(),
 			mock(),
 			mock(),
-			mock(),
 		);
 
 		owner = await createOwner();


### PR DESCRIPTION
## Summary
Adds the relevant project ID and project name to the log entries for the following events:
- `n8n.workflow.started`
- `n8n.workflow.success`
- `n8n.workflow.failed`
- `n8n.audit.workflow.executed`
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
Configure log streaming to a destination, then trigger workflows covering the potential flows in the app, including
- manual trigger
- schedule trigger
- webhook trigger
- MCP trigger
- workflow failure

There should be no functional changes, but in the log entries (for the events listed above), the properties `projectName` and `projectId` should now appear whereas before they would have been absent.
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
https://linear.app/n8n/issue/IAM-900/bug-log-streaming-execution-events-omit-projectidprojectname-for
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33854">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->