### PR TITLE
fix(editor): Fix What's New dialog layout and restore close button

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WhatsNewModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WhatsNewModal.test.ts
@@ -151,6 +151,25 @@ describe('WhatsNewModal', () => {
 		expect(queryByTestId('whats-new-modal-next-versions-link')).not.toBeInTheDocument();
 	});
 
+	it('should render a close button that dismisses the modal', async () => {
+		const { getByTestId, getByRole } = renderComponent({
+			props: {
+				data: {
+					articleId: 1,
+				},
+			},
+		});
+
+		await waitFor(() => expect(getByTestId('whatsNew-modal')).toBeInTheDocument());
+
+		const closeButton = getByRole('button', { name: 'Close this dialog' });
+		expect(closeButton).toBeInTheDocument();
+
+		await userEvent.click(closeButton);
+
+		expect(uiStore.closeModal).toHaveBeenCalledWith(WHATS_NEW_MODAL_KEY);
+	});
+
 	it('should render with update button enabled', async () => {
 		versionsStore.hasVersionUpdates = true;
 		versionsStore.nextVersions = [

--- a/packages/frontend/editor-ui/src/app/components/WhatsNewModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/WhatsNewModal.vue
@@ -88,39 +88,38 @@ modalBus.on('opened', () => {
 		:event-bus="modalBus"
 		:name="WHATS_NEW_MODAL_KEY"
 		:center="true"
-		:show-close="false"
 	>
 		<template #header>
 			<div :class="$style.header">
-				<div :class="$style.row">
-					<N8nIcon :icon="'bell'" :color="'primary'" :size="'large'" />
-					<div :class="$style.column">
+				<div :class="$style.column">
+					<div :class="$style.row">
+						<N8nIcon :icon="'bell'" :color="'primary'" :size="'large'" />
 						<N8nHeading size="xlarge">
 							{{ versionsStore.whatsNew.title }}
 						</N8nHeading>
+					</div>
 
-						<div :class="$style.row">
-							<N8nHeading size="medium" color="text-light">{{
-								dateformat(versionsStore.latestVersion.createdAt, `d mmmm, yyyy`)
-							}}</N8nHeading>
-							<template v-if="versionsStore.hasVersionUpdates">
-								<N8nText :size="'medium'" :class="$style.text" :color="'text-base'">•</N8nText>
-								<N8nLink
-									size="medium"
-									theme="primary"
-									data-test-id="whats-new-modal-next-versions-link"
-									@click="openUpdatesPanel"
-								>
-									{{
-										i18n.baseText('whatsNew.versionsBehind', {
-											interpolate: {
-												count: nextVersions.length > 99 ? '99+' : nextVersions.length,
-											},
-										})
-									}}
-								</N8nLink>
-							</template>
-						</div>
+					<div :class="$style.row">
+						<N8nHeading size="medium" color="text-light">{{
+							dateformat(versionsStore.latestVersion.createdAt, `d mmmm, yyyy`)
+						}}</N8nHeading>
+						<template v-if="versionsStore.hasVersionUpdates">
+							<N8nText :size="'medium'" :class="$style.text" :color="'text-base'">•</N8nText>
+							<N8nLink
+								size="medium"
+								theme="primary"
+								data-test-id="whats-new-modal-next-versions-link"
+								@click="openUpdatesPanel"
+							>
+								{{
+									i18n.baseText('whatsNew.versionsBehind', {
+										interpolate: {
+											count: nextVersions.length > 99 ? '99+' : nextVersions.length,
+										},
+									})
+								}}
+							</N8nLink>
+						</template>
 					</div>
 				</div>
 
@@ -211,6 +210,7 @@ modalBus.on('opened', () => {
 					/>
 				</div>
 				<N8nMarkdown
+					v-if="versionsStore.whatsNew.footer"
 					:content="versionsStore.whatsNew.footer"
 					:class="$style.markdown"
 					:options="{
@@ -247,6 +247,7 @@ modalBus.on('opened', () => {
 	align-items: center;
 	border-bottom: var(--border);
 	padding-bottom: var(--spacing--sm);
+	padding-right: var(--spacing--xl);
 }
 
 :global(.el-dialog__header) {
@@ -267,7 +268,17 @@ modalBus.on('opened', () => {
 }
 
 .container {
-	margin-bottom: var(--spacing--lg);
+	margin-bottom: 0;
+
+	// Collapse the trailing spacing of the last block (article or footer) and its innermost element
+	> :last-child {
+		margin-bottom: 0;
+		padding-bottom: 0;
+
+		:last-child {
+			margin-bottom: 0;
+		}
+	}
 }
 
 .article {
@@ -289,6 +300,10 @@ modalBus.on('opened', () => {
 
 	hr {
 		margin-bottom: var(--spacing--sm);
+	}
+
+	img {
+		margin: var(--spacing--sm) 0;
 	}
 }
 </style>


### PR DESCRIPTION
## Summary

The **What's New** release-features dialog had a broken layout (reported on Cloud 2.12.0): the close (X) button was missing, the header icon was misaligned, and there was excessive empty space at the bottom.

Before:
<img width="862" height="323" alt="Screenshot 2026-07-10 at 12 23 48" src="https://github.com/user-attachments/assets/c04581e8-9fe3-4b4d-94df-e50951ba20c2" />

After:
<img width="873" height="268" alt="Screenshot 2026-07-10 at 12 23 36" src="https://github.com/user-attachments/assets/f39da440-4cc9-440b-813a-7ed4b410345a" />

<img width="865" height="272" alt="Screenshot 2026-07-10 at 12 33 56" src="https://github.com/user-attachments/assets/e97f4512-b632-4c44-bec0-228c5b290d0a" />


## How to test

1. Open n8n → **Help** → **What's New**.
2. Verify:
   - A close (X) button appears top-right and dismisses the dialog.
   - The bell icon aligns with the title; date/version info sits below.
   - There is no oversized empty gap at the bottom of the dialog.
   - When there are version updates, the **Update** button does not overlap the close button.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5057

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33972">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

