### PR TITLE
fix(editor): Make selector dropdowns usable in Instance AI workflow setup

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -31,6 +31,16 @@ export const ExecutionDataStoreKey: InjectionKey<
 // derived from it via injectWorkflowExecutionStateStore(), so a subtree's
 // document scope and execution scope can never diverge.
 export const CanvasRenderDataKey: InjectionKey<Ref<CanvasRenderData>> = Symbol('CanvasRenderData');
+/**
+ * Opts resource-locator dropdowns into teleporting to `<body>`. Defaults to
+ * `false` (stay in the local stacking context, e.g. inside the NDV dialog).
+ * Hosts that render parameters inside a scroll container overlaid by sticky
+ * elements (e.g. the Instance AI workflow setup card above the chat input)
+ * provide `true` so the dropdown isn't painted underneath those overlays.
+ */
+export const ResourceLocatorDropdownTeleportedKey: InjectionKey<boolean> = Symbol(
+	'ResourceLocatorDropdownTeleported',
+);
 export const ChatHubToolContextKey: InjectionKey<boolean> = Symbol('ChatHubToolContext');
 export const AiBuilderScrollToBottomKey: InjectionKey<() => void> = Symbol('ChatScrollToBottom');
 /**

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/InstanceAiWorkflowSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/InstanceAiWorkflowSetup.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
-import { toRef } from 'vue';
+import { provide, toRef } from 'vue';
 import type { InstanceAiCredentialFlow, InstanceAiWorkflowSetupNode } from '@n8n/api-types';
 import WorkflowSetupWizard from './components/WorkflowSetupWizard.vue';
 import WorkflowSetupStatus from './components/WorkflowSetupStatus.vue';
 import { provideWorkflowSetupContext } from './composables/useWorkflowSetupContext';
+import { ResourceLocatorDropdownTeleportedKey } from '@/app/constants';
 
 const props = defineProps<{
 	requestId: string;
@@ -12,6 +13,8 @@ const props = defineProps<{
 	workflowId?: string;
 	credentialFlow?: InstanceAiCredentialFlow;
 }>();
+
+provide(ResourceLocatorDropdownTeleportedKey, true);
 
 const ctx = provideWorkflowSetupContext({
 	requestId: toRef(props, 'requestId'),

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -910,11 +910,27 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 					data-test-id="node-credentials-empty-state"
 				>
 					<N8nSelect
+						ref="selectRefs"
 						:class="$style.emptySelect"
 						size="small"
-						disabled
+						:disabled="!canCreateCredentials"
 						:placeholder="i18n.baseText('nodeCredentials.emptyState.noCredentials')"
-					/>
+						:popper-class="$style.selectPopper"
+					>
+						<template #empty> </template>
+						<template #footer>
+							<button
+								type="button"
+								data-test-id="node-credentials-select-item-new"
+								:class="[$style.newCredential]"
+								:disabled="!canCreateCredentials"
+								@click="onClickCreateCredential(type)"
+							>
+								<N8nIcon size="xsmall" icon="plus" />
+								{{ NEW_CREDENTIALS_TEXT }}
+							</button>
+						</template>
+					</N8nSelect>
 					<N8nButton
 						v-if="canCreateCredentials"
 						variant="subtle"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AgentSelectorParameterInput/AgentSelectorParameterInput.vue
@@ -264,7 +264,10 @@ watch(
 	},
 );
 
-onClickOutside(dropdown, () => {
+onClickOutside(dropdown, (event) => {
+	if (event.target instanceof HTMLElement && dropdown.value?.isWithinDropdown(event.target)) {
+		return;
+	}
 	isDropdownVisible.value = false;
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -611,7 +611,12 @@ onBeforeUnmount(() => {
 	}
 });
 
-onClickOutside(dropdownRef as Ref<VueInstance>, hideResourceDropdown);
+onClickOutside(dropdownRef as Ref<VueInstance>, (event) => {
+	if (event.target instanceof HTMLElement && dropdownRef.value?.isWithinDropdown(event.target)) {
+		return;
+	}
+	hideResourceDropdown();
+});
 
 function setWidth() {
 	if (containerRef.value) {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocatorDropdown.vue
@@ -6,7 +6,8 @@ import { useI18n } from '@n8n/i18n';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 import type { INodeParameterResourceLocator } from 'n8n-workflow';
-import { computed, onBeforeUnmount, onMounted, ref, useCssModule, watch } from 'vue';
+import { computed, inject, onBeforeUnmount, onMounted, ref, useCssModule, watch } from 'vue';
+import { ResourceLocatorDropdownTeleportedKey } from '@/app/constants';
 
 const SEARCH_BAR_HEIGHT_PX = 40;
 const SCROLL_MARGIN_PX = 10;
@@ -64,6 +65,8 @@ const debouncedLoadMore = debounce(
 
 const i18n = useI18n();
 const $style = useCssModule();
+
+const teleported = inject(ResourceLocatorDropdownTeleportedKey, false);
 
 const hoverIndex = ref(0);
 const showHoverUrl = ref(false);
@@ -269,7 +272,7 @@ watch(
 		:width="props.width ? `${props.width}px` : undefined"
 		:content-class="$style.popover"
 		:open="props.show"
-		:teleported="false"
+		:teleported="teleported"
 		:enable-scrolling="false"
 		data-test-id="resource-locator-dropdown"
 	>

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/WorkflowSelectorParameterInput/WorkflowSelectorParameterInput.vue
@@ -277,7 +277,10 @@ watch(
 	},
 );
 
-onClickOutside(dropdown, () => {
+onClickOutside(dropdown, (event) => {
+	if (event.target instanceof HTMLElement && dropdown.value?.isWithinDropdown(event.target)) {
+		return;
+	}
 	isDropdownVisible.value = false;
 });
 


### PR DESCRIPTION
## Summary

2 small quality of life issues i've seen from PH:

The dropdown was previously going underneath the input box:
<img width="712" height="484" alt="Screenshot 2026-07-10 at 12 21 08" src="https://github.com/user-attachments/assets/02d2e121-9236-44bf-8f3a-9b823f3f461e" />

Users were rage clicking on the select item expecting it to open a dropdown, but a dropdown never shows up. It now opens a dropdown with an action to create credential 

<img width="563" height="211" alt="Screenshot 2026-07-10 at 12 22 50" src="https://github.com/user-attachments/assets/62a2a021-8a20-4110-bc64-d3fa4a469f03" />


## How to test

1. Enable Instance AI and ask the assistant to build a workflow that requires credentials (e.g. WhatsApp, Google Sheets).
2. When the "Setting up workflow" card appears above the chat input:
   - Click a resource locator input — the dropdown should render above the chat input, not underneath it.
   - Click items inside the dropdown — it should not close on the first click inside it.
   - On a credential step with no existing credentials, click the "No credentials yet" select — it should open and offer "Create new credential", which opens the credential modal.
3. Regression check in the NDV: open a node with a resource locator and with credentials; dropdown behavior and the empty credential state should work as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-918

RESOLVS INS-918

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



