### PR TITLE
fix(core): Serialize circuit breaker options

### DIFF
--- a/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming-destination.service.test.ts
+++ b/packages/cli/src/modules/log-streaming.ee/__tests__/log-streaming-destination.service.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import type { OutboundHttp } from '@n8n/backend-network';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
+import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -11,7 +12,7 @@ import type { Publisher } from '@/scaling/pubsub/publisher.service';
 
 import type { EventDestinationsRepository } from '../database/repositories/event-destination.repository';
 import { messageEventBusDestinationFromDb } from '../destinations/message-event-bus-destination-from-db';
-import type { MessageEventBusDestinationWebhook } from '../destinations/message-event-bus-destination-webhook.ee';
+import { MessageEventBusDestinationWebhook } from '../destinations/message-event-bus-destination-webhook.ee';
 import { LogStreamingDestinationService } from '../log-streaming-destination.service';
 
 vi.mock('../destinations/message-event-bus-destination-from-db');
@@ -157,6 +158,60 @@ describe('LogStreamingDestinationService', () => {
 			await service.addDestination(destination, false);
 
 			expect(publisher.publishCommand).not.toHaveBeenCalled();
+		});
+
+		// Uses a real destination (not a mock) so the actual serialize() output is what
+		// reaches the repository — this is the payload persisted to the DB.
+		it('should persist the configured circuit breaker options to the database', async () => {
+			const id = '12345678-1234-1234-1234-123456789abc';
+			const circuitBreaker = { maxFailures: 7, failureWindow: 30000 };
+			const destination = new MessageEventBusDestinationWebhook(
+				eventBus,
+				{
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					id,
+					label: 'Test',
+					url: 'http://example.com',
+					circuitBreaker,
+				},
+				outboundHttp,
+			);
+
+			eventDestinationsRepository.upsert.mockResolvedValue({} as any);
+
+			await service.addDestination(destination, false);
+
+			const data = eventDestinationsRepository.upsert.mock.calls[0][0] as {
+				id: string;
+				destination: MessageEventBusDestinationOptions;
+			};
+			expect(data.id).toBe(id);
+			// Stored verbatim: exactly the configured subset, no defaults injected, no `timeout` key
+			expect(data.destination.circuitBreaker).toEqual(circuitBreaker);
+		});
+
+		it('should not persist circuit breaker options when none configured', async () => {
+			const id = '12345678-1234-1234-1234-123456789abc';
+			const destination = new MessageEventBusDestinationWebhook(
+				eventBus,
+				{
+					__type: MessageEventBusDestinationTypeNames.webhook,
+					id,
+					label: 'Test',
+					url: 'http://example.com',
+				},
+				outboundHttp,
+			);
+
+			eventDestinationsRepository.upsert.mockResolvedValue({} as any);
+
+			await service.addDestination(destination, false);
+
+			const data = eventDestinationsRepository.upsert.mock.calls[0][0] as {
+				id: string;
+				destination: MessageEventBusDestinationOptions;
+			};
+			expect(data.destination.circuitBreaker).toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/modules/log-streaming.ee/destinations/__tests__/message-event-bus-destination.ee.test.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/__tests__/message-event-bus-destination.ee.test.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
-import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 import type { MessageEventBusDestinationOptions } from 'n8n-workflow';
+import { MessageEventBusDestinationTypeNames } from 'n8n-workflow';
 
 import { EventMessageGeneric } from '@/eventbus/event-message-classes/event-message-generic';
 import type {
@@ -19,7 +19,9 @@ class TestDestination extends MessageEventBusDestination {
 }
 
 describe('MessageEventBusDestination', () => {
-	mockInstance(Logger);
+	const logger = mockInstance(Logger);
+	// CircuitBreaker resolves its logger via Container.get(Logger).scoped(...)
+	logger.scoped.mockReturnValue(logger);
 
 	const eventBus = {} as MessageEventBus;
 
@@ -198,6 +200,32 @@ describe('MessageEventBusDestination', () => {
 			expect(serialized.enabled).toBe(false);
 			expect(serialized.subscribedEvents).toEqual([]);
 			expect(serialized.anonymizeAuditMessages).toBe(false);
+		});
+
+		it('should serialize configured circuit breaker options verbatim', () => {
+			const circuitBreaker = { maxFailures: 7, failureWindow: 30000 };
+			const options: MessageEventBusDestinationOptions = {
+				__type: MessageEventBusDestinationTypeNames.webhook,
+				credentials: {},
+				circuitBreaker,
+			};
+
+			const destination = new TestDestination(eventBus, options);
+			const serialized = destination.serialize();
+
+			// No defaults injected (maxDuration/halfOpenRequests/...) and no `timeout` key
+			expect(serialized.circuitBreaker).toEqual(circuitBreaker);
+		});
+
+		it('should serialize circuit breaker as undefined when omitted', () => {
+			const options: MessageEventBusDestinationOptions = {
+				__type: MessageEventBusDestinationTypeNames.webhook,
+				credentials: {},
+			};
+
+			const destination = new TestDestination(eventBus, options);
+
+			expect(destination.serialize().circuitBreaker).toBeUndefined();
 		});
 	});
 

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination.ee.ts
@@ -42,6 +42,10 @@ export abstract class MessageEventBusDestination implements MessageEventBusDesti
 
 	anonymizeAuditMessages: boolean;
 
+	// Raw configured circuit-breaker options as received, used for serializing.
+	// Needed to be set this way so that we do not send default settings, only what user saved.
+	readonly circuitBreakerOptions?: MessageEventBusDestinationOptions['circuitBreaker'];
+
 	constructor(eventBusInstance: MessageEventBus, options: MessageEventBusDestinationOptions) {
 		// @TODO: Use DI
 		this.logger = Container.get(Logger);
@@ -63,6 +67,8 @@ export abstract class MessageEventBusDestination implements MessageEventBusDesti
 			failureWindow,
 			maxConcurrentHalfOpenRequests,
 		});
+
+		this.circuitBreakerOptions = options.circuitBreaker;
 
 		this.eventBusInstance = eventBusInstance;
 		this.id = !options.id || options.id.length !== 36 ? uuid() : options.id;
@@ -97,6 +103,7 @@ export abstract class MessageEventBusDestination implements MessageEventBusDesti
 			enabled: this.enabled,
 			subscribedEvents: this.subscribedEvents,
 			anonymizeAuditMessages: this.anonymizeAuditMessages,
+			circuitBreaker: this.circuitBreakerOptions,
 		};
 	}
 


### PR DESCRIPTION
## Summary
In order to return the log stream destinations to the frontend their properties were serialised into a JSON object, however the circuit-breaker options were omitted from this meaning that they would not display.
This PR adds the original circuit breaker options to the list of serialisable data. The original data is used as to avoid returning default options that the user did not set.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
Run n8n with the following environment variables: 
```env
N8N_LOG_STREAMING_MANAGED_BY_ENV=true
N8N_LOG_STREAMING_DESTINATIONS=[{ "type": "webhook", "label": "Audit", "url": "https://hooks.example.com/audit", "circuitBreaker": { "maxFailures": 10, "failureWindow": 60000 } }]
```
Then go to view the log streaming destinations at `[n8n_url]/settings/log-streaming`. Before this fix you will notice that there are no circuit breaker options visible when viewing the destination details, and after this fix you should see the 'max failures' and 'failure window' settings in the UI.
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-875
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->