### PR TITLE
fix(core): Construct execution errors correctly when Error.prototype is frozen

### DIFF
--- a/packages/workflow/src/errors/abstract/execution-base.error.ts
+++ b/packages/workflow/src/errors/abstract/execution-base.error.ts
@@ -27,7 +27,13 @@ export abstract class ExecutionBaseError extends BaseError {
 	constructor(message: string, options: ExecutionBaseErrorOptions = {}) {
 		super(message, options);
 
-		this.name = this.constructor.name;
+		// Defined, not assigned: assignment throws when `Error.prototype` is frozen (task runner secure mode)
+		Object.defineProperty(this, 'name', {
+			value: this.constructor.name,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		});
 		this.timestamp = Date.now();
 
 		const { cause, errorResponse } = options;

--- a/packages/workflow/src/errors/workflow-activation.error.ts
+++ b/packages/workflow/src/errors/workflow-activation.error.ts
@@ -24,8 +24,17 @@ export class WorkflowActivationError extends ExecutionBaseError {
 		let error = cause as Error;
 		if (cause instanceof ExecutionBaseError) {
 			error = new Error(cause.message);
-			error.constructor = cause.constructor;
-			error.name = cause.name;
+			// Defined, not assigned: a fresh `Error` has no own `constructor`/`name`, so
+			// assignment throws when `Error.prototype` is frozen (task runner secure mode)
+			Object.defineProperties(error, {
+				constructor: {
+					value: cause.constructor,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				},
+				name: { value: cause.name, writable: true, enumerable: true, configurable: true },
+			});
 			error.stack = cause.stack;
 		}
 		super(message, { cause: error });

--- a/packages/workflow/test/errors/execution-base.error.test.ts
+++ b/packages/workflow/test/errors/execution-base.error.test.ts
@@ -1,0 +1,28 @@
+import { ExpressionError } from '../../src/errors';
+
+describe('ExecutionBaseError', () => {
+	it('should set name to the concrete class name', () => {
+		const error = new ExpressionError('message');
+
+		expect(error.name).toBe('ExpressionError');
+	});
+
+	describe('with a frozen Error.prototype', () => {
+		const nameDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, 'name')!;
+
+		beforeAll(() => {
+			Object.defineProperty(Error.prototype, 'name', { ...nameDescriptor, writable: false });
+		});
+
+		afterAll(() => {
+			Object.defineProperty(Error.prototype, 'name', nameDescriptor);
+		});
+
+		it('should construct and set name without writing through the prototype', () => {
+			const error = new ExpressionError('Paired item data is unavailable');
+
+			expect(error.name).toBe('ExpressionError');
+			expect(Object.getOwnPropertyDescriptor(error, 'name')?.writable).toBe(true);
+		});
+	});
+});

--- a/packages/workflow/test/errors/workflow-activation.error.test.ts
+++ b/packages/workflow/test/errors/workflow-activation.error.test.ts
@@ -1,4 +1,4 @@
-import { WorkflowActivationError } from '../../src/errors';
+import { WorkflowActivationError, WorkflowOperationError } from '../../src/errors';
 
 describe('WorkflowActivationError', () => {
 	it('should default to `error` level', () => {
@@ -43,5 +43,33 @@ describe('WorkflowActivationError', () => {
 		const error = new WorkflowActivationError('Generic wrapper message', { cause: richCause });
 
 		expect(error.description).toBe('Actionable detail');
+	});
+
+	describe('with a frozen Error.prototype', () => {
+		const descriptors = {
+			name: Object.getOwnPropertyDescriptor(Error.prototype, 'name')!,
+			constructor: Object.getOwnPropertyDescriptor(Error.prototype, 'constructor')!,
+		};
+
+		beforeAll(() => {
+			for (const [key, descriptor] of Object.entries(descriptors)) {
+				Object.defineProperty(Error.prototype, key, { ...descriptor, writable: false });
+			}
+		});
+
+		afterAll(() => {
+			for (const [key, descriptor] of Object.entries(descriptors)) {
+				Object.defineProperty(Error.prototype, key, descriptor);
+			}
+		});
+
+		it('should wrap an ExecutionBaseError cause without writing through the prototype', () => {
+			const operationCause = new WorkflowOperationError('operation failed');
+
+			const error = new WorkflowActivationError('activation failed', { cause: operationCause });
+
+			expect(error.name).toBe('WorkflowActivationError');
+			expect(error.description).toBe('operation failed');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The JS task runner's secure mode (`preventPrototypePollution`, the default — `N8N_RUNNERS_INSECURE_MODE` unset) freezes every global function prototype, including `Error.prototype`. Any error class constructed inside the runner realm that assigns to an inherited non-writable property then throws in strict mode:

```
TypeError: Cannot assign to read only property 'name' of object 'Error: Paired item data for item from node '...' is unavailable...'
```

The practical effect: a graceful, actionable `ExpressionError` (e.g. the missing paired-item warning surfaced by the Code node) is replaced by an opaque `TypeError`, hiding the real problem from the user. Sibling reports of the same mechanism: #21227, #18328, #24307.

This PR switches the affected assignments to `Object.defineProperty`/`defineProperties`, which create own properties without consulting the prototype (same approach as the task runner's own `ExecutionError` uses for non-writable `stack`), with descriptors identical to what plain assignment produces:

- `ExecutionBaseError`: `this.name = this.constructor.name` → define. Derived classes that re-assign `name` (`WorkflowOperationError`, `SubworkflowOperationError`) are safe unchanged afterwards, since the instance then owns a writable `name`.
- `WorkflowActivationError`: `constructor`/`name` assignments onto a fresh `new Error()` (no own properties yet) → define.

## How to test

Unit tests reproduce the runner condition by making `Error.prototype.name`/`constructor` non-writable and constructing the errors — before this fix they fail with the exact production `TypeError`, after it they pass:

```
cd packages/workflow && pnpm test test/errors/execution-base.error.test.ts test/errors/workflow-activation.error.test.ts
```

Full `n8n-workflow` suite (5150 tests), typecheck and lint pass.

## Related Linear tickets, Github issues, and Community forum posts

Related context: #21227, #18328, #24307 (same frozen-prototype mechanism, different properties). Found while investigating eval-CI container log storms — the storm is this TypeError thrown per item in `runForEachItem` hot paths.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

