### PR TITLE
fix(Notion Node): Restore ASCII simplified property keys on earlier node versions

### DIFF
--- a/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Notion/shared/GenericFunctions.ts
@@ -656,9 +656,14 @@ export function getPropertyTitle(properties: { [key: string]: any }) {
 	);
 }
 
-function prepend(stringKey: string, properties: { [key: string]: any }) {
+// Fold non-ASCII to separators so keys keep their pre-change-case-v5 shape (é → `_`).
+const foldedSnakeCase = (value: string) => snakeCase(value.replace(/[^\x20-\x7E]/g, ' '));
+
+function prepend(stringKey: string, properties: { [key: string]: any }, version: number) {
+	// Pre-v3 restores the old ASCII key shape so existing workflows keep resolving.
+	const toKey = version >= 3 ? snakeCase : foldedSnakeCase;
 	for (const key of Object.keys(properties)) {
-		properties[`${stringKey}_${snakeCase(key)}`] = properties[key];
+		properties[`${stringKey}_${toKey(key)}`] = properties[key];
 		delete properties[key];
 	}
 	return properties;
@@ -683,7 +688,7 @@ export function simplifyObjects(objects: any, download = false, version = 2) {
 				...(notV1 ? { name: getPropertyTitle(properties as IDataObject) } : {}),
 				...(notV1 ? { url } : {}),
 				...(notV1
-					? { ...prepend('property', simplifyProperties(properties) as IDataObject) }
+					? { ...prepend('property', simplifyProperties(properties) as IDataObject, version) }
 					: { ...simplifyProperties(properties) }),
 			} as IDataObject);
 		} else if (download && json.object === 'page') {
@@ -693,7 +698,9 @@ export function simplifyObjects(objects: any, download = false, version = 2) {
 					...(notV1 ? { name: getPropertyTitle(json.properties as IDataObject) } : {}),
 					...(notV1 ? { url: json.url } : {}),
 					...(notV1
-						? { ...prepend('property', simplifyProperties(json.properties) as IDataObject) }
+						? {
+								...prepend('property', simplifyProperties(json.properties) as IDataObject, version),
+							}
 						: { ...simplifyProperties(json.properties) }),
 				},
 				binary,

--- a/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts
@@ -18,6 +18,7 @@ import {
 	getPageId,
 	notionApiRequest,
 	notionApiRequestAllItems,
+	simplifyObjects,
 } from '../shared/GenericFunctions';
 import { versionDescription as versionDescriptionV1 } from '../v1/VersionDescription';
 import { versionDescription as versionDescriptionV2 } from '../v2/VersionDescription';
@@ -545,5 +546,84 @@ describe('Test Notion, notionApiRequestAllItems', () => {
 
 		expect(result).toEqual([{ id: '1' }, { id: '2' }]);
 		expect(mockExecuteFunctions.helpers.requestWithAuthentication).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Test Notion, simplifyObjects', () => {
+	const richText = (text: string) => ({
+		type: 'rich_text',
+		rich_text: [{ type: 'text', plain_text: text }],
+	});
+
+	const page = (properties: Record<string, unknown>) => ({
+		object: 'page',
+		id: 'page-id',
+		url: 'https://www.notion.so/page-id',
+		properties: {
+			Name: { type: 'title', title: [{ type: 'text', plain_text: 'Roadmap' }] },
+			...properties,
+		},
+	});
+
+	describe('v3 keeps change-case v5 Unicode-aware keys', () => {
+		it('preserves non-ASCII characters in simplified property keys', () => {
+			const result = simplifyObjects([page({ Prénom: richText('Jean') })], false, 3);
+
+			expect(result[0]).toMatchObject({ property_prénom: 'Jean' });
+		});
+
+		it.each([
+			['naïve', 'property_naïve'],
+			['café', 'property_café'],
+			['Mädchen', 'property_mädchen'],
+			['Köln', 'property_köln'],
+			['Prüfung', 'property_prüfung'],
+			['Straße', 'property_straße'],
+		])('keeps %s as %s', (propertyName, expectedKey) => {
+			const result = simplifyObjects([page({ [propertyName]: richText('x') })], false, 3);
+
+			expect(result[0]).toHaveProperty(expectedKey, 'x');
+		});
+	});
+
+	describe('earlier versions fold to the pre-v5 ASCII shape', () => {
+		it('folds non-ASCII characters in simplified property keys', () => {
+			const result = simplifyObjects([page({ Prénom: richText('Jean') })], false, 2);
+
+			expect(result[0]).toMatchObject({ property_pr_nom: 'Jean' });
+			expect(result[0]).not.toHaveProperty('property_prénom');
+		});
+
+		it('snake-cases ASCII property keys without folding', () => {
+			const result = simplifyObjects([page({ 'First Name': richText('Jean') })], false, 2);
+
+			expect(result[0]).toMatchObject({
+				property_name: 'Roadmap',
+				property_first_name: 'Jean',
+			});
+		});
+
+		// Decomposed input (base letter + combining mark) must fold like change-case v4,
+		// which kept the ASCII base letter — i.e. no NFC normalization first.
+		it('folds decomposed accents without normalizing', () => {
+			const decomposedPrenom = 'Pre\u0301nom'; // e + combining acute, not the composed é
+			const result = simplifyObjects([page({ [decomposedPrenom]: richText('Jean') })], false, 2);
+
+			expect(result[0]).toMatchObject({ property_pre_nom: 'Jean' });
+		});
+
+		it.each([
+			['naïve', 'property_na_ve'],
+			['café', 'property_caf'],
+			['Prix (€)', 'property_prix'],
+			['Mädchen', 'property_m_dchen'],
+			['Köln', 'property_k_ln'],
+			['Prüfung', 'property_pr_fung'],
+			['Straße', 'property_stra_e'],
+		])('folds %s to %s', (propertyName, expectedKey) => {
+			const result = simplifyObjects([page({ [propertyName]: richText('x') })], false, 2);
+
+			expect(result[0]).toHaveProperty(expectedKey, 'x');
+		});
 	});
 });


### PR DESCRIPTION
## Summary

`change-case` was bumped from v4 to v5 (Unicode-aware) when `nodes-base` moved to the workspace catalog (PR #32569, shipped in **2.29.0**). v5 preserves non-ASCII letters where v4 treated them as word separators, which silently changed the shape of the Notion node's **simplified** output property keys:

- Before: `Prénom` → `property_pr_nom`
- After (2.29.0+): `Prénom` → `property_prénom`

Existing workflows referencing the old key (e.g. `{{ $json.property_pr_nom }}`) resolved to `undefined` with no edit-time error.

This restores the pre-v5 (ASCII-folded) key shape, but **only for earlier node versions**. Per team decision, the recently added **node version 3 keeps the v5 Unicode-aware keys** (it only ever emitted that shape, and the Notion overhaul owns v3 going forward). The fix threads the node `version` into `prepend()` and picks the caser accordingly:

- **v2 (and below):** `foldedSnakeCase` — non-ASCII folded to separators (verified 1:1 against `change-case@4.1.2`).
- **v3:** plain `snakeCase` — accents/umlauts preserved.

The fold is a no-op for pure-ASCII property names, so the common case is unchanged.

## How to test

Use the Notion node's **Database Page → Get Many** with **Simplify** enabled, against a database that has a property with an accented/non-ASCII name (e.g. `Prénom`, `Größe`).

- On **Notion v2**, the simplified output key is `property_pr_nom` (ASCII-folded, as before 2.29.0).
- On **Notion v3**, the key stays `property_prénom` (Unicode-aware).

Covered by unit tests in `packages/nodes-base/nodes/Notion/test/GenericFunctions.test.ts` (`Test Notion, simplifyObjects`), split into a v3-preserve block and a v2-fold block (incl. French accents and German umlauts/ß).

Notion Database for testing: https://app.notion.com/p/n8n/3995b6e0c94f8044bc54ddc58e8372fd?v=3995b6e0c94f805eb801000c7a816a80&source=copy_link

<details>
<summary>Test Workflow with both node versions</summary>

```
{
  "nodes": [
    {
      "parameters": {},
      "type": "n8n-nodes-base.manualTrigger",
      "typeVersion": 1,
      "position": [
        0,
        -48
      ],
      "id": "1ae31b74-363f-4b7e-b2c1-fd03fbb27fd4",
      "name": "When clicking ‘Execute workflow’"
    },
    {
      "parameters": {
        "authentication": "oAuth2",
        "resource": "databasePage",
        "operation": "getAll",
        "databaseId": {
          "__rl": true,
          "value": "3995b6e0-c94f-8044-bc54-ddc58e8372fd",
          "mode": "list",
          "cachedResultName": "Test database Umlauts",
          "cachedResultUrl": "https://app.notion.com/p/3995b6e0c94f8044bc54ddc58e8372fd"
        },
        "options": {}
      },
      "type": "n8n-nodes-base.notion",
      "typeVersion": 2.2,
      "position": [
        224,
        -144
      ],
      "id": "282866f9-20e2-4cd6-8f16-80505b7b0aad",
      "name": "v2",
      "credentials": {
        "notionOAuth2Api": {
          "id": "LqmRhDgpfse2ylVj",
          "name": "Notion account"
        }
      }
    },
    {
      "parameters": {
        "authentication": "oAuth2",
        "resource": "databasePage",
        "operation": "getAll",
        "dataSourceId": {
          "__rl": true,
          "value": "3995b6e0-c94f-80e8-9fc9-000b48f8e88b",
          "mode": "list",
          "cachedResultName": "Test database Umlauts",
          "cachedResultUrl": "https://app.notion.com/p/3995b6e0c94f8044bc54ddc58e8372fd"
        },
        "options": {}
      },
      "type": "n8n-nodes-base.notion",
      "typeVersion": 3,
      "position": [
        224,
        48
      ],
      "id": "bf75d391-d5f7-4028-9478-4336fb1e1941",
      "name": "v3",
      "credentials": {
        "notionOAuth2Api": {
          "id": "LqmRhDgpfse2ylVj",
          "name": "Notion account"
        }
      }
    }
  ],
  "connections": {
    "When clicking ‘Execute workflow’": {
      "main": [
        [
          {
            "node": "v2",
            "type": "main",
            "index": 0
          },
          {
            "node": "v3",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "v2": {
      "main": [
        []
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "4e88fdf2ca2358b3af9fbecc28c6de3cd7b5ec37486b1d0dd8bae0f15bd2a988"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5421

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

