### PR TITLE
ci: Add workflow to close stale community PRs awaiting contributor feedback

### DIFF
--- a/.github/workflows/community-pr-close-stale.yml
+++ b/.github/workflows/community-pr-close-stale.yml
@@ -1,0 +1,53 @@
+name: 'Community: Close Stale PRs'
+
+# Closes community PRs that were sent back to the contributor
+# (triage:needs-info / triage:tests-needed) and have been inactive since.
+# Scoped to those labels on purpose: we only close PRs where we asked for
+# changes and got no response — never PRs waiting on us.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1-5' # weekdays 9:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run: log actions without commenting/closing.'
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+  issues: write # actions/stale uses the issues API for comments/labels
+
+jobs:
+  close-stale-community-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          # PRs only — never touch issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          any-of-pr-labels: 'triage:needs-info,triage:tests-needed'
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: 'Stale'
+          close-pr-label: 'status:internal-closed'
+          # contributor activity resets the clock (remove-stale-when-updated defaults to true)
+          ascending: true # oldest first
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
+
+          stale-pr-message: >-
+            Hey! 👋 It's been a while since we asked for changes on this PR and
+            we haven't heard back. If you're still interested in getting it
+            merged, please address the feedback above — otherwise we'll close
+            it in 14 days to keep the review queue manageable. Closed PRs can
+            always be reopened, so nothing is lost. Thanks for contributing! 🙏
+
+          close-pr-message: >-
+            Closing this PR since the requested changes weren't made. This is
+            just housekeeping — if you'd like to pick it up again, address the
+            feedback and reopen (or open a fresh PR) and we'll happily take
+            another look. Thanks again for the contribution! 🙏


### PR DESCRIPTION
## Summary

Adds `.github/workflows/community-pr-close-stale.yml` — a scoped stale-bot for community PRs that were sent back to the contributor (`triage:needs-info` / `triage:tests-needed`) and have been inactive since.

**Deliberately scoped:** research shows general stale bots correlate with contributor churn. This only closes PRs where *we asked for changes and got no response* — never PRs waiting on us.

Behavior:
- 30 days of silence after our feedback → friendly warning comment + `Stale` label
- Any contributor activity removes the label and resets the clock
- 14 more days → close + `status:internal-closed`
- Issues are untouched (`days-before-issue-*: -1`)
- Weekday cron; `operations-per-run` default (30) drains the current ~29-PR backlog over a few days

## How to test

Trigger manually via `workflow_dispatch` with dry-run enabled (the default) and inspect the log — `debug-only` mode lists every PR it would warn/close without commenting or closing anything.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1524

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

