### PR TITLE
build: Fix intermittent insights extension build failure (no-changelog)

### DIFF
--- a/packages/extensions/insights/package.json
+++ b/packages/extensions/insights/package.json
@@ -38,7 +38,7 @@
     "typecheck": "vue-tsc --noEmit",
     "build:backend": "tsdown",
     "build:frontend": "vite build",
-    "build": "pnpm cleanup && pnpm run \"/^build:.*/\"",
+    "build": "pnpm cleanup && pnpm run \"/^build:(backend|frontend)$/\"",
     "build:unchecked": "pnpm cleanup && pnpm run build:backend && pnpm run build:frontend",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary

`pnpm build` in `packages/extensions/insights` fails intermittently with a bare `ELIFECYCLE Command failed with exit code 1`.

The package's `build` script runs its build steps via pnpm's regex runner: `pnpm run "/^build:.*/"`. Since #31636 added a `build:unchecked` script to every package, that regex also matches `build:unchecked`. pnpm runs regex-matched scripts **concurrently**, so `build:unchecked`'s `rimraf dist` races `build:backend` (tsdown) and `build:frontend` (vite) writing into `dist/` — the build flips between pass and fail run to run.

CI never hits this because it invokes `build:unchecked` directly (which chains its steps sequentially); only local/full `turbo build` runs are affected.

Fix: restrict the regex to the two actual build steps — `/^build:(backend|frontend)$/`.

## How to test

On `master`, run `pnpm build` in `packages/extensions/insights` repeatedly — it fails intermittently (reproduced as fail/pass/fail on consecutive runs). On this branch, ran it multiple consecutive times: all pass, `dist/backend` and `dist/frontend` produced. `pnpm build:unchecked` (the CI path) still passes.

## Related Linear tickets, Github issues, and Community forum posts

—

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33962">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->