### PR TITLE
test(ai-builder): Delete a build's backend artifacts when its last row finishes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -136,7 +136,7 @@ dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --iterations 3
 | `--filter` | — | Filter test cases by filename substring. Comma-separated values mean OR (e.g. `contact-form,deduplication`) |
 | `--exclude` | — | Skip test cases whose filename matches any of the substrings. Same comma-separated shape as `--filter`; applied after `--filter` |
 | `--prebuilt-workflows` | — | Path to a JSON manifest mapping test-case slugs to existing workflow IDs. Skips the orchestrator build for matched test cases — see [Running evals against pre-built workflows](#running-evals-against-pre-built-workflows) |
-| `--keep-workflows` | `false` | Don't delete built workflows after the run. Pair with the HTML report's "view in n8n" links to inspect each scenario's canvas execution |
+| `--keep-workflows` | `false` | Don't delete any build artifacts after the run — workflows, data tables, and threads (with their sandboxes) all survive. Pair with the HTML report's "view in n8n" links to inspect each scenario's canvas execution. Sandboxes have no auto-cleanup, so use with `--filter` on a few cases rather than full baselines |
 | `--delete-prebuilt-workflows` | `false` | With `--prebuilt-workflows`, delete successfully used manifest workflows after the eval run. Mutually exclusive with `--keep-workflows` |
 | `--base-url` | `http://localhost:5678` | n8n instance URL |
 | `--email` | E2E test owner | Override login email (or `N8N_EVAL_EMAIL`) |

--- a/packages/@n8n/instance-ai/evaluations/__tests__/cleanup-build.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/cleanup-build.test.ts
@@ -1,0 +1,69 @@
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import type { N8nClient } from '../clients/n8n-client';
+import type { EvalLogger } from '../harness/logger';
+import { cleanupBuild } from '../harness/runner';
+import type { BuildResult } from '../harness/runner';
+
+/**
+ * Locks in the cleanupBuild contract the CLI's per-case cleanup relies on:
+ * the return value reports whether every deletion succeeded, so a caller can
+ * keep the build cached and retry a transiently failed cleanup later.
+ */
+
+const silentLogger: EvalLogger = {
+	info: () => {},
+	verbose: () => {},
+	success: () => {},
+	warn: () => {},
+	error: () => {},
+	isVerbose: false,
+};
+
+function makeClient(overrides: Partial<Record<keyof N8nClient, Mock>> = {}): {
+	client: N8nClient;
+	mocks: Record<string, Mock>;
+} {
+	const mocks: Record<string, Mock> = {
+		deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+		deleteDataTable: vi.fn().mockResolvedValue(undefined),
+		getPersonalProjectId: vi.fn().mockResolvedValue('project-1'),
+		deleteThread: vi.fn().mockResolvedValue(undefined),
+		...overrides,
+	};
+	return { client: mocks as unknown as N8nClient, mocks };
+}
+
+function makeBuild(): BuildResult {
+	return {
+		success: true,
+		workflowJsons: [],
+		createdWorkflowIds: ['W1'],
+		createdDataTableIds: ['DT1'],
+		threadId: 'T1',
+	};
+}
+
+describe('cleanupBuild', () => {
+	it('deletes workflows, data tables and the thread, and reports clean', async () => {
+		const { client, mocks } = makeClient();
+
+		await expect(cleanupBuild(client, makeBuild(), silentLogger)).resolves.toBe(true);
+
+		expect(mocks.deleteWorkflow).toHaveBeenCalledWith('W1');
+		expect(mocks.deleteDataTable).toHaveBeenCalledWith('project-1', 'DT1');
+		expect(mocks.deleteThread).toHaveBeenCalledWith('T1');
+	});
+
+	it('reports not clean when a deletion fails, but still attempts the rest', async () => {
+		const { client, mocks } = makeClient({
+			deleteWorkflow: vi.fn().mockRejectedValue(new Error('HTTP 502')),
+		});
+
+		await expect(cleanupBuild(client, makeBuild(), silentLogger)).resolves.toBe(false);
+
+		expect(mocks.deleteDataTable).toHaveBeenCalledWith('project-1', 'DT1');
+		expect(mocks.deleteThread).toHaveBeenCalledWith('T1');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -922,6 +922,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	// with the thread its sandbox) are deleted right away instead of at the end
 	// of the run: sandboxes have no auto-cleanup, so end-of-run-only deletion
 	// let the sandbox runner grow to ~15 GB over a full N=10 baseline.
+	// --keep-workflows deliberately keeps everything, thread/sandbox included —
+	// it's a debugging flag for small filtered runs, not baselines.
 	const remainingRowsByKey = new Map<string, number>();
 
 	function rowsPerCase(fileSlug: string): number {
@@ -936,12 +938,19 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		if (remaining > 0 || args.keepWorkflows) return;
 		const cached = buildCache.get(key);
 		if (!cached) return; // evicted (transport failure) — nothing to clean
-		buildCache.delete(key);
 		try {
 			const { build, lane } = await cached;
 			// Run-debug capture reads the thread — let it settle before deletion.
 			if (build.threadId) await runDebugByThreadId.get(build.threadId)?.catch(() => {});
-			await cleanupBuild(lane.runner.client, build, logger);
+			const clean = await cleanupBuild(lane.runner.client, build, logger);
+			if (!clean) {
+				// Leave the entry in buildCache — the end-of-run pass retries it.
+				logger.verbose(
+					`  [cleanup] ${fileSlug} (iteration ${String(iteration)}) incomplete, retrying at end of run`,
+				);
+				return;
+			}
+			buildCache.delete(key);
 			logger.verbose(`  [cleanup] ${fileSlug} (iteration ${String(iteration)}) artifacts deleted`);
 		} catch {
 			// Best-effort — a failed cleanup must never fail the row.
@@ -1248,6 +1257,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		};
 	} finally {
 		if (!args.keepWorkflows) {
+			// Entries still here had no rows run, or their per-case cleanup failed
+			// (releaseCaseRow leaves those cached so this pass can retry them).
 			await Promise.all(
 				[...buildCache.values()].map(async (promise) => {
 					try {

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -917,8 +917,47 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		);
 	}
 
+	// Rows remaining per `iteration:fileSlug` build. When the last row of a
+	// build finishes, its backend artifacts (workflow, data tables, thread — and
+	// with the thread its sandbox) are deleted right away instead of at the end
+	// of the run: sandboxes have no auto-cleanup, so end-of-run-only deletion
+	// let the sandbox runner grow to ~15 GB over a full N=10 baseline.
+	const remainingRowsByKey = new Map<string, number>();
+
+	function rowsPerCase(fileSlug: string): number {
+		const scenarios = testCaseByFileSlug.get(fileSlug)?.executionScenarios?.length ?? 0;
+		return Math.max(1, scenarios); // scenario-less cases get one build-only row
+	}
+
+	async function releaseCaseRow(iteration: number, fileSlug: string): Promise<void> {
+		const key = `${String(iteration)}:${fileSlug}`;
+		const remaining = (remainingRowsByKey.get(key) ?? rowsPerCase(fileSlug)) - 1;
+		remainingRowsByKey.set(key, remaining);
+		if (remaining > 0 || args.keepWorkflows) return;
+		const cached = buildCache.get(key);
+		if (!cached) return; // evicted (transport failure) — nothing to clean
+		buildCache.delete(key);
+		try {
+			const { build, lane } = await cached;
+			// Run-debug capture reads the thread — let it settle before deletion.
+			if (build.threadId) await runDebugByThreadId.get(build.threadId)?.catch(() => {});
+			await cleanupBuild(lane.runner.client, build, logger);
+			logger.verbose(`  [cleanup] ${fileSlug} (iteration ${String(iteration)}) artifacts deleted`);
+		} catch {
+			// Best-effort — a failed cleanup must never fail the row.
+		}
+	}
+
 	const target = async (inputs: TargetInputs): Promise<TargetOutput> => {
 		const iteration = inputs._iteration ?? 0;
+		try {
+			return await targetRow(inputs, iteration);
+		} finally {
+			await releaseCaseRow(iteration, inputs.testCaseFile);
+		}
+	};
+
+	const targetRow = async (inputs: TargetInputs, iteration: number): Promise<TargetOutput> => {
 		const scenario: ExecutionScenario = {
 			name: inputs.scenarioName,
 			description: inputs.scenarioDescription,

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -842,17 +842,21 @@ export async function executeScenario(
 
 /**
  * Clean up workflows and data tables created during a build.
+ *
+ * Returns false when any deletion failed so callers can retry later.
  */
 export async function cleanupBuild(
 	client: N8nClient,
 	build: BuildResult,
 	logger: EvalLogger,
-): Promise<void> {
+): Promise<boolean> {
+	let clean = true;
+
 	for (const id of build.createdWorkflowIds) {
 		try {
 			await client.deleteWorkflow(id);
 		} catch {
-			// Best-effort cleanup
+			clean = false; // Best-effort cleanup
 		}
 	}
 
@@ -863,12 +867,12 @@ export async function cleanupBuild(
 				try {
 					await client.deleteDataTable(projectId, dtId);
 				} catch {
-					// Best-effort cleanup
+					clean = false; // Best-effort cleanup
 				}
 			}
 			logger.verbose(`  Cleaned up ${String(build.createdDataTableIds.length)} data table(s)`);
 		} catch {
-			// Non-fatal — project ID lookup may fail
+			clean = false; // Non-fatal — project ID lookup may fail
 		}
 	}
 
@@ -878,9 +882,11 @@ export async function cleanupBuild(
 		try {
 			await client.deleteThread(build.threadId);
 		} catch {
-			// Best-effort cleanup
+			clean = false; // Best-effort cleanup
 		}
 	}
+
+	return clean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stacked on #33904. Backend artifacts from eval builds — workflows, data tables, and threads — were only deleted in the end-of-run `finally`, so backend state accumulated for the entire run. The invisible cost was sandboxes: deleting a thread destroys its sandbox (`clearThreadState` → `destroySandbox`), and since sandboxes have no auto-cleanup, the **uncapped sandbox-runner container grew to 14.8 GiB during the last full N=10 baseline (host bottomed at 0.5 GiB free)**.

Each `iteration:case` build now carries a row countdown: when its last scenario row completes, `cleanupBuild` runs immediately (after letting the run-debug capture settle), keeping backend and sandbox memory flat across the run. `--keep-workflows` skips it, transport-evicted builds are skipped, and the end-of-run drain remains as an idempotent backstop.

## How to test

Live validation (2 scenario-ful cases, N=1, 2 local lanes): `[cleanup] telegram-chatbot-memory-session (iteration 0) artifacts deleted` fired mid-run while the other case was still executing; both cases then scored normally (3/3 scenarios passed, zero failure categories, no stray 404s). The next CI baseline's telemetry sampler (from #33903) will show the sandbox-runner memory curve staying flat.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to the sandbox-runner memory finding in baseline run 29012884140.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- validated by live run; countdown is exercised by every row -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33943">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

