### PR TITLE
perf(core): Reduce DB reads for global credentials check

### DIFF
--- a/docs/generated/postgres-schema/public.credentials_entity.md
+++ b/docs/generated/postgres-schema/public.credentials_entity.md
@@ -37,6 +37,7 @@
 
 | Name | Definition |
 | ---- | ---------- |
+| IDX_credentials_entity_is_global | CREATE INDEX "IDX_credentials_entity_is_global" ON public.credentials_entity USING btree (id) WHERE ("isGlobal" = true) |
 | credentials_entity_pkey | CREATE UNIQUE INDEX credentials_entity_pkey ON public.credentials_entity USING btree (id) |
 | idx_07fde106c0b471d8cc80a64fc8 | CREATE INDEX idx_07fde106c0b471d8cc80a64fc8 ON public.credentials_entity USING btree (type) |
 | pk_credentials_entity_id | CREATE UNIQUE INDEX pk_credentials_entity_id ON public.credentials_entity USING btree (id) |

--- a/docs/generated/sqlite-schema/credentials_entity.md
+++ b/docs/generated/sqlite-schema/credentials_entity.md
@@ -39,6 +39,7 @@ CREATE TABLE "credentials_entity" ("id" varchar(36) PRIMARY KEY NOT NULL, "name"
 
 | Name | Definition |
 | ---- | ---------- |
+| IDX_credentials_entity_is_global | CREATE INDEX "IDX_credentials_entity_is_global" ON "credentials_entity" ("id") WHERE "isGlobal" = true |
 | idx_credentials_entity_type | CREATE INDEX "idx_credentials_entity_type" ON "credentials_entity" ("type")  |
 | sqlite_autoindex_credentials_entity_1 | PRIMARY KEY (id) |
 

--- a/packages/@n8n/db/src/migrations/common/1784000000044-AddPartialIndexForGlobalCredentials.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000044-AddPartialIndexForGlobalCredentials.ts
@@ -1,0 +1,28 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+/**
+ * Add a partial index on `credentials_entity` for rows where `isGlobal = true`.
+ *
+ * Before every workflow execution, the permission check fetches the IDs of all
+ * global credentials (`WHERE "isGlobal" = true`). Without an index on this
+ * flag, that lookup scans the entire credentials table on every run, even
+ * though only a handful of credentials are global. The partial index contains
+ * only those rows, so the lookup becomes an index-only scan.
+ */
+export class AddPartialIndexForGlobalCredentials1784000000044 implements ReversibleMigration {
+	async up({ schemaBuilder: { createIndex }, tablePrefix }: MigrationContext) {
+		await createIndex(
+			'credentials_entity',
+			['id'],
+			false,
+			`IDX_${tablePrefix}credentials_entity_is_global`,
+			'"isGlobal" = true',
+		);
+	}
+
+	async down({ schemaBuilder: { dropIndex }, tablePrefix }: MigrationContext) {
+		await dropIndex('credentials_entity', ['id'], {
+			customIndexName: `IDX_${tablePrefix}credentials_entity_is_global`,
+		});
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -217,8 +217,8 @@ import { DropAgentExecutionFallbackColumns1784000000039 } from '../common/178400
 import { CreateWorkflowPublicationTriggerStatusTable1784000000040 } from '../common/1784000000040-CreateWorkflowPublicationTriggerStatusTable';
 import { AddUsedPrivateCredentialsToExecutionEntity1784000000041 } from '../common/1784000000041-AddUsedPrivateCredentialsToExecutionEntity';
 import { CreateSchedulerTables1784000000042 } from '../common/1784000000042-CreateSchedulerTables';
-import type { Migration } from '../migration-types';
 import { AddPartialIndexForGlobalCredentials1784000000044 } from '../common/1784000000044-AddPartialIndexForGlobalCredentials';
+import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -218,6 +218,7 @@ import { CreateWorkflowPublicationTriggerStatusTable1784000000040 } from '../com
 import { AddUsedPrivateCredentialsToExecutionEntity1784000000041 } from '../common/1784000000041-AddUsedPrivateCredentialsToExecutionEntity';
 import { CreateSchedulerTables1784000000042 } from '../common/1784000000042-CreateSchedulerTables';
 import type { Migration } from '../migration-types';
+import { AddPartialIndexForGlobalCredentials1784000000044 } from '../common/1784000000044-AddPartialIndexForGlobalCredentials';
 
 export const postgresMigrations: Migration[] = [
 	InitialMigration1587669153312,
@@ -439,4 +440,5 @@ export const postgresMigrations: Migration[] = [
 	AddUsedPrivateCredentialsToExecutionEntity1784000000041,
 	CreateSchedulerTables1784000000042,
 	CreateWorkflowStatisticsDeltaTable1784000000043,
+	AddPartialIndexForGlobalCredentials1784000000044,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -209,6 +209,7 @@ import { DropAgentExecutionFallbackColumns1784000000039 } from '../common/178400
 import { CreateWorkflowPublicationTriggerStatusTable1784000000040 } from '../common/1784000000040-CreateWorkflowPublicationTriggerStatusTable';
 import { AddUsedPrivateCredentialsToExecutionEntity1784000000041 } from '../common/1784000000041-AddUsedPrivateCredentialsToExecutionEntity';
 import { CreateSchedulerTables1784000000042 } from '../common/1784000000042-CreateSchedulerTables';
+import { AddPartialIndexForGlobalCredentials1784000000044 } from '../common/1784000000044-AddPartialIndexForGlobalCredentials';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -421,6 +422,7 @@ const sqliteMigrations: Migration[] = [
 	CreateWorkflowPublicationTriggerStatusTable1784000000040,
 	AddUsedPrivateCredentialsToExecutionEntity1784000000041,
 	CreateSchedulerTables1784000000042,
+	AddPartialIndexForGlobalCredentials1784000000044,
 ];
 
 export { sqliteMigrations };


### PR DESCRIPTION
## Summary

Before every execution, `CredentialsPermissionChecker` fetches the IDs of all global credentials. There is no index on that flag, so the lookup is a sequential scan of the entire table, on every single run. This PR adds a partial index on `credentials_entity` for rows where `isGlobal = true`, so the pre-execution credentials permission check stops scanning the whole credentials table on every workflow run.

On staging internal, which has ~3,800 credentials out of which 5 are global:
- This query has run ~890k times (once per execution), at 0.82 ms mean, amounting to ~9% of total DB time.
- This query accounts for essentially all sequential-scan activity on the table, ~940k seq scans reading 3.4 billion tuples
- `EXPLAIN (ANALYZE, BUFFERS)` before/after (index tested inside a rolled-back transaction on the live instance) shows

| | Seq scan (today) | Partial index |
|---|---|---|
| Plan | Seq Scan, filters 3,799 rows | Index Only Scan |
| Buffers | 396 | 4 |
| Execution | 1.57 ms | 0.039 ms (~40x) |

The per-call latency win is trivial. The point is removing a long-standing burn of ~9% of DB time with 400 buffer reads per second that scales with execution volume and credential count.

## Related Linear tickets, Github issues, and Community forum posts

n/a

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33918">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

