### PR TITLE
fix(core): Support bare models for custom AI Assistant endpoints

### DIFF
--- a/packages/@n8n/agents/src/runtime/model/model-factory.ts
+++ b/packages/@n8n/agents/src/runtime/model/model-factory.ts
@@ -82,6 +82,19 @@ const LANGUAGE_PROVIDERS: ProviderRegistry = {
 			return creds.baseURL ? provider.chat(model) : provider(model);
 		},
 	},
+	custom: {
+		build: (creds, model, fetch) => {
+			const { createOpenAICompatible } =
+				require('@ai-sdk/openai-compatible') as typeof import('@ai-sdk/openai-compatible');
+			return createOpenAICompatible({
+				name: 'custom',
+				baseURL: creds.baseURL,
+				apiKey: creds.apiKey,
+				headers: creds.headers,
+				fetch,
+			})(model);
+		},
+	},
 	anthropic: {
 		build: (creds, model, fetch) => {
 			const { createAnthropic } =

--- a/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
+++ b/packages/@n8n/agents/src/runtime/model/provider-credentials.ts
@@ -12,6 +12,9 @@ const apiKeyCreds = z.object({
  */
 export const PROVIDER_CREDENTIAL_SCHEMAS = {
 	openai: apiKeyCreds,
+	custom: apiKeyCreds.extend({
+		baseURL: z.string().min(1, 'baseURL is required'),
+	}),
 	anthropic: apiKeyCreds,
 	google: apiKeyCreds,
 	xai: apiKeyCreds,

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -4,7 +4,7 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class InstanceAiConfig {
-	/** LLM model in provider/model format (e.g. "anthropic/claude-opus-4-8"). */
+	/** LLM model in provider/model format, or a bare model name for a custom endpoint. */
 	@Env('N8N_INSTANCE_AI_MODEL')
 	model: string = 'anthropic/claude-opus-4-8';
 

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -8,7 +8,7 @@ All Instance AI configuration is done via environment variables.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-opus-4-8` | LLM model in `provider/model` format. Must be set for the module to enable. |
+| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-opus-4-8` | LLM model in `provider/model` format for built-in providers, or a bare model name when `N8N_INSTANCE_AI_MODEL_URL` is set. Must be set for the module to enable. |
 | `N8N_INSTANCE_AI_MODEL_URL` | string | `''` | Base URL for an OpenAI-compatible endpoint (e.g. `http://localhost:1234/v1` for LM Studio). When set, model requests go to this URL instead of the built-in provider. |
 | `N8N_INSTANCE_AI_MODEL_API_KEY` | string | `''` | API key for the custom model endpoint. Optional — some local servers don't require one. |
 | `N8N_INSTANCE_AI_MCP_SERVERS` | string | `''` | Comma-separated MCP server configs. Format: `name=url,name=url` |
@@ -208,6 +208,7 @@ N8N_INSTANCE_AI_GATEWAY_API_KEY=my-secret-key
 # User runs: npx @n8n/computer-use
 
 # With custom OpenAI-compatible endpoint (e.g. LM Studio, Ollama)
+N8N_INSTANCE_AI_MODEL=your-tool-capable-model
 N8N_INSTANCE_AI_MODEL_URL=http://localhost:1234/v1
 
 # Output filtering — secrets + email only, with a custom placeholder


### PR DESCRIPTION
## Summary

Restore the dedicated `custom` model provider in the agents runtime so Instance AI can use bare model names with OpenAI-compatible endpoints.

When `N8N_INSTANCE_AI_MODEL_URL` is configured and `N8N_INSTANCE_AI_MODEL` contains a bare model name, Instance AI resolves it as `custom/<model>`. The agents runtime now handles that provider with the OpenAI-compatible SDK, preserves the configured API key and headers, and sends requests to the configured endpoint using the chat-completions protocol.

This also clarifies that custom endpoints accept bare model names and that the configured model must support the capabilities required by Instance AI.

## How to test

1. Configure Instance AI with a tool-capable model exposed through an OpenAI-compatible endpoint:

   ```bash
   export N8N_INSTANCE_AI_MODEL=your-tool-capable-model
   export N8N_INSTANCE_AI_MODEL_URL=https://your-endpoint.example/v1
   export N8N_INSTANCE_AI_MODEL_API_KEY=your-api-key
   ```

2. Start n8n and send a message through the AI Assistant.
3. Verify the model request is sent to the configured endpoint's `/chat/completions` route and not to the default OpenAI endpoint.

Validation completed locally:

- `pnpm build`
- `pnpm typecheck` and `pnpm lint` in `packages/@n8n/agents`
- `pnpm typecheck` and `pnpm lint` in `packages/@n8n/config`
- `pnpm test src/runtime/__tests__/model-factory.test.ts` in `packages/@n8n/agents` — 36 tests passed

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if this urgent fix needs to be backported.

> 🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34016">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

