### PR TITLE
fix(editor): Keep AI Assistant thread state intact on editor hand-off

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -527,10 +527,15 @@ onMounted(() => {
 
 onUnmounted(() => {
 	// This view owns its thread's runtime, so it disposes it here (closes the
-	// SSE, clears state, drops it from the store). Per-thread ownership means a
-	// late-firing unmount only ever tears down its own thread — never a sibling
-	// or a freshly handed-off thread, which a bulk dispose-all would nuke.
-	store.disposeRuntime(props.threadId);
+	// SSE, clears state, drops it from the store) — but only once the app has
+	// left this thread's route. Suspense can create a duplicate instance of
+	// this view for the same thread during layout transitions (e.g. an editor
+	// hand-off that loads the AIA chunks) and discard one; that discarded
+	// instance's unmount fires while the route still points at the thread, and
+	// must not tear down the runtime the live instance is rendering.
+	if (router.currentRoute.value.params.threadId !== props.threadId) {
+		store.disposeRuntime(props.threadId);
+	}
 	contentResizeObserver?.disconnect();
 });
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -59,10 +59,14 @@ vi.mock('@/app/composables/usePageRedirectionHelper', () => ({
 	usePageRedirectionHelper: () => ({ goToUpgrade: vi.fn() }),
 }));
 
+const mockRouteState = vi.hoisted(() => ({
+	params: { threadId: 'thread-1' } as { threadId?: string },
+}));
+
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
 	useRoute: () => ({
-		params: { threadId: 'thread-1' },
+		params: mockRouteState.params,
 		path: '/instance-ai/thread-1',
 		matched: [],
 		fullPath: '/instance-ai/thread-1',
@@ -70,7 +74,15 @@ vi.mock('vue-router', async (importOriginal) => ({
 		hash: '',
 		meta: {},
 	}),
-	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		currentRoute: {
+			get value() {
+				return { params: mockRouteState.params };
+			},
+		},
+	}),
 }));
 
 vi.mock('@vueuse/core', async (importOriginal) => ({
@@ -311,6 +323,7 @@ describe('InstanceAiThreadView', () => {
 		inputFocusSpy.mockClear();
 		telemetryTrackSpy.mockClear();
 		planEditSubmitState.message = 'Make the plan simpler';
+		mockRouteState.params = { threadId: 'thread-1' };
 	});
 
 	afterEach(() => {
@@ -721,6 +734,28 @@ describe('InstanceAiThreadView', () => {
 			expect(thread.clearPlanUpdatePending).toHaveBeenCalledWith('req-plan');
 		});
 		expect(thread.resolveConfirmation).not.toHaveBeenCalled();
+	});
+
+	describe('runtime disposal on unmount', () => {
+		it('keeps the runtime when unmounting while the route still points at the thread', () => {
+			// A duplicate instance created and discarded during a layout transition
+			// (e.g. an editor hand-off) unmounts while the route still shows the
+			// thread — it must not tear down the runtime the live instance renders.
+			const { unmount } = renderView({ props: { threadId: 'thread-1' } });
+
+			unmount();
+
+			expect(store.disposeRuntime).not.toHaveBeenCalled();
+		});
+
+		it('disposes the runtime when unmounting after the route left the thread', () => {
+			const { unmount } = renderView({ props: { threadId: 'thread-1' } });
+
+			mockRouteState.params = { threadId: 'thread-2' };
+			unmount();
+
+			expect(store.disposeRuntime).toHaveBeenCalledWith('thread-1');
+		});
 	});
 
 	it('keeps normal composer submissions as chat messages', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoffCapability.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/composables/useInstanceAiHandoffCapability.ts
@@ -66,7 +66,9 @@ export function useInstanceAiHandoffCapability(): InstanceAiEditorCapability {
 	function persistedWorkflow(): { workflowId: string; projectId: string } | null {
 		const doc = documentStore.value;
 		const workflowId = doc.workflowId;
-		const projectId = doc.homeProject?.id;
+		// Sharing-unlicensed instances omit homeProject from the workflow response,
+		// so fall back to the personal project (the only project they have).
+		const projectId = doc.homeProject?.id ?? projectsStore.personalProject?.id;
 		const isPersisted = !!workflowId && !!workflowsListStore.getWorkflowById(workflowId)?.id;
 		return isPersisted && workflowId && projectId ? { workflowId, projectId } : null;
 	}


### PR DESCRIPTION
## Summary

The "Build with AI" canvas button intermittently landed users on an empty AI Assistant thread: no user message, no artifact, no streaming. The backend was fine (message persisted, title set); the state was destroyed client-side.

**Root cause:** on a cold page session (e.g. right after a page reload, when the assistant chunks are not yet in the module registry), Vue creates two `InstanceAiThreadView` instances for the same thread during the editor-to-assistant layout transition (`<Suspense>` pending-branch churn). The discarded instance's `onUnmounted` called `disposeRuntime(threadId)`, wiping and deleting the runtime the surviving instance was rendering. The surviving view held a zombie runtime, so nothing could ever load. Warm SPA navigation mounts once, hence "intermittent".

Instrumented sequence on a failing click:

```
t=531ms  ThreadView setup, instance #1
t=596ms  ThreadView setup, instance #2 (duplicate, same threadId)
t=663ms  instance #1 onUnmounted -> disposeRuntime(threadId)   <- kills #2's runtime
```

**Fix:** dispose the runtime on unmount only when the route no longer points at this thread. A stale duplicate unmounts while the route still shows its thread and now skips disposal; navigating away still cleans up (verified: nav-away, thread switch, and re-entry hydration all behave as before).

**Also fixed on the way:** on sharing-unlicensed instances `GET /workflows/:id` omits `homeProject` (only the licensed branch adds owner metadata), so the hand-off silently degraded to the bare empty assistant view. `persistedWorkflow()` now falls back to the personal project.

## How to test

1. Open a saved workflow in the editor.
2. Reload the page (Cmd+R), then click the AI Assistant sparkles button in the canvas action cluster.
3. The thread view must show the user message with the workflow chip, the artifact panel with the workflow canvas, and the agent response streaming in.
4. Repeat via warm navigation (editor -> assistant -> back -> click again), switch between threads, and leave the assistant: runtimes are still disposed on real navigation away.

Before the fix, step 3 reproducibly failed on cold loads (3/3 locally, also under CPU/network throttling). After the fix, 9/9 cold rounds plus warm rounds pass. The new unit test fails against the unfixed component.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-856

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33895">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

