### PR TITLE
fix(editor): Prevent duplicate $fromAI keys when editing tool node fields

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.test.ts
@@ -7,7 +7,10 @@ import {
 	isFromAIOverrideValue,
 	makeOverrideValue,
 	parseOverrides,
+	reconcileFromAIKeys,
+	reconcileNodeFromAIKeys,
 } from './fromAIOverride.utils';
+import type { INodeParameters, INodeProperties } from 'n8n-workflow';
 import type { INodeTypeDescription, NodePropertyTypes } from 'n8n-workflow';
 
 const getNodeType = vi.fn();
@@ -333,5 +336,187 @@ describe('buildUniqueName', () => {
 	])('should build a unique name with %s', (_description, path, expected) => {
 		const context = makeContext('value', path);
 		expect(buildUniqueName(context)).toEqual(expected);
+	});
+});
+
+const AUTO_GENERATED_MARKER = '/*n8n-auto-generated-fromAI-override*/';
+const makeOverrideExpression = (key: string, desc = '', type = 'string') =>
+	`={{ ${AUTO_GENERATED_MARKER} $fromAI('${key}', \`${desc}\`, '${type}') }}`;
+
+describe('reconcileFromAIKeys', () => {
+	const override = makeOverrideExpression;
+	const fieldValueField = [
+		{ name: 'fieldValue', displayName: 'Field Value', type: 'string' as NodePropertyTypes },
+	];
+
+	it('reindexes colliding auto-generated keys to match row position', () => {
+		const rows = [
+			{ fieldValue: override('Field_Value', 'desc A') },
+			{ fieldValue: override('Field_Value', 'desc B') },
+		];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		expect(result[0].fieldValue).toContain("$fromAI('fieldValues0_Field_Value'");
+		expect(result[0].fieldValue).toContain('desc A');
+		expect(result[1].fieldValue).toContain("$fromAI('fieldValues1_Field_Value'");
+		expect(result[1].fieldValue).toContain('desc B');
+	});
+
+	it('leaves hand-edited (non-marker) $fromAI and plain values untouched', () => {
+		const rows = [
+			{ fieldValue: "={{ $fromAI('Field_Value', `hand written`, 'string') }}" },
+			{ fieldValue: 'a plain static value' },
+		];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		expect(result[0]).toEqual(rows[0]);
+		expect(result[1]).toEqual(rows[1]);
+	});
+
+	it('is idempotent: already-correct keys are returned unchanged', () => {
+		const rows = [
+			{ fieldValue: override('fieldValues0_Field_Value', 'desc A') },
+			{ fieldValue: override('fieldValues1_Field_Value', 'desc B') },
+		];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		expect(result[0]).toEqual(rows[0]);
+		expect(result[1]).toEqual(rows[1]);
+	});
+
+	it('preserves the description byte-for-byte (including backslashes) when reindexing', () => {
+		const stored = buildValueFromOverride(
+			{
+				type: 'fromAI',
+				extraProps: fromAIExtraProps,
+				extraPropValues: { description: 'match C:\\Users and \\d+' },
+			},
+			makeContext('', 'parameters.fieldsUi.fieldValues[0].fieldValue', 'string', {
+				displayName: 'Field Value',
+			}),
+			true,
+		);
+		const rows = [{ fieldValue: stored }, { fieldValue: stored }];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		// row 0 keeps index 0 → key + description unchanged
+		expect(result[0].fieldValue).toBe(stored);
+		// row 1 only its key changes; the description bytes are untouched
+		expect(result[1].fieldValue).toBe(stored.replace('fieldValues0', 'fieldValues1'));
+	});
+
+	it('preserves a description containing a backtick when reindexing', () => {
+		const stored = buildValueFromOverride(
+			{
+				type: 'fromAI',
+				extraProps: fromAIExtraProps,
+				extraPropValues: { description: 'use the `code` node' },
+			},
+			makeContext('', 'parameters.fieldsUi.fieldValues[0].fieldValue', 'string', {
+				displayName: 'Field Value',
+			}),
+			true,
+		);
+		const rows = [{ fieldValue: stored }, { fieldValue: stored }];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		expect(result[0].fieldValue).toBe(stored);
+		expect(result[1].fieldValue).toBe(stored.replace('fieldValues0', 'fieldValues1'));
+	});
+
+	it('changes only the key, preserving the stored type and description', () => {
+		const rows = [{ fieldValue: override('Field_Value', 'a count', 'number') }];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.fieldsUi.fieldValues', fieldValueField);
+
+		expect(result[0].fieldValue).toBe(override('fieldValues0_Field_Value', 'a count', 'number'));
+	});
+
+	it('reconciles multiple override fields within a row independently', () => {
+		const rows = [{ first: override('First', 'd1'), second: override('Second', 'd2') }];
+
+		const result = reconcileFromAIKeys(rows, 'parameters.list', [
+			{ name: 'first', displayName: 'First', type: 'string' as NodePropertyTypes },
+			{ name: 'second', displayName: 'Second', type: 'string' as NodePropertyTypes },
+		]);
+
+		expect(result[0].first).toContain("$fromAI('list0_First'");
+		expect(result[0].second).toContain("$fromAI('list0_Second'");
+	});
+});
+
+describe('reconcileNodeFromAIKeys', () => {
+	const override = makeOverrideExpression;
+
+	it('reconciles override keys inside a fixedCollection list', () => {
+		const properties: INodeProperties[] = [
+			{
+				displayName: 'Fields',
+				name: 'fieldsUi',
+				type: 'fixedCollection',
+				default: {},
+				options: [
+					{
+						displayName: 'Field',
+						name: 'fieldValues',
+						values: [
+							{ displayName: 'Field Value', name: 'fieldValue', type: 'string', default: '' },
+						],
+					},
+				],
+			},
+		];
+		const nodeParameters: INodeParameters = {
+			fieldsUi: {
+				fieldValues: [
+					{ fieldValue: override('Field_Value', 'A') },
+					{ fieldValue: override('Field_Value', 'B') },
+				],
+			},
+		};
+
+		const result = reconcileNodeFromAIKeys(properties, nodeParameters);
+		const rows = (result.fieldsUi as { fieldValues: INodeParameters[] }).fieldValues;
+
+		expect(rows[0].fieldValue).toContain("$fromAI('fieldValues0_Field_Value'");
+		expect(rows[1].fieldValue).toContain("$fromAI('fieldValues1_Field_Value'");
+	});
+
+	it('reconciles override keys inside a multipleValues collection', () => {
+		const properties: INodeProperties[] = [
+			{
+				displayName: 'Items',
+				name: 'items',
+				type: 'collection',
+				typeOptions: { multipleValues: true },
+				default: {},
+				options: [{ displayName: 'Value', name: 'value', type: 'string', default: '' }],
+			},
+		];
+		const nodeParameters: INodeParameters = {
+			items: [{ value: override('Value', 'A') }, { value: override('Value', 'B') }],
+		};
+
+		const result = reconcileNodeFromAIKeys(properties, nodeParameters);
+		const rows = result.items as INodeParameters[];
+
+		expect(rows[0].value).toContain("$fromAI('items0_Value'");
+		expect(rows[1].value).toContain("$fromAI('items1_Value'");
+	});
+
+	it('leaves non-list parameters untouched', () => {
+		const properties: INodeProperties[] = [
+			{ displayName: 'Name', name: 'name', type: 'string', default: '' },
+		];
+		const nodeParameters: INodeParameters = { name: override('Field_Value', 'A') };
+
+		const result = reconcileNodeFromAIKeys(properties, nodeParameters);
+
+		expect(result.name).toBe(nodeParameters.name);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
@@ -1,6 +1,9 @@
 import {
 	extractFromAICalls,
 	FROM_AI_AUTO_GENERATED_MARKER,
+	isINodeProperties,
+	isINodePropertyCollection,
+	type INodeParameters,
 	type INodeProperties,
 	type NodeParameterValueType,
 	type NodePropertyTypes,
@@ -147,6 +150,10 @@ export function buildUniqueName(props: Pick<OverrideContext, 'parameter' | 'path
 	return result;
 }
 
+function buildFromAIKey(props: Pick<OverrideContext, 'parameter' | 'path'>) {
+	return sanitizeFromAiParameterName(buildUniqueName(props));
+}
+
 export function buildValueFromOverride(
 	override: FromAIOverride,
 	props: Pick<OverrideContext, 'parameter' | 'path'>,
@@ -154,7 +161,7 @@ export function buildValueFromOverride(
 ) {
 	const { extraPropValues, extraProps } = override;
 	const marker = includeMarker ? `${FROM_AI_AUTO_GENERATED_MARKER} ` : '';
-	const key = sanitizeFromAiParameterName(buildUniqueName(props));
+	const key = buildFromAIKey(props);
 	const description =
 		extraPropValues?.description?.toString() ?? extraProps.description.initialValue;
 
@@ -170,6 +177,68 @@ export function buildValueFromOverride(
 	const type = fieldTypeToFromAiType(props.parameter.type);
 
 	return `={{ ${marker}$fromAI('${key}', ${quoteChar}${sanitizedDescription}${quoteChar}, '${type}') }}`;
+}
+
+type ReconcileValueField = Pick<OverrideContext['parameter'], 'name' | 'displayName' | 'type'>;
+
+export function reconcileFromAIKeys(
+	rows: Array<Record<string, NodeParameterValueType>>,
+	basePath: string,
+	valueFields: ReconcileValueField[],
+): Array<Record<string, NodeParameterValueType>> {
+	return rows.map((row, index) => {
+		if (typeof row !== 'object' || row === null) return row;
+		const next = { ...row };
+
+		for (const field of valueFields) {
+			const value = next[field.name];
+			if (typeof value !== 'string' || !isFromAIOverrideValue(value)) continue;
+
+			const key = buildFromAIKey({
+				parameter: field,
+				path: `${basePath}[${index}].${field.name}`,
+			});
+			next[field.name] = value.replace(/(\$fromAI\(\s*')[^']*'/, `$1${key}'`);
+		}
+
+		return next;
+	});
+}
+
+export function reconcileNodeFromAIKeys(
+	properties: INodeProperties[],
+	nodeParameters: INodeParameters,
+): INodeParameters {
+	for (const property of properties) {
+		const value = nodeParameters[property.name];
+		if (value === undefined || value === null) continue;
+
+		if (property.type === 'fixedCollection' && typeof value === 'object' && !Array.isArray(value)) {
+			const collection = value as Record<string, NodeParameterValueType>;
+			for (const option of property.options ?? []) {
+				if (!isINodePropertyCollection(option)) continue;
+				const rows = collection[option.name];
+				if (!Array.isArray(rows)) continue;
+				collection[option.name] = reconcileFromAIKeys(
+					rows as Array<Record<string, NodeParameterValueType>>,
+					`parameters.${property.name}.${option.name}`,
+					option.values,
+				);
+			}
+		} else if (
+			property.type === 'collection' &&
+			property.typeOptions?.multipleValues &&
+			Array.isArray(value)
+		) {
+			nodeParameters[property.name] = reconcileFromAIKeys(
+				value as Array<Record<string, NodeParameterValueType>>,
+				`parameters.${property.name}`,
+				(property.options ?? []).filter(isINodeProperties),
+			);
+		}
+	}
+
+	return nodeParameters;
 }
 
 export function parseOverrides(

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/fromAIOverride.utils.ts
@@ -205,6 +205,8 @@ export function reconcileFromAIKeys(
 	});
 }
 
+// Depth-1 by design: only reconciles a node's top-level list params. Overrides inside
+// lists nested within other list rows are left as-is — no tool-capable node has that shape today.
 export function reconcileNodeFromAIKeys(
 	properties: INodeProperties[],
 	nodeParameters: INodeParameters,

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
@@ -1,7 +1,11 @@
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
+import { ref } from 'vue';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
-import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -10,7 +14,12 @@ import * as nodeHelpers from '@/app/composables/useNodeHelpers';
 import * as workflowHelpers from '@/app/composables/useWorkflowHelpers';
 import * as nodeSettingsUtils from '@/features/ndv/shared/ndv.utils';
 import * as nodeTypesUtils from '@/app/utils/nodeTypesUtils';
-import type { INodeParameters, INodeProperties, INodeTypeDescription } from 'n8n-workflow';
+import type {
+	INodeParameters,
+	INodeProperties,
+	INodeTypeDescription,
+	NodeParameterValue,
+} from 'n8n-workflow';
 import type { MockedStore } from '@/__tests__/utils';
 import { mockedStore } from '@/__tests__/utils';
 import type { INodeUi } from '@/Interface';
@@ -103,6 +112,116 @@ describe('useNodeSettingsParameters', () => {
 			handleFocus(undefined, 'parameters.foo', parameter);
 
 			expect(focusPanelStore.openWithFocusedNodeParameter).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateNodeParameter $fromAI key reconciliation', () => {
+		const AUTO_MARKER = '/*n8n-auto-generated-fromAI-override*/';
+		const staleOverride = (desc: string) =>
+			`={{ ${AUTO_MARKER} $fromAI('Field_Value', \`${desc}\`, 'string') }}`;
+
+		const toolNodeType: INodeTypeDescription = {
+			version: 1,
+			name: 'testTool',
+			displayName: 'Test Tool',
+			description: '',
+			group: ['transform'],
+			defaults: { name: 'Test Tool' },
+			inputs: [],
+			outputs: [],
+			properties: [
+				{
+					displayName: 'Fields',
+					name: 'fieldsUi',
+					type: 'fixedCollection',
+					default: {},
+					typeOptions: { multipleValues: true },
+					options: [
+						{
+							displayName: 'Field',
+							name: 'fieldValues',
+							values: [
+								{ displayName: 'Field Value', name: 'fieldValue', type: 'string', default: '' },
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const node: INodeUi = {
+			id: 'n1',
+			name: 'My Supabase Tool',
+			type: 'testTool',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		};
+
+		const collidingCollection = () => ({
+			fieldValues: [{ fieldValue: staleOverride('A') }, { fieldValue: staleOverride('B') }],
+		});
+
+		let docStore: MockedStore<typeof useWorkflowDocumentStore>;
+
+		beforeEach(() => {
+			setActivePinia(createTestingPinia());
+
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(toolNodeType);
+
+			docStore = mockedStore(useWorkflowDocumentStore, createWorkflowDocumentId(''));
+
+			vi.spyOn(nodeSettingsUtils, 'updateDynamicConnections').mockReturnValue(null);
+			vi.spyOn(nodeHelpers, 'useNodeHelpers').mockReturnValue({
+				...nodeHelpers.useNodeHelpers(),
+				updateNodeParameterIssuesByName: vi.fn(),
+				updateNodeCredentialIssuesByName: vi.fn(),
+			});
+		});
+
+		afterEach(() => {
+			vi.resetAllMocks();
+		});
+
+		const persistedFieldValues = () => {
+			const persisted = vi.mocked(docStore.setNodeParameters).mock.calls[0][0]
+				.value as INodeParameters;
+			return (persisted.fieldsUi as { fieldValues: INodeParameters[] }).fieldValues;
+		};
+
+		it('reindexes colliding auto-generated keys when the node is used as a tool', () => {
+			const { updateNodeParameter } = useNodeSettingsParameters();
+			const collection = collidingCollection();
+
+			updateNodeParameter(
+				ref<INodeParameters>({}),
+				{ name: 'parameters.fieldsUi', value: collection },
+				collection as unknown as NodeParameterValue,
+				node,
+				true,
+			);
+
+			const rows = persistedFieldValues();
+			expect(rows[0].fieldValue).toContain("$fromAI('fieldValues0_Field_Value'");
+			expect(rows[1].fieldValue).toContain("$fromAI('fieldValues1_Field_Value'");
+		});
+
+		it('leaves keys untouched when the node is not a tool', () => {
+			const { updateNodeParameter } = useNodeSettingsParameters();
+			const collection = collidingCollection();
+
+			updateNodeParameter(
+				ref<INodeParameters>({}),
+				{ name: 'parameters.fieldsUi', value: collection },
+				collection as unknown as NodeParameterValue,
+				node,
+				false,
+			);
+
+			const rows = persistedFieldValues();
+			expect(rows[0].fieldValue).toContain("$fromAI('Field_Value'");
+			expect(rows[1].fieldValue).toContain("$fromAI('Field_Value'");
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -32,6 +32,7 @@ import {
 } from '@/app/utils/nodeTypesUtils';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { reconcileNodeFromAIKeys } from '@/features/ndv/parameters/utils/fromAIOverride.utils';
 
 const hasPublicDisplayCondition = (parameter: INodeProperties, value: boolean) =>
 	parameter.displayOptions?.show?.public?.includes(value) ?? false;
@@ -120,6 +121,10 @@ export function useNodeSettingsParameters() {
 
 			if (updatedDescription && nodeParameters) {
 				nodeParameters.toolDescription = updatedDescription;
+			}
+
+			if (nodeParameters) {
+				reconcileNodeFromAIKeys(nodeTypeDescription.properties, nodeParameters);
 			}
 		}
 


### PR DESCRIPTION
## Summary

When a node is used as an AI tool, a field toggled to **"Defined automatically by the model"** stores a `$fromAI('<key>', …)` expression whose key encodes the field's **list index at the moment it was toggled** (`<listName><index>_<displayName>`). The key is baked into the stored expression and never updated afterwards, so editing the list — deleting a non-last row, reordering, or re-adding a row — can leave two rows carrying the **same key**.

At execution the tool-schema builder (`getSchema`) then either throws:

> Duplicate key 'fieldValues1_Field_Value' found with different description or type

or, when the colliding rows' descriptions/types happen to match, **silently gives both fields the same model-provided value**.

### Why a self-healing approach

The original report (#28900) isn't a fresh mistake — it's a workflow that was **already misconfigured on disk**. Its `$fromAI` keys were generated by an earlier version of the key logic (before #14696 / `n8n@1.90.0` made list keys unique), so every row collapsed to the same `Field_Value` key. **Upgrading n8n does not rewrite expressions already stored in a workflow**, so these historic misconfigurations survive upgrades and travel with the workflow when it's exported/imported (templates, shared JSON) — only surfacing when the tool eventually runs.

Rather than a one-off data migration (which still wouldn't stop the same collision recurring through later list edits) or asking users to manually delete and recreate their fields, this fix **re-derives the keys from each row's current index whenever the node's parameters change**. That:

- prevents new collisions from list edits (delete / reorder / re-add), and
- **self-heals historic workflows** the moment their field list is next touched — which is exactly the edit a user naturally makes while trying to get past the error.

`reconcileFromAIKeys` / `reconcileNodeFromAIKeys` (in `fromAIOverride.utils.ts`) run from `updateNodeParameter`, gated on `isToolNode`. Only the key argument is rewritten — the description bytes are preserved untouched (no lossy re-serialization).

## How to test

1. Add an **AI Agent** and attach a node that supports auto-defined fields as a tool (e.g. **Supabase → Create a Row**).
2. Set **Data to Send → Define Below**, add two fields, and toggle each **Field Value** to *"Defined automatically by the model"* with **distinct descriptions**.
3. **Delete the first field**, then **add another** auto-defined field.
4. Copy the node (⌘/Ctrl+C) and inspect the JSON:
   - **Before:** the two `$fromAI` keys collide (`fieldValues1_Field_Value` appears twice).
   - **After:** they are unique (`fieldValues0_Field_Value`, `fieldValues1_Field_Value`).
5. Run the agent so it calls the tool → no *"Duplicate key"* error, and each field gets its own value.

To exercise the **historic-data** case use the following workflow: 

<details>
<summary>Workflow JSON</summary>

```
{
  "nodes": [
    {
      "parameters": {
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
      "typeVersion": 1.4,
      "position": [
        0,
        0
      ],
      "id": "b97db6c5-fbce-48e9-bfeb-e040fdd1b0ea",
      "name": "When chat message received",
      "webhookId": "582a8a9a-f7dd-43a4-afcb-2f56aa6a785c"
    },
    {
      "parameters": {
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.agent",
      "typeVersion": 3.1,
      "position": [
        208,
        0
      ],
      "id": "8f147c8a-e2ca-4fe8-b16b-eaa67898025e",
      "name": "AI Agent"
    },
    {
      "parameters": {
        "model": {
          "__rl": true,
          "mode": "list",
          "value": "claude-sonnet-4-6",
          "cachedResultName": "Claude Sonnet 4.6",
          "cachedResultUrl": ""
        },
        "options": {}
      },
      "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
      "typeVersion": 1.5,
      "position": [
        80,
        208
      ],
      "id": "af79ccb6-8b05-4d09-8e2d-ca210704d8ac",
      "name": "Anthropic Chat Model",
      "credentials": {
        "anthropicApi": {
          "id": "1cIf0295km05Gb2S",
          "name": "Anthropic account"
        }
      }
    },
    {
      "parameters": {
        "tableId": "test",
        "fieldsUi": {
          "fieldValues": [
            {
              "fieldId": "content",
              "fieldValue": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Field_Value', `the article content`, 'string') }}"
            },
            {
              "fieldId": "summary",
              "fieldValue": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Field_Value', `a short summary`, 'string') }}"
            }
          ]
        }
      },
      "type": "n8n-nodes-base.supabaseTool",
      "typeVersion": 1,
      "position": [
        576,
        224
      ],
      "id": "eeb94137-f0de-4d79-8d76-5398150ff6f5",
      "name": "Create a row in Supabase",
      "credentials": {
        "supabaseApi": {
          "id": "HTA60gApQwqil3lq",
          "name": "Supabase account"
        }
      }
    }
  ],
  "connections": {
    "When chat message received": {
      "main": [
        [
          {
            "node": "AI Agent",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "Anthropic Chat Model": {
      "ai_languageModel": [
        [
          {
            "node": "AI Agent",
            "type": "ai_languageModel",
            "index": 0
          }
        ]
      ]
    },
    "Create a row in Supabase": {
      "ai_tool": [
        [
          {
            "node": "AI Agent",
            "type": "ai_tool",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "4e88fdf2ca2358b3af9fbecc28c6de3cd7b5ec37486b1d0dd8bae0f15bd2a988"
  }
}
```

</details>

No feature flag, license, or extra module needed — this is plain editor behaviour on any node usable as an AI tool.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-4911
- Closes GitHub issue: n8n-io/n8n#28900

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI