### PR TITLE
fix: Rundeck node supports configurable SSL validation

### DIFF
--- a/packages/nodes-base/credentials/RundeckApi.credentials.ts
+++ b/packages/nodes-base/credentials/RundeckApi.credentials.ts
@@ -27,6 +27,30 @@ export class RundeckApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 		},
+		{
+			displayName: 'SSL Certificate Validation',
+			name: 'sslCertificateValidation',
+			type: 'options',
+			options: [
+				{
+					name: 'Default',
+					value: 'default',
+					description:
+						'Validate certificates for Rundeck nodes of version 1.1 and newer, skip validation for older nodes',
+				},
+				{
+					name: 'Enabled',
+					value: 'enabled',
+					description: 'Always validate SSL certificates',
+				},
+				{
+					name: 'Disabled',
+					value: 'disabled',
+					description: 'Connect even if SSL certificate validation is not possible',
+				},
+			],
+			default: 'default',
+		},
 	];
 
 	authenticate: IAuthenticateGeneric = {
@@ -43,6 +67,7 @@ export class RundeckApi implements ICredentialType {
 			baseURL: '={{$credentials.url}}',
 			url: '/api/14/system/info',
 			method: 'GET',
+			skipSslCertificateValidation: '={{$credentials.sslCertificateValidation === "disabled"}}',
 		},
 	};
 }

--- a/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
+++ b/packages/nodes-base/nodes/Rundeck/Rundeck.node.ts
@@ -16,7 +16,7 @@ export class Rundeck implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:rundeck.png',
 		group: ['transform'],
-		version: 1,
+		version: [1, 1.1],
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 		description: 'Manage Rundeck API',
 		defaults: {

--- a/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
+++ b/packages/nodes-base/nodes/Rundeck/RundeckApi.ts
@@ -10,6 +10,7 @@ import { NodeApiError, NodeOperationError } from 'n8n-workflow';
 export interface RundeckCredentials {
 	url: string;
 	token: string;
+	sslCertificateValidation?: 'default' | 'enabled' | 'disabled';
 }
 
 export class RundeckApi {
@@ -21,6 +22,17 @@ export class RundeckApi {
 		this.executeFunctions = executeFunctions;
 	}
 
+	private shouldValidateCertificates(): boolean {
+		switch (this.credentials?.sslCertificateValidation) {
+			case 'enabled':
+				return true;
+			case 'disabled':
+				return false;
+			default:
+				return this.executeFunctions.getNode().typeVersion >= 1.1;
+		}
+	}
+
 	protected async request(
 		method: IHttpRequestMethods,
 		endpoint: string,
@@ -30,7 +42,7 @@ export class RundeckApi {
 		const credentialType = 'rundeckApi';
 
 		const options: IRequestOptions = {
-			rejectUnauthorized: false,
+			rejectUnauthorized: this.shouldValidateCertificates(),
 			method,
 			qs: query,
 			uri: (this.credentials?.url as string) + endpoint,

--- a/packages/nodes-base/nodes/Rundeck/__tests__/RundeckApi.test.ts
+++ b/packages/nodes-base/nodes/Rundeck/__tests__/RundeckApi.test.ts
@@ -1,0 +1,75 @@
+import type { ICredentialDataDecryptedObject, IExecuteFunctions, INode } from 'n8n-workflow';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { RundeckApi } from '../RundeckApi';
+
+describe('RundeckApi', () => {
+	const requestOptionsFor = async (
+		typeVersion: number,
+		credentials: ICredentialDataDecryptedObject,
+	) => {
+		const executeFunctions = mockDeep<IExecuteFunctions>();
+		executeFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion }));
+		executeFunctions.getCredentials.mockResolvedValue(credentials);
+		executeFunctions.helpers.requestWithAuthentication.mockResolvedValue({});
+
+		const rundeckApi = new RundeckApi(executeFunctions);
+		await rundeckApi.init();
+		await rundeckApi.getJobMetadata('job-1');
+
+		expect(executeFunctions.helpers.requestWithAuthentication).toHaveBeenCalledTimes(1);
+		return executeFunctions.helpers.requestWithAuthentication.mock.calls[0][1];
+	};
+
+	const credentials = { url: 'https://rundeck.example.com', token: 'test-token' };
+
+	describe('TLS certificate validation', () => {
+		describe('sslCertificateValidation: default', () => {
+			it('should validate certificates on node version 1.1', async () => {
+				const options = await requestOptionsFor(1.1, {
+					...credentials,
+					sslCertificateValidation: 'default',
+				});
+
+				expect(options.rejectUnauthorized).toBe(true);
+			});
+
+			it('should skip certificate validation on node version 1', async () => {
+				const options = await requestOptionsFor(1, {
+					...credentials,
+					sslCertificateValidation: 'default',
+				});
+
+				expect(options.rejectUnauthorized).toBe(false);
+			});
+
+			it('should treat a missing value as default', async () => {
+				const options = await requestOptionsFor(1.1, credentials);
+
+				expect(options.rejectUnauthorized).toBe(true);
+			});
+		});
+
+		describe('sslCertificateValidation: enabled', () => {
+			it('should validate certificates on any node version', async () => {
+				const options = await requestOptionsFor(1, {
+					...credentials,
+					sslCertificateValidation: 'enabled',
+				});
+
+				expect(options.rejectUnauthorized).toBe(true);
+			});
+		});
+
+		describe('sslCertificateValidation: disabled', () => {
+			it('should skip certificate validation on any node version', async () => {
+				const options = await requestOptionsFor(1.1, {
+					...credentials,
+					sslCertificateValidation: 'disabled',
+				});
+
+				expect(options.rejectUnauthorized).toBe(false);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds configurable option for SSL validation to Rundeck credentials and node.

Added `sslCertificateValidation` property in `Rundeck API` credentials with selectable values `default`, `enabled` and `disabled`. This is different than a boolean `sslCertificateValidation` flag in other credentials, but a boolean flag with default value would make the change breaking because we do not have versioning for credentials and missing values will fall back to the default value. Another alternative would be to always keep the current approach for node version 1, but this would mean that an upgrade path requires removing and adding the node again, with the current solution user's can simply enable validation in credentials without changing the node.

<img width="1063" height="603" alt="Bildschirmfoto 2026-07-10 um 10 09 07" src="https://github.com/user-attachments/assets/38bb4b35-82bc-438d-bd7e-5f19e3276d95" />


## How to test

1. start n8n, attach a debugger and add [breakpoint to observe Rundeck api options](https://github.com/n8n-io/n8n/blob/87a2571567fd7f876db70c287b8a9da424aac13a/packages/nodes-base/nodes/Rundeck/RundeckApi.ts#L53)
2. use the attached workflow and create Rundeck credentials with `SSL Certificate Validation=default`
3. select the credentials and execute the v1 node, observe that `rejectUnauthorized` is `false`
4. select the credentials and execute the v1.1 node, observe that `rejectUnauthorized` is `true`
5. change `SSL Certificate Validation=enabled` in the credentials and observe that `rejectUnauthorized` is `true` for both nodes
6. change `SSL Certificate Validation=disabled` in the credentials and observe that `rejectUnauthorized` is `false` for both nodes


<details>
<summary>test workflow</summary>
```json
{
  "nodes": [
    {
      "parameters": {
        "operation": "getMetadata",
        "jobid": "123"
      },
      "type": "n8n-nodes-base.rundeck",
      "typeVersion": 1,
      "position": [
        560,
        560
      ],
      "id": "aa59664f-cdd4-486a-a62d-e7d4a25436ae",
      "name": "v1 GetMetadata job",
      "credentials": {
        "rundeckApi": {
          "id": "VRIm1qNIhhh4ealM",
          "name": "rundend invalid old"
        }
      }
    },
    {
      "parameters": {
        "operation": "getMetadata",
        "jobid": "123"
      },
      "type": "n8n-nodes-base.rundeck",
      "typeVersion": 1.1,
      "position": [
        560,
        784
      ],
      "id": "9bfebb57-d97d-4682-86db-bbc90a04089d",
      "name": "v1.1 GetMetadata job1",
      "credentials": {
        "rundeckApi": {
          "id": "jm410usHLILo00uP",
          "name": "Rundeck account"
        }
      }
    }
  ],
  "connections": {},
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5300

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->