### PR TITLE
fix(Slack Node): Clarify unfurl field descriptions

### DIFF
--- a/packages/nodes-base/nodes/Slack/V1/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V1/MessageDescription.ts
@@ -204,14 +204,14 @@ export const messageFields: INodeProperties[] = [
 				name: 'unfurl_links',
 				type: 'boolean',
 				default: false,
-				description: 'Whether to enable unfurling of primarily text-based content',
+				description: 'Whether to unfurl primarily text-based content in the message',
 			},
 			{
 				displayName: 'Unfurl Media',
 				name: 'unfurl_media',
 				type: 'boolean',
 				default: true,
-				description: 'Whether to disable unfurling of media content',
+				description: 'Whether to unfurl media content in the message',
 			},
 			{
 				displayName: 'Send as User',

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -685,14 +685,14 @@ export const messageFields: INodeProperties[] = [
 				name: 'unfurl_links',
 				type: 'boolean',
 				default: false,
-				description: 'Whether to enable unfurling of primarily text-based content',
+				description: 'Whether to unfurl primarily text-based content in the message',
 			},
 			{
 				displayName: 'Unfurl Media',
 				name: 'unfurl_media',
 				type: 'boolean',
 				default: true,
-				description: 'Whether to disable unfurling of media content',
+				description: 'Whether to unfurl media content in the message',
 			},
 			{
 				displayName: 'Send as Ephemeral Message',


### PR DESCRIPTION
## Summary

The Slack node's `unfurl_media` field was described as *"Whether to disable unfurling of media content"* (default `true`). The value is passed straight through to Slack's `chat.postMessage` API via `Object.assign(body, otherOptions)`, where `unfurl_media: true` **enables** media unfurling. So the wording was inverted relative to the actual behaviour, and it read with the opposite polarity to its sibling `unfurl_links` (*"...enable..."*). This tripped up both users and Instance AI.

This reword makes both fields read with consistent, correct polarity (`true` = unfurl):

* `unfurl_media`: `Whether to unfurl media content in the message`
* `unfurl_links`: `Whether to unfurl primarily text-based content in the message`

Applied to both V1 and V2 of the node.

## Notes

* **No behaviour change** — copy only. Defaults are untouched and still match Slack's API defaults (`unfurl_media: true`, `unfurl_links: false`).
* An Instance AI eval trace fixture (`packages/testing/playwright/expectations/instance-ai/.../trace.jsonl`) still embeds the old wording; it's a regenerable recorded trace, not a string assertion, so it's left untouched.

Related: [NODE-5409](https://linear.app/n8n/issue/NODE-5409)

## Review / Merge Checklist

- [X] Tests included (existing Slack node tests pass; descriptions are not unit-tested)
- [X] PR title follows conventions

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

[![Open in Stage](https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/be62a65c-30f1-480d-9bb9-b09b8dae0bc2/aa6a4416-207e-4a7c-8e95-5f3dd88c88fa?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9iZTYyYTY1Yy0zMGYxLTQ4MGQtOWJiOS1iMDliOGRhZTBiYzIvYWE2YTQ0MTYtMjA3ZS00YTdjLThlOTUtNWYzZGQ4OGM4OGZhIiwiaWF0IjoxNzgzNTkwMjg1LCJleHAiOjE4MTUxNjA4NDV9.AYEmVij7wXD044qWNtAfgSmwk1oPUszqCb8xrGHDxUY)](<https://stagereview.app/n8n-io/n8n/pull/33900>)