### PR TITLE
fix(Google Workspace Admin Node): Not able to reactivate the user

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -770,8 +770,8 @@ export class GSuiteAdmin implements INodeType {
 							body.primaryEmail = updateFields.primaryEmail as string;
 						}
 
-						if (updateFields.suspendUi) {
-							body.suspended = updateFields.suspendUi as boolean;
+						if (typeof updateFields.suspendUi === 'boolean') {
+							body.suspended = updateFields.suspendUi;
 						}
 
 						if (updateFields.roles) {

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
@@ -642,6 +642,48 @@ describe('GSuiteAdmin Node - user:update logic', () => {
 		});
 	});
 
+	it('should include suspended set to false in update operation', async () => {
+		const mockCall = vi.fn().mockResolvedValue({ id: 'user-id-123', suspended: false });
+		(googleApiRequest as Mock).mockImplementation(mockCall);
+
+		const mockContext = {
+			getNode: () => ({ name: 'GSuiteAdmin' }),
+			getNodeParameter: vi.fn((paramName: string) => {
+				switch (paramName) {
+					case 'resource':
+						return 'user';
+					case 'operation':
+						return 'update';
+					case 'userId':
+						return 'user-id-123';
+					case 'updateFields':
+						return {
+							suspendUi: false,
+						};
+					default:
+						return undefined;
+				}
+			}),
+			helpers: {
+				returnJsonArray: (data: unknown) => [data],
+				constructExecutionMetaData: (data: unknown) => data,
+			},
+			continueOnFail: () => false,
+			getInputData: () => [{ json: {} }],
+		} as unknown as IExecuteFunctions;
+
+		await new GSuiteAdmin().execute.call(mockContext);
+
+		expect(mockCall).toHaveBeenCalledWith(
+			'PUT',
+			'/directory/v1/users/user-id-123',
+			{
+				suspended: false,
+			},
+			{},
+		);
+	});
+
 	it('should include password and changePasswordAtNextLogin in update operation', async () => {
 		const mockCall = vi.fn().mockResolvedValue({ id: 'user-id-456', success: true });
 		(googleApiRequest as Mock).mockImplementation(mockCall);


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

In Google Workspace Admin Node, there is an `Update` operation for the `User` resource which has `Suspend` as one of the update fields. If it's provided - the node should deactivate or reactivate the user, depending on if it's `true` or `false`. However, the reactivation doesn't work, because the code checks for truthiness, rather then if the value was provided. This PR fixes it by checking if the value provided is a boolean

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

We don't have a test account that has the necessary permissions and APIs enabled to use the node, and I wasn't able to set it up myself, so I didn't do manual testing, unfortunately

There are only unit tests to verify that the `false` value is properly handled

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-5399/community-issue-google-workspace-admin-node-cannot-unsuspendreactivate
Closes #33715

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

