### PR TITLE
fix(core): Keep credential-specific OAuth2 scopes under inherited overwrites

### DIFF
--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -264,6 +264,42 @@ describe('CredentialsOverwrites', () => {
 					scope: 'parent.Scope',
 				});
 			});
+
+			it('does not fill an inherited scope even when the child has its own (scope-less) overwrite entry', () => {
+				// `setPlainData` flattens the parent scope into the child entry; the fix must still
+				// recognise that the child did not define a scope of its own.
+				credentialsOverwrites.setPlainData({
+					parentOAuth2: { clientId: 'p-id', clientSecret: 'p-secret', scope: 'parent.Scope' },
+					childOAuth2: { clientId: 'c-id' },
+				});
+
+				const result = credentialsOverwrites.applyOverwrite('childOAuth2', {
+					clientId: '',
+					clientSecret: '',
+					scope: '',
+				});
+
+				expect(result).toEqual({ clientId: 'c-id', clientSecret: 'p-secret', scope: '' });
+			});
+
+			it("honours a scope set directly on the child's own overwrite", () => {
+				credentialsOverwrites.setPlainData({
+					parentOAuth2: { clientId: 'p-id', clientSecret: 'p-secret', scope: 'parent.Scope' },
+					childOAuth2: { scope: 'child.Override' },
+				});
+
+				const result = credentialsOverwrites.applyOverwrite('childOAuth2', {
+					clientId: '',
+					clientSecret: '',
+					scope: '',
+				});
+
+				expect(result).toEqual({
+					clientId: 'p-id',
+					clientSecret: 'p-secret',
+					scope: 'child.Override',
+				});
+			});
 		});
 	});
 

--- a/packages/cli/src/__tests__/credentials-overwrites.test.ts
+++ b/packages/cli/src/__tests__/credentials-overwrites.test.ts
@@ -13,8 +13,16 @@ import type { ICredentialsOverwrite } from '@/interfaces';
 import { StaticAuthService } from '@/services/static-auth-service';
 
 describe('CredentialsOverwrites', () => {
-	const testCredentialType = mock<ICredentialType>({ name: 'test', extends: ['parent'] });
-	const parentCredentialType = mock<ICredentialType>({ name: 'parent', extends: undefined });
+	const testCredentialType = mock<ICredentialType>({
+		name: 'test',
+		extends: ['parent'],
+		properties: [],
+	});
+	const parentCredentialType = mock<ICredentialType>({
+		name: 'parent',
+		extends: undefined,
+		properties: [],
+	});
 
 	const globalConfig = mock<GlobalConfig>({ credentials: { overwrite: {} } });
 	const credentialTypes = mock<CredentialTypes>();
@@ -185,6 +193,76 @@ describe('CredentialsOverwrites', () => {
 				const result = credentialsOverwrites.applyOverwrite('parent', { password: '' });
 
 				expect(result).toEqual({ password: 'pass' });
+			});
+		});
+
+		describe('inherited scope', () => {
+			// A service-specific OAuth2 child (e.g. microsoftOneDriveOAuth2Api) defines its own
+			// baked-in `scope`; the managed overwrite lives on the generic parent app.
+			const childWithScope = mock<ICredentialType>({
+				name: 'childOAuth2',
+				extends: ['parentOAuth2'],
+				properties: [
+					{ displayName: 'Scope', name: 'scope', type: 'hidden', default: 'child.Scope' },
+				],
+			});
+			const childWithoutScope = mock<ICredentialType>({
+				name: 'childNoScope',
+				extends: ['parentOAuth2'],
+				properties: [],
+			});
+			const parentOAuth2 = mock<ICredentialType>({
+				name: 'parentOAuth2',
+				extends: undefined,
+				properties: [],
+			});
+
+			beforeEach(async () => {
+				globalConfig.credentials.overwrite.data = JSON.stringify({
+					parentOAuth2: { clientId: 'p-id', clientSecret: 'p-secret', scope: 'parent.Scope' },
+				});
+				credentialTypes.getByName.mockImplementation((credentialType) => {
+					if (credentialType === 'childOAuth2') return childWithScope;
+					if (credentialType === 'childNoScope') return childWithoutScope;
+					if (credentialType === 'parentOAuth2') return parentOAuth2;
+					throw new UnrecognizedCredentialTypeError(credentialType);
+				});
+				credentialTypes.getParentTypes.calledWith('childOAuth2').mockReturnValue(['parentOAuth2']);
+				credentialTypes.getParentTypes.calledWith('childNoScope').mockReturnValue(['parentOAuth2']);
+				credentialTypes.getParentTypes.calledWith('parentOAuth2').mockReturnValue([]);
+				credentialsOverwrites = new CredentialsOverwrites(
+					globalConfig,
+					credentialTypes,
+					logger,
+					mock(),
+					mock(),
+				);
+				await credentialsOverwrites.init();
+			});
+
+			it('does not fill a child scope from a parent overwrite when the child defines its own scope', () => {
+				const result = credentialsOverwrites.applyOverwrite('childOAuth2', {
+					clientId: '',
+					clientSecret: '',
+					scope: '',
+				});
+
+				// client credentials come from the parent overwrite, but the child's own scope is preserved
+				expect(result).toEqual({ clientId: 'p-id', clientSecret: 'p-secret', scope: '' });
+			});
+
+			it('still inherits the parent scope for a child that does not define its own scope', () => {
+				const result = credentialsOverwrites.applyOverwrite('childNoScope', {
+					clientId: '',
+					clientSecret: '',
+					scope: '',
+				});
+
+				expect(result).toEqual({
+					clientId: 'p-id',
+					clientSecret: 'p-secret',
+					scope: 'parent.Scope',
+				});
 			});
 		});
 	});

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -20,6 +20,11 @@ export class CredentialsOverwrites {
 
 	private resolvedTypes: string[] = [];
 
+	// Types whose *own* overwrite payload defined a `scope`, captured before inheritance is
+	// resolved. `setPlainData` flattens inherited scopes into child entries, so this is the only
+	// reliable signal of whether a type's scope is its own or inherited from a parent.
+	private typesWithOwnScopeOverwrite = new Set<string>();
+
 	constructor(
 		private readonly globalConfig: GlobalConfig,
 		private readonly credentialTypes: CredentialTypes,
@@ -104,6 +109,12 @@ export class CredentialsOverwrites {
 		// If data gets reinitialized reset the resolved types cache
 		this.resolvedTypes.length = 0;
 
+		// Record which types carried their own `scope` before the loop below merges parent scopes
+		// into child entries.
+		this.typesWithOwnScopeOverwrite = new Set(
+			Object.keys(overwriteData).filter((type) => overwriteData[type]?.scope !== undefined),
+		);
+
 		this.overwriteData = overwriteData;
 
 		for (const type in overwriteData) {
@@ -167,8 +178,9 @@ export class CredentialsOverwrites {
 		// scopes they require) keeps that scope authoritative: a `scope` inherited from a parent
 		// type's overwrite must not fill it. Without this, a stripped/empty child scope would be
 		// replaced by the generic parent app's scope, dropping the child's required scopes.
+		// A `scope` set directly on this type's own overwrite is honoured (not skipped).
 		const skipInheritedScope =
-			this.overwriteData[type]?.scope === undefined && this.typeDefinesOwnScope(type);
+			!this.typesWithOwnScopeOverwrite.has(type) && this.typeDefinesOwnScope(type);
 
 		const returnData = deepCopy(data);
 		// Overwrite only if there is currently no data set

--- a/packages/cli/src/credentials-overwrites.ts
+++ b/packages/cli/src/credentials-overwrites.ts
@@ -163,9 +163,17 @@ export class CredentialsOverwrites {
 			}
 		}
 
+		// A credential type that defines its own `scope` (service-specific OAuth2 creds bake in the
+		// scopes they require) keeps that scope authoritative: a `scope` inherited from a parent
+		// type's overwrite must not fill it. Without this, a stripped/empty child scope would be
+		// replaced by the generic parent app's scope, dropping the child's required scopes.
+		const skipInheritedScope =
+			this.overwriteData[type]?.scope === undefined && this.typeDefinesOwnScope(type);
+
 		const returnData = deepCopy(data);
 		// Overwrite only if there is currently no data set
 		for (const key of Object.keys(overwrites)) {
+			if (key === 'scope' && skipInheritedScope) continue;
 			// @ts-ignore
 			if ([null, undefined, ''].includes(returnData[key])) {
 				returnData[key] = overwrites[key];
@@ -173,6 +181,12 @@ export class CredentialsOverwrites {
 		}
 
 		return returnData;
+	}
+
+	/** Whether the credential type declares a `scope` property in its own (non-inherited) properties. */
+	private typeDefinesOwnScope(type: string): boolean {
+		if (!this.credentialTypes.recognizes(type)) return false;
+		return this.credentialTypes.getByName(type).properties.some((p) => p.name === 'scope');
 	}
 
 	getOverwrites(type: string): ICredentialDataDecryptedObject | undefined {


### PR DESCRIPTION
## Summary

Service-specific OAuth2 credentials (e.g. `microsoftOneDriveOAuth2Api`) bake in the scopes they require via a hidden `scope` property. When a **managed credential overwrite** is configured on a **parent** credential type (e.g. the generic `microsoftOAuth2Api` app) and it carries a `scope`, that parent scope was filling the child's (stripped/empty) `scope`, replacing the child's required scopes — so connecting could request the wrong scopes (e.g. losing `Files.ReadWrite.All` for OneDrive).

This change makes a credential type's own `scope` authoritative: a `scope` inherited from a parent type's overwrite no longer fills a child that defines its own `scope` property. Client credentials (client ID/secret) still come from the managed overwrite as before, and children that do **not** define their own `scope` continue to inherit the parent's.

The scope had previously been protected from stripping via an inherited-scope check; once that was narrowed to a leaf-level check, the child scope started being emptied before defaults were applied, exposing it to the parent overwrite. This restores the correct behavior at the overwrite layer.

https://github.com/user-attachments/assets/b92a622b-2b3a-4198-b99c-d6a60891153a

## How to test

Unit tests cover the behavior:

```
cd packages/cli && pnpm test src/__tests__/credentials-overwrites.test.ts
```

- `applyOverwrite` on a child credential that defines its own `scope`, with a parent overwrite that sets `clientId`/`clientSecret`/`scope`: client credentials are applied from the parent, but the child's `scope` is **not** overwritten.
- A child credential that does **not** define its own `scope` still inherits the parent overwrite's `scope`.

End-to-end (managed OneDrive): with a managed overwrite on `microsoftOAuth2Api` that includes a `scope`, connecting a `microsoftOneDriveOAuth2Api` credential now requests the credential's own default scopes (`openid offline_access Files.ReadWrite.All`) rather than the parent app's scope.

### Manual Testing

Enable Overwrites Endpoint
```
export CREDENTIALS_OVERWRITE_ENDPOINT=send-credentials     
```
Start n8n

Save test credential overwrite
```
{
    "microsoftOAuth2Api": {
        "clientId": "<id from Bitwarden nodeqa>",
        "clientSecret": "<secret from Bitwarden nodeqa>"
    }
}
```
Inject into n8n
```
curl -H "Content-Type: application/json" --data @oauth-credentials.json http://localhost:5678/send-credentials
```
Create workflow and try to connect

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5410

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33906">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

