### PR TITLE
fix(editor): Disable view publish timeline action for new workflows

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -642,6 +642,25 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 		});
 	});
 
+	describe('View timeline action', () => {
+		it('should be disabled when workflow is new', async () => {
+			const { getByTestId } = renderComponent({
+				props: {
+					...defaultWorkflowProps,
+					isNewWorkflow: true,
+				},
+			});
+
+			const versionMenuButton = getByTestId('version-menu-button');
+			await userEvent.click(versionMenuButton);
+
+			const viewPublishTimelineAction = getByTestId('version-menu-item-publish-timeline');
+
+			expect(viewPublishTimelineAction).toBeInTheDocument();
+			expect(viewPublishTimelineAction).toHaveClass('is-disabled');
+		});
+	});
+
 	describe('Unpublish action', () => {
 		beforeEach(() => {
 			workflowDocumentStore.setActiveState({

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -642,32 +642,6 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 		});
 	});
 
-	describe('View timeline action', () => {
-		beforeEach(() => {
-			workflowDocumentStore.setActiveState({
-				activeVersionId: 'active-version-1',
-				activeVersion: createMockActiveVersion('active-version-1'),
-			});
-		});
-
-		it('should be disabled when workflow is new', async () => {
-			const { getByTestId } = renderComponent({
-				props: {
-					...defaultWorkflowProps,
-					isNewWorkflow: true,
-				},
-			});
-
-			const versionMenuButton = getByTestId('version-menu-button');
-			await userEvent.click(versionMenuButton);
-
-			const viewPublishTimelineAction = getByTestId('version-menu-item-publish-timeline');
-
-			expect(viewPublishTimelineAction).toBeInTheDocument();
-			expect(viewPublishTimelineAction).toHaveClass('is-disabled');
-		});
-	});
-
 	describe('Unpublish action', () => {
 		beforeEach(() => {
 			workflowDocumentStore.setActiveState({

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -744,6 +744,22 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 			const { container } = renderComponent();
 			expect(container).toBeInTheDocument();
 		});
+
+		it('should disable the menu button when workflow is new', () => {
+			settingsStore.isEnterpriseFeatureEnabled = createMockEnterpriseSettings({
+				[EnterpriseEditionFeature.NamedVersions]: false,
+			});
+
+			const { getByTestId } = renderComponent({
+				props: {
+					...defaultWorkflowProps,
+					isNewWorkflow: true,
+				},
+			});
+
+			const versionMenuButton = getByTestId('version-menu-button');
+			expect(versionMenuButton).toBeDisabled();
+		});
 	});
 
 	describe('Publication service states (flag on)', () => {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.test.ts
@@ -643,6 +643,13 @@ describe('WorkflowHeaderDraftPublishActions', () => {
 	});
 
 	describe('View timeline action', () => {
+		beforeEach(() => {
+			workflowDocumentStore.setActiveState({
+				activeVersionId: 'active-version-1',
+				activeVersion: createMockActiveVersion('active-version-1'),
+			});
+		});
+
 		it('should be disabled when workflow is new', async () => {
 			const { getByTestId } = renderComponent({
 				props: {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowHeaderDraftPublishActions.vue
@@ -418,6 +418,7 @@ const versionMenuActions = computed<Array<ActionDropdownItem<VERSION_ACTIONS>>>(
 	actions.push({
 		id: VERSION_ACTIONS.PUBLISH_TIMELINE,
 		label: i18n.baseText('workflowHistory.action.viewTimeline'),
+		disabled: props.isNewWorkflow,
 	});
 
 	actions.push({


### PR DESCRIPTION
## Summary

When a new Workflow is created, the user has the option within the editor UI to view the publish timeline via the 'View timeline' action in the 'More actions' menu. At this time, the Workflow is not saved. There are no published versions and the 'View timeline' action breaks with an error as the Workflow is not found.

This PR disables the 'View timeline' action when `isNewWorkflow` is `true`. This is the same setting used to disable the Version history button and is `true` when a Workflow is not saved to the back-end. Note that disabling the 'View timeline' can mean that the entire drop-down menu is disabled, the drop-down component has logic within to disable if all its child menu items are disabled.

Before:
<img width="1366" height="768" alt="Screen Recording 2026-07-09 at 11 09 45" src="https://github.com/user-attachments/assets/fcedfc09-b97e-4d02-9a2d-ae6f1271575f" />

After:
<img width="1366" height="768" alt="Screen Recording 2026-07-09 at 11 15 26" src="https://github.com/user-attachments/assets/80e58053-ad5b-4ef6-913e-a2e9d96ffc52" />

## How to test

1. Create a new Workflow, ensure you make no changes and add no nodes.
2. Notice the 'More actions' menu next to the publish button is disabled

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-773

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

