### PR TITLE
ci: Pick up Needs Feedback label in close-stale community PRs workflow

### DIFF
--- a/.github/workflows/community-pr-close-stale.yml
+++ b/.github/workflows/community-pr-close-stale.yml
@@ -1,9 +1,11 @@
 name: 'Community: Close Stale PRs'
 
 # Closes community PRs that were sent back to the contributor
-# (triage:needs-info / triage:tests-needed) and have been inactive since.
-# Scoped to those labels on purpose: we only close PRs where we asked for
-# changes and got no response — never PRs waiting on us.
+# (triage:needs-info / triage:tests-needed / Needs Feedback) and have been
+# inactive since. Scoped to those labels on purpose: we only close PRs where we
+# asked for changes and got no response — never PRs waiting on us.
+# "Needs Feedback" is the legacy equivalent of triage:needs-info (predates the
+# triage:* convention) and still sits on open community PRs awaiting a reply.
 
 on:
   schedule:
@@ -30,7 +32,7 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
 
-          any-of-pr-labels: 'triage:needs-info,triage:tests-needed'
+          any-of-pr-labels: 'triage:needs-info,triage:tests-needed,Needs Feedback'
           days-before-pr-stale: 30
           days-before-pr-close: 14
           stale-pr-label: 'Stale'


### PR DESCRIPTION
## Summary

The `community-pr-close-stale` workflow only matched `triage:needs-info` / `triage:tests-needed`, so community PRs carrying the legacy `Needs Feedback` label (the pre-`triage:*` equivalent of `triage:needs-info`) were never staled.

`Needs Feedback` is the label the readiness-check skill assigned before the `triage:*` convention existed. The skill does not assign it anymore and does not strip it during re-triage (step 2 only removes `triage:*` labels), so legacy PRs that carry it but no `triage:*` label are orphaned from the close-stale safety net. Two such PRs (#16359, #16331) have sat idle since Dec 2025 despite an n8n team member asking the contributor to act.

Adds `Needs Feedback` to `any-of-pr-labels`.

## How to test

Trigger the workflow manually via `workflow_dispatch` with `dry-run: true` (default). Confirm it now logs stale/close actions for PRs carrying only `Needs Feedback` (previously skipped). No PRs are commented or closed in dry-run mode.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1524/auto-close-community-prs-stuck-on-contributor-feedback

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs backporting)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

