### PR TITLE
feat(eslint-config): Spike module-boundary lint + package tags (no-changelog)

### DIFF
--- a/packages/@n8n/agents/package.json
+++ b/packages/@n8n/agents/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "sdk", "scope": "ai" },
   "name": "@n8n/agents",
   "version": "0.15.0",
   "description": "AI agent SDK for n8n's code-first execution engine",

--- a/packages/@n8n/ai-node-sdk/package.json
+++ b/packages/@n8n/ai-node-sdk/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "sdk", "scope": "nodes" },
   "name": "@n8n/ai-node-sdk",
   "version": "0.20.0",
   "description": "SDK for building AI nodes in n8n",

--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "nodes" },
   "name": "@n8n/ai-utilities",
   "version": "0.23.0",
   "description": "Utilities for building AI nodes in n8n",

--- a/packages/@n8n/ai-workflow-builder.ee/package.json
+++ b/packages/@n8n/ai-workflow-builder.ee/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "ai" },
   "name": "@n8n/ai-workflow-builder",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/api-types/package.json
+++ b/packages/@n8n/api-types/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "data-access", "scope": "shared" },
   "name": "@n8n/api-types",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/backend-common/package.json
+++ b/packages/@n8n/backend-common/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "platform" },
   "name": "@n8n/backend-common",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/backend-network/package.json
+++ b/packages/@n8n/backend-network/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "data-access", "scope": "platform" },
   "name": "@n8n/backend-network",
   "version": "1.4.0",
   "scripts": {

--- a/packages/@n8n/backend-test-utils/package.json
+++ b/packages/@n8n/backend-test-utils/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/backend-test-utils",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/benchmark/package.json
+++ b/packages/@n8n/benchmark/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/n8n-benchmark",
   "version": "2.15.0",
   "description": "Cli for running benchmark tests for n8n",

--- a/packages/@n8n/chat-hub/package.json
+++ b/packages/@n8n/chat-hub/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "ai" },
   "name": "@n8n/chat-hub",
   "version": "1.23.0",
   "scripts": {

--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "platform" },
   "name": "@n8n/cli",
   "version": "0.10.0",
   "description": "[beta] Client CLI for n8n — manage workflows, executions, and credentials from the terminal",

--- a/packages/@n8n/client-oauth2/package.json
+++ b/packages/@n8n/client-oauth2/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "platform" },
   "name": "@n8n/client-oauth2",
   "version": "1.12.0",
   "scripts": {

--- a/packages/@n8n/codemirror-lang-html/package.json
+++ b/packages/@n8n/codemirror-lang-html/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "editor" },
   "name": "@n8n/codemirror-lang-html",
   "version": "1.6.0",
   "description": "HTML + n8n expression language support for CodeMirror 6",

--- a/packages/@n8n/codemirror-lang-sql/package.json
+++ b/packages/@n8n/codemirror-lang-sql/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "editor" },
   "name": "@n8n/codemirror-lang-sql",
   "version": "1.11.0",
   "description": "SQL + n8n expression language support for CodeMirror 6",

--- a/packages/@n8n/codemirror-lang/package.json
+++ b/packages/@n8n/codemirror-lang/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "editor" },
   "name": "@n8n/codemirror-lang",
   "version": "0.10.0",
   "description": "Language support package for CodeMirror 6 in n8n",

--- a/packages/@n8n/computer-use/package.json
+++ b/packages/@n8n/computer-use/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "ai" },
   "name": "@n8n/computer-use",
   "version": "0.14.0",
   "description": "Local AI gateway for n8n AI Assistant — filesystem, shell, screenshots, mouse/keyboard, and browser automation",

--- a/packages/@n8n/config/package.json
+++ b/packages/@n8n/config/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/config",
   "version": "2.28.0",
   "scripts": {

--- a/packages/@n8n/constants/package.json
+++ b/packages/@n8n/constants/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/constants",
   "version": "0.30.0",
   "scripts": {

--- a/packages/@n8n/crdt/package.json
+++ b/packages/@n8n/crdt/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "persistence" },
   "name": "@n8n/crdt",
   "version": "0.8.0",
   "description": "CRDT abstraction layer for n8n collaborative editing",

--- a/packages/@n8n/create-node/package.json
+++ b/packages/@n8n/create-node/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "nodes" },
   "name": "@n8n/create-node",
   "version": "0.38.0",
   "description": "Official CLI to create new community nodes for n8n",

--- a/packages/@n8n/db/package.json
+++ b/packages/@n8n/db/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "data-access", "scope": "persistence" },
   "name": "@n8n/db",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/decorators/package.json
+++ b/packages/@n8n/decorators/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/decorators",
   "version": "1.30.0",
   "scripts": {

--- a/packages/@n8n/di/package.json
+++ b/packages/@n8n/di/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/di",
   "version": "0.14.0",
   "scripts": {

--- a/packages/@n8n/engine/package.json
+++ b/packages/@n8n/engine/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "runtime", "scope": "workflow-engine" },
   "name": "@n8n/engine",
   "version": "0.10.0",
   "description": "n8n workflow execution engine (v2)",

--- a/packages/@n8n/errors/package.json
+++ b/packages/@n8n/errors/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/errors",
   "version": "0.11.0",
   "scripts": {

--- a/packages/@n8n/eslint-config/package.json
+++ b/packages/@n8n/eslint-config/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "private": true,
   "name": "@n8n/eslint-config",
   "type": "module",

--- a/packages/@n8n/eslint-config/scripts/spike-apply-boundaries.mjs
+++ b/packages/@n8n/eslint-config/scripts/spike-apply-boundaries.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * SPIKE: stamp `boundaries: { type, scope }` into every workspace package.json,
+ * then validate the real workspace dependency graph against the module-boundary
+ * matrices. Run from the repo root: `node packages/@n8n/eslint-config/scripts/spike-apply-boundaries.mjs`
+ *
+ * Not production code — this is the throwaway harness that answers "what breaks
+ * if we adopt the tags in the table". The real tag source would be a generator
+ * wired into the eslint config; here we embed the mapping so it stays reviewable.
+ *
+ * NOTE: uses key `boundaries`, NOT `n8n` — the `n8n` key is already taken by
+ * node/credential registration in nodes-base et al.
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+// name -> [type, scope]. Mirrors the assessment table (extended type set).
+const TAGS = {
+	// shared
+	'@n8n/utils': ['util', 'shared'],
+	'@n8n/constants': ['util', 'shared'],
+	'@n8n/errors': ['util', 'shared'],
+	'@n8n/di': ['util', 'shared'],
+	'@n8n/decorators': ['util', 'shared'],
+	'@n8n/config': ['util', 'shared'],
+	'@n8n/permissions': ['util', 'shared'],
+	'@n8n/i18n': ['util', 'shared'],
+	'@n8n/json-schema-to-zod': ['util', 'shared'],
+	'@n8n/api-types': ['data-access', 'shared'],
+	// workflow-engine
+	'n8n-workflow': ['runtime', 'workflow-engine'],
+	'n8n-core': ['runtime', 'workflow-engine'],
+	'@n8n/engine': ['runtime', 'workflow-engine'],
+	'@n8n/expression-runtime': ['runtime', 'workflow-engine'],
+	'@n8n/scheduler': ['util', 'workflow-engine'],
+	'@n8n/tournament': ['util', 'workflow-engine'],
+	'@n8n/task-runner': ['app', 'workflow-engine'],
+	'@n8n/workflow-sdk': ['sdk', 'workflow-engine'],
+	// nodes
+	'n8n-nodes-base': ['nodes', 'nodes'],
+	'@n8n/n8n-nodes-langchain': ['nodes', 'nodes'],
+	'@n8n/ai-node-sdk': ['sdk', 'nodes'],
+	'@n8n/ai-utilities': ['util', 'nodes'],
+	'@n8n/extension-sdk': ['sdk', 'nodes'],
+	'@n8n/create-node': ['tooling', 'nodes'],
+	'@n8n/node-cli': ['tooling', 'nodes'],
+	'n8n-node-dev': ['tooling', 'nodes'],
+	'@n8n/scan-community-package': ['tooling', 'nodes'],
+	'@n8n/eslint-plugin-community-nodes': ['tooling', 'nodes'],
+	// ai
+	'@n8n/instance-ai': ['feature', 'ai'],
+	'@n8n/ai-workflow-builder': ['feature', 'ai'],
+	'@n8n/agents': ['sdk', 'ai'],
+	'@n8n/computer-use': ['app', 'ai'],
+	'@n8n/mcp-apps': ['feature', 'ai'],
+	'@n8n/mcp-browser': ['util', 'ai'],
+	'@n8n/mcp-browser-extension': ['app', 'ai'],
+	'@n8n/chat-hub': ['feature', 'ai'],
+	'@n8n/chat': ['feature', 'ai'],
+	// editor (frontend)
+	'n8n-editor-ui': ['app', 'editor'],
+	'@n8n/design-system': ['ui', 'editor'],
+	'@n8n/stores': ['data-access', 'editor'],
+	'@n8n/rest-api-client': ['data-access', 'editor'],
+	'@n8n/composables': ['util', 'editor'],
+	'@n8n/codemirror-lang': ['util', 'editor'],
+	'@n8n/codemirror-lang-html': ['util', 'editor'],
+	'@n8n/codemirror-lang-sql': ['util', 'editor'],
+	// persistence
+	'@n8n/db': ['data-access', 'persistence'],
+	'@n8n/typeorm': ['util', 'persistence'],
+	'@n8n/crdt': ['util', 'persistence'],
+	// platform (backend server)
+	n8n: ['app', 'platform'],
+	'@n8n/cli': ['app', 'platform'],
+	'@n8n/backend-common': ['util', 'platform'],
+	'@n8n/backend-network': ['data-access', 'platform'],
+	'@n8n/local-gateway': ['app', 'platform'],
+	'@n8n/syslog-client': ['util', 'platform'],
+	'@n8n/imap': ['util', 'platform'],
+	'@n8n/client-oauth2': ['util', 'platform'],
+	// insights
+	'@n8n/n8n-extension-insights': ['feature', 'insights'],
+	// tooling
+	'@n8n/eslint-config': ['tooling', 'tooling'],
+	'@n8n/typescript-config': ['tooling', 'tooling'],
+	'@n8n/vitest-config': ['tooling', 'tooling'],
+	'@n8n/stylelint-config': ['tooling', 'tooling'],
+	'@n8n/storybook': ['tooling', 'tooling'],
+	'@n8n/code-health': ['tooling', 'tooling'],
+	'@n8n/test-impact': ['tooling', 'tooling'],
+	'@n8n/playwright-janitor': ['tooling', 'tooling'],
+	'n8n-playwright': ['tooling', 'tooling'],
+	'n8n-containers': ['tooling', 'tooling'],
+	'@n8n/performance': ['tooling', 'tooling'],
+	'@n8n/n8n-benchmark': ['tooling', 'tooling'],
+	'@n8n/backend-test-utils': ['tooling', 'tooling'],
+	'@n8n/rules-engine': ['tooling', 'tooling'],
+};
+
+const ALL = [
+	'app', 'feature', 'runtime', 'nodes', 'sdk', 'data-access', 'domain-ui', 'ui', 'util', 'tooling',
+];
+const ALLOWED_TYPES = {
+	app: ALL,
+	tooling: ALL,
+	feature: ['data-access', 'domain-ui', 'ui', 'util', 'sdk'],
+	runtime: ['runtime', 'data-access', 'util'],
+	nodes: ['nodes', 'runtime', 'data-access', 'sdk', 'util'],
+	sdk: ['sdk', 'runtime', 'data-access', 'util'],
+	'data-access': ['data-access', 'util'],
+	'domain-ui': ['domain-ui', 'ui', 'util'],
+	ui: ['ui', 'util'],
+	util: ['util'],
+};
+const SCOPE_EXEMPT_TYPES = new Set(['app', 'tooling']);
+const SHARED_SCOPES = new Set(['shared', 'tooling']);
+
+// --- discover package.json files ---
+const roots = [
+	'packages',
+	'packages/@n8n',
+	'packages/frontend',
+	'packages/frontend/@n8n',
+	'packages/extensions',
+	'packages/testing',
+];
+const pkgFiles = [];
+for (const root of roots) {
+	if (!existsSync(root)) continue;
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const pj = join(root, entry.name, 'package.json');
+		if (existsSync(pj)) pkgFiles.push(pj);
+	}
+}
+
+// --- stamp tags (textual insert to keep diffs to one line) ---
+const byName = {};
+let stamped = 0;
+const untagged = [];
+for (const pj of pkgFiles) {
+	const raw = readFileSync(pj, 'utf8');
+	const pkg = JSON.parse(raw);
+	byName[pkg.name] = { pj, pkg };
+	const tag = TAGS[pkg.name];
+	if (!tag) { untagged.push(pkg.name); continue; }
+	const [type, scope] = tag;
+	if (raw.includes('"boundaries"')) { stamped++; continue; }
+	const insert = `  "boundaries": { "type": "${type}", "scope": "${scope}" },\n`;
+	writeFileSync(pj, raw.replace(/^{\n/, `{\n${insert}`));
+	stamped++;
+}
+
+// --- validate the runtime dependency graph ---
+const names = new Set(Object.keys(byName));
+const typeViol = [];
+const scopeViol = [];
+for (const [name, { pkg }] of Object.entries(byName)) {
+	const tag = TAGS[name];
+	if (!tag) continue;
+	const [fromType, fromScope] = tag;
+	for (const dep of Object.keys(pkg.dependencies ?? {})) {
+		if (!names.has(dep) || dep === name) continue;
+		const toTag = TAGS[dep];
+		if (!toTag) continue;
+		const [toType, toScope] = toTag;
+		if (!ALLOWED_TYPES[fromType].includes(toType)) {
+			typeViol.push(`${name} (${fromType}) -> ${dep} (${toType})`);
+			continue;
+		}
+		const scopeOk =
+			SCOPE_EXEMPT_TYPES.has(fromType) ||
+			fromScope === toScope ||
+			SHARED_SCOPES.has(toScope);
+		if (!scopeOk) scopeViol.push(`${name} [${fromScope}] -> ${dep} [${toScope}]`);
+	}
+}
+
+console.log(`\n=== stamped ${stamped}/${pkgFiles.length} package.json files ===`);
+if (untagged.length) console.log(`untagged (no mapping): ${untagged.join(', ')}`);
+console.log(`\n=== TYPE violations (${typeViol.length}) ===`);
+typeViol.sort().forEach((v) => console.log('  ' + v));
+console.log(`\n=== SCOPE violations (${scopeViol.length}) — need explicit opt-in ===`);
+scopeViol.sort().forEach((v) => console.log('  ' + v));

--- a/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.test.ts
@@ -1,0 +1,100 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import {
+	EnforceModuleBoundariesRule,
+	type Options,
+	type PackageTag,
+} from './enforce-module-boundaries.js';
+
+const ruleTester = new RuleTester();
+
+// A representative slice of a tagged n8n frontend monorepo.
+const packages: PackageTag[] = [
+	{ name: 'apps-frontend', path: 'apps/frontend', type: 'app', scope: 'shell' },
+	{ name: '@n8n/feature-ai', path: 'features/ai', type: 'feature', scope: 'ai' },
+	{
+		name: '@n8n/feature-credentials',
+		path: 'features/credentials',
+		type: 'feature',
+		scope: 'credentials',
+	},
+	{
+		name: '@n8n/credentials-data',
+		path: 'data-access/credentials',
+		type: 'data-access',
+		scope: 'credentials',
+	},
+	{
+		name: '@n8n/rest-api-client',
+		path: 'shared/rest-api-client',
+		type: 'data-access',
+		scope: 'shared',
+	},
+	{ name: '@n8n/design-system', path: 'shared/design-system', type: 'ui', scope: 'shared' },
+	{ name: '@n8n/utils', path: 'shared/utils', type: 'util', scope: 'shared' },
+];
+
+const options: [Options] = [{ packages }];
+
+ruleTester.run('enforce-module-boundaries', EnforceModuleBoundariesRule, {
+	valid: [
+		{
+			// app may glue together features
+			code: 'import { AiPanel } from "@n8n/feature-ai"',
+			filename: '/repo/apps/frontend/src/main.ts',
+			options,
+		},
+		{
+			// feature -> data-access (shared) is allowed
+			code: 'import { restApi } from "@n8n/rest-api-client"',
+			filename: '/repo/features/ai/src/store.ts',
+			options,
+		},
+		{
+			// feature -> shared UI is allowed
+			code: 'import { N8nButton } from "@n8n/design-system"',
+			filename: '/repo/features/ai/src/Panel.vue',
+			options,
+		},
+		{
+			// anyone -> util is allowed
+			code: 'import { deepCopy } from "@n8n/utils"',
+			filename: '/repo/shared/rest-api-client/src/client.ts',
+			options,
+		},
+		{
+			// external / relative imports are ignored
+			code: 'import { ref } from "vue"; import { helper } from "./helper";',
+			filename: '/repo/features/ai/src/store.ts',
+			options,
+		},
+		{
+			// cross-scope becomes valid once explicitly opted in
+			code: 'import { credData } from "@n8n/credentials-data"',
+			filename: '/repo/features/ai/src/store.ts',
+			options: [{ packages, allowedScopeDependencies: { ai: ['credentials'] } }] as [Options],
+		},
+	],
+	invalid: [
+		{
+			// data-access must stay UI-free
+			code: 'import { N8nButton } from "@n8n/design-system"',
+			filename: '/repo/shared/rest-api-client/src/client.ts',
+			options,
+			errors: [{ messageId: 'forbiddenType' }],
+		},
+		{
+			// features must not import each other (vertical slicing)
+			code: 'import { CredForm } from "@n8n/feature-credentials"',
+			filename: '/repo/features/ai/src/Panel.vue',
+			options,
+			errors: [{ messageId: 'forbiddenType' }],
+		},
+		{
+			// type is allowed (feature->data-access) but scope crosses without opt-in
+			code: 'import { credData } from "@n8n/credentials-data"',
+			filename: '/repo/features/ai/src/store.ts',
+			options,
+			errors: [{ messageId: 'forbiddenScope' }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.ts
+++ b/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.ts
@@ -1,0 +1,129 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+/**
+ * SPIKE: generalized library tagging + module-boundary enforcement.
+ *
+ * Every workspace package gets two tags: a `type` (its layer) and a `scope`
+ * (its domain/owner). Import edges between packages are then policed by two
+ * matrices:
+ *   - type hierarchy: e.g. a `data-access` package may not import a UI package.
+ *   - scope rules: a package may only import its own scope, a `shared` scope,
+ *     or a scope it has explicitly opted into depending on.
+ *
+ * This is the n8n-native version of NX's enforce-module-boundaries, built on
+ * the same custom-rule machinery n8n already uses for `misplaced-n8n-typeorm-import`
+ * and `no-import-enterprise-edition` — no new dependency.
+ *
+ * ponytail: tags are passed as options here so the rule stays hermetic and
+ * testable. Real wiring would generate the package list from each package.json's
+ * `n8n.tags` field at config-build time (one fs scan, cached). Add when adopted.
+ */
+
+export type BoundaryType = 'app' | 'feature' | 'data-access' | 'domain-ui' | 'ui' | 'util';
+
+export interface PackageTag {
+	name: string;
+	path: string;
+	type: BoundaryType;
+	scope: string;
+}
+
+export interface Options {
+	packages: PackageTag[];
+	/** importer type -> target types it may import. Overrides the default hierarchy. */
+	allowedTypes?: Partial<Record<BoundaryType, BoundaryType[]>>;
+	/** scopes any package may import regardless of its own scope. */
+	sharedScopes?: string[];
+	/** importer scope -> extra scopes it has opted into importing. */
+	allowedScopeDependencies?: Record<string, string[]>;
+}
+
+// Konstantin's hierarchy: apps glue everything, features slice vertically and
+// must not import each other, data-access stays UI-free, utils are universal.
+const DEFAULT_ALLOWED_TYPES: Record<BoundaryType, BoundaryType[]> = {
+	app: ['app', 'feature', 'data-access', 'domain-ui', 'ui', 'util'],
+	feature: ['data-access', 'domain-ui', 'ui', 'util'],
+	'data-access': ['data-access', 'util'],
+	'domain-ui': ['domain-ui', 'ui', 'util'],
+	ui: ['ui', 'util'],
+	util: ['util'],
+};
+
+export const EnforceModuleBoundariesRule = ESLintUtils.RuleCreator.withoutDocs({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Enforce type (layer) and scope (domain) import boundaries between tagged workspace packages.',
+		},
+		messages: {
+			forbiddenType:
+				'A "{{ fromType }}" package cannot import a "{{ toType }}" package ({{ toName }}).',
+			forbiddenScope:
+				'Scope "{{ fromScope }}" cannot import scope "{{ toScope }}" ({{ toName }}). Add it to allowedScopeDependencies or expose a shared package.',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					packages: { type: 'array' },
+					allowedTypes: { type: 'object' },
+					sharedScopes: { type: 'array', items: { type: 'string' } },
+					allowedScopeDependencies: { type: 'object' },
+				},
+				required: ['packages'],
+				additionalProperties: false,
+			},
+		],
+	},
+	defaultOptions: [{ packages: [] } as Options],
+	create(context, [options]) {
+		const { packages, allowedScopeDependencies = {} } = options;
+		const allowedTypes = { ...DEFAULT_ALLOWED_TYPES, ...options.allowedTypes };
+		const sharedScopes = options.sharedScopes ?? ['shared'];
+
+		const filename = context.filename.split('\\').join('/');
+
+		// Longest-matching path wins so nested packages resolve to themselves.
+		const fromPkg = packages
+			.filter((p) => filename.includes(p.path))
+			.sort((a, b) => b.path.length - a.path.length)[0];
+
+		if (!fromPkg) return {};
+
+		const resolveTarget = (specifier: string) =>
+			packages.find((p) => specifier === p.name || specifier.startsWith(`${p.name}/`));
+
+		return {
+			ImportDeclaration(node) {
+				if (typeof node.source.value !== 'string') return;
+
+				const toPkg = resolveTarget(node.source.value);
+				if (!toPkg || toPkg.name === fromPkg.name) return; // external dep or self import
+
+				if (!allowedTypes[fromPkg.type].includes(toPkg.type)) {
+					context.report({
+						node: node.source,
+						messageId: 'forbiddenType',
+						data: { fromType: fromPkg.type, toType: toPkg.type, toName: toPkg.name },
+					});
+					return;
+				}
+
+				const scopeAllowed =
+					fromPkg.type === 'app' || // apps glue every scope together
+					fromPkg.scope === toPkg.scope ||
+					sharedScopes.includes(toPkg.scope) ||
+					(allowedScopeDependencies[fromPkg.scope] ?? []).includes(toPkg.scope);
+
+				if (!scopeAllowed) {
+					context.report({
+						node: node.source,
+						messageId: 'forbiddenScope',
+						data: { fromScope: fromPkg.scope, toScope: toPkg.scope, toName: toPkg.name },
+					});
+				}
+			},
+		};
+	},
+});

--- a/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.ts
+++ b/packages/@n8n/eslint-config/src/rules/enforce-module-boundaries.ts
@@ -19,7 +19,17 @@ import { ESLintUtils } from '@typescript-eslint/utils';
  * `n8n.tags` field at config-build time (one fs scan, cached). Add when adopted.
  */
 
-export type BoundaryType = 'app' | 'feature' | 'data-access' | 'domain-ui' | 'ui' | 'util';
+export type BoundaryType =
+	| 'app'
+	| 'feature'
+	| 'runtime'
+	| 'nodes'
+	| 'sdk'
+	| 'data-access'
+	| 'domain-ui'
+	| 'ui'
+	| 'util'
+	| 'tooling';
 
 export interface PackageTag {
 	name: string;
@@ -40,9 +50,26 @@ export interface Options {
 
 // Konstantin's hierarchy: apps glue everything, features slice vertically and
 // must not import each other, data-access stays UI-free, utils are universal.
+const ALL_TYPES: BoundaryType[] = [
+	'app',
+	'feature',
+	'runtime',
+	'nodes',
+	'sdk',
+	'data-access',
+	'domain-ui',
+	'ui',
+	'util',
+	'tooling',
+];
+
 const DEFAULT_ALLOWED_TYPES: Record<BoundaryType, BoundaryType[]> = {
-	app: ['app', 'feature', 'data-access', 'domain-ui', 'ui', 'util'],
-	feature: ['data-access', 'domain-ui', 'ui', 'util'],
+	app: ALL_TYPES, // apps glue everything together
+	tooling: ALL_TYPES, // dev/CI only, not in any runtime bundle
+	feature: ['data-access', 'domain-ui', 'ui', 'util', 'sdk'],
+	runtime: ['runtime', 'data-access', 'util'],
+	nodes: ['nodes', 'runtime', 'data-access', 'sdk', 'util'],
+	sdk: ['sdk', 'runtime', 'data-access', 'util'],
 	'data-access': ['data-access', 'util'],
 	'domain-ui': ['domain-ui', 'ui', 'util'],
 	ui: ['ui', 'util'],
@@ -112,6 +139,7 @@ export const EnforceModuleBoundariesRule = ESLintUtils.RuleCreator.withoutDocs({
 
 				const scopeAllowed =
 					fromPkg.type === 'app' || // apps glue every scope together
+					fromPkg.type === 'tooling' || // dev/CI crosses every domain
 					fromPkg.scope === toPkg.scope ||
 					sharedScopes.includes(toPkg.scope) ||
 					(allowedScopeDependencies[fromPkg.scope] ?? []).includes(toPkg.scope);

--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -21,6 +21,7 @@ import { NoErrorInstanceInToThrowRule } from './no-error-instance-in-to-throw.js
 import { NoAwsCredentialDiscoveryImportsRule } from './no-aws-credential-discovery-imports.js';
 import { NoUncentralizedHttpRule } from './no-uncentralized-http.js';
 import { NoApplicationErrorRule } from './no-application-error.js';
+import { EnforceModuleBoundariesRule } from './enforce-module-boundaries.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -45,4 +46,5 @@ export const rules = {
 	'no-aws-credential-discovery-imports': NoAwsCredentialDiscoveryImportsRule,
 	'no-uncentralized-http': NoUncentralizedHttpRule,
 	'no-application-error': NoApplicationErrorRule,
+	'enforce-module-boundaries': EnforceModuleBoundariesRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-plugin-community-nodes/package.json
+++ b/packages/@n8n/eslint-plugin-community-nodes/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "nodes" },
   "name": "@n8n/eslint-plugin-community-nodes",
   "type": "module",
   "version": "0.24.0",

--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "runtime", "scope": "workflow-engine" },
   "name": "@n8n/expression-runtime",
   "version": "0.21.0",
   "description": "Secure, isolated expression evaluation runtime for n8n",

--- a/packages/@n8n/extension-sdk/package.json
+++ b/packages/@n8n/extension-sdk/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "sdk", "scope": "nodes" },
   "name": "@n8n/extension-sdk",
   "version": "0.14.0",
   "type": "module",

--- a/packages/@n8n/imap/package.json
+++ b/packages/@n8n/imap/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "platform" },
   "name": "@n8n/imap",
   "version": "0.23.0",
   "scripts": {

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "ai" },
   "name": "@n8n/instance-ai",
   "version": "1.15.0",
   "scripts": {

--- a/packages/@n8n/json-schema-to-zod/package.json
+++ b/packages/@n8n/json-schema-to-zod/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/json-schema-to-zod",
   "version": "1.13.0",
   "description": "Converts JSON schema objects into Zod schemas",

--- a/packages/@n8n/local-gateway/package.json
+++ b/packages/@n8n/local-gateway/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "platform" },
   "name": "@n8n/local-gateway",
   "version": "0.1.0",
   "description": "n8n Local Gateway",

--- a/packages/@n8n/mcp-apps/package.json
+++ b/packages/@n8n/mcp-apps/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "ai" },
   "name": "@n8n/mcp-apps",
   "version": "0.7.0",
   "description": "MCP Apps UI resources and server helpers for n8n",

--- a/packages/@n8n/mcp-browser-extension/package.json
+++ b/packages/@n8n/mcp-browser-extension/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "ai" },
   "name": "@n8n/mcp-browser-extension",
   "version": "0.0.4",
   "private": true,

--- a/packages/@n8n/mcp-browser/package.json
+++ b/packages/@n8n/mcp-browser/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "ai" },
   "name": "@n8n/mcp-browser",
   "version": "0.13.0",
   "description": "Browser automation MCP tools built on Playwright, WebDriver BiDi, and safaridriver",

--- a/packages/@n8n/node-cli/package.json
+++ b/packages/@n8n/node-cli/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "nodes" },
   "name": "@n8n/node-cli",
   "version": "0.39.0",
   "description": "Official CLI for developing community nodes for n8n",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "nodes", "scope": "nodes" },
   "name": "@n8n/n8n-nodes-langchain",
   "version": "2.30.0",
   "description": "",

--- a/packages/@n8n/permissions/package.json
+++ b/packages/@n8n/permissions/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/permissions",
   "version": "0.67.0",
   "scripts": {

--- a/packages/@n8n/scan-community-package/package.json
+++ b/packages/@n8n/scan-community-package/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "nodes" },
   "name": "@n8n/scan-community-package",
   "version": "0.26.0",
   "description": "Static code analyser for n8n community packages",

--- a/packages/@n8n/scheduler/package.json
+++ b/packages/@n8n/scheduler/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "workflow-engine" },
   "name": "@n8n/scheduler",
   "version": "0.2.0",
   "scripts": {

--- a/packages/@n8n/stylelint-config/package.json
+++ b/packages/@n8n/stylelint-config/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "private": true,
   "name": "@n8n/stylelint-config",
   "type": "module",

--- a/packages/@n8n/syslog-client/package.json
+++ b/packages/@n8n/syslog-client/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "platform" },
   "name": "@n8n/syslog-client",
   "version": "1.7.0",
   "scripts": {

--- a/packages/@n8n/task-runner/package.json
+++ b/packages/@n8n/task-runner/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "workflow-engine" },
   "name": "@n8n/task-runner",
   "version": "2.30.0",
   "scripts": {

--- a/packages/@n8n/tournament/package.json
+++ b/packages/@n8n/tournament/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "workflow-engine" },
   "name": "@n8n/tournament",
   "version": "1.6.0",
   "description": "Output compatible rewrite of riot tmpl",

--- a/packages/@n8n/typeorm/package.json
+++ b/packages/@n8n/typeorm/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "persistence" },
   "name": "@n8n/typeorm",
   "version": "0.4.0",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports PostgreSQL and SQLite databases.",

--- a/packages/@n8n/typescript-config/package.json
+++ b/packages/@n8n/typescript-config/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/typescript-config",
   "version": "1.8.0",
   "type": "module",

--- a/packages/@n8n/utils/package.json
+++ b/packages/@n8n/utils/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/utils",
   "type": "module",
   "version": "1.38.0",

--- a/packages/@n8n/vitest-config/package.json
+++ b/packages/@n8n/vitest-config/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/vitest-config",
   "version": "1.17.0",
   "type": "module",

--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "sdk", "scope": "workflow-engine" },
   "name": "@n8n/workflow-sdk",
   "version": "0.23.0",
   "description": "TypeScript SDK for programmatically creating n8n workflows",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "platform" },
   "name": "n8n",
   "version": "2.30.0",
   "description": "n8n Workflow Automation Tool",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "runtime", "scope": "workflow-engine" },
   "name": "n8n-core",
   "version": "2.30.0",
   "description": "Core functionality of n8n",

--- a/packages/extensions/insights/package.json
+++ b/packages/extensions/insights/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "insights" },
   "name": "@n8n/n8n-extension-insights",
   "version": "0.17.0",
   "type": "module",

--- a/packages/frontend/@n8n/chat/package.json
+++ b/packages/frontend/@n8n/chat/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "feature", "scope": "ai" },
   "name": "@n8n/chat",
   "version": "1.29.0",
   "scripts": {

--- a/packages/frontend/@n8n/composables/package.json
+++ b/packages/frontend/@n8n/composables/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "editor" },
   "name": "@n8n/composables",
   "type": "module",
   "version": "1.20.0",

--- a/packages/frontend/@n8n/design-system/package.json
+++ b/packages/frontend/@n8n/design-system/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "ui", "scope": "editor" },
   "type": "module",
   "name": "@n8n/design-system",
   "version": "2.29.0",

--- a/packages/frontend/@n8n/i18n/package.json
+++ b/packages/frontend/@n8n/i18n/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "util", "scope": "shared" },
   "name": "@n8n/i18n",
   "type": "module",
   "version": "2.30.0",

--- a/packages/frontend/@n8n/rest-api-client/package.json
+++ b/packages/frontend/@n8n/rest-api-client/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "data-access", "scope": "editor" },
   "name": "@n8n/rest-api-client",
   "type": "module",
   "version": "2.30.0",

--- a/packages/frontend/@n8n/stores/package.json
+++ b/packages/frontend/@n8n/stores/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "data-access", "scope": "editor" },
   "name": "@n8n/stores",
   "type": "module",
   "version": "2.30.0",

--- a/packages/frontend/@n8n/storybook/package.json
+++ b/packages/frontend/@n8n/storybook/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/storybook",
   "private": true,
   "version": "0.0.0",

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "app", "scope": "editor" },
   "name": "n8n-editor-ui",
   "version": "2.30.0",
   "description": "Workflow Editor UI for n8n",

--- a/packages/node-dev/package.json
+++ b/packages/node-dev/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "nodes" },
   "name": "n8n-node-dev",
   "version": "2.9.0",
   "description": "CLI to simplify n8n credentials/node development",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "nodes", "scope": "nodes" },
   "name": "n8n-nodes-base",
   "version": "2.30.0",
   "description": "Base nodes of n8n",

--- a/packages/testing/code-health/package.json
+++ b/packages/testing/code-health/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
 	"name": "@n8n/code-health",
 	"private": true,
 	"version": "0.1.0",

--- a/packages/testing/containers/package.json
+++ b/packages/testing/containers/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "n8n-containers",
   "private": true,
   "version": "1.0.0",

--- a/packages/testing/janitor/package.json
+++ b/packages/testing/janitor/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/playwright-janitor",
   "private": true,
   "version": "0.1.0",

--- a/packages/testing/performance/package.json
+++ b/packages/testing/performance/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/performance",
   "version": "1.0.0",
   "private": true,

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "n8n-playwright",
   "private": true,
   "scripts": {

--- a/packages/testing/rules-engine/package.json
+++ b/packages/testing/rules-engine/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
 	"name": "@n8n/rules-engine",
 	"private": true,
 	"version": "0.1.0",

--- a/packages/testing/test-impact/package.json
+++ b/packages/testing/test-impact/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "tooling", "scope": "tooling" },
   "name": "@n8n/test-impact",
   "private": true,
   "version": "0.1.0",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,4 +1,5 @@
 {
+  "boundaries": { "type": "runtime", "scope": "workflow-engine" },
   "name": "n8n-workflow",
   "version": "2.30.0",
   "description": "Workflow base code of n8n",


### PR DESCRIPTION
## Summary

Spike (`no-changelog`) exploring library tagging + enforced module boundaries for the frontend/backend modularization effort. Adds a tag-driven ESLint rule (`enforce-module-boundaries`) that generalizes n8n's existing homegrown import-policing rules (`misplaced-n8n-typeorm-import`, `no-import-enterprise-edition`) into one rule checking `type` (layer) and `scope` (domain) boundaries between packages — no new dependency. It then applies proposed `boundaries: { type, scope }` tags to all 71 workspace `package.json` files and includes a validation harness (`spike-apply-boundaries.mjs`) that checks the real dependency graph against the matrices. The harness surfaces 19 type + 21 scope violations that map to concrete refactors (split the types/runtime concerns of `n8n-workflow`, re-scope shared infra like `design-system`/`workflow-sdk` to `shared`, fix `core → platform` layering inversions). The rule is inert — not wired into any package's lint config yet.

## How to test

`cd packages/@n8n/eslint-config && pnpm vitest run src/rules/enforce-module-boundaries.test.ts` (9 tests) and `node packages/@n8n/eslint-config/scripts/spike-apply-boundaries.mjs` from the repo root to see the violation report.

## Related Linear tickets, Github issues, and Community forum posts

_None — exploratory spike from the frontend modularization discussion._

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/33985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

