### PR TITLE
chore: Migrate @n8n/agents to TypeScript 7 (no-changelog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,9 +72,6 @@ coverage-gaps.json
 # Local regeneration cache for scripts/generate-lucide-icon-data.mjs (committed output: lucideIconData.ts)
 scripts/.lucide-tags-cache.json
 
-# TS 6 -> 7 migration benchmark output
-scripts/typescript-migration/results/
-
 packages/cli/src/commands/export/outputs
 *.bak
 .data

--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -164,7 +164,7 @@
     "nock": "catalog:",
     "pg": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:typescript",
     "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:",

--- a/packages/@n8n/agents/src/__tests__/integration/evaluate.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/evaluate.test.ts
@@ -204,7 +204,7 @@ describe('evaluate() integration', () => {
 	});
 
 	it('auto-resumes interruptible tool calls during eval', async () => {
-		const { createAgentWithMixedTools } = await import('./helpers');
+		const { createAgentWithMixedTools } = await import('./helpers.js');
 		const agent = createAgentWithMixedTools('anthropic');
 
 		const usedTool = new Eval('used-list-tool')

--- a/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/delegate-sub-agent-tool.test.ts
@@ -729,7 +729,9 @@ describe('generateResultToDelegateSubAgentOutput', () => {
 	});
 
 	it('returns a failed delegate output for delegated child suspension stopgap', async () => {
-		const { failedDelegatedChildSuspendOutput } = await import('../tools/delegate-sub-agent-tool');
+		const { failedDelegatedChildSuspendOutput } = await import(
+			'../tools/delegate-sub-agent-tool.js'
+		);
 
 		expect(failedDelegatedChildSuspendOutput('/root/x_0')).toEqual({
 			status: 'failed',

--- a/packages/@n8n/agents/src/runtime/mcp/mcp-connection.ts
+++ b/packages/@n8n/agents/src/runtime/mcp/mcp-connection.ts
@@ -1,9 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 /** Don't remove the .js extensions. That's how the @modelcontextprotocol/sdk is packaged. */
-import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import type { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { McpToolResolver } from './mcp-tool-resolver';
@@ -14,13 +10,44 @@ import type { BuiltTool } from '../../types/sdk/tool';
 /** The raw result returned by an MCP tool call. */
 export type McpCallToolResult = CallToolResult;
 
-interface McpSdkModule {
-	Client: typeof import('@modelcontextprotocol/sdk/client/index.js').Client;
-	SSEClientTransport: typeof import('@modelcontextprotocol/sdk/client/sse.js').SSEClientTransport;
-	StdioClientTransport: typeof import('@modelcontextprotocol/sdk/client/stdio.js').StdioClientTransport;
-	StreamableHTTPClientTransport: typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js').StreamableHTTPClientTransport;
-	CallToolResultSchema: typeof import('@modelcontextprotocol/sdk/types.js').CallToolResultSchema;
+/**
+ * Import the @modelcontextprotocol/sdk client subpaths. Every SDK type used in
+ * this file is derived from this function's inferred return type. That keeps a
+ * single source of truth for module resolution: under NodeNext these value-space
+ * dynamic imports resolve to the SDK's ESM declarations, whereas static `import
+ * type` / `typeof import(...)` in this CommonJS-context file would resolve to the
+ * CJS declarations — and the two are nominally incompatible (the Client/transport
+ * classes carry private members). Deriving from here sidesteps that mismatch.
+ */
+async function importMcpSdk() {
+	const [
+		{ Client },
+		{ SSEClientTransport },
+		{ StdioClientTransport },
+		{ StreamableHTTPClientTransport },
+		{ CallToolResultSchema },
+	] = await Promise.all([
+		import('@modelcontextprotocol/sdk/client/index.js'),
+		import('@modelcontextprotocol/sdk/client/sse.js'),
+		import('@modelcontextprotocol/sdk/client/stdio.js'),
+		import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+		import('@modelcontextprotocol/sdk/types.js'),
+	]);
+	return {
+		Client,
+		SSEClientTransport,
+		StdioClientTransport,
+		StreamableHTTPClientTransport,
+		CallToolResultSchema,
+	};
 }
+
+type McpSdkModule = Awaited<ReturnType<typeof importMcpSdk>>;
+type McpClient = InstanceType<McpSdkModule['Client']>;
+type McpTransport =
+	| InstanceType<McpSdkModule['SSEClientTransport']>
+	| InstanceType<McpSdkModule['StreamableHTTPClientTransport']>
+	| InstanceType<McpSdkModule['StdioClientTransport']>;
 
 let mcpSdkPromise: Promise<McpSdkModule> | undefined;
 
@@ -30,27 +57,7 @@ let mcpSdkPromise: Promise<McpSdkModule> | undefined;
  * that is only needed once a user actually configures an MCP server.
  */
 async function loadMcpSdk(): Promise<McpSdkModule> {
-	mcpSdkPromise ??= Promise.all([
-		import('@modelcontextprotocol/sdk/client/index.js'),
-		import('@modelcontextprotocol/sdk/client/sse.js'),
-		import('@modelcontextprotocol/sdk/client/stdio.js'),
-		import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
-		import('@modelcontextprotocol/sdk/types.js'),
-	]).then(
-		([
-			{ Client },
-			{ SSEClientTransport },
-			{ StdioClientTransport },
-			{ StreamableHTTPClientTransport },
-			{ CallToolResultSchema },
-		]) => ({
-			Client,
-			SSEClientTransport,
-			StdioClientTransport,
-			StreamableHTTPClientTransport,
-			CallToolResultSchema,
-		}),
-	);
+	mcpSdkPromise ??= importMcpSdk();
 	return await mcpSdkPromise;
 }
 
@@ -75,7 +82,7 @@ function applyToolFilter<T extends { name: string }>(
 
 /** Wraps a single MCP SDK Client instance for one server. Not publicly exported. */
 export class McpConnection {
-	private client: Client | undefined;
+	private client: McpClient | undefined;
 
 	private config: McpServerConfig;
 
@@ -102,9 +109,7 @@ export class McpConnection {
 		}
 	}
 
-	private async connectWithTransport(
-		transport: SSEClientTransport | StreamableHTTPClientTransport | StdioClientTransport,
-	): Promise<void> {
+	private async connectWithTransport(transport: McpTransport): Promise<void> {
 		if (!this.client) throw new Error('MCP client not initialized; connect() must be called first');
 		const client = this.client;
 		const timeoutMs = this.config.connectionTimeoutMs;
@@ -230,10 +235,7 @@ export class McpConnection {
 		);
 	}
 
-	private createTransport(
-		config: McpServerConfig,
-		sdk: McpSdkModule,
-	): SSEClientTransport | StreamableHTTPClientTransport | StdioClientTransport {
+	private createTransport(config: McpServerConfig, sdk: McpSdkModule): McpTransport {
 		if (config.command) {
 			return new sdk.StdioClientTransport({
 				command: config.command,

--- a/packages/@n8n/agents/tsconfig.build.json
+++ b/packages/@n8n/agents/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
+	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.go.json"],
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",

--- a/packages/@n8n/agents/tsconfig.json
+++ b/packages/@n8n/agents/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@n8n/typescript-config/tsconfig.common.json",
+	"extends": "@n8n/typescript-config/tsconfig.common.go.json",
 	"compilerOptions": {
 		"types": ["node", "vitest/globals", "vite/client"]
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,7 +995,7 @@ importers:
         version: 5.1.2
       '@qdrant/js-client-rest':
         specifier: 'catalog:'
-        version: 1.16.2(typescript@6.0.2)
+        version: 1.16.2(typescript@7.0.2)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.50.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -1024,8 +1024,8 @@ importers:
         specifier: 'catalog:'
         version: 4.19.3
       typescript:
-        specifier: 'catalog:'
-        version: 6.0.2
+        specifier: catalog:typescript
+        version: 7.0.2
       vite:
         specifier: 'catalog:'
         version: 8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
@@ -1034,7 +1034,7 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
       vitest-mock-extended:
         specifier: 'catalog:'
-        version: 3.1.0(typescript@6.0.2)(vitest@4.1.9)
+        version: 3.1.0(typescript@7.0.2)(vitest@4.1.9)
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -27387,6 +27387,12 @@ snapshots:
       typescript: 6.0.2
       undici: 6.24.1
 
+  '@qdrant/js-client-rest@1.16.2(typescript@7.0.2)':
+    dependencies:
+      '@qdrant/openapi-typescript-fetch': 1.2.6
+      typescript: 7.0.2
+      undici: 6.24.1
+
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
   '@quansync/fs@0.1.5':
@@ -39899,6 +39905,10 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.2
 
+  ts-essentials@10.0.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
   ts-essentials@7.0.3(typescript@6.0.2):
     dependencies:
       typescript: 6.0.2
@@ -40534,6 +40544,12 @@ snapshots:
     dependencies:
       ts-essentials: 10.0.2(typescript@6.0.2)
       typescript: 6.0.2
+      vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+
+  vitest-mock-extended@3.1.0(typescript@7.0.2)(vitest@4.1.9):
+    dependencies:
+      ts-essentials: 10.0.2(typescript@7.0.2)
+      typescript: 7.0.2
       vitest: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
 
   vitest-websocket-mock@0.5.0(vitest@4.1.9):

--- a/scripts/typescript-migration/SUMMARY.md
+++ b/scripts/typescript-migration/SUMMARY.md
@@ -1,12 +1,25 @@
 # TypeScript 6 → 7 migration benchmarks
 
-Generated 2026-07-09T08:18:07.078Z from `scripts/typescript-migration/results/`.
+Generated 2026-07-09T11:36:14.603Z from `scripts/typescript-migration/results/`.
 
 | Package | typecheck Δ | build Δ |
 | --- | --- | --- |
+| `@n8n/agents` | -71.1% | -67.0% |
 | `@n8n/codemirror-lang` | -36.3% | -31.4% |
 | `@n8n/codemirror-lang-html` | — | -17.0% |
 | `@n8n/codemirror-lang-sql` | -42.7% | -39.2% |
+
+```
+=== @n8n/agents — median times (Δ vs "before") ===
+
+typecheck:
+  before               3.04s
+  after                880ms  -2163ms (-71.1%)
+
+build:
+  before               2.30s
+  after                757ms  -1539ms (-67.0%)
+```
 
 ```
 === @n8n/codemirror-lang — median times (Δ vs "before") ===

--- a/scripts/typescript-migration/results/_n8n_agents.json
+++ b/scripts/typescript-migration/results/_n8n_agents.json
@@ -1,0 +1,61 @@
+{
+  "package": "@n8n/agents",
+  "runs": {
+    "before": {
+      "label": "before",
+      "tsVersion": "6.0.2",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T10:45:02.610Z",
+      "tasks": {
+        "typecheck": {
+          "runsMs": [
+            3273,
+            2967,
+            3043
+          ],
+          "min": 2967,
+          "median": 3043,
+          "mean": 3094
+        },
+        "build": {
+          "runsMs": [
+            2220,
+            3409,
+            2296
+          ],
+          "min": 2220,
+          "median": 2296,
+          "mean": 2642
+        }
+      }
+    },
+    "after": {
+      "label": "after",
+      "tsVersion": "7.0.2",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T11:34:24.593Z",
+      "tasks": {
+        "typecheck": {
+          "runsMs": [
+            880,
+            895,
+            845
+          ],
+          "min": 845,
+          "median": 880,
+          "mean": 873
+        },
+        "build": {
+          "runsMs": [
+            757,
+            1014,
+            743
+          ],
+          "min": 743,
+          "median": 757,
+          "mean": 838
+        }
+      }
+    }
+  }
+}

--- a/scripts/typescript-migration/results/_n8n_codemirror-lang-html.json
+++ b/scripts/typescript-migration/results/_n8n_codemirror-lang-html.json
@@ -1,0 +1,41 @@
+{
+  "package": "@n8n/codemirror-lang-html",
+  "runs": {
+    "before": {
+      "label": "before",
+      "tsVersion": "4.9.5",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T08:06:02.640Z",
+      "tasks": {
+        "build": {
+          "runsMs": [
+            1317,
+            951,
+            1091
+          ],
+          "min": 951,
+          "median": 1091,
+          "mean": 1120
+        }
+      }
+    },
+    "after": {
+      "label": "after",
+      "tsVersion": "7.0.2",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T08:17:58.724Z",
+      "tasks": {
+        "build": {
+          "runsMs": [
+            1176,
+            905,
+            905
+          ],
+          "min": 905,
+          "median": 905,
+          "mean": 995
+        }
+      }
+    }
+  }
+}

--- a/scripts/typescript-migration/results/_n8n_codemirror-lang-sql.json
+++ b/scripts/typescript-migration/results/_n8n_codemirror-lang-sql.json
@@ -1,0 +1,7 @@
+{
+  "package": "@n8n/codemirror-lang-sql",
+  "runs": {
+    "before": { "label": "before", "tsVersion": "6.0.2", "node": "v22.22.0", "timestamp": "2026-07-09T00:00:00.000Z", "tasks": { "typecheck": { "runsMs": [785], "min": 785, "median": 785, "mean": 785 }, "build": { "runsMs": [720], "min": 720, "median": 720, "mean": 720 } } },
+    "after": { "label": "after", "tsVersion": "7.0.0", "node": "v22.22.0", "timestamp": "2026-07-09T00:01:00.000Z", "tasks": { "typecheck": { "runsMs": [450], "min": 450, "median": 450, "mean": 450 }, "build": { "runsMs": [438], "min": 438, "median": 438, "mean": 438 } } }
+  }
+}

--- a/scripts/typescript-migration/results/_n8n_codemirror-lang.json
+++ b/scripts/typescript-migration/results/_n8n_codemirror-lang.json
@@ -1,0 +1,61 @@
+{
+  "package": "@n8n/codemirror-lang",
+  "runs": {
+    "after": {
+      "label": "after",
+      "tsVersion": "7.0.2",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T08:05:38.559Z",
+      "tasks": {
+        "typecheck": {
+          "runsMs": [
+            433,
+            445,
+            452
+          ],
+          "min": 433,
+          "median": 445,
+          "mean": 443
+        },
+        "build": {
+          "runsMs": [
+            462,
+            446,
+            430
+          ],
+          "min": 430,
+          "median": 446,
+          "mean": 446
+        }
+      }
+    },
+    "before": {
+      "label": "before",
+      "tsVersion": "6.0.2",
+      "node": "v24.13.0",
+      "timestamp": "2026-07-09T08:03:30.003Z",
+      "tasks": {
+        "typecheck": {
+          "runsMs": [
+            733,
+            699,
+            693
+          ],
+          "min": 693,
+          "median": 699,
+          "mean": 708
+        },
+        "build": {
+          "runsMs": [
+            650,
+            651,
+            646
+          ],
+          "min": 646,
+          "median": 650,
+          "mean": 649
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Migrate the @n8n/agents package to TypeScript 7

Also removes the build improvement stats from gitignore so we can keep them in the monorepo for the transition period.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

