### PR TITLE
feat(Microsoft Excel Node): Rename node to Microsoft Excel (OneDrive)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.json
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.json
@@ -15,5 +15,5 @@
 			}
 		]
 	},
-	"alias": ["_Excel", "Excel", "Sheet", "CSV", "Spreadsheet"]
+	"alias": ["_Excel", "Excel", "Sheet", "CSV", "Spreadsheet", "OneDrive"]
 }

--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
@@ -7,12 +7,12 @@ import { MicrosoftExcelV2 } from './v2/MicrosoftExcelV2.node';
 export class MicrosoftExcel extends VersionedNodeType {
 	constructor() {
 		const baseDescription: INodeTypeBaseDescription = {
-			displayName: 'Microsoft Excel 365',
+			displayName: 'Microsoft Excel (OneDrive)',
 			name: 'microsoftExcel',
 			icon: 'file:excel.svg',
 			group: ['input'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-			description: 'Consume Microsoft Excel API',
+			description: 'Consume the Microsoft Excel API for workbooks stored in OneDrive',
 			defaultVersion: 2.2,
 		};
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/v1/MicrosoftExcelV1.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v1/MicrosoftExcelV1.node.ts
@@ -24,15 +24,15 @@ import { worksheetFields, worksheetOperations } from './WorksheetDescription';
 import { generatePairedItemData } from '../../../../utils/utilities';
 
 const versionDescription: INodeTypeDescription = {
-	displayName: 'Microsoft Excel',
+	displayName: 'Microsoft Excel (OneDrive)',
 	name: 'microsoftExcel',
 	icon: 'file:excel.svg',
 	group: ['input'],
 	version: 1,
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-	description: 'Consume Microsoft Excel API',
+	description: 'Consume the Microsoft Excel API for workbooks stored in OneDrive',
 	defaults: {
-		name: 'Microsoft Excel',
+		name: 'Microsoft Excel (OneDrive)',
 	},
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
@@ -7,15 +7,15 @@ import * as worksheet from './worksheet/Worksheet.resource';
 import { targetDescription } from '../descriptions/TargetDescription';
 
 export const versionDescription: INodeTypeDescription = {
-	displayName: 'Microsoft Excel 365',
+	displayName: 'Microsoft Excel (OneDrive)',
 	name: 'microsoftExcel',
 	icon: 'file:excel.svg',
 	group: ['input'],
 	version: [2, 2.1, 2.2],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-	description: 'Consume Microsoft Excel API',
+	description: 'Consume the Microsoft Excel API for workbooks stored in OneDrive',
 	defaults: {
-		name: 'Microsoft Excel 365',
+		name: 'Microsoft Excel (OneDrive)',
 	},
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],
@@ -75,7 +75,7 @@ export const versionDescription: INodeTypeDescription = {
 		...targetDescription,
 		{
 			displayName:
-				'This node connects to the Microsoft 365 cloud platform. Use the \'Extract from File\' and \'Convert to File\' nodes to directly manipulate spreadsheet files (.xls, .csv, etc). <a href="https://n8n.io/workflows/890-read-in-an-excel-spreadsheet-file/" target="_blank">More info</a>.',
+				'This node works with workbooks stored in OneDrive on the Microsoft 365 cloud platform. Use the \'Extract from File\' and \'Convert to File\' nodes to directly manipulate spreadsheet files (.xls, .csv, etc). <a href="https://n8n.io/workflows/890-read-in-an-excel-spreadsheet-file/" target="_blank">More info</a>.',
 			name: 'notice',
 			type: 'notice',
 			default: '',


### PR DESCRIPTION
## Summary

Renames the Microsoft Excel node's display name from "Microsoft Excel 365" to **"Microsoft Excel (OneDrive)"** to make explicit that the node operates on workbooks stored in the user's OneDrive. 

Display-only change — the node type identifier (`n8n-nodes-base.microsoftExcel`) is unchanged, so existing saved workflows are unaffected.

- Base description, v1 and v2 `displayName` and `defaults.name` renamed to "Microsoft Excel (OneDrive)"
- Node description updated to "Consume the Microsoft Excel API for workbooks stored in OneDrive"
- The in-node notice now states the node works with workbooks stored in OneDrive (previously it only mentioned "the Microsoft 365 cloud platform", implying broader access)
- Added "OneDrive" to the codex search aliases

The "Access As → Drive" hint mentioning SharePoint document libraries is intentionally kept: app-only Service Principal auth can genuinely target one by drive ID.

## How to test

1. Start n8n and open the node creator panel — searching for "Excel" or "OneDrive" should show **Microsoft Excel (OneDrive)**.
2. Add the node to a canvas — the new node instance is named "Microsoft Excel (OneDrive)" and the notice in the NDV mentions workbooks stored in OneDrive.
3. Open a workflow saved before this change containing a Microsoft Excel node — it loads and executes unchanged (type identifier untouched), only the displayed title changes.
4. `pnpm typecheck` and `pnpm lint` pass in `packages/nodes-base`; all existing Excel node tests pass (`pnpm test nodes/Microsoft/Excel`, 103 tests).


https://github.com/user-attachments/assets/b4233a7b-abd1-4dc4-adab-73902db29024



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-150

Docs PR: https://github.com/n8n-io/n8n-docs/pull/5022

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated: https://github.com/n8n-io/n8n-docs/pull/5022


🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


