### PR TITLE
fix(editor): Restore small tag size in personalization survey multi-selects

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nFormInput/FormInput.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormInput/FormInput.stories.ts
@@ -118,6 +118,36 @@ SchemaDriven.args = {
 	],
 };
 
+export const SchemaDrivenSmallTags = SchemaDrivenTemplate.bind({});
+SchemaDrivenSmallTags.args = {
+	columnView: true,
+	tagSize: 'small',
+	inputs: [
+		{
+			name: 'automationGoal',
+			properties: {
+				type: 'multi-select',
+				label: 'What are you looking to automate?',
+				options: [
+					{
+						label: 'Marketing',
+						value: 'marketing',
+					},
+					{
+						label: 'Sales',
+						value: 'sales',
+					},
+					{
+						label: 'Other',
+						value: 'other',
+					},
+				],
+			},
+			initialValue: ['marketing', 'other'],
+		},
+	],
+};
+
 const FramedFormTemplate: StoryFn = (args) => ({
 	setup: () => ({ args }),
 	components: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nFormInputs/FormInputs.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormInputs/FormInputs.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import type { IFormInput } from '@n8n/design-system/types';
 
 import FormInputs from './FormInputs.vue';
+import N8nFormInput from '../N8nFormInput';
 
 describe('FormInputs', () => {
 	describe('dangling field removal', () => {
@@ -436,6 +437,57 @@ describe('FormInputs', () => {
 			expect(result.field1.metadata).toEqual({ userId: 123, role: 'admin' });
 			expect(result.field1.metadata?.userId).toBe(123);
 			expect(result.field1.metadata?.role).toBe('admin');
+		});
+	});
+
+	describe('tag size', () => {
+		const multiSelectInput: IFormInput = {
+			name: 'skills',
+			properties: {
+				type: 'multi-select',
+				label: 'Skills',
+				options: [
+					{ label: 'One', value: 'one' },
+					{ label: 'Two', value: 'two' },
+				],
+			},
+		};
+
+		it('should pass tagSize down to each form input', () => {
+			const wrapper = mount(FormInputs, {
+				props: {
+					inputs: [multiSelectInput],
+					tagSize: 'small',
+				},
+			});
+
+			expect(wrapper.findComponent(N8nFormInput).props('tagSize')).toBe('small');
+		});
+
+		it('should let a per-field tagSize override the form-level one', () => {
+			const wrapper = mount(FormInputs, {
+				props: {
+					inputs: [
+						{
+							...multiSelectInput,
+							properties: { ...multiSelectInput.properties, tagSize: 'medium' },
+						},
+					],
+					tagSize: 'small',
+				},
+			});
+
+			expect(wrapper.findComponent(N8nFormInput).props('tagSize')).toBe('medium');
+		});
+
+		it('should keep the form input default when no tagSize is set', () => {
+			const wrapper = mount(FormInputs, {
+				props: {
+					inputs: [multiSelectInput],
+				},
+			});
+
+			expect(wrapper.findComponent(N8nFormInput).props('tagSize')).toBe('large');
 		});
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nFormInputs/FormInputs.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nFormInputs/FormInputs.vue
@@ -14,6 +14,7 @@ export interface FormInputsProps {
 	columnView?: boolean;
 	verticalSpacing?: '' | 'xs' | 's' | 'm' | 'l' | 'xl';
 	teleported?: boolean;
+	tagSize?: 'small' | 'medium' | 'large';
 }
 
 const props = withDefaults(defineProps<FormInputsProps>(), {
@@ -170,6 +171,7 @@ onMounted(() => {
 						v-bind="input.properties"
 						:name="input.name"
 						:label="input.properties.label || ''"
+						:tag-size="input.properties.tagSize ?? tagSize"
 						:model-value="values[input.name]"
 						:data-test-id="input.name"
 						:show-validation-warnings="showValidationWarnings"


### PR DESCRIPTION
## Summary

The personalization survey shown on first login renders selected multi-select values as oversized tags with broken padding.

`N8nFormInputs` lost its `tagSize` prop in #11040 (which moved tag sizing to per-field `properties.tagSize` and changed the `N8nFormInput` default from `small` to `large`), but `PersonalizationModal` still passes `tag-size="small"` at the container level. The attribute was silently ignored, so every survey field fell back to `large` and multi-select tags rendered with the default Element Plus padding.

This PR restores the `tagSize` prop on `N8nFormInputs`:

- **No default value** — consumers that don't pass it keep resolving `N8nFormInput`'s own `large` default, so the other 8 `N8nFormInputs` consumers (auth forms, LDAP settings, invite modal, …) are unaffected.
- **Per-field priority preserved** — `:tag-size="input.properties.tagSize ?? tagSize"` keeps the per-field mechanism from #11040 winning over the container-level prop.
- Adds a `SchemaDrivenSmallTags` Storybook story (multi-select with preselected tags) so Chromatic guards this visually.

**After (fixed):**
<img width="2452" height="1778" alt="image" src="https://github.com/user-attachments/assets/416e6825-ea6b-4a30-a466-fc815b579d6d" />

## How to test

1. On a fresh instance, complete owner setup — the personalization survey opens automatically.
2. Answer "What best describes your company?" with anything work-related (e.g. SaaS) and "Which role best describes you?" with Engineering/DevOps/IT.
3. "What are you looking to automate?" appears — select values and check the tags render compact (24px pills), not oversized.
4. Storybook: `Core/Form → Schema Driven Small Tags` — flip the `tagSize` control to `large`/unset to reproduce the pre-fix rendering.
5. Unit tests: `packages/frontend/@n8n/design-system` → `pnpm vitest run src/components/N8nFormInputs/FormInputs.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GROP-8

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

