### PR TITLE
fix(core): Exclude current, active, and published versions from workflow history compaction

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -109,16 +109,37 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.orderBy('wh.createdAt', 'ASC')
 			.getMany();
 
-		// Group by workflowId
-		const publishedVersions =
-			await this.workflowPublishHistoryRepository.getPublishedVersions(workflowId);
+		// The audit log alone is not a reliable source for versions that must be
+		// preserved: the live pointers (workflow_published_version.publishedVersionId,
+		// workflow_entity.activeVersionId) can reference versions that have no audit
+		// row, and both carry ON DELETE RESTRICT FKs that would abort the delete below.
+		// The current version (workflow_entity.versionId) has no FK, so pruning it
+		// would silently orphan the pointer instead. Mirror the exclusions of
+		// deleteEarlierThanExceptCurrentAndActive().
+		const [publishedVersions, publishedVersion, workflow] = await Promise.all([
+			this.workflowPublishHistoryRepository.getPublishedVersions(workflowId),
+			this.manager.findOne(WorkflowPublishedVersion, {
+				where: { workflowId },
+				select: ['publishedVersionId'],
+			}),
+			this.manager.findOne(WorkflowEntity, {
+				where: { id: workflowId },
+				select: ['versionId', 'activeVersionId'],
+			}),
+		]);
+
+		const preservedVersionIds = new Set(
+			publishedVersions.map((v) => v.versionId).filter((v) => v !== null),
+		);
+		if (publishedVersion) preservedVersionIds.add(publishedVersion.publishedVersionId);
+		if (workflow?.versionId) preservedVersionIds.add(workflow.versionId);
+		if (workflow?.activeVersionId) preservedVersionIds.add(workflow.activeVersionId);
+
 		const grouped = groupWorkflows<WorkflowHistory>(
 			workflows,
 			rules,
 			[
-				this.makeSkipActiveAndNamedVersionsRule(
-					new Set(publishedVersions.map((v) => v.versionId).filter((v) => v !== null)),
-				),
+				this.makeSkipActiveAndNamedVersionsRule(preservedVersionIds),
 				SKIP_RULES.skipDifferentUsers,
 				...skipRules,
 			],

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -4,7 +4,11 @@ import {
 	createWorkflowWithHistory,
 	testDb,
 } from '@n8n/backend-test-utils';
-import { WorkflowHistoryRepository, WorkflowPublishedVersionRepository } from '@n8n/db';
+import {
+	WorkflowHistoryRepository,
+	WorkflowPublishedVersionRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import { RULES, type INode } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
@@ -26,11 +30,13 @@ describe('WorkflowHistoryRepository', () => {
 	});
 
 	beforeEach(async () => {
+		// WorkflowEntity before WorkflowHistory: activeVersionId carries a RESTRICT
+		// FK onto workflow_history, so the referencing workflow must go first.
 		await testDb.truncate([
 			'WorkflowPublishedVersion',
 			'WorkflowPublishHistory',
-			'WorkflowHistory',
 			'WorkflowEntity',
+			'WorkflowHistory',
 			'User',
 		]);
 	});
@@ -63,6 +69,8 @@ describe('WorkflowHistoryRepository', () => {
 				versionId: id2,
 				nodes: [{ ...testNode1, parameters: { a: 'abcd' } }],
 			});
+			// The workflow's current version is the latest save
+			await Container.get(WorkflowRepository).update(workflow.id, { versionId: id2 });
 
 			// ACT
 			const repository = Container.get(WorkflowHistoryRepository);
@@ -211,6 +219,8 @@ describe('WorkflowHistoryRepository', () => {
 				versionId: id5,
 				nodes: [{ ...testNode1, parameters: { a: 'abcde' } }],
 			});
+			// The workflow's current version is the latest save
+			await Container.get(WorkflowRepository).update(workflow.id, { versionId: id5 });
 
 			// ACT
 			const repository = Container.get(WorkflowHistoryRepository);
@@ -241,6 +251,160 @@ describe('WorkflowHistoryRepository', () => {
 			// ASSERT
 			expect(redo.deleted).toBe(0);
 			expect(redo.seen).toBe(3);
+		});
+
+		// The live published version (workflow_published_version, RESTRICT FK) can be
+		// absent from the workflow_publish_history audit log, e.g. rows written by the
+		// startup backfill applier or activations predating the audit table. Pruning
+		// it aborts the whole DELETE with "FOREIGN KEY constraint failed", wedging
+		// compaction for the workflow.
+		it('should preserve the live published version even when absent from the publish history audit log', async () => {
+			// ARRANGE
+			const vPublished = uuid();
+			const vMid = uuid();
+			const vLatest = uuid();
+
+			const workflow = await createWorkflowWithHistory({
+				versionId: vPublished,
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: vMid,
+				nodes: [{ ...testNode1, parameters: { a: 'ab' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: vLatest,
+				nodes: [{ ...testNode1, parameters: { a: 'abc' } }],
+			});
+
+			// The workflow's current version is the latest save
+			await Container.get(WorkflowRepository).update(workflow.id, { versionId: vLatest });
+			// Live pointer at the oldest version, audit log stays empty
+			await Container.get(WorkflowPublishedVersionRepository).setPublishedVersion(
+				workflow.id,
+				vPublished,
+			);
+
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			const aDayAgo = new Date();
+			aDayAgo.setDate(aDayAgo.getDate() - 1);
+
+			const nextDay = new Date();
+			nextDay.setDate(nextDay.getDate() + 1);
+
+			// ACT
+			// Must not throw "SQLITE_CONSTRAINT: FOREIGN KEY constraint failed"
+			const { deleted, seen } = await repository.pruneHistory(workflow.id, aDayAgo, nextDay, [
+				alwaysMergeRule,
+			]);
+
+			// ASSERT
+			expect(seen).toBe(3);
+			expect(deleted).toBe(1);
+
+			const remainingIds = (await repository.find()).map((r) => r.versionId);
+			expect(remainingIds).toContain(vPublished);
+			expect(remainingIds).toContain(vLatest);
+			expect(remainingIds).not.toContain(vMid);
+		});
+
+		// Same failure mode via workflow_entity.activeVersionId (also RESTRICT FK):
+		// the active version is only protected through its audit-log rows, which the
+		// backfill applier does not write.
+		it('should preserve the active version even when absent from the publish history audit log', async () => {
+			// ARRANGE
+			const vActive = uuid();
+			const vMid = uuid();
+			const vLatest = uuid();
+
+			const workflow = await createWorkflowWithHistory({
+				versionId: vActive,
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: vMid,
+				nodes: [{ ...testNode1, parameters: { a: 'ab' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: vLatest,
+				nodes: [{ ...testNode1, parameters: { a: 'abc' } }],
+			});
+
+			// Current version is the latest save; active pointer at the oldest
+			// version, audit log stays empty
+			await Container.get(WorkflowRepository).update(workflow.id, {
+				versionId: vLatest,
+				activeVersionId: vActive,
+			});
+
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			const aDayAgo = new Date();
+			aDayAgo.setDate(aDayAgo.getDate() - 1);
+
+			const nextDay = new Date();
+			nextDay.setDate(nextDay.getDate() + 1);
+
+			// ACT
+			// Must not throw "SQLITE_CONSTRAINT: FOREIGN KEY constraint failed"
+			const { deleted, seen } = await repository.pruneHistory(workflow.id, aDayAgo, nextDay, [
+				alwaysMergeRule,
+			]);
+
+			// ASSERT
+			expect(seen).toBe(3);
+			expect(deleted).toBe(1);
+
+			const remainingIds = (await repository.find()).map((r) => r.versionId);
+			expect(remainingIds).toContain(vActive);
+			expect(remainingIds).toContain(vLatest);
+			expect(remainingIds).not.toContain(vMid);
+		});
+
+		// workflow_entity.versionId has no FK, so pruning the current version would
+		// silently orphan the pointer rather than abort. It is normally the newest
+		// version and survives as the group representative, but createdAt ordering
+		// is not guaranteed to put it last (e.g. timestamp ties).
+		it('should preserve the current version even when it is not the newest history entry', async () => {
+			// ARRANGE
+			const vCurrent = uuid();
+			const vLatest = uuid();
+
+			const workflow = await createWorkflowWithHistory({
+				versionId: vCurrent,
+				nodes: [{ ...testNode1, parameters: { a: 'a' } }],
+			});
+			await createWorkflowHistory({
+				...workflow,
+				versionId: vLatest,
+				nodes: [{ ...testNode1, parameters: { a: 'ab' } }],
+			});
+
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			const aDayAgo = new Date();
+			aDayAgo.setDate(aDayAgo.getDate() - 1);
+
+			const nextDay = new Date();
+			nextDay.setDate(nextDay.getDate() + 1);
+
+			// ACT
+			const { deleted, seen } = await repository.pruneHistory(workflow.id, aDayAgo, nextDay, [
+				alwaysMergeRule,
+			]);
+
+			// ASSERT
+			expect(seen).toBe(2);
+			expect(deleted).toBe(0);
+
+			const remainingIds = (await repository.find()).map((r) => r.versionId);
+			expect(remainingIds).toContain(vCurrent);
+			expect(remainingIds).toContain(vLatest);
 		});
 	});
 	describe('deleteEarlierThanExceptCurrentAndActive', () => {


### PR DESCRIPTION
## Summary

`WorkflowHistoryRepository.pruneHistory()` (used by the hourly/daily workflow history compaction) built its "versions to preserve" set solely from the `workflow_publish_history` audit log. That table is not a reliable source:

- The live published pointer (`workflow_published_version.publishedVersionId`) can reference a version with no audit row — e.g. rows written by the publication startup backfill (the applier never writes audit records), or an `activeVersionId` stranded by a failed `publishIfActive` update (persisted before validations run and before the audit row is written).
- Both `workflow_published_version.publishedVersionId` and `workflow_entity.activeVersionId` carry `ON DELETE RESTRICT` FKs, so pruning such a version aborts the **whole** per-workflow delete with `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` — including versions that were legitimately prunable. The affected window then stays uncompacted.
- The current version (`workflow_entity.versionId`) has no FK at all, so pruning it (possible on `createdAt` ordering ties) would silently orphan the pointer instead.

This PR keeps the audit-log source (preserving previously-activated versions is existing, tested behavior) and adds the live pointers on top, mirroring the exclusions of the sibling `deleteEarlierThanExceptCurrentAndActive()` fixed in #32239: current + active + published. Same class of bug as CAT-3293, in the sibling method.

## How to test

Integration tests cover the three new guards (each fails with the FK abort or silent orphaning without the fix):

```bash
cd packages/cli && pnpm test:integration workflow-history.repository.test
```

Manual repro against a live instance (verified): seed a workflow with three additive history versions, point `workflow_published_version` at the middle one with no `workflow_publish_history` rows, run with `N8N_WORKFLOW_HISTORY_OPTIMIZING_MINIMUM_AGE_HOURS=0`, restart. Before the fix the startup compaction pass logs `Failed to prune version history of workflow <id>` and deletes nothing; after it, the published version is preserved and the redundant older version is pruned.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3725

Follow-up to #32239 (CAT-3293).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/33995">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->