### PR TITLE
fix(editor): Restore correct height of credential modal sidebar tabs

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMenuItem/MenuItem.vue
@@ -161,6 +161,9 @@ const tooltipPlacement = computed(() => {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	// Match the height of items with icons (24px icon + 2 * 4px padding), so
+	// icon-less items (e.g. modal sidebar tabs) don't render shorter.
+	min-height: var(--spacing--xl);
 	padding: var(--spacing--4xs);
 	gap: var(--spacing--4xs);
 	cursor: pointer;


### PR DESCRIPTION
## Summary

The tabs in the credential modal sidebar (**Connection / Sharing / Details**) rendered ~26px tall — shorter than they used to be, and inconsistent with the visually identical menu items in other sidebars (32px).

Root cause: #20068 replaced the element-ui tabs (35px tall) in the credential modal with plain `N8nMenuItem`s, which have no minimum height. Items **with** icons come out at 32px (24px icon box + 2×4px padding), but the credential modal tabs have no icons, so they collapsed to text height + padding. #22395 later reduced the item padding, making it worse.

Fix: add `min-height: var(--spacing--xl)` (32px) to `.menuItem` in the design system, so icon-less items match icon-bearing ones. This also fixes the same collapse in the other icon-less modal sidebars (log-streaming destination settings, external secrets provider connection, credential resolver edit modal). Icon-bearing menus (main sidebar, settings) are already exactly 32px and are unaffected.

## How to test

1. Open any credential (e.g. create a new **Gmail OAuth2 API** credential).
2. Verify the sidebar tabs are 32px tall and match the height of the settings sidebar menu items.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-293/bug-tabs-in-cred-modal-have-the-wrong-spacing

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33926">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->