### PR TITLE
feat(core): Import a folder with workflows (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
@@ -453,6 +453,35 @@ describe('folder shell import', () => {
 		expect(await Container.get(WorkflowRepository).countBy({ id: localId })).toBe(1);
 	});
 
+	it('rejects a folder-nested workflow whose folder is missing from the manifest', async () => {
+		// Workflow nested under `folders/orphan`, but no such folder is declared.
+		const packageBuffer = await buildEntityPackageBuffer({
+			workflows: [
+				{
+					target: 'folders/orphan/workflows/triage',
+					workflow: serializedWorkflow({ id: 'WF', name: 'triage' }),
+				},
+			],
+		});
+
+		await expect(
+			importFolders({ user: owner, projectId: project.id, packageBuffer }),
+		).rejects.toThrow(/missing from the manifest/i);
+		expect(await Container.get(WorkflowRepository).countBy({ id: 'WF' })).toBe(0);
+	});
+
+	it('rejects a package whose manifest folder id disagrees with its folder.json', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [{ target: 'folders/f', folder: serializedFolder({ id: 'real-id', name: 'f' }) }],
+			// Manifest points the same target at a different id than folder.json declares.
+			manifestExtras: { folders: [{ id: 'manifest-id', name: 'f', target: 'folders/f' }] },
+		});
+
+		await expect(
+			importFolders({ user: owner, projectId: project.id, packageBuffer }),
+		).rejects.toThrow(/declares id "real-id" but the manifest lists it as "manifest-id"/);
+	});
+
 	it('blocks when a folder-nested workflow needs a credential missing under must-preexist', async () => {
 		const nestedWorkflow = serializedWorkflowWithCredential({
 			id: 'WF',

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-folders.integration.test.ts
@@ -1,11 +1,12 @@
 import { LicenseState } from '@n8n/backend-common';
 import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
-import { FolderRepository } from '@n8n/db';
+import { FolderRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 import { createFolder } from '@test-integration/db/folders';
 import { createOwner } from '@test-integration/db/users';
 import { LicenseMocker } from '@test-integration/license';
@@ -16,6 +17,7 @@ import {
 	buildEntityPackageBuffer,
 	credentialRequirementsFromWorkflows,
 	serializedFolder,
+	serializedWorkflow,
 	serializedWorkflowWithCredential,
 } from './fixtures/package-fixtures';
 
@@ -51,6 +53,13 @@ async function findFolder(id: string) {
 	return await Container.get(FolderRepository).findOne({
 		where: { id },
 		relations: { homeProject: true },
+	});
+}
+
+async function findWorkflow(id: string) {
+	return await Container.get(WorkflowRepository).findOne({
+		where: { id },
+		relations: { parentFolder: true },
 	});
 }
 
@@ -352,7 +361,99 @@ describe('folder shell import', () => {
 		});
 	});
 
-	it('does not process credentials needed only by skipped nested workflows', async () => {
+	it('imports a folder-nested workflow into its folder', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'F1', name: 'in_progress' }),
+				},
+			],
+			workflows: [
+				{
+					target: 'folders/in_progress/workflows/triage',
+					workflow: serializedWorkflow({ id: 'WF', name: 'triage' }),
+				},
+			],
+		});
+
+		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		expect(result.folders[0]).toMatchObject({ sourceFolderId: 'F1', status: 'created' });
+		const summary = result.workflows.find((w) => w.sourceWorkflowId === 'WF');
+		expect(summary).toMatchObject({ status: 'created', parentFolderId: 'F1' });
+		// Assert the persisted row, not just the summary.
+		expect((await findWorkflow(summary!.localId))?.parentFolder?.id).toBe('F1');
+	});
+
+	it('places each workflow under the folder it belongs to across a nested hierarchy', async () => {
+		const packageBuffer = await buildEntityPackageBuffer({
+			folders: [
+				{
+					target: 'folders/in_progress',
+					folder: serializedFolder({ id: 'P', name: 'in_progress' }),
+				},
+				{
+					target: 'folders/in_progress/nested',
+					folder: serializedFolder({ id: 'C', name: 'nested', parentFolderId: 'P' }),
+				},
+			],
+			workflows: [
+				{
+					target: 'folders/in_progress/workflows/triage',
+					workflow: serializedWorkflow({ id: 'WF1', name: 'triage' }),
+				},
+				{
+					target: 'folders/in_progress/nested/workflows/playground',
+					workflow: serializedWorkflow({ id: 'WF2', name: 'playground' }),
+				},
+			],
+		});
+
+		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
+
+		const triage = result.workflows.find((w) => w.sourceWorkflowId === 'WF1')!;
+		const playground = result.workflows.find((w) => w.sourceWorkflowId === 'WF2')!;
+		expect((await findWorkflow(triage.localId))?.parentFolder?.id).toBe('P');
+		expect((await findWorkflow(playground.localId))?.parentFolder?.id).toBe('C');
+	});
+
+	it('reuses the folder and updates the nested workflow on re-import', async () => {
+		const pkg = async () =>
+			await buildEntityPackageBuffer({
+				folders: [
+					{
+						target: 'folders/in_progress',
+						folder: serializedFolder({ id: 'F1', name: 'in_progress' }),
+					},
+				],
+				workflows: [
+					{
+						target: 'folders/in_progress/workflows/triage',
+						workflow: serializedWorkflow({ id: 'WF', name: 'triage' }),
+					},
+				],
+			});
+
+		const first = await importFolders({
+			user: owner,
+			projectId: project.id,
+			packageBuffer: await pkg(),
+		});
+		const localId = first.workflows[0].localId;
+
+		const second = await importFolders({
+			user: owner,
+			projectId: project.id,
+			packageBuffer: await pkg(),
+		});
+
+		expect(second.workflows[0]).toMatchObject({ status: 'updated', localId, parentFolderId: 'F1' });
+		expect(await Container.get(FolderRepository).countBy({ id: 'F1' })).toBe(1);
+		expect(await Container.get(WorkflowRepository).countBy({ id: localId })).toBe(1);
+	});
+
+	it('blocks when a folder-nested workflow needs a credential missing under must-preexist', async () => {
 		const nestedWorkflow = serializedWorkflowWithCredential({
 			id: 'WF',
 			name: 'triage',
@@ -372,11 +473,11 @@ describe('folder shell import', () => {
 			},
 		});
 
-		// credentialMissingMode defaults to must-preexist here; the folder-nested workflow (and its
-		// missing credential) are skipped, so the import must not be blocked.
-		const result = await importFolders({ user: owner, projectId: project.id, packageBuffer });
-
-		expect(result.folders[0].status).toBe('created');
-		expect(result.workflows).toEqual([]);
+		// The folder-nested workflow is now imported (LIGO-723), so its missing must-preexist credential
+		// resolves through the same gate as a top-level workflow and blocks the import before any writes.
+		await expect(
+			importFolders({ user: owner, projectId: project.id, packageBuffer }),
+		).rejects.toBeInstanceOf(UnprocessableRequestError);
+		expect(await findFolder('F1')).toBeNull();
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
@@ -1,52 +1,76 @@
 import type { ManifestEntry } from '../../spec/manifest.schema';
-import { isTopLevelTarget, topLevelFolders, topLevelWorkflows } from '../package-layout';
+import { deriveParentFolderId, foldersInScope, workflowsInScope } from '../package-layout';
 
 const entry = (id: string, target: string): ManifestEntry => ({ id, name: id, target });
 
 describe('package-layout', () => {
-	describe('isTopLevelTarget', () => {
-		it('treats a direct child of the dir as top-level', () => {
-			expect(isTopLevelTarget('folders/a', 'folders')).toBe(true);
-			expect(isTopLevelTarget('workflows/wf', 'workflows')).toBe(true);
-		});
-
-		it('treats a nested folder tree entry as top-level (folders/ appears once per scope)', () => {
-			expect(isTopLevelTarget('folders/a/b', 'folders')).toBe(true);
-		});
-
-		it('rejects project-nested entries', () => {
-			expect(isTopLevelTarget('projects/x/folders/a', 'folders')).toBe(false);
-			expect(isTopLevelTarget('projects/x/workflows/wf', 'workflows')).toBe(false);
-		});
-
-		it('rejects folder-nested workflows', () => {
-			expect(isTopLevelTarget('folders/a/workflows/wf', 'workflows')).toBe(false);
-		});
-	});
-
-	describe('topLevelFolders', () => {
-		it('keeps only folders/… entries and drops project-nested ones', () => {
+	describe('foldersInScope', () => {
+		it('keeps the whole folders/ subtree at package root, dropping project-nested folders', () => {
 			const entries = [
 				entry('a', 'folders/a'),
 				entry('b', 'folders/a/b'),
 				entry('c', 'projects/x/folders/c'),
 			];
-			expect(topLevelFolders(entries).map((e) => e.id)).toEqual(['a', 'b']);
+			expect(foldersInScope(entries).map((e) => e.id)).toEqual(['a', 'b']);
+		});
+
+		it('scopes to a project prefix', () => {
+			const entries = [
+				entry('a', 'folders/a'),
+				entry('c', 'projects/x/folders/c'),
+				entry('d', 'projects/x/folders/c/d'),
+			];
+			expect(foldersInScope(entries, 'projects/x/').map((e) => e.id)).toEqual(['c', 'd']);
 		});
 
 		it('returns [] for undefined', () => {
-			expect(topLevelFolders(undefined)).toEqual([]);
+			expect(foldersInScope(undefined)).toEqual([]);
 		});
 	});
 
-	describe('topLevelWorkflows', () => {
-		it('keeps only workflows/… entries and drops folder/project-nested ones', () => {
+	describe('workflowsInScope', () => {
+		it('keeps loose and folder-nested workflows at package root, dropping project-nested', () => {
 			const entries = [
 				entry('top', 'workflows/top'),
 				entry('inFolder', 'folders/a/workflows/inFolder'),
 				entry('inProject', 'projects/x/workflows/inProject'),
 			];
-			expect(topLevelWorkflows(entries).map((e) => e.id)).toEqual(['top']);
+			expect(workflowsInScope(entries).map((e) => e.id)).toEqual(['top', 'inFolder']);
+		});
+
+		it('scopes to a project prefix (project-root and project-folder-nested)', () => {
+			const entries = [
+				entry('top', 'workflows/top'),
+				entry('pRoot', 'projects/x/workflows/pRoot'),
+				entry('pFolder', 'projects/x/folders/a/workflows/pFolder'),
+			];
+			expect(workflowsInScope(entries, 'projects/x/').map((e) => e.id)).toEqual([
+				'pRoot',
+				'pFolder',
+			]);
+		});
+	});
+
+	describe('deriveParentFolderId', () => {
+		const map = new Map([
+			['folders/a', 'A'],
+			['folders/a/b', 'B'],
+			['projects/x/folders/c', 'C'],
+		]);
+
+		it('returns null for a scope-root workflow', () => {
+			expect(deriveParentFolderId('workflows/top', map)).toBeNull();
+			expect(deriveParentFolderId('projects/x/workflows/root', map)).toBeNull();
+		});
+
+		it('resolves a folder-nested workflow to its folder id', () => {
+			expect(deriveParentFolderId('folders/a/workflows/wf', map)).toBe('A');
+			expect(deriveParentFolderId('folders/a/b/workflows/wf', map)).toBe('B');
+			expect(deriveParentFolderId('projects/x/folders/c/workflows/wf', map)).toBe('C');
+		});
+
+		it('returns null when the folder is not in the map', () => {
+			expect(deriveParentFolderId('folders/missing/workflows/wf', map)).toBeNull();
 		});
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/__tests__/package-layout.test.ts
@@ -69,8 +69,14 @@ describe('package-layout', () => {
 			expect(deriveParentFolderId('projects/x/folders/c/workflows/wf', map)).toBe('C');
 		});
 
-		it('returns null when the folder is not in the map', () => {
-			expect(deriveParentFolderId('folders/missing/workflows/wf', map)).toBeNull();
+		it('throws when a folder-nested workflow references a folder missing from the manifest', () => {
+			expect(() => deriveParentFolderId('folders/missing/workflows/wf', map)).toThrow(
+				/missing from the manifest/,
+			);
+		});
+
+		it('returns null for a project-root workflow even when its project has no folder entry', () => {
+			expect(deriveParentFolderId('projects/unknown/workflows/wf', map)).toBeNull();
 		});
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -14,7 +14,7 @@ import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
 import type { PackageReader } from '../io/package-reader';
 import type { ManifestEntry, PackageManifest } from '../spec/manifest.schema';
 import { packageManifestSchema } from '../spec/manifest.schema';
-import { serializedFolderSchema } from '../spec/serialized/folder.schema';
+import { serializedFolderSchema, type SerializedFolder } from '../spec/serialized/folder.schema';
 import { serializedProjectSchema } from '../spec/serialized/project.schema';
 import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
 
@@ -107,19 +107,29 @@ export class N8nPackageParser {
 		const path = `${entry.target}/folder.json`;
 		const wire = await this.readJson(reader, path, 'folder');
 
+		let folder: SerializedFolder;
 		try {
-			const folder = serializedFolderSchema.parse(wire);
-			return {
-				sourceFolderId: folder.id,
-				name: folder.name,
-				parentFolderId: folder.parentFolderId,
-			};
+			folder = serializedFolderSchema.parse(wire);
 		} catch (cause) {
 			if (cause instanceof ZodError) {
 				throw new UserError(`Package folder file at ${path} failed schema validation.`, { cause });
 			}
 			throw cause;
 		}
+
+		// Nested workflows route to folders by manifest id, but folders are created
+		// under folder.json's id — a mismatch would place a workflow in the wrong folder.
+		if (folder.id !== entry.id) {
+			throw new UserError(
+				`Package folder at ${path} declares id "${folder.id}" but the manifest lists it as "${entry.id}".`,
+			);
+		}
+
+		return {
+			sourceFolderId: folder.id,
+			name: folder.name,
+			parentFolderId: folder.parentFolderId,
+		};
 	}
 
 	private async readProject(reader: PackageReader, entry: ManifestEntry): Promise<PreparedProject> {

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -6,7 +6,7 @@ import { ZodError } from 'zod';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import * as WorkflowHelpers from '@/workflow-helpers';
 
-import { topLevelFolders, topLevelWorkflows } from './package-layout';
+import { deriveParentFolderId, foldersInScope, workflowsInScope } from './package-layout';
 import type { PreparedFolder } from '../entities/folder/folder-import.types';
 import type { PreparedProject } from '../entities/project/project-import.types';
 import type { PreparedWorkflow } from '../entities/workflow/workflow-import.types';
@@ -39,23 +39,29 @@ export class N8nPackageParser {
 		}
 	}
 
-	/** Reads the package's top-level workflows; those nested in a folder or project are skipped. */
-	async getWorkflows(reader: PackageReader): Promise<PreparedWorkflow[]> {
+	/**
+	 * Reads a scope's workflows — both scope-root and folder-nested — attaching each to its package
+	 * folder (via {@link deriveParentFolderId}). `basePrefix` selects the scope: `''` for a workflow
+	 * package's root, `projects/<slug>/` for a project's contents.
+	 */
+	async getWorkflows(reader: PackageReader, basePrefix = ''): Promise<PreparedWorkflow[]> {
 		const manifest = await this.getManifest(reader);
+		const folderTargetToId = new Map((manifest.folders ?? []).map((f) => [f.target, f.id]));
 
 		const workflows: PreparedWorkflow[] = [];
-		for (const entry of topLevelWorkflows(manifest.workflows)) {
-			workflows.push(await this.readWorkflow(reader, entry));
+		for (const entry of workflowsInScope(manifest.workflows, basePrefix)) {
+			const parentFolderId = deriveParentFolderId(entry.target, folderTargetToId);
+			workflows.push(await this.readWorkflow(reader, entry, parentFolderId));
 		}
 		return workflows;
 	}
 
-	/** Reads the package's top-level folder shells (project-nested folders are skipped). */
-	async getFolders(reader: PackageReader): Promise<PreparedFolder[]> {
+	/** Reads a scope's folder shells (whole subtree). `basePrefix` selects the scope (see {@link getWorkflows}). */
+	async getFolders(reader: PackageReader, basePrefix = ''): Promise<PreparedFolder[]> {
 		const manifest = await this.getManifest(reader);
 
 		const folders: PreparedFolder[] = [];
-		for (const entry of topLevelFolders(manifest.folders)) {
+		for (const entry of foldersInScope(manifest.folders, basePrefix)) {
 			folders.push(await this.readFolder(reader, entry));
 		}
 		return folders;
@@ -75,6 +81,7 @@ export class N8nPackageParser {
 	private async readWorkflow(
 		reader: PackageReader,
 		entry: ManifestEntry,
+		parentFolderId: string | null,
 	): Promise<PreparedWorkflow> {
 		const path = `${entry.target}/workflow.json`;
 		const wire = await this.readJson<SerializedWorkflow>(reader, path, 'workflow');
@@ -94,7 +101,12 @@ export class N8nPackageParser {
 
 		WorkflowHelpers.validateWorkflowStructure(entity);
 
-		return { entity, sourceWorkflowId: entry.id, sourcePublished: wire.isPublished };
+		return {
+			entity,
+			sourceWorkflowId: entry.id,
+			sourcePublished: wire.isPublished,
+			parentFolderId,
+		};
 	}
 
 	private async readFolder(reader: PackageReader, entry: ManifestEntry): Promise<PreparedFolder> {

--- a/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/n8n-package-parser.ts
@@ -39,11 +39,6 @@ export class N8nPackageParser {
 		}
 	}
 
-	/**
-	 * Reads a scope's workflows — both scope-root and folder-nested — attaching each to its package
-	 * folder (via {@link deriveParentFolderId}). `basePrefix` selects the scope: `''` for a workflow
-	 * package's root, `projects/<slug>/` for a project's contents.
-	 */
 	async getWorkflows(reader: PackageReader, basePrefix = ''): Promise<PreparedWorkflow[]> {
 		const manifest = await this.getManifest(reader);
 		const folderTargetToId = new Map((manifest.folders ?? []).map((f) => [f.target, f.id]));
@@ -56,7 +51,6 @@ export class N8nPackageParser {
 		return workflows;
 	}
 
-	/** Reads a scope's folder shells (whole subtree). `basePrefix` selects the scope (see {@link getWorkflows}). */
 	async getFolders(reader: PackageReader, basePrefix = ''): Promise<PreparedFolder[]> {
 		const manifest = await this.getManifest(reader);
 

--- a/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
@@ -1,11 +1,5 @@
 import type { ManifestEntry } from '../spec/manifest.schema';
 
-// Within any scope — the package root, or a `projects/<slug>/` namespace — a workflow lives at
-// `<base>workflows/<slug>` (scope-root) or under a folder at `<base>folders/…/workflows/<slug>`, and
-// folders live at `<base>folders/<slug>[/<child>…]` (children nest as direct dirs). Nesting is encoded
-// entirely in the target-path prefix, so a `basePrefix` selects a scope's entries.
-
-/** Folder entries within a scope — the whole `<basePrefix>folders/…` subtree. */
 export function foldersInScope(
 	entries: ManifestEntry[] | undefined,
 	basePrefix = '',
@@ -13,7 +7,6 @@ export function foldersInScope(
 	return (entries ?? []).filter((entry) => entry.target.startsWith(`${basePrefix}folders/`));
 }
 
-/** Workflow entries within a scope — both scope-root (`<basePrefix>workflows/…`) and folder-nested (`<basePrefix>folders/…/workflows/…`). */
 export function workflowsInScope(
 	entries: ManifestEntry[] | undefined,
 	basePrefix = '',
@@ -25,13 +18,6 @@ export function workflowsInScope(
 	);
 }
 
-/**
- * The source folder id a workflow is nested under, derived from its manifest target. A workflow lives at
- * `<folderTarget>/workflows/<slug>`, so the prefix before the reserved `workflows` container names its
- * folder; looking that target up yields the folder's source id — which equals the recreated folder id,
- * since folders reuse their source ids on import. A scope-root workflow (`<base>workflows/<slug>`, or a
- * project's own root) has no in-package folder and returns null.
- */
 export function deriveParentFolderId(
 	workflowTarget: string,
 	folderTargetToId: Map<string, string>,

--- a/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
@@ -1,3 +1,5 @@
+import { UserError } from 'n8n-workflow';
+
 import type { ManifestEntry } from '../spec/manifest.schema';
 
 export function foldersInScope(
@@ -24,5 +26,15 @@ export function deriveParentFolderId(
 ): string | null {
 	const idx = workflowTarget.lastIndexOf('/workflows/');
 	if (idx === -1) return null;
-	return folderTargetToId.get(workflowTarget.slice(0, idx)) ?? null;
+
+	const containerTarget = workflowTarget.slice(0, idx);
+
+	if (!containerTarget.includes('folders/')) return null;
+	const folderId = folderTargetToId.get(containerTarget);
+	if (folderId === undefined) {
+		throw new UserError(
+			`Package workflow at "${workflowTarget}" is nested under folder "${containerTarget}", which is missing from the manifest.`,
+		);
+	}
+	return folderId;
 }

--- a/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/package-layout.ts
@@ -1,23 +1,42 @@
 import type { ManifestEntry } from '../spec/manifest.schema';
 
-export const PACKAGE_TOP_LEVEL_DIRS = {
-	workflows: 'workflows',
-	folders: 'folders',
-	projects: 'projects',
-} as const;
+// Within any scope — the package root, or a `projects/<slug>/` namespace — a workflow lives at
+// `<base>workflows/<slug>` (scope-root) or under a folder at `<base>folders/…/workflows/<slug>`, and
+// folders live at `<base>folders/<slug>[/<child>…]` (children nest as direct dirs). Nesting is encoded
+// entirely in the target-path prefix, so a `basePrefix` selects a scope's entries.
 
-type TopLevelDir = (typeof PACKAGE_TOP_LEVEL_DIRS)[keyof typeof PACKAGE_TOP_LEVEL_DIRS];
-
-// A top-level target begins with `${dir}/`; a nested one carries its scope's prefix first
-// (e.g. `projects/x/folders/a`, `folders/a/workflows/wf`).
-export function isTopLevelTarget(target: string, dir: TopLevelDir): boolean {
-	return target.startsWith(`${dir}/`);
+/** Folder entries within a scope — the whole `<basePrefix>folders/…` subtree. */
+export function foldersInScope(
+	entries: ManifestEntry[] | undefined,
+	basePrefix = '',
+): ManifestEntry[] {
+	return (entries ?? []).filter((entry) => entry.target.startsWith(`${basePrefix}folders/`));
 }
 
-export function topLevelFolders(entries: ManifestEntry[] | undefined): ManifestEntry[] {
-	return (entries ?? []).filter((entry) => isTopLevelTarget(entry.target, 'folders'));
+/** Workflow entries within a scope — both scope-root (`<basePrefix>workflows/…`) and folder-nested (`<basePrefix>folders/…/workflows/…`). */
+export function workflowsInScope(
+	entries: ManifestEntry[] | undefined,
+	basePrefix = '',
+): ManifestEntry[] {
+	return (entries ?? []).filter(
+		(entry) =>
+			entry.target.startsWith(`${basePrefix}workflows/`) ||
+			entry.target.startsWith(`${basePrefix}folders/`),
+	);
 }
 
-export function topLevelWorkflows(entries: ManifestEntry[] | undefined): ManifestEntry[] {
-	return (entries ?? []).filter((entry) => isTopLevelTarget(entry.target, 'workflows'));
+/**
+ * The source folder id a workflow is nested under, derived from its manifest target. A workflow lives at
+ * `<folderTarget>/workflows/<slug>`, so the prefix before the reserved `workflows` container names its
+ * folder; looking that target up yields the folder's source id — which equals the recreated folder id,
+ * since folders reuse their source ids on import. A scope-root workflow (`<base>workflows/<slug>`, or a
+ * project's own root) has no in-package folder and returns null.
+ */
+export function deriveParentFolderId(
+	workflowTarget: string,
+	folderTargetToId: Map<string, string>,
+): string | null {
+	const idx = workflowTarget.lastIndexOf('/workflows/');
+	if (idx === -1) return null;
+	return folderTargetToId.get(workflowTarget.slice(0, idx)) ?? null;
 }

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-publisher.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-publisher.test.ts
@@ -74,6 +74,7 @@ describe('WorkflowPublisher', () => {
 			sourceWorkflowId: 'wf-1',
 			decidedId: 'wf-1',
 			sourcePublished,
+			parentFolderId: null,
 			entity: mock<WorkflowEntity>(),
 		});
 
@@ -163,6 +164,7 @@ describe('WorkflowPublisher', () => {
 				action: 'update',
 				sourceWorkflowId: 'wf-stubbed',
 				sourcePublished: false,
+				parentFolderId: null,
 				entity: mock<WorkflowEntity>(),
 				existing: mock<WorkflowEntity>({ id: 'wf-1' }),
 			};
@@ -219,6 +221,7 @@ describe('WorkflowPublisher', () => {
 				action: 'update',
 				sourceWorkflowId: 'wf-stubbed',
 				sourcePublished: true,
+				parentFolderId: null,
 				entity: mock<WorkflowEntity>(),
 				existing: mock<WorkflowEntity>({ id: 'wf-1' }),
 			};

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
@@ -20,8 +20,7 @@ export interface PreparedWorkflow {
 	/** Whether the workflow was published (active) in the source instance. */
 	sourcePublished: boolean;
 	/**
-	 * Source id of the package folder this workflow is nested under (equal to the recreated folder id,
-	 * since folders reuse source ids), or null for a scope-root workflow that lands in the request's
+	 * Source id of the package folder this workflow is nested under or null for a scope-root workflow that lands in the request's
 	 * target folder.
 	 */
 	parentFolderId: string | null;

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
@@ -19,6 +19,12 @@ export interface PreparedWorkflow {
 	sourceWorkflowId: string;
 	/** Whether the workflow was published (active) in the source instance. */
 	sourcePublished: boolean;
+	/**
+	 * Source id of the package folder this workflow is nested under (equal to the recreated folder id,
+	 * since folders reuse source ids), or null for a scope-root workflow that lands in the request's
+	 * target folder.
+	 */
+	parentFolderId: string | null;
 }
 
 export type WorkflowPlannedAction = 'create' | 'update' | 'skip';

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -89,14 +89,17 @@ export class WorkflowImporter {
 				});
 			}
 
-			if (context.folderId && existing) {
+			// Each workflow targets its own package folder (nested import); loose workflows fall back to
+			// the request's target folder. Runs for any workflow resolving to a folder, incl. root-scope imports.
+			const targetFolderId = workflow.parentFolderId ?? context.folderId;
+			if (targetFolderId && existing) {
 				const existingParentFolderId = existing.parentFolder?.id ?? null;
-				if (existingParentFolderId !== context.folderId) {
+				if (existingParentFolderId !== targetFolderId) {
 					folderConflicts.push({
 						sourceWorkflowId: workflow.sourceWorkflowId,
 						existingWorkflowId: existing.id,
 						existingParentFolderId,
-						targetFolderId: context.folderId,
+						targetFolderId,
 						name: existing.name,
 					});
 				}
@@ -197,7 +200,7 @@ export class WorkflowImporter {
 			const entity = prepareEntityForPersist(item.entity, bindings, item.decidedId);
 			return await this.workflowCreationService.createWorkflow(context.user, entity, {
 				projectId: context.projectId,
-				parentFolderId: context.folderId ?? undefined,
+				parentFolderId: item.parentFolderId ?? context.folderId ?? undefined,
 				publicApi: true,
 				source: 'import',
 				sourceWorkflowId: item.sourceWorkflowId,

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -89,8 +89,6 @@ export class WorkflowImporter {
 				});
 			}
 
-			// Each workflow targets its own package folder (nested import); loose workflows fall back to
-			// the request's target folder. Runs for any workflow resolving to a folder, incl. root-scope imports.
 			const targetFolderId = workflow.parentFolderId ?? context.folderId;
 			if (targetFolderId && existing) {
 				const existingParentFolderId = existing.parentFolder?.id ?? null;


### PR DESCRIPTION
## Summary
Imports workflows within folders

## Related Linear tickets, Github issues, and Community forum posts
LIGO-723

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34022">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

