### PR TITLE
feat(ai-builder): Scale eval budgets by case complexity and bound the heaviest prompts (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/effective-timeout.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/effective-timeout.test.ts
@@ -1,0 +1,16 @@
+import { effectiveTimeoutMs } from '../harness/runner';
+
+describe('effectiveTimeoutMs', () => {
+	it('gives complex cases 1.5x the base budget', () => {
+		expect(effectiveTimeoutMs('complex', 900_000)).toBe(1_350_000);
+	});
+
+	it('keeps the base budget for simple and medium cases', () => {
+		expect(effectiveTimeoutMs('simple', 900_000)).toBe(900_000);
+		expect(effectiveTimeoutMs('medium', 900_000)).toBe(900_000);
+	});
+
+	it('keeps the base budget when complexity is missing', () => {
+		expect(effectiveTimeoutMs(undefined, 900_000)).toBe(900_000);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -72,6 +72,7 @@ import {
 	executeScenario,
 	cleanupBuild,
 	runWorkflowChecks,
+	effectiveTimeoutMs,
 	runWorkflowTestCase,
 	runWithConcurrency,
 	type BuildResult,
@@ -549,7 +550,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		| 'seedFile'
 		| 'priorConversation'
 		| 'seedThread'
-	>;
+	> & { timeoutMs: number };
 	interface LaneState {
 		runner: Lane;
 		activeBuilds: number;
@@ -560,6 +561,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			scenario: ExecutionScenario;
 			workflowJsons: BuildResult['workflowJsons'];
 			buildTrace?: BuildResult['buildTrace'];
+			timeoutMs: number;
 		}) => Promise<Awaited<ReturnType<typeof executeScenario>>>;
 	}
 
@@ -581,7 +583,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 						priorConversation: buildArgs.priorConversation,
 						seedThread: buildArgs.seedThread,
 						createdCredentialIds: lane.createdCredentialIds,
-						timeoutMs: args.timeoutMs,
+						timeoutMs: buildArgs.timeoutMs,
 						preRunWorkflowIds: lane.preRunWorkflowIds,
 						claimedWorkflowIds: lane.claimedWorkflowIds,
 						logger,
@@ -600,6 +602,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					scenario: ExecutionScenario;
 					workflowJsons: BuildResult['workflowJsons'];
 					buildTrace?: BuildResult['buildTrace'];
+					timeoutMs: number;
 				}) =>
 					await executeScenario(
 						lane.client,
@@ -607,7 +610,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 						execArgs.scenario,
 						execArgs.workflowJsons,
 						logger,
-						args.timeoutMs,
+						execArgs.timeoutMs,
 						undefined,
 						execArgs.buildTrace,
 						args.pinAiRoots,
@@ -725,6 +728,12 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			if (!entry) throw new Error(`No conversation found for fileSlug=${fileSlug}`);
 			try {
 				const start = Date.now();
+				const timeoutMs = effectiveTimeoutMs(entry.complexity, args.timeoutMs);
+				if (timeoutMs !== args.timeoutMs) {
+					logger.info(
+						`  Complex case: per-iteration budget ${String(Math.round(timeoutMs / 1000))}s [${fileSlug}]`,
+					);
+				}
 				const build = await lane.tracedBuild({
 					conversation: entry.conversation,
 					messageBudget: entry.messageBudget,
@@ -732,6 +741,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					seedFile: entry.seedFile,
 					priorConversation: entry.priorConversation,
 					seedThread: entry.seedThread,
+					timeoutMs,
 				});
 				const buildDurationMs = Date.now() - start;
 				buildDurations.set(key, buildDurationMs);
@@ -877,6 +887,10 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					scenario,
 					workflowJsons: build.workflowJsons,
 					buildTrace: build.buildTrace,
+					timeoutMs: effectiveTimeoutMs(
+						testCaseByFileSlug.get(inputs.testCaseFile)?.complexity,
+						args.timeoutMs,
+					),
 				});
 				break;
 			} catch (error: unknown) {

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/trading-bot-http-array-normalization.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/trading-bot-http-array-normalization.json
@@ -10,7 +10,7 @@
 		},
 		{
 			"role": "user",
-			"text": "Pull OHLCV candles from the Binance klines REST API (GET https://api.binance.com/api/v3/klines) via an HTTP Request node, normalize them, compute indicators, and send the final signal to Telegram. Binance returns a JSON array of candle rows, so the normalize step has to handle every candle, not just the first one."
+			"text": "Pull OHLCV candles from the Binance klines REST API (GET https://api.binance.com/api/v3/klines) via an HTTP Request node, normalize them, compute indicators, and send the final signal to Telegram. Binance returns a JSON array of candle rows, so the normalize step has to handle every candle, not just the first one. One symbol is plenty — no need to track several — and a couple of momentum indicators are enough for the signal."
 		}
 	],
 	"complexity": "complex",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/weekly-social-content-scheduler.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/weekly-social-content-scheduler.json
@@ -12,7 +12,7 @@
 		{
 			"role": "user",
 			"text": [
-				"Scrape the top trending topics from Hacker News, and read the 'Content Ideas' tab in my Marketing spreadsheet. Use Gemini to tailor the copy per platform — concise with hashtags for X, professional for LinkedIn, a discussion-style post for Reddit. Stagger them across the week: X on Monday 9am, LinkedIn on Wednesday 2pm, Reddit on Friday 11am.",
+				"Scrape the top trending topics from Hacker News — the top 5 titles are plenty — and read the 'Content Ideas' tab in my Marketing spreadsheet. Use Gemini to tailor the copy per platform — concise with hashtags for X, professional for LinkedIn, a discussion-style post for Reddit — one post per platform is enough. Stagger them across the week: X on Monday 9am, LinkedIn on Wednesday 2pm, Reddit on Friday 11am.",
 				"For every HITL step during the build — keep the run moving without stalling. Allow all permissions. Use any of the existing credentials or skip."
 			]
 		},

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -92,6 +92,23 @@ import { UserProxyLlm, type ProxyDecisionStats } from '../utils/user-proxy';
 const DEFAULT_TIMEOUT_MS = 900_000;
 const EVAL_DATA_DIR = path.join(__dirname, '..', '..', '.data');
 
+/**
+ * Per-case budget: `complex` cases get 1.5× the base timeout. The heaviest
+ * builds (multi-agent fan-outs, 5-integration pipelines) legitimately run at
+ * the shared default's cap — observed 777–900s with 4/10 builds timing out on
+ * weekly-social-content-scheduler in run 29012884140 — while the default must
+ * NOT rise globally (see the comment above: a generous default lets starved
+ * scenarios amplify the contention that starved them). Keyed off the authored
+ * `complexity` field so the budget travels with the case (incl. through the
+ * lang-tracer mirror) instead of a bespoke per-case knob.
+ */
+export function effectiveTimeoutMs(
+	complexity: WorkflowTestCase['complexity'] | undefined,
+	baseMs: number,
+): number {
+	return complexity === 'complex' ? Math.round(baseMs * 1.5) : baseMs;
+}
+
 function getMaxConcurrentScenarios(): number {
 	const raw = process.env.N8N_EVAL_MAX_CONCURRENT_SCENARIOS;
 	const parsed = raw ? Number.parseInt(raw, 10) : 4;
@@ -251,7 +268,11 @@ export async function runWorkflowTestCase(
 	config: WorkflowTestCaseConfig,
 ): Promise<WorkflowTestCaseResult> {
 	const { client, testCase, logger } = config;
-	const timeoutMs = config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const baseTimeoutMs = config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const timeoutMs = effectiveTimeoutMs(testCase.complexity, baseTimeoutMs);
+	if (timeoutMs !== baseTimeoutMs) {
+		logger.info(`  Complex case: per-iteration budget ${String(Math.round(timeoutMs / 1000))}s`);
+	}
 
 	const result: WorkflowTestCaseResult = {
 		testCase,


### PR DESCRIPTION
## Summary

The two heaviest eval cases (`trading-bot-http-array-normalization`, `weekly-social-content-scheduler`) ran at the 900s per-iteration cap — 777–900s builds, 7 `build_failure` timeout rows in the 2026-07-09 N=10 baseline (run `29012884140`). Rather than trimming their elaborate prompts (the suite has few maximalist asks and they're worth keeping), this PR:

1. **Scales the per-iteration budget by the authored `complexity` field**: `complex` cases get 1.5× the base timeout (900s→1350s) in both the LangSmith and direct loops (`effectiveTimeoutMs`, unit-tested, logged per build). The global default stays put — the comment above it documents why raising it for everyone amplifies contention. `complexity` was previously informational-only; 20 of 97 cases are `complex`. Because it rides the existing field, the budget survives the lang-tracer mirror round-trip (`evalComplexity`), unlike a bespoke per-case knob.
2. **Bounds unasserted sprawl in the two prompts with one user-voice sentence each** — "one symbol is plenty… a couple of momentum indicators are enough" / "top 5 HN titles are plenty… one post per platform". Everything the cases assert is untouched: multi-agent mandate, both idea sources, all three platforms, staggered scheduling, all scenarios and expectations, and trading-bot's load-bearing 32-row dataset.

## Validation

5-lane docker run (image from `eval-noise-family-fixes`), `trading-bot` at N=5: first three builds completed at **322s / 480s / 518s** with the multi-agent structure intact (10–18 node builds), vs 777–900s-at-the-cap before; early scenario verdicts passing. Budget scaling covered by unit tests; the 1350s headroom remains as insurance for genuinely long complex builds.

## Related

- #33944 (eval noise families — the timeout rows this addresses are its 'build-timeout budget' follow-up)
- https://linear.app/n8n/issue/INS-868 / https://linear.app/n8n/issue/INS-869 (builder bugs surfaced by the same investigation)

## Review checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33950">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

