### PR TITLE
fix(editor): Highlight Instance AI cards that are waiting for user input

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -1180,7 +1180,7 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 	margin: 0;
 	text-align: center;
 	color: var(--color--text--tint-1);
-	font-size: var(--font-size--3xs);
+	font-size: var(--font-size--2xs);
 	line-height: var(--line-height--md);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ApprovalOptionList.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/ApprovalOptionList.vue
@@ -115,7 +115,7 @@ function onKeydown(event: KeyboardEvent) {
 }
 
 .footer {
-	padding: 0;
+	padding: var(--spacing--2xs) var(--spacing--sm) var(--spacing--sm);
 }
 
 .row {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
@@ -130,7 +130,7 @@ async function confirm(decision: InstanceGatewayResourceDecision) {
 <style lang="scss" module>
 .root {
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/GatewayResourceDecision.vue
@@ -129,8 +129,8 @@ async function confirm(decision: InstanceGatewayResourceDecision) {
 
 <style lang="scss" module>
 .root {
-	border: var(--border);
-	border-radius: var(--radius--lg);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiChannelSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiChannelSetup.vue
@@ -292,7 +292,7 @@ watch(
 	gap: var(--spacing--sm);
 	padding-top: var(--spacing--sm);
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--background--surface);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiChannelSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiChannelSetup.vue
@@ -291,8 +291,8 @@ watch(
 	flex-direction: column;
 	gap: var(--spacing--sm);
 	padding-top: var(--spacing--sm);
-	border: var(--border);
-	border-radius: var(--radius);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--background--surface);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -407,7 +407,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 				<InstanceAiWorkflowSetup
 					v-if="chunk.item.toolCall.confirmation.setupRequests?.length"
 					:key="'setup-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 					:request-id="chunk.item.toolCall.confirmation.requestId"
 					:setup-requests="chunk.item.toolCall.confirmation.setupRequests!"
 					:project-id="chunk.item.toolCall.confirmation.projectId"
@@ -419,7 +418,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 				<InstanceAiCredentialSetup
 					v-else-if="chunk.item.toolCall.confirmation.credentialRequests?.length"
 					:key="'cred-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 					:request-id="chunk.item.toolCall.confirmation.requestId"
 					:credential-requests="chunk.item.toolCall.confirmation.credentialRequests!"
 					:message="chunk.item.toolCall.confirmation.message"
@@ -610,11 +608,9 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 }
 
 .root {
-	border: none;
+	border: 2px solid var(--color--primary);
 	border-radius: var(--radius--xl);
-	box-shadow:
-		var(--shadow--sm),
-		inset 0 0 0 1px light-dark(var(--color--black-alpha-100), var(--color--white-alpha-100));
+	box-shadow: var(--shadow--sm);
 	background-color: var(--background--surface);
 }
 
@@ -664,6 +660,8 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 }
 
 .textCard {
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -650,7 +650,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 }
 
 .textCard {
-	// N8nCard already rounds to --radius--lg; only the border needs overriding.
 	border: 2px solid var(--color--primary);
 	background-color: var(--color--background--light-3);
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -599,7 +599,7 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 <style lang="scss" module>
 .root {
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	box-shadow: var(--shadow--sm);
 	background-color: var(--background--surface);
 }
@@ -650,8 +650,8 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 }
 
 .textCard {
+	// N8nCard already rounds to --radius--lg; only the border needs overriding.
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -432,7 +432,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 						chunk.item.toolCall.confirmation.questions
 					"
 					:key="'q-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 					:questions="chunk.item.toolCall.confirmation.questions!"
 					:intro-message="chunk.item.toolCall.confirmation.introMessage"
 					@submit="(answers) => handleQuestionsSubmit(chunk.item.toolCall.confirmation, answers)"
@@ -442,7 +441,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 				<PlanReviewPanel
 					v-else-if="chunk.item.toolCall.confirmation.inputType === 'plan-review'"
 					:key="'plan-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 					:planned-tasks="
 						chunk.item.toolCall.confirmation?.planItems ??
 						(chunk.item.toolCall.args?.tasks as PlannedTaskArg[] | undefined) ??
@@ -473,7 +471,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 				<div
 					v-else-if="chunk.item.toolCall.confirmation.inputType === 'text'"
 					:key="'text-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 				>
 					<N8nCard :class="$style.textCard">
 						<N8nText tag="div">{{ chunk.item.toolCall.confirmation!.message }}</N8nText>
@@ -510,7 +507,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 				<div
 					v-else-if="chunk.item.toolCall.confirmation.inputType === 'continue'"
 					:key="'continue-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 				>
 					<N8nCard :class="$style.textCard">
 						<N8nText tag="div">{{ chunk.item.toolCall.confirmation!.message }}</N8nText>
@@ -533,7 +529,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 						chunk.item.toolCall.confirmation.resourceDecision
 					"
 					:key="'rd-' + chunk.item.toolCall.confirmation.requestId"
-					:class="$style.confirmation"
 					data-test-id="instance-ai-gateway-confirmation-panel"
 					:request-id="chunk.item.toolCall.confirmation.requestId"
 					:resource="chunk.item.toolCall.confirmation.resourceDecision.resource"
@@ -602,11 +597,6 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 </template>
 
 <style lang="scss" module>
-.confirmation {
-	max-width: 90%;
-	width: 90%;
-}
-
 .root {
 	border: 2px solid var(--color--primary);
 	border-radius: var(--radius--xl);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -613,8 +613,8 @@ async function handleSetupAutomatically() {
 	flex-direction: column;
 	gap: var(--spacing--sm);
 	padding: 0;
-	border: var(--border);
-	border-radius: var(--radius);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -614,7 +614,7 @@ async function handleSetupAutomatically() {
 	gap: var(--spacing--sm);
 	padding: 0;
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
@@ -586,8 +586,8 @@ function onOptionMouseEnter(idx: number) {
 
 .container {
 	outline: none;
-	border: var(--border);
-	border-radius: var(--radius--lg);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiQuestions.vue
@@ -587,7 +587,7 @@ function onOptionMouseEnter(idx: number) {
 .container {
 	outline: none;
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
@@ -269,7 +269,7 @@ function handleDeny() {
 
 .root {
 	border: var(--border);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	margin: var(--spacing--2xs) 0;
 	overflow: hidden;
 	background-color: var(--color--background--light-3);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
@@ -124,7 +124,7 @@ function handleDeny() {
 <template>
 	<CollapsibleRoot
 		v-model:open="isExpanded"
-		:class="$style.root"
+		:class="[$style.root, showActions && $style.awaitingInput]"
 		:aria-busy="isShimmering ? 'true' : undefined"
 		:data-loading="isShimmering ? 'true' : undefined"
 		data-test-id="instance-ai-plan-review"
@@ -269,11 +269,17 @@ function handleDeny() {
 
 .root {
 	border: var(--border);
-	border-radius: var(--radius--lg);
+	border-radius: var(--radius--xl);
 	margin: var(--spacing--2xs) 0;
 	overflow: hidden;
 	background-color: var(--color--background--light-3);
 	max-width: 90%;
+}
+
+// Highlight that the plan is waiting for the user's review; read-only /
+// resolved / building cards keep the regular border.
+.awaitingInput {
+	border: 2px solid var(--color--primary);
 }
 
 .expiredHint {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupCard.vue
@@ -92,7 +92,7 @@ const displayName = computed(() => {
 	gap: var(--spacing--sm);
 	padding-top: var(--spacing--sm);
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupCard.vue
@@ -91,8 +91,8 @@ const displayName = computed(() => {
 	flex-direction: column;
 	gap: var(--spacing--sm);
 	padding-top: var(--spacing--sm);
-	border: var(--border);
-	border-radius: var(--radius);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupGroupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupGroupCard.vue
@@ -115,7 +115,7 @@ function getSectionNodeType(section: WorkflowSetupSection) {
 	display: flex;
 	flex-direction: column;
 	border: 2px solid var(--color--primary);
-	border-radius: var(--radius--xl);
+	border-radius: var(--radius--lg);
 	background-color: var(--color--background--light-3);
 }
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupGroupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/components/WorkflowSetupGroupCard.vue
@@ -114,8 +114,8 @@ function getSectionNodeType(section: WorkflowSetupSection) {
 .card {
 	display: flex;
 	flex-direction: column;
-	border: var(--border);
-	border-radius: var(--radius);
+	border: 2px solid var(--color--primary);
+	border-radius: var(--radius--xl);
 	background-color: var(--color--background--light-3);
 }
 


### PR DESCRIPTION

<img width="1917" height="934" alt="image" src="https://github.com/user-attachments/assets/8ddd864a-fd51-42e0-bbe7-9d64674ae280" />
<img width="1917" height="281" alt="image" src="https://github.com/user-attachments/assets/b5ed9beb-d533-4793-8af8-bbb9fe8a76df" />
<img width="1917" height="486" alt="image" src="https://github.com/user-attachments/assets/67a035d2-de31-4569-b632-eb576e1c5ae9" />



## Summary

Makes it easier to notice that the AI Assistant is waiting for your input, plus two small tweaks (INS-866):

1. **2px `--color--primary` border on all HITL cards**: questions, plan review, workflow/credential/channel setup, gateway resource decision, text/continue prompts, and the floating approval panel (its 1px inset-ring box-shadow is replaced by the border). Corner rounding is preserved and harmonised to `--radius--lg`, matching the chat input (setup cards were 4px, the floating approval panel `xl`). Plan review only shows the highlight while actionable: read-only cards in the timeline, building/shimmering, resolved, and expired states keep the regular border.
2. **Inline confirmations render full width** in the chat flow (previously constrained to 90%, leaving a gap on the right of the setup card). The approval option list gets padding so options don't sit flush against the highlighted border.
3. **Input disclaimer font size** bumped from `3xs` to `2xs`.

## How to test

1. Open the AI Assistant and ask it to build a workflow that requires credentials (e.g. "build a workflow that triages Gmail calendar invites").
2. When the agent pauses for input, verify each HITL card shows a 2px orange border with rounded (20px) corners: clarifying questions, plan review, setup / credential setup, and tool approvals (floating panel replacing the input).
3. Verify the plan review card loses the orange border once approved/denied (historical cards in the conversation have the regular 1px border), and while the plan is still building.
4. Verify inline cards (setup, questions) span the full chat column width.
5. Verify the "Preview version. AI can make mistakes; always verify responses." line below the input is slightly larger (12px).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-866

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
