### PR TITLE
feat(core): Add QuickJS expression engine option alongside isolated-vm (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/expression-engine.config.ts
+++ b/packages/@n8n/config/src/configs/expression-engine.config.ts
@@ -2,19 +2,20 @@ import z from 'zod';
 
 import { Config, Env } from '../decorators';
 
-const expressionEngineSchema = z.enum(['legacy', 'vm']);
+const expressionEngineSchema = z.enum(['legacy', 'vm', 'quickjs']);
 
 @Config
 export class ExpressionEngineConfig {
 	/**
 	 * Which expression engine to use.
 	 * - `legacy` runs expressions without isolation.
-	 * - `vm` runs expressions in a V8 isolate.
+	 * - `vm` runs expressions in a V8 isolate (isolated-vm).
+	 * - `quickjs` runs expressions in a QuickJS WASM sandbox.
 	 *
-	 * `vm` is currently **experimental**. Use at your own risk.
+	 * `vm` and `quickjs` are currently **experimental**. Use at your own risk.
 	 */
 	@Env('N8N_EXPRESSION_ENGINE', expressionEngineSchema)
-	engine: 'legacy' | 'vm' = 'legacy';
+	engine: 'legacy' | 'vm' | 'quickjs' = 'legacy';
 
 	/** Number of V8 isolates ready in the pool. */
 	@Env('N8N_EXPRESSION_ENGINE_POOL_SIZE')

--- a/packages/@n8n/config/src/configs/expression-engine.config.ts
+++ b/packages/@n8n/config/src/configs/expression-engine.config.ts
@@ -2,17 +2,18 @@ import z from 'zod';
 
 import { Config, Env } from '../decorators';
 
-const expressionEngineSchema = z.enum(['legacy', 'vm']);
+const expressionEngineSchema = z.enum(['legacy', 'vm', 'quickjs']);
 
 @Config
 export class ExpressionEngineConfig {
 	/**
 	 * Which expression engine to use.
-	 * - `vm` (default) runs expressions in a V8 isolate.
+	 * - `vm` (default) runs expressions in a V8 isolate (isolated-vm).
 	 * - `legacy` runs expressions without isolation. Less secure and soon to be deprecated.
+	 * - `quickjs` runs expressions in a QuickJS WASM sandbox. Experimental.
 	 */
 	@Env('N8N_EXPRESSION_ENGINE', expressionEngineSchema)
-	engine: 'legacy' | 'vm' = 'vm';
+	engine: 'legacy' | 'vm' | 'quickjs' = 'vm';
 
 	/** Number of V8 isolates ready in the pool. */
 	@Env('N8N_EXPRESSION_ENGINE_POOL_SIZE')
@@ -41,8 +42,8 @@ export class ExpressionEngineConfig {
 
 	/**
 	 * Whether to emit observability signals (metrics, traces, logs) for the VM evaluator.
-	 * Only takes effect when `engine === 'vm'`; legacy mode never emits expression metrics
-	 * regardless of this setting.
+	 * Only takes effect when `engine === 'vm'` or `engine === 'quickjs'`; legacy mode never
+	 * emits expression metrics regardless of this setting.
 	 */
 	@Env('N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED')
 	observabilityEnabled: boolean = true;

--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -42,6 +42,7 @@
     "lodash": "catalog:",
     "luxon": "catalog:",
     "md5": "2.3.0",
+    "quickjs-emscripten": "^0.32.0",
     "title-case": "3.0.3",
     "transliteration": "2.3.5",
     "zod": "catalog:"

--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -43,6 +43,7 @@
     "lodash": "catalog:",
     "luxon": "catalog:",
     "md5": "2.3.0",
+    "quickjs-emscripten": "^0.32.0",
     "title-case": "3.0.3",
     "transliteration": "2.3.5",
     "zod": "catalog:"

--- a/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
@@ -155,4 +155,13 @@ describe('Host-fn shadowing: data.extend / data.extendOptional must not be invok
 		expect(result).toBe(1);
 		expect(hostJmespathCalls).toBe(0);
 	});
+
+	it('resolves function-typed data properties as undefined (no marker object)', () => {
+		const data: Record<string, unknown> = {
+			$json: { weirdFn: (x: number) => x + 1, value: 42 },
+		};
+
+		expect(evaluator.evaluate('{{ typeof $json.weirdFn }}', data, caller)).toBe('undefined');
+		expect(evaluator.evaluate('{{ $json.value }}', data, caller)).toBe(42);
+	});
 });

--- a/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
@@ -24,7 +24,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
-import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { createBridge } from './test-bridge';
 
 describe('Host-fn shadowing: data.extend / data.extendOptional must not be invoked in VM mode', () => {
 	let evaluator: ExpressionEvaluator;
@@ -32,7 +32,7 @@ describe('Host-fn shadowing: data.extend / data.extendOptional must not be invok
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();

--- a/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
@@ -90,29 +90,7 @@ describe('Host-fn shadowing: data.extend / data.extendOptional must not be invok
 		expect(hostExtendOptionalCalls).toBe(0);
 	});
 
-	it('does NOT invoke host-side data.extend when expression uses an extension method directly', () => {
-		// This test runs after extendSyntax-style expansion would have happened
-		// in the workflow package. We mimic that here by calling extend() directly,
-		// which is what Tournament's transformations end up producing.
-		let hostExtendCalls = 0;
-		const data: Record<string, unknown> = {
-			$json: { items: [{ a: 1 }, { a: 2 }, { a: 3 }] },
-			extend: (...args: unknown[]) => {
-				hostExtendCalls++;
-				throw new Error(`host-side data.extend was invoked with: ${JSON.stringify(args)}`);
-			},
-			extendOptional: (...args: unknown[]) => {
-				throw new Error('host-side data.extendOptional was invoked');
-			},
-		};
-
-		const result = evaluator.evaluate('{{ extend($json.items, "pluck", ["a"]) }}', data, caller);
-
-		expect(result).toEqual([1, 2, 3]);
-		expect(hostExtendCalls).toBe(0);
-	});
-
-	it('does NOT invoke host-side data.$jmespath when expression calls $jmespath(...)', () => {
+	it('does NOT invoke host-side data.$jmespath / data.$jmesPath for either casing', () => {
 		let hostJmespathCalls = 0;
 		const data: Record<string, unknown> = {
 			$json: { users: [{ name: 'a' }, { name: 'b' }] },
@@ -126,33 +104,14 @@ describe('Host-fn shadowing: data.extend / data.extendOptional must not be invok
 			},
 		};
 
-		const result = evaluator.evaluate(
-			'{{ $jmespath({users: [{name: "a"}, {name: "b"}]}, "users[*].name") }}',
-			data,
-			caller,
-		);
-
-		expect(result).toEqual(['a', 'b']);
-		expect(hostJmespathCalls).toBe(0);
-	});
-
-	it('does NOT invoke host-side data.$jmesPath when expression calls $jmesPath (capital P)', () => {
-		let hostJmespathCalls = 0;
-		const data: Record<string, unknown> = {
-			$json: {},
-			$jmespath: (...args: unknown[]) => {
-				hostJmespathCalls++;
-				throw new Error(`host-side data.$jmespath was invoked with: ${JSON.stringify(args)}`);
-			},
-			$jmesPath: (...args: unknown[]) => {
-				hostJmespathCalls++;
-				throw new Error(`host-side data.$jmesPath was invoked with: ${JSON.stringify(args)}`);
-			},
-		};
-
-		const result = evaluator.evaluate('{{ $jmesPath({a: 1, b: 2}, "a") }}', data, caller);
-
-		expect(result).toBe(1);
+		expect(
+			evaluator.evaluate(
+				'{{ $jmespath({users: [{name: "a"}, {name: "b"}]}, "users[*].name") }}',
+				data,
+				caller,
+			),
+		).toEqual(['a', 'b']);
+		expect(evaluator.evaluate('{{ $jmesPath({a: 1, b: 2}, "a") }}', data, caller)).toBe(1);
 		expect(hostJmespathCalls).toBe(0);
 	});
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -2,15 +2,26 @@ import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { QuickJsBridge } from '../bridge/quickjs-bridge';
 import { TimeoutError, MemoryLimitError } from '../types';
 
-describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
+const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
+const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
+
+function createBridge() {
+	if (isQuickJS) {
+		return new QuickJsBridge({ timeout: 5000 });
+	}
+	return new IsolatedVmBridge({ timeout: 5000 });
+}
+
+describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	let evaluator: ExpressionEvaluator;
 	const caller = {};
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 1024,
 		});
 		await evaluator.initialize();

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -313,6 +313,14 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		});
 	});
 
+	it('should enumerate keys that collide with internal marker strings', () => {
+		const data = { $json: { __NaN__: 'a', other: 'b' } };
+
+		expect(evaluator.evaluate('{{ Object.keys($json).sort().join(",") }}', data, caller)).toBe(
+			'__NaN__,other',
+		);
+	});
+
 	it('should throw on invalid timezone', async () => {
 		const data = { $json: { x: 1 } };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -556,6 +556,24 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 
 		expect(evaluator.evaluate('{{ $json.nested }}', data, caller)).toBe('inner');
 	});
+
+	it('should preserve the outer data bindings after a re-entrant execute() call', () => {
+		const data = {
+			$json: {
+				get nested() {
+					// Re-enters execute() on the same bridge with different data.
+					// The outer evaluation must keep resolving against its own data
+					// after the nested call returns.
+					return evaluator.evaluate('{{ "inner" }}', { $json: { val: 1 } }, caller);
+				},
+				other: 'OUTER_VALUE',
+			},
+		};
+
+		expect(evaluator.evaluate('{{ $json.nested + "|" + $json.other }}', data, caller)).toBe(
+			'inner|OUTER_VALUE',
+		);
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -2,18 +2,8 @@ import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
-import { QuickJsBridge } from '../bridge/quickjs-bridge';
 import { TimeoutError, MemoryLimitError } from '../types';
-
-const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
-const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
-
-function createBridge() {
-	if (isQuickJS) {
-		return new QuickJsBridge({ timeout: 5000 });
-	}
-	return new IsolatedVmBridge({ timeout: 5000 });
-}
+import { createBridge, engineName } from './test-bridge';
 
 describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	let evaluator: ExpressionEvaluator;

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -310,6 +310,20 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		).toBe('10:30 AM');
 	});
 
+	it('should throw when the result cannot be cloned (function or Promise)', () => {
+		const data = { $json: {} };
+
+		expect(() => evaluator.evaluate('{{ async () => 1 }}', data, caller)).toThrow(
+			'could not be cloned',
+		);
+		expect(() => evaluator.evaluate('{{ (async () => 1)() }}', data, caller)).toThrow(
+			'could not be cloned',
+		);
+		expect(() => evaluator.evaluate('{{ ({ fn: () => 1 }) }}', data, caller)).toThrow(
+			'could not be cloned',
+		);
+	});
+
 	it('should round-trip an invalid Date return value', () => {
 		const data = { $json: {} };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -4,7 +4,7 @@ import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
 import type { WorkflowData } from '../types';
 import { TimeoutError, MemoryLimitError } from '../types';
-import { createBridge, engineName } from './test-bridge';
+import { createBridge, engineName, isQuickJS, newBridge } from './test-bridge';
 
 describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	let evaluator: ExpressionEvaluator;
@@ -103,74 +103,33 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		expect(result).toBe('items-result');
 	});
 
-	it('should evaluate zero values', async () => {
+	it('should marshal falsy and primitive values', () => {
 		const data = {
-			$json: { zero: 0 },
+			$json: {
+				zero: 0,
+				empty: '',
+				field: null,
+				active: true,
+				items: ['first', 'second'],
+				numbers: [42, 99],
+			},
 		};
 
-		const result = evaluator.evaluate('{{ $json.zero }}', data, caller);
-
-		expect(result).toBe(0);
+		expect(evaluator.evaluate('{{ $json.zero }}', data, caller)).toBe(0);
+		expect(evaluator.evaluate('{{ $json.empty }}', data, caller)).toBe('');
+		expect(evaluator.evaluate('{{ $json.field }}', data, caller)).toBeNull();
+		expect(evaluator.evaluate('{{ $json.active }}', data, caller)).toBe(true);
+		// getArrayElement: falsy index 0 and primitive element
+		expect(evaluator.evaluate('{{ $json.items[0] }}', data, caller)).toBe('first');
+		expect(evaluator.evaluate('{{ $json.numbers[0] }}', data, caller)).toBe(42);
 	});
 
-	it('should evaluate empty string values', async () => {
-		const data = {
-			$json: { empty: '' },
-		};
-
-		const result = evaluator.evaluate('{{ $json.empty }}', data, caller);
-
-		expect(result).toBe('');
-	});
-
-	it('should evaluate array index 0 (falsy index)', async () => {
-		const data = {
-			$json: { items: ['first', 'second'] },
-		};
-
-		const result = evaluator.evaluate('{{ $json.items[0] }}', data, caller);
-
-		expect(result).toBe('first');
-	});
-
-	it('should evaluate primitive array elements', async () => {
-		const data = {
-			$json: { numbers: [42, 99] },
-		};
-
-		const result = evaluator.evaluate('{{ $json.numbers[0] }}', data, caller);
-
-		expect(result).toBe(42);
-	});
-
-	it('should evaluate array .length', async () => {
+	it('should evaluate array .length', () => {
 		const data = {
 			$json: { items: [1, 2, 3] },
 		};
 
-		const result = evaluator.evaluate('{{ $json.items.length }}', data, caller);
-
-		expect(result).toBe(3);
-	});
-
-	it('should evaluate null values', async () => {
-		const data = {
-			$json: { field: null },
-		};
-
-		const result = evaluator.evaluate('{{ $json.field }}', data, caller);
-
-		expect(result).toBeNull();
-	});
-
-	it('should evaluate boolean values', async () => {
-		const data = {
-			$json: { active: true },
-		};
-
-		const result = evaluator.evaluate('{{ $json.active }}', data, caller);
-
-		expect(result).toBe(true);
+		expect(evaluator.evaluate('{{ $json.items.length }}', data, caller)).toBe(3);
 	});
 
 	it('should handle large arrays with lazy loading', async () => {
@@ -287,22 +246,17 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	});
 
 	describe('Date marshaling from workflow data', () => {
-		it('should read a top-level Date in $json as a Date, not {}', () => {
-			const data = { $json: { d: new Date('2026-06-30T20:34:04.498Z') } };
+		it('should read a top-level or nested Date in $json as a Date, not {}', () => {
+			const iso = '2026-06-30T20:34:04.498Z';
+			const data = { $json: { d: new Date(iso), row: { createdAt: new Date(iso) } } };
 
-			const result = evaluator.evaluate('{{ $json.d }}', data, caller);
+			const top = evaluator.evaluate('{{ $json.d }}', data, caller);
+			expect(top).not.toEqual({});
+			expect(top).toBeInstanceOf(Date);
+			expect((top as Date).toISOString()).toBe(iso);
 
-			expect(result).not.toEqual({});
-			expect(result).toBeInstanceOf(Date);
-			expect((result as Date).toISOString()).toBe('2026-06-30T20:34:04.498Z');
-		});
-
-		it('should read a nested Date in $json (e.g. Data Table createdAt)', () => {
-			const data = { $json: { row: { createdAt: new Date('2026-06-30T20:34:04.498Z') } } };
-
-			const result = evaluator.evaluate('{{ $json.row.createdAt }}', data, caller);
-
-			expect(result).toBeInstanceOf(Date);
+			// nested (e.g. Data Table createdAt) travels the same getValueAtPath branch
+			expect(evaluator.evaluate('{{ $json.row.createdAt }}', data, caller)).toBeInstanceOf(Date);
 		});
 
 		it('should read a Date array element in $json', () => {
@@ -320,6 +274,21 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		expect(evaluator.evaluate('{{ Object.keys($json).sort().join(",") }}', data, caller)).toBe(
 			'__NaN__,other',
 		);
+	});
+
+	it('should resolve a function array element as undefined', () => {
+		const data = { $json: { items: [1, () => 2, 3] } };
+
+		expect(evaluator.evaluate('{{ typeof $json.items[1] }}', data, caller)).toBe('undefined');
+		expect(evaluator.evaluate('{{ $json.items[2] }}', data, caller)).toBe(3);
+	});
+
+	it('should round-trip Map, Set and NaN return values', () => {
+		const data = { $json: {} };
+
+		expect(evaluator.evaluate('{{ new Map([["a", 1]]) }}', data, caller)).toBeInstanceOf(Map);
+		expect(evaluator.evaluate('{{ new Set([1, 2]) }}', data, caller)).toBeInstanceOf(Set);
+		expect(evaluator.evaluate('{{ 0/0 }}', data, caller)).toBeNaN();
 	});
 
 	it('should throw on invalid timezone', async () => {
@@ -617,21 +586,6 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		).toBeUndefined();
 	});
 
-	it('should handle re-entrant execute() calls via closure-scoped contexts', () => {
-		const data = {
-			$json: {
-				get nested() {
-					// Trigger a nested evaluate() through the same bridge.
-					// With closure-scoped contexts, this should succeed —
-					// each evaluation gets its own closure with independent callbacks.
-					return evaluator.evaluate('{{ "inner" }}', { $json: { val: 1 } }, caller);
-				},
-			},
-		};
-
-		expect(evaluator.evaluate('{{ $json.nested }}', data, caller)).toBe('inner');
-	});
-
 	it('should preserve the outer data bindings after a re-entrant execute() call', () => {
 		const data = {
 			$json: {
@@ -651,9 +605,9 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	});
 });
 
-describe('Integration: IsolatedVmBridge error handling', () => {
+describe(`Integration: ${engineName} error handling`, () => {
 	it('should throw TimeoutError when expression exceeds timeout', async () => {
-		const bridge = new IsolatedVmBridge({ timeout: 100 });
+		const bridge = newBridge({ timeout: 100 });
 		await bridge.initialize();
 		try {
 			expect(() => bridge.execute('while(true){}', {})).toThrow(TimeoutError);
@@ -665,8 +619,38 @@ describe('Integration: IsolatedVmBridge error handling', () => {
 		}
 	});
 
+	// QuickJS-only: its interrupt deadline is wall-clock and was previously reset
+	// on every nested execute(), so a loop re-entering faster than the timeout
+	// never interrupted. isolated-vm uses a CPU-time budget per call and is not
+	// affected. The outer loop below burns CPU in the vm (so the interrupt fires
+	// in the outer context) while periodically re-entering via $evaluateExpression.
+	it.runIf(isQuickJS)(
+		'should enforce the timeout even when the expression re-enters execute()',
+		async () => {
+			const bridge = newBridge({ timeout: 150 });
+			await bridge.initialize();
+			try {
+				const data: Record<string, unknown> = {
+					$evaluateExpression: () => bridge.execute('1', data),
+				};
+				const code = `
+					var end = Date.now() + 5000;
+					var i = 0;
+					while (Date.now() < end) {
+						i++;
+						if (i % 100000 === 0) { this.$evaluateExpression("1"); }
+					}
+					return i;
+				`;
+				expect(() => bridge.execute(code, data)).toThrow(TimeoutError);
+			} finally {
+				await bridge.dispose();
+			}
+		},
+	);
+
 	it('should throw MemoryLimitError when expression exceeds memory limit', async () => {
-		const bridge = new IsolatedVmBridge({ memoryLimit: 8 });
+		const bridge = newBridge({ memoryLimit: 8 });
 		await bridge.initialize();
 		try {
 			expect(() =>

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -623,6 +623,24 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 
 		expect(evaluator.evaluate('{{ $json.nested }}', data, caller)).toBe('inner');
 	});
+
+	it('should preserve the outer data bindings after a re-entrant execute() call', () => {
+		const data = {
+			$json: {
+				get nested() {
+					// Re-enters execute() on the same bridge with different data.
+					// The outer evaluation must keep resolving against its own data
+					// after the nested call returns.
+					return evaluator.evaluate('{{ "inner" }}', { $json: { val: 1 } }, caller);
+				},
+				other: 'OUTER_VALUE',
+			},
+		};
+
+		expect(evaluator.evaluate('{{ $json.nested + "|" + $json.other }}', data, caller)).toBe(
+			'inner|OUTER_VALUE',
+		);
+	});
 });
 
 describe('Integration: IsolatedVmBridge error handling', () => {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -268,7 +268,7 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		});
 	});
 
-	it('should enumerate keys that collide with internal marker strings', () => {
+	it('should enumerate keys that look like internal sentinel markers', () => {
 		const data = { $json: { __NaN__: 'a', other: 'b' } };
 
 		expect(evaluator.evaluate('{{ Object.keys($json).sort().join(",") }}', data, caller)).toBe(

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -324,6 +324,34 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		);
 	});
 
+	it('should reject the opposite style option in toLocaleDateString/toLocaleTimeString', () => {
+		const data = { $json: {} };
+
+		// The in-sandbox TypeError is swallowed by the E() handler, so the
+		// expression yields undefined — same as the vm engine.
+		expect(
+			evaluator.evaluate(
+				'{{ new Date(0).toLocaleDateString("en-US", { timeStyle: "short" }) }}',
+				data,
+				caller,
+			),
+		).toBeUndefined();
+		expect(
+			evaluator.evaluate(
+				'{{ new Date(0).toLocaleTimeString("en-US", { dateStyle: "short" }) }}',
+				data,
+				caller,
+			),
+		).toBeUndefined();
+		expect(
+			evaluator.evaluate(
+				'{{ new Date(0).toLocaleString("en-US", { dateStyle: "short", timeStyle: "short", timeZone: "UTC" }) }}',
+				data,
+				caller,
+			),
+		).toBe('1/1/70, 12:00 AM');
+	});
+
 	it('should round-trip an invalid Date return value', () => {
 		const data = { $json: {} };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -2,16 +2,27 @@ import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { QuickJsBridge } from '../bridge/quickjs-bridge';
 import type { WorkflowData } from '../types';
 import { TimeoutError, MemoryLimitError } from '../types';
 
-describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
+const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
+const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
+
+function createBridge() {
+	if (isQuickJS) {
+		return new QuickJsBridge({ timeout: 5000 });
+	}
+	return new IsolatedVmBridge({ timeout: 5000 });
+}
+
+describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	let evaluator: ExpressionEvaluator;
 	const caller = {};
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 1024,
 		});
 		await evaluator.initialize();

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -849,7 +849,7 @@ describe('Integration: Concurrent execution pooling', () => {
 	});
 });
 
-describe('Integration: nested evaluation time budget', () => {
+describe(`Integration: nested evaluation time budget (${engineName})`, () => {
 	const TIMEOUT_MS = 400;
 	const BURN_MS = 150;
 	const DEPTH = 8;
@@ -859,7 +859,7 @@ describe('Integration: nested evaluation time budget', () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: TIMEOUT_MS }),
+			createBridge: () => newBridge({ timeout: TIMEOUT_MS }),
 			maxCodeCacheSize: 1024,
 		});
 		await evaluator.initialize();

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -291,6 +291,25 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		expect(evaluator.evaluate('{{ 0/0 }}', data, caller)).toBeNaN();
 	});
 
+	it('should honor locale and options in toLocaleString/toLocaleTimeString', () => {
+		const data = { $json: { n: 1234.5, iso: '2024-01-15T10:30:00.000Z' } };
+
+		expect(
+			evaluator.evaluate(
+				'{{ $json.n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) }}',
+				data,
+				caller,
+			),
+		).toBe('1,234.50');
+		expect(
+			evaluator.evaluate(
+				'{{ new Date($json.iso).toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true, timeZone: "UTC" }) }}',
+				data,
+				caller,
+			),
+		).toBe('10:30 AM');
+	});
+
 	it('should round-trip an invalid Date return value', () => {
 		const data = { $json: {} };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -2,19 +2,9 @@ import { DateTime, Duration, Interval } from 'luxon';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
-import { QuickJsBridge } from '../bridge/quickjs-bridge';
 import type { WorkflowData } from '../types';
 import { TimeoutError, MemoryLimitError } from '../types';
-
-const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
-const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
-
-function createBridge() {
-	if (isQuickJS) {
-		return new QuickJsBridge({ timeout: 5000 });
-	}
-	return new IsolatedVmBridge({ timeout: 5000 });
-}
+import { createBridge, engineName } from './test-bridge';
 
 describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 	let evaluator: ExpressionEvaluator;

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -314,6 +314,14 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		});
 	});
 
+	it('should enumerate keys that collide with internal marker strings', () => {
+		const data = { $json: { __NaN__: 'a', other: 'b' } };
+
+		expect(evaluator.evaluate('{{ Object.keys($json).sort().join(",") }}', data, caller)).toBe(
+			'__NaN__,other',
+		);
+	});
+
 	it('should throw on invalid timezone', async () => {
 		const data = { $json: { x: 1 } };
 

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -291,6 +291,36 @@ describe(`Integration: ExpressionEvaluator (${engineName})`, () => {
 		expect(evaluator.evaluate('{{ 0/0 }}', data, caller)).toBeNaN();
 	});
 
+	it('should round-trip an invalid Date return value', () => {
+		const data = { $json: {} };
+
+		const result = evaluator.evaluate('{{ new Date("not-a-date") }}', data, caller);
+		expect(result).toBeInstanceOf(Date);
+		expect(Number.isNaN((result as Date).getTime())).toBe(true);
+	});
+
+	it('should return user objects whose keys collide with transfer markers unchanged', () => {
+		const data = { $json: {} };
+
+		expect(
+			evaluator.evaluate('{{ ({ __isDate: true, __isoString: "x" }) }}', data, caller),
+		).toEqual({ __isDate: true, __isoString: 'x' });
+		expect(evaluator.evaluate('{{ ({ __isMap: true, __entries: [] }) }}', data, caller)).toEqual({
+			__isMap: true,
+			__entries: [],
+		});
+		expect(evaluator.evaluate('{{ ({ __isNaN: true }) }}', data, caller)).toEqual({
+			__isNaN: true,
+		});
+		expect(
+			evaluator.evaluate('{{ ({ nested: { __isSet: true, __values: [1] } }) }}', data, caller),
+		).toEqual({ nested: { __isSet: true, __values: [1] } });
+		expect(evaluator.evaluate('{{ ({ __isEscaped: true, __value: 1 }) }}', data, caller)).toEqual({
+			__isEscaped: true,
+			__value: 1,
+		});
+	});
+
 	it('should throw on invalid timezone', async () => {
 		const data = { $json: { x: 1 } };
 
@@ -648,6 +678,17 @@ describe(`Integration: ${engineName} error handling`, () => {
 			}
 		},
 	);
+
+	it('should not reinitialize or execute after dispose', async () => {
+		const bridge = newBridge({ timeout: 1000 });
+		await bridge.initialize();
+		await bridge.dispose();
+
+		expect(bridge.isDisposed()).toBe(true);
+		await expect(bridge.initialize()).rejects.toThrow();
+		expect(bridge.isDisposed()).toBe(true);
+		expect(() => bridge.execute('1', {})).toThrow();
+	});
 
 	it('should throw MemoryLimitError when expression exceeds memory limit', async () => {
 		const bridge = newBridge({ memoryLimit: 8 });

--- a/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
@@ -1,0 +1,17 @@
+import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { QuickJsBridge } from '../bridge/quickjs-bridge';
+
+/**
+ * Bridge factory for the dual-engine test projects (see vitest.config.ts).
+ * The `quickjs-engine` project sets N8N_EXPRESSION_ENGINE=quickjs so every
+ * suite using this factory runs against both bridges.
+ */
+export const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
+export const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
+
+export function createBridge() {
+	if (isQuickJS) {
+		return new QuickJsBridge({ timeout: 5000 });
+	}
+	return new IsolatedVmBridge({ timeout: 5000 });
+}

--- a/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
@@ -1,5 +1,6 @@
 import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
 import { QuickJsBridge } from '../bridge/quickjs-bridge';
+import type { BridgeConfig, RuntimeBridge } from '../types';
 
 /**
  * Bridge factory for the dual-engine test projects (see vitest.config.ts).
@@ -9,9 +10,11 @@ import { QuickJsBridge } from '../bridge/quickjs-bridge';
 export const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
 export const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
 
+/** Build the active engine's bridge with the given config. */
+export function newBridge(config: BridgeConfig = {}): RuntimeBridge {
+	return isQuickJS ? new QuickJsBridge(config) : new IsolatedVmBridge(config);
+}
+
 export function createBridge() {
-	if (isQuickJS) {
-		return new QuickJsBridge({ timeout: 5000 });
-	}
-	return new IsolatedVmBridge({ timeout: 5000 });
+	return newBridge({ timeout: 5000 });
 }

--- a/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
@@ -7,8 +7,15 @@ import type { BridgeConfig, RuntimeBridge } from '../types';
  * The `quickjs-engine` project sets N8N_EXPRESSION_ENGINE=quickjs so every
  * suite using this factory runs against both bridges.
  */
-export const isQuickJS = process.env.N8N_EXPRESSION_ENGINE === 'quickjs';
-export const engineName = process.env.N8N_EXPRESSION_ENGINE || 'isolated-vm';
+const engine = process.env.N8N_EXPRESSION_ENGINE;
+if (!engine) {
+	throw new Error(
+		'test-bridge imported outside an engine project — add this test file to ENGINE_AWARE in vitest.config.ts',
+	);
+}
+
+export const isQuickJS = engine === 'quickjs';
+export const engineName = engine;
 
 /** Build the active engine's bridge with the given config. */
 export function newBridge(config: BridgeConfig = {}): RuntimeBridge {

--- a/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/test-bridge.ts
@@ -8,9 +8,9 @@ import type { BridgeConfig, RuntimeBridge } from '../types';
  * suite using this factory runs against both bridges.
  */
 const engine = process.env.N8N_EXPRESSION_ENGINE;
-if (!engine) {
+if (!engine || engine === 'legacy') {
 	throw new Error(
-		'test-bridge imported outside an engine project — add this test file to ENGINE_AWARE in vitest.config.ts',
+		`test-bridge requires an isolated engine, got '${engine ?? ''}' — add this test file to ENGINE_AWARE in vitest.config.ts`,
 	);
 }
 

--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
-import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+import { createBridge } from './test-bridge';
 
 describe("Typed RPC: $('Foo').first() routes via getNodeFirst", () => {
 	let evaluator: ExpressionEvaluator;
@@ -27,7 +27,7 @@ describe("Typed RPC: $('Foo').first() routes via getNodeFirst", () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -150,7 +150,7 @@ describe("Typed RPC: $('Foo').last() routes via getNodeLast", () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -216,7 +216,7 @@ describe("Typed RPC: $('Foo').all() routes via getNodeAll", () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -271,7 +271,7 @@ describe("Typed RPC: $('Foo') proxy fallthrough and `in` checks", () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -323,7 +323,7 @@ describe('Typed RPC: $input.{first,last,all} route via getInput*', () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -438,7 +438,7 @@ describe('Typed RPC: $items() routes via getItems', () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -512,7 +512,7 @@ describe('Typed RPC: $fromAI() routes via fromAi', () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -606,7 +606,7 @@ describe("Typed RPC: $('Foo').pairedItem / .itemMatching / .item route via getNo
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -725,7 +725,7 @@ describe('Typed RPC: $evaluateExpression() routes via evaluateExpression', () =>
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();
@@ -778,7 +778,7 @@ describe('Typed RPC: $getPairedItem() routes via getPairedItem', () => {
 
 	beforeAll(async () => {
 		evaluator = new ExpressionEvaluator({
-			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			createBridge,
 			maxCodeCacheSize: 64,
 		});
 		await evaluator.initialize();

--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -836,3 +836,66 @@ describe('Typed RPC: $getPairedItem() routes via getPairedItem', () => {
 		expect(result).toBeUndefined();
 	});
 });
+
+describe('Typed RPC: nested special values in results', () => {
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge,
+			maxCodeCacheSize: 64,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	const when = new Date('2026-01-02T03:04:05.678Z');
+	const data: Record<string, unknown> = {
+		$: (_nodeName: string) => ({
+			first: () => ({
+				json: {
+					when,
+					n: NaN,
+					m: new Map([['a', 1]]),
+					s: new Set([1, 2]),
+					marked: { __isNaN: true },
+				},
+			}),
+		}),
+	};
+
+	it('delivers nested Date/NaN/Map/Set to the guest as real values', () => {
+		expect(
+			evaluator.evaluate("{{ $('SourceNode').first().json.when instanceof Date }}", data, caller),
+		).toBe(true);
+		expect(evaluator.evaluate("{{ typeof $('SourceNode').first().json.n }}", data, caller)).toBe(
+			'number',
+		);
+		expect(
+			evaluator.evaluate("{{ $('SourceNode').first().json.m instanceof Map }}", data, caller),
+		).toBe(true);
+		expect(
+			evaluator.evaluate("{{ $('SourceNode').first().json.s instanceof Set }}", data, caller),
+		).toBe(true);
+	});
+
+	it('round-trips nested special values back to the host', () => {
+		const result = evaluator.evaluate("{{ $('SourceNode').first().json }}", data, caller) as Record<
+			string,
+			unknown
+		>;
+
+		expect(result.when).toBeInstanceOf(Date);
+		expect((result.when as Date).toISOString()).toBe('2026-01-02T03:04:05.678Z');
+		expect(result.n).toBeNaN();
+		expect(result.m).toBeInstanceOf(Map);
+		expect(result.s).toBeInstanceOf(Set);
+		expect(result.marked).toEqual({ __isNaN: true });
+	});
+});

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -178,18 +178,18 @@ async function readRuntimeBundle(): Promise<string> {
 /**
  * Convert a host JavaScript value to a JSON string suitable for round-tripping
  * into QuickJS via evalCode. Handles undefined (not valid JSON) by returning
- * the string "undefined", and NaN by returning "NaN" (JSON.stringify turns NaN
- * into "null" which is incorrect).
+ * the string "undefined".
+ *
+ * Only objects/arrays reach this — primitives (including top-level NaN via
+ * newNumber) and Date are handled directly by the caller. Nested NaN numbers
+ * marshal as null (standard JSON.stringify behaviour); the only shapes that
+ * cross here (lazy-proxy key/length metadata, Intl outputs) never contain one.
  */
 function hostValueToJson(value: unknown): string {
 	if (value === undefined) return 'undefined';
 	if (value === null) return 'null';
-	if (typeof value === 'number' && isNaN(value)) return 'NaN';
 	try {
-		return JSON.stringify(value, (_key, v) => {
-			if (typeof v === 'number' && isNaN(v)) return '__NaN__';
-			return v;
-		}).replace(/"__NaN__"/g, 'NaN');
+		return JSON.stringify(value);
 	} catch {
 		return 'undefined';
 	}

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -224,12 +224,11 @@ function getValueAtPath(data: Record<string, unknown>, pathArr: string[]): unkno
 		}
 	}
 
+	// Functions are not reachable via the lazy-proxy data path — return
+	// undefined unconditionally, matching IsolatedVmBridge (see the invariant
+	// documented in __tests__/host-fn-shadowing.test.ts).
 	if (typeof value === 'function') {
-		const fnString = value.toString();
-		if (fnString.includes('[native code]')) {
-			return undefined;
-		}
-		return { __isFunction: true, __name: pathArr[pathArr.length - 1] };
+		return undefined;
 	}
 
 	if (Array.isArray(value)) {

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -387,9 +387,6 @@ export class QuickJsBridge implements RuntimeBridge {
 	// Long-lived host-callback handles (Intl polyfills) — disposed on dispose()
 	private intlHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
 
-	// Per-execute callback handles — disposed on the next execute() and on dispose()
-	private callbackHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
-
 	constructor(config: BridgeConfig = {}) {
 		this.config = {
 			...DEFAULT_BRIDGE_CONFIG,
@@ -838,27 +835,21 @@ export class QuickJsBridge implements RuntimeBridge {
 	}
 
 	/**
-	 * Register per-execute callback handles and create adapter shims that
-	 * make them look like ivm.Reference objects (with `.applySync`).
+	 * Create per-execute callback function handles, closure-scoped to `data`.
 	 *
-	 * `buildContext` (from the runtime bundle) accepts these references
-	 * and uses `.applySync(thisArg, [args], opts)` to invoke them. Since
-	 * QuickJS host functions are just plain functions, we wrap each in
-	 * a JS object with a `.applySync` method that delegates to the
-	 * underlying impl.
+	 * The handles are passed as arguments into the per-call wrapper function
+	 * (see execute()) instead of being set as VM globals: `execute()` can
+	 * re-enter synchronously (e.g. `$evaluateExpression`), and globals would
+	 * let the nested call's callbacks clobber the in-flight outer call's data
+	 * bindings. This mirrors IsolatedVmBridge's closure-scoped `$0`/`$1`/`$2`
+	 * evalClosureSync references.
 	 *
-	 * Callbacks are scoped to a single execute() call: existing callback
-	 * handles are disposed before new ones are registered, so concurrent
-	 * evaluations get fresh closures.
+	 * Callers must dispose the returned handles when the call completes.
 	 */
-	private registerCallbacks(data: WorkflowData): void {
+	private createCallbackHandles(
+		data: WorkflowData,
+	): Array<import('quickjs-emscripten').QuickJSHandle> {
 		if (!this.vm) throw new Error('Context not initialized');
-
-		// Dispose previous callback handles
-		for (const handle of this.callbackHandles) {
-			handle.dispose();
-		}
-		this.callbackHandles = [];
 
 		const vm = this.vm;
 
@@ -871,8 +862,6 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__getValueAtPathImpl', getValueFn);
-		this.callbackHandles.push(getValueFn);
 
 		const getArrayFn = vm.newFunction('__getArrayElementImpl', (pathHandle, indexHandle) => {
 			const pathArr = vm.dump(pathHandle) as string[];
@@ -884,8 +873,6 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__getArrayElementImpl', getArrayFn);
-		this.callbackHandles.push(getArrayFn);
 
 		const callHostFn = vm.newFunction('__callHostImpl', (msgHandle) => {
 			const rawMsg = vm.dump(msgHandle);
@@ -896,35 +883,8 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__callHostImpl', callHostFn);
-		this.callbackHandles.push(callHostFn);
 
-		// Create adapter shims that wrap the host fns to look like ivm.Reference.
-		// buildContext receives these and calls .applySync(thisArg, [args], opts).
-		const shimCode = `
-			globalThis.__getValueAtPathRef = {
-				applySync: function(thisArg, args, opts) {
-					return __getValueAtPathImpl(args[0]);
-				}
-			};
-			globalThis.__getArrayElementRef = {
-				applySync: function(thisArg, args, opts) {
-					return __getArrayElementImpl(args[0], args[1]);
-				}
-			};
-			globalThis.__callHostRef = {
-				applySync: function(thisArg, args, opts) {
-					return __callHostImpl(args[0]);
-				}
-			};
-		`;
-		const result = this.vm.evalCode(shimCode);
-		if (result.error) {
-			const errorStr = this.vm.dump(result.error);
-			result.error.dispose();
-			throw new Error(`Failed to register callbacks: ${String(errorStr)}`);
-		}
-		result.value.dispose();
+		return [getValueFn, getArrayFn, callHostFn];
 	}
 
 	/**
@@ -983,28 +943,26 @@ export class QuickJsBridge implements RuntimeBridge {
 			throw new Error('Bridge not initialized. Call initialize() first.');
 		}
 
+		const callbackHandles = this.createCallbackHandles(data);
+		let wrapperFn: import('quickjs-emscripten').QuickJSHandle | undefined;
 		try {
-			this.registerCallbacks(data);
-
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
 
 			// Set up timeout via interrupt handler
 			const deadline = Date.now() + this.config.timeout;
 			this.runtime.setInterruptHandler(() => Date.now() > deadline);
 
+			// The callback impls arrive as function arguments (closure-scoped to
+			// this call), never as globals — see createCallbackHandles(). The
+			// adapter shims make them look like ivm.Reference objects, since
+			// buildContext calls .applySync(thisArg, [args], opts).
 			const wrappedCode = `
-(function() {
-  var __ctx;
-  try {
-    __ctx = buildContext({
-      getValueAtPath: __getValueAtPathRef,
-      getArrayElement: __getArrayElementRef,
-      callHost: __callHostRef,
-    }, ${timezone});
-  } catch (e) {
-    if (e && e.message) throw e;
-    throw e;
-  }
+(function(__getValueAtPathImpl, __getArrayElementImpl, __callHostImpl) {
+  var __ctx = buildContext({
+    getValueAtPath: { applySync: function(thisArg, args, opts) { return __getValueAtPathImpl(args[0]); } },
+    getArrayElement: { applySync: function(thisArg, args, opts) { return __getArrayElementImpl(args[0], args[1]); } },
+    callHost: { applySync: function(thisArg, args, opts) { return __callHostImpl(args[0]); } },
+  }, ${timezone});
   try {
     var __result = (function() {
       ${code}
@@ -1025,9 +983,17 @@ export class QuickJsBridge implements RuntimeBridge {
       extra: extra
     };
   }
-})()`;
+})`;
 
-			const execResult = this.vm.evalCode(wrappedCode);
+			const wrapperResult = this.vm.evalCode(wrappedCode);
+			if (wrapperResult.error) {
+				const errDump = this.vm.dump(wrapperResult.error);
+				wrapperResult.error.dispose();
+				throw new Error(`Expression compilation failed: ${String(errDump)}`);
+			}
+			wrapperFn = wrapperResult.value;
+
+			const execResult = this.vm.callFunction(wrapperFn, this.vm.undefined, ...callbackHandles);
 
 			if (execResult.error) {
 				const errDump = this.vm.dump(execResult.error);
@@ -1084,6 +1050,11 @@ export class QuickJsBridge implements RuntimeBridge {
 				);
 			}
 			throw new Error(`Expression evaluation failed: ${errorMessage}`);
+		} finally {
+			wrapperFn?.dispose();
+			for (const handle of callbackHandles) {
+				handle.dispose();
+			}
 		}
 	}
 
@@ -1115,11 +1086,6 @@ export class QuickJsBridge implements RuntimeBridge {
 
 	async dispose(): Promise<void> {
 		if (this.disposed) return;
-
-		for (const handle of this.callbackHandles) {
-			handle.dispose();
-		}
-		this.callbackHandles = [];
 
 		for (const handle of this.intlHandles) {
 			handle.dispose();

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -1,0 +1,1147 @@
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { RuntimeBridge, BridgeConfig, ExecuteOptions, WorkflowData } from '../types';
+import { DEFAULT_BRIDGE_CONFIG, TimeoutError, MemoryLimitError } from '../types';
+import type { ErrorSentinel } from '../runtime/lazy-proxy';
+import { bridgeMessageSchema } from './bridge-messages';
+
+// Lazy-loaded quickjs-emscripten — avoids loading WASM when the barrel
+// file is statically imported (e.g. for error classes). The module is
+// only loaded when QuickJsBridge.initialize() is actually called.
+type QuickJSModule = typeof import('quickjs-emscripten');
+let _quickjs: QuickJSModule | null = null;
+
+async function getQuickJSModule(): Promise<QuickJSModule> {
+	if (!_quickjs) {
+		_quickjs = await import('quickjs-emscripten');
+	}
+	return _quickjs;
+}
+
+const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
+
+// ============================================================================
+// Sentinel helpers
+//
+// QuickJS's vm.dump() loses Date / NaN / Map / Set / Error type identity
+// (Date → ISO string, NaN → null, Map/Set → plain object, Error → plain
+// object without prototype). Inside the QuickJS context we wrap those
+// values as sentinel objects ({ __isDate: true, __isoString: ... } etc.)
+// before they cross the boundary, then unwrap them on the host side.
+// The isolated-vm bridge does NOT need this — structured clone preserves
+// type identity natively.
+// ============================================================================
+
+function isDateSentinel(value: unknown): value is { __isDate: true; __isoString: string } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isDate === true &&
+		typeof (value as Record<string, unknown>).__isoString === 'string'
+	);
+}
+
+function isNaNSentinel(value: unknown): value is { __isNaN: true } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isNaN === true
+	);
+}
+
+function isErrorValueSentinel(value: unknown): value is {
+	__isErrorValue: true;
+	__name: string;
+	__message: string;
+	__extra: Record<string, unknown>;
+} {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isErrorValue === true
+	);
+}
+
+function isMapSentinel(
+	value: unknown,
+): value is { __isMap: true; __entries: Array<[unknown, unknown]> } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isMap === true
+	);
+}
+
+function isSetSentinel(value: unknown): value is { __isSet: true; __values: unknown[] } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isSet === true
+	);
+}
+
+function isErrorSentinel(value: unknown): value is ErrorSentinel {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isError === true
+	);
+}
+
+/**
+ * Recursively reconstruct Date objects, NaN values, Map, and Set from
+ * sentinels produced by the QuickJS-side __prepareForTransfer wrapper.
+ */
+function unwrapSentinels(value: unknown): unknown {
+	if (value === null || value === undefined) return value;
+	if (typeof value !== 'object') return value;
+	if (isDateSentinel(value)) return new Date(value.__isoString);
+	if (isNaNSentinel(value)) return NaN;
+	if (isErrorValueSentinel(value)) {
+		const ErrorCtor =
+			(
+				{
+					TypeError,
+					SyntaxError,
+					EvalError,
+					RangeError,
+					ReferenceError,
+					URIError,
+				} as Record<string, ErrorConstructor>
+			)[value.__name] ?? Error;
+		const err = new ErrorCtor(value.__message);
+		if (value.__extra) {
+			for (const [k, v] of Object.entries(value.__extra)) {
+				(err as unknown as Record<string, unknown>)[k] = unwrapSentinels(v);
+			}
+		}
+		return err;
+	}
+	if (isMapSentinel(value)) {
+		return new Map(value.__entries.map(([k, v]) => [unwrapSentinels(k), unwrapSentinels(v)]));
+	}
+	if (isSetSentinel(value)) {
+		return new Set(value.__values.map(unwrapSentinels));
+	}
+	if (Array.isArray(value)) return value.map(unwrapSentinels);
+	// Don't recurse into error sentinels
+	if (isErrorSentinel(value)) return value;
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value as Record<string, unknown>)) {
+		result[key] = unwrapSentinels((value as Record<string, unknown>)[key]);
+	}
+	return result;
+}
+
+/**
+ * Serialize an error into a transferable metadata object.
+ *
+ * Host-side callbacks (getValueAtPath, etc.) catch errors and return this
+ * sentinel instead of letting the error cross the sandbox boundary (which
+ * strips custom class identity and properties). The sandbox-side proxy
+ * detects __isError and reconstructs a proper Error to throw.
+ */
+function serializeError(err: unknown): ErrorSentinel {
+	if (err instanceof Error) {
+		const extra = Object.fromEntries(
+			Object.entries(err).filter(([key]) => key !== 'name' && key !== 'message' && key !== 'stack'),
+		);
+		return {
+			__isError: true,
+			name: err.name,
+			message: err.message,
+			stack: err.stack,
+			extra,
+		};
+	}
+	return { __isError: true, name: 'Error', message: String(err), extra: {} };
+}
+
+/**
+ * Read the runtime IIFE bundle by walking up from `__dirname` until
+ * `dist/bundle/runtime.iife.js` is found.
+ */
+async function readRuntimeBundle(): Promise<string> {
+	let dir = __dirname;
+	while (dir !== path.dirname(dir)) {
+		try {
+			return await readFile(path.join(dir, BUNDLE_RELATIVE_PATH), 'utf-8');
+		} catch {}
+		dir = path.dirname(dir);
+	}
+	throw new Error(
+		`Could not find runtime bundle (${BUNDLE_RELATIVE_PATH}) in any parent of ${__dirname}`,
+	);
+}
+
+/**
+ * Convert a host JavaScript value to a JSON string suitable for round-tripping
+ * into QuickJS via evalCode. Handles undefined (not valid JSON) by returning
+ * the string "undefined", and NaN by returning "NaN" (JSON.stringify turns NaN
+ * into "null" which is incorrect).
+ */
+function hostValueToJson(value: unknown): string {
+	if (value === undefined) return 'undefined';
+	if (value === null) return 'null';
+	if (typeof value === 'number' && isNaN(value)) return 'NaN';
+	try {
+		return JSON.stringify(value, (_key, v) => {
+			if (typeof v === 'number' && isNaN(v)) return '__NaN__';
+			return v;
+		}).replace(/"__NaN__"/g, 'NaN');
+	} catch {
+		return 'undefined';
+	}
+}
+
+/**
+ * Navigate data object by path and return metadata or primitive value.
+ * Mirrors the IsolatedVmBridge getValueAtPath callback so QuickJS
+ * matches isolated-vm semantics, including special-cased $/$item navigation.
+ */
+function getValueAtPath(data: Record<string, unknown>, pathArr: string[]): unknown {
+	let value: unknown = data;
+	let startIndex = 0;
+	const itemFn = (data as Record<string, unknown>).$item;
+	if (pathArr.length >= 2 && pathArr[0] === '$item' && typeof itemFn === 'function') {
+		const itemIndex = parseInt(pathArr[1], 10);
+		if (!isNaN(itemIndex)) {
+			value = (itemFn as (i: number) => unknown)(itemIndex);
+			startIndex = 2;
+		}
+	} else {
+		const dollarFn = (data as Record<string, unknown>).$;
+		if (pathArr.length >= 2 && pathArr[0] === '$' && typeof dollarFn === 'function') {
+			value = (dollarFn as (name: string) => unknown)(pathArr[1]);
+			startIndex = 2;
+		}
+	}
+	for (let i = startIndex; i < pathArr.length; i++) {
+		value = (value as Record<string, unknown>)?.[pathArr[i]];
+		if (value === undefined || value === null) {
+			return value;
+		}
+	}
+
+	if (typeof value === 'function') {
+		const fnString = value.toString();
+		if (fnString.includes('[native code]')) {
+			return undefined;
+		}
+		return { __isFunction: true, __name: pathArr[pathArr.length - 1] };
+	}
+
+	if (Array.isArray(value)) {
+		return {
+			__isArray: true,
+			__length: value.length,
+			__data: null,
+		};
+	}
+
+	// Dates have no enumerable own keys; pass through instead of
+	// marshaling as an empty object.
+	if (value instanceof Date) {
+		return value;
+	}
+
+	if (value !== null && typeof value === 'object') {
+		return {
+			__isObject: true,
+			__keys: Object.keys(value),
+		};
+	}
+
+	return value;
+}
+
+function getArrayElement(data: Record<string, unknown>, pathArr: string[], index: number): unknown {
+	let arr: unknown = data;
+	let startIndex = 0;
+	const itemFn = (data as Record<string, unknown>).$item;
+	if (pathArr.length >= 2 && pathArr[0] === '$item' && typeof itemFn === 'function') {
+		const itemIndex = parseInt(pathArr[1], 10);
+		if (!isNaN(itemIndex)) {
+			arr = (itemFn as (i: number) => unknown)(itemIndex);
+			startIndex = 2;
+		}
+	} else {
+		const dollarFn = (data as Record<string, unknown>).$;
+		if (pathArr.length >= 2 && pathArr[0] === '$' && typeof dollarFn === 'function') {
+			arr = (dollarFn as (name: string) => unknown)(pathArr[1]);
+			startIndex = 2;
+		}
+	}
+	for (let i = startIndex; i < pathArr.length; i++) {
+		arr = (arr as Record<string, unknown>)?.[pathArr[i]];
+		if (arr === undefined || arr === null) {
+			return undefined;
+		}
+	}
+
+	if (!Array.isArray(arr)) {
+		return undefined;
+	}
+
+	const element = arr[index];
+
+	// Dates have no enumerable own keys; pass through instead of
+	// marshaling as an empty object.
+	if (element instanceof Date) {
+		return element;
+	}
+
+	if (element !== null && typeof element === 'object') {
+		if (Array.isArray(element)) {
+			return {
+				__isArray: true,
+				__length: element.length,
+				__data: null,
+			};
+		}
+		return {
+			__isObject: true,
+			__keys: Object.keys(element),
+		};
+	}
+
+	return element;
+}
+
+/**
+ * Host-side dispatcher for the typed-RPC `callHost` channel.
+ *
+ * Mirrors IsolatedVmBridge's dispatcher — see isolated-vm-bridge.ts for the
+ * per-message rationale. The two copies are kept in sync at compile time:
+ * the `never` check in the default case fails to compile when a new schema
+ * lands in bridge-messages.ts without a matching case here.
+ */
+function dispatchHostCall(rawMsg: unknown, data: WorkflowData): unknown {
+	const msg = bridgeMessageSchema.parse(rawMsg);
+	switch (msg.type) {
+		case 'getNodeFirst':
+			return data.$?.(msg.nodeName)?.first?.(msg.branchIndex, msg.runIndex);
+		case 'getNodeLast':
+			return data.$?.(msg.nodeName)?.last?.(msg.branchIndex, msg.runIndex);
+		case 'getNodeAll':
+			return data.$?.(msg.nodeName)?.all?.(msg.branchIndex, msg.runIndex);
+		case 'getInputFirst':
+			return data.$input?.first?.();
+		case 'getInputLast':
+			return data.$input?.last?.();
+		case 'getInputAll':
+			return data.$input?.all?.();
+		case 'getItems':
+			return data.$items?.(msg.nodeName, msg.outputIndex, msg.runIndex);
+		case 'fromAi':
+			return data.$fromAI?.(msg.name, msg.description, msg.valueType, msg.defaultValue);
+		case 'getNodePairedItem':
+			return data.$?.(msg.nodeName)?.pairedItem?.(msg.itemIndex);
+		case 'getNodeItemMatching':
+			return data.$?.(msg.nodeName)?.itemMatching?.(msg.itemIndex);
+		case 'getNodeItem':
+			// `.item` is a host getter — accessing it invokes the resolver.
+			return data.$?.(msg.nodeName)?.item;
+		case 'evaluateExpression':
+			return data.$evaluateExpression?.(msg.expression, msg.itemIndex);
+		case 'getPairedItem':
+			return data.$getPairedItem?.(
+				msg.destinationNodeName,
+				msg.incomingSourceData,
+				msg.initialPairedItem,
+			);
+		default: {
+			// Unreachable at runtime — zod rejects unknown `type` values before
+			// the switch. The `never` assignment is the compile-time guard.
+			const exhaustive: never = msg;
+			void exhaustive;
+			throw new Error('Unhandled bridge message');
+		}
+	}
+}
+
+/**
+ * QuickJsBridge - Runtime bridge using quickjs-emscripten for expression evaluation.
+ *
+ * Mirrors the IsolatedVmBridge contract:
+ * - Memory limit enforcement
+ * - No access to Node.js APIs
+ * - Timeout enforcement via interrupt handler
+ * - Complete isolation from host process
+ *
+ * Like IsolatedVmBridge, callbacks are scoped per-execute() call: the host
+ * functions are re-registered each call, so concurrent / nested evaluations
+ * see fresh data. The runtime bundle's `buildContext(callbacks, timezone)`
+ * is invoked with adapter-shim references that look like ivm.Reference
+ * objects (they expose `.applySync()`).
+ */
+export class QuickJsBridge implements RuntimeBridge {
+	private runtime: import('quickjs-emscripten').QuickJSRuntime | undefined;
+	private vm: import('quickjs-emscripten').QuickJSContext | undefined;
+	private initialized = false;
+	private disposed = false;
+	private config: Required<BridgeConfig>;
+	private logger: Required<BridgeConfig>['logger'];
+
+	// Long-lived host-callback handles (Intl polyfills) — disposed on dispose()
+	private intlHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
+
+	// Per-execute callback handles — disposed on the next execute() and on dispose()
+	private callbackHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
+
+	constructor(config: BridgeConfig = {}) {
+		this.config = {
+			...DEFAULT_BRIDGE_CONFIG,
+			...config,
+		};
+		this.logger = this.config.logger;
+	}
+
+	async initialize(): Promise<void> {
+		if (this.initialized) return;
+
+		const { getQuickJS } = await getQuickJSModule();
+		const QuickJS = await getQuickJS();
+
+		// Create runtime with memory limit (MB → bytes)
+		this.runtime = QuickJS.newRuntime();
+		this.runtime.setMemoryLimit(this.config.memoryLimit * 1024 * 1024);
+
+		// Create context
+		this.vm = this.runtime.newContext();
+
+		// Set up 'global' / 'globalThis' self-reference
+		const globalHandle = this.vm.global;
+		this.vm.setProp(globalHandle, 'global', globalHandle);
+		this.vm.setProp(globalHandle, 'globalThis', globalHandle);
+
+		// Inject Intl polyfill — QuickJS doesn't include Intl, but Luxon needs it
+		this.injectIntlPolyfill();
+
+		// Load runtime bundle (DateTime, extend, SafeObject, proxy system, buildContext)
+		await this.loadRuntimeBundle();
+
+		// Wrap __prepareForTransfer to mark Date/NaN/Map/Set/Error so they survive vm.dump()
+		this.injectTransferWrapper();
+
+		// Inject E() error handler matching the new IsolatedVmBridge semantics
+		this.injectErrorHandler();
+
+		// Verify proxy system loaded correctly
+		this.verifyProxySystem();
+
+		this.initialized = true;
+
+		this.logger.info('[QuickJsBridge] Initialized successfully');
+	}
+
+	/**
+	 * Load the runtime IIFE bundle and verify required globals are present.
+	 */
+	private async loadRuntimeBundle(): Promise<void> {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const runtimeBundle = await readRuntimeBundle();
+
+		const result = this.vm.evalCode(runtimeBundle);
+		if (result.error) {
+			const errorStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(`Failed to load runtime bundle: ${String(errorStr)}`);
+		}
+		result.value.dispose();
+
+		this.logger.info('[QuickJsBridge] Runtime bundle loaded');
+
+		this.evalCodeOrThrow('typeof DateTime !== "undefined"', 'DateTime verification');
+		this.evalCodeOrThrow('typeof extend !== "undefined"', 'extend verification');
+
+		this.logger.info('[QuickJsBridge] Vendor libraries verified successfully');
+	}
+
+	/**
+	 * Inject a polyfill for the Intl API.
+	 *
+	 * QuickJS doesn't include Intl, but Luxon (bundled in the runtime) uses
+	 * Intl.DateTimeFormat, Intl.NumberFormat, Intl.RelativeTimeFormat, and
+	 * Intl.ListFormat extensively. Rather than shimming all of this in pure JS,
+	 * we register host callback functions that delegate to Node.js's real Intl
+	 * implementation, then build lightweight JS wrapper classes that call them.
+	 */
+	private injectIntlPolyfill(): void {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const vm = this.vm;
+
+		const dtfFn = vm.newFunction('__intl_dtf', (...handles) => {
+			const args = handles.map((h) => vm.dump(h));
+			const op = args[0] as string;
+			const locales = args[1] as string | string[] | undefined;
+			const options = args[2] as Intl.DateTimeFormatOptions | undefined;
+
+			try {
+				if (op === 'resolvedOptions') {
+					const fmt = new Intl.DateTimeFormat(locales, options);
+					return this.hostValueToQuickJSHandle(fmt.resolvedOptions());
+				}
+				if (op === 'format') {
+					const fmt = new Intl.DateTimeFormat(locales, options);
+					const ts = args[3] as number | undefined;
+					const date = ts !== undefined ? new Date(ts) : new Date();
+					return this.hostValueToQuickJSHandle(fmt.format(date));
+				}
+				if (op === 'formatToParts') {
+					const fmt = new Intl.DateTimeFormat(locales, options);
+					const ts = args[3] as number | undefined;
+					const date = ts !== undefined ? new Date(ts) : new Date();
+					return this.hostValueToQuickJSHandle(fmt.formatToParts(date));
+				}
+				if (op === 'supportedLocalesOf') {
+					return this.hostValueToQuickJSHandle(
+						Intl.DateTimeFormat.supportedLocalesOf(locales ?? []),
+					);
+				}
+			} catch (err) {
+				return this.hostValueToQuickJSHandle({
+					__intlError: true,
+					message: err instanceof Error ? err.message : String(err),
+				});
+			}
+			return vm.undefined;
+		});
+		vm.setProp(vm.global, '__intl_dtf', dtfFn);
+		this.intlHandles.push(dtfFn);
+
+		const nfFn = vm.newFunction('__intl_nf', (...handles) => {
+			const args = handles.map((h) => vm.dump(h));
+			const op = args[0] as string;
+			const locales = args[1] as string | string[] | undefined;
+			const options = args[2] as Intl.NumberFormatOptions | undefined;
+
+			try {
+				if (op === 'resolvedOptions') {
+					const fmt = new Intl.NumberFormat(locales, options);
+					return this.hostValueToQuickJSHandle(fmt.resolvedOptions());
+				}
+				if (op === 'format') {
+					const fmt = new Intl.NumberFormat(locales, options);
+					const num = args[3] as number;
+					return this.hostValueToQuickJSHandle(fmt.format(num));
+				}
+				if (op === 'formatToParts') {
+					const fmt = new Intl.NumberFormat(locales, options);
+					const num = args[3] as number;
+					return this.hostValueToQuickJSHandle(fmt.formatToParts(num));
+				}
+			} catch (err) {
+				return this.hostValueToQuickJSHandle({
+					__intlError: true,
+					message: err instanceof Error ? err.message : String(err),
+				});
+			}
+			return vm.undefined;
+		});
+		vm.setProp(vm.global, '__intl_nf', nfFn);
+		this.intlHandles.push(nfFn);
+
+		const rtfFn = vm.newFunction('__intl_rtf', (...handles) => {
+			const args = handles.map((h) => vm.dump(h));
+			const op = args[0] as string;
+			const locales = args[1] as string | string[] | undefined;
+			const options = args[2] as Intl.RelativeTimeFormatOptions | undefined;
+
+			try {
+				if (op === 'resolvedOptions') {
+					const fmt = new Intl.RelativeTimeFormat(locales, options);
+					return this.hostValueToQuickJSHandle(fmt.resolvedOptions());
+				}
+				if (op === 'format') {
+					const fmt = new Intl.RelativeTimeFormat(locales, options);
+					const value = args[3] as number;
+					const unit = args[4] as Intl.RelativeTimeFormatUnit;
+					return this.hostValueToQuickJSHandle(fmt.format(value, unit));
+				}
+				if (op === 'formatToParts') {
+					const fmt = new Intl.RelativeTimeFormat(locales, options);
+					const value = args[3] as number;
+					const unit = args[4] as Intl.RelativeTimeFormatUnit;
+					return this.hostValueToQuickJSHandle(fmt.formatToParts(value, unit));
+				}
+			} catch (err) {
+				return this.hostValueToQuickJSHandle({
+					__intlError: true,
+					message: err instanceof Error ? err.message : String(err),
+				});
+			}
+			return vm.undefined;
+		});
+		vm.setProp(vm.global, '__intl_rtf', rtfFn);
+		this.intlHandles.push(rtfFn);
+
+		const lfFn = vm.newFunction('__intl_lf', (...handles) => {
+			const args = handles.map((h) => vm.dump(h));
+			const op = args[0] as string;
+			const locales = args[1] as string | string[] | undefined;
+			const options = args[2] as Intl.ListFormatOptions | undefined;
+
+			try {
+				if (op === 'format') {
+					const fmt = new Intl.ListFormat(locales, options);
+					const list = args[3] as string[];
+					return this.hostValueToQuickJSHandle(fmt.format(list));
+				}
+				if (op === 'formatToParts') {
+					const fmt = new Intl.ListFormat(locales, options);
+					const list = args[3] as string[];
+					return this.hostValueToQuickJSHandle(fmt.formatToParts(list));
+				}
+				if (op === 'resolvedOptions') {
+					const fmt = new Intl.ListFormat(locales, options);
+					return this.hostValueToQuickJSHandle(fmt.resolvedOptions());
+				}
+			} catch (err) {
+				return this.hostValueToQuickJSHandle({
+					__intlError: true,
+					message: err instanceof Error ? err.message : String(err),
+				});
+			}
+			return vm.undefined;
+		});
+		vm.setProp(vm.global, '__intl_lf', lfFn);
+		this.intlHandles.push(lfFn);
+
+		const shimCode = `
+(function() {
+	function checkError(result) {
+		if (result && typeof result === 'object' && result.__intlError) {
+			throw new Error(result.message);
+		}
+		return result;
+	}
+
+	function DateTimeFormat(locales, options) {
+		this._locales = locales;
+		this._options = options || {};
+	}
+	DateTimeFormat.prototype.resolvedOptions = function() {
+		return checkError(__intl_dtf('resolvedOptions', this._locales, this._options));
+	};
+	DateTimeFormat.prototype.format = function(date) {
+		var ts = date instanceof Date ? date.getTime() : (typeof date === 'number' ? date : Date.now());
+		return checkError(__intl_dtf('format', this._locales, this._options, ts));
+	};
+	DateTimeFormat.prototype.formatToParts = function(date) {
+		var ts = date instanceof Date ? date.getTime() : (typeof date === 'number' ? date : Date.now());
+		return checkError(__intl_dtf('formatToParts', this._locales, this._options, ts));
+	};
+	DateTimeFormat.supportedLocalesOf = function(locales) {
+		return checkError(__intl_dtf('supportedLocalesOf', locales));
+	};
+
+	function NumberFormat(locales, options) {
+		this._locales = locales;
+		this._options = options || {};
+	}
+	NumberFormat.prototype.resolvedOptions = function() {
+		return checkError(__intl_nf('resolvedOptions', this._locales, this._options));
+	};
+	NumberFormat.prototype.format = function(num) {
+		return checkError(__intl_nf('format', this._locales, this._options, num));
+	};
+	NumberFormat.prototype.formatToParts = function(num) {
+		return checkError(__intl_nf('formatToParts', this._locales, this._options, num));
+	};
+
+	function RelativeTimeFormat(locales, options) {
+		this._locales = locales;
+		this._options = options || {};
+	}
+	RelativeTimeFormat.prototype.resolvedOptions = function() {
+		return checkError(__intl_rtf('resolvedOptions', this._locales, this._options));
+	};
+	RelativeTimeFormat.prototype.format = function(value, unit) {
+		return checkError(__intl_rtf('format', this._locales, this._options, value, unit));
+	};
+	RelativeTimeFormat.prototype.formatToParts = function(value, unit) {
+		return checkError(__intl_rtf('formatToParts', this._locales, this._options, value, unit));
+	};
+
+	function ListFormat(locales, options) {
+		this._locales = locales;
+		this._options = options || {};
+	}
+	ListFormat.prototype.format = function(list) {
+		return checkError(__intl_lf('format', this._locales, this._options, list));
+	};
+	ListFormat.prototype.formatToParts = function(list) {
+		return checkError(__intl_lf('formatToParts', this._locales, this._options, list));
+	};
+	ListFormat.prototype.resolvedOptions = function() {
+		return checkError(__intl_lf('resolvedOptions', this._locales, this._options));
+	};
+
+	globalThis.Intl = {
+		DateTimeFormat: DateTimeFormat,
+		NumberFormat: NumberFormat,
+		RelativeTimeFormat: RelativeTimeFormat,
+		ListFormat: ListFormat,
+		Locale: function Locale(tag) { this.baseName = tag; this.language = tag.split('-')[0]; }
+	};
+})();
+`;
+
+		const result = this.vm.evalCode(shimCode);
+		if (result.error) {
+			const errStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(
+				`Failed to inject Intl polyfill: ${typeof errStr === 'object' ? JSON.stringify(errStr) : String(errStr)}`,
+			);
+		}
+		result.value.dispose();
+
+		this.logger.debug('[QuickJsBridge] Intl polyfill injected');
+	}
+
+	/**
+	 * Wrap __prepareForTransfer so values that don't survive vm.dump()
+	 * (Date, NaN, Map, Set, Error) are converted to sentinel objects.
+	 * The host post-processes vm.dump() output to reconstruct real instances
+	 * via unwrapSentinels().
+	 */
+	private injectTransferWrapper(): void {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const wrapperCode = `
+(function() {
+	var original = __prepareForTransfer;
+	globalThis.__prepareForTransfer = function(value) {
+		var prepared = original(value);
+		return wrapSpecialValues(prepared);
+	};
+	function wrapSpecialValues(v) {
+		if (v === null || v === undefined) return v;
+		if (v instanceof Date) {
+			return { __isDate: true, __isoString: v.toISOString() };
+		}
+		if (typeof v === 'number' && isNaN(v)) {
+			return { __isNaN: true };
+		}
+		if (typeof v !== 'object') return v;
+		if (v instanceof Error) {
+			var errExtra = {};
+			var errKeys = Object.keys(v);
+			for (var ei = 0; ei < errKeys.length; ei++) {
+				if (errKeys[ei] !== 'name' && errKeys[ei] !== 'message' && errKeys[ei] !== 'stack') {
+					errExtra[errKeys[ei]] = wrapSpecialValues(v[errKeys[ei]]);
+				}
+			}
+			return { __isErrorValue: true, __name: v.name || 'Error', __message: v.message || '', __extra: errExtra };
+		}
+		if (v instanceof Map) {
+			var entries = [];
+			v.forEach(function(val, key) {
+				entries.push([wrapSpecialValues(key), wrapSpecialValues(val)]);
+			});
+			return { __isMap: true, __entries: entries };
+		}
+		if (v instanceof Set) {
+			var values = [];
+			v.forEach(function(val) {
+				values.push(wrapSpecialValues(val));
+			});
+			return { __isSet: true, __values: values };
+		}
+		if (Array.isArray(v)) return v.map(wrapSpecialValues);
+		// Don't recurse into error sentinels
+		if (v.__isError) return v;
+		var result = {};
+		var keys = Object.keys(v);
+		for (var i = 0; i < keys.length; i++) {
+			result[keys[i]] = wrapSpecialValues(v[keys[i]]);
+		}
+		return result;
+	}
+})();
+`;
+
+		const result = this.vm.evalCode(wrapperCode);
+		if (result.error) {
+			const errStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(
+				`Failed to inject transfer wrapper: ${typeof errStr === 'object' ? JSON.stringify(errStr) : String(errStr)}`,
+			);
+		}
+		result.value.dispose();
+
+		this.logger.debug('[QuickJsBridge] Transfer wrapper injected');
+	}
+
+	/**
+	 * Inject the E() error handler matching IsolatedVmBridge semantics:
+	 * - Re-throw ExpressionError / ExpressionExtensionError
+	 * - Swallow everything else (TypeErrors, generic Errors, etc.)
+	 *
+	 * Errors from host callbacks arrive as sentinel objects (not class
+	 * instances), so we match by `name` instead of instanceof.
+	 */
+	private injectErrorHandler(): void {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const result = this.vm.evalCode(`
+			if (typeof E === 'undefined') {
+				globalThis.E = function(error, _context) {
+					var name = error && error.name;
+					if (name === 'ExpressionError' || name === 'ExpressionExtensionError') {
+						throw error;
+					}
+					return undefined;
+				};
+			}
+		`);
+		if (result.error) {
+			const errorStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(`Failed to inject error handler: ${String(errorStr)}`);
+		}
+		result.value.dispose();
+
+		this.logger.debug('[QuickJsBridge] Error handler injected');
+	}
+
+	private verifyProxySystem(): void {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const checks = [
+			['createDeepLazyProxy', 'typeof createDeepLazyProxy !== "undefined"'],
+			['buildContext', 'typeof buildContext !== "undefined"'],
+			['SafeObject', 'typeof SafeObject !== "undefined"'],
+			['SafeError', 'typeof SafeError !== "undefined"'],
+		] as const;
+
+		for (const [name, code] of checks) {
+			const result = this.vm.evalCode(code);
+			if (result.error) {
+				result.error.dispose();
+				throw new Error(`Proxy system verification failed: ${name} check errored`);
+			}
+			const val = this.vm.dump(result.value);
+			result.value.dispose();
+			if (val !== true) {
+				throw new Error(`Proxy system verification failed: ${name} not available`);
+			}
+		}
+
+		this.logger.debug('[QuickJsBridge] Proxy system verified');
+	}
+
+	/**
+	 * Register per-execute callback handles and create adapter shims that
+	 * make them look like ivm.Reference objects (with `.applySync`).
+	 *
+	 * `buildContext` (from the runtime bundle) accepts these references
+	 * and uses `.applySync(thisArg, [args], opts)` to invoke them. Since
+	 * QuickJS host functions are just plain functions, we wrap each in
+	 * a JS object with a `.applySync` method that delegates to the
+	 * underlying impl.
+	 *
+	 * Callbacks are scoped to a single execute() call: existing callback
+	 * handles are disposed before new ones are registered, so concurrent
+	 * evaluations get fresh closures.
+	 */
+	private registerCallbacks(data: WorkflowData): void {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		// Dispose previous callback handles
+		for (const handle of this.callbackHandles) {
+			handle.dispose();
+		}
+		this.callbackHandles = [];
+
+		const vm = this.vm;
+
+		const getValueFn = vm.newFunction('__getValueAtPathImpl', (pathHandle) => {
+			const pathArr = vm.dump(pathHandle) as string[];
+			try {
+				const result = getValueAtPath(data, pathArr);
+				return this.hostValueToQuickJSHandle(result);
+			} catch (err) {
+				return this.hostValueToQuickJSHandle(serializeError(err));
+			}
+		});
+		vm.setProp(vm.global, '__getValueAtPathImpl', getValueFn);
+		this.callbackHandles.push(getValueFn);
+
+		const getArrayFn = vm.newFunction('__getArrayElementImpl', (pathHandle, indexHandle) => {
+			const pathArr = vm.dump(pathHandle) as string[];
+			const index = vm.dump(indexHandle) as number;
+			try {
+				const result = getArrayElement(data, pathArr, index);
+				return this.hostValueToQuickJSHandle(result);
+			} catch (err) {
+				return this.hostValueToQuickJSHandle(serializeError(err));
+			}
+		});
+		vm.setProp(vm.global, '__getArrayElementImpl', getArrayFn);
+		this.callbackHandles.push(getArrayFn);
+
+		const callHostFn = vm.newFunction('__callHostImpl', (msgHandle) => {
+			const rawMsg = vm.dump(msgHandle);
+			try {
+				const result = dispatchHostCall(rawMsg, data);
+				return this.hostValueToQuickJSHandle(result);
+			} catch (err) {
+				return this.hostValueToQuickJSHandle(serializeError(err));
+			}
+		});
+		vm.setProp(vm.global, '__callHostImpl', callHostFn);
+		this.callbackHandles.push(callHostFn);
+
+		// Create adapter shims that wrap the host fns to look like ivm.Reference.
+		// buildContext receives these and calls .applySync(thisArg, [args], opts).
+		const shimCode = `
+			globalThis.__getValueAtPathRef = {
+				applySync: function(thisArg, args, opts) {
+					return __getValueAtPathImpl(args[0]);
+				}
+			};
+			globalThis.__getArrayElementRef = {
+				applySync: function(thisArg, args, opts) {
+					return __getArrayElementImpl(args[0], args[1]);
+				}
+			};
+			globalThis.__callHostRef = {
+				applySync: function(thisArg, args, opts) {
+					return __callHostImpl(args[0]);
+				}
+			};
+		`;
+		const result = this.vm.evalCode(shimCode);
+		if (result.error) {
+			const errorStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(`Failed to register callbacks: ${String(errorStr)}`);
+		}
+		result.value.dispose();
+	}
+
+	/**
+	 * Convert a host JavaScript value to a QuickJS handle.
+	 *
+	 * For primitives, uses the dedicated vm.newXxx() methods.
+	 * For complex objects (arrays, objects), uses JSON round-trip via evalCode.
+	 */
+	private hostValueToQuickJSHandle(value: unknown): import('quickjs-emscripten').QuickJSHandle {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		if (value === undefined) return this.vm.undefined;
+		if (value === null) return this.vm.null;
+
+		if (typeof value === 'number') {
+			return this.vm.newNumber(value);
+		}
+		if (typeof value === 'string') return this.vm.newString(value);
+		if (typeof value === 'boolean') {
+			return value ? this.vm.true : this.vm.false;
+		}
+
+		// Construct a real Date inside the context — JSON round-tripping would
+		// collapse it to an ISO string (via Date.prototype.toJSON).
+		if (value instanceof Date) {
+			const dateResult = this.vm.evalCode(`(new Date(${value.getTime()}))`);
+			if (dateResult.error) {
+				dateResult.error.dispose();
+				return this.vm.undefined;
+			}
+			return dateResult.value;
+		}
+
+		const json = hostValueToJson(value);
+		if (json === 'undefined') return this.vm.undefined;
+
+		const result = this.vm.evalCode(`(${json})`);
+		if (result.error) {
+			result.error.dispose();
+			return this.vm.undefined;
+		}
+		return result.value;
+	}
+
+	/**
+	 * Execute JavaScript code in the QuickJS context.
+	 *
+	 * Mirrors IsolatedVmBridge.execute():
+	 * 1. Register per-call host callbacks (closure-scoped to `data`)
+	 * 2. Build a fresh evaluation context via buildContext(callbacks, timezone)
+	 * 3. Run wrapped code with `this` set to the context
+	 * 4. Reconstruct error sentinels into real Errors
+	 */
+	execute(code: string, data: WorkflowData, options?: ExecuteOptions): unknown {
+		if (!this.initialized || !this.vm || !this.runtime) {
+			throw new Error('Bridge not initialized. Call initialize() first.');
+		}
+
+		try {
+			this.registerCallbacks(data);
+
+			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
+
+			// Set up timeout via interrupt handler
+			const deadline = Date.now() + this.config.timeout;
+			this.runtime.setInterruptHandler(() => Date.now() > deadline);
+
+			const wrappedCode = `
+(function() {
+  var __ctx;
+  try {
+    __ctx = buildContext({
+      getValueAtPath: __getValueAtPathRef,
+      getArrayElement: __getArrayElementRef,
+      callHost: __callHostRef,
+    }, ${timezone});
+  } catch (e) {
+    if (e && e.message) throw e;
+    throw e;
+  }
+  try {
+    var __result = (function() {
+      ${code}
+    }).call(__ctx);
+    return __prepareForTransfer(__result);
+  } catch(e) {
+    if (e && e.__isError) return e;
+    if (e == null) return { __isError: true, name: "Error", message: String(e), stack: "", extra: {} };
+    var extra = {};
+    for (var k in e) {
+      if (Object.prototype.hasOwnProperty.call(e, k) && k !== "name" && k !== "message" && k !== "stack") extra[k] = e[k];
+    }
+    return {
+      __isError: true,
+      name: e.name || "Error",
+      message: e.message || "",
+      stack: e.stack || "",
+      extra: extra
+    };
+  }
+})()`;
+
+			const execResult = this.vm.evalCode(wrappedCode);
+
+			if (execResult.error) {
+				const errDump = this.vm.dump(execResult.error);
+				execResult.error.dispose();
+
+				// buildContext throws on invalid timezone — propagate the original message
+				const errStr = String(
+					typeof errDump === 'object' && errDump !== null
+						? ((errDump as Record<string, unknown>).message ?? errDump)
+						: errDump,
+				);
+				if (errStr.includes('interrupted')) {
+					throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
+				}
+				if (
+					typeof errDump === 'object' &&
+					errDump !== null &&
+					typeof (errDump as Record<string, unknown>).message === 'string'
+				) {
+					throw new Error((errDump as Record<string, unknown>).message as string);
+				}
+				throw new Error(`Expression evaluation failed: ${errStr}`);
+			}
+
+			const rawResult = this.vm.dump(execResult.value);
+			execResult.value.dispose();
+			const result = unwrapSentinels(rawResult);
+
+			if (isErrorSentinel(result)) {
+				throw this.reconstructError(result);
+			}
+
+			this.logger.debug('[QuickJsBridge] Expression executed successfully');
+
+			return result;
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				(error.name === 'ExpressionError' || error.name === 'ExpressionExtensionError')
+			) {
+				throw error;
+			}
+			if (error instanceof TimeoutError || error instanceof MemoryLimitError) {
+				throw error;
+			}
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			if (errorMessage.includes('interrupted')) {
+				throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
+			}
+			if (errorMessage.includes('out of memory') || errorMessage.includes('memory')) {
+				throw new MemoryLimitError(
+					`Expression exceeded memory limit of ${this.config.memoryLimit}MB`,
+					{},
+				);
+			}
+			throw new Error(`Expression evaluation failed: ${errorMessage}`);
+		}
+	}
+
+	private reconstructError(data: ErrorSentinel): Error {
+		const error = new Error(data.message);
+		error.name = data.name || 'Error';
+		if (data.stack) {
+			error.stack = data.stack;
+		}
+		if (data.extra) {
+			Object.assign(error, data.extra);
+		}
+		return error;
+	}
+
+	private evalCodeOrThrow(code: string, label: string): unknown {
+		if (!this.vm) throw new Error('Context not initialized');
+
+		const result = this.vm.evalCode(code);
+		if (result.error) {
+			const errStr = this.vm.dump(result.error);
+			result.error.dispose();
+			throw new Error(`${label} failed: ${String(errStr)}`);
+		}
+		const value = this.vm.dump(result.value);
+		result.value.dispose();
+		return value;
+	}
+
+	async dispose(): Promise<void> {
+		if (this.disposed) return;
+
+		for (const handle of this.callbackHandles) {
+			handle.dispose();
+		}
+		this.callbackHandles = [];
+
+		for (const handle of this.intlHandles) {
+			handle.dispose();
+		}
+		this.intlHandles = [];
+
+		if (this.vm) {
+			this.vm.dispose();
+			this.vm = undefined;
+		}
+		if (this.runtime) {
+			this.runtime.dispose();
+			this.runtime = undefined;
+		}
+
+		this.disposed = true;
+		this.initialized = false;
+
+		this.logger.info('[QuickJsBridge] Disposed');
+	}
+
+	isDisposed(): boolean {
+		return this.disposed;
+	}
+}

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -373,8 +373,8 @@ function dispatchHostCall(rawMsg: unknown, data: WorkflowData): unknown {
  * Like IsolatedVmBridge, callbacks are scoped per-execute() call: the host
  * functions are re-registered each call, so concurrent / nested evaluations
  * see fresh data. The runtime bundle's `buildContext(callbacks, timezone)`
- * is invoked with adapter-shim references that look like ivm.Reference
- * objects (they expose `.applySync()`).
+ * is invoked with the host callback functions directly — the runtime treats
+ * bridge callbacks as plain functions.
  */
 export class QuickJsBridge implements RuntimeBridge {
 	private runtime: import('quickjs-emscripten').QuickJSRuntime | undefined;
@@ -386,9 +386,6 @@ export class QuickJsBridge implements RuntimeBridge {
 
 	// Long-lived host-callback handles (Intl polyfills) — disposed on dispose()
 	private intlHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
-
-	// Per-execute callback handles — disposed on the next execute() and on dispose()
-	private callbackHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
 
 	constructor(config: BridgeConfig = {}) {
 		this.config = {
@@ -838,27 +835,21 @@ export class QuickJsBridge implements RuntimeBridge {
 	}
 
 	/**
-	 * Register per-execute callback handles and create adapter shims that
-	 * make them look like ivm.Reference objects (with `.applySync`).
+	 * Create per-execute callback function handles, closure-scoped to `data`.
 	 *
-	 * `buildContext` (from the runtime bundle) accepts these references
-	 * and uses `.applySync(thisArg, [args], opts)` to invoke them. Since
-	 * QuickJS host functions are just plain functions, we wrap each in
-	 * a JS object with a `.applySync` method that delegates to the
-	 * underlying impl.
+	 * The handles are passed as arguments into the per-call wrapper function
+	 * (see execute()) instead of being set as VM globals: `execute()` can
+	 * re-enter synchronously (e.g. `$evaluateExpression`), and globals would
+	 * let the nested call's callbacks clobber the in-flight outer call's data
+	 * bindings. This mirrors IsolatedVmBridge's closure-scoped `$0`/`$1`/`$2`
+	 * evalClosureSync references.
 	 *
-	 * Callbacks are scoped to a single execute() call: existing callback
-	 * handles are disposed before new ones are registered, so concurrent
-	 * evaluations get fresh closures.
+	 * Callers must dispose the returned handles when the call completes.
 	 */
-	private registerCallbacks(data: WorkflowData): void {
+	private createCallbackHandles(
+		data: WorkflowData,
+	): Array<import('quickjs-emscripten').QuickJSHandle> {
 		if (!this.vm) throw new Error('Context not initialized');
-
-		// Dispose previous callback handles
-		for (const handle of this.callbackHandles) {
-			handle.dispose();
-		}
-		this.callbackHandles = [];
 
 		const vm = this.vm;
 
@@ -871,8 +862,6 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__getValueAtPathImpl', getValueFn);
-		this.callbackHandles.push(getValueFn);
 
 		const getArrayFn = vm.newFunction('__getArrayElementImpl', (pathHandle, indexHandle) => {
 			const pathArr = vm.dump(pathHandle) as string[];
@@ -884,8 +873,6 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__getArrayElementImpl', getArrayFn);
-		this.callbackHandles.push(getArrayFn);
 
 		const callHostFn = vm.newFunction('__callHostImpl', (msgHandle) => {
 			const rawMsg = vm.dump(msgHandle);
@@ -896,35 +883,8 @@ export class QuickJsBridge implements RuntimeBridge {
 				return this.hostValueToQuickJSHandle(serializeError(err));
 			}
 		});
-		vm.setProp(vm.global, '__callHostImpl', callHostFn);
-		this.callbackHandles.push(callHostFn);
 
-		// Create adapter shims that wrap the host fns to look like ivm.Reference.
-		// buildContext receives these and calls .applySync(thisArg, [args], opts).
-		const shimCode = `
-			globalThis.__getValueAtPathRef = {
-				applySync: function(thisArg, args, opts) {
-					return __getValueAtPathImpl(args[0]);
-				}
-			};
-			globalThis.__getArrayElementRef = {
-				applySync: function(thisArg, args, opts) {
-					return __getArrayElementImpl(args[0], args[1]);
-				}
-			};
-			globalThis.__callHostRef = {
-				applySync: function(thisArg, args, opts) {
-					return __callHostImpl(args[0]);
-				}
-			};
-		`;
-		const result = this.vm.evalCode(shimCode);
-		if (result.error) {
-			const errorStr = this.vm.dump(result.error);
-			result.error.dispose();
-			throw new Error(`Failed to register callbacks: ${String(errorStr)}`);
-		}
-		result.value.dispose();
+		return [getValueFn, getArrayFn, callHostFn];
 	}
 
 	/**
@@ -983,28 +943,27 @@ export class QuickJsBridge implements RuntimeBridge {
 			throw new Error('Bridge not initialized. Call initialize() first.');
 		}
 
+		const callbackHandles = this.createCallbackHandles(data);
+		let wrapperFn: import('quickjs-emscripten').QuickJSHandle | undefined;
 		try {
-			this.registerCallbacks(data);
-
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
 
 			// Set up timeout via interrupt handler
 			const deadline = Date.now() + this.config.timeout;
 			this.runtime.setInterruptHandler(() => Date.now() > deadline);
 
+			// The callback impls arrive as function arguments (closure-scoped to
+			// this call), never as globals — see createCallbackHandles(). The
+			// runtime expects plain functions (host-side ivm.Callback instances in
+			// the isolated-vm bridge); QuickJS host functions already are plain
+			// functions in-vm, so they pass through directly.
 			const wrappedCode = `
-(function() {
-  var __ctx;
-  try {
-    __ctx = buildContext({
-      getValueAtPath: __getValueAtPathRef,
-      getArrayElement: __getArrayElementRef,
-      callHost: __callHostRef,
-    }, ${timezone});
-  } catch (e) {
-    if (e && e.message) throw e;
-    throw e;
-  }
+(function(__getValueAtPathImpl, __getArrayElementImpl, __callHostImpl) {
+  var __ctx = buildContext({
+    getValueAtPath: __getValueAtPathImpl,
+    getArrayElement: __getArrayElementImpl,
+    callHost: __callHostImpl,
+  }, ${timezone});
   try {
     var __result = (function() {
       ${code}
@@ -1025,9 +984,17 @@ export class QuickJsBridge implements RuntimeBridge {
       extra: extra
     };
   }
-})()`;
+})`;
 
-			const execResult = this.vm.evalCode(wrappedCode);
+			const wrapperResult = this.vm.evalCode(wrappedCode);
+			if (wrapperResult.error) {
+				const errDump = this.vm.dump(wrapperResult.error);
+				wrapperResult.error.dispose();
+				throw new Error(`Expression compilation failed: ${String(errDump)}`);
+			}
+			wrapperFn = wrapperResult.value;
+
+			const execResult = this.vm.callFunction(wrapperFn, this.vm.undefined, ...callbackHandles);
 
 			if (execResult.error) {
 				const errDump = this.vm.dump(execResult.error);
@@ -1084,6 +1051,11 @@ export class QuickJsBridge implements RuntimeBridge {
 				);
 			}
 			throw new Error(`Expression evaluation failed: ${errorMessage}`);
+		} finally {
+			wrapperFn?.dispose();
+			for (const handle of callbackHandles) {
+				handle.dispose();
+			}
 		}
 	}
 
@@ -1115,11 +1087,6 @@ export class QuickJsBridge implements RuntimeBridge {
 
 	async dispose(): Promise<void> {
 		if (this.disposed) return;
-
-		for (const handle of this.callbackHandles) {
-			handle.dispose();
-		}
-		this.callbackHandles = [];
 
 		for (const handle of this.intlHandles) {
 			handle.dispose();

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -283,7 +283,19 @@ function getArrayElement(data: Record<string, unknown>, pathArr: string[], index
 		return undefined;
 	}
 
+	// Reject non-integer / negative indices so a crafted "index" can't read off
+	// the prototype chain. Mirrors IsolatedVmBridge.getArrayElement.
+	if (!Number.isInteger(index) || index < 0) {
+		return undefined;
+	}
+
 	const element = arr[index];
+
+	// Functions must never cross the boundary — resolve as undefined, matching
+	// getValueAtPath and IsolatedVmBridge (invariant: host-fn-shadowing.test.ts).
+	if (typeof element === 'function') {
+		return undefined;
+	}
 
 	// Dates have no enumerable own keys; pass through instead of
 	// marshaling as an empty object.
@@ -386,6 +398,12 @@ export class QuickJsBridge implements RuntimeBridge {
 	// Long-lived host-callback handles (Intl polyfills) — disposed on dispose()
 	private intlHandles: Array<import('quickjs-emscripten').QuickJSHandle> = [];
 
+	// Wall-clock deadlines of the execute() calls currently in flight, outer to
+	// inner. execute() can re-enter (e.g. $evaluateExpression), and the runtime
+	// has a single interrupt handler; the handler interrupts once the earliest
+	// deadline passes, so a nested call cannot extend the outer call's budget.
+	private deadlines: number[] = [];
+
 	constructor(config: BridgeConfig = {}) {
 		this.config = {
 			...DEFAULT_BRIDGE_CONFIG,
@@ -406,6 +424,11 @@ export class QuickJsBridge implements RuntimeBridge {
 
 		// Create context
 		this.vm = this.runtime.newContext();
+
+		// Install the interrupt handler once. It reads the live deadline stack, so
+		// nested execute() calls share one budget: the earliest deadline wins.
+		// Math.min() of an empty stack is Infinity, so an idle runtime never fires.
+		this.runtime.setInterruptHandler(() => Date.now() > Math.min(...this.deadlines));
 
 		// Set up 'global' / 'globalThis' self-reference
 		const globalHandle = this.vm.global;
@@ -944,12 +967,12 @@ export class QuickJsBridge implements RuntimeBridge {
 
 		const callbackHandles = this.createCallbackHandles(data);
 		let wrapperFn: import('quickjs-emscripten').QuickJSHandle | undefined;
+		// Push this call's deadline; the interrupt handler (set in initialize)
+		// interrupts on the earliest in-flight deadline. Popped in finally so a
+		// nested call can't leave the outer budget extended.
+		this.deadlines.push(Date.now() + this.config.timeout);
 		try {
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
-
-			// Set up timeout via interrupt handler
-			const deadline = Date.now() + this.config.timeout;
-			this.runtime.setInterruptHandler(() => Date.now() > deadline);
 
 			// The callback impls arrive as function arguments (closure-scoped to
 			// this call), never as globals — see createCallbackHandles(). The
@@ -1051,6 +1074,7 @@ export class QuickJsBridge implements RuntimeBridge {
 			}
 			throw new Error(`Expression evaluation failed: ${errorMessage}`);
 		} finally {
+			this.deadlines.pop();
 			wrapperFn?.dispose();
 			for (const handle of callbackHandles) {
 				handle.dispose();

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -1138,12 +1138,23 @@ export class QuickJsBridge implements RuntimeBridge {
 			throw new Error('Bridge not initialized. Call initialize() first.');
 		}
 
+		// A nested call runs on what is left of the configured timeout, so the
+		// chain shares one budget (mirrors IsolatedVmBridge). A configured
+		// timeout of 0 means "no limit", so there is nothing to share.
+		const elapsedMs = options?.elapsedMs ?? 0;
+		const nested = elapsedMs > 0 && this.config.timeout > 0;
+		let timeout = this.config.timeout;
+		if (nested) {
+			timeout = Math.trunc(this.config.timeout - elapsedMs);
+			if (timeout <= 0) throw this.timeoutError(true);
+		}
+
 		const callbackHandles = this.createCallbackHandles(data);
 		let wrapperFn: import('quickjs-emscripten').QuickJSHandle | undefined;
 		// Push this call's deadline; the interrupt handler (set in initialize)
 		// interrupts on the earliest in-flight deadline. Popped in finally so a
 		// nested call can't leave the outer budget extended.
-		this.deadlines.push(Date.now() + this.config.timeout);
+		this.deadlines.push(Date.now() + timeout);
 		try {
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
 
@@ -1201,7 +1212,7 @@ export class QuickJsBridge implements RuntimeBridge {
 						: errDump,
 				);
 				if (errStr.includes('interrupted')) {
-					throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
+					throw this.timeoutError(nested);
 				}
 				if (
 					typeof errDump === 'object' &&
@@ -1236,7 +1247,7 @@ export class QuickJsBridge implements RuntimeBridge {
 			}
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			if (errorMessage.includes('interrupted')) {
-				throw new TimeoutError(`Expression timed out after ${this.config.timeout}ms`, {});
+				throw this.timeoutError(nested);
 			}
 			if (errorMessage.includes('out of memory') || errorMessage.includes('memory')) {
 				throw new MemoryLimitError(
@@ -1252,6 +1263,19 @@ export class QuickJsBridge implements RuntimeBridge {
 				handle.dispose();
 			}
 		}
+	}
+
+	/**
+	 * Always names the configured limit, never the reduced budget a nested call
+	 * ran on — reporting "timed out after 137ms" would misstate the limit.
+	 */
+	private timeoutError(nested: boolean): TimeoutError {
+		return new TimeoutError(
+			nested
+				? `Nested expressions timed out after sharing the ${this.config.timeout}ms limit`
+				: `Expression timed out after ${this.config.timeout}ms`,
+			{},
+		);
 	}
 
 	private reconstructError(data: ErrorSentinel): Error {

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -798,10 +798,14 @@ export class QuickJsBridge implements RuntimeBridge {
 	}
 	var DATE_COMPONENTS = ['weekday', 'year', 'month', 'day'];
 	var TIME_COMPONENTS = ['dayPeriod', 'hour', 'minute', 'second', 'fractionalSecondDigits'];
-	// ToDateTimeOptions (ECMA-402 sec. 12): when options carry none of the
-	// method's required components (and no dateStyle/timeStyle), fill in the
-	// method's numeric defaults so e.g. toLocaleTimeString() shows a time.
-	function toDateTimeOptions(options, requiredKeys, addDate, addTime) {
+	// ToDateTimeOptions (ECMA-402 sec. 12): reject the style option the method
+	// doesn't cover (as V8 does), and when options carry none of the method's
+	// required components (and no dateStyle/timeStyle), fill in the method's
+	// numeric defaults so e.g. toLocaleTimeString() shows a time.
+	function toDateTimeOptions(options, requiredKeys, addDate, addTime, rejectedStyle) {
+		if (rejectedStyle && options && options[rejectedStyle] !== undefined) {
+			throw new TypeError('Invalid option : ' + rejectedStyle);
+		}
 		var merged = {};
 		for (var k in options || {}) merged[k] = options[k];
 		if (merged.dateStyle !== undefined || merged.timeStyle !== undefined) return merged;
@@ -815,10 +819,10 @@ export class QuickJsBridge implements RuntimeBridge {
 		return new DateTimeFormat(locales, toDateTimeOptions(options, ANY_COMPONENTS, true, true)).format(this);
 	};
 	Date.prototype.toLocaleDateString = function(locales, options) {
-		return new DateTimeFormat(locales, toDateTimeOptions(options, DATE_COMPONENTS, true, false)).format(this);
+		return new DateTimeFormat(locales, toDateTimeOptions(options, DATE_COMPONENTS, true, false, 'timeStyle')).format(this);
 	};
 	Date.prototype.toLocaleTimeString = function(locales, options) {
-		return new DateTimeFormat(locales, toDateTimeOptions(options, TIME_COMPONENTS, false, true)).format(this);
+		return new DateTimeFormat(locales, toDateTimeOptions(options, TIME_COMPONENTS, false, true, 'dateStyle')).format(this);
 	};
 })();
 `;

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -856,6 +856,11 @@ export class QuickJsBridge implements RuntimeBridge {
 	};
 	function wrapSpecialValues(v) {
 		if (v === null || v === undefined) return v;
+		// Functions and Promises must not leave the sandbox as results.
+		// isolated-vm's structured clone rejects them; match its error.
+		if (typeof v === 'function') {
+			throw new TypeError(String(v) + ' could not be cloned');
+		}
 		if (v instanceof Date) {
 			// Invalid Dates have no ISO string; '' rebuilds an Invalid Date on the host.
 			return { __isDate: true, __isoString: isNaN(v.getTime()) ? '' : v.toISOString() };
@@ -864,6 +869,9 @@ export class QuickJsBridge implements RuntimeBridge {
 			return { __isNaN: true };
 		}
 		if (typeof v !== 'object') return v;
+		if (v instanceof Promise) {
+			throw new TypeError('#<Promise> could not be cloned');
+		}
 		if (v instanceof Error) {
 			var errExtra = {};
 			var errKeys = Object.keys(v);

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -155,6 +155,56 @@ function unwrapSentinels(value: unknown): unknown {
 	return result;
 }
 
+/** Keys the transfer encoding reserves — keep in sync with the guest-side wrappers in injectTransferWrapper(). */
+const TRANSFER_MARKER_KEYS = new Set([
+	'__isDate',
+	'__isNaN',
+	'__isErrorValue',
+	'__isMap',
+	'__isSet',
+	'__isEscaped',
+]);
+
+/**
+ * Recursively wrap host values that JSON.stringify would flatten (Date, NaN,
+ * Map, Set) into the same sentinel format the guest transfer wrapper uses,
+ * escaping user objects whose keys collide with the markers. The guest
+ * rebuilds real instances via __unwrapFromHost (see injectTransferWrapper),
+ * so host-callback results match what isolated-vm's structured clone delivers.
+ */
+function wrapSpecialValuesForGuest(value: unknown): unknown {
+	if (value === null || value === undefined) return value;
+	if (value instanceof Date) {
+		// Invalid Dates have no ISO string; '' rebuilds an Invalid Date in the guest.
+		return { __isDate: true, __isoString: isNaN(value.getTime()) ? '' : value.toISOString() };
+	}
+	if (typeof value === 'number' && Number.isNaN(value)) return { __isNaN: true };
+	if (typeof value !== 'object') return value;
+	if (value instanceof Map) {
+		return {
+			__isMap: true,
+			__entries: [...value.entries()].map(([k, v]) => [
+				wrapSpecialValuesForGuest(k),
+				wrapSpecialValuesForGuest(v),
+			]),
+		};
+	}
+	if (value instanceof Set) {
+		return { __isSet: true, __values: [...value.values()].map(wrapSpecialValuesForGuest) };
+	}
+	if (Array.isArray(value)) return value.map(wrapSpecialValuesForGuest);
+	// Error sentinels are already in transfer shape — leave them intact.
+	if (isErrorSentinel(value)) return value;
+	const record = value as Record<string, unknown>;
+	const result: Record<string, unknown> = {};
+	let collides = false;
+	for (const key of Object.keys(record)) {
+		if (TRANSFER_MARKER_KEYS.has(key)) collides = true;
+		result[key] = wrapSpecialValuesForGuest(record[key]);
+	}
+	return collides ? { __isEscaped: true, __value: result } : result;
+}
+
 /**
  * Serialize an error into a transferable metadata object.
  *
@@ -207,15 +257,15 @@ async function readRuntimeBundle(): Promise<string> {
  * Only objects/arrays reach this — primitives (including top-level NaN via
  * newNumber) and Date are handled directly by the caller. Everything else
  * (lazy-proxy metadata, Intl outputs, typed-RPC results, error-sentinel
- * extras) goes through JSON.stringify, so a nested NaN marshals as null and a
- * nested Date as an ISO string. isolated-vm keeps both via structured clone;
- * this is a known divergence for nested values inside RPC results.
+ * extras) is sentinel-wrapped first so nested Date/NaN/Map/Set survive the
+ * JSON round-trip and rebuild in the guest via __unwrapFromHost — matching
+ * what isolated-vm's structured clone delivers.
  */
 function hostValueToJson(value: unknown): string {
 	if (value === undefined) return 'undefined';
 	if (value === null) return 'null';
 	try {
-		return JSON.stringify(value);
+		return JSON.stringify(wrapSpecialValuesForGuest(value));
 	} catch {
 		return 'undefined';
 	}
@@ -751,7 +801,9 @@ export class QuickJsBridge implements RuntimeBridge {
 	 * Wrap __prepareForTransfer so values that don't survive vm.dump()
 	 * (Date, NaN, Map, Set, Error) are converted to sentinel objects.
 	 * The host post-processes vm.dump() output to reconstruct real instances
-	 * via unwrapSentinels().
+	 * via unwrapSentinels(). Also injects __unwrapFromHost, the guest-side
+	 * reverse: it rebuilds instances from the sentinels the host's
+	 * wrapSpecialValuesForGuest() emits for callback results.
 	 */
 	private injectTransferWrapper(): void {
 		if (!this.vm) throw new Error('Context not initialized');
@@ -818,6 +870,40 @@ export class QuickJsBridge implements RuntimeBridge {
 		// misreading them as sentinels.
 		return collides ? { __isEscaped: true, __value: result } : result;
 	}
+
+	// Reverse direction: rebuild real instances from the sentinels the host's
+	// wrapSpecialValuesForGuest() produces for callback results.
+	globalThis.__unwrapFromHost = function unwrapFromHost(v) {
+		if (v === null || typeof v !== 'object') return v;
+		// Error sentinels stay as-is — the in-context proxy detects and throws them.
+		if (v.__isError === true) return v;
+		if (v.__isDate === true) return new Date(v.__isoString);
+		if (v.__isNaN === true) return NaN;
+		if (v.__isMap === true) {
+			var m = new Map();
+			for (var i = 0; i < v.__entries.length; i++) {
+				m.set(unwrapFromHost(v.__entries[i][0]), unwrapFromHost(v.__entries[i][1]));
+			}
+			return m;
+		}
+		if (v.__isSet === true) {
+			var s = new Set();
+			for (var j = 0; j < v.__values.length; j++) s.add(unwrapFromHost(v.__values[j]));
+			return s;
+		}
+		if (v.__isEscaped === true) {
+			var inner = v.__value;
+			var out = {};
+			var ekeys = Object.keys(inner);
+			for (var e = 0; e < ekeys.length; e++) out[ekeys[e]] = unwrapFromHost(inner[ekeys[e]]);
+			return out;
+		}
+		if (Array.isArray(v)) return v.map(unwrapFromHost);
+		var result = {};
+		var keys = Object.keys(v);
+		for (var n = 0; n < keys.length; n++) result[keys[n]] = unwrapFromHost(v[keys[n]]);
+		return result;
+	};
 })();
 `;
 
@@ -979,7 +1065,7 @@ export class QuickJsBridge implements RuntimeBridge {
 		const json = hostValueToJson(value);
 		if (json === 'undefined') return this.vm.undefined;
 
-		const result = this.vm.evalCode(`(${json})`);
+		const result = this.vm.evalCode(`__unwrapFromHost(${json})`);
 		if (result.error) {
 			result.error.dispose();
 			return this.vm.undefined;

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -781,6 +781,45 @@ export class QuickJsBridge implements RuntimeBridge {
 		ListFormat: ListFormat,
 		Locale: function Locale(tag) { this.baseName = tag; this.language = tag.split('-')[0]; }
 	};
+
+	// QuickJS's built-in toLocale* methods are locale-unaware (no ECMA-402) and
+	// ignore locales/options. Route them through the polyfill so they format on
+	// the host, like the spec routes them through NumberFormat/DateTimeFormat.
+	Number.prototype.toLocaleString = function(locales, options) {
+		return new NumberFormat(locales, options).format(Number(this));
+	};
+
+	function hasAny(options, keys) {
+		if (!options) return false;
+		for (var i = 0; i < keys.length; i++) {
+			if (options[keys[i]] !== undefined) return true;
+		}
+		return false;
+	}
+	var DATE_COMPONENTS = ['weekday', 'year', 'month', 'day'];
+	var TIME_COMPONENTS = ['dayPeriod', 'hour', 'minute', 'second', 'fractionalSecondDigits'];
+	// ToDateTimeOptions (ECMA-402 sec. 12): when options carry none of the
+	// method's required components (and no dateStyle/timeStyle), fill in the
+	// method's numeric defaults so e.g. toLocaleTimeString() shows a time.
+	function toDateTimeOptions(options, requiredKeys, addDate, addTime) {
+		var merged = {};
+		for (var k in options || {}) merged[k] = options[k];
+		if (merged.dateStyle !== undefined || merged.timeStyle !== undefined) return merged;
+		if (hasAny(options, requiredKeys)) return merged;
+		if (addDate) { merged.year = 'numeric'; merged.month = 'numeric'; merged.day = 'numeric'; }
+		if (addTime) { merged.hour = 'numeric'; merged.minute = 'numeric'; merged.second = 'numeric'; }
+		return merged;
+	}
+	var ANY_COMPONENTS = DATE_COMPONENTS.concat(TIME_COMPONENTS);
+	Date.prototype.toLocaleString = function(locales, options) {
+		return new DateTimeFormat(locales, toDateTimeOptions(options, ANY_COMPONENTS, true, true)).format(this);
+	};
+	Date.prototype.toLocaleDateString = function(locales, options) {
+		return new DateTimeFormat(locales, toDateTimeOptions(options, DATE_COMPONENTS, true, false)).format(this);
+	};
+	Date.prototype.toLocaleTimeString = function(locales, options) {
+		return new DateTimeFormat(locales, toDateTimeOptions(options, TIME_COMPONENTS, false, true)).format(this);
+	};
 })();
 `;
 

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -25,12 +25,11 @@ const BUNDLE_RELATIVE_PATH = path.join('dist', 'bundle', 'runtime.iife.js');
 // Sentinel helpers
 //
 // QuickJS's vm.dump() loses Date / NaN / Map / Set / Error type identity
-// (Date → ISO string, NaN → null, Map/Set → plain object, Error → plain
-// object without prototype). Inside the QuickJS context we wrap those
-// values as sentinel objects ({ __isDate: true, __isoString: ... } etc.)
-// before they cross the boundary, then unwrap them on the host side.
-// The isolated-vm bridge does NOT need this — structured clone preserves
-// type identity natively.
+// (Date → ISO string, NaN → null, Map/Set/Error → empty plain object). Inside
+// the QuickJS context we wrap those values as sentinel objects
+// ({ __isDate: true, __isoString: ... } etc.) before they cross the boundary,
+// then unwrap them on the host side. The isolated-vm bridge does NOT need this
+// — structured clone preserves type identity natively.
 // ============================================================================
 
 function isDateSentinel(value: unknown): value is { __isDate: true; __isoString: string } {
@@ -125,7 +124,8 @@ function unwrapSentinels(value: unknown): unknown {
 		return new Set(value.__values.map(unwrapSentinels));
 	}
 	if (Array.isArray(value)) return value.map(unwrapSentinels);
-	// Don't recurse into error sentinels
+	// Pass error sentinels through untouched — execute() detects them after
+	// unwrapping and reconstructs the Error on the host.
 	if (isErrorSentinel(value)) return value;
 	const result: Record<string, unknown> = {};
 	for (const key of Object.keys(value as Record<string, unknown>)) {
@@ -138,9 +138,10 @@ function unwrapSentinels(value: unknown): unknown {
  * Serialize an error into a transferable metadata object.
  *
  * Host-side callbacks (getValueAtPath, etc.) catch errors and return this
- * sentinel instead of letting the error cross the sandbox boundary (which
- * strips custom class identity and properties). The sandbox-side proxy
- * detects __isError and reconstructs a proper Error to throw.
+ * sentinel instead of letting the error cross the boundary (which strips
+ * custom class identity and properties). The in-context proxy detects
+ * __isError and throws the sentinel; the host reconstructs a real Error
+ * after it round-trips back (see execute() / reconstructError).
  */
 function serializeError(err: unknown): ErrorSentinel {
 	if (err instanceof Error) {
@@ -160,7 +161,9 @@ function serializeError(err: unknown): ErrorSentinel {
 
 /**
  * Read the runtime IIFE bundle by walking up from `__dirname` until
- * `dist/bundle/runtime.iife.js` is found.
+ * `dist/bundle/runtime.iife.js` is found. Walking up (rather than a fixed
+ * relative path) works from either compiled output dir — `dist/cjs/bridge/`
+ * and `dist/esm/bridge/` sit at different depths from the bundle.
  */
 async function readRuntimeBundle(): Promise<string> {
 	let dir = __dirname;
@@ -181,9 +184,11 @@ async function readRuntimeBundle(): Promise<string> {
  * the string "undefined".
  *
  * Only objects/arrays reach this — primitives (including top-level NaN via
- * newNumber) and Date are handled directly by the caller. Nested NaN numbers
- * marshal as null (standard JSON.stringify behaviour); the only shapes that
- * cross here (lazy-proxy key/length metadata, Intl outputs) never contain one.
+ * newNumber) and Date are handled directly by the caller. Everything else
+ * (lazy-proxy metadata, Intl outputs, typed-RPC results, error-sentinel
+ * extras) goes through JSON.stringify, so a nested NaN marshals as null and a
+ * nested Date as an ISO string. isolated-vm keeps both via structured clone;
+ * this is a known divergence for nested values inside RPC results.
  */
 function hostValueToJson(value: unknown): string {
 	if (value === undefined) return 'undefined';
@@ -224,9 +229,8 @@ function getValueAtPath(data: Record<string, unknown>, pathArr: string[]): unkno
 		}
 	}
 
-	// Functions are not reachable via the lazy-proxy data path — return
-	// undefined unconditionally, matching IsolatedVmBridge (see the invariant
-	// documented in __tests__/host-fn-shadowing.test.ts).
+	// Functions must never cross the boundary — resolve them as undefined,
+	// matching IsolatedVmBridge (invariant: __tests__/host-fn-shadowing.test.ts).
 	if (typeof value === 'function') {
 		return undefined;
 	}
@@ -381,11 +385,10 @@ function dispatchHostCall(rawMsg: unknown, data: WorkflowData): unknown {
  * - Timeout enforcement via interrupt handler
  * - Complete isolation from host process
  *
- * Like IsolatedVmBridge, callbacks are scoped per-execute() call: the host
- * functions are re-registered each call, so concurrent / nested evaluations
- * see fresh data. The runtime bundle's `buildContext(callbacks, timezone)`
- * is invoked with the host callback functions directly — the runtime treats
- * bridge callbacks as plain functions.
+ * Callbacks are scoped per execute() call (see createCallbackHandles), so
+ * concurrent / nested evaluations see fresh data. The runtime treats bridge
+ * callbacks as plain functions, so `buildContext(callbacks, timezone)` gets
+ * the host callback functions directly.
  */
 export class QuickJsBridge implements RuntimeBridge {
 	private runtime: import('quickjs-emscripten').QuickJSRuntime | undefined;
@@ -422,7 +425,6 @@ export class QuickJsBridge implements RuntimeBridge {
 		this.runtime = QuickJS.newRuntime();
 		this.runtime.setMemoryLimit(this.config.memoryLimit * 1024 * 1024);
 
-		// Create context
 		this.vm = this.runtime.newContext();
 
 		// Install the interrupt handler once. It reads the live deadline stack, so
@@ -444,10 +446,9 @@ export class QuickJsBridge implements RuntimeBridge {
 		// Wrap __prepareForTransfer to mark Date/NaN/Map/Set/Error so they survive vm.dump()
 		this.injectTransferWrapper();
 
-		// Inject E() error handler matching the new IsolatedVmBridge semantics
+		// Inject E() error handler matching IsolatedVmBridge's E() semantics
 		this.injectErrorHandler();
 
-		// Verify proxy system loaded correctly
 		this.verifyProxySystem();
 
 		this.initialized = true;
@@ -773,7 +774,7 @@ export class QuickJsBridge implements RuntimeBridge {
 			return { __isSet: true, __values: values };
 		}
 		if (Array.isArray(v)) return v.map(wrapSpecialValues);
-		// Don't recurse into error sentinels
+		// Error sentinels are already in transfer shape — leave them intact.
 		if (v.__isError) return v;
 		var result = {};
 		var keys = Object.keys(v);
@@ -955,7 +956,7 @@ export class QuickJsBridge implements RuntimeBridge {
 	 * Execute JavaScript code in the QuickJS context.
 	 *
 	 * Mirrors IsolatedVmBridge.execute():
-	 * 1. Register per-call host callbacks (closure-scoped to `data`)
+	 * 1. Create per-call host callbacks scoped to `data` (createCallbackHandles)
 	 * 2. Build a fresh evaluation context via buildContext(callbacks, timezone)
 	 * 3. Run wrapped code with `this` set to the context
 	 * 4. Reconstruct error sentinels into real Errors
@@ -974,11 +975,10 @@ export class QuickJsBridge implements RuntimeBridge {
 		try {
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
 
-			// The callback impls arrive as function arguments (closure-scoped to
-			// this call), never as globals — see createCallbackHandles(). The
-			// runtime expects plain functions (host-side ivm.Callback instances in
-			// the isolated-vm bridge); QuickJS host functions already are plain
-			// functions in-vm, so they pass through directly.
+			// The callback impls arrive as function arguments (scoped to this call),
+			// never as globals — see createCallbackHandles(). The runtime calls them
+			// as plain functions; the isolated-vm bridge wires ivm.Callback there,
+			// while QuickJS host functions are already plain functions in the context.
 			const wrappedCode = `
 (function(__getValueAtPathImpl, __getArrayElementImpl, __callHostImpl) {
   var __ctx = buildContext({

--- a/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/quickjs-bridge.ts
@@ -88,6 +88,16 @@ function isErrorSentinel(value: unknown): value is ErrorSentinel {
 	);
 }
 
+function isEscapedObject(
+	value: unknown,
+): value is { __isEscaped: true; __value: Record<string, unknown> } {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as Record<string, unknown>).__isEscaped === true
+	);
+}
+
 /**
  * Recursively reconstruct Date objects, NaN values, Map, and Set from
  * sentinels produced by the QuickJS-side __prepareForTransfer wrapper.
@@ -95,6 +105,17 @@ function isErrorSentinel(value: unknown): value is ErrorSentinel {
 function unwrapSentinels(value: unknown): unknown {
 	if (value === null || value === undefined) return value;
 	if (typeof value !== 'object') return value;
+	// Escaped user objects: keys collided with the sentinel markers, so the
+	// guest wrapped them (see injectTransferWrapper). Unwrap the values but
+	// treat the object itself as plain data.
+	if (isEscapedObject(value)) {
+		const inner = value.__value;
+		const result: Record<string, unknown> = {};
+		for (const key of Object.keys(inner)) {
+			result[key] = unwrapSentinels(inner[key]);
+		}
+		return result;
+	}
 	if (isDateSentinel(value)) return new Date(value.__isoString);
 	if (isNaNSentinel(value)) return NaN;
 	if (isErrorValueSentinel(value)) {
@@ -416,6 +437,8 @@ export class QuickJsBridge implements RuntimeBridge {
 	}
 
 	async initialize(): Promise<void> {
+		// Disposal is terminal (matches IsolatedVmBridge, whose isolate cannot be revived).
+		if (this.disposed) throw new Error('Bridge has been disposed and cannot be reinitialized.');
 		if (this.initialized) return;
 
 		const { getQuickJS } = await getQuickJSModule();
@@ -743,7 +766,8 @@ export class QuickJsBridge implements RuntimeBridge {
 	function wrapSpecialValues(v) {
 		if (v === null || v === undefined) return v;
 		if (v instanceof Date) {
-			return { __isDate: true, __isoString: v.toISOString() };
+			// Invalid Dates have no ISO string; '' rebuilds an Invalid Date on the host.
+			return { __isDate: true, __isoString: isNaN(v.getTime()) ? '' : v.toISOString() };
 		}
 		if (typeof v === 'number' && isNaN(v)) {
 			return { __isNaN: true };
@@ -778,10 +802,21 @@ export class QuickJsBridge implements RuntimeBridge {
 		if (v.__isError) return v;
 		var result = {};
 		var keys = Object.keys(v);
+		var collides = false;
 		for (var i = 0; i < keys.length; i++) {
-			result[keys[i]] = wrapSpecialValues(v[keys[i]]);
+			var key = keys[i];
+			if (
+				key === '__isDate' || key === '__isNaN' || key === '__isErrorValue' ||
+				key === '__isMap' || key === '__isSet' || key === '__isEscaped'
+			) {
+				collides = true;
+			}
+			result[key] = wrapSpecialValues(v[key]);
 		}
-		return result;
+		// User objects whose keys collide with transfer markers are escaped so
+		// the host returns them as plain data (as isolated-vm does) instead of
+		// misreading them as sentinels.
+		return collides ? { __isEscaped: true, __value: result } : result;
 	}
 })();
 `;

--- a/packages/@n8n/expression-runtime/src/index.ts
+++ b/packages/@n8n/expression-runtime/src/index.ts
@@ -5,6 +5,10 @@ export { ExpressionEvaluator } from './evaluator/expression-evaluator';
 // so this value re-export does NOT pull in the native binary at import time.
 export { IsolatedVmBridge } from './bridge/isolated-vm-bridge';
 
+// QuickJsBridge lazy-loads quickjs-emscripten internally; importing this
+// value does NOT pull in the WASM module at import time.
+export { QuickJsBridge } from './bridge/quickjs-bridge';
+
 // Types
 export type {
 	IExpressionEvaluator,

--- a/packages/@n8n/expression-runtime/vitest.config.ts
+++ b/packages/@n8n/expression-runtime/vitest.config.ts
@@ -1,7 +1,31 @@
-import { createVitestConfig } from '@n8n/vitest-config/node';
+import { defineConfig } from 'vitest/config';
+import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
-export default createVitestConfig({
+const { reporters, outputFile, ...sharedTestConfig } = createBaseInlineConfig({
 	coverage: {
 		exclude: ['dist/**', 'bundle/**', '**/*.test.ts', '**/*.config.ts'],
+	},
+});
+
+export default defineConfig({
+	test: {
+		reporters,
+		outputFile,
+		projects: [
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'isolated-vm-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'isolated-vm' },
+				},
+			},
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'quickjs-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'quickjs' },
+				},
+			},
+		],
 	},
 });

--- a/packages/@n8n/expression-runtime/vitest.config.ts
+++ b/packages/@n8n/expression-runtime/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
 const { reporters, outputFile, ...sharedTestConfig } = createBaseInlineConfig({
@@ -6,6 +6,15 @@ const { reporters, outputFile, ...sharedTestConfig } = createBaseInlineConfig({
 		exclude: ['dist/**', 'bundle/**', '**/*.test.ts', '**/*.config.ts'],
 	},
 });
+
+// Only these suites vary by engine (they build the bridge from N8N_EXPRESSION_ENGINE
+// via test-bridge). Everything else is engine-independent and runs once in the
+// default project instead of twice, once per engine.
+const ENGINE_AWARE = [
+	'**/integration.test.ts',
+	'**/typed-rpc.test.ts',
+	'**/host-fn-shadowing.test.ts',
+];
 
 export default defineConfig({
 	test: {
@@ -15,7 +24,15 @@ export default defineConfig({
 			{
 				test: {
 					...sharedTestConfig,
+					name: 'default',
+					exclude: [...defaultExclude, ...ENGINE_AWARE],
+				},
+			},
+			{
+				test: {
+					...sharedTestConfig,
 					name: 'isolated-vm-engine',
+					include: ENGINE_AWARE,
 					env: { N8N_EXPRESSION_ENGINE: 'isolated-vm' },
 				},
 			},
@@ -23,6 +40,7 @@ export default defineConfig({
 				test: {
 					...sharedTestConfig,
 					name: 'quickjs-engine',
+					include: ENGINE_AWARE,
 					env: { N8N_EXPRESSION_ENGINE: 'quickjs' },
 				},
 			},

--- a/packages/@n8n/expression-runtime/vitest.config.ts
+++ b/packages/@n8n/expression-runtime/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
 					...sharedTestConfig,
 					name: 'isolated-vm-engine',
 					include: ENGINE_AWARE,
-					env: { N8N_EXPRESSION_ENGINE: 'isolated-vm' },
+					env: { N8N_EXPRESSION_ENGINE: 'vm' },
 				},
 			},
 			{

--- a/packages/@n8n/node-engine-compatibility/src/__tests__/v1-step-executor.test.ts
+++ b/packages/@n8n/node-engine-compatibility/src/__tests__/v1-step-executor.test.ts
@@ -44,6 +44,17 @@ describe('V1StepExecutor', () => {
 		}
 	});
 
+	it('accepts the quickjs expression engine', async () => {
+		vi.spyOn(Expression, 'getActiveImplementation').mockReturnValue('quickjs');
+		try {
+			const graph = graphWith('test.echoParam', { message: 'hi' });
+			const result = await testStepExecutor(graph).execute(stepRequest(graph, 'n', items({})));
+			expect(result.outputs).toEqual([[{ json: { message: 'hi' } }]]);
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+
 	it('resolves `getNodeParameter` per item', async () => {
 		const graph = graphWith('test.echoParam', { message: 'hi' });
 		const result = await testStepExecutor(graph).execute(

--- a/packages/@n8n/node-engine-compatibility/src/errors.ts
+++ b/packages/@n8n/node-engine-compatibility/src/errors.ts
@@ -74,7 +74,7 @@ export class UnsupportedNodeTypeError extends UserError {
 export class VmExpressionEngineRequiredError extends UnexpectedError {
 	constructor() {
 		super(
-			'V1StepExecutor requires the VM expression engine. Initialize it via `Expression.initExpressionEngine()` before executing steps.',
+			'V1StepExecutor requires an isolated expression engine (vm or quickjs). Initialize it via `Expression.initExpressionEngine()` before executing steps.',
 		);
 	}
 }

--- a/packages/@n8n/node-engine-compatibility/src/v1-step-executor.ts
+++ b/packages/@n8n/node-engine-compatibility/src/v1-step-executor.ts
@@ -76,7 +76,9 @@ export class V1StepExecutor implements IStepExecutor {
 	}
 
 	private validateExpressionEngine(): void {
-		if (Expression.getActiveImplementation() !== 'vm') {
+		// Any isolated engine works here — v1 steps only need the pooled
+		// evaluator that initExpressionEngine() sets up; 'legacy' has none.
+		if (Expression.getActiveImplementation() === 'legacy') {
 			throw new VmExpressionEngineRequiredError();
 		}
 	}

--- a/packages/cli/src/expression-observability/expression-observability.provider.ts
+++ b/packages/cli/src/expression-observability/expression-observability.provider.ts
@@ -53,7 +53,10 @@ export class ExpressionObservabilityProvider implements ObservabilityProvider {
 	) {
 		this.scopedLogger = this.logger.scoped('expression-engine');
 
-		if (!this.config.observabilityEnabled || this.config.engine !== 'vm') {
+		if (
+			!this.config.observabilityEnabled ||
+			(this.config.engine !== 'vm' && this.config.engine !== 'quickjs')
+		) {
 			this.metrics = NoOpProvider.metrics;
 			this.traces = NoOpProvider.traces;
 			this.logs = NoOpProvider.logs;
@@ -168,7 +171,7 @@ export class ExpressionObservabilityProvider implements ObservabilityProvider {
 		const errorType = tags?.type && tags.type !== 'none' ? tags.type : undefined;
 		const span = tracer.startSpan('expression.evaluate', {
 			attributes: {
-				[ATTRIBUTE.EXPRESSION_ENGINE]: 'vm',
+				[ATTRIBUTE.EXPRESSION_ENGINE]: this.config.engine,
 				[ATTRIBUTE.EXPRESSION_DURATION_SECONDS]: durationSeconds,
 				[ATTRIBUTE.EXPRESSION_OUTCOME]: outcome,
 				...(errorType ? { [ATTRIBUTE.EXPRESSION_ERROR_TYPE]: errorType } : {}),

--- a/packages/testing/performance/benchmarks/expression-engine/fixtures/data.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/fixtures/data.ts
@@ -154,3 +154,16 @@ export async function useVmEngine(): Promise<void> {
 		bridgeMemoryLimit: 128,
 	});
 }
+
+export async function useQuickJsEngine(): Promise<void> {
+	// Dispose any previously initialized engine so initExpressionEngine
+	// creates a fresh evaluator with the QuickJS bridge.
+	await Expression.disposeExpressionEngine();
+	await Expression.initExpressionEngine({
+		engine: 'quickjs',
+		poolSize: 1,
+		maxCodeCacheSize: 1024,
+		bridgeTimeout: 60_000,
+		bridgeMemoryLimit: 128,
+	});
+}

--- a/packages/testing/performance/benchmarks/expression-engine/fixtures/data.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/fixtures/data.ts
@@ -163,7 +163,10 @@ export async function useQuickJsEngine(): Promise<void> {
 		engine: 'quickjs',
 		poolSize: 1,
 		maxCodeCacheSize: 1024,
-		bridgeTimeout: 60_000,
+		// QuickJS (WASM) is several times slower than isolated-vm; under CodSpeed
+		// instrumentation the remaining pattern benchmarks need extra headroom
+		// beyond the vm engine's 60s.
+		bridgeTimeout: 120_000,
 		bridgeMemoryLimit: 128,
 	});
 }

--- a/packages/testing/performance/benchmarks/expression-engine/fixtures/pattern-benchmarks.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/fixtures/pattern-benchmarks.ts
@@ -27,6 +27,10 @@ export function definePatternBenchmarks(
 	smallData: INodeExecutionData[],
 	mediumData: INodeExecutionData[],
 	largeData: INodeExecutionData[],
+	// The 10k-item map is ~5-6x slower on QuickJS (WASM); under CodSpeed's
+	// instruction-counting instrumentation it exceeds the bridge timeout. Opt
+	// out for that engine — the 100-item array cases still cover the pattern.
+	{ includeLargeArray = true }: { includeLargeArray?: boolean } = {},
 ) {
 	// Simple Property
 	bench(
@@ -112,13 +116,15 @@ export function definePatternBenchmarks(
 		BENCH_OPTIONS,
 	);
 
-	bench(
-		`${engine}: Array Iteration - map 10k items`,
-		() => {
-			evalFn(workflow, ARRAY_ITERATION[0], largeData);
-		},
-		BENCH_OPTIONS,
-	);
+	if (includeLargeArray) {
+		bench(
+			`${engine}: Array Iteration - map 10k items`,
+			() => {
+				evalFn(workflow, ARRAY_ITERATION[0], largeData);
+			},
+			BENCH_OPTIONS,
+		);
+	}
 
 	// Conditional
 	bench(

--- a/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
@@ -16,7 +16,7 @@ import {
 	DollarSignValidator,
 	PrototypeSanitizer,
 	ThisSanitizer,
-} from 'n8n-workflow/src/expression-sandboxing';
+} from 'n8n-workflow/expression-sandboxing';
 
 // Top-level await — vitest bench doesn't support beforeAll
 const evaluator = new ExpressionEvaluator({

--- a/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
@@ -1,0 +1,80 @@
+/**
+ * Tier 2: QuickJS Micro-benchmarks
+ *
+ * Isolates the costliest operations in the QuickJS expression engine:
+ * - QuickJS boundary crossing (single evaluation call)
+ * - Script compilation (cache miss vs cache hit)
+ * - Data access patterns (shallow vs deep, arrays)
+ *
+ * These use ExpressionEvaluator and QuickJsBridge directly.
+ *
+ * Run: pnpm --filter=@n8n/performance bench
+ */
+import { bench } from 'vitest';
+import { ExpressionEvaluator, QuickJsBridge } from '@n8n/expression-runtime';
+import {
+	DollarSignValidator,
+	PrototypeSanitizer,
+	ThisSanitizer,
+} from 'n8n-workflow/src/expression-sandboxing';
+
+// Top-level await — vitest bench doesn't support beforeAll
+const evaluator = new ExpressionEvaluator({
+	createBridge: () => new QuickJsBridge({ timeout: 5000 }),
+	maxCodeCacheSize: 1024,
+	hooks: {
+		before: [ThisSanitizer],
+		after: [PrototypeSanitizer, DollarSignValidator],
+	},
+});
+await evaluator.initialize();
+const caller = {};
+await evaluator.acquire(caller);
+
+const testData: Record<string, unknown> = {
+	$json: { id: 123, name: 'test', email: 'test@example.com' },
+	$runIndex: 0,
+	$itemIndex: 0,
+};
+
+// Script Compilation
+bench('quickjs micro: Script Compilation - cache hit (repeated expression)', () => {
+	evaluator.evaluate('$json.id', testData, caller);
+});
+
+let counter = 0;
+bench('quickjs micro: Script Compilation - cache miss (unique expressions)', () => {
+	evaluator.evaluate(`$json.id + ${counter++}`, testData, caller);
+});
+
+// Data Complexity
+const shallowData: Record<string, unknown> = {
+	$json: { value: 42 },
+};
+
+const deepData: Record<string, unknown> = {
+	$json: { a: { b: { c: { d: { e: { value: 42 } } } } } },
+};
+
+bench('quickjs micro: Data Complexity - shallow access (depth 1)', () => {
+	evaluator.evaluate('$json.value', shallowData, caller);
+});
+
+bench('quickjs micro: Data Complexity - deep access (depth 6)', () => {
+	evaluator.evaluate('$json.a.b.c.d.e.value', deepData, caller);
+});
+
+// Array Element Access
+const arrayData: Record<string, unknown> = {
+	$json: {
+		items: Array.from({ length: 100 }, (_, i) => ({ id: i })),
+	},
+};
+
+bench('quickjs micro: Array Element Access - single element', () => {
+	evaluator.evaluate('$json.items[0].id', arrayData, caller);
+});
+
+bench('quickjs micro: Array Element Access - map 100 elements', () => {
+	evaluator.evaluate('$json.items.map(i => i.id)', arrayData, caller);
+});

--- a/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
@@ -20,7 +20,9 @@ import {
 
 // Top-level await — vitest bench doesn't support beforeAll
 const evaluator = new ExpressionEvaluator({
-	createBridge: () => new QuickJsBridge({ timeout: 5000 }),
+	// Higher than the vm micro bench: QuickJS (WASM) is slower and CodSpeed
+	// instrumentation adds overhead, so the small micro cases need headroom.
+	createBridge: () => new QuickJsBridge({ timeout: 60_000 }),
 	maxCodeCacheSize: 1024,
 	hooks: {
 		before: [ThisSanitizer],

--- a/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/micro-quickjs.bench.ts
@@ -12,11 +12,9 @@
  */
 import { bench } from 'vitest';
 import { ExpressionEvaluator, QuickJsBridge } from '@n8n/expression-runtime';
-import {
-	DollarSignValidator,
-	PrototypeSanitizer,
-	ThisSanitizer,
-} from 'n8n-workflow/expression-sandboxing';
+import { expressionSandboxHooks } from 'n8n-workflow/expression-sandboxing';
+
+import { BENCH_OPTIONS } from '../bench-options';
 
 // Top-level await — vitest bench doesn't support beforeAll
 const evaluator = new ExpressionEvaluator({
@@ -24,10 +22,7 @@ const evaluator = new ExpressionEvaluator({
 	// instrumentation adds overhead, so the small micro cases need headroom.
 	createBridge: () => new QuickJsBridge({ timeout: 60_000 }),
 	maxCodeCacheSize: 1024,
-	hooks: {
-		before: [ThisSanitizer],
-		after: [PrototypeSanitizer, DollarSignValidator],
-	},
+	hooks: expressionSandboxHooks,
 });
 await evaluator.initialize();
 const caller = {};
@@ -40,14 +35,22 @@ const testData: Record<string, unknown> = {
 };
 
 // Script Compilation
-bench('quickjs micro: Script Compilation - cache hit (repeated expression)', () => {
-	evaluator.evaluate('$json.id', testData, caller);
-});
+bench(
+	'quickjs micro: Script Compilation - cache hit (repeated expression)',
+	() => {
+		evaluator.evaluate('$json.id', testData, caller);
+	},
+	BENCH_OPTIONS,
+);
 
 let counter = 0;
-bench('quickjs micro: Script Compilation - cache miss (unique expressions)', () => {
-	evaluator.evaluate(`$json.id + ${counter++}`, testData, caller);
-});
+bench(
+	'quickjs micro: Script Compilation - cache miss (unique expressions)',
+	() => {
+		evaluator.evaluate(`$json.id + ${counter++}`, testData, caller);
+	},
+	BENCH_OPTIONS,
+);
 
 // Data Complexity
 const shallowData: Record<string, unknown> = {
@@ -58,13 +61,21 @@ const deepData: Record<string, unknown> = {
 	$json: { a: { b: { c: { d: { e: { value: 42 } } } } } },
 };
 
-bench('quickjs micro: Data Complexity - shallow access (depth 1)', () => {
-	evaluator.evaluate('$json.value', shallowData, caller);
-});
+bench(
+	'quickjs micro: Data Complexity - shallow access (depth 1)',
+	() => {
+		evaluator.evaluate('$json.value', shallowData, caller);
+	},
+	BENCH_OPTIONS,
+);
 
-bench('quickjs micro: Data Complexity - deep access (depth 6)', () => {
-	evaluator.evaluate('$json.a.b.c.d.e.value', deepData, caller);
-});
+bench(
+	'quickjs micro: Data Complexity - deep access (depth 6)',
+	() => {
+		evaluator.evaluate('$json.a.b.c.d.e.value', deepData, caller);
+	},
+	BENCH_OPTIONS,
+);
 
 // Array Element Access
 const arrayData: Record<string, unknown> = {
@@ -73,10 +84,18 @@ const arrayData: Record<string, unknown> = {
 	},
 };
 
-bench('quickjs micro: Array Element Access - single element', () => {
-	evaluator.evaluate('$json.items[0].id', arrayData, caller);
-});
+bench(
+	'quickjs micro: Array Element Access - single element',
+	() => {
+		evaluator.evaluate('$json.items[0].id', arrayData, caller);
+	},
+	BENCH_OPTIONS,
+);
 
-bench('quickjs micro: Array Element Access - map 100 elements', () => {
-	evaluator.evaluate('$json.items.map(i => i.id)', arrayData, caller);
-});
+bench(
+	'quickjs micro: Array Element Access - map 100 elements',
+	() => {
+		evaluator.evaluate('$json.items.map(i => i.id)', arrayData, caller);
+	},
+	BENCH_OPTIONS,
+);

--- a/packages/testing/performance/benchmarks/expression-engine/patterns-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/patterns-quickjs.bench.ts
@@ -1,0 +1,39 @@
+/**
+ * Tier 1: QuickJS Engine Pattern Benchmarks
+ *
+ * Benchmarks expression evaluation through the full Workflow.expression path
+ * using the QuickJS engine.
+ *
+ * Run: pnpm --filter=@n8n/performance bench
+ */
+import { afterAll } from 'vitest';
+import { Expression } from 'n8n-workflow';
+
+import {
+	createWorkflow,
+	evaluate,
+	makeSmallData,
+	makeMediumData,
+	makeLargeData,
+	useQuickJsEngine,
+} from './fixtures/data';
+import { definePatternBenchmarks } from './fixtures/pattern-benchmarks';
+
+await useQuickJsEngine();
+if (Expression.getActiveImplementation() !== 'quickjs') {
+	throw new Error(`Engine not set to 'quickjs' — got '${Expression.getActiveImplementation()}'`);
+}
+
+const workflow = createWorkflow();
+await workflow.expression.acquireIsolate();
+
+afterAll(() => workflow.expression.releaseIsolate());
+
+definePatternBenchmarks(
+	'quickjs',
+	workflow,
+	evaluate,
+	makeSmallData(),
+	makeMediumData(),
+	makeLargeData(),
+);

--- a/packages/testing/performance/benchmarks/expression-engine/patterns-quickjs.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/patterns-quickjs.bench.ts
@@ -36,4 +36,6 @@ definePatternBenchmarks(
 	makeSmallData(),
 	makeMediumData(),
 	makeLargeData(),
+	// Skip the 10k-item map: too slow on QuickJS under CodSpeed instrumentation.
+	{ includeLargeArray: false },
 );

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -224,7 +224,7 @@ const createSafeErrorSubclass = <T extends ErrorConstructor>(ErrorClass: T): T =
 };
 
 export class Expression {
-	private static expressionEngine: 'legacy' | 'vm' = 'legacy';
+	private static expressionEngine: 'legacy' | 'vm' | 'quickjs' = 'legacy';
 
 	private static vmEvaluator?: IExpressionEvaluator;
 
@@ -235,7 +235,11 @@ export class Expression {
 	 * @private
 	 */
 	private static shouldUseVm(): boolean {
-		return this.expressionEngine === 'vm' && !IS_FRONTEND && !!this.vmEvaluator;
+		return (
+			(this.expressionEngine === 'vm' || this.expressionEngine === 'quickjs') &&
+			!IS_FRONTEND &&
+			!!this.vmEvaluator
+		);
 	}
 
 	/**
@@ -244,7 +248,7 @@ export class Expression {
 	 * Only available in Node.js environments (not in browser).
 	 */
 	static async initExpressionEngine(options: {
-		engine: 'legacy' | 'vm';
+		engine: 'legacy' | 'vm' | 'quickjs';
 		bridgeTimeout: number;
 		bridgeMemoryLimit: number;
 		poolSize: number;
@@ -252,19 +256,28 @@ export class Expression {
 		observability?: ObservabilityProvider;
 		idleTimeoutMs?: number;
 	}): Promise<void> {
-		if (options.engine !== 'vm' || IS_FRONTEND) return;
+		if ((options.engine !== 'vm' && options.engine !== 'quickjs') || IS_FRONTEND) return;
 		this.expressionEngine = options.engine;
 
 		if (!this.vmEvaluator) {
 			// Dynamic import to avoid loading expression-runtime in browser environments
-			const { ExpressionEvaluator, IsolatedVmBridge } = await import('@n8n/expression-runtime');
-			this.vmEvaluator = new ExpressionEvaluator({
-				createBridge: () =>
-					new IsolatedVmBridge({
-						timeout: options.bridgeTimeout,
-						memoryLimit: options.bridgeMemoryLimit,
-						logger: LoggerProxy,
-					}),
+			const runtime = await import('@n8n/expression-runtime');
+			const createBridge =
+				options.engine === 'quickjs'
+					? () =>
+							new runtime.QuickJsBridge({
+								timeout: options.bridgeTimeout,
+								memoryLimit: options.bridgeMemoryLimit,
+								logger: LoggerProxy,
+							})
+					: () =>
+							new runtime.IsolatedVmBridge({
+								timeout: options.bridgeTimeout,
+								memoryLimit: options.bridgeMemoryLimit,
+								logger: LoggerProxy,
+							});
+			this.vmEvaluator = new runtime.ExpressionEvaluator({
+				createBridge,
 				maxCodeCacheSize: options.maxCodeCacheSize,
 				poolSize: options.poolSize,
 				idleTimeoutMs: options.idleTimeoutMs,
@@ -304,8 +317,8 @@ export class Expression {
 	 * Get the active expression evaluation implementation.
 	 * Used for testing and verification.
 	 */
-	static getActiveImplementation(): 'legacy' | 'vm' {
-		if (this.shouldUseVm()) return 'vm';
+	static getActiveImplementation(): 'legacy' | 'vm' | 'quickjs' {
+		if (this.shouldUseVm()) return this.expressionEngine as 'vm' | 'quickjs';
 		return 'legacy';
 	}
 
@@ -317,7 +330,7 @@ export class Expression {
 	 * another. Only use this in benchmarks and tests, never in production code.
 	 * In production, set `N8N_EXPRESSION_ENGINE` before process startup instead.
 	 */
-	static setExpressionEngine(engine: 'legacy' | 'vm'): void {
+	static setExpressionEngine(engine: 'legacy' | 'vm' | 'quickjs'): void {
 		this.expressionEngine = engine;
 	}
 
@@ -626,11 +639,14 @@ export class Expression {
 	}
 
 	private renderExpression(expression: string, data: IWorkflowDataProxyData) {
-		// Use VM evaluator if engine is set to 'vm' and we're not in the browser
-		if (Expression.expressionEngine === 'vm' && !IS_FRONTEND) {
+		// Use VM evaluator if engine is set to 'vm' or 'quickjs' and we're not in the browser
+		if (
+			(Expression.expressionEngine === 'vm' || Expression.expressionEngine === 'quickjs') &&
+			!IS_FRONTEND
+		) {
 			if (!Expression.vmEvaluator) {
 				throw new UnexpectedError(
-					'N8N_EXPRESSION_ENGINE=vm is enabled but VM evaluator is not initialized. Call Expression.initExpressionEngine() during application startup.',
+					`N8N_EXPRESSION_ENGINE=${Expression.expressionEngine} is enabled but VM evaluator is not initialized. Call Expression.initExpressionEngine() during application startup.`,
 				);
 			}
 

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -218,7 +218,7 @@ const createSafeErrorSubclass = <T extends ErrorConstructor>(ErrorClass: T): T =
 };
 
 export class Expression {
-	private static expressionEngine: 'legacy' | 'vm' = 'legacy';
+	private static expressionEngine: 'legacy' | 'vm' | 'quickjs' = 'legacy';
 
 	private static vmEvaluator?: IExpressionEvaluator;
 
@@ -229,7 +229,11 @@ export class Expression {
 	 * @private
 	 */
 	private static shouldUseVm(): boolean {
-		return this.expressionEngine === 'vm' && !IS_FRONTEND && !!this.vmEvaluator;
+		return (
+			(this.expressionEngine === 'vm' || this.expressionEngine === 'quickjs') &&
+			!IS_FRONTEND &&
+			!!this.vmEvaluator
+		);
 	}
 
 	/**
@@ -238,7 +242,7 @@ export class Expression {
 	 * Only available in Node.js environments (not in browser).
 	 */
 	static async initExpressionEngine(options: {
-		engine: 'legacy' | 'vm';
+		engine: 'legacy' | 'vm' | 'quickjs';
 		bridgeTimeout: number;
 		bridgeMemoryLimit: number;
 		poolSize: number;
@@ -246,19 +250,28 @@ export class Expression {
 		observability?: ObservabilityProvider;
 		idleTimeoutMs?: number;
 	}): Promise<void> {
-		if (options.engine !== 'vm' || IS_FRONTEND) return;
+		if ((options.engine !== 'vm' && options.engine !== 'quickjs') || IS_FRONTEND) return;
 		this.expressionEngine = options.engine;
 
 		if (!this.vmEvaluator) {
 			// Dynamic import to avoid loading expression-runtime in browser environments
-			const { ExpressionEvaluator, IsolatedVmBridge } = await import('@n8n/expression-runtime');
-			this.vmEvaluator = new ExpressionEvaluator({
-				createBridge: () =>
-					new IsolatedVmBridge({
-						timeout: options.bridgeTimeout,
-						memoryLimit: options.bridgeMemoryLimit,
-						logger: LoggerProxy,
-					}),
+			const runtime = await import('@n8n/expression-runtime');
+			const createBridge =
+				options.engine === 'quickjs'
+					? () =>
+							new runtime.QuickJsBridge({
+								timeout: options.bridgeTimeout,
+								memoryLimit: options.bridgeMemoryLimit,
+								logger: LoggerProxy,
+							})
+					: () =>
+							new runtime.IsolatedVmBridge({
+								timeout: options.bridgeTimeout,
+								memoryLimit: options.bridgeMemoryLimit,
+								logger: LoggerProxy,
+							});
+			this.vmEvaluator = new runtime.ExpressionEvaluator({
+				createBridge,
 				maxCodeCacheSize: options.maxCodeCacheSize,
 				poolSize: options.poolSize,
 				idleTimeoutMs: options.idleTimeoutMs,
@@ -310,8 +323,8 @@ export class Expression {
 	 * Get the active expression evaluation implementation.
 	 * Used for testing and verification.
 	 */
-	static getActiveImplementation(): 'legacy' | 'vm' {
-		if (this.shouldUseVm()) return 'vm';
+	static getActiveImplementation(): 'legacy' | 'vm' | 'quickjs' {
+		if (this.shouldUseVm()) return this.expressionEngine as 'vm' | 'quickjs';
 		return 'legacy';
 	}
 
@@ -324,7 +337,7 @@ export class Expression {
 	 * never mid-execution. In production, set `N8N_EXPRESSION_ENGINE` before
 	 * process startup instead.
 	 */
-	static setExpressionEngine(engine: 'legacy' | 'vm'): void {
+	static setExpressionEngine(engine: 'legacy' | 'vm' | 'quickjs'): void {
 		this.expressionEngine = engine;
 	}
 
@@ -633,11 +646,14 @@ export class Expression {
 	}
 
 	private renderExpression(expression: string, data: IWorkflowDataProxyData) {
-		// Use VM evaluator if engine is set to 'vm' and we're not in the browser
-		if (Expression.expressionEngine === 'vm' && !IS_FRONTEND) {
+		// Use VM evaluator if engine is set to 'vm' or 'quickjs' and we're not in the browser
+		if (
+			(Expression.expressionEngine === 'vm' || Expression.expressionEngine === 'quickjs') &&
+			!IS_FRONTEND
+		) {
 			if (!Expression.vmEvaluator) {
 				throw new UnexpectedError(
-					'The VM expression engine has not been initialized. Call Expression.initExpressionEngine() during application startup.',
+					`The ${Expression.expressionEngine} expression engine has not been initialized. Call Expression.initExpressionEngine() during application startup.`,
 				);
 			}
 

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -324,8 +324,8 @@ export class Expression {
 	 * Used for testing and verification.
 	 */
 	static getActiveImplementation(): 'legacy' | 'vm' | 'quickjs' {
-		if (this.shouldUseVm()) return this.expressionEngine as 'vm' | 'quickjs';
-		return 'legacy';
+		if (!this.shouldUseVm()) return 'legacy';
+		return this.expressionEngine === 'quickjs' ? 'quickjs' : 'vm';
 	}
 
 	/**

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -646,7 +646,8 @@ export class Expression {
 	}
 
 	private renderExpression(expression: string, data: IWorkflowDataProxyData) {
-		// Use VM evaluator if engine is set to 'vm' or 'quickjs' and we're not in the browser
+		// The VM engines (isolated-vm, quickjs) are Node-only; the browser always
+		// uses the legacy path below.
 		if (
 			(Expression.expressionEngine === 'vm' || Expression.expressionEngine === 'quickjs') &&
 			!IS_FRONTEND

--- a/packages/workflow/test/expression-vm-errors.test.ts
+++ b/packages/workflow/test/expression-vm-errors.test.ts
@@ -37,7 +37,7 @@ describe('Expression VM error handling', () => {
 		nodeTypes,
 	});
 
-	let originalEngine: 'legacy' | 'vm';
+	let originalEngine: 'legacy' | 'vm' | 'quickjs';
 	let originalEvaluator: IExpressionEvaluator | undefined;
 
 	beforeEach(async () => {

--- a/packages/workflow/test/setup-vm-evaluator.ts
+++ b/packages/workflow/test/setup-vm-evaluator.ts
@@ -1,12 +1,13 @@
 import { Expression } from '../src/expression';
 
-// Only runs when N8N_EXPRESSION_ENGINE=vm is set.
-// Initializes the VM evaluator once per vitest worker before all tests,
+// Only runs when N8N_EXPRESSION_ENGINE is set to 'vm' or 'quickjs'.
+// Initializes the expression evaluator once per vitest worker before all tests,
 // and disposes it after.
-if (process.env.N8N_EXPRESSION_ENGINE === 'vm') {
+const engine = process.env.N8N_EXPRESSION_ENGINE as 'vm' | 'quickjs' | undefined;
+if (engine === 'vm' || engine === 'quickjs') {
 	beforeAll(async () => {
 		await Expression.initExpressionEngine({
-			engine: 'vm',
+			engine,
 			poolSize: 1,
 			maxCodeCacheSize: 1024,
 			bridgeTimeout: 5000,

--- a/packages/workflow/test/setup-vm-evaluator.ts
+++ b/packages/workflow/test/setup-vm-evaluator.ts
@@ -13,6 +13,13 @@ if (engine === 'vm' || engine === 'quickjs') {
 			bridgeTimeout: 5000,
 			bridgeMemoryLimit: 128,
 		});
+		// Guard the dual-engine matrix: if init silently fell back, every suite in
+		// this project would pass against the wrong engine.
+		if (Expression.getActiveImplementation() !== engine) {
+			throw new Error(
+				`Expected active expression engine '${engine}', got '${Expression.getActiveImplementation()}'`,
+			);
+		}
 	});
 
 	afterAll(async () => {

--- a/packages/workflow/vitest.config.ts
+++ b/packages/workflow/vitest.config.ts
@@ -24,6 +24,13 @@ export default defineConfig({
 					env: { N8N_EXPRESSION_ENGINE: 'vm' },
 				},
 			},
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'quickjs-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'quickjs' },
+				},
+			},
 		],
 	},
 });

--- a/packages/workflow/vitest.config.ts
+++ b/packages/workflow/vitest.config.ts
@@ -25,6 +25,13 @@ export default defineConfig({
 					env: { N8N_EXPRESSION_ENGINE: 'legacy' },
 				},
 			},
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'quickjs-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'quickjs' },
+				},
+			},
 		],
 	},
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2314,6 +2314,9 @@ importers:
       md5:
         specifier: 2.3.0
         version: 2.3.0
+      quickjs-emscripten:
+        specifier: ^0.32.0
+        version: 0.32.0
       title-case:
         specifier: 3.0.3
         version: 3.0.3
@@ -8673,6 +8676,21 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jitsi/robotjs@0.6.21':
     resolution: {integrity: sha512-rIF1itj1syWbdv1vEK3Xd+QVp7yQVUwuKb2s7+PFiLyYG4c4bDPhXvXxHHAGHYcnkmFZMB7ArwI0W44OtN5Crw==}
@@ -19473,6 +19491,13 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
+
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
 
@@ -25589,6 +25614,24 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
+
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jitsi/robotjs@0.6.21':
     dependencies:
@@ -38098,6 +38141,18 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   quote-unquote@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2531,6 +2531,9 @@ importers:
       md5:
         specifier: 2.3.0
         version: 2.3.0
+      quickjs-emscripten:
+        specifier: ^0.32.0
+        version: 0.32.0
       title-case:
         specifier: 3.0.3
         version: 3.0.3
@@ -9944,6 +9947,21 @@ packages:
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jitsi/robotjs@0.6.21':
     resolution: {integrity: sha512-rIF1itj1syWbdv1vEK3Xd+QVp7yQVUwuKb2s7+PFiLyYG4c4bDPhXvXxHHAGHYcnkmFZMB7ArwI0W44OtN5Crw==}
@@ -21430,6 +21448,13 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
+
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
 
@@ -28910,6 +28935,24 @@ snapshots:
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
+
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jitsi/robotjs@0.6.21':
     dependencies:
@@ -42388,6 +42431,18 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@5.1.1: {}
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   quote-unquote@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds a QuickJS expression engine as an opt-in alternative to isolated-vm. Nothing changes by default. The engine only activates with `N8N_EXPRESSION_ENGINE=quickjs`.

**Why:** isolated-vm is a native module and only runs in Node.js. QuickJS (`quickjs-emscripten`) compiles to WASM, which runs in Node.js and in the browser. This lets the frontend and backend share one sandboxed expression engine later. This PR adds the backend part. A follow-up PR wires the engine into the editor.

What's in the PR:

- `QuickJsBridge` in `@n8n/expression-runtime`. It implements the same `RuntimeBridge` contract as `IsolatedVmBridge`: typed-RPC `callHost` dispatch, lazy data proxies, per-execute callback scoping, timeout enforcement, and a memory limit.
- Values that QuickJS cannot transfer directly (Date, NaN, Map, Set, Error) cross the boundary as sentinels. Both directions rebuild the real values, so results match isolated-vm.
- `@n8n/config` accepts `N8N_EXPRESSION_ENGINE=quickjs`. Existing values and the default are unchanged.
- `V1StepExecutor` (Engine 2.0) now accepts any isolated engine, not only `vm`. Without this, every v1-node step would fail under quickjs.
- The expression metrics in `packages/cli` cover both engines.
- The three engine-aware test suites in `expression-runtime` run against both bridges. The `packages/workflow` expression suite runs against legacy, vm, and quickjs.
- QuickJS variants of the expression-engine micro and pattern benchmarks.

## How to test

- `pnpm test` in `packages/@n8n/expression-runtime` and in `packages/workflow`. The suites run once per engine.
- Manually: start n8n with `N8N_EXPRESSION_ENGINE=quickjs` and run any workflow that uses expressions (`{{ $json.x }}`, `$('Node').first()`, `$now`, extensions).
- Benchmarks: `packages/testing/performance/benchmarks/expression-engine/*quickjs*`.

## Related Linear tickets, Github issues, and Community forum posts

- Linear project: https://linear.app/n8n/project/expression-isolation-production-readiness-c9423b5669c2/issues

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33969">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


