### PR TITLE
feat: Add Korean (ko) locale for MCP workflow preview app

### DIFF
--- a/packages/@n8n/mcp-apps/src/i18n/index.test.ts
+++ b/packages/@n8n/mcp-apps/src/i18n/index.test.ts
@@ -28,6 +28,12 @@ describe('mcp-apps i18n', () => {
 			['returns the matching language for an exact match', 'en', 'en'],
 			['returns the matching language from a BCP 47 tag', 'en-US', 'en'],
 			['lowercases the language tag', 'EN-gb', 'en'],
+			['returns the matching language for another supported locale', 'ko', 'ko'],
+			[
+				'returns the matching language from a BCP 47 tag for another supported locale',
+				'ko-KR',
+				'ko',
+			],
 			['falls back to default for unsupported languages', 'zz-ZZ', DEFAULT_LOCALE],
 		])('%s', (_label, input, expected) => {
 			expect(resolveLocale(input)).toBe(expected);
@@ -36,12 +42,27 @@ describe('mcp-apps i18n', () => {
 		it('only includes supported locales', () => {
 			expect(SUPPORTED_LOCALES).toContain(DEFAULT_LOCALE);
 		});
+
+		it('every supported locale ships a message file with the same keys as the default locale', () => {
+			const defaultMessages = i18n.global.getLocaleMessage(DEFAULT_LOCALE);
+			const defaultKeys = Object.keys(defaultMessages).sort();
+
+			for (const locale of SUPPORTED_LOCALES) {
+				const messages = i18n.global.getLocaleMessage(locale);
+				expect(Object.keys(messages).sort(), `locale "${locale}" key parity`).toEqual(defaultKeys);
+			}
+		});
 	});
 
 	describe('setLocaleFromHost', () => {
 		it('applies the resolved locale to the i18n instance', () => {
 			expect(setLocaleFromHost('en-US')).toBe('en');
 			expect(i18n.global.locale.value).toBe('en');
+		});
+
+		it('applies another supported locale to the i18n instance', () => {
+			expect(setLocaleFromHost('ko-KR')).toBe('ko');
+			expect(i18n.global.locale.value).toBe('ko');
 		});
 
 		it('falls back to the default locale for unsupported tags', () => {

--- a/packages/@n8n/mcp-apps/src/i18n/index.ts
+++ b/packages/@n8n/mcp-apps/src/i18n/index.ts
@@ -1,6 +1,7 @@
 import { createI18n, useI18n as useVueI18n } from 'vue-i18n';
 
 import en from '../locales/en.json';
+import ko from '../locales/ko.json';
 
 /**
  * Locales bundled with MCP apps. When adding a new locale:
@@ -9,7 +10,7 @@ import en from '../locales/en.json';
  * Locale files use the same flat-key style as `@n8n/i18n` (e.g.
  * `workflowPreview.openButton`), namespaced by app.
  */
-export const SUPPORTED_LOCALES = ['en'] as const;
+export const SUPPORTED_LOCALES = ['en', 'ko'] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: SupportedLocale = 'en';
@@ -21,7 +22,7 @@ export const i18n = createI18n<MessageSchema, SupportedLocale, false>({
 	legacy: false,
 	locale: DEFAULT_LOCALE,
 	fallbackLocale: DEFAULT_LOCALE,
-	messages: { en },
+	messages: { en, ko },
 	warnHtmlMessage: false,
 });
 

--- a/packages/@n8n/mcp-apps/src/locales/ko.json
+++ b/packages/@n8n/mcp-apps/src/locales/ko.json
@@ -1,0 +1,17 @@
+{
+	"workflowPreview.ariaLabel.creating": "워크플로우 생성 중",
+	"workflowPreview.ariaLabel.preview": "워크플로우 미리보기",
+	"workflowPreview.ariaLabel.ready": "워크플로우 열기 준비 완료",
+	"workflowPreview.error.detailsUnavailable": "미리보기를 불러올 수 없습니다. n8n에서 워크플로우를 열어 확인해 주세요.",
+	"workflowPreview.error.invalidWorkflow": "워크플로우 데이터가 불완전하여 미리보기를 불러올 수 없습니다. n8n에서 워크플로우를 열어 확인해 주세요.",
+	"workflowPreview.error.previewUnavailable": "사용 중인 MCP 클라이언트가 워크플로우 미리보기를 지원하지 않는 것 같습니다. n8n에서 워크플로우를 열어 확인해 주세요.",
+	"workflowPreview.fallbackDescription": "n8n에서 워크플로우 보기",
+	"workflowPreview.frameTitle": "n8n 워크플로우 미리보기",
+	"workflowPreview.loadingPreview": "미리보기 불러오는 중",
+	"workflowPreview.nodeCount.many": "노드 {count}개",
+	"workflowPreview.nodeCount.one": "노드 1개",
+	"workflowPreview.openButton": "n8n에서 열기",
+	"workflowPreview.openButtonShort": "열기",
+	"workflowPreview.readyLabel": "워크플로우 생성됨",
+	"workflowPreview.untitledWorkflow": "제목 없는 워크플로우"
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Added `packages/@n8n/mcp-apps/src/locales/ko.json`, a full Korean translation of the `en.json` base text used by the `@n8n/mcp-apps` workflow-preview widget (the iframe shown in MCP clients when previewing/opening an n8n workflow created via MCP).
- Registered `ko` in `SUPPORTED_LOCALES` in `packages/@n8n/mcp-apps/src/i18n/index.ts` and imported the new locale file, following the two-step process already documented in that file's comment.
- Added test cases in `packages/@n8n/mcp-apps/src/i18n/index.test.ts` covering `resolveLocale`/`setLocaleFromHost` for `ko`/`ko-KR` tags, plus a key-parity check that asserts every entry in `SUPPORTED_LOCALES` has a message file with exactly the same keys as the default (`en`) locale.

## How to test

- `pnpm --filter @n8n/mcp-apps test` — all 107 tests pass (13 files), including the 15 in `src/i18n/index.test.ts` covering the new locale.
- `pnpm --filter @n8n/mcp-apps typecheck` and `pnpm --filter @n8n/mcp-apps lint` both pass with no errors.
- Verified 100% key parity between `en.json` (15 keys) and `ko.json` (15 keys) and confirmed the `{count}` interpolation placeholder is preserved unchanged in `workflowPreview.nodeCount.many`.
- Manually reviewed each translated string for natural, professional Korean phrasing rather than literal/machine-translated wording.

## Related Linear tickets, Github issues, and Community forum posts

N/A — this is a direct community translation contribution with no associated ticket or issue.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (not applicable — no user-facing docs describe individual MCP-app locales)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (not applicable — new locale addition, not an urgent fix)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33954">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->