### PR TITLE
fix(core): Reconcile data table name collisions on source control pull

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-ddl.service.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-ddl.service.test.ts
@@ -10,6 +10,7 @@ import * as sqlUtils from '../utils/sql-utils';
 vi.mock('../utils/sql-utils', async () => ({
 	...(await vi.importActual<typeof import('../utils/sql-utils')>('../utils/sql-utils')),
 	renameColumnQuery: vi.fn(),
+	renameTableQuery: vi.fn(),
 	toTableName: vi.fn(),
 }));
 
@@ -47,6 +48,47 @@ describe('DataTableDDLService', () => {
 
 		// Reset all mocks
 		vi.clearAllMocks();
+	});
+
+	describe('renameTable', () => {
+		beforeEach(() => {
+			(sqlUtils.toTableName as Mock).mockImplementation(
+				(id: string) => `n8n_data_table_user_${id}`,
+			);
+		});
+
+		it('should execute the rename table query', async () => {
+			const expectedQuery =
+				'ALTER TABLE "n8n_data_table_user_oldId1" RENAME TO "n8n_data_table_user_newId1"';
+			(sqlUtils.renameTableQuery as Mock).mockReturnValue(expectedQuery);
+
+			await ddlService.renameTable('oldId1', 'newId1', 'postgres');
+
+			expect(sqlUtils.renameTableQuery).toHaveBeenCalledWith(
+				'n8n_data_table_user_oldId1',
+				'n8n_data_table_user_newId1',
+				'postgres',
+			);
+			expect(mockEntityManager.query).toHaveBeenCalledWith(expectedQuery);
+		});
+
+		it('should reject invalid data table ids', async () => {
+			await expect(ddlService.renameTable('old-id!', 'newId1', 'postgres')).rejects.toThrow(
+				'Invalid data table ID',
+			);
+			expect(mockEntityManager.query).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('tableExists', () => {
+		it('should check the physical table via the query runner', async () => {
+			(sqlUtils.toTableName as Mock).mockReturnValue('n8n_data_table_user_dt1');
+			const hasTable = vi.fn().mockResolvedValue(true);
+			(mockEntityManager as any).queryRunner = { hasTable };
+
+			await expect(ddlService.tableExists('dt1')).resolves.toBe(true);
+			expect(hasTable).toHaveBeenCalledWith('n8n_data_table_user_dt1');
+		});
 	});
 
 	describe('renameColumn', () => {

--- a/packages/cli/src/modules/data-table/data-table-ddl.service.ts
+++ b/packages/cli/src/modules/data-table/data-table-ddl.service.ts
@@ -7,7 +7,9 @@ import { DataTableColumn } from './data-table-column.entity';
 import {
 	addColumnQuery,
 	deleteColumnQuery,
+	isValidDataTableId,
 	renameColumnQuery,
+	renameTableQuery,
 	toDslColumns,
 	toTableName,
 } from './utils/sql-utils';
@@ -45,6 +47,33 @@ export class DataTableDDLService {
 				throw new UnexpectedError('QueryRunner is not available');
 			}
 			await em.queryRunner.dropTable(toTableName(dataTableId), true);
+		});
+	}
+
+	async renameTable(
+		oldDataTableId: string,
+		newDataTableId: string,
+		dbType: DataSourceOptions['type'],
+		trx?: EntityManager,
+	) {
+		// These ids come from git files and the local DB rather than validated
+		// API requests, so guard before deriving SQL identifiers from them
+		if (!isValidDataTableId(oldDataTableId) || !isValidDataTableId(newDataTableId)) {
+			throw new UnexpectedError('Invalid data table ID');
+		}
+		await withTransaction(this.dataSource.manager, trx, async (em) => {
+			await em.query(
+				renameTableQuery(toTableName(oldDataTableId), toTableName(newDataTableId), dbType),
+			);
+		});
+	}
+
+	async tableExists(dataTableId: string, trx?: EntityManager): Promise<boolean> {
+		return await withTransaction(this.dataSource.manager, trx, async (em) => {
+			if (!em.queryRunner) {
+				throw new UnexpectedError('QueryRunner is not available');
+			}
+			return await em.queryRunner.hasTable(toTableName(dataTableId));
 		});
 	}
 

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -130,7 +130,7 @@ export function renameTableQuery(
 	newTableName: DataTableUserTableName,
 	dbType: DataSourceOptions['type'],
 ): string {
-	// `ALTER TABLE ... RENAME TO` is valid on SQLite, Postgres and MySQL 8+
+	// `ALTER TABLE ... RENAME TO` is valid on both SQLite and Postgres
 	return `ALTER TABLE ${quoteIdentifier(oldTableName, dbType)} RENAME TO ${quoteIdentifier(newTableName, dbType)}`;
 }
 

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -125,6 +125,15 @@ export function renameColumnQuery(
 	return `ALTER TABLE ${quotedTableName} RENAME COLUMN ${quotedOldName} TO ${quotedNewName}`;
 }
 
+export function renameTableQuery(
+	oldTableName: DataTableUserTableName,
+	newTableName: DataTableUserTableName,
+	dbType: DataSourceOptions['type'],
+): string {
+	// `ALTER TABLE ... RENAME TO` is valid on SQLite, Postgres and MySQL 8+
+	return `ALTER TABLE ${quoteIdentifier(oldTableName, dbType)} RENAME TO ${quoteIdentifier(newTableName, dbType)}`;
+}
+
 export function quoteIdentifier(name: string, dbType: DataSourceOptions['type']): string {
 	switch (dbType) {
 		case 'postgres':

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -21,7 +21,6 @@ import {
 	getTrackingInformationFromPrePushResult,
 	getTrackingInformationFromPullResult,
 	hasOwnerChanged,
-	isLosslessDataTableMerge,
 	isWorkflowModified,
 	mergeRemoteCrendetialDataIntoLocalCredentialData,
 	sanitizeCredentialData,
@@ -549,39 +548,6 @@ describe('Source Control Helper', () => {
 
 			const result = await readDataTablesFromSourceControlFile('valid/path/data_tables.json');
 			expect(result).toEqual(mockDataTables);
-		});
-	});
-
-	describe('isLosslessDataTableMerge', () => {
-		it('is lossless when every local column has an incoming (name, type) match', () => {
-			expect(
-				isLosslessDataTableMerge(
-					[{ name: 'a', type: 'string' }],
-					[
-						{ name: 'a', type: 'string' },
-						{ name: 'b', type: 'number' },
-					],
-				),
-			).toBe(true);
-		});
-
-		it('is lossless when the local table has no columns', () => {
-			expect(isLosslessDataTableMerge([], [{ name: 'a', type: 'string' }])).toBe(true);
-		});
-
-		it('is lossy when a local column is missing from the incoming table', () => {
-			expect(
-				isLosslessDataTableMerge(
-					[{ name: 'localOnly', type: 'string' }],
-					[{ name: 'a', type: 'string' }],
-				),
-			).toBe(false);
-		});
-
-		it('is lossy when a local column would be retyped', () => {
-			expect(
-				isLosslessDataTableMerge([{ name: 'a', type: 'string' }], [{ name: 'a', type: 'number' }]),
-			).toBe(false);
 		});
 	});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -21,6 +21,7 @@ import {
 	getTrackingInformationFromPrePushResult,
 	getTrackingInformationFromPullResult,
 	hasOwnerChanged,
+	isLosslessDataTableMerge,
 	isWorkflowModified,
 	mergeRemoteCrendetialDataIntoLocalCredentialData,
 	sanitizeCredentialData,
@@ -548,6 +549,39 @@ describe('Source Control Helper', () => {
 
 			const result = await readDataTablesFromSourceControlFile('valid/path/data_tables.json');
 			expect(result).toEqual(mockDataTables);
+		});
+	});
+
+	describe('isLosslessDataTableMerge', () => {
+		it('is lossless when every local column has an incoming (name, type) match', () => {
+			expect(
+				isLosslessDataTableMerge(
+					[{ name: 'a', type: 'string' }],
+					[
+						{ name: 'a', type: 'string' },
+						{ name: 'b', type: 'number' },
+					],
+				),
+			).toBe(true);
+		});
+
+		it('is lossless when the local table has no columns', () => {
+			expect(isLosslessDataTableMerge([], [{ name: 'a', type: 'string' }])).toBe(true);
+		});
+
+		it('is lossy when a local column is missing from the incoming table', () => {
+			expect(
+				isLosslessDataTableMerge(
+					[{ name: 'localOnly', type: 'string' }],
+					[{ name: 'a', type: 'string' }],
+				),
+			).toBe(false);
+		});
+
+		it('is lossy when a local column would be retyped', () => {
+			expect(
+				isLosslessDataTableMerge([{ name: 'a', type: 'string' }], [{ name: 'a', type: 'number' }]),
+			).toBe(false);
 		});
 	});
 

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -3604,7 +3604,7 @@ describe('SourceControlImportService', () => {
 						expect.objectContaining({ id: 'dt1' }),
 						['id'],
 					);
-					expect(result?.conflicts).toEqual([]);
+					expect(result?.reconciliationFailures).toEqual([]);
 				});
 
 				it('should degrade a failed adoption to a per-table conflict and import the rest', async () => {
@@ -3638,7 +3638,7 @@ describe('SourceControlImportService', () => {
 					await expect(
 						service.importDataTablesFromWorkFolder([mockCandidate, otherCandidate], mockUser.id),
 					).resolves.toMatchObject({
-						conflicts: [{ id: 'dt1', name: 'Test Table' }],
+						reconciliationFailures: [{ id: 'dt1', name: 'Test Table' }],
 					});
 					expect(mockLogger.error).toHaveBeenCalledWith(
 						expect.stringContaining('Test Table'),

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -39,7 +39,6 @@ import type { WorkflowHistoryService } from '@/workflows/workflow-history/workfl
 import type { WorkflowService } from '@/workflows/workflow.service';
 
 import type { SourceControlContextFactory } from '../source-control-context.factory';
-import type { SourceControlGitService } from '../source-control-git.service.ee';
 import { SourceControlImportService } from '../source-control-import.service.ee';
 import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { ExportableFolder } from '../types/exportable-folders';
@@ -71,7 +70,6 @@ describe('SourceControlImportService', () => {
 	const dataTableDDLService = mock<DataTableDDLService>();
 	const redactionEnforcementService = mock<RedactionEnforcementService>();
 	const dataTableSizeValidator = mock<DataTableSizeValidator>();
-	const gitService = mock<SourceControlGitService>();
 
 	const globalAdminContext = new SourceControlContext(
 		Object.assign(new User(), { role: GLOBAL_ADMIN_ROLE }),
@@ -111,7 +109,6 @@ describe('SourceControlImportService', () => {
 		dataTableDDLService,
 		redactionEnforcementService,
 		dataTableSizeValidator,
-		gitService,
 	);
 
 	const globMock = fastGlob.default as unknown as Mock<(...args: string[]) => Promise<string[]>>;
@@ -3241,7 +3238,6 @@ describe('SourceControlImportService', () => {
 					mockPersonalProject,
 					{ id: 'project1', type: 'team' },
 				] as any);
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 				dataTableDDLService.tableExists.mockResolvedValue(false);
 
 				mockTransaction = {
@@ -3525,12 +3521,7 @@ describe('SourceControlImportService', () => {
 					dataTableColumnRepository.save.mockImplementation(async (col: any) => col);
 				});
 
-				it('should adopt the incoming id when the local table was previously synced (recreated table)', async () => {
-					// Arrange — lossy merge, but the table's old id appears in git history
-					gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-						new Set(['datatables/dt-old.json']),
-					);
-
+				it('should adopt the incoming id on a name collision, even for a lossy merge', async () => {
 					// Act
 					const result = await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
 
@@ -3567,31 +3558,9 @@ describe('SourceControlImportService', () => {
 					expect(result?.conflicts).toEqual([]);
 				});
 
-				it('should adopt the incoming id for a never-synced table when the merge is lossless (pre-sync twin)', async () => {
-					// Arrange — never synced, but every local column has an incoming match
-					const losslessLocal = {
-						...localTable,
-						columns: [{ id: 'lc1', name: 'Column1', type: 'string', index: 0 }],
-					};
-					dataTableRepository.findOne.mockImplementation(async (opts: any) =>
-						opts?.where?.id ? ({ id: 'dt1', columns: [] } as any) : (losslessLocal as any),
-					);
-
-					// Act
-					const result = await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
-
-					// Assert
-					expect(dataTableDDLService.renameTable).toHaveBeenCalledWith(
-						'dt-old',
-						'dt1',
-						'sqlite',
-						mockTransaction,
-					);
-					expect(result?.conflicts).toEqual([]);
-				});
-
-				it('should skip a never-synced lossy collision as a per-table conflict and import the rest', async () => {
-					// Arrange — a second, collision-free table in the same pull
+				it('should degrade a failed adoption to a per-table conflict and import the rest', async () => {
+					// Arrange — a second, collision-free table in the same pull; the
+					// colliding table's adoption fails at the physical rename
 					const otherDataTable = {
 						...incomingDataTable,
 						id: 'dt2',
@@ -3613,16 +3582,19 @@ describe('SourceControlImportService', () => {
 						if (opts?.where?.id) return null;
 						return opts?.where?.name === 'Test Table' ? (localTable as any) : null;
 					});
+					dataTableDDLService.renameTable.mockRejectedValue(new Error('rename failed'));
 
-					// Act
-					const result = await service.importDataTablesFromWorkFolder(
-						[mockCandidate, otherCandidate],
-						mockUser.id,
+					// Act & Assert — resolves instead of rejecting; the colliding table is
+					// recorded as a conflict, the other table imports
+					await expect(
+						service.importDataTablesFromWorkFolder([mockCandidate, otherCandidate], mockUser.id),
+					).resolves.toMatchObject({
+						conflicts: [{ id: 'dt1', name: 'Test Table' }],
+					});
+					expect(mockLogger.error).toHaveBeenCalledWith(
+						expect.stringContaining('Test Table'),
+						expect.anything(),
 					);
-
-					// Assert — colliding table skipped, no throw, other table imported
-					expect(result?.conflicts).toEqual([{ id: 'dt1', name: 'Test Table' }]);
-					expect(dataTableDDLService.renameTable).not.toHaveBeenCalled();
 					expect(dataTableRepository.upsert).toHaveBeenCalledTimes(1);
 					expect(dataTableRepository.upsert).toHaveBeenCalledWith(
 						expect.objectContaining({ id: 'dt2' }),
@@ -3630,28 +3602,8 @@ describe('SourceControlImportService', () => {
 					);
 				});
 
-				it('should warn instead of blocking the whole import on an unreconcilable collision', async () => {
-					// Arrange — never synced, lossy merge (localTable has a LocalOnly column)
-					dataTableRepository.findOne.mockImplementation(async (opts: any) =>
-						opts?.where?.id ? null : (localTable as any),
-					);
-
-					// Act & Assert — resolves instead of rejecting; conflict is only warned about
-					await expect(
-						service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id),
-					).resolves.toMatchObject({
-						imported: [],
-						conflicts: [{ id: 'dt1', name: 'Test Table' }],
-					});
-					expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Test Table'));
-					expect(dataTableRepository.upsert).not.toHaveBeenCalled();
-				});
-
 				it('should complete a half-finished adoption without renaming again (idempotency)', async () => {
 					// Arrange — physical table already renamed, metadata still holds the old id
-					gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-						new Set(['datatables/dt-old.json']),
-					);
 					dataTableDDLService.tableExists.mockResolvedValue(true);
 
 					// Act

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -32,12 +32,14 @@ import { mock } from 'vitest-mock-extended';
 import type { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import type { DataTableColumnRepository } from '@/modules/data-table/data-table-column.repository';
 import type { DataTableDDLService } from '@/modules/data-table/data-table-ddl.service';
+import type { DataTableSizeValidator } from '@/modules/data-table/data-table-size-validator.service';
 import type { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import type { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
 import type { WorkflowHistoryService } from '@/workflows/workflow-history/workflow-history.service';
 import type { WorkflowService } from '@/workflows/workflow.service';
 
 import type { SourceControlContextFactory } from '../source-control-context.factory';
+import type { SourceControlGitService } from '../source-control-git.service.ee';
 import { SourceControlImportService } from '../source-control-import.service.ee';
 import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { ExportableFolder } from '../types/exportable-folders';
@@ -68,6 +70,8 @@ describe('SourceControlImportService', () => {
 	const dataTableColumnRepository = mock<DataTableColumnRepository>();
 	const dataTableDDLService = mock<DataTableDDLService>();
 	const redactionEnforcementService = mock<RedactionEnforcementService>();
+	const dataTableSizeValidator = mock<DataTableSizeValidator>();
+	const gitService = mock<SourceControlGitService>();
 
 	const globalAdminContext = new SourceControlContext(
 		Object.assign(new User(), { role: GLOBAL_ADMIN_ROLE }),
@@ -106,6 +110,8 @@ describe('SourceControlImportService', () => {
 		dataTableColumnRepository,
 		dataTableDDLService,
 		redactionEnforcementService,
+		dataTableSizeValidator,
+		gitService,
 	);
 
 	const globMock = fastGlob.default as unknown as Mock<(...args: string[]) => Promise<string[]>>;
@@ -3225,6 +3231,8 @@ describe('SourceControlImportService', () => {
 				updatedAt: '2024-01-01T00:00:00.000Z',
 			};
 
+			let mockTransaction: { save: Mock; delete: Mock; insert: Mock };
+
 			beforeEach(() => {
 				projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue(
 					mockPersonalProject as any,
@@ -3233,10 +3241,13 @@ describe('SourceControlImportService', () => {
 					mockPersonalProject,
 					{ id: 'project1', type: 'team' },
 				] as any);
+				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
+				dataTableDDLService.tableExists.mockResolvedValue(false);
 
-				const mockTransaction = {
+				mockTransaction = {
 					save: vi.fn(async (_entity: any, data: any) => data),
 					delete: vi.fn(async () => {}),
+					insert: vi.fn(async () => {}),
 				};
 
 				Object.defineProperty(dataTableRepository, 'manager', {
@@ -3475,9 +3486,8 @@ describe('SourceControlImportService', () => {
 				expect(dataTableRepository.upsert).not.toHaveBeenCalled();
 			});
 
-			it('should throw UserError when a data table with the same name but different ID exists locally', async () => {
-				// Arrange
-				const mockDataTable = {
+			describe('name collisions (same name, different id)', () => {
+				const incomingDataTable = {
 					id: 'dt1',
 					name: 'Test Table',
 					ownedBy: {
@@ -3490,20 +3500,173 @@ describe('SourceControlImportService', () => {
 					updatedAt: '2024-01-02T00:00:00.000Z',
 				};
 
-				fsReadFile.mockResolvedValue(JSON.stringify(mockDataTable) as any);
-				projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
+				const localColumns = [
+					{ id: 'lc1', name: 'Column1', type: 'string', index: 0 },
+					{ id: 'lc2', name: 'LocalOnly', type: 'number', index: 1 },
+				];
 
-				// Return a different ID for the same name — simulates name collision
-				dataTableRepository.findOne.mockResolvedValueOnce({ id: 'dt-other' } as any);
+				const localTable = {
+					id: 'dt-old',
+					name: 'Test Table',
+					projectId: 'project1',
+					columns: localColumns,
+					createdAt: new Date('2023-01-01T00:00:00.000Z'),
+					updatedAt: new Date('2023-01-02T00:00:00.000Z'),
+				};
 
-				// Act & Assert
-				await expect(
-					service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id),
-				).rejects.toThrow(
-					'A data table with the name <strong>Test Table</strong> already exists locally.',
-				);
+				beforeEach(() => {
+					fsReadFile.mockResolvedValue(JSON.stringify(incomingDataTable) as any);
+					projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
+					// Phase 2 looks the table up by (name, project); Phase 3 by the adopted id
+					dataTableRepository.findOne.mockImplementation(async (opts: any) =>
+						opts?.where?.id ? ({ id: 'dt1', columns: localColumns } as any) : (localTable as any),
+					);
+					dataTableColumnRepository.find.mockResolvedValue([] as any);
+					dataTableColumnRepository.save.mockImplementation(async (col: any) => col);
+				});
 
-				expect(dataTableRepository.upsert).not.toHaveBeenCalled();
+				it('should adopt the incoming id when the local table was previously synced (recreated table)', async () => {
+					// Arrange — lossy merge, but the table's old id appears in git history
+					gitService.getHistoricallyTrackedFiles.mockResolvedValue(
+						new Set(['datatables/dt-old.json']),
+					);
+
+					// Act
+					const result = await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
+
+					// Assert
+					expect(dataTableDDLService.renameTable).toHaveBeenCalledWith(
+						'dt-old',
+						'dt1',
+						'sqlite',
+						mockTransaction,
+					);
+					expect(mockTransaction.delete).toHaveBeenCalledWith(expect.anything(), {
+						id: 'dt-old',
+					});
+					expect(mockTransaction.insert).toHaveBeenCalledWith(
+						expect.anything(),
+						expect.objectContaining({ id: 'dt1', name: 'Test Table', projectId: 'project1' }),
+					);
+					// Matching (name, type) column adopts the incoming column id
+					expect(mockTransaction.insert).toHaveBeenCalledWith(
+						expect.anything(),
+						expect.objectContaining({ id: 'col1', name: 'Column1', dataTableId: 'dt1' }),
+					);
+					// Non-matching local column keeps its id (dropped later by schema alignment)
+					expect(mockTransaction.insert).toHaveBeenCalledWith(
+						expect.anything(),
+						expect.objectContaining({ id: 'lc2', name: 'LocalOnly', dataTableId: 'dt1' }),
+					);
+					expect(dataTableSizeValidator.reset).toHaveBeenCalled();
+					// The regular import path still runs
+					expect(dataTableRepository.upsert).toHaveBeenCalledWith(
+						expect.objectContaining({ id: 'dt1' }),
+						['id'],
+					);
+					expect(result?.conflicts).toEqual([]);
+				});
+
+				it('should adopt the incoming id for a never-synced table when the merge is lossless (pre-sync twin)', async () => {
+					// Arrange — never synced, but every local column has an incoming match
+					const losslessLocal = {
+						...localTable,
+						columns: [{ id: 'lc1', name: 'Column1', type: 'string', index: 0 }],
+					};
+					dataTableRepository.findOne.mockImplementation(async (opts: any) =>
+						opts?.where?.id ? ({ id: 'dt1', columns: [] } as any) : (losslessLocal as any),
+					);
+
+					// Act
+					const result = await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
+
+					// Assert
+					expect(dataTableDDLService.renameTable).toHaveBeenCalledWith(
+						'dt-old',
+						'dt1',
+						'sqlite',
+						mockTransaction,
+					);
+					expect(result?.conflicts).toEqual([]);
+				});
+
+				it('should skip a never-synced lossy collision as a per-table conflict and import the rest', async () => {
+					// Arrange — a second, collision-free table in the same pull
+					const otherDataTable = {
+						...incomingDataTable,
+						id: 'dt2',
+						name: 'Other Table',
+						columns: [{ id: 'col9', name: 'Column9', type: 'string', index: 0 }],
+					};
+					const otherCandidate = {
+						...mockCandidate,
+						id: 'dt2',
+						name: 'Other Table',
+						file: '/mock/n8n/git/datatables/dt2.json',
+					};
+					fsReadFile.mockImplementation(async (file: any) =>
+						String(file).includes('dt2')
+							? (JSON.stringify(otherDataTable) as any)
+							: (JSON.stringify(incomingDataTable) as any),
+					);
+					dataTableRepository.findOne.mockImplementation(async (opts: any) => {
+						if (opts?.where?.id) return null;
+						return opts?.where?.name === 'Test Table' ? (localTable as any) : null;
+					});
+
+					// Act
+					const result = await service.importDataTablesFromWorkFolder(
+						[mockCandidate, otherCandidate],
+						mockUser.id,
+					);
+
+					// Assert — colliding table skipped, no throw, other table imported
+					expect(result?.conflicts).toEqual([{ id: 'dt1', name: 'Test Table' }]);
+					expect(dataTableDDLService.renameTable).not.toHaveBeenCalled();
+					expect(dataTableRepository.upsert).toHaveBeenCalledTimes(1);
+					expect(dataTableRepository.upsert).toHaveBeenCalledWith(
+						expect.objectContaining({ id: 'dt2' }),
+						['id'],
+					);
+				});
+
+				it('should warn instead of blocking the whole import on an unreconcilable collision', async () => {
+					// Arrange — never synced, lossy merge (localTable has a LocalOnly column)
+					dataTableRepository.findOne.mockImplementation(async (opts: any) =>
+						opts?.where?.id ? null : (localTable as any),
+					);
+
+					// Act & Assert — resolves instead of rejecting; conflict is only warned about
+					await expect(
+						service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id),
+					).resolves.toMatchObject({
+						imported: [],
+						conflicts: [{ id: 'dt1', name: 'Test Table' }],
+					});
+					expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Test Table'));
+					expect(dataTableRepository.upsert).not.toHaveBeenCalled();
+				});
+
+				it('should complete a half-finished adoption without renaming again (idempotency)', async () => {
+					// Arrange — physical table already renamed, metadata still holds the old id
+					gitService.getHistoricallyTrackedFiles.mockResolvedValue(
+						new Set(['datatables/dt-old.json']),
+					);
+					dataTableDDLService.tableExists.mockResolvedValue(true);
+
+					// Act
+					await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
+
+					// Assert — metadata swap still runs, rename is skipped
+					expect(dataTableDDLService.renameTable).not.toHaveBeenCalled();
+					expect(mockTransaction.delete).toHaveBeenCalledWith(expect.anything(), {
+						id: 'dt-old',
+					});
+					expect(mockTransaction.insert).toHaveBeenCalledWith(
+						expect.anything(),
+						expect.objectContaining({ id: 'dt1' }),
+					);
+				});
 			});
 
 			it('should skip columns with invalid names', async () => {
@@ -3571,49 +3734,6 @@ describe('SourceControlImportService', () => {
 				await service.importDataTablesFromWorkFolder([mockCandidate], mockUser.id);
 
 				// Assert
-				expect(dataTableRepository.upsert).not.toHaveBeenCalled();
-			});
-
-			it('should not partially import when a name collision exists among multiple tables', async () => {
-				// Arrange — two tables: dt1 is valid, dt2 has a name collision
-				const validTable = {
-					id: 'dt1',
-					name: 'Valid Table',
-					ownedBy: { type: 'team', teamId: 'project1', teamName: 'Team Project 1' },
-					columns: [{ id: 'col1', name: 'Column1', type: 'string', index: 0 }],
-					createdAt: '2024-01-01T00:00:00.000Z',
-					updatedAt: '2024-01-02T00:00:00.000Z',
-				};
-				const collidingTable = {
-					id: 'dt2',
-					name: 'Colliding Table',
-					ownedBy: { type: 'team', teamId: 'project1', teamName: 'Team Project 1' },
-					columns: [{ id: 'col2', name: 'Column2', type: 'string', index: 0 }],
-					createdAt: '2024-01-01T00:00:00.000Z',
-					updatedAt: '2024-01-02T00:00:00.000Z',
-				};
-
-				fsReadFile
-					.mockResolvedValueOnce(JSON.stringify(validTable) as any)
-					.mockResolvedValueOnce(JSON.stringify(collidingTable) as any);
-				projectRepository.findOne.mockResolvedValue({ id: 'project1', type: 'team' } as any);
-
-				// First call (for "Valid Table") → no collision
-				dataTableRepository.findOne.mockResolvedValueOnce(null as any);
-				// Second call (for "Colliding Table") → collision with a different ID
-				dataTableRepository.findOne.mockResolvedValueOnce({ id: 'dt-other' } as any);
-
-				const candidate1 = { ...mockCandidate, id: 'dt1', name: 'Valid Table' };
-				const candidate2 = { ...mockCandidate, id: 'dt2', name: 'Colliding Table' };
-
-				// Act & Assert — the whole operation should fail
-				await expect(
-					service.importDataTablesFromWorkFolder([candidate1, candidate2], mockUser.id),
-				).rejects.toThrow(
-					'A data table with the name <strong>Colliding Table</strong> already exists locally.',
-				);
-
-				// No table should have been imported (no partial import)
 				expect(dataTableRepository.upsert).not.toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -2971,6 +2971,55 @@ describe('SourceControlImportService', () => {
 		});
 	});
 
+	describe('resolveRemoteDataTableProjectId', () => {
+		it('resolves a team owner to the team id', async () => {
+			await expect(
+				service.resolveRemoteDataTableProjectId(
+					{ type: 'team', teamId: 'team1', teamName: 'Team 1' },
+					'puller',
+				),
+			).resolves.toBe('team1');
+		});
+
+		it('resolves a known personal owner to their personal project', async () => {
+			userRepository.findOne.mockResolvedValue({ id: 'user1' } as any);
+			projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue({ id: 'pp1' } as any);
+
+			await expect(
+				service.resolveRemoteDataTableProjectId(
+					{ type: 'personal', personalEmail: 'owner@test.com' },
+					'puller',
+				),
+			).resolves.toBe('pp1');
+			expect(projectRepository.getPersonalProjectForUserOrFail).toHaveBeenCalledWith('user1');
+		});
+
+		it("falls back to the pulling user's personal project for an unknown personal owner", async () => {
+			userRepository.findOne.mockResolvedValue(null);
+			projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue({
+				id: 'pp-puller',
+			} as any);
+
+			await expect(
+				service.resolveRemoteDataTableProjectId(
+					{ type: 'personal', personalEmail: 'unknown@test.com' },
+					'puller',
+				),
+			).resolves.toBe('pp-puller');
+			expect(projectRepository.getPersonalProjectForUserOrFail).toHaveBeenCalledWith('puller');
+		});
+
+		it("falls back to the pulling user's personal project when there is no owner", async () => {
+			projectRepository.getPersonalProjectForUserOrFail.mockResolvedValue({
+				id: 'pp-puller',
+			} as any);
+
+			await expect(service.resolveRemoteDataTableProjectId(null, 'puller')).resolves.toBe(
+				'pp-puller',
+			);
+		});
+	});
+
 	describe('Data Tables', () => {
 		describe('getRemoteDataTablesFromFiles', () => {
 			it('should return data tables from individual files', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -2747,13 +2747,17 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT — collision must be flagged even though the local table was never synced
+				// ASSERT — exactly ONE entry for the collision: a conflict on the
+				// incoming table, never a plain "created" alongside it
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
-				const collisionFile = result.find(
-					(f) => f.type === 'datatable' && f.status === 'modified' && f.conflict,
-				);
-				expect(collisionFile).toBeDefined();
-				expect(collisionFile?.name).toBe('Shared Name');
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-remote',
+					name: 'Shared Name',
+					status: 'modified',
+					conflict: true,
+				});
 			});
 
 			it('should mark a recreated table (previously synced, lossy merge) as reconcilable during pull', async () => {
@@ -2788,21 +2792,24 @@ describe('getStatus', () => {
 					new Set(['datatables/dt-local.json']),
 				);
 
-				// ACT
+				// ACT — preferLocalVersion true (the UI dry-run flag) must not change
+				// which id the entry carries
 				const result = await sourceControlStatusService.getStatus(user, {
 					direction: 'pull',
 					verbose: false,
-					preferLocalVersion: false,
+					preferLocalVersion: true,
 				});
 
-				// ASSERT
+				// ASSERT — exactly ONE "modified" entry carrying the incoming id: no
+				// "created" for the incoming id, no "deleted" for the old local id
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
-				const collisionFile = result.find(
-					(f) => f.type === 'datatable' && f.id === 'dt-recreated' && f.status === 'modified',
-				);
-				expect(collisionFile).toBeDefined();
-				expect(collisionFile?.status).toBe('modified');
-				expect(collisionFile?.conflict).toBe(false);
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-recreated',
+					status: 'modified',
+					conflict: false,
+				});
 			});
 
 			it('should mark a pre-sync twin (never synced, lossless merge) as reconcilable during pull', async () => {
@@ -2843,14 +2850,125 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
+				// ASSERT — exactly ONE "modified" entry for the merge, no "created"
+				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-remote',
+					status: 'modified',
+					conflict: false,
+				});
+			});
+
+			it('should detect a collision even when another project has a same-named remote table', async () => {
+				// ARRANGE — the other-project table is listed last so a name-only
+				// lookup would mask the real same-project collision
+				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+
+				const remoteSameProject = {
+					id: 'dt-remote-a',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const remoteOtherProject = {
+					id: 'dt-remote-b',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, teamId: 'projB', teamName: 'ProjectB' },
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const localDataTable = {
+					id: 'dt-local',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
+					filename: 'test.json',
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
+					remoteSameProject,
+					remoteOtherProject,
+				]);
+				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
+				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
+					new Set(['datatables/dt-local.json']),
+				);
+
+				// ACT
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				});
+
+				// ASSERT — the same-project collision reconciles; the other-project
+				// table is an unrelated plain create
+				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(2);
+				expect(dataTableFiles).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: 'dt-remote-a', status: 'modified', conflict: false }),
+						expect.objectContaining({ id: 'dt-remote-b', status: 'created' }),
+					]),
+				);
+			});
+
+			it('should keep the created + conflict entry pair for a name collision during push', async () => {
+				// ARRANGE — the single-entry collision shape applies to pull only
+				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+
+				const remoteDataTable = {
+					id: 'dt-remote',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const localDataTable = {
+					id: 'dt-local',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
+					filename: 'test.json',
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
+					remoteDataTable,
+				]);
+				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
+				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
+
+				// ACT
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'push',
+					verbose: false,
+					preferLocalVersion: true,
+				});
+
 				// ASSERT
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
-				const collisionFile = result.find(
-					(f) => f.type === 'datatable' && f.id === 'dt-remote' && f.status === 'modified',
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(2);
+				expect(dataTableFiles).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: 'dt-local', status: 'modified', conflict: true }),
+						expect.objectContaining({ id: 'dt-local', status: 'created' }),
+					]),
 				);
-				expect(collisionFile).toBeDefined();
-				expect(collisionFile?.status).toBe('modified');
-				expect(collisionFile?.conflict).toBe(false);
 			});
 		});
 	});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -2709,7 +2709,7 @@ describe('getStatus', () => {
 				expect(dataTableFiles[0].status).toBe('created');
 			});
 
-			it('should detect name collision during pull even when local table was never synced', async () => {
+			it('should flag a genuine collision (never synced, lossy merge) as conflict during pull', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2717,7 +2717,7 @@ describe('getStatus', () => {
 					id: 'dt-remote',
 					name: 'Shared Name',
 					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
-					columns: [],
+					columns: [{ id: 'rc1', name: 'other', type: 'string', index: 0 }],
 					createdAt: '2024-01-01T00:00:00.000Z',
 					updatedAt: '2024-01-01T00:00:00.000Z',
 				};
@@ -2727,7 +2727,8 @@ describe('getStatus', () => {
 					name: 'Shared Name',
 					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
 					filename: 'test.json',
-					columns: [],
+					// Local-only column that the incoming table lacks — lossy merge
+					columns: [{ id: 'lc1', name: 'localOnly', type: 'string', index: 0 }],
 					createdAt: '2024-01-01T00:00:00.000Z',
 					updatedAt: '2024-01-01T00:00:00.000Z',
 				};
@@ -2753,6 +2754,103 @@ describe('getStatus', () => {
 				);
 				expect(collisionFile).toBeDefined();
 				expect(collisionFile?.name).toBe('Shared Name');
+			});
+
+			it('should mark a recreated table (previously synced, lossy merge) as reconcilable during pull', async () => {
+				// ARRANGE
+				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+
+				const remoteDataTable = {
+					id: 'dt-recreated',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
+					columns: [{ id: 'rc1', name: 'other', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const localDataTable = {
+					id: 'dt-local',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
+					filename: 'test.json',
+					columns: [{ id: 'lc1', name: 'localOnly', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
+					remoteDataTable,
+				]);
+				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
+				// Local table id appears in git history — delete+recreate upstream
+				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
+					new Set(['datatables/dt-local.json']),
+				);
+
+				// ACT
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				});
+
+				// ASSERT
+				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
+				const collisionFile = result.find(
+					(f) => f.type === 'datatable' && f.id === 'dt-recreated' && f.status === 'modified',
+				);
+				expect(collisionFile).toBeDefined();
+				expect(collisionFile?.status).toBe('modified');
+				expect(collisionFile?.conflict).toBe(false);
+			});
+
+			it('should mark a pre-sync twin (never synced, lossless merge) as reconcilable during pull', async () => {
+				// ARRANGE
+				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+
+				const sharedColumns = [{ id: 'rc1', name: 'shared', type: 'string', index: 0 }];
+				const remoteDataTable = {
+					id: 'dt-remote',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
+					columns: sharedColumns,
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const localDataTable = {
+					id: 'dt-local',
+					name: 'Shared Name',
+					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
+					filename: 'test.json',
+					// Same (name, type) columns under a different id — lossless merge
+					columns: [{ id: 'lc1', name: 'shared', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
+					remoteDataTable,
+				]);
+				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
+				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
+
+				// ACT
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				});
+
+				// ASSERT
+				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
+				const collisionFile = result.find(
+					(f) => f.type === 'datatable' && f.id === 'dt-remote' && f.status === 'modified',
+				);
+				expect(collisionFile).toBeDefined();
+				expect(collisionFile?.status).toBe('modified');
+				expect(collisionFile?.conflict).toBe(false);
 			});
 		});
 	});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -110,7 +110,6 @@ describe('getStatus', () => {
 		// data tables
 		sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([]);
 		sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([]);
-		gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 		// repositories
 		tagRepository.find.mockResolvedValue([]);
@@ -1853,8 +1852,6 @@ describe('getStatus', () => {
 
 			sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([remoteDataTable]);
 			sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([]);
-			// Table was previously synced, so it should be marked as deleted during push
-			gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set(['datatables/dt1.json']));
 
 			// ACT
 			const result = await sourceControlStatusService.getStatus(user, {
@@ -2056,8 +2053,6 @@ describe('getStatus', () => {
 
 			sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue(remoteDataTables);
 			sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue(localDataTables);
-			// dt8 was previously synced, so it should be marked as deleted during push
-			gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set(['datatables/dt8.json']));
 
 			// ACT
 			const result = await sourceControlStatusService.getStatus(user, {
@@ -2512,8 +2507,8 @@ describe('getStatus', () => {
 			});
 		});
 
-		describe('git history protection', () => {
-			it('should not mark local-only data table as deleted during pull when never synced', async () => {
+		describe('git as source of truth', () => {
+			it('should mark local-only data table as deleted during pull', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2529,8 +2524,6 @@ describe('getStatus', () => {
 
 				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				// Table was never synced — no git history
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2539,50 +2532,19 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT
+				// ASSERT — a table absent from git is deleted on pull, surfaced as a
+				// conflict so the non-force pull requires confirmation
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				expect(dataTableFiles).toHaveLength(0);
-			});
-
-			it('should mark local-only data table as deleted during pull when previously synced', async () => {
-				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
-
-				const localDataTable = {
-					id: 'dt-was-synced',
-					name: 'Previously Synced Table',
-					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
-					filename: 'test.json',
-					columns: [],
-					createdAt: '2024-01-01T00:00:00.000Z',
-					updatedAt: '2024-01-01T00:00:00.000Z',
-				};
-
-				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([]);
-				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				// Table was previously synced — exists in git history
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-					new Set(['datatables/dt-was-synced.json']),
-				);
-
-				// ACT
-				const result = await sourceControlStatusService.getStatus(user, {
-					direction: 'pull',
-					verbose: false,
-					preferLocalVersion: false,
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-local-only',
+					status: 'deleted',
+					conflict: true,
 				});
-
-				// ASSERT
-				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
-				const dataTableFile = result.find(
-					(f) => f.type === 'datatable' && f.id === 'dt-was-synced',
-				);
-				expect(dataTableFile).toBeDefined();
-				expect(dataTableFile?.status).toBe('deleted');
 			});
 
-			it('should not mark remote-only data table as deleted during push when never synced locally', async () => {
+			it('should mark remote-only data table as deleted during push', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2599,8 +2561,6 @@ describe('getStatus', () => {
 					remoteDataTable,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([]);
-				// Table was never synced from this instance
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2609,13 +2569,18 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT
+				// ASSERT — a table absent locally is offered as a deletion to push
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				expect(dataTableFiles).toHaveLength(0);
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-remote-only',
+					status: 'deleted',
+					location: 'local',
+				});
 			});
 
-			it('should preserve local table during pull when remote has same-named table in different project', async () => {
+			it('should not treat same-named tables in different projects as a collision during pull', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2642,10 +2607,6 @@ describe('getStatus', () => {
 					remoteDataTable,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				// Only the remote table has git history — local was never pushed
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-					new Set(['datatables/dt-remote.json']),
-				);
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2654,16 +2615,20 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT
+				// ASSERT — same name in DIFFERENT projects is not a collision: the
+				// remote table is a plain create, the local one a plain delete
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				// Only the remote table should appear as "created", local table should be preserved (not listed)
-				expect(dataTableFiles).toHaveLength(1);
-				expect(dataTableFiles[0].id).toBe('dt-remote');
-				expect(dataTableFiles[0].status).toBe('created');
+				expect(dataTableFiles).toHaveLength(2);
+				expect(dataTableFiles).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: 'dt-remote', status: 'created' }),
+						expect.objectContaining({ id: 'dt-local', status: 'deleted' }),
+					]),
+				);
 			});
 
-			it('should not delete remote table from another instance during push', async () => {
+			it('should offer a remote-only table as a deletion during push even when a same-named local table exists in another project', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2690,8 +2655,6 @@ describe('getStatus', () => {
 					remoteFromInstanceA,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localTable]);
-				// Only the local table has been synced from this instance, not Instance A's table
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2700,16 +2663,20 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT
+				// ASSERT — different projects, so no collision: local is a plain
+				// create, the remote-only table an offered deletion
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				// Local table should be "created", remote table should NOT be "deleted"
-				expect(dataTableFiles).toHaveLength(1);
-				expect(dataTableFiles[0].id).toBe('dt-local');
-				expect(dataTableFiles[0].status).toBe('created');
+				expect(dataTableFiles).toHaveLength(2);
+				expect(dataTableFiles).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({ id: 'dt-local', status: 'created' }),
+						expect.objectContaining({ id: 'dt-instance-a', status: 'deleted' }),
+					]),
+				);
 			});
 
-			it('should flag a genuine collision (never synced, lossy merge) as conflict during pull', async () => {
+			it('should emit a single modified entry for a name collision during pull', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
@@ -2727,7 +2694,6 @@ describe('getStatus', () => {
 					name: 'Shared Name',
 					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
 					filename: 'test.json',
-					// Local-only column that the incoming table lacks — lossy merge
 					columns: [{ id: 'lc1', name: 'localOnly', type: 'string', index: 0 }],
 					createdAt: '2024-01-01T00:00:00.000Z',
 					updatedAt: '2024-01-01T00:00:00.000Z',
@@ -2737,8 +2703,6 @@ describe('getStatus', () => {
 					remoteDataTable,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				// Local table was never synced
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2747,8 +2711,9 @@ describe('getStatus', () => {
 					preferLocalVersion: false,
 				});
 
-				// ASSERT — exactly ONE entry for the collision: a conflict on the
-				// incoming table, never a plain "created" alongside it
+				// ASSERT — exactly ONE "modified" entry carrying the incoming id,
+				// flagged like any other schema modification: no "created" for the
+				// incoming id, no "deleted" for the old local id
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
 				expect(dataTableFiles).toHaveLength(1);
@@ -2760,12 +2725,12 @@ describe('getStatus', () => {
 				});
 			});
 
-			it('should mark a recreated table (previously synced, lossy merge) as reconcilable during pull', async () => {
+			it('should carry the incoming id on a collision entry regardless of preferLocalVersion', async () => {
 				// ARRANGE
 				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
 
 				const remoteDataTable = {
-					id: 'dt-recreated',
+					id: 'dt-remote',
 					name: 'Shared Name',
 					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
 					columns: [{ id: 'rc1', name: 'other', type: 'string', index: 0 }],
@@ -2787,10 +2752,6 @@ describe('getStatus', () => {
 					remoteDataTable,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				// Local table id appears in git history — delete+recreate upstream
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-					new Set(['datatables/dt-local.json']),
-				);
 
 				// ACT — preferLocalVersion true (the UI dry-run flag) must not change
 				// which id the entry carries
@@ -2800,64 +2761,14 @@ describe('getStatus', () => {
 					preferLocalVersion: true,
 				});
 
-				// ASSERT — exactly ONE "modified" entry carrying the incoming id: no
-				// "created" for the incoming id, no "deleted" for the old local id
-				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
-				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				expect(dataTableFiles).toHaveLength(1);
-				expect(dataTableFiles[0]).toMatchObject({
-					id: 'dt-recreated',
-					status: 'modified',
-					conflict: false,
-				});
-			});
-
-			it('should mark a pre-sync twin (never synced, lossless merge) as reconcilable during pull', async () => {
-				// ARRANGE
-				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
-
-				const sharedColumns = [{ id: 'rc1', name: 'shared', type: 'string', index: 0 }];
-				const remoteDataTable = {
-					id: 'dt-remote',
-					name: 'Shared Name',
-					ownedBy: { type: 'team' as const, teamId: 'projA', teamName: 'ProjectA' },
-					columns: sharedColumns,
-					createdAt: '2024-01-01T00:00:00.000Z',
-					updatedAt: '2024-01-01T00:00:00.000Z',
-				};
-
-				const localDataTable = {
-					id: 'dt-local',
-					name: 'Shared Name',
-					ownedBy: { type: 'team' as const, projectId: 'projA', projectName: 'ProjectA' },
-					filename: 'test.json',
-					// Same (name, type) columns under a different id — lossless merge
-					columns: [{ id: 'lc1', name: 'shared', type: 'string', index: 0 }],
-					createdAt: '2024-01-01T00:00:00.000Z',
-					updatedAt: '2024-01-01T00:00:00.000Z',
-				};
-
-				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
-					remoteDataTable,
-				]);
-				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
-
-				// ACT
-				const result = await sourceControlStatusService.getStatus(user, {
-					direction: 'pull',
-					verbose: false,
-					preferLocalVersion: false,
-				});
-
-				// ASSERT — exactly ONE "modified" entry for the merge, no "created"
+				// ASSERT
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
 				expect(dataTableFiles).toHaveLength(1);
 				expect(dataTableFiles[0]).toMatchObject({
 					id: 'dt-remote',
 					status: 'modified',
-					conflict: false,
+					conflict: true,
 				});
 			});
 
@@ -2899,9 +2810,6 @@ describe('getStatus', () => {
 					remoteOtherProject,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(
-					new Set(['datatables/dt-local.json']),
-				);
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2917,7 +2825,7 @@ describe('getStatus', () => {
 				expect(dataTableFiles).toHaveLength(2);
 				expect(dataTableFiles).toEqual(
 					expect.arrayContaining([
-						expect.objectContaining({ id: 'dt-remote-a', status: 'modified', conflict: false }),
+						expect.objectContaining({ id: 'dt-remote-a', status: 'modified', conflict: true }),
 						expect.objectContaining({ id: 'dt-remote-b', status: 'created' }),
 					]),
 				);
@@ -2950,7 +2858,6 @@ describe('getStatus', () => {
 					remoteDataTable,
 				]);
 				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
-				gitService.getHistoricallyTrackedFiles.mockResolvedValue(new Set());
 
 				// ACT
 				const result = await sourceControlStatusService.getStatus(user, {
@@ -2959,14 +2866,16 @@ describe('getStatus', () => {
 					preferLocalVersion: true,
 				});
 
-				// ASSERT
+				// ASSERT — the collision keeps its conflict pair; the remote-only id is
+				// additionally offered as a deletion (git as source of truth)
 				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
 				const dataTableFiles = result.filter((f) => f.type === 'datatable');
-				expect(dataTableFiles).toHaveLength(2);
+				expect(dataTableFiles).toHaveLength(3);
 				expect(dataTableFiles).toEqual(
 					expect.arrayContaining([
 						expect.objectContaining({ id: 'dt-local', status: 'modified', conflict: true }),
 						expect.objectContaining({ id: 'dt-local', status: 'created' }),
+						expect.objectContaining({ id: 'dt-remote', status: 'deleted' }),
 					]),
 				);
 			});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -110,6 +110,11 @@ describe('getStatus', () => {
 		// data tables
 		sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([]);
 		sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([]);
+		// Mirrors the real resolution: team id for team owners, the pulling
+		// user's personal project otherwise
+		sourceControlImportService.resolveRemoteDataTableProjectId.mockImplementation(
+			async (ownedBy) => (ownedBy?.type === 'team' ? ownedBy.teamId : 'pulling-user-project'),
+		);
 
 		// repositories
 		tagRepository.find.mockResolvedValue([]);
@@ -2720,6 +2725,54 @@ describe('getStatus', () => {
 				expect(dataTableFiles[0]).toMatchObject({
 					id: 'dt-remote',
 					name: 'Shared Name',
+					status: 'modified',
+					conflict: true,
+				});
+			});
+
+			it('should emit a single modified entry for a personal-project name collision during pull', async () => {
+				// ARRANGE — the owner email resolves to the same local personal
+				// project the colliding table lives in
+				const user = mock<User>({ id: '1', role: GLOBAL_ADMIN_ROLE });
+
+				const remoteDataTable = {
+					id: 'dt-remote',
+					name: 'Shared Name',
+					ownedBy: { type: 'personal' as const, personalEmail: 'owner@test.com' },
+					columns: [{ id: 'rc1', name: 'col', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				const localDataTable = {
+					id: 'dt-local',
+					name: 'Shared Name',
+					ownedBy: { type: 'personal' as const, projectId: 'pp-local', projectName: 'Owner' },
+					filename: 'test.json',
+					columns: [{ id: 'lc1', name: 'col', type: 'string', index: 0 }],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+				};
+
+				sourceControlImportService.getRemoteDataTablesFromFiles.mockResolvedValue([
+					remoteDataTable,
+				]);
+				sourceControlImportService.getLocalDataTablesFromDb.mockResolvedValue([localDataTable]);
+				sourceControlImportService.resolveRemoteDataTableProjectId.mockResolvedValue('pp-local');
+
+				// ACT
+				const result = await sourceControlStatusService.getStatus(user, {
+					direction: 'pull',
+					verbose: false,
+					preferLocalVersion: false,
+				});
+
+				// ASSERT — one "modified" entry, never a "created" + "deleted" pair
+				if (!Array.isArray(result)) expect.fail('Expected result to be an array.');
+				const dataTableFiles = result.filter((f) => f.type === 'datatable');
+				expect(dataTableFiles).toHaveLength(1);
+				expect(dataTableFiles[0]).toMatchObject({
+					id: 'dt-remote',
 					status: 'modified',
 					conflict: true,
 				});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -590,7 +590,7 @@ describe('SourceControlService', () => {
 			const callOrder: string[] = [];
 			sourceControlImportService.importDataTablesFromWorkFolder.mockImplementation(async () => {
 				callOrder.push('import');
-				return { imported: [], conflicts: [] };
+				return { imported: [], reconciliationFailures: [] };
 			});
 			sourceControlImportService.deleteDataTablesNotInWorkFolder.mockImplementation(async () => {
 				callOrder.push('delete');
@@ -626,7 +626,7 @@ describe('SourceControlService', () => {
 			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([]);
 			sourceControlImportService.importDataTablesFromWorkFolder.mockResolvedValue({
 				imported: [],
-				conflicts: [{ id: 'dtNew', name: 'Test Table' }],
+				reconciliationFailures: [{ id: 'dtNew', name: 'Test Table' }],
 			});
 
 			// ACT

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -562,10 +562,11 @@ describe('SourceControlService', () => {
 			expect(result).toMatchObject({ statusCode: 409, statusResult: statuses });
 		});
 
-		it('imports data tables before deleting them, so a reconciled old id no-ops in the delete phase', async () => {
-			// ARRANGE — a recreated table produces both a "modified" entry (new id) and
-			// a "deleted" entry (old id). Import must run first: identity adoption
-			// removes the old id, so the delete no-ops instead of dropping local rows.
+		it('imports data tables before deleting them', async () => {
+			// ARRANGE — a reconciled collision emits a single "modified" entry (no
+			// "deleted" for the old id), so ordering is defense in depth: should a
+			// "deleted" entry ever coincide with an adoption again, import must run
+			// first so the delete no-ops instead of dropping local rows.
 			const user = mock<User>();
 			const statuses = [
 				mock<SourceControlledFile>({

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control.service.test.ts
@@ -561,6 +561,84 @@ describe('SourceControlService', () => {
 			// ASSERT
 			expect(result).toMatchObject({ statusCode: 409, statusResult: statuses });
 		});
+
+		it('imports data tables before deleting them, so a reconciled old id no-ops in the delete phase', async () => {
+			// ARRANGE — a recreated table produces both a "modified" entry (new id) and
+			// a "deleted" entry (old id). Import must run first: identity adoption
+			// removes the old id, so the delete no-ops instead of dropping local rows.
+			const user = mock<User>();
+			const statuses = [
+				mock<SourceControlledFile>({
+					status: 'modified',
+					location: 'remote',
+					type: 'datatable',
+					conflict: false,
+					id: 'dtNew',
+				}),
+				mock<SourceControlledFile>({
+					status: 'deleted',
+					location: 'remote',
+					type: 'datatable',
+					conflict: false,
+					id: 'dtOld',
+				}),
+			];
+			mockStatusService.getStatus.mockResolvedValueOnce(statuses);
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([]);
+
+			const callOrder: string[] = [];
+			sourceControlImportService.importDataTablesFromWorkFolder.mockImplementation(async () => {
+				callOrder.push('import');
+				return { imported: [], conflicts: [] };
+			});
+			sourceControlImportService.deleteDataTablesNotInWorkFolder.mockImplementation(async () => {
+				callOrder.push('delete');
+			});
+
+			// ACT
+			await sourceControlService.pullWorkfolder(user, { force: true, autoPublish: 'none' });
+
+			// ASSERT
+			expect(sourceControlImportService.importDataTablesFromWorkFolder).toHaveBeenCalledWith(
+				[statuses[0]],
+				user.id,
+			);
+			expect(sourceControlImportService.deleteDataTablesNotInWorkFolder).toHaveBeenCalledWith([
+				statuses[1],
+			]);
+			expect(callOrder).toEqual(['import', 'delete']);
+		});
+
+		it('surfaces data table conflicts discovered at import time on the pull result', async () => {
+			// ARRANGE
+			const user = mock<User>();
+			const statuses = [
+				mock<SourceControlledFile>({
+					status: 'modified',
+					location: 'remote',
+					type: 'datatable',
+					conflict: false,
+					id: 'dtNew',
+				}),
+			];
+			mockStatusService.getStatus.mockResolvedValueOnce(statuses);
+			sourceControlImportService.importWorkflowFromWorkFolder.mockResolvedValue([]);
+			sourceControlImportService.importDataTablesFromWorkFolder.mockResolvedValue({
+				imported: [],
+				conflicts: [{ id: 'dtNew', name: 'Test Table' }],
+			});
+
+			// ACT
+			const result = await sourceControlService.pullWorkfolder(user, {
+				force: true,
+				autoPublish: 'none',
+			});
+
+			// ASSERT
+			expect(result.statusCode).toBe(200);
+			const dataTableEntry = result.statusResult.find((f) => f.id === 'dtNew');
+			expect(dataTableEntry?.conflict).toBe(true);
+		});
 	});
 
 	describe('getStatus', () => {

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -500,36 +500,6 @@ export class SourceControlGitService {
 		return statusResult;
 	}
 
-	/**
-	 * Returns all file paths that have ever been committed under the given directory
-	 * on the current branch. Scoped to the current branch (ancestors of HEAD) so that
-	 * data tables pushed by other instances on different branches are not mistaken
-	 * for previously-synced resources on this instance.
-	 */
-	async getHistoricallyTrackedFiles(directory: string): Promise<Set<string>> {
-		if (!this.git) {
-			throw new UnexpectedError('Git is not initialized (getHistoricallyTrackedFiles)');
-		}
-		try {
-			const output = await this.git.raw([
-				'log',
-				'--pretty=format:',
-				'--name-only',
-				'--',
-				`${directory}/`,
-			]);
-			const files = new Set(
-				output
-					.split('\n')
-					.map((line) => line.trim())
-					.filter((line) => line.length > 0),
-			);
-			return files;
-		} catch {
-			return new Set();
-		}
-	}
-
 	async getFileContent(filePath: string, commit: string = 'HEAD'): Promise<string> {
 		try {
 			if (!this.git) {

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -495,63 +495,13 @@ export function isDataTableModified(
 }
 
 /**
- * Extracts resource ids from git-tracked export file paths of the
- * `<folder>/<id>.json` form.
- */
-export function extractResourceIdsFromFilePaths(filePaths: Set<string>): Set<string> {
-	const ids = new Set<string>();
-	for (const filePath of filePaths) {
-		const match = filePath.match(/([^/]+)\.json$/);
-		if (match) {
-			ids.add(match[1]);
-		}
-	}
-	return ids;
-}
-
-/**
- * Identity of a data table column for merge purposes. Columns matched by this
- * key are treated as the same column across instances — the lossless-merge
- * rule and identity adoption must use the same matching.
+ * Identity of a data table column across instances for identity adoption:
+ * columns matching by `(name, type)` adopt the incoming column id.
  */
 export function dataTableColumnKey(
 	column: Pick<ExportableDataTableColumn, 'name' | 'type'>,
 ): string {
 	return `${column.name}:${column.type}`;
-}
-
-/**
- * A merge is lossless when every local column has an incoming `(name, type)`
- * match, so schema alignment would drop or retype no local column and no cell
- * data can be lost.
- */
-export function isLosslessDataTableMerge(
-	localColumns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>,
-	incomingColumns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>,
-): boolean {
-	const incoming = new Set(incomingColumns.map(dataTableColumnKey));
-	return localColumns.every((c) => incoming.has(dataTableColumnKey(c)));
-}
-
-type DataTableColumnsForMerge = {
-	columns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>;
-};
-
-/**
- * Whether a pull may resolve a data table name collision by adopting the
- * incoming id: always when the local table was previously synced (recreated
- * upstream), otherwise only when the merge is lossless (pre-sync twin).
- * Status and import must share this rule so the pull preview matches pull
- * execution.
- */
-export function canReconcileDataTableNameCollision(
-	local: { id: string } & DataTableColumnsForMerge,
-	incoming: DataTableColumnsForMerge,
-	previouslySyncedIds: Set<string>,
-): boolean {
-	return (
-		previouslySyncedIds.has(local.id) || isLosslessDataTableMerge(local.columns, incoming.columns)
-	);
 }
 
 /**

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -498,7 +498,7 @@ export function isDataTableModified(
  * Identity of a data table column across instances for identity adoption:
  * columns matching by `(name, type)` adopt the incoming column id.
  */
-export function dataTableColumnKey(
+export function getDataTableColumnKey(
 	column: Pick<ExportableDataTableColumn, 'name' | 'type'>,
 ): string {
 	return `${column.name}:${column.type}`;

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -495,6 +495,66 @@ export function isDataTableModified(
 }
 
 /**
+ * Extracts resource ids from git-tracked export file paths of the
+ * `<folder>/<id>.json` form.
+ */
+export function extractResourceIdsFromFilePaths(filePaths: Set<string>): Set<string> {
+	const ids = new Set<string>();
+	for (const filePath of filePaths) {
+		const match = filePath.match(/([^/]+)\.json$/);
+		if (match) {
+			ids.add(match[1]);
+		}
+	}
+	return ids;
+}
+
+/**
+ * Identity of a data table column for merge purposes. Columns matched by this
+ * key are treated as the same column across instances — the lossless-merge
+ * rule and identity adoption must use the same matching.
+ */
+export function dataTableColumnKey(
+	column: Pick<ExportableDataTableColumn, 'name' | 'type'>,
+): string {
+	return `${column.name}:${column.type}`;
+}
+
+/**
+ * A merge is lossless when every local column has an incoming `(name, type)`
+ * match, so schema alignment would drop or retype no local column and no cell
+ * data can be lost.
+ */
+export function isLosslessDataTableMerge(
+	localColumns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>,
+	incomingColumns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>,
+): boolean {
+	const incoming = new Set(incomingColumns.map(dataTableColumnKey));
+	return localColumns.every((c) => incoming.has(dataTableColumnKey(c)));
+}
+
+type DataTableColumnsForMerge = {
+	columns: Array<Pick<ExportableDataTableColumn, 'name' | 'type'>>;
+};
+
+/**
+ * Whether a pull may resolve a data table name collision by adopting the
+ * incoming id: always when the local table was previously synced (recreated
+ * upstream), otherwise only when the merge is lossless (pre-sync twin).
+ * Status and import must share this rule so the pull preview matches pull
+ * execution.
+ */
+export function canReconcileDataTableNameCollision(
+	local: { id: string } & DataTableColumnsForMerge,
+	incoming: DataTableColumnsForMerge,
+	previouslySyncedIds: Set<string>,
+): boolean {
+	return (
+		previouslySyncedIds.has(local.id) || isLosslessDataTableMerge(local.columns, incoming.columns)
+	);
+}
+
+/**
  * Type guard to check if a string is a valid DataTableColumnType.
  */
 export function isValidDataTableColumnType(type: string): type is DataTableColumnType {

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -65,8 +65,8 @@ import {
 } from './constants';
 import { SourceControlContextFactory } from './source-control-context.factory';
 import {
-	dataTableColumnKey,
 	getCredentialExportPath,
+	getDataTableColumnKey,
 	getDataTableExportPath,
 	getProjectExportPath,
 	getWorkflowExportPath,
@@ -1271,7 +1271,7 @@ export class SourceControlImportService {
 		};
 
 		// Phase 1: Parse all data table files and resolve target projects upfront
-		// so we can validate name collisions before any imports happen.
+		// so name collisions can be resolved before any imports happen.
 		const parsedTables: Array<{
 			dataTable: ExportableDataTable;
 			candidate: SourceControlledFile;
@@ -1525,12 +1525,12 @@ export class SourceControlImportService {
 			await trx.delete(DataTable, { id: localTable.id });
 			await trx.insert(DataTable, { ...localTableProps, id: incoming.id });
 			const incomingIdByColumnKey = new Map(
-				incoming.columns.map((c) => [dataTableColumnKey(c), c.id]),
+				incoming.columns.map((c) => [getDataTableColumnKey(c), c.id]),
 			);
 			for (const column of localColumns) {
 				await trx.insert(DataTableColumn, {
 					...column,
-					id: incomingIdByColumnKey.get(dataTableColumnKey(column)) ?? column.id,
+					id: incomingIdByColumnKey.get(getDataTableColumnKey(column)) ?? column.id,
 					dataTableId: incoming.id,
 				});
 			}

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1365,8 +1365,6 @@ export class SourceControlImportService {
 			if (localTable && localTable.id !== dataTable.id) {
 				previouslySyncedIds ??= await this.getPreviouslySyncedDataTableIds();
 				if (!canReconcileDataTableNameCollision(localTable, dataTable, previouslySyncedIds)) {
-					// The status result can list the same table as both created and
-					// modified, so guard against recording the conflict twice
 					if (!result.conflicts.some((c) => c.id === dataTable.id)) {
 						this.logger.warn(
 							`Data table "${dataTable.name}" already exists locally with columns that the incoming table lacks. Skipping import; rename or delete the local data table to accept the incoming one.`,

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1508,9 +1508,9 @@ export class SourceControlImportService {
 	 * align the schema. Local columns adopt the incoming column id where
 	 * `(name, type)` matches, so an identical recreate imports as a no-op.
 	 *
-	 * Idempotent: on MySQL DDL commits implicitly, so a failure between rename
-	 * and metadata swap leaves the physical table already renamed; a retry
-	 * detects that and only completes the metadata swap.
+	 * Idempotent as defense in depth: a retry that finds the physical table
+	 * already renamed skips the rename and only completes the metadata swap,
+	 * so a half-finished adoption cannot wedge the pull.
 	 */
 	private async adoptDataTableIdentity(
 		localTable: DataTable,

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -1265,9 +1265,12 @@ export class SourceControlImportService {
 		// Get database type from the repository's connection
 		const dbType = this.dataTableRepository.manager.connection.options.type;
 
-		const result: { imported: string[]; conflicts: Array<{ id: string; name: string }> } = {
+		const result: {
+			imported: string[];
+			reconciliationFailures: Array<{ id: string; name: string }>;
+		} = {
 			imported: [],
-			conflicts: [],
+			reconciliationFailures: [],
 		};
 
 		// Phase 1: Parse all data table files and resolve target projects upfront
@@ -1343,7 +1346,7 @@ export class SourceControlImportService {
 					this.logger.error(`Failed to reconcile data table ${dataTable.name}`, {
 						error: ensureError(error),
 					});
-					result.conflicts.push({ id: dataTable.id, name: dataTable.name });
+					result.reconciliationFailures.push({ id: dataTable.id, name: dataTable.name });
 					continue;
 				}
 			}

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -25,7 +25,7 @@ import {
 } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { PROJECT_ADMIN_ROLE_SLUG, PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
-import { In } from '@n8n/typeorm';
+import { In, type DataSourceOptions } from '@n8n/typeorm';
 import { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import glob from 'fast-glob';
 import isEqual from 'lodash/isEqual';
@@ -41,6 +41,8 @@ import type { IWorkflowToImport } from '@/interfaces';
 import { DataTableColumn } from '@/modules/data-table/data-table-column.entity';
 import { DataTableColumnRepository } from '@/modules/data-table/data-table-column.repository';
 import { DataTableDDLService } from '@/modules/data-table/data-table-ddl.service';
+import { DataTableSizeValidator } from '@/modules/data-table/data-table-size-validator.service';
+import { DataTable } from '@/modules/data-table/data-table.entity';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { isValidColumnName, isValidDataTableId } from '@/modules/data-table/utils/sql-utils';
 import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
@@ -62,7 +64,11 @@ import {
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
 import { SourceControlContextFactory } from './source-control-context.factory';
+import { SourceControlGitService } from './source-control-git.service.ee';
 import {
+	canReconcileDataTableNameCollision,
+	dataTableColumnKey,
+	extractResourceIdsFromFilePaths,
 	getCredentialExportPath,
 	getDataTableExportPath,
 	getProjectExportPath,
@@ -135,6 +141,8 @@ export class SourceControlImportService {
 		private readonly dataTableColumnRepository: DataTableColumnRepository,
 		private readonly dataTableDDLService: DataTableDDLService,
 		private readonly redactionEnforcementService: RedactionEnforcementService,
+		private readonly dataTableSizeValidator: DataTableSizeValidator,
+		private readonly gitService: SourceControlGitService,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
@@ -1261,7 +1269,10 @@ export class SourceControlImportService {
 		const pullingUserPersonalProject =
 			await this.projectRepository.getPersonalProjectForUserOrFail(userId);
 
-		const result: { imported: string[] } = { imported: [] };
+		const result: { imported: string[]; conflicts: Array<{ id: string; name: string }> } = {
+			imported: [],
+			conflicts: [],
+		};
 
 		// Phase 1: Parse all data table files and resolve target projects upfront
 		// so we can validate name collisions before any imports happen.
@@ -1338,22 +1349,47 @@ export class SourceControlImportService {
 			parsedTables.push({ dataTable, candidate, targetProjectId: targetProject.id });
 		}
 
-		// Phase 2: Validate all name collisions before importing anything.
-		// This prevents partial imports when a collision is detected mid-way.
-		for (const { dataTable, targetProjectId } of parsedTables) {
-			const existingByName = await this.dataTableRepository.findOne({
+		// Phase 2: Resolve name collisions (same (project, name), different id —
+		// typically a delete+recreate upstream). The local table adopts the
+		// incoming id when it was previously synced or the merge is lossless;
+		// otherwise local-only column data is at stake, so the single table is
+		// skipped as a conflict and the rest of the pull proceeds.
+		let previouslySyncedIds: Set<string> | undefined;
+		const importableTables: typeof parsedTables = [];
+		for (const entry of parsedTables) {
+			const { dataTable, targetProjectId } = entry;
+			const localTable = await this.dataTableRepository.findOne({
 				where: { name: dataTable.name, projectId: targetProjectId },
-				select: ['id'],
+				relations: ['columns'],
 			});
-			if (existingByName && existingByName.id !== dataTable.id) {
-				throw new UserError(
-					`A data table with the name <strong>${dataTable.name}</strong> already exists locally.<br />Please either rename the local data table, or the remote one with the id <strong>${dataTable.id}</strong> in the source control files.`,
-				);
+			if (localTable && localTable.id !== dataTable.id) {
+				previouslySyncedIds ??= await this.getPreviouslySyncedDataTableIds();
+				if (!canReconcileDataTableNameCollision(localTable, dataTable, previouslySyncedIds)) {
+					// The status result can list the same table as both created and
+					// modified, so guard against recording the conflict twice
+					if (!result.conflicts.some((c) => c.id === dataTable.id)) {
+						this.logger.warn(
+							`Data table "${dataTable.name}" already exists locally with columns that the incoming table lacks. Skipping import; rename or delete the local data table to accept the incoming one.`,
+						);
+						result.conflicts.push({ id: dataTable.id, name: dataTable.name });
+					}
+					continue;
+				}
+				try {
+					await this.adoptDataTableIdentity(localTable, dataTable, dbType);
+				} catch (error) {
+					this.logger.error(`Failed to reconcile data table ${dataTable.name}`, {
+						error: ensureError(error),
+					});
+					result.conflicts.push({ id: dataTable.id, name: dataTable.name });
+					continue;
+				}
 			}
+			importableTables.push(entry);
 		}
 
 		// Phase 3: Import all data tables (no name collisions at this point)
-		for (const { dataTable, candidate, targetProjectId } of parsedTables) {
+		for (const { dataTable, candidate, targetProjectId } of importableTables) {
 			try {
 				this.logger.debug(`Importing data table from file ${candidate.file}`);
 
@@ -1474,6 +1510,56 @@ export class SourceControlImportService {
 		}
 
 		return result;
+	}
+
+	/** Data table ids that have ever appeared in the git repository's history. */
+	private async getPreviouslySyncedDataTableIds(): Promise<Set<string>> {
+		return extractResourceIdsFromFilePaths(
+			await this.gitService.getHistoricallyTrackedFiles(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER),
+		);
+	}
+
+	/**
+	 * Re-keys a local data table (metadata and physical rows table) to the
+	 * incoming id, preserving its rows, so the regular import path can then
+	 * align the schema. Local columns adopt the incoming column id where
+	 * `(name, type)` matches, so an identical recreate imports as a no-op.
+	 *
+	 * Idempotent: on MySQL DDL commits implicitly, so a failure between rename
+	 * and metadata swap leaves the physical table already renamed; a retry
+	 * detects that and only completes the metadata swap.
+	 */
+	private async adoptDataTableIdentity(
+		localTable: DataTable,
+		incoming: ExportableDataTable,
+		dbType: DataSourceOptions['type'],
+	) {
+		this.logger.info(
+			`Reconciling data table "${localTable.name}": adopting id ${incoming.id} (was ${localTable.id})`,
+		);
+		await this.dataTableRepository.manager.transaction(async (trx) => {
+			const alreadyRenamed = await this.dataTableDDLService.tableExists(incoming.id, trx);
+			if (!alreadyRenamed) {
+				await this.dataTableDDLService.renameTable(localTable.id, incoming.id, dbType, trx);
+			}
+			// Spread the loaded entities so future scalar fields carry over
+			// automatically; only the id (and the column FK) are re-keyed.
+			const { columns: localColumns, ...localTableProps } = localTable;
+			// The delete cascades to the old data_table_column rows
+			await trx.delete(DataTable, { id: localTable.id });
+			await trx.insert(DataTable, { ...localTableProps, id: incoming.id });
+			const incomingIdByColumnKey = new Map(
+				incoming.columns.map((c) => [dataTableColumnKey(c), c.id]),
+			);
+			for (const column of localColumns) {
+				await trx.insert(DataTableColumn, {
+					...column,
+					id: incomingIdByColumnKey.get(dataTableColumnKey(column)) ?? column.id,
+					dataTableId: incoming.id,
+				});
+			}
+		});
+		this.dataTableSizeValidator.reset();
 	}
 
 	/**

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -64,11 +64,8 @@ import {
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
 import { SourceControlContextFactory } from './source-control-context.factory';
-import { SourceControlGitService } from './source-control-git.service.ee';
 import {
-	canReconcileDataTableNameCollision,
 	dataTableColumnKey,
-	extractResourceIdsFromFilePaths,
 	getCredentialExportPath,
 	getDataTableExportPath,
 	getProjectExportPath,
@@ -142,7 +139,6 @@ export class SourceControlImportService {
 		private readonly dataTableDDLService: DataTableDDLService,
 		private readonly redactionEnforcementService: RedactionEnforcementService,
 		private readonly dataTableSizeValidator: DataTableSizeValidator,
-		private readonly gitService: SourceControlGitService,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
@@ -1350,11 +1346,10 @@ export class SourceControlImportService {
 		}
 
 		// Phase 2: Resolve name collisions (same (project, name), different id —
-		// typically a delete+recreate upstream). The local table adopts the
-		// incoming id when it was previously synced or the merge is lossless;
-		// otherwise local-only column data is at stake, so the single table is
-		// skipped as a conflict and the rest of the pull proceeds.
-		let previouslySyncedIds: Set<string> | undefined;
+		// typically a delete+recreate upstream). A same-named table in the same
+		// project is the same logical table: it adopts the incoming id, then the
+		// regular import path below aligns the schema. A failed adoption degrades
+		// to a per-table conflict so the rest of the pull proceeds.
 		const importableTables: typeof parsedTables = [];
 		for (const entry of parsedTables) {
 			const { dataTable, targetProjectId } = entry;
@@ -1363,16 +1358,6 @@ export class SourceControlImportService {
 				relations: ['columns'],
 			});
 			if (localTable && localTable.id !== dataTable.id) {
-				previouslySyncedIds ??= await this.getPreviouslySyncedDataTableIds();
-				if (!canReconcileDataTableNameCollision(localTable, dataTable, previouslySyncedIds)) {
-					if (!result.conflicts.some((c) => c.id === dataTable.id)) {
-						this.logger.warn(
-							`Data table "${dataTable.name}" already exists locally with columns that the incoming table lacks. Skipping import; rename or delete the local data table to accept the incoming one.`,
-						);
-						result.conflicts.push({ id: dataTable.id, name: dataTable.name });
-					}
-					continue;
-				}
 				try {
 					await this.adoptDataTableIdentity(localTable, dataTable, dbType);
 				} catch (error) {
@@ -1508,13 +1493,6 @@ export class SourceControlImportService {
 		}
 
 		return result;
-	}
-
-	/** Data table ids that have ever appeared in the git repository's history. */
-	private async getPreviouslySyncedDataTableIds(): Promise<Set<string>> {
-		return extractResourceIdsFromFilePaths(
-			await this.gitService.getHistoricallyTrackedFiles(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER),
-		);
 	}
 
 	/**

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -79,7 +79,11 @@ import type {
 	ExportableCredential,
 	StatusExportableCredential,
 } from './types/exportable-credential';
-import type { ExportableDataTable, StatusExportableDataTable } from './types/exportable-data-table';
+import type {
+	DataTableResourceOwner,
+	ExportableDataTable,
+	StatusExportableDataTable,
+} from './types/exportable-data-table';
 import type { ExportableFolder } from './types/exportable-folders';
 import type { ExportableProject, ExportableProjectWithFileName } from './types/exportable-project';
 import type { ExportableTags } from './types/exportable-tags';
@@ -1261,10 +1265,6 @@ export class SourceControlImportService {
 		// Get database type from the repository's connection
 		const dbType = this.dataTableRepository.manager.connection.options.type;
 
-		// Get the pulling user's personal project as a fallback for personal projects
-		const pullingUserPersonalProject =
-			await this.projectRepository.getPersonalProjectForUserOrFail(userId);
-
 		const result: { imported: string[]; conflicts: Array<{ id: string; name: string }> } = {
 			imported: [],
 			conflicts: [],
@@ -1304,45 +1304,24 @@ export class SourceControlImportService {
 				continue;
 			}
 
-			let targetProject: Project | null = null;
+			let targetProjectId: string;
 
-			if (dataTable.ownedBy) {
-				if (dataTable.ownedBy.type === 'personal') {
-					const personalEmail = dataTable.ownedBy.personalEmail;
-					if (personalEmail) {
-						const user = await this.userRepository.findOne({ where: { email: personalEmail } });
-						if (user) {
-							targetProject = await this.projectRepository.getPersonalProjectForUserOrFail(user.id);
-						} else {
-							this.logger.debug(
-								`User ${personalEmail} not found locally for data table ${dataTable.name}. Using pulling user's personal project as fallback.`,
-							);
-							targetProject = pullingUserPersonalProject;
-						}
-					}
-				} else if (dataTable.ownedBy.type === 'team') {
-					targetProject = await this.projectRepository.findOne({
+			if (dataTable.ownedBy?.type === 'team') {
+				const teamProject =
+					(await this.projectRepository.findOne({
 						where: { id: dataTable.ownedBy.teamId },
-					});
-
-					if (!targetProject) {
-						targetProject = await this.createTeamProject({
-							type: 'team',
-							teamId: dataTable.ownedBy.teamId,
-							teamName: dataTable.ownedBy.teamName,
-						});
-					}
-				}
+					})) ??
+					(await this.createTeamProject({
+						type: 'team',
+						teamId: dataTable.ownedBy.teamId,
+						teamName: dataTable.ownedBy.teamName,
+					}));
+				targetProjectId = teamProject.id;
+			} else {
+				targetProjectId = await this.resolveRemoteDataTableProjectId(dataTable.ownedBy, userId);
 			}
 
-			if (!targetProject) {
-				this.logger.debug(
-					`No owner specified for data table ${dataTable.name}. Using pulling user's personal project.`,
-				);
-				targetProject = pullingUserPersonalProject;
-			}
-
-			parsedTables.push({ dataTable, candidate, targetProjectId: targetProject.id });
+			parsedTables.push({ dataTable, candidate, targetProjectId });
 		}
 
 		// Phase 2: Resolve name collisions (same (project, name), different id —
@@ -1493,6 +1472,34 @@ export class SourceControlImportService {
 		}
 
 		return result;
+	}
+
+	/**
+	 * Resolves the local project a remote data table belongs to: the team id
+	 * for team-owned tables, the owner's personal project for personal ones,
+	 * falling back to the pulling user's personal project when the owner is
+	 * unknown locally. The status service uses this for collision detection so
+	 * the pull preview matches where the import will place the table.
+	 */
+	async resolveRemoteDataTableProjectId(
+		ownedBy: DataTableResourceOwner | null,
+		pullingUserId: string,
+	): Promise<string> {
+		if (ownedBy?.type === 'team') {
+			return ownedBy.teamId;
+		}
+		if (ownedBy?.type === 'personal' && ownedBy.personalEmail) {
+			const user = await this.userRepository.findOne({
+				where: { email: ownedBy.personalEmail },
+			});
+			if (user) {
+				return (await this.projectRepository.getPersonalProjectForUserOrFail(user.id)).id;
+			}
+			this.logger.debug(
+				`User ${ownedBy.personalEmail} not found locally. Using pulling user's personal project as fallback.`,
+			);
+		}
+		return (await this.projectRepository.getPersonalProjectForUserOrFail(pullingUserId)).id;
 	}
 
 	/**

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -24,8 +24,6 @@ import {
 	getVariablesPath,
 	isWorkflowModified,
 	isDataTableModified,
-	canReconcileDataTableNameCollision,
-	extractResourceIdsFromFilePaths,
 	areSameCredentials,
 } from './source-control-helper.ee';
 import { SourceControlImportService } from './source-control-import.service.ee';
@@ -710,13 +708,6 @@ export class SourceControlStatusService {
 			}
 		}
 
-		// Query git history to find data table IDs that were previously synced.
-		// This lets us distinguish "deleted from remote" (should delete locally on pull)
-		// from "never pushed" (should preserve locally on pull), and vice versa for push.
-		const previouslySyncedIds = extractResourceIdsFromFilePaths(
-			await this.gitService.getHistoricallyTrackedFiles(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER),
-		);
-
 		const dtMissingInLocal: ExportableDataTable[] = [];
 		const dtMissingInRemote: StatusExportableDataTable[] = [];
 		const dtModifiedInEither: Array<ExportableDataTable | StatusExportableDataTable> = [];
@@ -742,13 +733,6 @@ export class SourceControlStatusService {
 
 		for (const remote of dataTablesRemote) {
 			if (!localById.has(remote.id)) {
-				// During push, a remote-only table would be marked as "deleted" from remote.
-				// Skip if this table was never synced from this instance (it was pushed by
-				// another instance and should not be deleted).
-				if (options.direction === 'push' && !previouslySyncedIds.has(remote.id)) {
-					continue;
-				}
-
 				// On pull, an id claimed by a name collision is covered by that
 				// collision's single "modified" entry.
 				if (options.direction === 'pull' && collidingRemoteIds.has(remote.id)) {
@@ -779,12 +763,11 @@ export class SourceControlStatusService {
 				const nameCollision = nameCollisionByLocalId.get(local.id);
 				if (nameCollision) {
 					const isPull = options.direction === 'pull';
-					// A pull reconciles the collision by adopting the incoming id; an
-					// unreconcilable one puts local-only column data at stake and is
-					// surfaced as a genuine conflict. Either way the entry carries the
-					// incoming id and file — that is what the import consumes.
-					const canReconcile =
-						isPull && canReconcileDataTableNameCollision(local, nameCollision, previouslySyncedIds);
+					// A same-named table in the same project is the same logical table:
+					// a pull adopts the incoming id and aligns the schema through the
+					// regular import path. The entry carries the incoming id and file —
+					// that is what the import consumes — and is flagged like any other
+					// schema modification.
 					const modified = isPull
 						? nameCollision
 						: options.preferLocalVersion
@@ -799,7 +782,7 @@ export class SourceControlStatusService {
 						type: 'datatable',
 						status: 'modified',
 						location: options.direction === 'push' ? 'local' : 'remote',
-						conflict: !canReconcile,
+						conflict: true,
 						file: getDataTableExportPath(modified.id, this.dataTableExportFolder),
 						updatedAt: new Date().toISOString(),
 						owner: this.convertToStatusResourceOwner(modified.ownedBy),
@@ -809,13 +792,6 @@ export class SourceControlStatusService {
 					if (isPull) {
 						continue;
 					}
-				}
-
-				// During pull, a local-only table would be marked as "deleted" locally.
-				// Skip if this table was never synced — it was created locally and not yet
-				// pushed, so it should not be deleted.
-				if (options.direction === 'pull' && !previouslySyncedIds.has(local.id)) {
-					continue;
 				}
 
 				if (collectVerbose) {

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -97,35 +97,6 @@ export class SourceControlStatusService {
 		return;
 	}
 
-	/**
-	 * Checks whether a local and remote data table belong to the same project.
-	 * For team projects, compares the project/team ID.
-	 * Returns true when both owners are null (unowned) or when neither is a team
-	 * (conservative match to avoid suppressing real collisions).
-	 */
-	private isSameDataTableProject(
-		localOwner: StatusResourceOwner | null,
-		remoteOwner: DataTableResourceOwner | null,
-	): boolean {
-		if (!localOwner && !remoteOwner) {
-			return true;
-		}
-
-		if (localOwner?.type === 'team' && remoteOwner?.type === 'team') {
-			return localOwner.projectId === remoteOwner.teamId;
-		}
-
-		// Personal projects don't have stable IDs across instances,
-		// so we can't reliably determine if they're the same project.
-		// Return false to avoid false-positive collision flags.
-		if (localOwner?.type === 'personal' || remoteOwner?.type === 'personal') {
-			return false;
-		}
-
-		// Mixed (one null, one not) — different projects
-		return false;
-	}
-
 	private buildFolderPath(
 		parentFolderId: string | null | undefined,
 		foldersById: Map<string, FolderPathNode>,
@@ -715,16 +686,23 @@ export class SourceControlStatusService {
 		// Cross-id name collisions (same (project, name), different id — typically a
 		// delete+recreate upstream). Computed before the remote loop because a pull
 		// reports a collision as ONE user-facing change: the incoming id must not
-		// also appear as "created", nor the old local id as "deleted".
+		// also appear as "created", nor the old local id as "deleted". A remote
+		// table's project is resolved the way the import resolves it, so the
+		// preview matches where the pull will place the table.
 		const nameCollisionByLocalId = new Map<string, ExportableDataTable>();
 		for (const local of dataTablesLocal) {
-			if (remoteById.has(local.id)) continue;
-			const candidate = (remotesByName.get(local.name) ?? []).find(
-				(remote) =>
-					remote.id !== local.id && this.isSameDataTableProject(local.ownedBy, remote.ownedBy),
-			);
-			if (candidate) {
-				nameCollisionByLocalId.set(local.id, candidate);
+			if (remoteById.has(local.id) || !local.ownedBy) continue;
+			for (const candidate of remotesByName.get(local.name) ?? []) {
+				if (candidate.id === local.id) continue;
+				const candidateProjectId =
+					await this.sourceControlImportService.resolveRemoteDataTableProjectId(
+						candidate.ownedBy,
+						context.user.id,
+					);
+				if (candidateProjectId === local.ownedBy.projectId) {
+					nameCollisionByLocalId.set(local.id, candidate);
+					break;
+				}
 			}
 		}
 		const collidingRemoteIds = new Set(

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -741,13 +741,12 @@ export class SourceControlStatusService {
 				const nameCollision = nameCollisionByLocalId.get(local.id);
 				if (nameCollision) {
 					const isPull = options.direction === 'pull';
-					// On pull the entry carries the incoming id and file — that is what
-					// the import consumes — and is flagged like any other schema change.
-					const modified = isPull
-						? nameCollision
-						: options.preferLocalVersion
-							? local
-							: nameCollision;
+					// On pull the entry carries the incoming table regardless of
+					// preferLocalVersion: its file is what the import consumes, and the
+					// dry-run (which always has preferLocalVersion=true) must preview the
+					// same entry the pull acts on. On push the collision surfaces on the
+					// local table.
+					const modified = isPull ? nameCollision : local;
 					if (collectVerbose) {
 						dtModifiedInEither.push(modified);
 					}

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -698,7 +698,17 @@ export class SourceControlStatusService {
 
 		const localById = new Map(dataTablesLocal.map((dt) => [dt.id, dt]));
 		const remoteById = new Map(dataTablesRemote.map((dt) => [dt.id, dt]));
-		const remoteByName = new Map(dataTablesRemote.map((dt) => [dt.name, dt]));
+		// Same-named tables may exist in several projects, so group by name and
+		// pick the candidate per project below.
+		const remotesByName = new Map<string, ExportableDataTable[]>();
+		for (const dt of dataTablesRemote) {
+			const sameName = remotesByName.get(dt.name);
+			if (sameName) {
+				sameName.push(dt);
+			} else {
+				remotesByName.set(dt.name, [dt]);
+			}
+		}
 
 		// Query git history to find data table IDs that were previously synced.
 		// This lets us distinguish "deleted from remote" (should delete locally on pull)
@@ -711,12 +721,37 @@ export class SourceControlStatusService {
 		const dtMissingInRemote: StatusExportableDataTable[] = [];
 		const dtModifiedInEither: Array<ExportableDataTable | StatusExportableDataTable> = [];
 
+		// Cross-id name collisions (same (project, name), different id — typically a
+		// delete+recreate upstream). Computed before the remote loop because a pull
+		// reports a collision as ONE user-facing change: the incoming id must not
+		// also appear as "created", nor the old local id as "deleted".
+		const nameCollisionByLocalId = new Map<string, ExportableDataTable>();
+		for (const local of dataTablesLocal) {
+			if (remoteById.has(local.id)) continue;
+			const candidate = (remotesByName.get(local.name) ?? []).find(
+				(remote) =>
+					remote.id !== local.id && this.isSameDataTableProject(local.ownedBy, remote.ownedBy),
+			);
+			if (candidate) {
+				nameCollisionByLocalId.set(local.id, candidate);
+			}
+		}
+		const collidingRemoteIds = new Set(
+			[...nameCollisionByLocalId.values()].map((remote) => remote.id),
+		);
+
 		for (const remote of dataTablesRemote) {
 			if (!localById.has(remote.id)) {
 				// During push, a remote-only table would be marked as "deleted" from remote.
 				// Skip if this table was never synced from this instance (it was pushed by
 				// another instance and should not be deleted).
 				if (options.direction === 'push' && !previouslySyncedIds.has(remote.id)) {
+					continue;
+				}
+
+				// On pull, an id claimed by a name collision is covered by that
+				// collision's single "modified" entry.
+				if (options.direction === 'pull' && collidingRemoteIds.has(remote.id)) {
 					continue;
 				}
 
@@ -741,25 +776,20 @@ export class SourceControlStatusService {
 			const remote = remoteById.get(local.id);
 
 			if (!remote) {
-				// Check for cross-ID name collision (different tables sharing the same name
-				// in the same project). This must run before the never-synced early-continue
-				// below, otherwise a pull would silently create a remote table that collides
-				// with an unsynced local one.
-				const nameCandidate = remoteByName.get(local.name);
-				const nameCollision =
-					nameCandidate &&
-					nameCandidate.id !== local.id &&
-					this.isSameDataTableProject(local.ownedBy, nameCandidate.ownedBy)
-						? nameCandidate
-						: undefined;
+				const nameCollision = nameCollisionByLocalId.get(local.id);
 				if (nameCollision) {
+					const isPull = options.direction === 'pull';
 					// A pull reconciles the collision by adopting the incoming id; an
 					// unreconcilable one puts local-only column data at stake and is
-					// surfaced as a genuine conflict.
+					// surfaced as a genuine conflict. Either way the entry carries the
+					// incoming id and file — that is what the import consumes.
 					const canReconcile =
-						options.direction === 'pull' &&
-						canReconcileDataTableNameCollision(local, nameCollision, previouslySyncedIds);
-					const modified = options.preferLocalVersion ? local : nameCollision;
+						isPull && canReconcileDataTableNameCollision(local, nameCollision, previouslySyncedIds);
+					const modified = isPull
+						? nameCollision
+						: options.preferLocalVersion
+							? local
+							: nameCollision;
 					if (collectVerbose) {
 						dtModifiedInEither.push(modified);
 					}
@@ -774,6 +804,11 @@ export class SourceControlStatusService {
 						updatedAt: new Date().toISOString(),
 						owner: this.convertToStatusResourceOwner(modified.ownedBy),
 					});
+					// On pull the collision entry is the ONLY entry for this table:
+					// never emit a "deleted" entry for the old local id.
+					if (isPull) {
+						continue;
+					}
 				}
 
 				// During pull, a local-only table would be marked as "deleted" locally.

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -763,11 +763,8 @@ export class SourceControlStatusService {
 				const nameCollision = nameCollisionByLocalId.get(local.id);
 				if (nameCollision) {
 					const isPull = options.direction === 'pull';
-					// A same-named table in the same project is the same logical table:
-					// a pull adopts the incoming id and aligns the schema through the
-					// regular import path. The entry carries the incoming id and file —
-					// that is what the import consumes — and is flagged like any other
-					// schema modification.
+					// On pull the entry carries the incoming id and file — that is what
+					// the import consumes — and is flagged like any other schema change.
 					const modified = isPull
 						? nameCollision
 						: options.preferLocalVersion

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -24,6 +24,8 @@ import {
 	getVariablesPath,
 	isWorkflowModified,
 	isDataTableModified,
+	canReconcileDataTableNameCollision,
+	extractResourceIdsFromFilePaths,
 	areSameCredentials,
 } from './source-control-helper.ee';
 import { SourceControlImportService } from './source-control-import.service.ee';
@@ -701,16 +703,9 @@ export class SourceControlStatusService {
 		// Query git history to find data table IDs that were previously synced.
 		// This lets us distinguish "deleted from remote" (should delete locally on pull)
 		// from "never pushed" (should preserve locally on pull), and vice versa for push.
-		const historicallyTrackedFiles = await this.gitService.getHistoricallyTrackedFiles(
-			SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER,
+		const previouslySyncedIds = extractResourceIdsFromFilePaths(
+			await this.gitService.getHistoricallyTrackedFiles(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER),
 		);
-		const previouslySyncedIds = new Set<string>();
-		for (const filePath of historicallyTrackedFiles) {
-			const match = filePath.match(/([^/]+)\.json$/);
-			if (match) {
-				previouslySyncedIds.add(match[1]);
-			}
-		}
 
 		const dtMissingInLocal: ExportableDataTable[] = [];
 		const dtMissingInRemote: StatusExportableDataTable[] = [];
@@ -758,6 +753,12 @@ export class SourceControlStatusService {
 						? nameCandidate
 						: undefined;
 				if (nameCollision) {
+					// A pull reconciles the collision by adopting the incoming id; an
+					// unreconcilable one puts local-only column data at stake and is
+					// surfaced as a genuine conflict.
+					const canReconcile =
+						options.direction === 'pull' &&
+						canReconcileDataTableNameCollision(local, nameCollision, previouslySyncedIds);
 					const modified = options.preferLocalVersion ? local : nameCollision;
 					if (collectVerbose) {
 						dtModifiedInEither.push(modified);
@@ -768,7 +769,7 @@ export class SourceControlStatusService {
 						type: 'datatable',
 						status: 'modified',
 						location: options.direction === 'push' ? 'local' : 'remote',
-						conflict: true,
+						conflict: !canReconcile,
 						file: getDataTableExportPath(modified.id, this.dataTableExportFolder),
 						updatedAt: new Date().toISOString(),
 						owner: this.convertToStatusResourceOwner(modified.ownedBy),

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -622,11 +622,11 @@ export class SourceControlService {
 					user.id,
 				);
 
-			// Surface conflicts only discovered at import time (e.g. a failed
-			// reconciliation) on the pull result, not just in the logs
-			for (const conflict of dataTableImportResult?.conflicts ?? []) {
+			// Surface reconciliation failures as conflicts on the pull result, not
+			// just in the logs
+			for (const failure of dataTableImportResult?.reconciliationFailures ?? []) {
 				for (const item of statusResult) {
-					if (item.type === 'datatable' && item.id === conflict.id) {
+					if (item.type === 'datatable' && item.id === failure.id) {
 						item.conflict = true;
 					}
 				}

--- a/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control.service.ee.ts
@@ -616,10 +616,21 @@ export class SourceControlService {
 
 		const dataTableCandidates = getNonDeletedResources(statusResult, 'datatable');
 		if (dataTableCandidates.length > 0) {
-			await this.sourceControlImportService.importDataTablesFromWorkFolder(
-				dataTableCandidates,
-				user.id,
-			);
+			const dataTableImportResult =
+				await this.sourceControlImportService.importDataTablesFromWorkFolder(
+					dataTableCandidates,
+					user.id,
+				);
+
+			// Surface conflicts only discovered at import time (e.g. a failed
+			// reconciliation) on the pull result, not just in the logs
+			for (const conflict of dataTableImportResult?.conflicts ?? []) {
+				for (const item of statusResult) {
+					if (item.type === 'datatable' && item.id === conflict.id) {
+						item.conflict = true;
+					}
+				}
+			}
 		}
 		const dataTablesToBeDeleted = getDeletedResources(statusResult, 'datatable');
 		await this.sourceControlImportService.deleteDataTablesNotInWorkFolder(dataTablesToBeDeleted);

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -123,6 +123,8 @@ describe('SourceControlImportService', () => {
 			mock(),
 			mock(),
 			mock(), // redactionEnforcementService
+			mock(), // dataTableSizeValidator
+			mock(), // gitService
 		);
 	});
 

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -124,7 +124,6 @@ describe('SourceControlImportService', () => {
 			mock(),
 			mock(), // redactionEnforcementService
 			mock(), // dataTableSizeValidator
-			mock(), // gitService
 		);
 	});
 

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -543,7 +543,6 @@ describe('SourceControlService', () => {
 		service.sanityCheck = async () => {};
 		statusService['resetWorkfolder'] = async () => undefined;
 		(statusService as any).gitService = gitService;
-		(gitService.getHistoricallyTrackedFiles as Mock).mockResolvedValue(new Set<string>());
 
 		// Git mocking
 		gitFiles = {
@@ -962,10 +961,21 @@ describe('SourceControlService', () => {
 
 					const dataTables = result.filter((r) => r.type === 'datatable');
 
+					// Local in-scope tables are offered as creations, the in-scope
+					// remote-only table as a deletion (git holds it, the instance doesn't)
 					expect(new Set(dataTables.map((dataTable) => dataTable.id))).toEqual(
-						new Set(projectAScope.dataTables.map((dataTable) => dataTable.id)),
+						new Set([
+							...projectAScope.dataTables.map((dataTable) => dataTable.id),
+							remoteInScopeDataTable.id,
+						]),
 					);
-					expect(dataTables.every((dataTable) => dataTable.status === 'created')).toBe(true);
+					expect(
+						dataTables.every((dataTable) =>
+							dataTable.id === remoteInScopeDataTable.id
+								? dataTable.status === 'deleted'
+								: dataTable.status === 'created',
+						),
+					).toBe(true);
 					expect(
 						dataTables.some((dataTable) =>
 							projectBScope.dataTables.some((outOfScope) => outOfScope.id === dataTable.id),
@@ -977,14 +987,7 @@ describe('SourceControlService', () => {
 
 		describe('remote data tables', () => {
 			describe('project:Admin user', () => {
-				it('should see only tracked remote data tables in correct scope', async () => {
-					(gitService.getHistoricallyTrackedFiles as Mock).mockResolvedValueOnce(
-						new Set([
-							`${SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER}/${remoteInScopeDataTable.id}.json`,
-							`${SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER}/${remoteOutOfScopeDataTable.id}.json`,
-						]),
-					);
-
+				it('should see only remote data tables in correct scope', async () => {
 					const result = await service.getStatus(projectAdmin, {
 						direction: 'push',
 						preferLocalVersion: true,


### PR DESCRIPTION
## Summary

### Issue
Deleting a data table upstream and recreating it with the same name gives it a new id. On pull, the receiving instance hit the name-collision guard (introduced as a fix in #26416), which threw a `UserError` that **aborted the entire data table pull and re-fired on every subsequent pull** — a cluster-wide sync freeze for data tables. The in-product workaround (deleting the table from git) makes the next pull drop the local table including its local-only rows.

- [Video walkthrough the bug](https://www.loom.com/share/160d50c0596d404ab0d69b4463aabc8f)
- [Quick demo of the fix](https://www.loom.com/share/e364cff1940944e28179eefef8c92a1a)

### Solution

- Always reconcile the id based on the data table name and adopt the incoming Id 
- Show a reconciled data table as modified to the user
- Keep/run the table update logic as is 

Two rules replace the guard  and the git-history machinery around it (that were introduced #26416) and cleanup the logic conceptually:

**1. A same-named data table in the same project is the same logical table.** On pull, a name collision (same `(project, name)`, different id) is always resolved by an identity-adoption pre-step: rename the physical rows table to the incoming id and re-key the metadata, adopting incoming column ids where `(name, type)` matches. The **unchanged** existing import path then aligns the schema — an identical recreate is a zero-DDL no-op with rows preserved; column differences follow the already-shipped (lossy) add/drop contract, exactly as for any schema change on a matching id. In the pull preview a collision is a single `modified` + `conflict: true` entry — the same shape as a plain schema change (previously a misleading `created` + `deleted` pair).

**2. Git is the source of truth — no git-history lookups.** #26416's history-based delete protection is removed along with the collision guard: a data table absent from git is offered as a deletion in the pull confirmation (deleted on confirmed/forced pulls); a remote-only table is offered as a deletion on push. This matches how workflows, credentials, and variables already behave — data tables were the only resource type consulting git history. `getHistoricallyTrackedFiles` is deleted.

## How to test

Requires source control (enterprise license) and data tables enabled. Two instances (A, B) on the same repo:

1. On A: create a data table, push. On B: pull, then add local rows. On A: delete + recreate the table with the same name, push.
2. On B: pull → the table shows as a single `modified` entry, the pull succeeds, B keeps its rows. **Before**: `UserError` aborted every pull.
3. Variant — recreate with changed columns: schema aligns (documented lossy contract), untouched columns keep their data.
4. Variant — local-only table (never pushed): the pull confirmation lists it as `deleted` and a confirmed pull removes it (git as source of truth).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/LIGO-768
- Replaces the guard behavior introduced in #26416

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33867">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

