### PR TITLE
feat(core, editor): Add telemetry events for generation errors and assistant views

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -117,6 +117,12 @@ describe('TelemetryEventRelay', () => {
 		database: {
 			type: 'sqlite',
 		},
+		instanceAi: {
+			sandboxEnabled: false,
+			sandboxProvider: 'n8n-sandbox',
+			braveSearchApiKey: '',
+			searxngUrl: '',
+		},
 		instanceSettingsLoader: getDefaultInstanceSettingsLoaderConfig(),
 	});
 	const binaryDataConfig = mock<BinaryDataConfig>({
@@ -2730,6 +2736,44 @@ describe('TelemetryEventRelay', () => {
 					}),
 				}),
 			);
+		});
+
+		it('should track instance AI sandbox and search configuration on `server-started` event', async () => {
+			workflowRepository.findOne.mockResolvedValue(null);
+			Object.assign(globalConfig.instanceAi, {
+				sandboxEnabled: true,
+				sandboxProvider: 'daytona',
+				braveSearchApiKey: 'some-api-key',
+				searxngUrl: '',
+			});
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			const startupEvent = telemetry.track.mock.calls.find(
+				([eventName]) => eventName === 'Instance started',
+			);
+			expect(startupEvent).toBeDefined();
+			expect(startupEvent?.[1]).toEqual(
+				expect.objectContaining({
+					instance_ai: {
+						sandbox_enabled: true,
+						sandbox_provider: 'daytona',
+						search_brave_set: true,
+						search_searxng_set: false,
+					},
+				}),
+			);
+			// Key values must never leave the instance — only set/unset booleans
+			expect(JSON.stringify(startupEvent?.[1])).not.toContain('some-api-key');
+
+			Object.assign(globalConfig.instanceAi, {
+				sandboxEnabled: false,
+				sandboxProvider: 'n8n-sandbox',
+				braveSearchApiKey: '',
+				searxngUrl: '',
+			});
 		});
 
 		it('should track on `session-started` event', () => {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1465,6 +1465,13 @@ export class TelemetryEventRelay extends EventRelay {
 			license_tenant_id: this.globalConfig.license.tenantId,
 			binary_data_s3: isS3Available && isS3Selected && isS3Licensed,
 			multi_main_setup_enabled: this.globalConfig.multiMainSetup.enabled,
+			instance_ai: {
+				// Which sandbox and AIA search providers are configured (booleans/names only, never key values)
+				sandbox_enabled: this.globalConfig.instanceAi.sandboxEnabled,
+				sandbox_provider: this.globalConfig.instanceAi.sandboxProvider,
+				search_brave_set: this.globalConfig.instanceAi.braveSearchApiKey !== '',
+				search_searxng_set: this.globalConfig.instanceAi.searxngUrl !== '',
+			},
 			metrics: {
 				metrics_enabled: this.globalConfig.endpoints.metrics.enable,
 				metrics_category_default: this.globalConfig.endpoints.metrics.includeDefaultMetrics,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -2508,6 +2508,55 @@ describe('InstanceAiService — terminal response guard wiring', () => {
 
 		expect(service.eventBus.events.map((event) => event.type)).toEqual(['error', 'run-finish']);
 		expect(service.saveAgentTreeSnapshot).toHaveBeenCalledWith('thread-a', 'run-1', {});
+		// Thrown run-loop errors must reach telemetry too, not just the SSE stream
+		expect(service.telemetry.track).toHaveBeenCalledWith('instance_ai_run_finished', {
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			status: 'error',
+			user_id: 'user-1',
+		});
+		expect(service.telemetry.track).toHaveBeenCalledWith('Builder generation errored', {
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			error_message: 'provider failed',
+			error_source: 'exception',
+			user_id: 'user-1',
+		});
+	});
+
+	it('tracks "Builder generation errored" when a resumed stream reports an error', async () => {
+		const service = createTerminalGuardOrderService();
+		const abortController = new AbortController();
+		vi.mocked(resumeAgentRun).mockResolvedValueOnce({
+			status: 'errored',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve(''),
+			error: new Error('model overloaded'),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		});
+
+		await service.processResumedStream(
+			{},
+			{},
+			{
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				threadId: 'thread-a',
+				user: fakeUser,
+				toolCallId: 'tool-call-1',
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: {},
+			},
+		);
+
+		expect(service.telemetry.track).toHaveBeenCalledWith('Builder generation errored', {
+			thread_id: 'thread-a',
+			run_id: 'run-1',
+			error_message: 'model overloaded',
+			error_source: 'stream',
+			user_id: 'user-1',
+		});
 	});
 
 	it('claims credits when a resumed run completes', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -304,6 +304,14 @@ function getAbortReason(signal: AbortSignal): string {
 	return typeof reason === 'string' ? reason : 'user_cancelled';
 }
 
+/** Error details for the 'Builder generation errored' telemetry event. */
+type RunFinishErrorInfo = {
+	/** Raw error message — the SSE run-finish payload carries the user-facing reason instead. */
+	errorMessage?: string;
+	/** 'stream' = the run reported an error but terminated cleanly; 'exception' = the run loop threw. */
+	errorSource?: 'stream' | 'exception';
+};
+
 const MAX_CONCURRENT_BACKGROUND_TASKS_PER_THREAD = 5;
 
 const TITLE_REFINE_HISTORY_LIMIT = 50;
@@ -3466,6 +3474,16 @@ export class InstanceAiService {
 				workSummary: result.workSummary,
 				usage: result.usage,
 				errorReason: userFacingErrorMessage,
+				...(result.status === 'errored'
+					? {
+							errorInfo: {
+								errorMessage: result.error
+									? getErrorMessage(result.error)
+									: 'Instance AI stream errored',
+								errorSource: 'stream' as const,
+							},
+						}
+					: {}),
 			});
 
 			// Bill token usage for every terminal outcome (completed / cancelled / errored),
@@ -3583,16 +3601,15 @@ export class InstanceAiService {
 				aiCreatedWorkflowIds,
 				this.backgroundTasks.getRunningTasks(threadId).length,
 			);
-			this.eventBus.publish(threadId, {
-				type: 'run-finish',
+			this.publishRunFinish(
+				threadId,
 				runId,
-				agentId: orchestratorAgentId(runId),
-				payload: {
-					status: 'error',
-					reason: userFacingErrorMessage,
-					...(archivedWorkflowIds.length > 0 ? { archivedWorkflowIds } : {}),
-				},
-			});
+				'errored',
+				userFacingErrorMessage,
+				archivedWorkflowIds,
+				user.id,
+				{ errorMessage, errorSource: 'exception' },
+			);
 			if (activeSnapshotStorage) {
 				await this.saveAgentTreeSnapshot(threadId, runId, activeSnapshotStorage);
 			}
@@ -4587,6 +4604,16 @@ export class InstanceAiService {
 				workSummary: result.workSummary,
 				usage: result.usage,
 				errorReason: userFacingErrorMessage,
+				...(result.status === 'errored'
+					? {
+							errorInfo: {
+								errorMessage: result.error
+									? getErrorMessage(result.error)
+									: 'Instance AI resumed stream errored',
+								errorSource: 'stream' as const,
+							},
+						}
+					: {}),
 			});
 
 			// Bill token usage for every terminal outcome, deduped per run segment.
@@ -4697,16 +4724,15 @@ export class InstanceAiService {
 				undefined,
 				this.backgroundTasks.getRunningTasks(opts.threadId).length,
 			);
-			this.eventBus.publish(opts.threadId, {
-				type: 'run-finish',
-				runId: opts.runId,
-				agentId: orchestratorAgentId(opts.runId),
-				payload: {
-					status: 'error',
-					reason: userFacingErrorMessage,
-					...(archivedWorkflowIds.length > 0 ? { archivedWorkflowIds } : {}),
-				},
-			});
+			this.publishRunFinish(
+				opts.threadId,
+				opts.runId,
+				'errored',
+				userFacingErrorMessage,
+				archivedWorkflowIds,
+				opts.user.id,
+				{ errorMessage, errorSource: 'exception' },
+			);
 			await this.saveAgentTreeSnapshot(opts.threadId, opts.runId, opts.snapshotStorage);
 		} finally {
 			this.runState.clearActiveRun(opts.threadId);
@@ -5109,6 +5135,7 @@ export class InstanceAiService {
 		reason?: string,
 		archivedWorkflowIds?: string[],
 		userId?: string,
+		errorInfo?: RunFinishErrorInfo,
 	): void {
 		const effectiveStatus = status === 'errored' ? 'error' : status;
 		const hasArchived = archivedWorkflowIds && archivedWorkflowIds.length > 0;
@@ -5133,6 +5160,15 @@ export class InstanceAiService {
 			status: effectiveStatus,
 			...(userId ? { user_id: userId } : {}),
 		});
+		if (status === 'errored') {
+			this.telemetry.track('Builder generation errored', {
+				thread_id: threadId,
+				run_id: runId,
+				error_message: errorInfo?.errorMessage ?? reason ?? 'unknown',
+				...(errorInfo?.errorSource ? { error_source: errorInfo.errorSource } : {}),
+				...(userId ? { user_id: userId } : {}),
+			});
+		}
 	}
 
 	private async finalizeRun(
@@ -5147,6 +5183,7 @@ export class InstanceAiService {
 			workSummary?: WorkSummary;
 			usage?: RunTokenUsage;
 			errorReason?: string;
+			errorInfo?: RunFinishErrorInfo;
 		},
 	): Promise<void> {
 		this.publishRunFinish(
@@ -5156,6 +5193,7 @@ export class InstanceAiService {
 			options?.errorReason,
 			options?.archivedWorkflowIds,
 			options?.userId,
+			options?.errorInfo,
 		);
 		this.emitRunMetrics(threadId, status, options);
 		await this.saveAgentTreeSnapshot(threadId, runId, snapshotStorage);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -7,6 +7,7 @@ import { useI18n } from '@n8n/i18n';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useInstanceAiStore } from './instanceAi.store';
 import { useInstanceAiSettingsStore } from './instanceAiSettings.store';
@@ -21,6 +22,7 @@ const documentTitle = useDocumentTitle();
 const route = useRoute();
 const router = useRouter();
 const uiStore = useUIStore();
+const rootStore = useRootStore();
 const telemetry = useTelemetry();
 const { isCtrlKeyPressed } = useDeviceSupport();
 
@@ -82,8 +84,11 @@ onMounted(() => {
 	// In-app navigations expose the previous route via history state; direct
 	// visits (bookmark, external link) fall back to the document referrer.
 	const previousRoute = router.options.history.state.back;
+	const sourceUrl = typeof previousRoute === 'string' ? previousRoute : document.referrer || null;
+
 	telemetry.track('User viewed AI assistant', {
-		source_url: typeof previousRoute === 'string' ? previousRoute : document.referrer || null,
+		instance_id: rootStore.instanceId,
+		source_url: sourceUrl,
 	});
 
 	void store.loadThreads();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiView.vue
@@ -6,6 +6,7 @@ import { useEventListener, useSessionStorage } from '@vueuse/core';
 import { useI18n } from '@n8n/i18n';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useInstanceAiStore } from './instanceAi.store';
 import { useInstanceAiSettingsStore } from './instanceAiSettings.store';
@@ -20,6 +21,7 @@ const documentTitle = useDocumentTitle();
 const route = useRoute();
 const router = useRouter();
 const uiStore = useUIStore();
+const telemetry = useTelemetry();
 const { isCtrlKeyPressed } = useDeviceSupport();
 
 documentTitle.set(i18n.baseText('instanceAi.view.title'));
@@ -77,6 +79,13 @@ useEventListener(document, 'keydown', (event: KeyboardEvent) => {
 // These run once when the user enters the InstanceAi feature. Route changes
 // (empty ↔ thread) don't remount the layout, so the listeners persist.
 onMounted(() => {
+	// In-app navigations expose the previous route via history state; direct
+	// visits (bookmark, external link) fall back to the document referrer.
+	const previousRoute = router.options.history.state.back;
+	telemetry.track('User viewed AI assistant', {
+		source_url: typeof previousRoute === 'string' ? previousRoute : document.referrer || null,
+	});
+
 	void store.loadThreads();
 	void store.fetchCredits();
 	store.startCreditsPushListener();

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
@@ -6,13 +6,19 @@ import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
 import { INSTANCE_AI_VIEW } from '../constants';
 
 const routerPush = vi.hoisted(() => vi.fn());
+const routerHistoryState = vi.hoisted(() => ({ back: null as string | null }));
+const telemetryTrack = vi.hoisted(() => vi.fn());
 
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
 	useRoute: () => ({ params: { threadId: 'thread-1' } }),
-	useRouter: () => ({ push: routerPush }),
+	useRouter: () => ({ push: routerPush, options: { history: { state: routerHistoryState } } }),
 	onBeforeRouteLeave: vi.fn(),
 	RouterView: { template: '<div data-test-id="router-view-stub" />' },
+}));
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: telemetryTrack }),
 }));
 
 vi.mock('@n8n/composables/useDeviceSupport', () => ({
@@ -31,17 +37,21 @@ const renderView = createComponentRenderer(InstanceAiView, {
 });
 
 describe('InstanceAiView', () => {
+	let pinia: ReturnType<typeof createTestingPinia>;
+
 	beforeEach(() => {
-		const pinia = createTestingPinia();
+		pinia = createTestingPinia();
 		const settingsStore = useInstanceAiSettingsStore();
 		settingsStore.refreshModuleSettings = vi.fn().mockResolvedValue(undefined);
 		settingsStore.ensurePreferencesLoaded = vi.fn().mockResolvedValue(undefined);
 		routerPush.mockClear();
-
-		renderView({ pinia });
+		telemetryTrack.mockClear();
+		routerHistoryState.back = null;
 	});
 
 	it('opens a new thread with Ctrl/Cmd+Shift+O', () => {
+		renderView({ pinia });
+
 		document.dispatchEvent(
 			new KeyboardEvent('keydown', {
 				key: 'o',
@@ -53,5 +63,25 @@ describe('InstanceAiView', () => {
 		);
 
 		expect(routerPush).toHaveBeenCalledWith({ name: INSTANCE_AI_VIEW, force: true });
+	});
+
+	it('tracks "User viewed AI assistant" with the previous in-app route on mount', () => {
+		routerHistoryState.back = '/workflow/abc123';
+
+		renderView({ pinia });
+
+		expect(telemetryTrack).toHaveBeenCalledWith('User viewed AI assistant', {
+			source_url: '/workflow/abc123',
+		});
+	});
+
+	it('tracks "User viewed AI assistant" with a null source on direct visits', () => {
+		routerHistoryState.back = null;
+
+		renderView({ pinia });
+
+		expect(telemetryTrack).toHaveBeenCalledWith('User viewed AI assistant', {
+			source_url: null,
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts
@@ -5,6 +5,8 @@ import InstanceAiView from '../InstanceAiView.vue';
 import { useInstanceAiSettingsStore } from '../instanceAiSettings.store';
 import { INSTANCE_AI_VIEW } from '../constants';
 
+const TEST_INSTANCE_ID = 'test-instance-id';
+
 const routerPush = vi.hoisted(() => vi.fn());
 const routerHistoryState = vi.hoisted(() => ({ back: null as string | null }));
 const telemetryTrack = vi.hoisted(() => vi.fn());
@@ -25,6 +27,10 @@ vi.mock('@n8n/composables/useDeviceSupport', () => ({
 	useDeviceSupport: () => ({
 		isCtrlKeyPressed: (event: KeyboardEvent) => event.ctrlKey || event.metaKey,
 	}),
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({ instanceId: TEST_INSTANCE_ID }),
 }));
 
 const renderView = createComponentRenderer(InstanceAiView, {
@@ -71,6 +77,7 @@ describe('InstanceAiView', () => {
 		renderView({ pinia });
 
 		expect(telemetryTrack).toHaveBeenCalledWith('User viewed AI assistant', {
+			instance_id: TEST_INSTANCE_ID,
 			source_url: '/workflow/abc123',
 		});
 	});
@@ -81,6 +88,7 @@ describe('InstanceAiView', () => {
 		renderView({ pinia });
 
 		expect(telemetryTrack).toHaveBeenCalledWith('User viewed AI assistant', {
+			instance_id: TEST_INSTANCE_ID,
 			source_url: null,
 		});
 	});


### PR DESCRIPTION
## Summary

Adds the three telemetry items from [INS-833](https://linear.app/n8n/issue/INS-833/aia-telemetry-events):

- **`Builder generation errored`** (backend): fired from `publishRunFinish` when a run ends with `status: 'errored'`, including `thread_id`, `run_id`, `user_id`, `error_message`, and `error_source` (`stream` vs `exception`). Thrown-exception catch paths now route through `publishRunFinish` so they also emit `instance_ai_run_finished`.
- **`User viewed AI assistant`** (frontend): fired once when the user lands on `/assistant`, with `source_url` from router history (or `document.referrer` / `null` for direct visits).
- **`Instance started` enrichment** (backend): adds `instance_ai.sandbox_enabled`, `sandbox_provider`, `search_brave_set`, and `search_searxng_set` (booleans/names only — no secret values).

Notion event definitions updated for the new params.

## How to test

1. **Builder generation errored**
   - Trigger a generation failure in Instance AI (e.g. interrupt provider / force an error).
   - Confirm `Builder generation errored` is emitted with `error_source: stream` or `exception`, alongside the existing `instance_ai_run_finished` event.

2. **User viewed AI assistant**
   - Navigate to `/assistant` from the workflow editor.
   - Confirm `User viewed AI assistant` fires with `source_url` set to the previous route.
   - Open `/assistant` directly (bookmark / new tab) and confirm `source_url` is `null` or the referrer.

3. **Instance started**
   - Restart n8n with sandbox/search env vars set (e.g. `N8N_INSTANCE_AI_SANDBOX_ENABLED=true`, `INSTANCE_AI_BRAVE_SEARCH_API_KEY=...`).
   - Confirm the `Instance started` event includes the `instance_ai` block and does **not** contain API key values.

4. **Unit tests**
   - `pnpm vitest run src/modules/instance-ai/__tests__/instance-ai.service.test.ts` (cli)
   - `pnpm vitest run src/events/__tests__/telemetry-event-relay.test.ts` (cli)
   - `pnpm vitest run src/features/ai/instanceAi/__tests__/InstanceAiView.test.ts` (editor-ui)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-833/aia-telemetry-events

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34000">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

