### PR TITLE
fix(ai-builder): Return experimentUrl from the empty-selection eval early exit (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -499,6 +499,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		return {
 			evaluation: { totalRuns: 0, testCases: [] },
 			experimentName: '',
+			experimentUrl: undefined,
 			outcome: { kind: 'no_baseline' },
 			slugByTestCase: new Map(),
 		};


### PR DESCRIPTION
## Summary

The zero-test-cases early return in `runWithLangSmith` (`evaluations/cli/index.ts`) omits the required `experimentUrl` key from its result object, violating the function's declared return type. This is invisible to CI because `evaluations/` has no typecheck coverage — the eval tsconfig isn't part of any `pnpm typecheck` target. This PR adds the missing `experimentUrl: undefined` so the early exit matches the contract. No behavior change: every consumer of `experimentUrl` already handles `undefined`.

## How to test

From `packages/@n8n/instance-ai`:

```bash
npx tsc -p evaluations/tsconfig.json --noEmit --moduleResolution bundler --module preserve 2>&1 | grep 'cli/index.ts'
```

Before this PR it reports `error TS2741: Property 'experimentUrl' is missing` at the empty-selection return; after, no errors in that file. Behavior-wise, running the eval CLI with a filter that matches no cases (e.g. `--filter does-not-exist`) still logs "No workflow test cases selected" and exits cleanly.

## Related Linear tickets, Github issues, and Community forum posts

Found while rebasing #33942; the omission was introduced alongside the comparison outcome plumbing from #33789.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33947">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

