### PR TITLE
perf(core): Skip persisting run data for discarded executions

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1554,6 +1554,17 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(payload.workflowData).toBeDefined();
 			});
 
+			it('should write run data for integrated executions so the parent workflow can read it', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('integrated');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
 			it('should write run data when a workflow.postExecute external hook is registered', async () => {
 				workflowData.settings = { saveDataSuccessExecution: 'none' };
 				externalHooks.hasHook.mockReturnValueOnce(true);

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1477,7 +1477,12 @@ describe('Execution Lifecycle Hooks', () => {
 				return executionPersistence.updateExistingExecution.mock.calls[0][1];
 			};
 
+			beforeEach(() => {
+				process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES = 'true';
+			});
+
 			afterEach(() => {
+				delete process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES;
 				workflowData.settings = {};
 			});
 
@@ -1491,6 +1496,18 @@ describe('Execution Lifecycle Hooks', () => {
 				expect(payload.data).toBeUndefined();
 				expect(payload.workflowData).toBeUndefined();
 				expect(payload.status).toBe('success');
+			});
+
+			it('should write run data when the flag is not enabled', async () => {
+				delete process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES;
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
 			});
 
 			it('should write run data when successful executions are saved', async () => {

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1470,6 +1470,85 @@ describe('Execution Lifecycle Hooks', () => {
 				);
 			});
 		});
+
+		describe('discarding run data for unsaved successful executions', () => {
+			const getUpdatePayload = () => {
+				expect(executionPersistence.updateExistingExecution).toHaveBeenCalledTimes(1);
+				return executionPersistence.updateExistingExecution.mock.calls[0][1];
+			};
+
+			afterEach(() => {
+				workflowData.settings = {};
+			});
+
+			it('should skip writing run data when a successful execution will be discarded', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeUndefined();
+				expect(payload.workflowData).toBeUndefined();
+				expect(payload.status).toBe('success');
+			});
+
+			it('should write run data when successful executions are saved', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'all' };
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
+			it('should write run data for failed executions even when successes are discarded', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [failedRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
+			it('should write run data for waiting executions', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [waitingRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
+			it('should write run data for webhook executions', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				const lifecycleHooks = createHooks('webhook');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+
+			it('should write run data when a workflow.postExecute external hook is registered', async () => {
+				workflowData.settings = { saveDataSuccessExecution: 'none' };
+				externalHooks.hasHook.mockReturnValueOnce(true);
+				const lifecycleHooks = createHooks('trigger');
+
+				await lifecycleHooks.runHook('workflowExecuteAfter', [successfulRun, {}]);
+
+				const payload = getUpdatePayload();
+				expect(payload.data).toBeDefined();
+				expect(payload.workflowData).toBeDefined();
+			});
+		});
 	});
 
 	describe('getLifecycleHooksForSubExecutions', () => {

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -700,6 +700,7 @@ function hookFunctionsSaveWorker(
 				runDataAttemptedDynamicCredentials(resultRunData);
 
 			const mainWillDiscardData =
+				process.env.N8N_SKIP_UNSAVED_EXECUTION_DATA_WRITES === 'true' &&
 				fullRunData.status === 'success' &&
 				!saveSettings.success &&
 				!fullRunData.waitTill &&

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -638,6 +638,8 @@ function hookFunctionsSave(
 	});
 }
 
+const DISCARDABLE_DATA_MODES: WorkflowExecuteMode[] = ['trigger', 'cli', 'error', 'internal'];
+
 /**
  * Returns hook functions to save workflow execution and call error workflow
  * for running with queues. Manual executions should never run on queues as
@@ -645,7 +647,7 @@ function hookFunctionsSave(
  */
 function hookFunctionsSaveWorker(
 	hooks: ExecutionLifecycleHooks,
-	{ pushRef, retryOf }: HooksSetupParameters,
+	{ pushRef, retryOf, saveSettings }: HooksSetupParameters,
 ) {
 	const logger = Container.get(Logger);
 	const errorReporter = Container.get(ErrorReporter);
@@ -697,12 +699,23 @@ function hookFunctionsSaveWorker(
 				runDataUsedDynamicCredentials(resultRunData) ||
 				runDataAttemptedDynamicCredentials(resultRunData);
 
+			const mainWillDiscardData =
+				fullRunData.status === 'success' &&
+				!saveSettings.success &&
+				!fullRunData.waitTill &&
+				DISCARDABLE_DATA_MODES.includes(this.mode) &&
+				!Container.get(ExternalHooks).hasHook('workflow.postExecute');
+
+			const executionData = mainWillDiscardData
+				? { ...fullExecutionData, data: undefined, workflowData: undefined }
+				: fullExecutionData;
+
 			// In scaling mode, worker saves execution without metadata
 			// Main process will save metadata after deletion decisions to avoid FK violations
 			await updateExistingExecution({
 				executionId: this.executionId,
 				workflowId: this.workflowData.id,
-				executionData: fullExecutionData,
+				executionData,
 			});
 		} finally {
 			workflowStatisticsService.emit('workflowExecutionCompleted', {


### PR DESCRIPTION
When a worker finishes an execution, its save hook writes the full blob to the DB unconditionally, deferring the keep-or-delete decision to main. Originally it was the worker who made the save decision and deleted unsaved executions itself, but that broke webhook workflows as main needed the rundata to send the HTTP response to the caller. The fix at #1509 in 2021 was to make workers save, deferring deletion to main. This flow has stayed the same until very recently.

This year we minimized execution data reads at #25073, so workers now send a `job-finished` msg via Redis from which main can finalize. Main now needs the full DB row only in specific cases: sub-workflow executions, webhooks with `lastNode` response mode, and instances with a `workflow.postExecute` external hook. The consequences of #25073 were hard to anticipate, but it turned out to be safe and it's now the only flow since last month at #30969. This means the 2021 constraint in most cases no longer holds.

Hence this PR changes the worker hook to skip the payload when main is certain to discard it: the execution succeeded, the save settings say not to keep successes, it is not waiting, its mode is allowlisted and no `workflow.postExecute` hook is registered. If this checks out, the worker strips `data` and `workflowData` from the update and writes only the entity's terminal status, kept so that main's fallback path and the job processor's error check still find a finished row. Every other case (failed, waiting, manual, webhook, etc.) writes exactly as today, and deletion remains main's job.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

