### PR TITLE
test(ai-builder): Make eval lanes self-healing under container failure (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -311,6 +311,7 @@ jobs:
           fi
 
       - name: Run Instance AI Evals
+        id: run-evals
         continue-on-error: true
         working-directory: packages/@n8n/instance-ai
         env:
@@ -459,3 +460,13 @@ jobs:
             packages/@n8n/instance-ai/.data/workflow-eval-report.html
             eval-diag/
           retention-days: 14
+
+      # continue-on-error keeps PR-comparison runs green, but a baseline
+      # capture that reported framework noise (or crashed) must fail the job —
+      # findLatestBaseline trusts the newest experiment by prefix, so a
+      # silently-poisoned capture would poison every subsequent comparison.
+      - name: Fail baseline captures on framework noise
+        if: ${{ always() && startsWith(inputs.experiment-name, 'instance-ai-baseline') && steps.run-evals.outcome == 'failure' }}
+        run: |
+          echo "::error::Baseline capture failed or reported framework noise — do not use this experiment as a baseline."
+          exit 1

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -461,10 +461,9 @@ jobs:
             eval-diag/
           retention-days: 14
 
-      # continue-on-error keeps PR-comparison runs green, but a baseline
-      # capture that reported framework noise (or crashed) must fail the job —
-      # findLatestBaseline trusts the newest experiment by prefix, so a
-      # silently-poisoned capture would poison every subsequent comparison.
+      # continue-on-error keeps PR runs green, but a baseline capture that
+      # reported framework noise must fail the job — findLatestBaseline trusts
+      # the newest experiment by prefix.
       - name: Fail baseline captures on framework noise
         if: ${{ always() && startsWith(inputs.experiment-name, 'instance-ai-baseline') && steps.run-evals.outcome == 'failure' }}
         run: |

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -311,7 +311,6 @@ jobs:
           fi
 
       - name: Run Instance AI Evals
-        id: run-evals
         continue-on-error: true
         working-directory: packages/@n8n/instance-ai
         env:
@@ -460,12 +459,3 @@ jobs:
             packages/@n8n/instance-ai/.data/workflow-eval-report.html
             eval-diag/
           retention-days: 14
-
-      # continue-on-error keeps PR runs green, but a baseline capture that
-      # reported framework noise must fail the job — findLatestBaseline trusts
-      # the newest experiment by prefix.
-      - name: Fail baseline captures on framework noise
-        if: ${{ always() && startsWith(inputs.experiment-name, 'instance-ai-baseline') && steps.run-evals.outcome == 'failure' }}
-        run: |
-          echo "::error::Baseline capture failed or reported framework noise — do not use this experiment as a baseline."
-          exit 1

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -136,7 +136,7 @@ dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --iterations 3
 | `--filter` | — | Filter test cases by filename substring. Comma-separated values mean OR (e.g. `contact-form,deduplication`) |
 | `--exclude` | — | Skip test cases whose filename matches any of the substrings. Same comma-separated shape as `--filter`; applied after `--filter` |
 | `--prebuilt-workflows` | — | Path to a JSON manifest mapping test-case slugs to existing workflow IDs. Skips the orchestrator build for matched test cases — see [Running evals against pre-built workflows](#running-evals-against-pre-built-workflows) |
-| `--keep-workflows` | `false` | Don't delete built workflows after the run. Pair with the HTML report's "view in n8n" links to inspect each scenario's canvas execution |
+| `--keep-workflows` | `false` | Don't delete any build artifacts after the run — workflows, data tables, and threads (with their sandboxes) all survive. Pair with the HTML report's "view in n8n" links to inspect each scenario's canvas execution. Sandboxes have no auto-cleanup, so use with `--filter` on a few cases rather than full baselines |
 | `--delete-prebuilt-workflows` | `false` | With `--prebuilt-workflows`, delete successfully used manifest workflows after the eval run. Mutually exclusive with `--keep-workflows` |
 | `--base-url` | `http://localhost:5678` | n8n instance URL |
 | `--email` | E2E test owner | Override login email (or `N8N_EVAL_EMAIL`) |

--- a/packages/@n8n/instance-ai/evaluations/__tests__/cleanup-build.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/cleanup-build.test.ts
@@ -1,0 +1,69 @@
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import type { N8nClient } from '../clients/n8n-client';
+import type { EvalLogger } from '../harness/logger';
+import { cleanupBuild } from '../harness/runner';
+import type { BuildResult } from '../harness/runner';
+
+/**
+ * Locks in the cleanupBuild contract the CLI's per-case cleanup relies on:
+ * the return value reports whether every deletion succeeded, so a caller can
+ * keep the build cached and retry a transiently failed cleanup later.
+ */
+
+const silentLogger: EvalLogger = {
+	info: () => {},
+	verbose: () => {},
+	success: () => {},
+	warn: () => {},
+	error: () => {},
+	isVerbose: false,
+};
+
+function makeClient(overrides: Partial<Record<keyof N8nClient, Mock>> = {}): {
+	client: N8nClient;
+	mocks: Record<string, Mock>;
+} {
+	const mocks: Record<string, Mock> = {
+		deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+		deleteDataTable: vi.fn().mockResolvedValue(undefined),
+		getPersonalProjectId: vi.fn().mockResolvedValue('project-1'),
+		deleteThread: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+	return { client: mocks as unknown as N8nClient, mocks };
+}
+
+function makeBuild(): BuildResult {
+	return {
+		success: true,
+		workflowJsons: [],
+		createdWorkflowIds: ['W1'],
+		createdDataTableIds: ['DT1'],
+		threadId: 'T1',
+	};
+}
+
+describe('cleanupBuild', () => {
+	it('deletes workflows, data tables and the thread, and reports clean', async () => {
+		const { client, mocks } = makeClient();
+
+		await expect(cleanupBuild(client, makeBuild(), silentLogger)).resolves.toBe(true);
+
+		expect(mocks.deleteWorkflow).toHaveBeenCalledWith('W1');
+		expect(mocks.deleteDataTable).toHaveBeenCalledWith('project-1', 'DT1');
+		expect(mocks.deleteThread).toHaveBeenCalledWith('T1');
+	});
+
+	it('reports not clean when a deletion fails, but still attempts the rest', async () => {
+		const { client, mocks } = makeClient({
+			deleteWorkflow: vi.fn().mockRejectedValue(new Error('HTTP 502')),
+		});
+
+		await expect(cleanupBuild(client, makeBuild(), silentLogger)).resolves.toBe(false);
+
+		expect(mocks.deleteDataTable).toHaveBeenCalledWith('project-1', 'DT1');
+		expect(mocks.deleteThread).toHaveBeenCalledWith('T1');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/fetch-baseline.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fetch-baseline.test.ts
@@ -7,6 +7,7 @@ import { BASELINE_EXPERIMENT_PREFIX, findLatestBaseline } from '../comparison/fe
 interface FakeProject {
 	name?: string;
 	start_time?: string;
+	extra?: Record<string, unknown>;
 }
 
 /**
@@ -21,8 +22,16 @@ function clientWith(projects: FakeProject[]): { client: Client; listProjects: Mo
 			for (const p of projects) yield p;
 		})(),
 	);
-	return { client: { listProjects } as unknown as Client, listProjects };
+	const readProject = vi.fn(async ({ projectName }: { projectName: string }) => {
+		const project = projects.find((p) => p.name === projectName);
+		if (!project) throw new Error(`not found: ${projectName}`);
+		return await Promise.resolve(project);
+	});
+	return { client: { listProjects, readProject } as unknown as Client, listProjects };
 }
+
+/** Aggregate metadata written by the CLI only when a run completes. */
+const COMPLETED = { metadata: { pass_rate_per_iter: '78%' } };
 
 describe('findLatestBaseline', () => {
 	it('queries with the default instance-ai baseline prefix when none is given', async () => {
@@ -69,5 +78,29 @@ describe('findLatestBaseline', () => {
 			{ name: 'mcp-baseline-no-ts' }, // no start_time → ts 0, still the only match
 		]);
 		expect(await findLatestBaseline(client, 'mcp-baseline-')).toBe('mcp-baseline-no-ts');
+	});
+
+	it('skips a newer capture that never wrote the completion marker (killed run)', async () => {
+		const { client } = clientWith([
+			{ name: 'instance-ai-baseline-done', start_time: '2026-07-08T00:00:00Z', extra: COMPLETED },
+			{ name: 'instance-ai-baseline-killed', start_time: '2026-07-09T00:00:00Z', extra: {} },
+		]);
+		expect(await findLatestBaseline(client)).toBe('instance-ai-baseline-done');
+	});
+
+	it('picks the newest among completed captures', async () => {
+		const { client } = clientWith([
+			{ name: 'instance-ai-baseline-old', start_time: '2026-07-01T00:00:00Z', extra: COMPLETED },
+			{ name: 'instance-ai-baseline-new', start_time: '2026-07-08T00:00:00Z', extra: COMPLETED },
+		]);
+		expect(await findLatestBaseline(client)).toBe('instance-ai-baseline-new');
+	});
+
+	it('falls back to the newest candidate when none carry the marker', async () => {
+		const { client } = clientWith([
+			{ name: 'instance-ai-baseline-a', start_time: '2026-07-01T00:00:00Z' },
+			{ name: 'instance-ai-baseline-b', start_time: '2026-07-08T00:00:00Z' },
+		]);
+		expect(await findLatestBaseline(client)).toBe('instance-ai-baseline-b');
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
@@ -91,4 +91,109 @@ describe('LaneAllocator', () => {
 		await w1;
 		expect(order).toEqual(['p3', 'p1']);
 	});
+
+	describe('lane health', () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('quarantines a lane after consecutive transient failures and stops assigning to it', async () => {
+			const lanes = newLanes(2);
+			const onQuarantine = vi.fn();
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(false),
+				quarantineThreshold: 3,
+				onQuarantine,
+			});
+			for (let i = 0; i < 3; i++) a.reportBuildOutcome(lanes[0], 'transient-failure');
+			expect(a.isQuarantined(lanes[0])).toBe(true);
+			expect(onQuarantine).toHaveBeenCalledWith(lanes[0]);
+			const l1 = await a.acquire('p1');
+			const l2 = await a.acquire('p2');
+			expect([l1.id, l2.id]).toEqual([1, 1]);
+		});
+
+		it('resets the consecutive-failure counter on a successful build', () => {
+			const lanes = newLanes(1);
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(false),
+				quarantineThreshold: 3,
+			});
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportBuildOutcome(lanes[0], 'ok');
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			expect(a.isQuarantined(lanes[0])).toBe(false);
+		});
+
+		it('re-admits a lane once the probe reports healthy and serves queued waiters', async () => {
+			vi.useFakeTimers();
+			const lanes = newLanes(1);
+			let healthy = false;
+			const onReadmit = vi.fn();
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(healthy),
+				probeIntervalMs: 1000,
+				quarantineThreshold: 1,
+				allQuarantinedGraceMs: 60_000,
+				onReadmit,
+			});
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			expect(a.isQuarantined(lanes[0])).toBe(true);
+			const waiter = a.acquire('p1');
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(a.isQuarantined(lanes[0])).toBe(true);
+			healthy = true;
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(a.isQuarantined(lanes[0])).toBe(false);
+			expect(onReadmit).toHaveBeenCalledWith(lanes[0]);
+			await expect(waiter).resolves.toBe(lanes[0]);
+		});
+
+		it('prefers a lane other than `not`, falling back to it when nothing else is free', async () => {
+			const lanes = newLanes(2);
+			const a = new LaneAllocator(lanes, 4);
+			const first = await a.acquire('p1');
+			const retry = await a.acquire('p2', { not: first });
+			expect(retry.id).not.toBe(first.id);
+
+			const single = newLanes(1);
+			const b = new LaneAllocator(single, 4);
+			const only = await b.acquire('p1');
+			const fallback = await b.acquire('p2', { not: only });
+			expect(fallback).toBe(only);
+		});
+
+		it('remembers when a lane was quarantined so mid-flight failures can be attributed', () => {
+			const before = Date.now();
+			const lanes = newLanes(1);
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(false),
+				quarantineThreshold: 1,
+			});
+			expect(a.wasQuarantinedSince(lanes[0], before)).toBe(false);
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			expect(a.wasQuarantinedSince(lanes[0], before)).toBe(true);
+			expect(a.wasQuarantinedSince(lanes[0], Date.now() + 1000)).toBe(false);
+		});
+
+		it('aborts pending and future acquires when all lanes stay quarantined past the grace period', async () => {
+			vi.useFakeTimers();
+			const lanes = newLanes(2);
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(false),
+				probeIntervalMs: 1000,
+				quarantineThreshold: 1,
+				allQuarantinedGraceMs: 5000,
+			});
+			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportBuildOutcome(lanes[1], 'transient-failure');
+			const pending = a.acquire('p1');
+			const rejection = expect(pending).rejects.toThrow('All 2 lanes quarantined');
+			await vi.advanceTimersByTimeAsync(5000);
+			await rejection;
+			await expect(a.acquire('p2')).rejects.toThrow('quarantined');
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -107,8 +107,8 @@ const MAX_CONCURRENT_BUILDS = 4;
 /** Attempts (initial + retries) for a build hitting transient network errors. */
 const MAX_BUILD_ATTEMPTS = 3;
 
-/** Max share of framework_issue trials tolerated in a baseline capture. */
-const BASELINE_MAX_FRAMEWORK_NOISE_RATE = 0.02;
+/** Framework-noise share above which a baseline capture gets a quality warning. */
+const BASELINE_MAX_FRAMEWORK_NOISE_RATE = 0.05;
 
 /** Count framework-noise trials and cases that failed on nothing but noise. */
 function assessFrameworkNoise(
@@ -491,9 +491,8 @@ async function main(): Promise<void> {
 			'\n' + formatComparisonTerminal(evaluation, outcome, { commitSha, slugByTestCase, gate }),
 		);
 
-		// findLatestBaseline trusts the newest experiment by prefix — a noisy
-		// baseline capture must fail loudly instead of silently becoming the
-		// comparison target for every subsequent run.
+		// Advisory only: findLatestBaseline trusts the newest experiment by
+		// prefix, so surface elevated harness noise for the humans reading the log.
 		if (args.experimentName?.startsWith('instance-ai-baseline')) {
 			const { frameworkTrials, totalTrials, fullyNoisyCases } = assessFrameworkNoise(
 				evaluation,
@@ -501,14 +500,16 @@ async function main(): Promise<void> {
 			);
 			const noiseRate = totalTrials > 0 ? frameworkTrials / totalTrials : 0;
 			if (noiseRate > BASELINE_MAX_FRAMEWORK_NOISE_RATE || fullyNoisyCases.length > 0) {
-				console.error(
-					`Baseline capture rejected: framework noise in ${String(frameworkTrials)}/${String(totalTrials)} trials (${(noiseRate * 100).toFixed(1)}%)` +
+				console.warn(
+					`Baseline quality warning: ${String(frameworkTrials)}/${String(totalTrials)} trials (${(noiseRate * 100).toFixed(1)}%) failed for harness reasons` +
+						' (lane transport, seeding, timeouts) rather than agent behavior' +
 						(fullyNoisyCases.length > 0
 							? `; cases with only framework failures: ${fullyNoisyCases.join(', ')}`
 							: '') +
-						'. Do not use this experiment as a baseline — fix the noise and re-dispatch.',
+						'. This experiment becomes the comparison target for future runs, but those scenarios will' +
+						' under-count the agent — deltas against them may reflect harness noise, not regressions or' +
+						' improvements. Consider fixing the noise and re-capturing.',
 				);
-				process.exitCode = 1;
 			}
 		}
 	} finally {

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -78,6 +78,7 @@ import {
 } from '../harness/runner';
 import {
 	extractErrorMessage,
+	isTransientNetworkError,
 	MAX_EXEC_ATTEMPTS,
 	shouldRetryScenarioExecution,
 } from '../harness/transient-error';
@@ -102,6 +103,39 @@ import { caseDisplayPrompt, conversationUserTurnsAsText } from '../utils/convers
 
 // n8n degrades above ~4 concurrent builds.
 const MAX_CONCURRENT_BUILDS = 4;
+
+/** Attempts (initial + retries) for a build hitting transient network errors. */
+const MAX_BUILD_ATTEMPTS = 3;
+
+/** Max share of framework_issue trials tolerated in a baseline capture. */
+const BASELINE_MAX_FRAMEWORK_NOISE_RATE = 0.02;
+
+/** Count framework-noise trials and cases that failed on nothing but noise. */
+function assessFrameworkNoise(
+	evaluation: MultiRunEvaluation,
+	slugByTestCase?: Map<WorkflowTestCase, string>,
+): { frameworkTrials: number; totalTrials: number; fullyNoisyCases: string[] } {
+	let frameworkTrials = 0;
+	let totalTrials = 0;
+	const fullyNoisyCases: string[] = [];
+	for (const tc of evaluation.testCases) {
+		let caseFramework = 0;
+		let caseTotal = 0;
+		for (const sa of tc.executionScenarios) {
+			for (const run of sa.runs) {
+				if (run.incomplete) continue;
+				caseTotal++;
+				if (!run.success && run.failureCategory === 'framework_issue') caseFramework++;
+			}
+		}
+		frameworkTrials += caseFramework;
+		totalTrials += caseTotal;
+		if (caseTotal > 0 && caseFramework === caseTotal) {
+			fullyNoisyCases.push(slugByTestCase?.get(tc.testCase) ?? caseDisplayPrompt(tc.testCase));
+		}
+	}
+	return { frameworkTrials, totalTrials, fullyNoisyCases };
+}
 
 /** Target input shape with the iteration index we inject for multi-run. */
 type TargetInputs = DatasetExampleInputs & { _iteration?: number };
@@ -456,6 +490,28 @@ async function main(): Promise<void> {
 		console.log(
 			'\n' + formatComparisonTerminal(evaluation, outcome, { commitSha, slugByTestCase, gate }),
 		);
+
+		// A noisy baseline capture must fail loudly: findLatestBaseline picks the
+		// newest experiment by prefix, so a silently-poisoned capture (e.g. a dead
+		// lane converting whole cases into 0-score rows) would become the
+		// comparison target for every subsequent run.
+		if (args.experimentName?.startsWith('instance-ai-baseline')) {
+			const { frameworkTrials, totalTrials, fullyNoisyCases } = assessFrameworkNoise(
+				evaluation,
+				slugByTestCase,
+			);
+			const noiseRate = totalTrials > 0 ? frameworkTrials / totalTrials : 0;
+			if (noiseRate > BASELINE_MAX_FRAMEWORK_NOISE_RATE || fullyNoisyCases.length > 0) {
+				console.error(
+					`Baseline capture rejected: framework noise in ${String(frameworkTrials)}/${String(totalTrials)} trials (${(noiseRate * 100).toFixed(1)}%)` +
+						(fullyNoisyCases.length > 0
+							? `; cases with only framework failures: ${fullyNoisyCases.join(', ')}`
+							: '') +
+						'. Do not use this experiment as a baseline — fix the noise and re-dispatch.',
+				);
+				process.exitCode = 1;
+			}
+		}
 	} finally {
 		// Per-lane cleanup: each lane only holds the workflows built/fetched on it,
 		// so delete them via that lane's own client (multi-lane MCP builds spread
@@ -552,6 +608,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	>;
 	interface LaneState {
 		runner: Lane;
+		laneNum: number;
 		activeBuilds: number;
 		inflightKeys: Set<string>;
 		tracedBuild: (buildArgs: BuildArgs) => Promise<BuildResult>;
@@ -568,6 +625,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		const laneTag = lanes.length > 1 ? ` [lane ${String(laneNum)}/${String(lanes.length)}]` : '';
 		return {
 			runner: lane,
+			laneNum,
 			activeBuilds: 0,
 			inflightKeys: new Set<string>(),
 			tracedBuild: traceable(
@@ -622,10 +680,43 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		};
 	});
 
+	// Direct fetch (not N8nClient) so a hung lane can't stall the probe.
+	async function laneHealthy(lane: LaneState): Promise<boolean> {
+		try {
+			const res = await fetch(`${lane.runner.baseUrl}/healthz/readiness`, {
+				signal: AbortSignal.timeout(5_000),
+			});
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	// Distinguish agent build failures from transport ones. Error-message
+	// matching alone misses the nastiest case — a build that sat out its
+	// timeout against a dead lane reports "Run timed out", not "fetch failed" —
+	// so any failed build also health-probes its lane.
+	async function isTransportFailure(build: BuildResult, lane: LaneState): Promise<boolean> {
+		if (build.success) return false;
+		if (build.error !== undefined && isTransientNetworkError(build.error)) return true;
+		return !(await laneHealthy(lane));
+	}
+
 	// Work-stealing: each build acquires a lane that isn't already running its
 	// fileSlug, runs there (capped per-lane), then releases. Scenarios re-use the
-	// lane that built their workflow.
-	const allocator = new LaneAllocator(laneStates, MAX_CONCURRENT_BUILDS);
+	// lane that built their workflow. Health options keep a dead lane's instant
+	// failures from turning it into the permanently-least-loaded "black hole":
+	// it gets quarantined and re-admitted only once /healthz responds again.
+	const allocator = new LaneAllocator(laneStates, MAX_CONCURRENT_BUILDS, {
+		probe: laneHealthy,
+		onQuarantine: (lane) =>
+			logger.error(
+				`[lane ${String(lane.laneNum)}] quarantined after consecutive transport failures; probing ${lane.runner.baseUrl} for recovery`,
+			),
+		onReadmit: (lane) => logger.info(`[lane ${String(lane.laneNum)}] healthy again — re-admitted`),
+		onAllQuarantined: () =>
+			logger.error('All lanes quarantined — builds paused pending lane recovery'),
+	});
 	const buildCache = new Map<
 		string,
 		Promise<{ build: BuildResult; lane: LaneState; buildDurationMs: number }>
@@ -668,6 +759,11 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					// LLM-judged bookkeeping below needs only the fetched JSON, and
 					// holding the slot through it would idle the lane's build capacity.
 					allocator.release(lane, fileSlug);
+				}
+				{
+					const transient = await isTransportFailure(build, lane);
+					if (!build.success) build.transportFailure = transient;
+					allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
 				}
 				const buildDurationMs = Date.now() - start;
 				// Cleanup registration happens inside buildWorkflowViaMcpOnLane (as soon
@@ -720,30 +816,63 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			}
 			// Orchestrator path: allocator spreads distinct fileSlugs across lanes;
 			// the build cache dedupes scenarios within one file.
-			const lane = await allocator.acquire(fileSlug);
 			const entry = testCaseByFileSlug.get(fileSlug);
 			if (!entry) throw new Error(`No conversation found for fileSlug=${fileSlug}`);
-			try {
+			// A transient build failure (dropped socket, lane process dying) is a
+			// transport problem, not an agent verdict — retry on a different lane
+			// instead of recording a 0-score row for every scenario of the case.
+			let lane = await allocator.acquire(fileSlug);
+			let build: BuildResult;
+			let buildDurationMs: number;
+			for (let attempt = 1; ; attempt++) {
 				const start = Date.now();
-				const build = await lane.tracedBuild({
-					conversation: entry.conversation,
-					messageBudget: entry.messageBudget,
-					credentials: entry.credentials,
-					seedFile: entry.seedFile,
-					priorConversation: entry.priorConversation,
-					seedThread: entry.seedThread,
-				});
-				const buildDurationMs = Date.now() - start;
-				buildDurations.set(key, buildDurationMs);
-				stashTranscript(build);
-				stashBuildExpectations(key, fileSlug, build, false);
-				stashRunDebug(lane.runner.client, build);
-				return { build, lane, buildDurationMs };
-			} finally {
-				allocator.release(lane, fileSlug);
+				try {
+					build = await lane.tracedBuild({
+						conversation: entry.conversation,
+						messageBudget: entry.messageBudget,
+						credentials: entry.credentials,
+						seedFile: entry.seedFile,
+						priorConversation: entry.priorConversation,
+						seedThread: entry.seedThread,
+					});
+				} finally {
+					allocator.release(lane, fileSlug);
+				}
+				buildDurationMs = Date.now() - start;
+				const transient =
+					(await isTransportFailure(build, lane)) ||
+					(!build.success && allocator.wasQuarantinedSince(lane, start));
+				if (!build.success) build.transportFailure = transient;
+				allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
+				if (!transient || attempt >= MAX_BUILD_ATTEMPTS) break;
+				logger.warn(
+					`Build ${fileSlug} attempt ${String(attempt)}/${String(MAX_BUILD_ATTEMPTS)} failed transiently on lane ${String(lane.laneNum)} (${build.error ?? 'unknown'}); retrying on another lane`,
+				);
+				lane = await allocator.acquire(fileSlug, { not: lane });
 			}
+			buildDurations.set(key, buildDurationMs);
+			stashTranscript(build);
+			stashBuildExpectations(key, fileSlug, build, false);
+			stashRunDebug(lane.runner.client, build);
+			logger.info(
+				`[lane ${String(lane.laneNum)}] built ${fileSlug} (iteration ${String(iteration)}) thread=${build.threadId ?? 'none'} success=${String(build.success)}`,
+			);
+			// Captured SSE events are only consumed by the pairwise flow; dropping
+			// them keeps the largest chunk of each BuildResult out of the run-long cache.
+			build.events = undefined;
+			return { build, lane, buildDurationMs };
 		})();
 		buildCache.set(key, promise);
+		// A transport-failed build must not poison every remaining scenario of
+		// the case — evict it so a later scenario triggers a fresh build. Agent
+		// build failures stay cached: they are the verdict, and rebuilding would
+		// multiply cost without changing it.
+		void promise.then(
+			({ build }) => {
+				if (build.transportFailure) buildCache.delete(key);
+			},
+			() => buildCache.delete(key),
+		);
 		return await promise;
 	}
 
@@ -815,9 +944,11 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				passed: false,
 				score: 0,
 				reasoning: `Build failed: ${build.error ?? 'unknown'}`,
-				// Seeding failures are a harness setup problem, not an agent build
-				// failure — keep them out of the agent's build_failure bucket.
-				failureCategory: build.seedingFailed ? 'framework_issue' : 'build_failure',
+				// Seeding failures and transport-level failures (retries exhausted
+				// against a dead/restarting lane) are harness problems, not agent
+				// build failures — keep them out of the agent's build_failure bucket.
+				failureCategory:
+					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
 				execErrors: build.error ? [build.error] : [],
 				buildDurationMs,
 				execDurationMs: 0,

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -491,9 +491,8 @@ async function main(): Promise<void> {
 			'\n' + formatComparisonTerminal(evaluation, outcome, { commitSha, slugByTestCase, gate }),
 		);
 
-		// A noisy baseline capture must fail loudly: findLatestBaseline picks the
-		// newest experiment by prefix, so a silently-poisoned capture (e.g. a dead
-		// lane converting whole cases into 0-score rows) would become the
+		// findLatestBaseline trusts the newest experiment by prefix — a noisy
+		// baseline capture must fail loudly instead of silently becoming the
 		// comparison target for every subsequent run.
 		if (args.experimentName?.startsWith('instance-ai-baseline')) {
 			const { frameworkTrials, totalTrials, fullyNoisyCases } = assessFrameworkNoise(
@@ -692,10 +691,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		}
 	}
 
-	// Distinguish agent build failures from transport ones. Error-message
-	// matching alone misses the nastiest case — a build that sat out its
-	// timeout against a dead lane reports "Run timed out", not "fetch failed" —
-	// so any failed build also health-probes its lane.
+	// A build that sat out its timeout against a dead lane reports "Run timed
+	// out", not "fetch failed" — so any failed build also health-probes its lane.
 	async function isTransportFailure(build: BuildResult, lane: LaneState): Promise<boolean> {
 		if (build.success) return false;
 		if (build.error !== undefined && isTransientNetworkError(build.error)) return true;
@@ -703,10 +700,9 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	}
 
 	// Work-stealing: each build acquires a lane that isn't already running its
-	// fileSlug, runs there (capped per-lane), then releases. Scenarios re-use the
-	// lane that built their workflow. Health options keep a dead lane's instant
-	// failures from turning it into the permanently-least-loaded "black hole":
-	// it gets quarantined and re-admitted only once /healthz responds again.
+	// fileSlug, runs there (capped per-lane), then releases. Scenarios re-use
+	// the lane that built their workflow. Health options quarantine a dead lane
+	// instead of letting its instant failures attract the whole queue.
 	const allocator = new LaneAllocator(laneStates, MAX_CONCURRENT_BUILDS, {
 		probe: laneHealthy,
 		onQuarantine: (lane) =>
@@ -818,9 +814,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			// the build cache dedupes scenarios within one file.
 			const entry = testCaseByFileSlug.get(fileSlug);
 			if (!entry) throw new Error(`No conversation found for fileSlug=${fileSlug}`);
-			// A transient build failure (dropped socket, lane process dying) is a
-			// transport problem, not an agent verdict — retry on a different lane
-			// instead of recording a 0-score row for every scenario of the case.
+			// Transport failures are not agent verdicts — retry on a different lane
+			// instead of recording 0-score rows for every scenario of the case.
 			let lane = await allocator.acquire(fileSlug);
 			let build: BuildResult;
 			let buildDurationMs: number;
@@ -857,16 +852,14 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			logger.info(
 				`[lane ${String(lane.laneNum)}] built ${fileSlug} (iteration ${String(iteration)}) thread=${build.threadId ?? 'none'} success=${String(build.success)}`,
 			);
-			// Captured SSE events are only consumed by the pairwise flow; dropping
-			// them keeps the largest chunk of each BuildResult out of the run-long cache.
+			// Only the pairwise flow reads captured events — drop the largest chunk
+			// of each BuildResult from the run-long cache.
 			build.events = undefined;
 			return { build, lane, buildDurationMs };
 		})();
 		buildCache.set(key, promise);
-		// A transport-failed build must not poison every remaining scenario of
-		// the case — evict it so a later scenario triggers a fresh build. Agent
-		// build failures stay cached: they are the verdict, and rebuilding would
-		// multiply cost without changing it.
+		// Evict transport-failed builds so a later scenario rebuilds. Agent build
+		// failures stay cached — they are the verdict; rebuilding just multiplies cost.
 		void promise.then(
 			({ build }) => {
 				if (build.transportFailure) buildCache.delete(key);
@@ -944,9 +937,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				passed: false,
 				score: 0,
 				reasoning: `Build failed: ${build.error ?? 'unknown'}`,
-				// Seeding failures and transport-level failures (retries exhausted
-				// against a dead/restarting lane) are harness problems, not agent
-				// build failures — keep them out of the agent's build_failure bucket.
+				// Seeding and transport failures are harness problems, not agent build
+				// failures — keep them out of the agent's build_failure bucket.
 				failureCategory:
 					build.seedingFailed || build.transportFailure ? 'framework_issue' : 'build_failure',
 				execErrors: build.error ? [build.error] : [],

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -917,8 +917,56 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		);
 	}
 
+	// Rows remaining per `iteration:fileSlug` build. When the last row of a
+	// build finishes, its backend artifacts (workflow, data tables, thread — and
+	// with the thread its sandbox) are deleted right away instead of at the end
+	// of the run: sandboxes have no auto-cleanup, so end-of-run-only deletion
+	// let the sandbox runner grow to ~15 GB over a full N=10 baseline.
+	// --keep-workflows deliberately keeps everything, thread/sandbox included —
+	// it's a debugging flag for small filtered runs, not baselines.
+	const remainingRowsByKey = new Map<string, number>();
+
+	function rowsPerCase(fileSlug: string): number {
+		const scenarios = testCaseByFileSlug.get(fileSlug)?.executionScenarios?.length ?? 0;
+		return Math.max(1, scenarios); // scenario-less cases get one build-only row
+	}
+
+	async function releaseCaseRow(iteration: number, fileSlug: string): Promise<void> {
+		const key = `${String(iteration)}:${fileSlug}`;
+		const remaining = (remainingRowsByKey.get(key) ?? rowsPerCase(fileSlug)) - 1;
+		remainingRowsByKey.set(key, remaining);
+		if (remaining > 0 || args.keepWorkflows) return;
+		const cached = buildCache.get(key);
+		if (!cached) return; // evicted (transport failure) — nothing to clean
+		try {
+			const { build, lane } = await cached;
+			// Run-debug capture reads the thread — let it settle before deletion.
+			if (build.threadId) await runDebugByThreadId.get(build.threadId)?.catch(() => {});
+			const clean = await cleanupBuild(lane.runner.client, build, logger);
+			if (!clean) {
+				// Leave the entry in buildCache — the end-of-run pass retries it.
+				logger.verbose(
+					`  [cleanup] ${fileSlug} (iteration ${String(iteration)}) incomplete, retrying at end of run`,
+				);
+				return;
+			}
+			buildCache.delete(key);
+			logger.verbose(`  [cleanup] ${fileSlug} (iteration ${String(iteration)}) artifacts deleted`);
+		} catch {
+			// Best-effort — a failed cleanup must never fail the row.
+		}
+	}
+
 	const target = async (inputs: TargetInputs): Promise<TargetOutput> => {
 		const iteration = inputs._iteration ?? 0;
+		try {
+			return await targetRow(inputs, iteration);
+		} finally {
+			await releaseCaseRow(iteration, inputs.testCaseFile);
+		}
+	};
+
+	const targetRow = async (inputs: TargetInputs, iteration: number): Promise<TargetOutput> => {
 		const scenario: ExecutionScenario = {
 			name: inputs.scenarioName,
 			description: inputs.scenarioDescription,
@@ -1209,6 +1257,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		};
 	} finally {
 		if (!args.keepWorkflows) {
+			// Entries still here had no rows run, or their per-case cleanup failed
+			// (releaseCaseRow leaves those cached so this pass can retry them).
 			await Promise.all(
 				[...buildCache.values()].map(async (promise) => {
 					try {

--- a/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
@@ -1,6 +1,14 @@
 // Pull-based lane allocator. Each lane caps at `maxConcurrentBuilds` and never
 // runs the same key twice concurrently — pairing those rules eliminates the
 // same-key concentration that breaks the agent under load.
+//
+// Lanes additionally report build transport outcomes. A dead lane fails builds
+// in milliseconds, so under the least-loaded policy it is permanently the
+// emptiest lane and would swallow the entire remaining queue ("black hole").
+// Consecutive transient failures therefore quarantine a lane, and a health
+// probe re-admits it once its backend responds again (pairing with the
+// containers' restart policy). If every lane stays quarantined past a grace
+// period, pending and future acquires abort instead of hanging the run.
 
 export interface AllocatableLane {
 	activeBuilds: number;
@@ -10,24 +18,57 @@ export interface AllocatableLane {
 interface Waiter<L> {
 	key: string;
 	resolve: (lane: L) => void;
+	reject: (error: Error) => void;
 }
+
+export interface LaneHealthOptions<L> {
+	/** Resolves true when the lane's backend responds healthy again. */
+	probe: (lane: L) => Promise<boolean>;
+	/** Delay between health probes of a quarantined lane. */
+	probeIntervalMs?: number;
+	/** Consecutive transient build failures before a lane is quarantined. */
+	quarantineThreshold?: number;
+	/** How long ALL lanes may stay quarantined before acquires abort. */
+	allQuarantinedGraceMs?: number;
+	onQuarantine?: (lane: L) => void;
+	onReadmit?: (lane: L) => void;
+	onAllQuarantined?: () => void;
+}
+
+const DEFAULT_PROBE_INTERVAL_MS = 30_000;
+const DEFAULT_QUARANTINE_THRESHOLD = 3;
+const DEFAULT_ALL_QUARANTINED_GRACE_MS = 5 * 60_000;
 
 export class LaneAllocator<L extends AllocatableLane> {
 	private readonly waiters: Array<Waiter<L>> = [];
 
+	private readonly consecutiveFailures = new Map<L, number>();
+
+	private readonly quarantined = new Set<L>();
+
+	private readonly lastQuarantinedAt = new Map<L, number>();
+
+	private allQuarantinedTimer?: NodeJS.Timeout;
+
+	private aborted?: Error;
+
 	constructor(
 		private readonly lanes: L[],
 		private readonly maxConcurrentBuilds: number,
+		private readonly health?: LaneHealthOptions<L>,
 	) {}
 
-	async acquire(key: string): Promise<L> {
-		const lane = this.findFree(key);
+	async acquire(key: string, opts?: { not?: L }): Promise<L> {
+		if (this.aborted) throw this.aborted;
+		// Prefer a lane other than `not` (e.g. retrying a build that just failed
+		// there), but fall back to it rather than starving.
+		const lane = this.findFree(key, opts?.not) ?? this.findFree(key);
 		if (lane) {
 			this.markBusy(lane, key);
 			return lane;
 		}
-		return await new Promise<L>((resolve) => {
-			this.waiters.push({ key, resolve });
+		return await new Promise<L>((resolve, reject) => {
+			this.waiters.push({ key, resolve, reject });
 		});
 	}
 
@@ -37,19 +78,107 @@ export class LaneAllocator<L extends AllocatableLane> {
 		this.wakeNext(lane);
 	}
 
-	private findFree(key: string): L | undefined {
+	/**
+	 * Record whether a build's transport to the lane worked. A completed build —
+	 * even one the agent failed — is 'ok'; only network-level failures count
+	 * toward quarantine.
+	 */
+	reportBuildOutcome(lane: L, outcome: 'ok' | 'transient-failure'): void {
+		if (outcome === 'ok') {
+			this.consecutiveFailures.delete(lane);
+			return;
+		}
+		const failures = (this.consecutiveFailures.get(lane) ?? 0) + 1;
+		this.consecutiveFailures.set(lane, failures);
+		const threshold = this.health?.quarantineThreshold ?? DEFAULT_QUARANTINE_THRESHOLD;
+		if (failures >= threshold && !this.quarantined.has(lane)) this.quarantine(lane);
+	}
+
+	isQuarantined(lane: L): boolean {
+		return this.quarantined.has(lane);
+	}
+
+	/**
+	 * Whether the lane entered quarantine at or after `sinceMs`. Lets callers
+	 * attribute a slow failure (e.g. a build timing out) to a lane death that
+	 * happened mid-flight, even if the lane has since restarted and probes healthy.
+	 */
+	wasQuarantinedSince(lane: L, sinceMs: number): boolean {
+		const at = this.lastQuarantinedAt.get(lane);
+		return at !== undefined && at >= sinceMs;
+	}
+
+	private quarantine(lane: L): void {
+		this.quarantined.add(lane);
+		this.lastQuarantinedAt.set(lane, Date.now());
+		this.health?.onQuarantine?.(lane);
+		if (this.health?.probe) this.scheduleProbe(lane);
+		if (this.quarantined.size === this.lanes.length) {
+			this.health?.onAllQuarantined?.();
+			const graceMs = this.health?.allQuarantinedGraceMs ?? DEFAULT_ALL_QUARANTINED_GRACE_MS;
+			this.allQuarantinedTimer = setTimeout(() => {
+				if (this.quarantined.size === this.lanes.length) {
+					this.abort(
+						new Error(
+							`All ${String(this.lanes.length)} lanes quarantined for ${String(graceMs)}ms — no healthy backend to build on`,
+						),
+					);
+				}
+			}, graceMs);
+			this.allQuarantinedTimer.unref?.();
+		}
+	}
+
+	private scheduleProbe(lane: L): void {
+		const intervalMs = this.health?.probeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
+		const timer = setTimeout(() => {
+			if (!this.quarantined.has(lane) || this.aborted) return;
+			this.health
+				?.probe(lane)
+				.then((healthy) => {
+					if (healthy) this.readmit(lane);
+					else this.scheduleProbe(lane);
+				})
+				.catch(() => this.scheduleProbe(lane));
+		}, intervalMs);
+		timer.unref?.();
+	}
+
+	private readmit(lane: L): void {
+		this.quarantined.delete(lane);
+		this.consecutiveFailures.delete(lane);
+		if (this.allQuarantinedTimer) {
+			clearTimeout(this.allQuarantinedTimer);
+			this.allQuarantinedTimer = undefined;
+		}
+		this.health?.onReadmit?.(lane);
+		// A re-admitted lane is idle — wake every waiter it can serve.
+		let woke = true;
+		while (woke) woke = this.wakeNext(lane);
+	}
+
+	private abort(error: Error): void {
+		this.aborted = error;
+		for (const w of this.waiters.splice(0)) w.reject(error);
+	}
+
+	private findFree(key: string, not?: L): L | undefined {
 		// Least-loaded policy: spread builds evenly across lanes rather than
 		// filling lane 0 to cap before touching lane 1. Avoids hot-spotting.
 		let best: L | undefined;
 		for (const lane of this.lanes) {
-			if (!this.canRun(lane, key)) continue;
+			if (lane === not || !this.canRun(lane, key)) continue;
 			if (best === undefined || lane.activeBuilds < best.activeBuilds) best = lane;
 		}
 		return best;
 	}
 
 	private canRun(lane: L, key: string): boolean {
-		return lane.activeBuilds < this.maxConcurrentBuilds && !lane.inflightKeys.has(key);
+		return (
+			!this.quarantined.has(lane) &&
+			lane.activeBuilds < this.maxConcurrentBuilds &&
+			!lane.inflightKeys.has(key)
+		);
 	}
 
 	private markBusy(lane: L, key: string): void {
@@ -57,7 +186,7 @@ export class LaneAllocator<L extends AllocatableLane> {
 		lane.inflightKeys.add(key);
 	}
 
-	private wakeNext(lane: L): void {
+	private wakeNext(lane: L): boolean {
 		// Wake the first waiter this lane can now serve. FIFO ordering.
 		for (let i = 0; i < this.waiters.length; i++) {
 			const w = this.waiters[i];
@@ -65,8 +194,9 @@ export class LaneAllocator<L extends AllocatableLane> {
 				this.waiters.splice(i, 1);
 				this.markBusy(lane, w.key);
 				w.resolve(lane);
-				return;
+				return true;
 			}
 		}
+		return false;
 	}
 }

--- a/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
@@ -2,13 +2,10 @@
 // runs the same key twice concurrently — pairing those rules eliminates the
 // same-key concentration that breaks the agent under load.
 //
-// Lanes additionally report build transport outcomes. A dead lane fails builds
-// in milliseconds, so under the least-loaded policy it is permanently the
-// emptiest lane and would swallow the entire remaining queue ("black hole").
-// Consecutive transient failures therefore quarantine a lane, and a health
-// probe re-admits it once its backend responds again (pairing with the
-// containers' restart policy). If every lane stays quarantined past a grace
-// period, pending and future acquires abort instead of hanging the run.
+// A dead lane fails builds in milliseconds, making it permanently the
+// least-loaded lane — it would swallow the whole remaining queue. Consecutive
+// transport failures therefore quarantine a lane; a health probe re-admits it
+// once its backend responds; all-lanes-quarantined aborts after a grace period.
 
 export interface AllocatableLane {
 	activeBuilds: number;
@@ -78,11 +75,8 @@ export class LaneAllocator<L extends AllocatableLane> {
 		this.wakeNext(lane);
 	}
 
-	/**
-	 * Record whether a build's transport to the lane worked. A completed build —
-	 * even one the agent failed — is 'ok'; only network-level failures count
-	 * toward quarantine.
-	 */
+	/** A completed build — even one the agent failed — is 'ok'; only
+	 *  network-level failures count toward quarantine. */
 	reportBuildOutcome(lane: L, outcome: 'ok' | 'transient-failure'): void {
 		if (outcome === 'ok') {
 			this.consecutiveFailures.delete(lane);
@@ -98,11 +92,8 @@ export class LaneAllocator<L extends AllocatableLane> {
 		return this.quarantined.has(lane);
 	}
 
-	/**
-	 * Whether the lane entered quarantine at or after `sinceMs`. Lets callers
-	 * attribute a slow failure (e.g. a build timing out) to a lane death that
-	 * happened mid-flight, even if the lane has since restarted and probes healthy.
-	 */
+	/** Attributes a slow failure (e.g. a build timeout) to a lane death that
+	 *  happened mid-flight, even if the lane has since restarted. */
 	wasQuarantinedSince(lane: L, sinceMs: number): boolean {
 		const at = this.lastQuarantinedAt.get(lane);
 		return at !== undefined && at >= sinceMs;

--- a/packages/@n8n/instance-ai/evaluations/comparison/fetch-baseline.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/fetch-baseline.ts
@@ -48,10 +48,36 @@ const outputsSchema = z
 	})
 	.passthrough();
 
+/** How many newest candidates to probe for the completion marker. */
+const MAX_COMPLETION_PROBES = 10;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
- * Return the most recently created baseline experiment, or `undefined` if
- * none exist. We pick by `start_time` so a re-run of an older snapshot
- * doesn't displace the latest one.
+ * A capture killed mid-run (job timeout, runner death) leaves a partial
+ * experiment with the baseline prefix. The CLI writes aggregate metadata
+ * (`pass_rate_per_iter`) only at successful run end — treat it as the
+ * completion marker so partial captures never become the comparison target.
+ */
+async function hasCompletionMarker(client: Client, projectName: string): Promise<boolean> {
+	try {
+		const project = await client.readProject({ projectName });
+		const extra: unknown = project.extra;
+		if (!isRecord(extra) || !isRecord(extra.metadata)) return false;
+		return 'pass_rate_per_iter' in extra.metadata;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Return the most recently created COMPLETED baseline experiment, or
+ * `undefined` if none exist. We pick by `start_time` so a re-run of an older
+ * snapshot doesn't displace the latest one, and require the completion marker
+ * so a killed capture doesn't either (falling back to the plain newest when
+ * no probed candidate carries the marker, e.g. legacy cohorts).
  *
  * `prefix` defaults to the Instance AI baseline. Pass a different prefix (e.g.
  * `mcp-baseline-`) to scope the lookup to an isolated cohort, so an MCP run
@@ -61,14 +87,18 @@ export async function findLatestBaseline(
 	client: Client,
 	prefix: string = BASELINE_EXPERIMENT_PREFIX,
 ): Promise<string | undefined> {
-	let latest: { name: string; ts: number } | undefined;
+	const candidates: Array<{ name: string; ts: number }> = [];
 	for await (const project of client.listProjects({ nameContains: prefix })) {
 		const name = project.name;
 		if (!name?.startsWith(prefix)) continue;
 		const ts = project.start_time ? new Date(project.start_time).getTime() : 0;
-		if (!latest || ts > latest.ts) latest = { name, ts };
+		candidates.push({ name, ts });
 	}
-	return latest?.name;
+	candidates.sort((a, b) => b.ts - a.ts);
+	for (const candidate of candidates.slice(0, MAX_COMPLETION_PROBES)) {
+		if (await hasCompletionMarker(client, candidate.name)) return candidate.name;
+	}
+	return candidates[0]?.name;
 }
 
 /**

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -842,17 +842,21 @@ export async function executeScenario(
 
 /**
  * Clean up workflows and data tables created during a build.
+ *
+ * Returns false when any deletion failed so callers can retry later.
  */
 export async function cleanupBuild(
 	client: N8nClient,
 	build: BuildResult,
 	logger: EvalLogger,
-): Promise<void> {
+): Promise<boolean> {
+	let clean = true;
+
 	for (const id of build.createdWorkflowIds) {
 		try {
 			await client.deleteWorkflow(id);
 		} catch {
-			// Best-effort cleanup
+			clean = false; // Best-effort cleanup
 		}
 	}
 
@@ -863,12 +867,12 @@ export async function cleanupBuild(
 				try {
 					await client.deleteDataTable(projectId, dtId);
 				} catch {
-					// Best-effort cleanup
+					clean = false; // Best-effort cleanup
 				}
 			}
 			logger.verbose(`  Cleaned up ${String(build.createdDataTableIds.length)} data table(s)`);
 		} catch {
-			// Non-fatal — project ID lookup may fail
+			clean = false; // Non-fatal — project ID lookup may fail
 		}
 	}
 
@@ -878,9 +882,11 @@ export async function cleanupBuild(
 		try {
 			await client.deleteThread(build.threadId);
 		} catch {
-			// Best-effort cleanup
+			clean = false; // Best-effort cleanup
 		}
 	}
+
+	return clean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -453,6 +453,10 @@ export interface BuildResult {
 	 *  gone, reconstruction drift, restore failed) — a harness/framework problem,
 	 *  not an agent build failure. Routed to `framework_issue`. */
 	seedingFailed?: boolean;
+	/** True when the failure was transport-level (network error, or the lane's
+	 *  backend was unreachable right after the failure — e.g. a build that sat
+	 *  out its timeout against a dead lane). Routed to `framework_issue`. */
+	transportFailure?: boolean;
 }
 
 export interface BuildWorkflowConfig {
@@ -866,6 +870,16 @@ export async function cleanupBuild(
 			logger.verbose(`  Cleaned up ${String(build.createdDataTableIds.length)} data table(s)`);
 		} catch {
 			// Non-fatal — project ID lookup may fail
+		}
+	}
+
+	// Also clears backend-side thread state (run-state registries, memory) that
+	// otherwise accumulates for the container's lifetime — one entry per build.
+	if (build.threadId) {
+		try {
+			await client.deleteThread(build.threadId);
+		} catch {
+			// Best-effort cleanup
 		}
 	}
 }

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -453,9 +453,8 @@ export interface BuildResult {
 	 *  gone, reconstruction drift, restore failed) — a harness/framework problem,
 	 *  not an agent build failure. Routed to `framework_issue`. */
 	seedingFailed?: boolean;
-	/** True when the failure was transport-level (network error, or the lane's
-	 *  backend was unreachable right after the failure — e.g. a build that sat
-	 *  out its timeout against a dead lane). Routed to `framework_issue`. */
+	/** Transport-level failure (network error, or the lane unreachable right
+	 *  after failing — e.g. timed out against a dead lane). Routed to `framework_issue`. */
 	transportFailure?: boolean;
 }
 
@@ -873,8 +872,8 @@ export async function cleanupBuild(
 		}
 	}
 
-	// Also clears backend-side thread state (run-state registries, memory) that
-	// otherwise accumulates for the container's lifetime — one entry per build.
+	// Clears backend thread state (run-state registries, memory) that otherwise
+	// grows one entry per build for the container's lifetime.
 	if (build.threadId) {
 		try {
 			await client.deleteThread(build.threadId);


### PR DESCRIPTION
## Summary

Second of two PRs from the 2026-07-09 eval-CI investigation (stacked on #33903). In run `28941020577`, lane 6's n8n process died of heap exhaustion at minute 97 and the failure-blind least-loaded allocator then drained **251 of the remaining queue into the dead lane in a single second** — 27 of 88 cases ended 0/10 and the poisoned capture became baseline `instance-ai-baseline-267114a2`.

- **LaneAllocator health:** consecutive transport failures quarantine a lane; a `/healthz/readiness` probe re-admits it once the backend responds (pairs with #33903's `--restart on-failure`); if ALL lanes stay quarantined past a grace period, acquires abort loudly instead of hanging the run.
- **Build retry + attribution:** transient build failures retry up to 2× on a *different* lane. Any failed build health-probes its lane — this catches the nastiest shape found during chaos testing: an in-flight build on a killed lane gets **no socket error** and sits out its full timeout, reporting `Run timed out`, which used to be misattributed as an agent `build_failure`. `BuildResult.transportFailure` routes these to `framework_issue`, and `wasQuarantinedSince()` attributes them even when the lane already restarted. Transport-failed builds are evicted from the build cache instead of failing every scenario of the case.
- **Baseline quality warning (advisory):** `instance-ai-baseline*` captures print a quality warning when framework noise exceeds 5% (or any case failed on nothing but noise), explaining that comparisons against such a capture may reflect harness noise rather than agent changes. `findLatestBaseline` additionally requires the end-of-run completion marker, so a capture killed mid-run (job timeout, runner death) never becomes the comparison target.

- **Backend-state hygiene:** threads are deleted in build cleanup (clears instance-ai run-state registries that grew one entry per build for the container's lifetime); captured SSE events are dropped from the run-long build cache (only the pairwise flow consumes them); per-build `[lane N] built <slug> thread=<id>` logging so the next post-mortem can map threads to lanes.

## How to test

Unit: `pnpm test evaluations/__tests__/lane-allocator.test.ts` (11 tests incl. quarantine/probe/re-admission/abort).

Live chaos test (2 local lanes, pr tier, `docker kill` lane 2 mid-run):
- before this PR: 2 cases zeroed as agent `build_failure` after hanging 13 min against the dead lane;
- after: all killed-lane builds logged `failed transiently on lane 2 … retrying on another lane`, lane 2 `quarantined` on the 3rd failure, `re-admitted` 38s after container restart, and the final results show **7/7 cases built, zero framework-noise rows**.

## Related Linear tickets, Github issues, and Community forum posts

Stacked on #33903.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33904">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


