### PR TITLE
feat(core): Send user cloud id on backend telemetry events (no-changelog)

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -29,6 +29,7 @@ import { isApiEnabled, loadPublicApiVersions } from '@/public-api';
 import { Push } from '@/push';
 import * as ResponseHelper from '@/response-helper';
 import type { FrontendService } from '@/services/frontend.service';
+import { Telemetry } from '@/telemetry';
 
 import '@/controllers/active-workflows.controller';
 import '@/controllers/annotation-tags.controller.ee';
@@ -168,7 +169,12 @@ export class Server extends AbstractServer {
 
 		const { frontendService } = this;
 		if (frontendService) {
-			await this.externalHooks.run('frontend.settings', [await frontendService.getSettings()]);
+			const frontendSettings = await frontendService.getSettings();
+			await this.externalHooks.run('frontend.settings', [frontendSettings]);
+
+			if (this.globalConfig.deployment.type === 'cloud') {
+				Container.get(Telemetry).setUserCloudId(frontendSettings.n8nMetadata?.userId);
+			}
 		}
 
 		await this.postHogClient.init();

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -999,6 +999,21 @@ describe('Telemetry', () => {
 			);
 		});
 
+		test('should call rudderStack.track() with the user_cloud_id context trait when set', () => {
+			telemetry.setUserCloudId('cloud-user-123');
+
+			telemetry.track('Test Event', { user_id: '1234' });
+
+			expect(mockRudderStack.track).toHaveBeenCalledWith(
+				expect.objectContaining({
+					context: {
+						ip: '0.0.0.0',
+						traits: { user_cloud_id: 'cloud-user-123' },
+					},
+				}),
+			);
+		});
+
 		test('should include instance_id, version_cli, and user_id in track properties', () => {
 			const eventName = 'Test Event';
 			const properties = { user_id: '1234', custom_prop: 'value' };

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -99,6 +99,8 @@ interface IAgentSessionMetricsBuffer {
 export class Telemetry {
 	private rudderStack?: RudderStack;
 
+	private userCloudId?: string;
+
 	private pulseIntervalReference: NodeJS.Timeout;
 
 	private executionCountsBuffer: IExecutionsBuffer = {};
@@ -549,6 +551,10 @@ export class Telemetry {
 		}
 	}
 
+	setUserCloudId(userCloudId?: string) {
+		this.userCloudId = userCloudId;
+	}
+
 	track(eventName: string, properties: ITelemetryTrackProperties = {}) {
 		if (!this.rudderStack) {
 			return;
@@ -567,7 +573,7 @@ export class Telemetry {
 			userId: `${instanceId}${user_id ? `#${user_id}` : ''}`,
 			event: eventName,
 			properties: updatedProperties,
-			context: {},
+			context: this.userCloudId ? { traits: { user_cloud_id: this.userCloudId } } : {},
 		};
 
 		// Build the actual payload that will be sent to RudderStack (with fake IP)


### PR DESCRIPTION
## Summary

Backend telemetry events don't carry the cloud user id; frontend events do. This PR attaches `user_cloud_id` as a context trait on backend RudderStack `track()` calls, so backend events get the same `context_traits_user_cloud_id` column frontend events already have.

On cloud, `Server.configure()` reads `n8nMetadata.userId` (injected by the `frontend.settings` external hook) and hands it to the `Telemetry` service. The trait is only attached when the value is present, gated on `deployment.type === 'cloud'` — self-hosted payloads are unchanged. It identifies the instance owner's cloud account, not the acting user (still `user_id` + `instance_id`).

## How to test

In `packages/cli`: `pnpm test src/telemetry/__tests__/telemetry.test.ts`

After release to cloud, backend event tables in BigQuery should show `context_traits_user_cloud_id` populated.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GROP-48

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33923">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
