### PR TITLE
feat(API): Add public API endpoints for the security policy settings

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -240,6 +240,10 @@ export {
 	SecuritySettingsDto,
 	UpdateSecuritySettingsDto,
 } from './security-settings/security-settings.dto';
+export {
+	UpdateSecurityPolicyDto,
+	type SecurityPolicyResponse,
+} from './security-settings/security-policy.dto';
 
 export { WorkflowHistoryVersionsByIdsDto } from './workflow-history/workflow-history-versions-by-ids.dto';
 export { UpdateWorkflowHistoryVersionDto } from './workflow-history/update-workflow-history-version.dto';

--- a/packages/@n8n/api-types/src/dto/security-settings/security-policy.dto.ts
+++ b/packages/@n8n/api-types/src/dto/security-settings/security-policy.dto.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+import { redactionFloorSchema, type RedactionFloor } from '../../redaction-enforcement-floor';
+import { Z } from '../../zod-class';
+
+const redactionEnforcementFieldSchema = z.object({
+	floor: redactionFloorSchema,
+});
+
+/**
+ * Public API request body for updating the security policy group. Mirrors the
+ * writable subset of the internal security settings, validated with the same
+ * field schemas so behaviour stays in sync.
+ */
+export class UpdateSecurityPolicyDto extends Z.class({
+	personalSpacePublishing: z.boolean().optional(),
+	personalSpaceSharing: z.boolean().optional(),
+	redactionEnforcement: redactionEnforcementFieldSchema.optional(),
+}) {}
+
+/**
+ * Public API response shape for the security policy group.
+ */
+export interface SecurityPolicyResponse {
+	personalSpacePublishing: boolean;
+	personalSpaceSharing: boolean;
+	publishedPersonalWorkflowsCount: number;
+	sharedPersonalWorkflowsCount: number;
+	sharedPersonalCredentialsCount: number;
+	redactionEnforcement: { floor: RedactionFloor };
+}

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -89,6 +89,7 @@ export const API_KEY_RESOURCES = {
 	workflow: [...DEFAULT_OPERATIONS, 'move', 'activate', 'deactivate', 'export', 'import'] as const,
 	variable: ['create', 'update', 'delete', 'list'] as const,
 	securityAudit: ['generate'] as const,
+	securitySettings: ['manage'] as const,
 	project: ['create', 'update', 'delete', 'list', 'export'] as const,
 	user: ['read', 'list', 'create', 'changeRole', 'delete'] as const,
 	execution: ['delete', 'read', 'retry', 'list', 'stop'] as const,

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -14,6 +14,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'user:delete',
 	'sourceControl:pull',
 	'securityAudit:generate',
+	'securitySettings:manage',
 	'project:create',
 	'project:update',
 	'project:delete',

--- a/packages/cli/src/controllers/__tests__/security-settings.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/security-settings.controller.test.ts
@@ -1,11 +1,10 @@
 import type { UpdateSecuritySettingsDto } from '@n8n/api-types';
+import type { LicenseState } from '@n8n/backend-common';
 import type { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { AuthenticatedRequest } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
 
-import type { LicenseState } from '@n8n/backend-common';
-import type { EventService } from '@/events/event.service';
-import type { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { SecuritySettingsService } from '@/services/security-settings.service';
 import type { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 
@@ -15,113 +14,168 @@ describe('SecuritySettingsController', () => {
 	const securitySettingsService = mock<SecuritySettingsService>();
 	const workflowReviewPolicyService = mock<WorkflowReviewPolicyService>();
 	const licenseState = mock<LicenseState>();
-	const eventService = mock<EventService>();
 	const instanceSettingsLoaderConfig = mock<InstanceSettingsLoaderConfig>({
 		securityPolicyManagedByEnv: false,
 	});
-	const instanceRedactionEnforcementService = mock<InstanceRedactionEnforcementService>();
 
 	const controller = new SecuritySettingsController(
 		securitySettingsService,
 		workflowReviewPolicyService,
 		licenseState,
-		eventService,
 		instanceSettingsLoaderConfig,
-		instanceRedactionEnforcementService,
 	);
 
-	const req = mock<AuthenticatedRequest>({
-		user: { id: 'user-1', email: 'admin@n8n.io', firstName: 'Admin', lastName: 'User' },
-	});
+	const req = {
+		user: {
+			id: 'user-1',
+			email: 'admin@n8n.io',
+			firstName: 'Admin',
+			lastName: 'User',
+			role: { slug: 'global:owner' },
+		},
+	} as unknown as AuthenticatedRequest;
+
+	const originalWorkflowReviewsFlag = process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
+		delete process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS;
+		licenseState.isWorkflowReviewsLicensed.mockReturnValue(false);
 	});
 
-	const redactionPolicyEvents = () =>
-		eventService.emit.mock.calls.filter(
-			([name, payload]) =>
-				name === 'instance-policies-updated' &&
-				typeof payload === 'object' &&
-				payload !== null &&
-				'settingName' in payload &&
-				String(payload.settingName).startsWith('data_redaction'),
-		);
+	afterAll(() => {
+		if (originalWorkflowReviewsFlag === undefined) {
+			delete process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS;
+		} else {
+			process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS = originalWorkflowReviewsFlag;
+		}
+	});
 
-	const dto = (floor: 'off' | 'production' | 'all') =>
-		({ redactionEnforcement: { floor } }) as UpdateSecuritySettingsDto;
+	describe('getSecuritySettings', () => {
+		it('delegates to the service and adds managedByEnv', async () => {
+			securitySettingsService.getSecuritySettings.mockResolvedValue({
+				personalSpacePublishing: true,
+				personalSpaceSharing: false,
+				publishedPersonalWorkflowsCount: 5,
+				sharedPersonalWorkflowsCount: 12,
+				sharedPersonalCredentialsCount: 3,
+				redactionEnforcement: { floor: 'production' },
+			});
 
-	describe('updateSecuritySettings — redaction telemetry', () => {
-		it('emits the redaction floor when enforcement is enabled', async () => {
-			instanceRedactionEnforcementService.get.mockResolvedValue('off');
+			const result = await controller.getSecuritySettings(req, mock());
 
-			await controller.updateSecuritySettings(req, mock(), dto('all'));
+			expect(result).toEqual({
+				personalSpacePublishing: true,
+				personalSpaceSharing: false,
+				publishedPersonalWorkflowsCount: 5,
+				sharedPersonalWorkflowsCount: 12,
+				sharedPersonalCredentialsCount: 3,
+				redactionEnforcement: { floor: 'production' },
+				managedByEnv: false,
+			});
+		});
 
-			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('all');
-			expect(eventService.emit).toHaveBeenCalledWith(
-				'redaction-enforcement-updated',
-				expect.anything(),
+		it('reflects managedByEnv when set', async () => {
+			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
+			securitySettingsService.getSecuritySettings.mockResolvedValue({
+				personalSpacePublishing: true,
+				personalSpaceSharing: true,
+				publishedPersonalWorkflowsCount: 0,
+				sharedPersonalWorkflowsCount: 0,
+				sharedPersonalCredentialsCount: 0,
+				redactionEnforcement: { floor: 'off' },
+			});
+
+			const result = await controller.getSecuritySettings(req, mock());
+
+			expect(result.managedByEnv).toBe(true);
+		});
+
+		it('includes workflowReviews when licensed and dev flag is on', async () => {
+			process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS = 'true';
+			licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
+			securitySettingsService.getSecuritySettings.mockResolvedValue({
+				personalSpacePublishing: true,
+				personalSpaceSharing: true,
+				publishedPersonalWorkflowsCount: 0,
+				sharedPersonalWorkflowsCount: 0,
+				sharedPersonalCredentialsCount: 0,
+				redactionEnforcement: { floor: 'off' },
+			});
+			workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
+
+			const result = await controller.getSecuritySettings(req, mock());
+
+			expect(result).toMatchObject({ workflowReviews: { enabled: true } });
+		});
+	});
+
+	describe('updateSecuritySettings', () => {
+		const dto = (overrides: Partial<UpdateSecuritySettingsDto> = {}) =>
+			overrides as UpdateSecuritySettingsDto;
+
+		it('delegates the writable subset to the service with the request user', async () => {
+			securitySettingsService.updateSecuritySettings.mockResolvedValue({
+				personalSpacePublishing: false,
+				redactionEnforcement: { floor: 'all' },
+			});
+
+			const result = await controller.updateSecuritySettings(
+				req,
+				mock(),
+				dto({ personalSpacePublishing: false, redactionEnforcement: { floor: 'all' } }),
 			);
-			expect(redactionPolicyEvents()).toEqual([
-				[
-					'instance-policies-updated',
-					expect.objectContaining({
-						settingName: 'data_redaction_enforcement_floor',
-						value: 'all',
-					}),
-				],
-			]);
-		});
 
-		it('reports the production-only floor as `production`', async () => {
-			instanceRedactionEnforcementService.get.mockResolvedValue('off');
-
-			await controller.updateSecuritySettings(req, mock(), dto('production'));
-
-			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('production');
-			expect(redactionPolicyEvents().map(([, payload]) => payload)).toEqual([
-				expect.objectContaining({
-					settingName: 'data_redaction_enforcement_floor',
-					value: 'production',
-				}),
-			]);
-		});
-
-		it('reports `off` when enforcement is disabled', async () => {
-			instanceRedactionEnforcementService.get.mockResolvedValue('production');
-
-			await controller.updateSecuritySettings(req, mock(), dto('off'));
-
-			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('off');
-			expect(redactionPolicyEvents().map(([, payload]) => payload)).toEqual([
-				expect.objectContaining({
-					settingName: 'data_redaction_enforcement_floor',
-					value: 'off',
-				}),
-			]);
-		});
-
-		it('emits nothing when the floor is unchanged', async () => {
-			instanceRedactionEnforcementService.get.mockResolvedValue('production');
-
-			await controller.updateSecuritySettings(req, mock(), dto('production'));
-
-			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
-			expect(redactionPolicyEvents()).toHaveLength(0);
-		});
-
-		it('does not persist or emit when the redaction floor is unchanged', async () => {
-			instanceRedactionEnforcementService.get.mockResolvedValue('all');
-
-			const result = await controller.updateSecuritySettings(req, mock(), dto('all'));
-
-			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
-			expect(eventService.emit).not.toHaveBeenCalledWith(
-				'redaction-enforcement-updated',
-				expect.anything(),
+			expect(securitySettingsService.updateSecuritySettings).toHaveBeenCalledWith(
+				{
+					personalSpacePublishing: false,
+					personalSpaceSharing: undefined,
+					redactionEnforcement: { floor: 'all' },
+				},
+				req.user,
 			);
-			expect(redactionPolicyEvents()).toHaveLength(0);
-			expect(result.redactionEnforcement).toEqual({ floor: 'all' });
+			expect(result).toEqual({
+				personalSpacePublishing: false,
+				redactionEnforcement: { floor: 'all' },
+			});
+		});
+
+		it('throws ForbiddenError when settings are managed by env', async () => {
+			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
+
+			await expect(
+				controller.updateSecuritySettings(req, mock(), dto({ personalSpacePublishing: false })),
+			).rejects.toThrow(ForbiddenError);
+			expect(securitySettingsService.updateSecuritySettings).not.toHaveBeenCalled();
+		});
+
+		it('updates workflowReviews and emits its policy event when available', async () => {
+			process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS = 'true';
+			licenseState.isWorkflowReviewsLicensed.mockReturnValue(true);
+			securitySettingsService.updateSecuritySettings.mockResolvedValue({});
+			workflowReviewPolicyService.get.mockResolvedValue({ enabled: false });
+			workflowReviewPolicyService.set.mockResolvedValue({ enabled: true });
+
+			const result = await controller.updateSecuritySettings(
+				req,
+				mock(),
+				dto({ workflowReviews: { enabled: true } }),
+			);
+
+			expect(workflowReviewPolicyService.set).toHaveBeenCalledWith(true);
+			expect(result).toMatchObject({ workflowReviews: { enabled: true } });
+			expect(securitySettingsService.emitInstancePolicyUpdated).toHaveBeenCalledWith(req.user, {
+				settingName: 'workflow_reviews',
+				value: true,
+			});
+		});
+
+		it('rejects workflowReviews when the feature is unavailable', async () => {
+			await expect(
+				controller.updateSecuritySettings(req, mock(), dto({ workflowReviews: { enabled: true } })),
+			).rejects.toThrow(ForbiddenError);
+			expect(workflowReviewPolicyService.set).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -3,27 +3,12 @@ import { LicenseState } from '@n8n/backend-common';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import { type AuthenticatedRequest } from '@n8n/db';
 import { Body, Get, GlobalScope, Licensed, Post, RestController } from '@n8n/decorators';
-import {
-	PERSONAL_SPACE_PUBLISHING_SETTING,
-	PERSONAL_SPACE_SHARING_SETTING,
-} from '@n8n/permissions';
-import type { DistributiveOmit } from '@n8n/utils/types';
 import type { Response } from 'express';
 
 import { isWorkflowReviewsFeatureAvailable } from '@/constants/workflow-reviews';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
-import { EventService } from '@/events/event.service';
-import type { RelayEventMap } from '@/events/maps/relay.event-map';
-import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
-
-/**
- * The `instance-policies-updated` payload without the `user` envelope. Kept as a
- * distributed union so each `settingName` stays bound to its own `value` type
- * (boolean settings cannot be emitted with a redaction floor, and vice versa).
- */
-type InstancePolicyUpdate = DistributiveOmit<RelayEventMap['instance-policies-updated'], 'user'>;
 
 @RestController('/settings/security')
 export class SecuritySettingsController {
@@ -31,38 +16,21 @@ export class SecuritySettingsController {
 		private readonly securitySettingsService: SecuritySettingsService,
 		private readonly workflowReviewPolicyService: WorkflowReviewPolicyService,
 		private readonly licenseState: LicenseState,
-		private readonly eventService: EventService,
 		private readonly instanceSettingsLoaderConfig: InstanceSettingsLoaderConfig,
-		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
 	) {}
 
 	@Licensed('feat:personalSpacePolicy')
 	@GlobalScope('securitySettings:manage')
 	@Get('/')
 	async getSecuritySettings(_req: AuthenticatedRequest, _res: Response) {
-		const [
-			settings,
-			publishedPersonalWorkflowsCount,
-			sharedPersonalWorkflowsCount,
-			sharedPersonalCredentialsCount,
-			redactionSettings,
-			workflowReviews,
-		] = await Promise.all([
-			this.securitySettingsService.arePersonalSpaceSettingsEnabled(),
-			this.securitySettingsService.getPublishedPersonalWorkflowsCount(),
-			this.securitySettingsService.getSharedPersonalWorkflowsCount(),
-			this.securitySettingsService.getSharedPersonalCredentialsCount(),
-			this.instanceRedactionEnforcementService.get(),
+		const [settings, workflowReviews] = await Promise.all([
+			this.securitySettingsService.getSecuritySettings(),
 			this.getWorkflowReviewsIfAvailable(),
 		]);
 
 		return {
 			...settings,
-			publishedPersonalWorkflowsCount,
-			sharedPersonalWorkflowsCount,
-			sharedPersonalCredentialsCount,
 			managedByEnv: this.instanceSettingsLoaderConfig.securityPolicyManagedByEnv,
-			redactionEnforcement: { floor: redactionSettings },
 			...(workflowReviews !== undefined ? { workflowReviews } : {}),
 		};
 	}
@@ -85,56 +53,15 @@ export class SecuritySettingsController {
 			this.assertWorkflowReviewsAvailable();
 		}
 
-		const updatedSettings: Partial<UpdateSecuritySettingsDto> = {};
-		if (dto.personalSpacePublishing !== undefined) {
-			await this.securitySettingsService.setPersonalSpaceSetting(
-				PERSONAL_SPACE_PUBLISHING_SETTING,
-				dto.personalSpacePublishing,
+		const updatedSettings: Partial<UpdateSecuritySettingsDto> =
+			await this.securitySettingsService.updateSecuritySettings(
+				{
+					personalSpacePublishing: dto.personalSpacePublishing,
+					personalSpaceSharing: dto.personalSpaceSharing,
+					redactionEnforcement: dto.redactionEnforcement,
+				},
+				req.user,
 			);
-			updatedSettings.personalSpacePublishing = dto.personalSpacePublishing;
-			this.emitInstancePolicyUpdated(req, {
-				settingName: 'workflow_publishing',
-				value: dto.personalSpacePublishing,
-			});
-		}
-		if (dto.personalSpaceSharing !== undefined) {
-			await this.securitySettingsService.setPersonalSpaceSetting(
-				PERSONAL_SPACE_SHARING_SETTING,
-				dto.personalSpaceSharing,
-			);
-			updatedSettings.personalSpaceSharing = dto.personalSpaceSharing;
-			this.emitInstancePolicyUpdated(req, {
-				settingName: 'workflow_sharing',
-				value: dto.personalSpaceSharing,
-			});
-		}
-
-		if (dto.redactionEnforcement !== undefined) {
-			const before = await this.instanceRedactionEnforcementService.get();
-			const after = dto.redactionEnforcement.floor;
-			updatedSettings.redactionEnforcement = { floor: after };
-			if (before !== after) {
-				await this.instanceRedactionEnforcementService.set(after);
-				this.eventService.emit('redaction-enforcement-updated', {
-					user: {
-						id: req.user.id,
-						email: req.user.email,
-						firstName: req.user.firstName,
-						lastName: req.user.lastName,
-						role: req.user.role,
-					},
-					before,
-					after,
-				});
-				// Report the redaction enforcement floor alongside the other instance
-				// policies. `'off' | 'production' | 'all'` captures both adoption
-				// (off vs not) and scope (production vs production+manual).
-				this.emitInstancePolicyUpdated(req, {
-					settingName: 'data_redaction_enforcement_floor',
-					value: after,
-				});
-			}
-		}
 
 		if (dto.workflowReviews?.enabled !== undefined) {
 			const before = (await this.workflowReviewPolicyService.get()).enabled;
@@ -143,7 +70,7 @@ export class SecuritySettingsController {
 			if (before !== after) {
 				const workflowReviews = await this.workflowReviewPolicyService.set(after);
 				updatedSettings.workflowReviews = workflowReviews;
-				this.emitInstancePolicyUpdated(req, {
+				this.securitySettingsService.emitInstancePolicyUpdated(req.user, {
 					settingName: 'workflow_reviews',
 					value: workflowReviews.enabled,
 				});
@@ -166,18 +93,5 @@ export class SecuritySettingsController {
 		if (!this.isWorkflowReviewsAvailable()) {
 			throw new ForbiddenError('Workflow reviews settings are not enabled in this instance');
 		}
-	}
-
-	private emitInstancePolicyUpdated(req: AuthenticatedRequest, update: InstancePolicyUpdate) {
-		this.eventService.emit('instance-policies-updated', {
-			user: {
-				id: req.user.id,
-				email: req.user.email,
-				firstName: req.user.firstName,
-				lastName: req.user.lastName,
-				role: req.user.role,
-			},
-			...update,
-		});
 	}
 }

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -7,6 +7,7 @@ import type {
 	UpdateDataTableColumnDto,
 	UpdateDataTableRowDto,
 	UpsertDataTableRowDto,
+	UpdateSecurityPolicyDto,
 } from '@n8n/api-types';
 import type { AuthenticatedRequest, TagEntity, WorkflowEntity } from '@n8n/db';
 import type { ExecutionStatus, ICredentialDataDecryptedObject } from 'n8n-workflow';
@@ -377,4 +378,13 @@ export declare namespace AuditRequest {
 		{},
 		{ additionalOptions?: { categories?: Risk.Category[]; daysAbandonedWorkflow?: number } }
 	>;
+}
+
+// ----------------------------------
+//        /settings/security-policy
+// ----------------------------------
+
+export declare namespace SecurityPolicyRequest {
+	type Get = AuthenticatedRequest;
+	type Update = AuthenticatedRequest<{}, {}, UpdateSecurityPolicyDto>;
 }

--- a/packages/cli/src/public-api/v1/handlers/security-policy/security-policy.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/security-policy/security-policy.handler.ts
@@ -1,0 +1,59 @@
+import { UpdateSecurityPolicyDto, type SecurityPolicyResponse } from '@n8n/api-types';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import type { SecurityPolicyReadResult } from '@/services/security-settings.service';
+import { SecuritySettingsService } from '@/services/security-settings.service';
+
+import type { SecurityPolicyRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import {
+	apiKeyHasScopeWithGlobalScopeFallback,
+	isLicensed,
+} from '../../shared/middlewares/global.middleware';
+
+const toResponse = (settings: SecurityPolicyReadResult): SecurityPolicyResponse => settings;
+
+type SecurityPolicyHandlers = {
+	getSecurityPolicy: PublicAPIEndpoint<SecurityPolicyRequest.Get>;
+	updateSecurityPolicy: PublicAPIEndpoint<SecurityPolicyRequest.Update>;
+};
+
+const securityPolicyHandlers: SecurityPolicyHandlers = {
+	getSecurityPolicy: [
+		isLicensed('feat:personalSpacePolicy'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'securitySettings:manage' }),
+		async (_req, res) => {
+			const settings = await Container.get(SecuritySettingsService).getSecuritySettings();
+			return res.json(toResponse(settings));
+		},
+	],
+
+	updateSecurityPolicy: [
+		isLicensed('feat:personalSpacePolicy'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'securitySettings:manage' }),
+		async (req, res) => {
+			const payload = UpdateSecurityPolicyDto.safeParse(req.body);
+			if (!payload.success) {
+				throw new BadRequestError(payload.error.errors[0]?.message ?? 'Invalid request body');
+			}
+
+			const { securityPolicyManagedByEnv } = Container.get(InstanceSettingsLoaderConfig);
+			if (securityPolicyManagedByEnv) {
+				throw new ConflictError(
+					'These settings are managed via environment variables and cannot be modified through the API',
+				);
+			}
+
+			const service = Container.get(SecuritySettingsService);
+			await service.updateSecuritySettings(payload.data, req.user);
+			const settings = await service.getSecuritySettings();
+
+			return res.json(toResponse(settings));
+		},
+	],
+};
+
+export = securityPolicyHandlers;

--- a/packages/cli/src/public-api/v1/handlers/security-policy/spec/paths/security-policy.yml
+++ b/packages/cli/src/public-api/v1/handlers/security-policy/spec/paths/security-policy.yml
@@ -1,0 +1,57 @@
+get:
+  x-eov-operation-id: getSecurityPolicy
+  x-required-scope: securitySettings:manage
+  x-eov-operation-handler: v1/handlers/security-policy/security-policy.handler
+  tags:
+    - SecurityPolicy
+  summary: Retrieve the security policy
+  description: >
+    Retrieve the instance security policy: personal-space publishing and sharing, the
+    execution-data redaction enforcement floor, and the read-only usage counts shown in the UI.
+    Requires the `securitySettings:manage` scope and the Personal Space Policy feature to be licensed.
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security-policy.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+put:
+  x-eov-operation-id: updateSecurityPolicy
+  x-required-scope: securitySettings:manage
+  x-eov-operation-handler: v1/handlers/security-policy/security-policy.handler
+  tags:
+    - SecurityPolicy
+  summary: Update the security policy
+  description: >
+    Update the instance security policy. Only the provided fields are changed and the update
+    takes effect exactly as it would from the UI, using the same validation. Requires the
+    `securitySettings:manage` scope and the Personal Space Policy feature to be licensed.
+    When the group is managed via environment variables, the write is rejected with 409 and no
+    changes are made; a read still returns the current values.
+  requestBody:
+    description: The security policy fields to update.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/security-policy.update.yml'
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/security-policy.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/handlers/security-policy/spec/schemas/security-policy.update.yml
+++ b/packages/cli/src/public-api/v1/handlers/security-policy/spec/schemas/security-policy.update.yml
@@ -1,0 +1,23 @@
+type: object
+additionalProperties: false
+description: Security policy fields to update. Omitted fields are left unchanged.
+properties:
+  personalSpacePublishing:
+    type: boolean
+    description: Whether members may publish workflows and agents from their personal space.
+    example: false
+  personalSpaceSharing:
+    type: boolean
+    description: Whether members may share workflows and credentials from their personal space.
+    example: false
+  redactionEnforcement:
+    type: object
+    additionalProperties: false
+    required:
+      - floor
+    properties:
+      floor:
+        type: string
+        enum: [off, production, all]
+        description: Minimum execution-data redaction level enforced across the instance.
+        example: production

--- a/packages/cli/src/public-api/v1/handlers/security-policy/spec/schemas/security-policy.yml
+++ b/packages/cli/src/public-api/v1/handlers/security-policy/spec/schemas/security-policy.yml
@@ -1,0 +1,44 @@
+type: object
+additionalProperties: false
+required:
+  - personalSpacePublishing
+  - personalSpaceSharing
+  - publishedPersonalWorkflowsCount
+  - sharedPersonalWorkflowsCount
+  - sharedPersonalCredentialsCount
+  - redactionEnforcement
+properties:
+  personalSpacePublishing:
+    type: boolean
+    description: Whether members may publish workflows and agents from their personal space.
+    example: true
+  personalSpaceSharing:
+    type: boolean
+    description: Whether members may share workflows and credentials from their personal space.
+    example: true
+  publishedPersonalWorkflowsCount:
+    type: integer
+    readOnly: true
+    description: Number of currently published personal workflows, shown for awareness before tightening the policy.
+    example: 3
+  sharedPersonalWorkflowsCount:
+    type: integer
+    readOnly: true
+    description: Number of personal workflows currently shared with other users.
+    example: 5
+  sharedPersonalCredentialsCount:
+    type: integer
+    readOnly: true
+    description: Number of personal credentials currently shared with other users.
+    example: 2
+  redactionEnforcement:
+    type: object
+    additionalProperties: false
+    required:
+      - floor
+    properties:
+      floor:
+        type: string
+        enum: [off, production, all]
+        description: Minimum execution-data redaction level enforced across the instance.
+        example: production

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -20,6 +20,8 @@ tags:
     description: Operations about users
   - name: Audit
     description: Operations about security audit
+  - name: SecurityPolicy
+    description: Operations about the instance security policy settings
   - name: Execution
     description: Operations about executions
   - name: Workflow
@@ -52,6 +54,8 @@ tags:
 paths:
   /audit:
     $ref: './handlers/audit/spec/paths/audit.yml'
+  /settings/security-policy:
+    $ref: './handlers/security-policy/spec/paths/security-policy.yml'
   /credentials:
     $ref: './handlers/credentials/spec/paths/credentials.yml'
   /credentials/{id}:

--- a/packages/cli/src/services/__tests__/security-settings.service.test.ts
+++ b/packages/cli/src/services/__tests__/security-settings.service.test.ts
@@ -10,6 +10,8 @@ import {
 	PERSONAL_SPACE_SHARING_SETTING,
 } from '@n8n/permissions';
 
+import { EventService } from '@/events/event.service';
+import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { RoleService } from '@/services/role.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 
@@ -19,13 +21,25 @@ describe('SecuritySettingsService', () => {
 	const workflowRepository = mockInstance(WorkflowRepository);
 	const sharedWorkflowRepository = mockInstance(SharedWorkflowRepository);
 	const sharedCredentialsRepository = mockInstance(SharedCredentialsRepository);
+	const instanceRedactionEnforcementService = mockInstance(InstanceRedactionEnforcementService);
+	const eventService = mockInstance(EventService);
 	const securitySettingsService = new SecuritySettingsService(
 		settingsRepository,
 		roleService,
 		workflowRepository,
 		sharedWorkflowRepository,
 		sharedCredentialsRepository,
+		instanceRedactionEnforcementService,
+		eventService,
 	);
+
+	const actor = {
+		id: 'user-1',
+		email: 'admin@n8n.io',
+		firstName: 'Admin',
+		lastName: 'User',
+		role: { slug: 'global:owner' },
+	};
 
 	const PERSONAL_OWNER_ROLE_SLUG = 'project:personalOwner';
 
@@ -258,6 +272,166 @@ describe('SecuritySettingsService', () => {
 			const result = await securitySettingsService.getSharedPersonalCredentialsCount();
 
 			expect(result).toBe(0);
+		});
+	});
+
+	describe('getSecuritySettings', () => {
+		test('assembles personal-space settings, counts and redaction floor', async () => {
+			settingsRepository.findByKeys.mockResolvedValue([
+				{ key: PERSONAL_SPACE_PUBLISHING_SETTING.key, value: 'true' },
+				{ key: PERSONAL_SPACE_SHARING_SETTING.key, value: 'false' },
+			] as never);
+			workflowRepository.getPublishedPersonalWorkflowsCount.mockResolvedValue(5);
+			sharedWorkflowRepository.getSharedPersonalWorkflowsCount.mockResolvedValue(12);
+			sharedCredentialsRepository.getSharedPersonalCredentialsCount.mockResolvedValue(3);
+			instanceRedactionEnforcementService.get.mockResolvedValue('production');
+
+			const result = await securitySettingsService.getSecuritySettings();
+
+			expect(result).toEqual({
+				personalSpacePublishing: true,
+				personalSpaceSharing: false,
+				publishedPersonalWorkflowsCount: 5,
+				sharedPersonalWorkflowsCount: 12,
+				sharedPersonalCredentialsCount: 3,
+				redactionEnforcement: { floor: 'production' },
+			});
+		});
+	});
+
+	describe('updateSecuritySettings', () => {
+		test('updates only personalSpacePublishing and emits its policy event', async () => {
+			const result = await securitySettingsService.updateSecuritySettings(
+				{ personalSpacePublishing: false },
+				actor,
+			);
+
+			expect(result).toEqual({ personalSpacePublishing: false });
+			expect(settingsRepository.upsert).toHaveBeenCalledWith(
+				{ key: PERSONAL_SPACE_PUBLISHING_SETTING.key, value: 'false', loadOnStartup: true },
+				['key'],
+			);
+			expect(eventService.emit).toHaveBeenCalledWith('instance-policies-updated', {
+				user: actor,
+				settingName: 'workflow_publishing',
+				value: false,
+			});
+		});
+
+		test('updates only personalSpaceSharing and emits its policy event', async () => {
+			const result = await securitySettingsService.updateSecuritySettings(
+				{ personalSpaceSharing: true },
+				actor,
+			);
+
+			expect(result).toEqual({ personalSpaceSharing: true });
+			expect(eventService.emit).toHaveBeenCalledWith('instance-policies-updated', {
+				user: actor,
+				settingName: 'workflow_sharing',
+				value: true,
+			});
+		});
+
+		test('does nothing and emits nothing when no fields are provided', async () => {
+			const result = await securitySettingsService.updateSecuritySettings({}, actor);
+
+			expect(result).toEqual({});
+			expect(settingsRepository.upsert).not.toHaveBeenCalled();
+			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		test('normalizes the actor to the minimal audit envelope', async () => {
+			await securitySettingsService.updateSecuritySettings({ personalSpacePublishing: true }, {
+				id: 'user-1',
+				email: 'admin@n8n.io',
+				firstName: 'Admin',
+				lastName: 'User',
+				role: { slug: 'global:owner' },
+				password: 'secret-hash',
+			} as never);
+
+			const [, payload] = eventService.emit.mock.calls[0];
+			expect(payload).not.toHaveProperty('user.password');
+			expect(payload).toMatchObject({
+				user: {
+					id: 'user-1',
+					email: 'admin@n8n.io',
+					firstName: 'Admin',
+					lastName: 'User',
+					role: { slug: 'global:owner' },
+				},
+			});
+		});
+
+		describe('redaction enforcement', () => {
+			test('persists the floor and emits both events when it changes', async () => {
+				instanceRedactionEnforcementService.get.mockResolvedValue('off');
+
+				const result = await securitySettingsService.updateSecuritySettings(
+					{ redactionEnforcement: { floor: 'all' } },
+					actor,
+				);
+
+				expect(result).toEqual({ redactionEnforcement: { floor: 'all' } });
+				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('all');
+				expect(eventService.emit).toHaveBeenCalledWith('redaction-enforcement-updated', {
+					user: actor,
+					before: 'off',
+					after: 'all',
+				});
+				expect(eventService.emit).toHaveBeenCalledWith('instance-policies-updated', {
+					user: actor,
+					settingName: 'data_redaction_enforcement_floor',
+					value: 'all',
+				});
+			});
+
+			test('reports the production-only floor as `production`', async () => {
+				instanceRedactionEnforcementService.get.mockResolvedValue('off');
+
+				await securitySettingsService.updateSecuritySettings(
+					{ redactionEnforcement: { floor: 'production' } },
+					actor,
+				);
+
+				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('production');
+				expect(eventService.emit).toHaveBeenCalledWith('instance-policies-updated', {
+					user: actor,
+					settingName: 'data_redaction_enforcement_floor',
+					value: 'production',
+				});
+			});
+
+			test('does not persist or emit when the floor is unchanged', async () => {
+				instanceRedactionEnforcementService.get.mockResolvedValue('all');
+
+				const result = await securitySettingsService.updateSecuritySettings(
+					{ redactionEnforcement: { floor: 'all' } },
+					actor,
+				);
+
+				expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+				expect(eventService.emit).not.toHaveBeenCalled();
+				// The applied subset still echoes the requested floor.
+				expect(result.redactionEnforcement).toEqual({ floor: 'all' });
+			});
+		});
+
+		test('applies personal-space and redaction changes together', async () => {
+			instanceRedactionEnforcementService.get.mockResolvedValue('off');
+
+			const result = await securitySettingsService.updateSecuritySettings(
+				{ personalSpacePublishing: true, redactionEnforcement: { floor: 'production' } },
+				actor,
+			);
+
+			expect(result).toEqual({
+				personalSpacePublishing: true,
+				redactionEnforcement: { floor: 'production' },
+			});
+			expect(settingsRepository.upsert).toHaveBeenCalledTimes(1);
+			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/services/security-settings.service.ts
+++ b/packages/cli/src/services/security-settings.service.ts
@@ -1,3 +1,4 @@
+import type { RedactionFloor } from '@n8n/api-types';
 import {
 	SettingsRepository,
 	SharedCredentialsRepository,
@@ -9,8 +10,42 @@ import {
 	PERSONAL_SPACE_PUBLISHING_SETTING,
 	PERSONAL_SPACE_SHARING_SETTING,
 } from '@n8n/permissions';
+import type { DistributiveOmit } from '@n8n/utils/types';
 
+import { EventService } from '@/events/event.service';
+import type { RelayEventMap, UserLike } from '@/events/maps/relay.event-map';
+import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { RoleService } from '@/services/role.service';
+
+/**
+ * The writable subset of the security policy shared by the internal controller
+ * and the public API. Workflow reviews are handled separately by the caller as
+ * they are gated behind a dedicated license + dev flag.
+ */
+export interface SecurityPolicyUpdate {
+	personalSpacePublishing?: boolean;
+	personalSpaceSharing?: boolean;
+	redactionEnforcement?: { floor: RedactionFloor };
+}
+
+/**
+ * The core security policy read shared by the internal controller and the
+ * public API, without the layer-specific "managed by" representation.
+ */
+export interface SecurityPolicyReadResult {
+	personalSpacePublishing: boolean;
+	personalSpaceSharing: boolean;
+	publishedPersonalWorkflowsCount: number;
+	sharedPersonalWorkflowsCount: number;
+	sharedPersonalCredentialsCount: number;
+	redactionEnforcement: { floor: RedactionFloor };
+}
+
+/**
+ * The `instance-policies-updated` payload without the `user` envelope. Kept as a
+ * distributed union so each `settingName` stays bound to its own `value` type.
+ */
+type InstancePolicyUpdate = DistributiveOmit<RelayEventMap['instance-policies-updated'], 'user'>;
 
 @Service()
 export class SecuritySettingsService {
@@ -22,7 +57,102 @@ export class SecuritySettingsService {
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly sharedWorkflowRepository: SharedWorkflowRepository,
 		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
+		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
+		private readonly eventService: EventService,
 	) {}
+
+	/**
+	 * Read the core security policy (personal-space toggles, usage counts and the
+	 * redaction enforcement floor). Callers add their own "managed by"
+	 * representation on top.
+	 */
+	async getSecuritySettings(): Promise<SecurityPolicyReadResult> {
+		const [
+			settings,
+			publishedPersonalWorkflowsCount,
+			sharedPersonalWorkflowsCount,
+			sharedPersonalCredentialsCount,
+			floor,
+		] = await Promise.all([
+			this.arePersonalSpaceSettingsEnabled(),
+			this.getPublishedPersonalWorkflowsCount(),
+			this.getSharedPersonalWorkflowsCount(),
+			this.getSharedPersonalCredentialsCount(),
+			this.instanceRedactionEnforcementService.get(),
+		]);
+
+		return {
+			...settings,
+			publishedPersonalWorkflowsCount,
+			sharedPersonalWorkflowsCount,
+			sharedPersonalCredentialsCount,
+			redactionEnforcement: { floor },
+		};
+	}
+
+	/**
+	 * Apply a security policy update and emit the corresponding audit events.
+	 * Only the provided fields are changed; the returned object echoes the
+	 * applied subset. Callers must enforce access/licensing/managed-by rules
+	 * before invoking this.
+	 */
+	async updateSecuritySettings(
+		securityPolicyUpdate: SecurityPolicyUpdate,
+		actor: UserLike,
+	): Promise<SecurityPolicyUpdate> {
+		const updatedSettings: SecurityPolicyUpdate = {};
+
+		const { personalSpacePublishing, personalSpaceSharing, redactionEnforcement } =
+			securityPolicyUpdate;
+		if (personalSpacePublishing !== undefined) {
+			await this.setPersonalSpaceSetting(
+				PERSONAL_SPACE_PUBLISHING_SETTING,
+				personalSpacePublishing,
+			);
+			updatedSettings.personalSpacePublishing = personalSpacePublishing;
+			this.emitInstancePolicyUpdated(actor, {
+				settingName: 'workflow_publishing',
+				value: personalSpacePublishing,
+			});
+		}
+
+		if (personalSpaceSharing !== undefined) {
+			await this.setPersonalSpaceSetting(PERSONAL_SPACE_SHARING_SETTING, personalSpaceSharing);
+			updatedSettings.personalSpaceSharing = personalSpaceSharing;
+			this.emitInstancePolicyUpdated(actor, {
+				settingName: 'workflow_sharing',
+				value: personalSpaceSharing,
+			});
+		}
+
+		if (redactionEnforcement !== undefined) {
+			const before = await this.instanceRedactionEnforcementService.get();
+			const after = redactionEnforcement.floor;
+			updatedSettings.redactionEnforcement = { floor: after };
+			if (before !== after) {
+				await this.instanceRedactionEnforcementService.set(after);
+				const user = this.toEventUser(actor);
+				this.eventService.emit('redaction-enforcement-updated', { user, before, after });
+				// Report the redaction enforcement floor alongside the other instance
+				// policies. `'off' | 'production' | 'all'` captures both adoption
+				// (off vs not) and scope (production vs production+manual).
+				this.emitInstancePolicyUpdated(actor, {
+					settingName: 'data_redaction_enforcement_floor',
+					value: after,
+				});
+			}
+		}
+
+		return updatedSettings;
+	}
+
+	emitInstancePolicyUpdated(actor: UserLike, update: InstancePolicyUpdate) {
+		const user = this.toEventUser(actor);
+		this.eventService.emit('instance-policies-updated', {
+			user,
+			...update,
+		});
+	}
 
 	async setPersonalSpaceSetting(
 		setting: typeof PERSONAL_SPACE_PUBLISHING_SETTING | typeof PERSONAL_SPACE_SHARING_SETTING,
@@ -73,5 +203,16 @@ export class SecuritySettingsService {
 
 	async getSharedPersonalCredentialsCount(): Promise<number> {
 		return await this.sharedCredentialsRepository.getSharedPersonalCredentialsCount();
+	}
+
+	/** Normalize to the minimal audit envelope so a full user entity never leaks extra fields. */
+	private toEventUser(actor: UserLike): UserLike {
+		return {
+			id: actor.id,
+			email: actor.email,
+			firstName: actor.firstName,
+			lastName: actor.lastName,
+			role: actor.role,
+		};
 	}
 }

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -1,7 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
 
-import { EventService } from '@/events/event.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 
@@ -12,7 +11,6 @@ import { setupTestServer } from '../shared/utils';
 describe('SecuritySettingsController', () => {
 	const securitySettingsService = mockInstance(SecuritySettingsService);
 	const workflowReviewPolicyService = mockInstance(WorkflowReviewPolicyService);
-	const eventService = mockInstance(EventService);
 	const instanceSettingsLoaderConfig = mockInstance(InstanceSettingsLoaderConfig, {
 		securityPolicyManagedByEnv: false,
 	});
@@ -170,9 +168,9 @@ describe('SecuritySettingsController', () => {
 
 			expect(response.body.data).toEqual({ workflowReviews: { enabled: true } });
 			expect(workflowReviewPolicyService.set).toHaveBeenCalledWith(true);
-			expect(eventService.emit).toHaveBeenCalledWith(
-				'instance-policies-updated',
-				expect.objectContaining({ settingName: 'workflow_reviews', value: true }),
+			expect(securitySettingsService.emitInstancePolicyUpdated).toHaveBeenCalledWith(
+				expect.objectContaining({ id: expect.any(String) }),
+				{ settingName: 'workflow_reviews', value: true },
 			);
 		});
 

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -1,12 +1,7 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
-import {
-	PERSONAL_SPACE_PUBLISHING_SETTING,
-	PERSONAL_SPACE_SHARING_SETTING,
-} from '@n8n/permissions';
 
 import { EventService } from '@/events/event.service';
-import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 import { WorkflowReviewPolicyService } from '@/services/workflow-review-policy.service';
 
@@ -17,7 +12,6 @@ import { setupTestServer } from '../shared/utils';
 describe('SecuritySettingsController', () => {
 	const securitySettingsService = mockInstance(SecuritySettingsService);
 	const workflowReviewPolicyService = mockInstance(WorkflowReviewPolicyService);
-	const instanceRedactionEnforcementService = mockInstance(InstanceRedactionEnforcementService);
 	const eventService = mockInstance(EventService);
 	const instanceSettingsLoaderConfig = mockInstance(InstanceSettingsLoaderConfig, {
 		securityPolicyManagedByEnv: false,
@@ -25,6 +19,15 @@ describe('SecuritySettingsController', () => {
 
 	const testServer = setupTestServer({ endpointGroups: ['security-settings'] });
 	let ownerAgent: SuperAgentTest;
+
+	const readResult = {
+		personalSpacePublishing: true,
+		personalSpaceSharing: false,
+		publishedPersonalWorkflowsCount: 5,
+		sharedPersonalWorkflowsCount: 12,
+		sharedPersonalCredentialsCount: 3,
+		redactionEnforcement: { floor: 'off' as const },
+	};
 
 	beforeAll(async () => {
 		const owner = await createOwner();
@@ -35,6 +38,7 @@ describe('SecuritySettingsController', () => {
 		vi.clearAllMocks();
 		testServer.license.enable('feat:personalSpacePolicy');
 		instanceSettingsLoaderConfig.securityPolicyManagedByEnv = false;
+		securitySettingsService.getSecuritySettings.mockResolvedValue(readResult);
 	});
 
 	describe('GET /settings/security', () => {
@@ -43,68 +47,28 @@ describe('SecuritySettingsController', () => {
 			await ownerAgent.get('/settings/security').expect(403);
 		});
 
-		it('should return security settings and all counts', async () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: false,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(5);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(12);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(3);
-			instanceRedactionEnforcementService.get.mockResolvedValue('off');
-
+		it('should return the delegated settings plus managedByEnv', async () => {
 			const response = await ownerAgent.get('/settings/security').expect(200);
 
 			expect(response.body).toEqual({
 				data: {
-					personalSpacePublishing: true,
-					personalSpaceSharing: false,
-					publishedPersonalWorkflowsCount: 5,
-					sharedPersonalWorkflowsCount: 12,
-					sharedPersonalCredentialsCount: 3,
+					...readResult,
 					managedByEnv: false,
-					redactionEnforcement: { floor: 'off' },
 				},
 			});
-			expect(securitySettingsService.arePersonalSpaceSettingsEnabled).toHaveBeenCalledTimes(1);
-			expect(securitySettingsService.getPublishedPersonalWorkflowsCount).toHaveBeenCalledTimes(1);
-			expect(securitySettingsService.getSharedPersonalWorkflowsCount).toHaveBeenCalledTimes(1);
-			expect(securitySettingsService.getSharedPersonalCredentialsCount).toHaveBeenCalledTimes(1);
+			expect(securitySettingsService.getSecuritySettings).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return 0 for all counts when no resources exist', async () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: true,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
+		it('should reflect managedByEnv when the policy is env-managed', async () => {
+			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
 
 			const response = await ownerAgent.get('/settings/security').expect(200);
 
-			expect(response.body.data.publishedPersonalWorkflowsCount).toBe(0);
-			expect(response.body.data.sharedPersonalWorkflowsCount).toBe(0);
-			expect(response.body.data.sharedPersonalCredentialsCount).toBe(0);
+			expect(response.body.data.managedByEnv).toBe(true);
 		});
 
-		it('should handle service errors gracefully', async () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockRejectedValue(
-				new Error('Database connection failed'),
-			);
-
-			await ownerAgent.get('/settings/security').expect(500);
-		});
-
-		it('should return 500 when reading the redaction floor fails', async () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: false,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
-			instanceRedactionEnforcementService.get.mockRejectedValueOnce(new Error('boom'));
+		it('should return 500 when the service throws', async () => {
+			securitySettingsService.getSecuritySettings.mockRejectedValueOnce(new Error('boom'));
 
 			await ownerAgent.get('/settings/security').expect(500);
 		});
@@ -119,304 +83,54 @@ describe('SecuritySettingsController', () => {
 				.expect(403);
 		});
 
-		it('should update only personalSpacePublishing when only that is set in body', async () => {
-			securitySettingsService.setPersonalSpaceSetting.mockResolvedValue(undefined);
-
-			const response = await ownerAgent
-				.post('/settings/security')
-				.send({ personalSpacePublishing: false })
-				.expect(200);
-
-			expect(response.body).toEqual({
-				data: { personalSpacePublishing: false },
+		it('should delegate the writable subset to the service and return the result', async () => {
+			securitySettingsService.updateSecuritySettings.mockResolvedValue({
+				personalSpacePublishing: false,
+				redactionEnforcement: { floor: 'production' },
 			});
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledTimes(1);
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
-				PERSONAL_SPACE_PUBLISHING_SETTING,
-				false,
-			);
-		});
-
-		it('should update only personalSpaceSharing when only that is set in body', async () => {
-			securitySettingsService.setPersonalSpaceSetting.mockResolvedValue(undefined);
-			const response = await ownerAgent
-				.post('/settings/security')
-				.send({ personalSpaceSharing: true })
-				.expect(200);
-
-			expect(response.body).toEqual({
-				data: { personalSpaceSharing: true },
-			});
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledTimes(1);
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledWith(
-				PERSONAL_SPACE_SHARING_SETTING,
-				true,
-			);
-		});
-
-		it('should update both settings when both are set in body', async () => {
-			securitySettingsService.setPersonalSpaceSetting.mockResolvedValue(undefined);
 
 			const response = await ownerAgent
 				.post('/settings/security')
-				.send({ personalSpacePublishing: true, personalSpaceSharing: false })
+				.send({ personalSpacePublishing: false, redactionEnforcement: { floor: 'production' } })
 				.expect(200);
 
 			expect(response.body).toEqual({
 				data: {
-					personalSpacePublishing: true,
-					personalSpaceSharing: false,
+					personalSpacePublishing: false,
+					redactionEnforcement: { floor: 'production' },
 				},
 			});
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledTimes(2);
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenNthCalledWith(
-				1,
-				PERSONAL_SPACE_PUBLISHING_SETTING,
-				true,
-			);
-			expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenNthCalledWith(
-				2,
-				PERSONAL_SPACE_SHARING_SETTING,
-				false,
+			expect(securitySettingsService.updateSecuritySettings).toHaveBeenCalledWith(
+				{
+					personalSpacePublishing: false,
+					personalSpaceSharing: undefined,
+					redactionEnforcement: { floor: 'production' },
+				},
+				expect.objectContaining({ id: expect.any(String) }),
 			);
 		});
 
-		it('should call no service and return empty object when body has no settings', async () => {
-			const response = await ownerAgent.post('/settings/security').send({}).expect(200);
-
-			expect(response.body).toEqual({ data: {} });
-			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
-		});
-
-		it('should handle service errors gracefully', async () => {
-			securitySettingsService.setPersonalSpaceSetting.mockRejectedValue(
-				new Error('Database connection failed'),
-			);
-
+		it('should reject invalid floor values with 400', async () => {
 			await ownerAgent
 				.post('/settings/security')
-				.send({ personalSpacePublishing: true })
-				.expect(500);
-		});
-	});
+				.send({ redactionEnforcement: { floor: 'bogus' } })
+				.expect(400);
 
-	describe('when securityPolicyManagedByEnv is true', () => {
-		beforeEach(() => {
-			instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
+			expect(securitySettingsService.updateSecuritySettings).not.toHaveBeenCalled();
 		});
 
-		it('GET should return managedByEnv: true', async () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: true,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
-
-			const response = await ownerAgent.get('/settings/security').expect(200);
-
-			expect(response.body.data.managedByEnv).toBe(true);
-		});
-
-		it('POST should return 403 when settings are managed by env', async () => {
-			await ownerAgent
-				.post('/settings/security')
-				.send({ personalSpacePublishing: false })
-				.expect(403);
-
-			expect(securitySettingsService.setPersonalSpaceSetting).not.toHaveBeenCalled();
-		});
-
-		it('POST should return 403 when settings are managed by env, even for redactionEnforcement', async () => {
-			await ownerAgent
-				.post('/settings/security')
-				.send({ redactionEnforcement: { floor: 'production' } })
-				.expect(403);
-
-			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('redactionEnforcement', () => {
-		beforeEach(() => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: true,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
-		});
-
-		describe('GET /settings/security', () => {
-			it('should include redactionEnforcement.floor = "off" by default', async () => {
-				instanceRedactionEnforcementService.get.mockResolvedValue('off');
-
-				const response = await ownerAgent.get('/settings/security').expect(200);
-
-				expect(response.body.data.redactionEnforcement).toEqual({ floor: 'off' });
-				expect(instanceRedactionEnforcementService.get).toHaveBeenCalledTimes(1);
-			});
-
-			it('should return stored floor = "production"', async () => {
-				instanceRedactionEnforcementService.get.mockResolvedValue('production');
-
-				const response = await ownerAgent.get('/settings/security').expect(200);
-
-				expect(response.body.data.redactionEnforcement).toEqual({ floor: 'production' });
-			});
-
-			it('should return stored floor = "all"', async () => {
-				instanceRedactionEnforcementService.get.mockResolvedValue('all');
-
-				const response = await ownerAgent.get('/settings/security').expect(200);
-
-				expect(response.body.data.redactionEnforcement).toEqual({ floor: 'all' });
-			});
-		});
-
-		describe('POST /settings/security', () => {
+		describe('when securityPolicyManagedByEnv is true', () => {
 			beforeEach(() => {
-				instanceRedactionEnforcementService.get.mockResolvedValue('off');
+				instanceSettingsLoaderConfig.securityPolicyManagedByEnv = true;
 			});
 
-			it('should persist redactionEnforcement when provided', async () => {
-				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-				const response = await ownerAgent
-					.post('/settings/security')
-					.send({ redactionEnforcement: { floor: 'production' } })
-					.expect(200);
-
-				expect(response.body).toEqual({
-					data: { redactionEnforcement: { floor: 'production' } },
-				});
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('production');
-			});
-
-			it('should persist redactionEnforcement.floor = "production"', async () => {
-				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-				const response = await ownerAgent
-					.post('/settings/security')
-					.send({ redactionEnforcement: { floor: 'production' } })
-					.expect(200);
-
-				expect(response.body).toEqual({
-					data: { redactionEnforcement: { floor: 'production' } },
-				});
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledTimes(1);
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('production');
-			});
-
-			it('should persist redactionEnforcement.floor = "all"', async () => {
-				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
+			it('should return 403 and not call the service', async () => {
 				await ownerAgent
 					.post('/settings/security')
-					.send({ redactionEnforcement: { floor: 'all' } })
-					.expect(200);
+					.send({ personalSpacePublishing: false })
+					.expect(403);
 
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('all');
-			});
-
-			it('should persist redactionEnforcement.floor = "off"', async () => {
-				instanceRedactionEnforcementService.get.mockResolvedValue('production');
-				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-				await ownerAgent
-					.post('/settings/security')
-					.send({ redactionEnforcement: { floor: 'off' } })
-					.expect(200);
-
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('off');
-			});
-
-			it('should update personalSpace and redactionEnforcement together', async () => {
-				securitySettingsService.setPersonalSpaceSetting.mockResolvedValue(undefined);
-				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-				const response = await ownerAgent
-					.post('/settings/security')
-					.send({
-						personalSpacePublishing: true,
-						redactionEnforcement: { floor: 'production' },
-					})
-					.expect(200);
-
-				expect(response.body).toEqual({
-					data: {
-						personalSpacePublishing: true,
-						redactionEnforcement: { floor: 'production' },
-					},
-				});
-				expect(securitySettingsService.setPersonalSpaceSetting).toHaveBeenCalledTimes(1);
-				expect(instanceRedactionEnforcementService.set).toHaveBeenCalledTimes(1);
-			});
-
-			it('should reject invalid floor values', async () => {
-				await ownerAgent
-					.post('/settings/security')
-					.send({ redactionEnforcement: { floor: 'bogus' } })
-					.expect(400);
-
-				expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
-			});
-
-			describe('audit event emission', () => {
-				it('should emit `redaction-enforcement-updated` with before/after when settings change', async () => {
-					instanceRedactionEnforcementService.get.mockResolvedValue('off');
-					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-					await ownerAgent
-						.post('/settings/security')
-						.send({ redactionEnforcement: { floor: 'production' } })
-						.expect(200);
-
-					expect(eventService.emit).toHaveBeenCalledWith(
-						'redaction-enforcement-updated',
-						expect.objectContaining({
-							user: expect.objectContaining({ id: expect.any(String) }),
-							before: 'off',
-							after: 'production',
-						}),
-					);
-				});
-
-				it('should emit `redaction-enforcement-updated` with before/after when settings are disabled', async () => {
-					instanceRedactionEnforcementService.get.mockResolvedValue('production');
-					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-					await ownerAgent
-						.post('/settings/security')
-						.send({ redactionEnforcement: { floor: 'off' } })
-						.expect(200);
-
-					expect(eventService.emit).toHaveBeenCalledWith(
-						'redaction-enforcement-updated',
-						expect.objectContaining({
-							user: expect.objectContaining({ id: expect.any(String) }),
-							before: 'production',
-							after: 'off',
-						}),
-					);
-				});
-
-				it('should not emit when save is idempotent', async () => {
-					instanceRedactionEnforcementService.get.mockResolvedValue('production');
-					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
-
-					await ownerAgent
-						.post('/settings/security')
-						.send({ redactionEnforcement: { floor: 'production' } })
-						.expect(200);
-
-					expect(eventService.emit).not.toHaveBeenCalledWith(
-						'redaction-enforcement-updated',
-						expect.anything(),
-					);
-				});
+				expect(securitySettingsService.updateSecuritySettings).not.toHaveBeenCalled();
 			});
 		});
 	});
@@ -424,20 +138,10 @@ describe('SecuritySettingsController', () => {
 	describe('workflowReviews', () => {
 		const originalWorkflowReviewsFlag = process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS;
 
-		const mockSecuritySettingsReadDependencies = () => {
-			securitySettingsService.arePersonalSpaceSettingsEnabled.mockResolvedValue({
-				personalSpacePublishing: true,
-				personalSpaceSharing: true,
-			});
-			securitySettingsService.getPublishedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalWorkflowsCount.mockResolvedValue(0);
-			securitySettingsService.getSharedPersonalCredentialsCount.mockResolvedValue(0);
-			instanceRedactionEnforcementService.get.mockResolvedValue('off');
-		};
-
 		beforeEach(() => {
 			process.env.N8N_ENV_FEAT_WORKFLOW_REVIEWS = 'true';
 			testServer.license.enable('feat:workflowReviews');
+			securitySettingsService.updateSecuritySettings.mockResolvedValue({});
 			workflowReviewPolicyService.get.mockResolvedValue({ enabled: false });
 			workflowReviewPolicyService.set.mockResolvedValue({ enabled: true });
 		});
@@ -451,18 +155,14 @@ describe('SecuritySettingsController', () => {
 		});
 
 		it('GET should include workflowReviews when licensed and dev flag is on', async () => {
-			mockSecuritySettingsReadDependencies();
 			workflowReviewPolicyService.get.mockResolvedValue({ enabled: true });
 
 			const response = await ownerAgent.get('/settings/security').expect(200);
 
 			expect(response.body.data.workflowReviews).toEqual({ enabled: true });
-			expect(workflowReviewPolicyService.get).toHaveBeenCalledTimes(1);
 		});
 
-		it('POST should update workflowReviews when licensed and dev flag is on', async () => {
-			workflowReviewPolicyService.set.mockResolvedValue({ enabled: true });
-
+		it('POST should update workflowReviews and emit its policy event', async () => {
 			const response = await ownerAgent
 				.post('/settings/security')
 				.send({ workflowReviews: { enabled: true } })
@@ -472,10 +172,7 @@ describe('SecuritySettingsController', () => {
 			expect(workflowReviewPolicyService.set).toHaveBeenCalledWith(true);
 			expect(eventService.emit).toHaveBeenCalledWith(
 				'instance-policies-updated',
-				expect.objectContaining({
-					settingName: 'workflow_reviews',
-					value: true,
-				}),
+				expect.objectContaining({ settingName: 'workflow_reviews', value: true }),
 			);
 		});
 

--- a/packages/cli/test/integration/public-api/security-policy.test.ts
+++ b/packages/cli/test/integration/public-api/security-policy.test.ts
@@ -1,0 +1,226 @@
+import { testDb } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import type { User } from '@n8n/db';
+import { SettingsRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import {
+	PERSONAL_SPACE_PUBLISHING_SETTING,
+	PERSONAL_SPACE_SHARING_SETTING,
+} from '@n8n/permissions';
+import { In } from '@n8n/typeorm';
+
+import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { CacheService } from '@/services/cache/cache.service';
+import { createMemberWithApiKey, createOwnerWithApiKey } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+// Mirrors the private key in InstanceRedactionEnforcementService so tests can reset stored state.
+const REDACTION_SETTING_KEY = 'redaction.enforcement';
+
+describe('Security policy in Public API', () => {
+	let owner: User;
+	const testServer = setupTestServer({ endpointGroups: ['publicApi'] });
+	const licenseErrorMessage = new FeatureNotLicensedError('feat:personalSpacePolicy').message;
+
+	const setManagedByEnv = (value: boolean) => {
+		Container.get(InstanceSettingsLoaderConfig).securityPolicyManagedByEnv = value;
+	};
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+		await Container.get(SettingsRepository).delete({
+			key: In([
+				PERSONAL_SPACE_PUBLISHING_SETTING.key,
+				PERSONAL_SPACE_SHARING_SETTING.key,
+				REDACTION_SETTING_KEY,
+			]),
+		});
+		await Container.get(CacheService).delete(REDACTION_SETTING_KEY);
+		setManagedByEnv(false);
+
+		owner = await createOwnerWithApiKey();
+	});
+
+	afterEach(() => {
+		setManagedByEnv(false);
+	});
+
+	describe('GET /settings/security-policy', () => {
+		it('returns the current policy when licensed', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/security-policy');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({
+				personalSpacePublishing: true,
+				personalSpaceSharing: true,
+				publishedPersonalWorkflowsCount: 0,
+				sharedPersonalWorkflowsCount: 0,
+				sharedPersonalCredentialsCount: 0,
+				redactionEnforcement: { floor: 'off' },
+			});
+		});
+
+		it('still allows reads when the policy is env-managed', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+			setManagedByEnv(true);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/security-policy');
+
+			expect(response.status).toBe(200);
+			expect(response.body.personalSpacePublishing).toBe(true);
+		});
+
+		it('rejects with 403 when not licensed', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/security-policy');
+
+			expect(response.status).toBe(403);
+			expect(response.body).toHaveProperty('message', licenseErrorMessage);
+		});
+
+		it('rejects with 403 when the API key lacks the securitySettings:manage scope', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.get('/settings/security-policy');
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 401 without a valid API key', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.get('/settings/security-policy');
+
+			expect(response.status).toBe(401);
+		});
+	});
+
+	describe('PUT /settings/security-policy', () => {
+		it('updates the policy and returns the new values', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: false, redactionEnforcement: { floor: 'production' } });
+
+			expect(response.status).toBe(200);
+			expect(response.body).toMatchObject({
+				personalSpacePublishing: false,
+				personalSpaceSharing: true,
+				redactionEnforcement: { floor: 'production' },
+			});
+
+			// The change is persisted and readable.
+			const readResponse = await testServer
+				.publicApiAgentFor(owner)
+				.get('/settings/security-policy');
+			expect(readResponse.body).toMatchObject({
+				personalSpacePublishing: false,
+				redactionEnforcement: { floor: 'production' },
+			});
+		});
+
+		it('rejects a malformed request body with 400', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: 'not-a-boolean', redactionEnforcement: 'nope' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects a well-formed body with invalid values with 400', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put('/settings/security-policy')
+				.send({ redactionEnforcement: { floor: 'bogus' } });
+
+			expect(response.status).toBe(400);
+			expect(response.body).toHaveProperty('message');
+		});
+
+		it('rejects with 401 without a valid API key', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: false });
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when not licensed', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: false });
+
+			expect(response.status).toBe(403);
+			expect(response.body).toHaveProperty('message', licenseErrorMessage);
+		});
+
+		it('rejects with 403 when the API key lacks the securitySettings:manage scope', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: false });
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects a write with 409 when the group is managed declaratively, but still allows reads', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+			setManagedByEnv(true);
+
+			const writeResponse = await testServer
+				.publicApiAgentFor(owner)
+				.put('/settings/security-policy')
+				.send({ personalSpacePublishing: false });
+
+			expect(writeResponse.status).toBe(409);
+
+			// The value was not changed.
+			const readResponse = await testServer
+				.publicApiAgentFor(owner)
+				.get('/settings/security-policy');
+			expect(readResponse.status).toBe(200);
+			expect(readResponse.body.personalSpacePublishing).toBe(true);
+		});
+
+		it('is available to a default owner API key (default scopes include the scope)', async () => {
+			testServer.license.enable('feat:personalSpacePolicy');
+			const member = await createMemberWithApiKey();
+
+			// A member's default key does not include securitySettings:manage.
+			const memberResponse = await testServer
+				.publicApiAgentFor(member)
+				.get('/settings/security-policy');
+			expect(memberResponse.status).toBe(403);
+
+			// The owner's default key does.
+			const ownerResponse = await testServer
+				.publicApiAgentFor(owner)
+				.get('/settings/security-policy');
+			expect(ownerResponse.status).toBe(200);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

https://www.loom.com/share/6569a1a1931a42dfa73609c63eaaa92c

Adds public API endpoints to read and manage the instance **security policy** so OEM partners can configure it headlessly across fleets, without touching the UI. This is the first settings group exposed on the public API.

**Endpoints** (gated behind the `securitySettings:manage` scope and the `feat:personalSpacePolicy` license):

- `GET /settings/security-policy` — returns the current policy: personal-space publishing and sharing toggles, the execution-data redaction enforcement floor, and the read-only usage counts shown in the UI.
- `PUT /settings/security-policy` — updates the policy. Only provided fields change; the update takes effect exactly as it would from the UI, using the same validation. A write to a group managed via environment variables is refused with `409` and leaves values unchanged (a read still returns current values).

**Refactor:** the shared read/update logic (including audit-event emission) moves from `SecuritySettingsController` into `SecuritySettingsService`, so the internal REST controller and the new public API handler go through the same settings logic and validation — no settings behaviour or validation is reimplemented in the API layer.

Error behaviour follows the public API's existing response shapes: `400` for malformed or invalid bodies, `401` for a missing/invalid key, `403` for a missing scope or an unlicensed instance, `409` when the group is managed declaratively.

## How to test

This feature requires the **Personal Space Policy** enterprise feature (`feat:personalSpacePolicy`) to be licensed; without it both endpoints return `403`.

1. Start n8n with a license that includes `feat:personalSpacePolicy`.
2. Create an API key that has the `securitySettings:manage` scope (owner keys include it).
3. Read the policy:
   ```
   curl -H "X-N8N-API-KEY: <key>" http://localhost:5678/api/v1/settings/security-policy
   ```
4. Update it:
   ```
   curl -X PUT -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"personalSpacePublishing": false, "redactionEnforcement": {"floor": "production"}}' \
     http://localhost:5678/api/v1/settings/security-policy
   ```
5. Verify error paths: a key without the scope → `403`; a malformed body → `400`; an invalid `floor` value → `400`; no key → `401`; with the group managed via env vars → `409`.

Integration tests cover successful read/update, `400` malformed, `400` invalid values, `401`, `403` unauthorised, `403` unlicensed, and `409`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-9

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33922">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

