### PR TITLE
chore: Add repo-local Nathan CLI for deploying test instances

### DIFF
--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -17,10 +17,9 @@ the same commands from the repo via `pnpm nathan`.
    build takes. The `npx localtunnel` fallback frequently drops mid-deploy and
    loses the reply. Check with `command -v cloudflared` — **if it's missing, ask
    the user to run `brew install cloudflared` before deploying.**
-2. **A Nathan token is needed**, read from (in order): `NATHAN_TOKEN` env →
-   `~/.n8n/nathan-token` → `.env.local`. If none exists (check with
-   `test -s ~/.n8n/nathan-token || echo missing`), **ask the user for one
-   yourself** — point them at the form
+2. **A Nathan token is needed**, read from `~/.n8n/nathan-token`. If it's missing
+   (check with `test -s ~/.n8n/nathan-token || echo missing`), **ask the user for
+   one yourself** — point them at the form
    (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
    where they log in with their n8n account and copy the token from the response
    — then write it for them:

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -17,14 +17,21 @@ the same commands from the repo via `pnpm nathan`.
    build takes. The `npx localtunnel` fallback frequently drops mid-deploy and
    loses the reply. Check with `command -v cloudflared` — **if it's missing, ask
    the user to run `brew install cloudflared` before deploying.**
-2. **A Nathan token is needed.** On first run the script prints a form link
+2. **A Nathan token is needed**, read from (in order): `NATHAN_TOKEN` env →
+   `~/.n8n/nathan-token` → `.env.local`. If none exists (check with
+   `test -s ~/.n8n/nathan-token || echo missing`), **ask the user for one
+   yourself** — point them at the form
    (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
-   the user logs in with their n8n account, pastes the token back, and it's
-   cached to `~/.n8n/nathan-token` for future runs. **The paste prompt only works
-   in an interactive terminal** — if you're running non-interactively (agent /
-   background), ask the user to run `pnpm nathan help` once themselves to set it
-   up (or to export `NATHAN_TOKEN`). Resolution order: `NATHAN_TOKEN` env →
-   `~/.n8n/nathan-token` → `.env.local`.
+   where they log in with their n8n account and copy the token from the response
+   — then write it for them:
+
+   ```bash
+   mkdir -p ~/.n8n && printf '%s\n' '<PASTED_TOKEN>' > ~/.n8n/nathan-token && chmod 600 ~/.n8n/nathan-token
+   ```
+
+   Future runs reuse it. (Humans running the script interactively get the same
+   flow via a paste prompt; that prompt needs a real terminal, so as an agent do
+   the write yourself rather than relying on it.)
 
 ## Offer a test instance after a PR
 

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -73,8 +73,10 @@ Key flags (pass after the deploy args): `--license community|enterprise|starter|
 
 `pnpm nathan local ...` generates a runnable `docker run` bundle, but Nathan
 delivers it as **Slack file attachments** (`run-n8n.sh` + `.env`), not to the
-terminal. Set `NATHAN_SLACK_CHANNEL=<slack channel id>` to receive them, or run
-`/nathan local` in Slack. `deploy` and `help` return fully in the terminal.
+terminal — they land in **#updates-pnpm-nathan**
+(https://n8nio.slack.com/archives/C0BGVHZ0SCW). Override the destination with
+`NATHAN_SLACK_CHANNEL=<slack channel id>`. `deploy` and `help` return fully in
+the terminal.
 
 ## Unsupported
 

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -18,7 +18,7 @@ the same commands from the repo via `pnpm nathan`.
   success even if the tunnel drops. (Redeploying a name that's *already up* skips
   the poll — it can't tell the old instance from the new — so it falls back to the
   tunnel; prefer a fresh name when you need the reliable report.)
-- **A token in `~/.n8n/nathan-token`.** If a command reports no token, **ask the
+- **A token in `~/.n8n/dev/nathan-token`.** If a command reports no token, **ask the
   user for one** — point them at the form
   (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
   where they log in with their n8n account and copy the token from the response —

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -74,9 +74,11 @@ Key flags (pass after the deploy args): `--license community|enterprise|starter|
 `pnpm nathan local ...` generates a runnable `docker run` bundle, but Nathan
 delivers it as **Slack file attachments** (`run-n8n.sh` + `.env`), not to the
 terminal — they land in **#updates-pnpm-nathan**
-(https://n8nio.slack.com/archives/C0BGVHZ0SCW). Override the destination with
-`NATHAN_SLACK_CHANNEL=<slack channel id>`. `deploy` and `help` return fully in
-the terminal.
+(https://n8nio.slack.com/archives/C0BGVHZ0SCW). `deploy` and `help` return fully
+in the terminal.
+
+**Do not invent a `NATHAN_SLACK_CHANNEL`.** Leave it unset (it defaults to
+#updates-pnpm-nathan); only set it if the user explicitly gives you a channel id.
 
 ## Unsupported
 

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -27,11 +27,33 @@ the same commands from the repo via `pnpm nathan`.
   mkdir -p ~/.n8n && printf '%s\n' '<PASTED_TOKEN>' > ~/.n8n/nathan-token && chmod 600 ~/.n8n/nathan-token
   ```
 
-## Offer a test instance after a PR
+## Offer a test instance
 
-After you open a PR, **offer the user a live test instance for the branch.** Don't
-just ask a bare yes/no — look at the diff and **propose a sensible profile**, then
-let them confirm or adjust. For example:
+### Only when it's worth it
+
+Use judgement — don't offer for every branch. **Offer** when the change is
+something a person would actually want to click through in a running instance:
+
+- New features / feature branches
+- UI / editor changes, node changes, workflow-execution or behaviour changes
+- Larger or user-facing diffs
+
+**Skip the offer** (a test instance adds nothing) for:
+
+- Dev tooling, CI, build config, scripts (like this one)
+- Docs-only or tests-only changes
+- Tiny bug fixes, no-behaviour-change refactors, dependency bumps
+
+When skipping, don't nag — at most mention once that a test instance is available
+on request.
+
+### Offer after opening a PR, and re-offer on push
+
+After you open a PR for a branch that warrants it, **offer a live test instance.**
+Also **re-offer whenever you `git push` new commits** to such a branch — the
+deployed instance reflects the pushed code, so a new push means a new build worth
+redeploying. Don't just ask a bare yes/no — look at the diff and **propose a
+sensible profile**, then let them confirm or adjust. For example:
 
 > "Want a test instance for this? Based on the diff I'd deploy it with instance AI
 > enabled (`--ai`) since it touches the AI assistant. Sound good, or a different

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: n8n:nathan
+description: Deploy a temporary n8n test instance (or generate a local docker run command) via the internal "Nathan" bot, from the repo instead of Slack. Use after opening a PR to offer the user a live test instance, or whenever someone asks to spin up / deploy a test instance for a branch.
+allowed-tools: Bash(pnpm nathan:*), Bash(node scripts/nathan.mjs:*), Read
+---
+
+# Nathan — repo-local test instances
+
+Nathan is n8n's internal bot that deploys throwaway test instances from a branch
+or Docker image. It's normally driven from Slack (`/nathan ...`); this skill runs
+the same commands from the repo via `pnpm nathan`.
+
+## Offer a test instance after a PR
+
+After you open a PR for a branch, **ask the user if they want a live test
+instance** for it. If yes, deploy the PR's branch:
+
+```bash
+pnpm nathan deploy <branch-name>
+```
+
+Nathan builds the branch image (a few minutes) and replies with the instance URL
++ a Grafana dashboard link. Relay that URL to the user when it arrives.
+
+## How it works
+
+`pnpm nathan <args>` sends the command, opens a short-lived public tunnel so
+Nathan can call back, prints its reply to the terminal, then exits. Deploys take
+minutes — the command waits (Ctrl-C to stop; the deploy keeps running).
+
+Requires `NATHAN_TOKEN` in `.env.local` (gitignored). If it's missing, the
+command says so — ask the user to set it. A reliable tunnel needs `cloudflared`
+(`brew install cloudflared`); otherwise it falls back to `npx localtunnel`.
+
+## Common commands
+
+```bash
+pnpm nathan help                              # full option reference
+pnpm nathan deploy my-branch                  # deploy a branch (community license)
+pnpm nathan deploy my-branch --license pro2   # licensed instance
+pnpm nathan deploy master test-ai --ai        # enable instance AI
+pnpm nathan deploy nightly                     # deploy the n8nio/n8n:nightly image
+```
+
+Key flags (pass after the deploy args): `--license community|enterprise|starter|pro1|pro2|trial`,
+`--enterprise`, `--ai`, `-e KEY=value` (repeatable), `--featureOverride key:value`
+(needs a generated license). Run `pnpm nathan help` for the complete list and rules.
+
+## `local` caveat
+
+`pnpm nathan local ...` generates a runnable `docker run` bundle, but Nathan
+delivers it as **Slack file attachments** (`run-n8n.sh` + `.env`), not to the
+terminal. Set `NATHAN_SLACK_CHANNEL=<slack channel id>` to receive them, or run
+`/nathan local` in Slack. `deploy` and `help` return fully in the terminal.
+
+## Unsupported
+
+Queue mode, multi-main, and non-SQLite databases are not supported by Nathan.

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -10,27 +10,37 @@ Nathan is n8n's internal bot that deploys throwaway test instances from a branch
 or Docker image. It's normally driven from Slack (`/nathan ...`); this skill runs
 the same commands from the repo via `pnpm nathan`.
 
+## Before you use it (check once)
+
+1. **`cloudflared` must be installed.** Nathan replies asynchronously through a
+   public tunnel; `cloudflared` holds it reliably for the 10-20 min a branch
+   build takes. The `npx localtunnel` fallback frequently drops mid-deploy and
+   loses the reply. Check with `command -v cloudflared` — **if it's missing, ask
+   the user to run `brew install cloudflared` before deploying.**
+2. **`NATHAN_TOKEN` must be in `.env.local`** (gitignored) or the environment.
+   The command errors clearly if it's not set — ask the user to add it.
+
 ## Offer a test instance after a PR
 
 After you open a PR for a branch, **ask the user if they want a live test
-instance** for it. If yes, deploy the PR's branch:
+instance** for it (and confirm `cloudflared` is installed — see above). If yes,
+deploy the PR's branch with an explicit `test-` instance name:
 
 ```bash
-pnpm nathan deploy <branch-name>
+pnpm nathan deploy <branch-name> test-<short-name>
 ```
 
-Nathan builds the branch image (a few minutes) and replies with the instance URL
-+ a Grafana dashboard link. Relay that URL to the user when it arrives.
+Nathan builds the branch image (a few minutes) and the command prints the
+instance URL (`https://test-<short-name>.stage-app.n8n.cloud`, login
+`test@n8n.io` / `helloWorld7`). Relay that URL to the user.
 
 ## How it works
 
 `pnpm nathan <args>` sends the command, opens a short-lived public tunnel so
-Nathan can call back, prints its reply to the terminal, then exits. Deploys take
-minutes — the command waits (Ctrl-C to stop; the deploy keeps running).
-
-Requires `NATHAN_TOKEN` in `.env.local` (gitignored). If it's missing, the
-command says so — ask the user to set it. A reliable tunnel needs `cloudflared`
-(`brew install cloudflared`); otherwise it falls back to `npx localtunnel`.
+Nathan can call back, prints its reply, then exits. Deploys take minutes — the
+command waits (Ctrl-C to stop; the deploy keeps running). Passing an explicit
+`test-<name>` also lets it poll the instance URL directly, so it still reports
+success even if the tunnel drops.
 
 ## Common commands
 

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -12,11 +12,12 @@ the same commands from the repo via `pnpm nathan`.
 
 ## Before you use it (check once)
 
-1. **`cloudflared` must be installed.** Nathan replies asynchronously through a
-   public tunnel; `cloudflared` holds it reliably for the 10-20 min a branch
-   build takes. The `npx localtunnel` fallback frequently drops mid-deploy and
-   loses the reply. Check with `command -v cloudflared` — **if it's missing, ask
-   the user to run `brew install cloudflared` before deploying.**
+1. **No tunnel setup needed.** Nathan replies asynchronously through a
+   short-lived public tunnel that the script opens for you via `npx localtunnel`.
+   Do **not** use cloudflared on n8n's network — its `*.trycloudflare.com`
+   hostnames don't resolve there, so Nathan's callback fails. A deploy with an
+   explicit `test-<name>` also polls the instance URL directly, so it still
+   reports success even if the tunnel drops.
 2. **A Nathan token is needed**, read from `~/.n8n/nathan-token`. If it's missing
    (check with `test -s ~/.n8n/nathan-token || echo missing`), **ask the user for
    one yourself** — point them at the form
@@ -35,8 +36,8 @@ the same commands from the repo via `pnpm nathan`.
 ## Offer a test instance after a PR
 
 After you open a PR for a branch, **ask the user if they want a live test
-instance** for it (and confirm `cloudflared` is installed — see above). If yes,
-deploy the PR's branch with an explicit `test-` instance name:
+instance** for it. If yes, deploy the PR's branch with an explicit `test-`
+instance name:
 
 ```bash
 pnpm nathan deploy <branch-name> test-<short-name>

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -17,8 +17,14 @@ the same commands from the repo via `pnpm nathan`.
    build takes. The `npx localtunnel` fallback frequently drops mid-deploy and
    loses the reply. Check with `command -v cloudflared` — **if it's missing, ask
    the user to run `brew install cloudflared` before deploying.**
-2. **`NATHAN_TOKEN` must be in `.env.local`** (gitignored) or the environment.
-   The command errors clearly if it's not set — ask the user to add it.
+2. **A Nathan token is needed.** On first run the script prints a form link
+   (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
+   the user logs in with their n8n account, pastes the token back, and it's
+   cached to `~/.n8n/nathan-token` for future runs. **The paste prompt only works
+   in an interactive terminal** — if you're running non-interactively (agent /
+   background), ask the user to run `pnpm nathan help` once themselves to set it
+   up (or to export `NATHAN_TOKEN`). Resolution order: `NATHAN_TOKEN` env →
+   `~/.n8n/nathan-token` → `.env.local`.
 
 ## Offer a test instance after a PR
 

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -13,18 +13,20 @@ the same commands from the repo via `pnpm nathan`.
 ## Prerequisites
 
 - **No tunnel setup needed.** Nathan replies asynchronously through a short-lived
-  public tunnel that the script opens for you (`npx localtunnel`). A `deploy` with
-  an explicit `test-<name>` also polls the instance URL directly, so it still
-  reports success even if the tunnel drops.
-- **A token in `~/.n8n/nathan-token`.** Check with `test -s ~/.n8n/nathan-token || echo missing`.
-  If missing, **ask the user for one** — point them at the form
+  public tunnel that the script opens for you (`npx localtunnel`). A `deploy` to a
+  **new** `test-<name>` also polls that instance URL directly, so it still reports
+  success even if the tunnel drops. (Redeploying a name that's *already up* skips
+  the poll — it can't tell the old instance from the new — so it falls back to the
+  tunnel; prefer a fresh name when you need the reliable report.)
+- **A token in `~/.n8n/nathan-token`.** If a command reports no token, **ask the
+  user for one** — point them at the form
   (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
   where they log in with their n8n account and copy the token from the response —
-  then write it for them (don't rely on the script's interactive paste prompt; it
-  needs a real terminal):
+  then save it for them (the script's interactive paste prompt needs a real
+  terminal, so as an agent use the subcommand):
 
   ```bash
-  mkdir -p ~/.n8n && printf '%s\n' '<PASTED_TOKEN>' > ~/.n8n/nathan-token && chmod 600 ~/.n8n/nathan-token
+  pnpm nathan set-token '<PASTED_TOKEN>'
   ```
 
 ## Offer a test instance

--- a/.agents/skills/nathan/SKILL.md
+++ b/.agents/skills/nathan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: n8n:nathan
 description: Deploy a temporary n8n test instance (or generate a local docker run command) via the internal "Nathan" bot, from the repo instead of Slack. Use after opening a PR to offer the user a live test instance, or whenever someone asks to spin up / deploy a test instance for a branch.
-allowed-tools: Bash(pnpm nathan:*), Bash(node scripts/nathan.mjs:*), Read
+allowed-tools: Bash(pnpm nathan:*), Bash(node scripts/nathan.mjs:*), Bash(git diff:*), Read
 ---
 
 # Nathan — repo-local test instances
@@ -10,64 +10,71 @@ Nathan is n8n's internal bot that deploys throwaway test instances from a branch
 or Docker image. It's normally driven from Slack (`/nathan ...`); this skill runs
 the same commands from the repo via `pnpm nathan`.
 
-## Before you use it (check once)
+## Prerequisites
 
-1. **No tunnel setup needed.** Nathan replies asynchronously through a
-   short-lived public tunnel that the script opens for you via `npx localtunnel`.
-   Do **not** use cloudflared on n8n's network — its `*.trycloudflare.com`
-   hostnames don't resolve there, so Nathan's callback fails. A deploy with an
-   explicit `test-<name>` also polls the instance URL directly, so it still
-   reports success even if the tunnel drops.
-2. **A Nathan token is needed**, read from `~/.n8n/nathan-token`. If it's missing
-   (check with `test -s ~/.n8n/nathan-token || echo missing`), **ask the user for
-   one yourself** — point them at the form
-   (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
-   where they log in with their n8n account and copy the token from the response
-   — then write it for them:
+- **No tunnel setup needed.** Nathan replies asynchronously through a short-lived
+  public tunnel that the script opens for you (`npx localtunnel`). A `deploy` with
+  an explicit `test-<name>` also polls the instance URL directly, so it still
+  reports success even if the tunnel drops.
+- **A token in `~/.n8n/nathan-token`.** Check with `test -s ~/.n8n/nathan-token || echo missing`.
+  If missing, **ask the user for one** — point them at the form
+  (`https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d`),
+  where they log in with their n8n account and copy the token from the response —
+  then write it for them (don't rely on the script's interactive paste prompt; it
+  needs a real terminal):
 
-   ```bash
-   mkdir -p ~/.n8n && printf '%s\n' '<PASTED_TOKEN>' > ~/.n8n/nathan-token && chmod 600 ~/.n8n/nathan-token
-   ```
-
-   Future runs reuse it. (Humans running the script interactively get the same
-   flow via a paste prompt; that prompt needs a real terminal, so as an agent do
-   the write yourself rather than relying on it.)
+  ```bash
+  mkdir -p ~/.n8n && printf '%s\n' '<PASTED_TOKEN>' > ~/.n8n/nathan-token && chmod 600 ~/.n8n/nathan-token
+  ```
 
 ## Offer a test instance after a PR
 
-After you open a PR for a branch, **ask the user if they want a live test
-instance** for it. If yes, deploy the PR's branch with an explicit `test-`
-instance name:
+After you open a PR, **offer the user a live test instance for the branch.** Don't
+just ask a bare yes/no — look at the diff and **propose a sensible profile**, then
+let them confirm or adjust. For example:
+
+> "Want a test instance for this? Based on the diff I'd deploy it with instance AI
+> enabled (`--ai`) since it touches the AI assistant. Sound good, or a different
+> license?"
+
+### Pick the profile from the PR contents
+
+Inspect what the PR changes (`git diff --stat origin/master...HEAD` and the file
+paths / feature area), then choose:
+
+| PR touches… | Suggest | Why |
+|---|---|---|
+| AI features — `@n8n/nodes-langchain`, `@n8n/instance-ai`, the AI assistant/builder, `N8N_AI_*`, "askAi"/agent code | `--ai` | Enables instance AI (and defaults the license to pro2) so the AI features actually run |
+| License-gated / enterprise features — `.ee.ts` files or `/ee/` dirs, license checks (`@n8n_io/license-sdk`, `hasFeature`), SSO/SAML/OIDC/LDAP, RBAC/roles/scopes, projects, variables, external secrets, source control/environments, log streaming, insights, folders | `--enterprise` | The feature is gated behind a license and won't be testable on community |
+| A specific gated feature/quota you want on/off | `--license pro2 --featureOverride <featureKey>:<value>` | Bakes the override into a generated license (community/enterprise can't be overridden) |
+| Anything else — core nodes, generic UI, non-gated bug fixes | *(nothing — community default)* | No license needed |
+
+If both AI and enterprise apply, combine them: `--ai --enterprise`. When unsure,
+state your best guess and ask. Run `pnpm nathan help` for the full flag reference.
+
+### Deploy
 
 ```bash
-pnpm nathan deploy <branch-name> test-<short-name>
+pnpm nathan deploy <branch-name> test-<short-name> [flags]
 ```
 
-Nathan builds the branch image (a few minutes) and the command prints the
-instance URL (`https://test-<short-name>.stage-app.n8n.cloud`, login
-`test@n8n.io` / `helloWorld7`). Relay that URL to the user.
-
-## How it works
-
-`pnpm nathan <args>` sends the command, opens a short-lived public tunnel so
-Nathan can call back, prints its reply, then exits. Deploys take minutes — the
-command waits (Ctrl-C to stop; the deploy keeps running). Passing an explicit
-`test-<name>` also lets it poll the instance URL directly, so it still reports
-success even if the tunnel drops.
+Nathan builds the branch image (a few minutes) and the command prints the instance
+URL (`https://test-<short-name>.stage-app.n8n.cloud`, login `test@n8n.io` /
+`helloWorld7`). Relay that URL to the user.
 
 ## Common commands
 
 ```bash
-pnpm nathan help                              # full option reference
-pnpm nathan deploy my-branch                  # deploy a branch (community license)
-pnpm nathan deploy my-branch --license pro2   # licensed instance
-pnpm nathan deploy master test-ai --ai        # enable instance AI
-pnpm nathan deploy nightly                     # deploy the n8nio/n8n:nightly image
+pnpm nathan help                                   # full option reference
+pnpm nathan deploy my-branch test-my-feature       # community license
+pnpm nathan deploy my-branch test-sso --enterprise # enterprise license
+pnpm nathan deploy my-branch test-ai --ai          # instance AI (license -> pro2)
+pnpm nathan deploy nightly test-nightly            # deploy the n8nio/n8n:nightly image
 ```
 
-Key flags (pass after the deploy args): `--license community|enterprise|starter|pro1|pro2|trial`,
+Key flags (after the deploy args): `--license community|enterprise|starter|pro1|pro2|trial`,
 `--enterprise`, `--ai`, `-e KEY=value` (repeatable), `--featureOverride key:value`
-(needs a generated license). Run `pnpm nathan help` for the complete list and rules.
+(needs a generated license).
 
 ## `local` caveat
 

--- a/.claude/plugins/n8n/skills/nathan
+++ b/.claude/plugins/n8n/skills/nathan
@@ -1,0 +1,1 @@
+../../../../.agents/skills/nathan

--- a/.env.local.example
+++ b/.env.local.example
@@ -55,13 +55,3 @@ N8N_AI_ANTHROPIC_KEY=
 LANGSMITH_ENDPOINT=
 LANGSMITH_PROJECT=
 LANGSMITH_TRACING=
-
-# -----------------------------------------------------------------------------
-# Nathan deploy bot (pnpm nathan)
-# -----------------------------------------------------------------------------
-# Token for the internal "Nathan" bot used by `pnpm nathan` / scripts/nathan.mjs
-# to deploy test instances. You normally don't set this here: on first run the
-# script links you to a form to log in and get a token, then caches it in
-# ~/.n8n/nathan-token. Set it here only to override that. Optional:
-# NATHAN_SLACK_CHANNEL=<slack channel id> to receive `/nathan local` files in Slack.
-NATHAN_TOKEN=

--- a/.env.local.example
+++ b/.env.local.example
@@ -55,3 +55,12 @@ N8N_AI_ANTHROPIC_KEY=
 LANGSMITH_ENDPOINT=
 LANGSMITH_PROJECT=
 LANGSMITH_TRACING=
+
+# -----------------------------------------------------------------------------
+# Nathan deploy bot (pnpm nathan)
+# -----------------------------------------------------------------------------
+# Token for the internal "Nathan" bot used by `pnpm nathan` / scripts/nathan.mjs
+# to deploy test instances. Ask in Slack (the same token the /nathan Slack
+# command uses). Optional: NATHAN_SLACK_CHANNEL=<slack channel id> to receive
+# `/nathan local` file attachments in Slack.
+NATHAN_TOKEN=

--- a/.env.local.example
+++ b/.env.local.example
@@ -60,7 +60,8 @@ LANGSMITH_TRACING=
 # Nathan deploy bot (pnpm nathan)
 # -----------------------------------------------------------------------------
 # Token for the internal "Nathan" bot used by `pnpm nathan` / scripts/nathan.mjs
-# to deploy test instances. Ask in Slack (the same token the /nathan Slack
-# command uses). Optional: NATHAN_SLACK_CHANNEL=<slack channel id> to receive
-# `/nathan local` file attachments in Slack.
+# to deploy test instances. You normally don't set this here: on first run the
+# script links you to a form to log in and get a token, then caches it in
+# ~/.n8n/nathan-token. Set it here only to override that. Optional:
+# NATHAN_SLACK_CHANNEL=<slack channel id> to receive `/nathan local` files in Slack.
 NATHAN_TOKEN=

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "reset": "node scripts/ensure-zx.mjs && zx scripts/reset.mjs",
     "format": "turbo run format && node scripts/format.mjs",
     "grind": "node scripts/grind.mjs",
+    "nathan": "node scripts/nathan.mjs",
     "agent:setup": "node scripts/agent-setup.mjs",
     "format:check": "turbo run format:check",
     "lint": "turbo run lint",

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -75,15 +75,18 @@ if (process.argv.includes('--selftest')) {
 	process.exit(0);
 }
 
-// --- token: load from .env.local / .env (repo root or cwd), then env ---------
-const root = path.resolve(import.meta.dirname, '..');
-for (const dir of [process.cwd(), root])
-	for (const f of ['.env.local', '.env']) {
-		try { process.loadEnvFile(path.join(dir, f)); } catch { /* missing file is fine */ }
-	}
-const token = process.env.NATHAN_TOKEN;
+// --- token: prefer the NATHAN_TOKEN env var; fall back to .env.local / .env --
+let token = process.env.NATHAN_TOKEN;
 if (!token) {
-	console.error('NATHAN_TOKEN is not set. Add it to .env.local (gitignored) at the repo root:\n  NATHAN_TOKEN=<token from the Nathan Slack bot>');
+	const root = path.resolve(import.meta.dirname, '..');
+	for (const dir of [process.cwd(), root])
+		for (const f of ['.env.local', '.env']) {
+			try { process.loadEnvFile(path.join(dir, f)); } catch { /* missing file is fine */ }
+		}
+	token = process.env.NATHAN_TOKEN;
+}
+if (!token) {
+	console.error('NATHAN_TOKEN is not set. Export it in your shell, or add it to .env.local (gitignored) at the repo root:\n  export NATHAN_TOKEN=<token from the Nathan Slack bot>\n  # or in .env.local:  NATHAN_TOKEN=<token>');
 	process.exit(1);
 }
 

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -12,8 +12,8 @@
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
 // Needs a token in ~/.n8n/nathan-token — on first run it links you to a form to
-// get one and saves it there. A public tunnel is opened via `cloudflared`
-// (preferred) or `npx localtunnel` as a fallback.
+// get one and saves it there. A public tunnel is opened via `npx localtunnel`
+// (set NATHAN_TUNNEL=cloudflared to use cloudflared, where its hosts resolve).
 import http from 'node:http';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -123,6 +123,9 @@ const finished = new Promise((r) => (done = r));
 const finish = (reason) => { if (settled) return; settled = true; doneReason = reason; done(); };
 let idleTimer;
 const server = http.createServer((req, res) => {
+	// Nathan always POSTs its replies; a GET is our own reachability probe (or
+	// noise) — ack it without treating it as a callback.
+	if (req.method !== 'POST') { res.writeHead(200).end('ok'); return; }
 	let raw = '';
 	req.on('data', (c) => (raw += c));
 	req.on('end', () => {
@@ -145,10 +148,11 @@ function hasBinary(bin) {
 	catch { return false; }
 }
 function startTunnel() {
-	const hasCloudflared = hasBinary('cloudflared');
-	if (!hasCloudflared)
-		console.error('⚠️  cloudflared not found — falling back to `npx localtunnel`, which often drops on\n    long deploys (you may miss the final reply). For reliable capture: brew install cloudflared\n');
-	const [cmd, args] = hasCloudflared
+	// localtunnel by default. Cloudflare quick-tunnel hostnames (*.trycloudflare.com)
+	// don't resolve on n8n's network — neither here nor on the internal instance
+	// that calls back — so cloudflared is opt-in via NATHAN_TUNNEL=cloudflared.
+	const useCloudflared = process.env.NATHAN_TUNNEL === 'cloudflared' && hasBinary('cloudflared');
+	const [cmd, args] = useCloudflared
 		? ['cloudflared', ['tunnel', '--no-autoupdate', '--url', `http://127.0.0.1:${port}`]]
 		: ['npx', ['-y', 'localtunnel', '--port', String(port)]];
 	const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -165,12 +169,29 @@ function startTunnel() {
 	});
 }
 
+// cloudflared prints its URL a beat before Cloudflare's edge registers the DNS,
+// so firing immediately makes Nathan's callback fail with ENOTFOUND. Self-probe
+// the tunnel (GET, ignored by the server above) until it routes back to us.
+async function waitReachable(url) {
+	const deadline = Date.now() + TUNNEL_START_MS;
+	while (Date.now() < deadline) {
+		try { if ((await fetch(url, { signal: AbortSignal.timeout(5000) })).ok) return true; }
+		catch { /* DNS/edge not ready yet */ }
+		await new Promise((r) => setTimeout(r, 1500));
+	}
+	return false;
+}
+
 let tunnel;
 try {
 	console.error(`Opening tunnel + sending: /nathan ${text}`);
 	tunnel = await startTunnel();
 } catch (e) {
 	console.error('Could not open a public tunnel:', e.message);
+	await cleanup(1);
+}
+if (!(await waitReachable(tunnel.url))) {
+	console.error(`Tunnel ${tunnel.url} did not become reachable in time.`);
 	await cleanup(1);
 }
 

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -20,8 +20,11 @@ import { spawn, spawnSync } from 'node:child_process';
 
 const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
 const IDLE_MS = Number(process.env.NATHAN_IDLE_MS ?? 8000); // grace after a result for trailing msgs
-const TIMEOUT_MS = Number(process.env.NATHAN_TIMEOUT_MS ?? 600000); // overall backstop (deploys are slow)
+// Overall backstop. A cold branch build (docker-build-push CI) + deploy can run
+// 15-20 min, so keep this generous; override via NATHAN_TIMEOUT_MS.
+const TIMEOUT_MS = Number(process.env.NATHAN_TIMEOUT_MS ?? 1_500_000); // 25 min
 const TUNNEL_START_MS = 45000;
+const STAGING_DOMAIN = 'stage-app.n8n.cloud'; // instances live at https://<name>.<domain>
 
 // Nathan sends these as an immediate ack before the async work; seeing one means
 // "keep waiting", not "done". Everything else is a terminal reply.
@@ -41,6 +44,20 @@ function extractText(payload) {
 	return parts.join('\n') || JSON.stringify(payload);
 }
 
+// For `deploy <target> <name>` with an explicit instance name, predict the
+// staging URL Nathan deploys to (mirrors its name sanitisation) so we can poll
+// the instance directly — a reliable backstop when the tunnel callback is lost.
+// Returns null when no explicit name is given (Nathan derives it from the branch
+// otherwise, which isn't safely predictable here).
+function predictDeployUrl(text) {
+	const t = text.trim().split(/\s+/);
+	if (t[0] !== 'deploy' || !t[2] || t[2].startsWith('-')) return null;
+	let name = t[2].replace(/[^a-zA-Z0-9_.-]/g, '-');
+	if (!name.startsWith('test-')) name = `test-${name}`;
+	if (name.length > 25) name = name.slice(0, 25);
+	return `https://${name}.${STAGING_DOMAIN}`;
+}
+
 if (process.argv.includes('--selftest')) {
 	const ok = (c, m) => { if (!c) { console.error('FAIL:', m); process.exit(1); } };
 	ok(isAck('🚀 Deploying *foo*'), 'deploy ack');
@@ -49,6 +66,11 @@ if (process.argv.includes('--selftest')) {
 	ok(!isAck('Error: unknown option'), 'error not ack');
 	ok(extractText({ text: 'hi' }) === 'hi', 'text');
 	ok(extractText({ blocks: [{ text: { text: 'blk' } }] }) === 'blk', 'block text');
+	ok(predictDeployUrl('deploy master test-foo') === `https://test-foo.${STAGING_DOMAIN}`, 'predict explicit name');
+	ok(predictDeployUrl('deploy br my/name') === `https://test-my-name.${STAGING_DOMAIN}`, 'predict sanitise + prefix');
+	ok(predictDeployUrl('deploy master') === null, 'predict no name');
+	ok(predictDeployUrl('deploy master --license pro2') === null, 'predict flag not name');
+	ok(predictDeployUrl('help') === null, 'predict non-deploy');
 	console.log('selftest OK');
 	process.exit(0);
 }
@@ -73,8 +95,9 @@ if (text.startsWith('local')) {
 }
 
 // --- local sink for Nathan's callbacks ---------------------------------------
-let done, doneReason;
+let done, doneReason, settled = false;
 const finished = new Promise((r) => (done = r));
+const finish = (reason) => { if (settled) return; settled = true; doneReason = reason; done(); };
 let idleTimer;
 const server = http.createServer((req, res) => {
 	let raw = '';
@@ -87,7 +110,7 @@ const server = http.createServer((req, res) => {
 		console.log('\n' + '─'.repeat(60) + '\n' + body + '\n');
 		clearTimeout(idleTimer); // any new message cancels a pending exit
 		if (isAck(body)) return; // work is starting; wait (overall timeout backstops)
-		idleTimer = setTimeout(() => done((doneReason = 'idle')), IDLE_MS);
+		idleTimer = setTimeout(() => finish('idle'), IDLE_MS);
 	});
 });
 await new Promise((r) => server.listen(0, '127.0.0.1', r));
@@ -100,6 +123,8 @@ function hasBinary(bin) {
 }
 function startTunnel() {
 	const hasCloudflared = hasBinary('cloudflared');
+	if (!hasCloudflared)
+		console.error('⚠️  cloudflared not found — falling back to `npx localtunnel`, which often drops on\n    long deploys (you may miss the final reply). For reliable capture: brew install cloudflared\n');
 	const [cmd, args] = hasCloudflared
 		? ['cloudflared', ['tunnel', '--no-autoupdate', '--url', `http://127.0.0.1:${port}`]]
 		: ['npx', ['-y', 'localtunnel', '--port', String(port)]];
@@ -148,14 +173,35 @@ if (!res.ok) {
 }
 console.error('Sent. Waiting for Nathan to reply (Ctrl-C to stop)…\n');
 
-const overall = setTimeout(() => done((doneReason = 'timeout')), TIMEOUT_MS);
-process.on('SIGINT', () => done((doneReason = 'interrupted')));
+// Reliable backstop: if the instance URL is predictable, poll it directly so a
+// dropped tunnel doesn't cost us the result. Skip if it already responds — that's
+// the previous deployment still up mid-redeploy, indistinguishable from the new one.
+const pollUrl = predictDeployUrl(text);
+if (pollUrl) {
+	const up = (u) => fetch(`${u}/healthz`, { signal: AbortSignal.timeout(8000) }).then((r) => r.ok).catch(() => false);
+	if (await up(pollUrl)) {
+		console.error(`(${pollUrl} already responds — redeploy in progress; relying on the tunnel for completion.)`);
+	} else {
+		(async () => {
+			while (!settled) {
+				if (await up(pollUrl)) {
+					if (!settled) console.log(`\n${'─'.repeat(60)}\n✅ Instance is up: ${pollUrl}\n   Login: test@n8n.io / helloWorld7 (default test owner)\n`);
+					return finish('up');
+				}
+				await new Promise((r) => setTimeout(r, 10000));
+			}
+		})();
+	}
+}
+
+const overall = setTimeout(() => finish('timeout'), TIMEOUT_MS);
+process.on('SIGINT', () => finish('interrupted'));
 await finished;
 clearTimeout(overall);
 
 if (doneReason === 'timeout') console.error('\n⏱  Timed out waiting for the final reply — the deploy may still be running (check Slack / Grafana).');
 if (doneReason === 'interrupted') console.error('\nStopped. The command may still be running on Nathan.');
-await cleanup(doneReason === 'idle' ? 0 : 1);
+await cleanup(doneReason === 'idle' || doneReason === 'up' ? 0 : 1);
 
 function cleanup(code) {
 	try { tunnel?.proc.kill(); } catch {}

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -112,7 +112,8 @@ if (!token) {
 if (!token) process.exit(1);
 
 const text = process.argv.slice(2).join(' ').trim() || 'help';
-if (text.startsWith('local')) {
+const isLocal = text.startsWith('local');
+if (isLocal) {
 	console.error('⚠️  `local` delivers its run-n8n.sh + .env (with the license cert) as Slack file');
 	if (process.env.NATHAN_SLACK_CHANNEL) {
 		console.error(`    attachments, not to this terminal — they post to Slack channel ${process.env.NATHAN_SLACK_CHANNEL}.\n`);
@@ -140,7 +141,12 @@ const server = http.createServer((req, res) => {
 		const body = extractText(payload);
 		console.log('\n' + '─'.repeat(60) + '\n' + body + '\n');
 		clearTimeout(idleTimer); // any new message cancels a pending exit
-		if (isAck(body)) return; // work is starting; wait (overall timeout backstops)
+		if (isAck(body)) {
+			// `local` posts its bundle to Slack, never to this callback — the ack is
+			// the last thing we'll see, so stop here instead of waiting for the timeout.
+			if (isLocal) { console.error('Bundle is being posted to Slack (see the note above).'); finish('local'); }
+			return; // otherwise work is starting; wait (overall timeout backstops)
+		}
 		idleTimer = setTimeout(() => finish('idle'), IDLE_MS);
 	});
 });
@@ -245,7 +251,7 @@ clearTimeout(overall);
 
 if (doneReason === 'timeout') console.error('\n⏱  Timed out waiting for the final reply — the deploy may still be running (check Slack / Grafana).');
 if (doneReason === 'interrupted') console.error('\nStopped. The command may still be running on Nathan.');
-await cleanup(doneReason === 'idle' || doneReason === 'up' ? 0 : 1);
+await cleanup(['idle', 'up', 'local'].includes(doneReason) ? 0 : 1);
 
 function cleanup(code) {
 	try { tunnel?.proc.kill(); } catch {}

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -104,8 +104,8 @@ if (!token) process.exit(1);
 const text = process.argv.slice(2).join(' ').trim() || 'help';
 if (text.startsWith('local')) {
 	console.error('⚠️  `local` delivers its run-n8n.sh + .env (with the license cert) as Slack file');
-	console.error('    attachments, not to this callback — set NATHAN_SLACK_CHANNEL=<slack channel id>');
-	console.error('    to receive them in Slack, or run `/nathan local` in Slack directly.\n');
+	console.error('    attachments, not to this callback — they post to the default Slack channel');
+	console.error('    (override with NATHAN_SLACK_CHANNEL=<slack channel id>), or run it in Slack.\n');
 }
 
 // --- local sink for Nathan's callbacks ---------------------------------------
@@ -177,7 +177,7 @@ const res = await fetch(WEBHOOK, {
 		response_url: tunnel.url,
 		user_id: user,
 		user_name: user,
-		channel_id: process.env.NATHAN_SLACK_CHANNEL || 'cli',
+		channel_id: process.env.NATHAN_SLACK_CHANNEL || 'C0BGVHZ0SCW',
 		trigger_id: String(Date.now()),
 	}),
 });

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -37,6 +37,8 @@ const IDLE_MS = posNum(process.env.NATHAN_IDLE_MS, 8000, 'NATHAN_IDLE_MS'); // g
 const TIMEOUT_MS = posNum(process.env.NATHAN_TIMEOUT_MS, 1_500_000, 'NATHAN_TIMEOUT_MS'); // 25 min
 const TUNNEL_START_MS = 45000;
 const STAGING_DOMAIN = 'stage-app.n8n.cloud'; // instances live at https://<name>.<domain>
+const DEFAULT_SLACK_CHANNEL = 'C0BGVHZ0SCW'; // #updates-pnpm-nathan
+const DEFAULT_SLACK_CHANNEL_URL = 'https://n8nio.slack.com/archives/C0BGVHZ0SCW';
 
 // Nathan sends these as an immediate ack before the async work; seeing one means
 // "keep waiting", not "done". Everything else is a terminal reply.
@@ -113,8 +115,12 @@ if (!token) process.exit(1);
 const text = process.argv.slice(2).join(' ').trim() || 'help';
 if (text.startsWith('local')) {
 	console.error('⚠️  `local` delivers its run-n8n.sh + .env (with the license cert) as Slack file');
-	console.error('    attachments, not to this callback — they post to the default Slack channel');
-	console.error('    (override with NATHAN_SLACK_CHANNEL=<slack channel id>), or run it in Slack.\n');
+	if (process.env.NATHAN_SLACK_CHANNEL) {
+		console.error(`    attachments, not to this terminal — they post to Slack channel ${process.env.NATHAN_SLACK_CHANNEL}.\n`);
+	} else {
+		console.error('    attachments, not to this terminal — they post to #updates-pnpm-nathan:');
+		console.error(`    ${DEFAULT_SLACK_CHANNEL_URL}\n`);
+	}
 }
 
 // --- local sink for Nathan's callbacks ---------------------------------------
@@ -209,7 +215,7 @@ try {
 			response_url: tunnel.url,
 			user_id: user,
 			user_name: user,
-			channel_id: process.env.NATHAN_SLACK_CHANNEL || 'C0BGVHZ0SCW',
+			channel_id: process.env.NATHAN_SLACK_CHANNEL || DEFAULT_SLACK_CHANNEL,
 			trigger_id: String(Date.now()),
 		}),
 	});

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -105,6 +105,7 @@ const readSavedToken = () => { try { return fs.readFileSync(tokenFile, 'utf8').t
 function saveToken(t) {
 	fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
 	fs.writeFileSync(tokenFile, `${t}\n`, { mode: 0o600 });
+	fs.chmodSync(tokenFile, 0o600); // writeFileSync's mode is ignored when overwriting an existing file
 }
 
 // Non-interactive setup (agents/scripts): `nathan set-token <token>`.

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -11,8 +11,9 @@
 //   node scripts/nathan.mjs deploy my-branch --license pro2
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
-// Requires NATHAN_TOKEN (put it in .env.local — gitignored). A public tunnel is
-// opened via `cloudflared` (preferred) or `npx localtunnel` as a fallback.
+// Needs a token in ~/.n8n/nathan-token — on first run it links you to a form to
+// get one and saves it there. A public tunnel is opened via `cloudflared`
+// (preferred) or `npx localtunnel` as a fallback.
 import http from 'node:http';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -77,7 +78,7 @@ if (process.argv.includes('--selftest')) {
 	process.exit(0);
 }
 
-// --- token: NATHAN_TOKEN env → ~/.n8n/nathan-token → .env files → prompt ------
+// --- token: read from ~/.n8n/nathan-token; prompt + save it on first run -----
 const TOKEN_FORM_URL = 'https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d';
 const tokenFile = path.join(os.homedir(), '.n8n', 'nathan-token');
 const readSavedToken = () => { try { return fs.readFileSync(tokenFile, 'utf8').trim() || null; } catch { return null; } };
@@ -86,15 +87,7 @@ function saveToken(t) {
 	fs.writeFileSync(tokenFile, `${t}\n`, { mode: 0o600 });
 }
 
-let token = process.env.NATHAN_TOKEN || readSavedToken();
-if (!token) {
-	const root = path.resolve(import.meta.dirname, '..');
-	for (const dir of [process.cwd(), root])
-		for (const f of ['.env.local', '.env']) {
-			try { process.loadEnvFile(path.join(dir, f)); } catch { /* missing file is fine */ }
-		}
-	token = process.env.NATHAN_TOKEN;
-}
+let token = readSavedToken();
 if (!token) {
 	console.error(`\nNo Nathan token found. Get one here:\n  ${TOKEN_FORM_URL}\n  → log in with your n8n account and copy the token from the response.\n`);
 	if (process.stdin.isTTY) {
@@ -103,7 +96,7 @@ if (!token) {
 		rl.close();
 		if (token) { saveToken(token); console.error(`\nSaved to ${tokenFile} — future runs will reuse it.\n`); }
 	} else {
-		console.error(`Then save it to ${tokenFile} (or set NATHAN_TOKEN) and re-run.`);
+		console.error(`Then save it to ${tokenFile} and re-run.`);
 	}
 }
 if (!token) process.exit(1);

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -22,10 +22,19 @@ import readline from 'node:readline/promises';
 import { spawn, spawnSync } from 'node:child_process';
 
 const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
-const IDLE_MS = Number(process.env.NATHAN_IDLE_MS ?? 8000); // grace after a result for trailing msgs
+// Read a positive-number override from the env, warning and falling back to the
+// default on anything invalid (a NaN would make setTimeout fire immediately).
+function posNum(value, fallback, name) {
+	if (value == null) return fallback;
+	const n = Number(value);
+	if (Number.isFinite(n) && n > 0) return n;
+	console.error(`⚠️  Ignoring invalid ${name}=${value}; using ${fallback}.`);
+	return fallback;
+}
+const IDLE_MS = posNum(process.env.NATHAN_IDLE_MS, 8000, 'NATHAN_IDLE_MS'); // grace after a result for trailing msgs
 // Overall backstop. A cold branch build (docker-build-push CI) + deploy can run
 // 15-20 min, so keep this generous; override via NATHAN_TIMEOUT_MS.
-const TIMEOUT_MS = Number(process.env.NATHAN_TIMEOUT_MS ?? 1_500_000); // 25 min
+const TIMEOUT_MS = posNum(process.env.NATHAN_TIMEOUT_MS, 1_500_000, 'NATHAN_TIMEOUT_MS'); // 25 min
 const TUNNEL_START_MS = 45000;
 const STAGING_DOMAIN = 'stage-app.n8n.cloud'; // instances live at https://<name>.<domain>
 
@@ -167,20 +176,26 @@ try {
 
 // --- fire the command --------------------------------------------------------
 const user = process.env.NATHAN_USER || os.userInfo().username;
-const res = await fetch(WEBHOOK, {
-	method: 'POST',
-	headers: { 'content-type': 'application/json' },
-	body: JSON.stringify({
-		token,
-		text,
-		command: '/nathan',
-		response_url: tunnel.url,
-		user_id: user,
-		user_name: user,
-		channel_id: process.env.NATHAN_SLACK_CHANNEL || 'C0BGVHZ0SCW',
-		trigger_id: String(Date.now()),
-	}),
-});
+let res;
+try {
+	res = await fetch(WEBHOOK, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({
+			token,
+			text,
+			command: '/nathan',
+			response_url: tunnel.url,
+			user_id: user,
+			user_name: user,
+			channel_id: process.env.NATHAN_SLACK_CHANNEL || 'C0BGVHZ0SCW',
+			trigger_id: String(Date.now()),
+		}),
+	});
+} catch (e) {
+	console.error(`Could not reach the Nathan webhook: ${e.message}`);
+	await cleanup(1);
+}
 if (!res.ok) {
 	console.error(`Webhook returned HTTP ${res.status}`);
 	await cleanup(1);

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -11,7 +11,7 @@
 //   node scripts/nathan.mjs deploy my-branch --license pro2
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
-// Needs a token in ~/.n8n/nathan-token — on first run it links you to a form to
+// Needs a token in ~/.n8n/dev/nathan-token — on first run it links you to a form to
 // get one and saves it there. A public tunnel is opened via `npx localtunnel`.
 import http from 'node:http';
 import fs from 'node:fs';
@@ -98,9 +98,9 @@ if (process.argv.includes('--selftest')) {
 	process.exit(0);
 }
 
-// --- token: read from ~/.n8n/nathan-token; prompt + save it on first run -----
+// --- token: read from ~/.n8n/dev/nathan-token; prompt + save it on first run -
 const TOKEN_FORM_URL = 'https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d';
-const tokenFile = path.join(os.homedir(), '.n8n', 'nathan-token');
+const tokenFile = path.join(os.homedir(), '.n8n', 'dev', 'nathan-token');
 const readSavedToken = () => { try { return fs.readFileSync(tokenFile, 'utf8').trim() || null; } catch { return null; } };
 function saveToken(t) {
 	fs.mkdirSync(path.dirname(tokenFile), { recursive: true });

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -113,14 +113,12 @@ if (!token) process.exit(1);
 
 const text = process.argv.slice(2).join(' ').trim() || 'help';
 const isLocal = text.startsWith('local');
+const slackTarget = process.env.NATHAN_SLACK_CHANNEL
+	? `Slack channel ${process.env.NATHAN_SLACK_CHANNEL}`
+	: `#updates-pnpm-nathan (${DEFAULT_SLACK_CHANNEL_URL})`;
 if (isLocal) {
 	console.error('⚠️  `local` delivers its run-n8n.sh + .env (with the license cert) as Slack file');
-	if (process.env.NATHAN_SLACK_CHANNEL) {
-		console.error(`    attachments, not to this terminal — they post to Slack channel ${process.env.NATHAN_SLACK_CHANNEL}.\n`);
-	} else {
-		console.error('    attachments, not to this terminal — they post to #updates-pnpm-nathan:');
-		console.error(`    ${DEFAULT_SLACK_CHANNEL_URL}\n`);
-	}
+	console.error(`    attachments, not to this terminal — they post to ${slackTarget}.\n`);
 }
 
 // --- local sink for Nathan's callbacks ---------------------------------------
@@ -144,7 +142,7 @@ const server = http.createServer((req, res) => {
 		if (isAck(body)) {
 			// `local` posts its bundle to Slack, never to this callback — the ack is
 			// the last thing we'll see, so stop here instead of waiting for the timeout.
-			if (isLocal) { console.error('Bundle is being posted to Slack (see the note above).'); finish('local'); }
+			if (isLocal) { console.error(`Bundle is being posted to ${slackTarget}.`); finish('local'); }
 			return; // otherwise work is starting; wait (overall timeout backstops)
 		}
 		idleTimer = setTimeout(() => finish('idle'), IDLE_MS);

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -14,8 +14,10 @@
 // Requires NATHAN_TOKEN (put it in .env.local — gitignored). A public tunnel is
 // opened via `cloudflared` (preferred) or `npx localtunnel` as a fallback.
 import http from 'node:http';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import readline from 'node:readline/promises';
 import { spawn, spawnSync } from 'node:child_process';
 
 const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
@@ -75,8 +77,16 @@ if (process.argv.includes('--selftest')) {
 	process.exit(0);
 }
 
-// --- token: prefer the NATHAN_TOKEN env var; fall back to .env.local / .env --
-let token = process.env.NATHAN_TOKEN;
+// --- token: NATHAN_TOKEN env → ~/.n8n/nathan-token → .env files → prompt ------
+const TOKEN_FORM_URL = 'https://internal.users.n8n.cloud/form/d6d34a2f-4899-4ee8-afc8-f8c41a8a243d';
+const tokenFile = path.join(os.homedir(), '.n8n', 'nathan-token');
+const readSavedToken = () => { try { return fs.readFileSync(tokenFile, 'utf8').trim() || null; } catch { return null; } };
+function saveToken(t) {
+	fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
+	fs.writeFileSync(tokenFile, `${t}\n`, { mode: 0o600 });
+}
+
+let token = process.env.NATHAN_TOKEN || readSavedToken();
 if (!token) {
 	const root = path.resolve(import.meta.dirname, '..');
 	for (const dir of [process.cwd(), root])
@@ -86,9 +96,17 @@ if (!token) {
 	token = process.env.NATHAN_TOKEN;
 }
 if (!token) {
-	console.error('NATHAN_TOKEN is not set. Export it in your shell, or add it to .env.local (gitignored) at the repo root:\n  export NATHAN_TOKEN=<token from the Nathan Slack bot>\n  # or in .env.local:  NATHAN_TOKEN=<token>');
-	process.exit(1);
+	console.error(`\nNo Nathan token found. Get one here:\n  ${TOKEN_FORM_URL}\n  → log in with your n8n account and copy the token from the response.\n`);
+	if (process.stdin.isTTY) {
+		const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+		token = (await rl.question('Paste your Nathan token here: ')).trim();
+		rl.close();
+		if (token) { saveToken(token); console.error(`\nSaved to ${tokenFile} — future runs will reuse it.\n`); }
+	} else {
+		console.error(`Then save it to ${tokenFile} (or set NATHAN_TOKEN) and re-run.`);
+	}
 }
+if (!token) process.exit(1);
 
 const text = process.argv.slice(2).join(' ').trim() || 'help';
 if (text.startsWith('local')) {

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -12,14 +12,13 @@
 //   node scripts/nathan.mjs deploy master test-ai --ai
 //
 // Needs a token in ~/.n8n/nathan-token — on first run it links you to a form to
-// get one and saves it there. A public tunnel is opened via `npx localtunnel`
-// (set NATHAN_TUNNEL=cloudflared to use cloudflared, where its hosts resolve).
+// get one and saves it there. A public tunnel is opened via `npx localtunnel`.
 import http from 'node:http';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline/promises';
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
 // Read a positive-number override from the env, warning and falling back to the
@@ -148,21 +147,10 @@ const server = http.createServer((req, res) => {
 await new Promise((r) => server.listen(0, '127.0.0.1', r));
 const port = server.address().port;
 
-// --- public tunnel: cloudflared (preferred) or npx localtunnel ---------------
-function hasBinary(bin) {
-	try { return spawnSync(bin, ['--version'], { stdio: 'ignore' }).status === 0; }
-	catch { return false; }
-}
+// --- public tunnel via npx localtunnel ---------------------------------------
 function startTunnel() {
-	// localtunnel by default. Cloudflare quick-tunnel hostnames (*.trycloudflare.com)
-	// don't resolve on n8n's network — neither here nor on the internal instance
-	// that calls back — so cloudflared is opt-in via NATHAN_TUNNEL=cloudflared.
-	const useCloudflared = process.env.NATHAN_TUNNEL === 'cloudflared' && hasBinary('cloudflared');
-	const [cmd, args] = useCloudflared
-		? ['cloudflared', ['tunnel', '--no-autoupdate', '--url', `http://127.0.0.1:${port}`]]
-		: ['npx', ['-y', 'localtunnel', '--port', String(port)]];
-	const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-	const urlRe = /https:\/\/[^\s]+\.(?:trycloudflare\.com|loca\.lt)/;
+	const proc = spawn('npx', ['-y', 'localtunnel', '--port', String(port)], { stdio: ['ignore', 'pipe', 'pipe'] });
+	const urlRe = /https:\/\/[^\s]+\.loca\.lt/;
 	return new Promise((resolve, reject) => {
 		const t = setTimeout(() => reject(new Error('tunnel did not start in time')), TUNNEL_START_MS);
 		const scan = (buf) => {
@@ -171,12 +159,12 @@ function startTunnel() {
 		};
 		proc.stdout.on('data', scan);
 		proc.stderr.on('data', scan);
-		proc.on('exit', (code) => reject(new Error(`tunnel process exited (${code}); install cloudflared (brew install cloudflared) for a reliable tunnel`)));
+		proc.on('exit', (code) => reject(new Error(`localtunnel process exited (${code})`)));
 	});
 }
 
-// cloudflared prints its URL a beat before Cloudflare's edge registers the DNS,
-// so firing immediately makes Nathan's callback fail with ENOTFOUND. Self-probe
+// The tunnel host can take a moment to resolve/route after the URL is printed,
+// so firing immediately can make Nathan's callback fail with ENOTFOUND. Self-probe
 // the tunnel (GET, ignored by the server above) until it routes back to us.
 async function waitReachable(url) {
 	const deadline = Date.now() + TUNNEL_START_MS;

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -18,6 +18,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline/promises';
+import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 
 const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
@@ -43,6 +44,10 @@ const DEFAULT_SLACK_CHANNEL_URL = 'https://n8nio.slack.com/archives/C0BGVHZ0SCW'
 // "keep waiting", not "done". Everything else is a terminal reply.
 const isAck = (text = '') =>
 	text.startsWith('🚀 Deploying') || text.startsWith('🐳 Building a `docker run` command');
+
+// Nathan's known error replies — a terminal reply matching these means the
+// command failed and we must exit non-zero (callers/agents rely on that).
+const isError = (text = '') => /^(?:Error:|Unknown command|Deploy failed)/.test(text);
 
 // Pull human-readable text out of a Slack message payload (text + any block text).
 function extractText(payload) {
@@ -77,6 +82,11 @@ if (process.argv.includes('--selftest')) {
 	ok(isAck('🐳 Building a `docker run` command for image *x*'), 'docker ack');
 	ok(!isAck('✅ Deployment complete'), 'success not ack');
 	ok(!isAck('Error: unknown option'), 'error not ack');
+	ok(isError('Error: unknown option'), 'error reply');
+	ok(isError('Deploy failed: boom'), 'deploy failed');
+	ok(isError('Unknown command `x`'), 'unknown command');
+	ok(!isError('✅ Instance is up'), 'success not error');
+	ok(!isError('*Nathan — deployment bot*'), 'help not error');
 	ok(extractText({ text: 'hi' }) === 'hi', 'text');
 	ok(extractText({ blocks: [{ text: { text: 'blk' } }] }) === 'blk', 'block text');
 	ok(predictDeployUrl('deploy master test-foo') === `https://test-foo.${STAGING_DOMAIN}`, 'predict explicit name');
@@ -97,6 +107,15 @@ function saveToken(t) {
 	fs.writeFileSync(tokenFile, `${t}\n`, { mode: 0o600 });
 }
 
+// Non-interactive setup (agents/scripts): `nathan set-token <token>`.
+if (process.argv[2] === 'set-token') {
+	const t = (process.argv[3] || '').trim();
+	if (!t) { console.error('Usage: pnpm nathan set-token <token>'); process.exit(1); }
+	saveToken(t);
+	console.error(`Saved token to ${tokenFile}.`);
+	process.exit(0);
+}
+
 let token = readSavedToken();
 if (!token) {
 	console.error(`\nNo Nathan token found. Get one here:\n  ${TOKEN_FORM_URL}\n  → log in with your n8n account and copy the token from the response.\n`);
@@ -106,7 +125,7 @@ if (!token) {
 		rl.close();
 		if (token) { saveToken(token); console.error(`\nSaved to ${tokenFile} — future runs will reuse it.\n`); }
 	} else {
-		console.error(`Then save it to ${tokenFile} and re-run.`);
+		console.error('Then save it with:  pnpm nathan set-token <token>');
 	}
 }
 if (!token) process.exit(1);
@@ -122,17 +141,27 @@ if (isLocal) {
 }
 
 // --- local sink for Nathan's callbacks ---------------------------------------
+// The tunnel is public, so only accept callbacks on an unguessable path and cap
+// the body — the URL is an unauthenticated completion channel otherwise.
+const CALLBACK_PATH = `/cb/${randomUUID()}`;
+const MAX_BODY = 1_000_000; // Nathan's replies are small Slack messages
 let done, doneReason, settled = false;
 const finished = new Promise((r) => (done = r));
 const finish = (reason) => { if (settled) return; settled = true; doneReason = reason; done(); };
 let idleTimer;
 const server = http.createServer((req, res) => {
-	// Nathan always POSTs its replies; a GET is our own reachability probe (or
-	// noise) — ack it without treating it as a callback.
+	// A GET is our own reachability probe (or noise) — ack it, don't process it.
 	if (req.method !== 'POST') { res.writeHead(200).end('ok'); return; }
-	let raw = '';
-	req.on('data', (c) => (raw += c));
+	// Reject anything not on the secret path before reading its body.
+	if (req.url !== CALLBACK_PATH) { res.writeHead(403).end('forbidden'); return; }
+	let raw = '', tooBig = false;
+	req.on('data', (c) => {
+		if (tooBig) return;
+		raw += c;
+		if (raw.length > MAX_BODY) { tooBig = true; res.writeHead(413).end('payload too large'); req.destroy(); }
+	});
 	req.on('end', () => {
+		if (tooBig) return;
 		res.writeHead(200).end('ok');
 		let payload;
 		try { payload = JSON.parse(raw); } catch { payload = raw; }
@@ -145,15 +174,20 @@ const server = http.createServer((req, res) => {
 			if (isLocal) { console.error(`Bundle is being posted to ${slackTarget}.`); finish('local'); }
 			return; // otherwise work is starting; wait (overall timeout backstops)
 		}
-		idleTimer = setTimeout(() => finish('idle'), IDLE_MS);
+		// A known error reply must fail the run; anything else is a success.
+		idleTimer = setTimeout(() => finish(isError(body) ? 'error' : 'idle'), IDLE_MS);
 	});
 });
 await new Promise((r) => server.listen(0, '127.0.0.1', r));
 const port = server.address().port;
 
 // --- public tunnel via npx localtunnel ---------------------------------------
+// Pin an exact, vetted version — an unpinned `npx localtunnel` would run whatever
+// the registry currently serves, as the user, with read access to the token file.
+// To update: bump this version deliberately after reviewing the release.
+const LOCALTUNNEL_VERSION = '2.0.2';
 function startTunnel() {
-	const proc = spawn('npx', ['-y', 'localtunnel', '--port', String(port)], { stdio: ['ignore', 'pipe', 'pipe'] });
+	const proc = spawn('npx', ['-y', `localtunnel@${LOCALTUNNEL_VERSION}`, '--port', String(port)], { stdio: ['ignore', 'pipe', 'pipe'] });
 	const urlRe = /https:\/\/[^\s]+\.loca\.lt/;
 	return new Promise((resolve, reject) => {
 		const t = setTimeout(() => reject(new Error('tunnel did not start in time')), TUNNEL_START_MS);
@@ -204,7 +238,7 @@ try {
 			token,
 			text,
 			command: '/nathan',
-			response_url: tunnel.url,
+			response_url: tunnel.url + CALLBACK_PATH,
 			user_id: user,
 			user_name: user,
 			channel_id: process.env.NATHAN_SLACK_CHANNEL || DEFAULT_SLACK_CHANNEL,
@@ -249,6 +283,7 @@ clearTimeout(overall);
 
 if (doneReason === 'timeout') console.error('\n⏱  Timed out waiting for the final reply — the deploy may still be running (check Slack / Grafana).');
 if (doneReason === 'interrupted') console.error('\nStopped. The command may still be running on Nathan.');
+if (doneReason === 'error') console.error('\n✖ Nathan reported an error (see the reply above).');
 await cleanup(['idle', 'up', 'local'].includes(doneReason) ? 0 : 1);
 
 function cleanup(code) {

--- a/scripts/nathan.mjs
+++ b/scripts/nathan.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Repo-local client for the "Nathan" deploy bot (normally driven via Slack
+// `/nathan ...`). Nathan is fire-and-forget: the webhook returns instantly and
+// POSTs its real reply (deploy URL, help text, errors) back to the
+// `response_url` we hand it — the same mechanism Slack uses. Since the internal
+// instance can't reach localhost, we open a throwaway public tunnel to a local
+// server, use that as the response_url, print whatever Nathan sends, and clean up.
+//
+// Usage:  node scripts/nathan.mjs <nathan args>     (or: pnpm nathan -- <args>)
+//   node scripts/nathan.mjs help
+//   node scripts/nathan.mjs deploy my-branch --license pro2
+//   node scripts/nathan.mjs deploy master test-ai --ai
+//
+// Requires NATHAN_TOKEN (put it in .env.local — gitignored). A public tunnel is
+// opened via `cloudflared` (preferred) or `npx localtunnel` as a fallback.
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+
+const WEBHOOK = 'https://internal.users.n8n.cloud/webhook/85070485-140c-46e8-9b4b-d161bf7ee1ac';
+const IDLE_MS = Number(process.env.NATHAN_IDLE_MS ?? 8000); // grace after a result for trailing msgs
+const TIMEOUT_MS = Number(process.env.NATHAN_TIMEOUT_MS ?? 600000); // overall backstop (deploys are slow)
+const TUNNEL_START_MS = 45000;
+
+// Nathan sends these as an immediate ack before the async work; seeing one means
+// "keep waiting", not "done". Everything else is a terminal reply.
+const isAck = (text = '') =>
+	text.startsWith('🚀 Deploying') || text.startsWith('🐳 Building a `docker run` command');
+
+// Pull human-readable text out of a Slack message payload (text + any block text).
+function extractText(payload) {
+	if (typeof payload === 'string') return payload;
+	const parts = [];
+	if (payload?.text) parts.push(payload.text);
+	for (const b of payload?.blocks ?? []) {
+		if (b?.text?.text) parts.push(b.text.text);
+		for (const el of b?.elements ?? []) if (el?.text) parts.push(el.text);
+	}
+	for (const a of payload?.attachments ?? []) if (a?.text) parts.push(a.text);
+	return parts.join('\n') || JSON.stringify(payload);
+}
+
+if (process.argv.includes('--selftest')) {
+	const ok = (c, m) => { if (!c) { console.error('FAIL:', m); process.exit(1); } };
+	ok(isAck('🚀 Deploying *foo*'), 'deploy ack');
+	ok(isAck('🐳 Building a `docker run` command for image *x*'), 'docker ack');
+	ok(!isAck('✅ Deployment complete'), 'success not ack');
+	ok(!isAck('Error: unknown option'), 'error not ack');
+	ok(extractText({ text: 'hi' }) === 'hi', 'text');
+	ok(extractText({ blocks: [{ text: { text: 'blk' } }] }) === 'blk', 'block text');
+	console.log('selftest OK');
+	process.exit(0);
+}
+
+// --- token: load from .env.local / .env (repo root or cwd), then env ---------
+const root = path.resolve(import.meta.dirname, '..');
+for (const dir of [process.cwd(), root])
+	for (const f of ['.env.local', '.env']) {
+		try { process.loadEnvFile(path.join(dir, f)); } catch { /* missing file is fine */ }
+	}
+const token = process.env.NATHAN_TOKEN;
+if (!token) {
+	console.error('NATHAN_TOKEN is not set. Add it to .env.local (gitignored) at the repo root:\n  NATHAN_TOKEN=<token from the Nathan Slack bot>');
+	process.exit(1);
+}
+
+const text = process.argv.slice(2).join(' ').trim() || 'help';
+if (text.startsWith('local')) {
+	console.error('⚠️  `local` delivers its run-n8n.sh + .env (with the license cert) as Slack file');
+	console.error('    attachments, not to this callback — set NATHAN_SLACK_CHANNEL=<slack channel id>');
+	console.error('    to receive them in Slack, or run `/nathan local` in Slack directly.\n');
+}
+
+// --- local sink for Nathan's callbacks ---------------------------------------
+let done, doneReason;
+const finished = new Promise((r) => (done = r));
+let idleTimer;
+const server = http.createServer((req, res) => {
+	let raw = '';
+	req.on('data', (c) => (raw += c));
+	req.on('end', () => {
+		res.writeHead(200).end('ok');
+		let payload;
+		try { payload = JSON.parse(raw); } catch { payload = raw; }
+		const body = extractText(payload);
+		console.log('\n' + '─'.repeat(60) + '\n' + body + '\n');
+		clearTimeout(idleTimer); // any new message cancels a pending exit
+		if (isAck(body)) return; // work is starting; wait (overall timeout backstops)
+		idleTimer = setTimeout(() => done((doneReason = 'idle')), IDLE_MS);
+	});
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const port = server.address().port;
+
+// --- public tunnel: cloudflared (preferred) or npx localtunnel ---------------
+function hasBinary(bin) {
+	try { return spawnSync(bin, ['--version'], { stdio: 'ignore' }).status === 0; }
+	catch { return false; }
+}
+function startTunnel() {
+	const hasCloudflared = hasBinary('cloudflared');
+	const [cmd, args] = hasCloudflared
+		? ['cloudflared', ['tunnel', '--no-autoupdate', '--url', `http://127.0.0.1:${port}`]]
+		: ['npx', ['-y', 'localtunnel', '--port', String(port)]];
+	const proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+	const urlRe = /https:\/\/[^\s]+\.(?:trycloudflare\.com|loca\.lt)/;
+	return new Promise((resolve, reject) => {
+		const t = setTimeout(() => reject(new Error('tunnel did not start in time')), TUNNEL_START_MS);
+		const scan = (buf) => {
+			const m = String(buf).match(urlRe);
+			if (m) { clearTimeout(t); resolve({ url: m[0], proc }); }
+		};
+		proc.stdout.on('data', scan);
+		proc.stderr.on('data', scan);
+		proc.on('exit', (code) => reject(new Error(`tunnel process exited (${code}); install cloudflared (brew install cloudflared) for a reliable tunnel`)));
+	});
+}
+
+let tunnel;
+try {
+	console.error(`Opening tunnel + sending: /nathan ${text}`);
+	tunnel = await startTunnel();
+} catch (e) {
+	console.error('Could not open a public tunnel:', e.message);
+	await cleanup(1);
+}
+
+// --- fire the command --------------------------------------------------------
+const user = process.env.NATHAN_USER || os.userInfo().username;
+const res = await fetch(WEBHOOK, {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({
+		token,
+		text,
+		command: '/nathan',
+		response_url: tunnel.url,
+		user_id: user,
+		user_name: user,
+		channel_id: process.env.NATHAN_SLACK_CHANNEL || 'cli',
+		trigger_id: String(Date.now()),
+	}),
+});
+if (!res.ok) {
+	console.error(`Webhook returned HTTP ${res.status}`);
+	await cleanup(1);
+}
+console.error('Sent. Waiting for Nathan to reply (Ctrl-C to stop)…\n');
+
+const overall = setTimeout(() => done((doneReason = 'timeout')), TIMEOUT_MS);
+process.on('SIGINT', () => done((doneReason = 'interrupted')));
+await finished;
+clearTimeout(overall);
+
+if (doneReason === 'timeout') console.error('\n⏱  Timed out waiting for the final reply — the deploy may still be running (check Slack / Grafana).');
+if (doneReason === 'interrupted') console.error('\nStopped. The command may still be running on Nathan.');
+await cleanup(doneReason === 'idle' ? 0 : 1);
+
+function cleanup(code) {
+	try { tunnel?.proc.kill(); } catch {}
+	server.close();
+	// give the tunnel a beat to die, then exit hard (server/proc keep the loop alive)
+	setTimeout(() => process.exit(code), 200);
+	return new Promise(() => {});
+}


### PR DESCRIPTION
## Summary

Adds a repo-local CLI (`pnpm nathan` → `scripts/nathan.mjs`) for the internal **Nathan** deploy bot, so humans and agents can spin up test instances from the repo instead of Slack. Nathan is fire-and-forget (it POSTs its reply to a `response_url`), so the script opens a short-lived public tunnel (`npx localtunnel` by default), **waits until the tunnel is actually reachable** before firing, prints Nathan's reply, then tears down. For a `deploy` with an explicit `test-<name>`, it also polls the instance URL (`https://<name>.stage-app.n8n.cloud`) directly, so it still reports the live URL even if the tunnel drops mid-build. The Nathan token is read solely from `~/.n8n/nathan-token` — populated on first run via a login form prompt, or written directly by an agent. Also ships an `n8n:nathan` agent skill that offers a test instance after a PR is opened.

Notes: `local` output (docker bundle + license cert) is delivered as Slack attachments to **#updates-pnpm-nathan** (override with `NATHAN_SLACK_CHANNEL`); cloudflared is opt-in via `NATHAN_TUNNEL=cloudflared` (its `*.trycloudflare.com` hosts don't resolve on n8n's network).

## How to test

1. Get a token from the form the CLI links on first run (log in with your n8n account); it's cached to `~/.n8n/nathan-token`.
2. `pnpm nathan help` — opens a tunnel and prints Nathan's help text.
3. `pnpm nathan deploy <branch> test-<short-name>` — returns `https://test-<short-name>.stage-app.n8n.cloud` (login `test@n8n.io` / `helloWorld7`). Validated end-to-end by deploying this branch.
4. `node scripts/nathan.mjs --selftest` runs the offline parsing/validation checks.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)