### PR TITLE
feat(core): Add description field to credentials

### DIFF
--- a/docs/generated/postgres-schema/README.md
+++ b/docs/generated/postgres-schema/README.md
@@ -40,7 +40,7 @@ Auto-generated from the PostgreSQL migrations in @n8n/db. Do not edit by hand.
 | [public.chat_hub_sessions](public.chat_hub_sessions.md) | 13 |  | BASE TABLE |
 | [public.chat_hub_tools](public.chat_hub_tools.md) | 9 |  | BASE TABLE |
 | [public.credential_dependency](public.credential_dependency.md) | 5 |  | BASE TABLE |
-| [public.credentials_entity](public.credentials_entity.md) | 11 |  | BASE TABLE |
+| [public.credentials_entity](public.credentials_entity.md) | 12 |  | BASE TABLE |
 | [public.data_table](public.data_table.md) | 5 |  | BASE TABLE |
 | [public.data_table_column](public.data_table_column.md) | 7 |  | BASE TABLE |
 | [public.deployment_key](public.deployment_key.md) | 7 |  | BASE TABLE |
@@ -631,6 +631,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.chat_hub_agents.md
+++ b/docs/generated/postgres-schema/public.chat_hub_agents.md
@@ -71,6 +71,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.chat_hub_sessions.md
+++ b/docs/generated/postgres-schema/public.chat_hub_sessions.md
@@ -88,6 +88,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.credential_dependency.md
+++ b/docs/generated/postgres-schema/public.credential_dependency.md
@@ -48,6 +48,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.credentials_entity.md
+++ b/docs/generated/postgres-schema/public.credentials_entity.md
@@ -6,6 +6,7 @@
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | createdAt | timestamp(3) with time zone | CURRENT_TIMESTAMP(3) | false |  |  |  |
 | data | text |  | false |  |  |  |
+| description | text |  | true |  |  |  |
 | id | varchar(36) |  | false | [public.chat_hub_agents](public.chat_hub_agents.md) [public.chat_hub_sessions](public.chat_hub_sessions.md) [public.credential_dependency](public.credential_dependency.md) [public.dynamic_credential_entry](public.dynamic_credential_entry.md) [public.dynamic_credential_user_entry](public.dynamic_credential_user_entry.md) [public.instance_ai_mcp_registry_connections](public.instance_ai_mcp_registry_connections.md) [public.shared_credentials](public.shared_credentials.md) |  |  |
 | isGlobal | boolean | false | false |  |  |  |
 | isManaged | boolean | false | false |  |  |  |
@@ -59,6 +60,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.dynamic_credential_entry.md
+++ b/docs/generated/postgres-schema/public.dynamic_credential_entry.md
@@ -52,6 +52,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.dynamic_credential_resolver.md
+++ b/docs/generated/postgres-schema/public.dynamic_credential_resolver.md
@@ -50,6 +50,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.dynamic_credential_user_entry.md
+++ b/docs/generated/postgres-schema/public.dynamic_credential_user_entry.md
@@ -54,6 +54,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.instance_ai_mcp_registry_connections.md
+++ b/docs/generated/postgres-schema/public.instance_ai_mcp_registry_connections.md
@@ -55,6 +55,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/postgres-schema/public.shared_credentials.md
+++ b/docs/generated/postgres-schema/public.shared_credentials.md
@@ -47,6 +47,7 @@ erDiagram
 "public.credentials_entity" {
   timestamp_3__with_time_zone createdAt
   text data
+  text description
   varchar_36_ id
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/README.md
+++ b/docs/generated/sqlite-schema/README.md
@@ -40,7 +40,7 @@ Auto-generated from the SQLite migrations in @n8n/db. Do not edit by hand.
 | [chat_hub_sessions](chat_hub_sessions.md) | 13 |  | table |
 | [chat_hub_tools](chat_hub_tools.md) | 9 |  | table |
 | [credential_dependency](credential_dependency.md) | 5 |  | table |
-| [credentials_entity](credentials_entity.md) | 11 |  | table |
+| [credentials_entity](credentials_entity.md) | 12 |  | table |
 | [data_table](data_table.md) | 5 |  | table |
 | [data_table_column](data_table_column.md) | 7 |  | table |
 | [deployment_key](deployment_key.md) | 7 |  | table |
@@ -618,6 +618,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/chat_hub_agents.md
+++ b/docs/generated/sqlite-schema/chat_hub_agents.md
@@ -73,6 +73,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/chat_hub_sessions.md
+++ b/docs/generated/sqlite-schema/chat_hub_sessions.md
@@ -92,6 +92,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/credential_dependency.md
+++ b/docs/generated/sqlite-schema/credential_dependency.md
@@ -53,6 +53,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/credentials_entity.md
+++ b/docs/generated/sqlite-schema/credentials_entity.md
@@ -6,7 +6,7 @@
 <summary><strong>Table Definition</strong></summary>
 
 ```sql
-CREATE TABLE "credentials_entity" ("id" varchar(36) PRIMARY KEY NOT NULL, "name" varchar(128) NOT NULL, "data" text NOT NULL, "type" varchar(32) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "isManaged" boolean NOT NULL DEFAULT (0), "isGlobal" boolean NOT NULL DEFAULT (0), "isResolvable" boolean NOT NULL DEFAULT (false), "resolvableAllowFallback" boolean NOT NULL DEFAULT (false), "resolverId" varchar(16), CONSTRAINT "credentials_entity_resolverId_foreign" FOREIGN KEY ("resolverId") REFERENCES "dynamic_credential_resolver" ("id") ON DELETE SET NULL)
+CREATE TABLE "credentials_entity" ("id" varchar(36) PRIMARY KEY NOT NULL, "name" varchar(128) NOT NULL, "data" text NOT NULL, "type" varchar(32) NOT NULL, "createdAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "updatedAt" datetime(3) NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "isManaged" boolean NOT NULL DEFAULT (0), "isGlobal" boolean NOT NULL DEFAULT (0), "isResolvable" boolean NOT NULL DEFAULT (false), "resolvableAllowFallback" boolean NOT NULL DEFAULT (false), "resolverId" varchar(16), "description" text, CONSTRAINT "credentials_entity_resolverId_foreign" FOREIGN KEY ("resolverId") REFERENCES "dynamic_credential_resolver" ("id") ON DELETE SET NULL ON UPDATE NO ACTION)
 ```
 
 </details>
@@ -17,6 +17,7 @@ CREATE TABLE "credentials_entity" ("id" varchar(36) PRIMARY KEY NOT NULL, "name"
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | createdAt | datetime(3) | STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW') | false |  |  |  |
 | data | TEXT |  | false |  |  |  |
+| description | TEXT |  | true |  |  |  |
 | id | varchar(36) |  | false | [chat_hub_agents](chat_hub_agents.md) [chat_hub_sessions](chat_hub_sessions.md) [credential_dependency](credential_dependency.md) [dynamic_credential_entry](dynamic_credential_entry.md) [dynamic_credential_user_entry](dynamic_credential_user_entry.md) [instance_ai_mcp_registry_connections](instance_ai_mcp_registry_connections.md) [shared_credentials](shared_credentials.md) |  |  |
 | isGlobal | boolean | 0 | false |  |  |  |
 | isManaged | boolean | 0 | false |  |  |  |
@@ -60,6 +61,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/dynamic_credential_entry.md
+++ b/docs/generated/sqlite-schema/dynamic_credential_entry.md
@@ -60,6 +60,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/dynamic_credential_resolver.md
+++ b/docs/generated/sqlite-schema/dynamic_credential_resolver.md
@@ -56,6 +56,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/dynamic_credential_user_entry.md
+++ b/docs/generated/sqlite-schema/dynamic_credential_user_entry.md
@@ -62,6 +62,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/instance_ai_mcp_registry_connections.md
+++ b/docs/generated/sqlite-schema/instance_ai_mcp_registry_connections.md
@@ -61,6 +61,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/docs/generated/sqlite-schema/shared_credentials.md
+++ b/docs/generated/sqlite-schema/shared_credentials.md
@@ -55,6 +55,7 @@ erDiagram
 "credentials_entity" {
   datetime_3_ createdAt
   TEXT data
+  TEXT description
   varchar_36_ id PK
   boolean isGlobal
   boolean isManaged

--- a/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/create-credential.dto.ts
@@ -4,6 +4,7 @@ import { Z } from '../../zod-class';
 
 export class CreateCredentialDto extends Z.class({
 	name: z.string().min(1).max(128),
+	description: z.string().nullable().optional(),
 	type: z.string().min(1).max(128),
 	data: z.record(z.string(), z.unknown()),
 	projectId: z.string().optional(),

--- a/packages/@n8n/db/src/entities/credentials-entity.ts
+++ b/packages/@n8n/db/src/entities/credentials-entity.ts
@@ -14,6 +14,9 @@ export class CredentialsEntity extends WithTimestampsAndStringId implements ICre
 	})
 	name: string;
 
+	@Column({ type: 'text', nullable: true })
+	description: string | null;
+
 	@Column('text')
 	@IsObject()
 	data: string;

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -99,6 +99,7 @@ export interface IWorkflowDb extends IWorkflowBase {
 export interface ICredentialsDb extends ICredentialsBase, ICredentialsEncrypted {
 	id: string;
 	name: string;
+	description?: string | null;
 	shared?: SharedCredentials[];
 	isGlobal?: boolean;
 	isResolvable?: boolean;

--- a/packages/@n8n/db/src/migrations/common/1784000000045-AddCredentialDescriptionColumn.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000045-AddCredentialDescriptionColumn.ts
@@ -1,0 +1,13 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+export class AddCredentialDescriptionColumn1784000000045 implements ReversibleMigration {
+	async up({ schemaBuilder: { addColumns, column } }: MigrationContext) {
+		await addColumns('credentials_entity', [column('description').text], {
+			recreatesOnSqlite: true,
+		});
+	}
+
+	async down({ schemaBuilder: { dropColumns } }: MigrationContext) {
+		await dropColumns('credentials_entity', ['description'], { recreatesOnSqlite: true });
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -218,6 +218,7 @@ import { CreateWorkflowPublicationTriggerStatusTable1784000000040 } from '../com
 import { AddUsedPrivateCredentialsToExecutionEntity1784000000041 } from '../common/1784000000041-AddUsedPrivateCredentialsToExecutionEntity';
 import { CreateSchedulerTables1784000000042 } from '../common/1784000000042-CreateSchedulerTables';
 import { AddPartialIndexForGlobalCredentials1784000000044 } from '../common/1784000000044-AddPartialIndexForGlobalCredentials';
+import { AddCredentialDescriptionColumn1784000000045 } from '../common/1784000000045-AddCredentialDescriptionColumn';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -441,4 +442,5 @@ export const postgresMigrations: Migration[] = [
 	CreateSchedulerTables1784000000042,
 	CreateWorkflowStatisticsDeltaTable1784000000043,
 	AddPartialIndexForGlobalCredentials1784000000044,
+	AddCredentialDescriptionColumn1784000000045,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -210,6 +210,7 @@ import { CreateWorkflowPublicationTriggerStatusTable1784000000040 } from '../com
 import { AddUsedPrivateCredentialsToExecutionEntity1784000000041 } from '../common/1784000000041-AddUsedPrivateCredentialsToExecutionEntity';
 import { CreateSchedulerTables1784000000042 } from '../common/1784000000042-CreateSchedulerTables';
 import { AddPartialIndexForGlobalCredentials1784000000044 } from '../common/1784000000044-AddPartialIndexForGlobalCredentials';
+import { AddCredentialDescriptionColumn1784000000045 } from '../common/1784000000045-AddCredentialDescriptionColumn';
 
 const sqliteMigrations: Migration[] = [
 	InitialMigration1588102412422,
@@ -423,6 +424,7 @@ const sqliteMigrations: Migration[] = [
 	AddUsedPrivateCredentialsToExecutionEntity1784000000041,
 	CreateSchedulerTables1784000000042,
 	AddPartialIndexForGlobalCredentials1784000000044,
+	AddCredentialDescriptionColumn1784000000045,
 ];
 
 export { sqliteMigrations };

--- a/packages/@n8n/db/src/repositories/credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/credentials.repository.ts
@@ -74,6 +74,7 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		const defaultSelect: Select = [
 			'id',
 			'name',
+			'description',
 			'type',
 			'isManaged',
 			'createdAt',
@@ -234,6 +235,7 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		const defaultSelect: Array<keyof CredentialsEntity> = [
 			'id',
 			'name',
+			'description',
 			'type',
 			'isManaged',
 			'createdAt',
@@ -405,6 +407,7 @@ export class CredentialsRepository extends Repository<CredentialsEntity> {
 		const defaultSelect: Array<keyof CredentialsEntity> = [
 			'id',
 			'name',
+			'description',
 			'type',
 			'isManaged',
 			'createdAt',

--- a/packages/cli/src/commands/import/credentials.ts
+++ b/packages/cli/src/commands/import/credentials.ts
@@ -344,6 +344,7 @@ export class ImportCredentialsCommand extends BaseCommand<z.infer<typeof flagsSc
 			updatedAt: true,
 			id: true,
 			name: true,
+			description: true,
 			data: true,
 			type: true,
 			isManaged: true,

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -268,6 +268,10 @@ export class CredentialsController {
 
 		newCredentialData.isResolvable = body.isResolvable ?? credential.isResolvable;
 
+		// `??` would discard an explicit `null`, which is how the description is cleared
+		newCredentialData.description =
+			body.description !== undefined ? body.description : credential.description;
+
 		// A private credential's per-user connections are minted against its shared
 		// (static) config, so changing that config makes them stale — invalidate them.
 		let sharedFieldsChanged = false;

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -1482,6 +1482,7 @@ export class CredentialsService {
 
 		const credentialEntity = this.credentialsRepository.create({
 			...encryptedCredential,
+			description: opts.description ?? null,
 			isManaged: opts.isManaged,
 			isResolvable: opts.isResolvable ?? false,
 		});

--- a/packages/cli/src/modules/mcp/__tests__/list-credentials.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/list-credentials.tool.test.ts
@@ -63,6 +63,7 @@ describe('list-credentials MCP tool', () => {
 				buildCredential({
 					id: 'a',
 					name: 'Slack',
+					description: 'Bot token for the #alerts channel',
 					type: 'slackApi',
 					scopes: ['credential:read', 'credential:update'],
 				}),
@@ -70,6 +71,7 @@ describe('list-credentials MCP tool', () => {
 					id: 'b',
 					name: 'HTTP Header',
 					type: 'httpHeaderAuth',
+					description: null,
 					isGlobal: true,
 					homeProject: null,
 					scopes: [],
@@ -84,6 +86,7 @@ describe('list-credentials MCP tool', () => {
 					{
 						id: 'a',
 						name: 'Slack',
+						description: 'Bot token for the #alerts channel',
 						type: 'slackApi',
 						scopes: ['credential:read', 'credential:update'],
 						isManaged: false,

--- a/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/webhook-utils.test.ts
@@ -21,6 +21,7 @@ const mockCredentialsService = (
 			const data = await impl(id);
 			return {
 				name: 'MockCredentialsService',
+				description: null,
 				type: 'mock',
 				shared: [] as SharedCredentials[],
 				isManaged: false,

--- a/packages/cli/src/modules/mcp/tools/list-credentials.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/list-credentials.tool.ts
@@ -47,6 +47,10 @@ const outputSchema = {
 			z.object({
 				id: z.string().describe('The unique identifier of the credential'),
 				name: z.string().describe('The name of the credential'),
+				description: z
+					.string()
+					.optional()
+					.describe('A user-provided description of the credential, if set'),
 				type: z.string().describe('The credential type (e.g. "slackApi")'),
 				scopes: z
 					.array(z.string())
@@ -74,6 +78,7 @@ export type ListCredentialsParams = {
 export type ListCredentialsItem = {
 	id: string;
 	name: string;
+	description?: string;
 	type: string;
 	scopes: string[];
 	isManaged: boolean;
@@ -193,6 +198,7 @@ export async function listCredentials(
 	const data: ListCredentialsItem[] = enriched.map((c) => ({
 		id: c.id,
 		name: c.name,
+		description: c.description ?? undefined,
 		type: c.type,
 		scopes: c.scopes ?? [],
 		isManaged: c.isManaged,

--- a/packages/cli/src/requests.ts
+++ b/packages/cli/src/requests.ts
@@ -74,6 +74,7 @@ export declare namespace CredentialRequest {
 	type CredentialProperties = Partial<{
 		id: string; // deleted if sent
 		name: string;
+		description: string | null;
 		type: string;
 		data: ICredentialDataDecryptedObject;
 		projectId?: string;

--- a/packages/cli/test/integration/credentials/credentials.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.api.test.ts
@@ -891,6 +891,18 @@ describe('POST /credentials', () => {
 		expect(sharedCredential.credentials.name).toBe(payload.name);
 	});
 
+	test('should create cred with description', async () => {
+		const payload = { ...randomCredentialPayload(), description: 'For the staging account' };
+
+		const response = await authMemberAgent.post('/credentials').send(payload);
+		expect(response.statusCode).toBe(200);
+		expect(response.body.data.description).toBe(payload.description);
+
+		const credential = await getCredentialById(response.body.data.id);
+		a.ok(credential);
+		expect(credential.description).toBe(payload.description);
+	});
+
 	test('should create cred with uiContext parameter', async () => {
 		const payload = { ...randomCredentialPayload(), uiContext: 'credentials_list' };
 
@@ -1280,6 +1292,33 @@ describe('PATCH /credentials/:id', () => {
 		});
 
 		expect(sharedCredential.credentials.name).toBe(patchPayload.name); // updated
+	});
+
+	test('should set, keep, and clear description', async () => {
+		const savedCredential = await saveCredential(randomCredentialPayload(), {
+			user: owner,
+			role: 'credential:owner',
+		});
+
+		const setResponse = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ ...randomCredentialPayload(), description: 'Rotated key for prod' });
+		expect(setResponse.statusCode).toBe(200);
+		expect(setResponse.body.data.description).toBe('Rotated key for prod');
+
+		// a payload without the field keeps the existing description
+		const keepResponse = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send(randomCredentialPayload());
+		expect(keepResponse.statusCode).toBe(200);
+		expect(keepResponse.body.data.description).toBe('Rotated key for prod');
+
+		// an explicit null clears it
+		const clearResponse = await authOwnerAgent
+			.patch(`/credentials/${savedCredential.id}`)
+			.send({ ...randomCredentialPayload(), description: null });
+		expect(clearResponse.statusCode).toBe(200);
+		expect(clearResponse.body.data.description).toBeNull();
 	});
 
 	test('should update non-owned cred for owner', async () => {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1104,6 +1104,7 @@
 	"credentialEdit.credentialEdit.info.sharee.team": "Only users with credential edit permission can edit this connection",
 	"credentialEdit.credentialInfo.allowUseBy": "Allow use by",
 	"credentialEdit.credentialInfo.created": "Created",
+	"credentialEdit.credentialInfo.description": "Description",
 	"credentialEdit.credentialInfo.id": "ID",
 	"credentialEdit.credentialInfo.lastModified": "Last modified",
 	"credentialEdit.credentialEdit.setupGuide": "Setup guide",

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -204,6 +204,7 @@ const form = useCredentialForm({
 const {
 	credentialData,
 	credentialName,
+	credentialDescription,
 	credentialId,
 	currentCredential,
 	selectedCredential,
@@ -572,6 +573,11 @@ function onNameEdit(text: string) {
 	credentialName.value = text;
 }
 
+function onDescriptionEdit(text: string) {
+	hasUnsavedChanges.value = true;
+	credentialDescription.value = text.trim() === '' ? null : text;
+}
+
 function scrollToTop() {
 	setTimeout(() => {
 		if (contentRef.value) {
@@ -614,6 +620,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 	const credentialDetails: ICredentialsDecrypted = {
 		id: credentialId.value,
 		name: credentialName.value,
+		description: credentialDescription.value,
 		type: credentialTypeName.value,
 		data: data as unknown as ICredentialDataDecryptedObject,
 		isGlobal: isSharedGlobally.value,
@@ -1385,7 +1392,17 @@ const { width } = useElementSize(credNameRef);
 						/>
 					</div>
 					<div v-else-if="activeTab === 'details' && credentialType" :class="$style.mainContent">
-						<CredentialInfo :current-credential="currentCredential" />
+						<CredentialInfo
+							:current-credential="currentCredential"
+							:description="credentialDescription"
+							:readonly="
+								!(
+									(credentialPermissions.create && props.mode === 'new') ||
+									credentialPermissions.update
+								) || isEditingManagedCredential
+							"
+							@update:description="onDescriptionEdit"
+						/>
 					</div>
 				</div>
 			</template>

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialInfo.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialInfo.vue
@@ -3,18 +3,41 @@ import TimeAgo from '@/app/components/TimeAgo.vue';
 import { useI18n } from '@n8n/i18n';
 import type { ICredentialsDecryptedResponse, ICredentialsResponse } from '../../credentials.types';
 import { ElCol, ElRow } from 'element-plus';
-import { N8nText } from '@n8n/design-system';
+import { N8nInput, N8nText } from '@n8n/design-system';
 type Props = {
 	currentCredential: ICredentialsResponse | ICredentialsDecryptedResponse | null;
+	description?: string | null;
+	readonly?: boolean;
 };
 
 defineProps<Props>();
+
+const emit = defineEmits<{
+	'update:description': [value: string];
+}>();
 
 const i18n = useI18n();
 </script>
 
 <template>
 	<div :class="$style.container">
+		<ElRow>
+			<ElCol :span="8" :class="$style.label">
+				<N8nText :compact="true" :bold="true">
+					{{ i18n.baseText('credentialEdit.credentialInfo.description') }}
+				</N8nText>
+			</ElCol>
+			<ElCol :span="16" :class="$style.valueLabel">
+				<N8nInput
+					:model-value="description ?? ''"
+					type="textarea"
+					:rows="4"
+					:disabled="readonly"
+					data-test-id="credential-description"
+					@update:model-value="emit('update:description', $event)"
+				/>
+			</ElCol>
+		</ElRow>
 		<ElRow v-if="currentCredential">
 			<ElCol :span="8" :class="$style.label">
 				<N8nText :compact="true" :bold="true">

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialForm.ts
@@ -72,6 +72,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 	// --- state -------------------------------------------------------------
 	const credentialData = ref<ICredentialDataDecryptedObject>({});
 	const credentialName = ref('');
+	const credentialDescription = ref<string | null>(null);
 	const credentialId = ref('');
 	const currentCredential = ref<ICredentialsResponse | ICredentialsDecryptedResponse | null>(null);
 	/** Set when the host switches auth type; overrides `activeId` as the type source. */
@@ -410,6 +411,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 			credentialData.value.homeProject = loaded.homeProject;
 		}
 		credentialName.value = loaded.name;
+		credentialDescription.value = loaded.description ?? null;
 		isResolvable.value =
 			'isResolvable' in loaded && typeof loaded.isResolvable === 'boolean'
 				? loaded.isResolvable
@@ -523,6 +525,7 @@ export function useCredentialForm(options: UseCredentialFormOptions) {
 		// state
 		credentialData,
 		credentialName,
+		credentialDescription,
 		credentialId,
 		currentCredential,
 		selectedCredential,

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.store.ts
@@ -355,6 +355,7 @@ export const useCredentialsStore = defineStore(STORES.CREDENTIALS, () => {
 		const settingsStore = useSettingsStore();
 		const credential = await credentialsApi.createNewCredential(rootStore.restApiContext, {
 			name: data.name,
+			description: data.description,
 			type: data.type,
 			data: data.data ?? {},
 			projectId,

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.types.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.types.ts
@@ -6,6 +6,7 @@ import type { IUserResponse } from '@n8n/rest-api-client/api/users';
 
 export interface ICredentialsResponse extends ICredentialsEncrypted {
 	id: string;
+	description?: string | null;
 	createdAt: Iso8601DateTimeString;
 	updatedAt: Iso8601DateTimeString;
 	sharedWithProjects?: ProjectSharingData[];

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -166,6 +166,7 @@ export type ProjectSharingData = {
 export interface ICredentialsDecrypted<T extends object = ICredentialDataDecryptedObject> {
 	id: string;
 	name: string;
+	description?: string | null;
 	type: string;
 	data?: T;
 	homeProject?: ProjectSharingData;


### PR DESCRIPTION
## Summary

Adds an optional **description** to credentials, mirroring the existing workflow and project description feature set:

- **Database:** new nullable `text` column on `credentials_entity` via reversible migration `AddCredentialDescriptionColumn1784000000045` (registered for sqlite + postgres), included in the repository's default selects, generated schema docs regenerated.
- **API:** `CreateCredentialDto` accepts `description` (nullable string, same validation as the workflow description); the PATCH endpoint sets it alongside `isGlobal`/`isResolvable` — omitting the field keeps the current value, an explicit `null` clears it. `import:credentials` treats it as importable.
- **MCP:** `list_credentials` returns `description` in its output schema, so MCP clients get the same context they already get for workflows.
- **Editor:** the Details tab of the credential modal gets an editable description textarea (read-only without update permission), wired through `useCredentialForm` → store → API for both create and update.

Not exposed in the public REST API, matching workflow/project descriptions which aren't either.

## How to test

1. Open any credential → **Details** tab → add a description → **Save**. Reopen: the description persists. Clear it and save: it stays cleared.
2. Create a new credential and set a description on the Details tab before the first save — it's stored on create.
3. As a user with read-only access to a shared credential, the field is not editable.
4. With MCP access enabled, call the `list_credentials` MCP tool — items include `description` when set.
5. Tests: `pnpm test` in `packages/cli` (unit) and `pnpm test:integration test/integration/credentials/credentials.api.test.ts` (includes new create/set/keep/clear round-trip tests); `pnpm test src/features/credentials` in `packages/frontend/editor-ui`.

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

