### PR TITLE
test(editor): Stabilize N8nPopover trigger clicks in unit tests (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -47,8 +47,15 @@ vi.mock('reka-ui', async (importOriginal) => {
 				const context = inject<{ isOpen: { value: boolean }; setOpen: (v: boolean) => void }>(
 					POPOVER_OPEN_KEY,
 				);
+				// Capture phase avoids Vue's "event fired before listener attached" guard
+				// (`e._vts <= invoker.attached`), which flakily skips a bubble-phase onClick
+				// when a test renders and clicks within the same millisecond.
 				return () =>
-					h('div', { onClick: () => context?.setOpen(!context.isOpen.value) }, slots.default?.());
+					h(
+						'div',
+						{ onClickCapture: () => context?.setOpen(!context.isOpen.value) },
+						slots.default?.(),
+					);
 			},
 		}),
 		PopoverPortal: defineComponent({


### PR DESCRIPTION
## Summary

Master's frontend unit tests were flaking on `ToolCredentialPicker.test.ts > emits credential-dropdown-open when the credential dropdown opens` ([failing runs](https://github.com/n8n-io/n8n/commits/master/)). Root cause: the global Reka UI Popover test stub toggled `open` from a **bubble-phase** `onClick` on its wrapper `div`, and Vue's "event fired before listener attached" guard (`e._vts <= invoker.attached`) intermittently skips such a handler when a synchronous test renders and clicks within the same millisecond — so the popover never opened and the trigger emitted nothing (component triggers like `N8nButton` push the collision rate to ~50%). The fix switches the stub to a **capture-phase** listener, which is the first invoker to see the event, stamps `_vts`, and never hits the skip branch — stabilizing every popover-triggered test, not just this one.

## How to test

Run the previously-flaky file repeatedly (was ~20% flake, now 8/8): `pnpm --filter n8n-editor-ui test src/features/shared/toolsConnection/__tests__/ToolCredentialPicker.test.ts`. All 12 other `N8nPopover`-dependent test files still pass (156 tests).

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

