### PR TITLE
fix(editor): Make Slack setup snapshots row horizontally scrollable

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetup.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetup.vue
@@ -430,6 +430,7 @@ defineExpose({ credentialId, validationError: null });
 	align-items: flex-start;
 	gap: var(--spacing--2xs);
 	padding-top: var(--spacing--xs);
+	min-width: 0;
 }
 
 .setupDescriptionContainer {
@@ -468,6 +469,8 @@ defineExpose({ credentialId, validationError: null });
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--sm);
+	width: 100%;
+	min-width: 0;
 }
 
 .manualPanel {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetupSnapshots.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelSlackSetupSnapshots.vue
@@ -594,9 +594,12 @@
 	display: flex;
 	gap: var(--spacing--sm);
 	width: 100%;
+	min-width: 0;
 	font-size: var(--font-size--sm);
 	color: var(--text-color);
-	overflow: hidden;
+	overflow-x: auto;
+	scrollbar-width: thin;
+	scrollbar-color: var(--border-color) transparent;
 }
 
 .panel {


### PR DESCRIPTION
## Summary

Make the Slack channel setup snapshot row scroll horizontally when the agent builder sidebar narrows the available width, so the third snapshot no longer overflows outside the setup panel.

## How to test

1. Open an agent and start Slack channel setup.
2. On step 1 ("Create token"), confirm the three snapshot panels are visible.
3. Narrow the viewport or open the right-side sidebar so the setup area is tight.
4. Verify the snapshot row scrolls horizontally and no panel hangs outside the container.
5. Confirm Linear and Telegram setup flows are unchanged (no snapshot row).

## Preview
When enough space:
<img width="836" height="915" alt="image" src="https://github.com/user-attachments/assets/d054cd79-dea2-457e-a9e6-183e1f4bfeeb" />
When squished:
<img width="697" height="738" alt="image" src="https://github.com/user-attachments/assets/1f8d71ad-c5a2-4e8d-b3a3-378672629e97" />


## Related Linear tickets, Github issues, and Community forum posts

NA

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A -->
- [ ] Tests included. <!-- Visual/layout fix; no unit test added -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33977">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

