### PR TITLE
fix(S3 Node): Url-encode source path for copy operations

### DIFF
--- a/packages/nodes-base/nodes/Aws/S3/V1/AwsS3V1.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V1/AwsS3V1.node.ts
@@ -477,7 +477,7 @@ export class AwsS3V1 implements INodeType {
 						const destinationPath = this.getNodeParameter('destinationPath', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-						headers['x-amz-copy-source'] = sourcePath;
+						headers['x-amz-copy-source'] = encodeURI(sourcePath);
 
 						if (additionalFields.requesterPays) {
 							headers['x-amz-request-payer'] = 'requester';

--- a/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
+++ b/packages/nodes-base/nodes/Aws/S3/V2/AwsS3V2.node.ts
@@ -497,7 +497,7 @@ export class AwsS3V2 implements INodeType {
 						const destinationPath = this.getNodeParameter('destinationPath', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i);
 
-						headers['x-amz-copy-source'] = sourcePath;
+						headers['x-amz-copy-source'] = encodeURI(sourcePath);
 
 						if (additionalFields.requesterPays) {
 							headers['x-amz-request-payer'] = 'requester';


### PR DESCRIPTION
## Summary

This PR fixes an issue where the AWS S3 node's "Copy" operation throws a `SignatureDoesNotMatch` error when copying files with Chinese characters or other non-ASCII characters in their path. The AWS S3 SDK strictly requires the `x-amz-copy-source` header to be URL-encoded, otherwise the computed Signature Version 4 does not match.

I've updated both `AwsS3V1.node.ts` and `AwsS3V2.node.ts` to wrap `sourcePath` in `encodeURI()` before sending the header, which preserves the strict directory separators `/` while safely encoding special characters.

## How to test

1. Create a workflow using the AWS S3 node with valid AWS credentials.
2. Select Resource: `File`, Operation: `Copy`.
3. Try to copy a file that contains Chinese characters in its path, for example: `/my-bucket/测试/test.txt`.
4. Run the node. It should now successfully copy the file without returning a `SignatureDoesNotMatch` error.

## Related Linear tickets, Github issues, and Community forum posts

fixes #33936

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. 
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

