### PR TITLE
fix(core): Accept instance MCP OAuth resource indicators from alias hostnames

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-protected-resource.test.ts
@@ -53,4 +53,8 @@ describe('McpProtectedResource', () => {
 	it('should be the default audience for resource-less token requests', () => {
 		expect(resource.isDefault).toBe(true);
 	});
+
+	it('should accept host aliases for split-hostname deployments', () => {
+		expect(resource.acceptsHostAliases).toBe(true);
+	});
 });

--- a/packages/cli/src/modules/mcp/mcp-protected-resource.ts
+++ b/packages/cli/src/modules/mcp/mcp-protected-resource.ts
@@ -44,6 +44,14 @@ export class McpProtectedResource implements ProtectedResource {
 	 */
 	readonly isDefault = true;
 
+	/**
+	 * Accept any hostname that reaches this instance as an alias of the
+	 * canonical resource URL. Split-hostname deployments serve the MCP endpoint
+	 * at a hostname the config does not know about, and clients build their
+	 * resource indicator from the URL they connect to.
+	 */
+	readonly acceptsHostAliases = true;
+
 	constructor(
 		private readonly urlService: UrlService,
 		private readonly mcpSettingsService: McpSettingsService,

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
@@ -48,6 +48,7 @@ describe('OAuthServerService', () => {
 			getAudiences: () => [TEST_RESOURCE_URL, 'mcp-server-api'],
 			scopes: SUPPORTED_SCOPES,
 			isDefault: true,
+			acceptsHostAliases: true,
 			getAllowedRedirectUris,
 			authorize: async () => true,
 		});
@@ -467,7 +468,8 @@ describe('OAuthServerService', () => {
 			const params = {
 				redirectUri: 'https://example.com/callback',
 				codeChallenge: 'challenge-123',
-				resource: new URL('https://attacker.example.com/mcp-server/http'),
+				// path matches no registered resource, regardless of host
+				resource: new URL('https://n8n.example.com/unknown/path'),
 			};
 
 			const res = mock<Response>();
@@ -516,6 +518,41 @@ describe('OAuthServerService', () => {
 				codeChallenge: 'challenge-123',
 				state: null,
 				resource: 'https://n8n.example.com/mcp-server/http',
+			});
+			expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
+		});
+
+		it('should accept a resource served at an alias hostname and store it as sent', async () => {
+			const client = {
+				client_id: 'client-123',
+				client_name: 'Test Client',
+				redirect_uris: ['https://example.com/callback'],
+				grant_types: ['authorization_code'],
+				token_endpoint_auth_method: 'none',
+				response_types: ['code'],
+				scope: 'read',
+				logo_uri: undefined,
+				tos_uri: undefined,
+			};
+
+			const params = {
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge-123',
+				// split-hostname deployment: clients reach the same backend at a
+				// hostname the config does not know about
+				resource: new URL('https://n8n-mcp.example.com/mcp-server/http'),
+			};
+
+			const res = mock<Response>();
+
+			await service.authorize(client, params, res);
+
+			expect(oauthSessionService.createSession).toHaveBeenCalledWith(res, {
+				clientId: 'client-123',
+				redirectUri: 'https://example.com/callback',
+				codeChallenge: 'challenge-123',
+				state: null,
+				resource: 'https://n8n-mcp.example.com/mcp-server/http',
 			});
 			expect(res.redirect).toHaveBeenCalledWith('/oauth/consent');
 		});
@@ -650,6 +687,49 @@ describe('OAuthServerService', () => {
 				expires_in: 3600,
 				refresh_token: 'refresh-token-456',
 			});
+		});
+
+		it('should mint the token with the alias resource the client authorized with', async () => {
+			const aliasResource = 'https://n8n-mcp.example.com/mcp-server/http';
+			const client = {
+				client_id: 'client-123',
+				client_name: 'Test Client',
+				redirect_uris: ['https://example.com/callback'],
+				grant_types: ['authorization_code'],
+				token_endpoint_auth_method: 'none',
+				response_types: ['code'],
+				scope: 'read',
+				logo_uri: undefined,
+				tos_uri: undefined,
+			};
+
+			const authRecord = {
+				userId: 'user-456',
+				clientId: 'client-123',
+				resource: aliasResource,
+			} as AuthorizationCode;
+
+			authorizationCodeService.findAuthorizationCode.mockResolvedValue(authRecord);
+			tokenService.generateTokenPair.mockReturnValue({
+				accessToken: 'access-token-123',
+				refreshToken: 'refresh-token-456',
+			});
+			tokenService.saveTokenPair.mockResolvedValue();
+			tokenService.getAccessTokenExpirySeconds.mockReturnValue(3600);
+
+			await service.exchangeAuthorizationCode(
+				client,
+				'auth-code-123',
+				'verifier-123',
+				'https://example.com/callback',
+				new URL(aliasResource),
+			);
+
+			expect(tokenService.generateTokenPair).toHaveBeenCalledWith(
+				'user-456',
+				'client-123',
+				aliasResource,
+			);
 		});
 
 		it('should handle authorization code exchange without redirect URI', async () => {
@@ -814,9 +894,44 @@ describe('OAuthServerService', () => {
 					client,
 					'old-refresh-token',
 					['read'],
-					new URL('https://attacker.example.com/mcp-server/http'),
+					// path matches no registered resource, regardless of host
+					new URL('https://n8n.example.com/unknown/path'),
 				),
 			).rejects.toThrow(InvalidTargetError);
+		});
+
+		it('should accept an alias-hostname resource on refresh token exchange', async () => {
+			const client = {
+				client_id: 'client-123',
+				client_name: 'Test Client',
+				redirect_uris: ['https://example.com/callback'],
+				grant_types: ['refresh_token'],
+				token_endpoint_auth_method: 'none',
+				response_types: ['code'],
+				scope: 'read',
+				logo_uri: undefined,
+				tos_uri: undefined,
+			};
+
+			tokenService.validateAndRotateRefreshToken.mockResolvedValue({
+				access_token: 'new-access-token',
+				token_type: 'Bearer',
+				expires_in: 3600,
+				refresh_token: 'new-refresh-token',
+			});
+
+			await service.exchangeRefreshToken(
+				client,
+				'old-refresh-token',
+				['read'],
+				new URL('https://n8n-mcp.example.com/mcp-server/http'),
+			);
+
+			expect(tokenService.validateAndRotateRefreshToken).toHaveBeenCalledWith(
+				'old-refresh-token',
+				'client-123',
+				'https://n8n-mcp.example.com/mcp-server/http',
+			);
 		});
 
 		it('should normalize a trailing-slash resource before passing it to token rotation', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
@@ -37,6 +37,7 @@ registry.register({
 	scopes: [],
 	isDefault: true,
 	authorize: async () => true,
+	acceptsHostAliases: true,
 });
 
 describe('OAuthTokenService', () => {
@@ -490,18 +491,60 @@ describe('OAuthTokenService', () => {
 		});
 	});
 
-	describe('getAllowedAudiences', () => {
-		it('should return canonical URL and legacy audience when expectedAudience is the canonical URL', async () => {
-			const audiences = await (service as any).getAllowedAudiences(
-				'https://n8n.example.com/mcp-server/http',
+	describe('alias audiences (split-hostname deployments)', () => {
+		const ALIAS_AUDIENCE = 'https://n8n-mcp.example.com/mcp-server/http';
+
+		it('should accept a token whose aud is an alias of the expected resource', async () => {
+			const aliasToken = jwtService.sign({
+				sub: 'user-123',
+				aud: ALIAS_AUDIENCE,
+				client_id: 'client-456',
+			});
+			accessTokenRepository.findOne.mockResolvedValue(
+				mock<AccessToken>({ token: aliasToken, clientId: 'client-456', userId: 'user-123' }),
 			);
-			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
+
+			await expect(service.verifyAccessToken(aliasToken, TEST_RESOURCE_URL)).resolves.toMatchObject(
+				{ clientId: 'client-456' },
+			);
 		});
 
-		it('should return only canonical URL and legacy audience when expectedAudience is undefined', async () => {
-			const audiences = await (service as any).getAllowedAudiences(undefined);
-			// Should still return the canonical resource URL (from getCanonicalResourceUrl) and legacy
-			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
+		it('should accept an alias-audience token without an expected audience', async () => {
+			const aliasToken = jwtService.sign({
+				sub: 'user-123',
+				aud: ALIAS_AUDIENCE,
+				client_id: 'client-456',
+			});
+			accessTokenRepository.findOne.mockResolvedValue(
+				mock<AccessToken>({ token: aliasToken, clientId: 'client-456', userId: 'user-123' }),
+			);
+
+			await expect(service.verifyAccessToken(aliasToken)).resolves.toMatchObject({
+				clientId: 'client-456',
+			});
+		});
+
+		it('should reject a token whose aud path matches no registered resource', async () => {
+			const unknownPathToken = jwtService.sign({
+				sub: 'user-123',
+				aud: 'https://n8n.example.com/unknown/path',
+				client_id: 'client-456',
+			});
+
+			await expect(service.verifyAccessToken(unknownPathToken, TEST_RESOURCE_URL)).rejects.toThrow(
+				'JWT Verification Failed',
+			);
+		});
+
+		it('should reject a token without an aud claim', async () => {
+			const audlessToken = jwtService.sign({
+				sub: 'user-123',
+				client_id: 'client-456',
+			});
+
+			await expect(service.verifyAccessToken(audlessToken, TEST_RESOURCE_URL)).rejects.toThrow(
+				'JWT Verification Failed',
+			);
 		});
 	});
 
@@ -520,6 +563,7 @@ describe('OAuthTokenService', () => {
 				scopes: [],
 				authorize: async () => true,
 				isDefault: true,
+				acceptsHostAliases: true,
 			});
 			multiResourceRegistry.register({
 				id: 'workflow-trigger',
@@ -576,6 +620,30 @@ describe('OAuthTokenService', () => {
 			await expect(
 				multiResourceService.verifyAccessToken(tokenForResourceB, RESOURCE_B_URL),
 			).resolves.toMatchObject({ clientId: 'client-456' });
+		});
+
+		it('should reject an alias audience for a resource that does not accept aliases', async () => {
+			const aliasToken = jwtService.sign({
+				sub: 'user-123',
+				aud: 'https://alias.example.com/webhook/wf-1/mcp',
+				client_id: 'client-456',
+			});
+
+			await expect(
+				multiResourceService.verifyAccessToken(aliasToken, RESOURCE_B_URL),
+			).rejects.toThrow('JWT Verification Failed');
+		});
+
+		it('should reject a token whose aud is an alias of another resource', async () => {
+			const aliasOfResourceA = jwtService.sign({
+				sub: 'user-123',
+				aud: 'https://alias.example.com/mcp-server/http',
+				client_id: 'client-456',
+			});
+
+			await expect(
+				multiResourceService.verifyAccessToken(aliasOfResourceA, RESOURCE_B_URL),
+			).rejects.toThrow('JWT Verification Failed');
 		});
 
 		it('should still accept the legacy audience at the default (instance MCP) resource', async () => {

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
@@ -36,16 +36,21 @@ const makeRes = () => {
 };
 
 // Express 5 delivers wildcard params as an array of segments; the handler also
-// tolerates a plain string. Only `params` is read, so a cast keeps the fixture small.
-const makeReq = (resourcePath: string | string[]): Request =>
-	({ params: { resourcePath } }) as unknown as Request;
+// tolerates a plain string. Only `params` and `get('host')` are read, so a cast
+// keeps the fixture small.
+const makeReq = (resourcePath: string | string[], host?: string): Request =>
+	({
+		params: { resourcePath },
+		get: (name: string) => (name.toLowerCase() === 'host' ? host : undefined),
+	}) as unknown as Request;
 
-const resource = (scopes: string[]): ProtectedResource => ({
+const resource = (scopes: string[], acceptsHostAliases = true): ProtectedResource => ({
 	id: 'instance-mcp',
 	getResourceUrl: () => 'https://n8n.test/mcp-server/http',
 	getAudiences: () => ['https://n8n.test/mcp-server/http'],
 	authorize: async () => true,
 	scopes,
+	acceptsHostAliases,
 });
 
 beforeEach(() => {
@@ -95,6 +100,49 @@ describe('OAuthController', () => {
 				authorization_servers: ['https://n8n.test'],
 				scopes_supported: scopes,
 			});
+		});
+
+		test('advertises the resource at the host the client used', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource([]));
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(
+				makeReq(['mcp-server', 'http'], 'n8n-mcp.test'),
+				res,
+			);
+
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({
+					resource: 'https://n8n-mcp.test/mcp-server/http',
+					// The authorization server stays at the configured base URL
+					authorization_servers: ['https://n8n.test'],
+				}),
+			);
+		});
+
+		test('keeps the canonical resource URL when the request host matches it', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource([]));
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(makeReq(['mcp-server', 'http'], 'n8n.test'), res);
+
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({ resource: 'https://n8n.test/mcp-server/http' }),
+			);
+		});
+
+		test('keeps the canonical resource URL for resources that do not accept host aliases', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource([], false));
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(
+				makeReq(['mcp-server', 'http'], 'n8n-mcp.test'),
+				res,
+			);
+
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({ resource: 'https://n8n.test/mcp-server/http' }),
+			);
 		});
 
 		test('omits scopes_supported when the resource advertises no scopes', async () => {

--- a/packages/cli/src/modules/oauth-server/oauth-server.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.service.ts
@@ -358,9 +358,14 @@ export class OAuthServerService implements OAuthServerProvider {
 		return await this.tokenService.verifyAccessToken(token);
 	}
 
-	// Exact-match against a registered resource, as required by RFC 8707 §2.1.
-	// Prefix/wildcard matching would open the door to malicious-host or
-	// path-traversal indicators like ".../mcp-server/http/../admin".
+	// Matches a registered resource by exact URL, falling back to an exact path
+	// match for resources that opt into host aliases (the instance MCP server),
+	// so hostnames the config does not know about (split-hostname deployments,
+	// proxy scheme/port rewrites) are accepted as aliases of this instance. No
+	// prefix or wildcard matching, so traversal-style indicators like
+	// ".../mcp-server/http/../admin" still fail. Tokens minted for an alias
+	// stay bound to this instance: they are signed with the instance key and
+	// verified against server-side token records.
 	private async resolveAndValidateResourceIndicator(
 		resource: string | undefined,
 	): Promise<string | undefined> {

--- a/packages/cli/src/modules/oauth-server/oauth-token.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-token.service.ts
@@ -169,21 +169,32 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 	}
 
 	async verifyAccessToken(token: string, expectedAudience?: string): Promise<AuthInfo> {
-		return await this.verifyTokenWithAudiences(
-			token,
-			await this.getAllowedAudiences(expectedAudience),
-		);
+		const resource = expectedAudience
+			? await this.resourceRegistry.getByResourceUrl(expectedAudience)
+			: undefined;
+		return await this.verifyTokenForResource(token, resource, expectedAudience);
 	}
 
-	private async verifyTokenWithAudiences(
+	private async verifyTokenForResource(
 		token: string,
-		allowedAudiences: string[],
+		resource: ProtectedResource | undefined,
+		expectedAudience?: string,
 	): Promise<AuthInfo> {
 		let decoded: unknown;
 
 		try {
-			decoded = this.verifyJwtWithAllowedAudiences(token, allowedAudiences);
+			// Audience is validated separately: alias audiences resolve through the
+			// resource registry, which `jsonwebtoken`'s string-equality check can't do.
+			decoded = this.jwtService.verify(token);
 		} catch (error) {
+			throw new JWTVerificationError();
+		}
+
+		const audiences = this.getAudienceClaim(decoded);
+		if (
+			audiences.length === 0 ||
+			!(await this.isAudienceAllowed(audiences, resource, expectedAudience))
+		) {
 			throw new JWTVerificationError();
 		}
 
@@ -222,10 +233,7 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 				return { user: null, context: { reason: 'insufficient_scope', auth_type: 'oauth' } };
 			}
 
-			const authInfo = await this.verifyTokenWithAudiences(
-				token,
-				this.audiencesForResource(resource, expectedAudience),
-			);
+			const authInfo = await this.verifyTokenForResource(token, resource, expectedAudience);
 
 			const userId =
 				authInfo.extra && typeof authInfo.extra === 'object'
@@ -303,38 +311,56 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 	}
 
 	/**
-	 * Resolve the `aud` values a token may carry for the given resource.
+	 * Whether a token's `aud` values may be accepted at the given resource's gate.
 	 *
 	 * Audiences come from the matching registered resource ONLY — never union
 	 * audiences across resources, otherwise a token minted for one resource
 	 * would pass another resource's gate (cross-resource token replay).
 	 * Resource-specific legacy audiences (e.g. the instance MCP server's
 	 * pre-RFC-8707 `mcp-server-api`) stay scoped to their own resource this way.
+	 *
+	 * Beyond the resource's declared audiences, an `aud` that resolves through
+	 * the registry to the same resource is also accepted — for alias-accepting
+	 * resources this includes any hostname with the resource's URL path: on
+	 * split-hostname deployments clients request tokens with the hostname they
+	 * connect through, so the minted `aud` may carry an alias of the resource
+	 * rather than its canonical URL.
+	 *
+	 * Because that alias host is client-supplied, the `aud` host is not a
+	 * trustworthy provenance signal — never treat it as one in logs/audit. Token
+	 * trust rests on the instance signing key and the server-side token record,
+	 * not on `aud`.
 	 */
-	private async getAllowedAudiences(expectedAudience?: string): Promise<string[]> {
-		const resource = expectedAudience
-			? await this.resourceRegistry.getByResourceUrl(expectedAudience)
-			: undefined;
-		return this.audiencesForResource(resource, expectedAudience);
-	}
-
-	/**
-	 * Derive the `aud` values accepted for a (possibly pre-resolved) resource.
-	 * Single source of the audience-derivation rule shared by `getAllowedAudiences`
-	 * and the resolve-once path in `verifyOAuthAccessToken`.
-	 */
-	private audiencesForResource(
+	// TODO: drop legacy audiences once all legacy tokens minted before n8n v2.19
+	// have aged out (refresh-token lifespan).
+	private async isAudienceAllowed(
+		audiences: string[],
 		resource: ProtectedResource | undefined,
 		expectedAudience?: string,
-	): string[] {
+	): Promise<boolean> {
 		if (expectedAudience) {
-			return resource ? resource.getAudiences() : [expectedAudience];
+			if (!resource) {
+				return audiences.includes(expectedAudience);
+			}
+
+			const allowed = resource.getAudiences();
+			for (const audience of audiences) {
+				if (allowed.includes(audience)) return true;
+				const audienceResource = await this.resourceRegistry.getByResourceUrl(audience);
+				if (audienceResource?.id === resource.id) return true;
+			}
+			return false;
 		}
 
 		// No expected audience: the caller cannot know which resource the token
 		// targets (MCP SDK generic verification), so accept any registered
 		// resource's audiences. Resource gates must pass `expectedAudience`.
-		return this.resourceRegistry.getAllAudiences();
+		const allAudiences = this.resourceRegistry.getAllAudiences();
+		for (const audience of audiences) {
+			if (allAudiences.includes(audience)) return true;
+			if (await this.resourceRegistry.getByResourceUrl(audience)) return true;
+		}
+		return false;
 	}
 
 	private async getResourceByAudience(
@@ -346,25 +372,15 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 		return await this.resourceRegistry.getByResourceUrl(expectedAudience);
 	}
 
-	// TODO: drop legacy audiences and the per-audience fallback once all legacy
-	// tokens minted before n8n v2.19 have aged out (refresh-token lifespan).
-	private verifyJwtWithAllowedAudiences(token: string, audiences: string[]): unknown {
-		try {
-			return this.jwtService.verify(token, {
-				audience: audiences as [string, ...string[]],
-			});
-		} catch (error) {
-			// Some jsonwebtoken builds reject the array form for tokens signed with a single-string aud.
-			for (const audience of audiences) {
-				try {
-					return this.jwtService.verify(token, { audience });
-				} catch {
-					continue;
-				}
-			}
-
-			throw error;
+	/** JWT `aud` may be a single string or an array of strings (RFC 7519 §4.1.3). */
+	private getAudienceClaim(payload: unknown): string[] {
+		if (!payload || typeof payload !== 'object') return [];
+		const audience = (payload as Record<string, unknown>).aud;
+		if (typeof audience === 'string') return [audience];
+		if (Array.isArray(audience)) {
+			return audience.filter((value): value is string => typeof value === 'string');
 		}
+		return [];
 	}
 
 	private getStringClaim(payload: unknown, claim: string): string | null {

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -214,8 +214,21 @@ export class OAuthController {
 		}
 
 		const baseUrl = this.urlService.getInstanceBaseUrl();
+
+		// Advertise alias-accepting resources at the host the client used:
+		// RFC 9728 clients check that `resource` matches the URL they derived
+		// this document from, and split-hostname deployments serve it at
+		// hostnames the config does not know about. The OAuth server accepts
+		// these aliases as resource indicators via the registry's path-based
+		// matching.
+		const resourceUrl = new URL(resource.getResourceUrl());
+		const requestHost = req.get('host');
+		if (requestHost && resource.acceptsHostAliases) {
+			resourceUrl.host = requestHost;
+		}
+
 		const metadata: Record<string, unknown> = {
-			resource: resource.getResourceUrl(),
+			resource: resourceUrl.toString().replace(/\/$/, ''),
 			bearer_methods_supported: ['header'],
 			authorization_servers: [baseUrl],
 		};

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -106,6 +106,29 @@ describe('ProtectedResourceRegistry', () => {
 			expect(emptyDefault.getDefaultResource()).toBeUndefined();
 		});
 
+		it('should reject a second alias-accepting resource on the same path', () => {
+			const conflicting: ProtectedResource = {
+				id: 'other-instance-mcp',
+				getResourceUrl: () => 'https://other.example.com/mcp-server/http',
+				getAudiences: () => ['https://other.example.com/mcp-server/http'],
+				authorize: async () => true,
+				scopes: [],
+				acceptsHostAliases: true,
+			};
+			expect(() => registry.register(conflicting)).toThrow(/already owns the path/);
+		});
+
+		it('should allow a non-alias resource to share a path with an alias-accepting one', () => {
+			const sharedPath: ProtectedResource = {
+				id: 'strict-same-path',
+				getResourceUrl: () => 'https://other.example.com/mcp-server/http',
+				getAudiences: () => ['https://other.example.com/mcp-server/http'],
+				authorize: async () => true,
+				scopes: [],
+			};
+			expect(() => registry.register(sharedPath)).not.toThrow();
+		});
+
 		it('should replace a resource registered with the same id', () => {
 			const replacement: ProtectedResource = { ...resourceA, scopes: [] };
 			registry.register(replacement);

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -11,6 +11,7 @@ const resourceA: ProtectedResource = {
 	scopes: ['tool:listWorkflows', 'tool:getWorkflowDetails'],
 	authorize: async () => true,
 	isDefault: true,
+	acceptsHostAliases: true,
 };
 
 const resourceB: ProtectedResource = {
@@ -47,15 +48,52 @@ describe('ProtectedResourceRegistry', () => {
 			expect(await registry.getByResourceUrl('https://n8n.example.com/webhook/wf-1/mcp')).toBe(
 				resourceB,
 			);
+		});
+
+		it('should resolve alias-accepting resources served at other hostnames by URL path', async () => {
+			// Split-hostname deployments: the client-facing hostname differs from the
+			// configured base URL but routes to the same backend.
+			expect(await registry.getByResourceUrl('https://n8n-mcp.example.com/mcp-server/http')).toBe(
+				resourceA,
+			);
+			expect(await registry.getByResourceUrl('http://localhost:5678/mcp-server/http/')).toBe(
+				resourceA,
+			);
+		});
+
+		it('should not match other hostnames for resources that do not accept aliases', async () => {
 			expect(
-				await registry.getByResourceUrl('https://evil.example.com/mcp-server/http'),
+				await registry.getByResourceUrl('https://n8n-mcp.example.com/webhook/wf-1/mcp'),
 			).toBeUndefined();
+		});
+
+		it('should not resolve resource URLs with an unknown path', async () => {
+			expect(
+				await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http/../admin'),
+			).toBeUndefined();
+			expect(
+				await registry.getByResourceUrl('https://n8n.example.com/unknown/path'),
+			).toBeUndefined();
+			expect(await registry.getByResourceUrl('not-a-url')).toBeUndefined();
 		});
 
 		it('should resolve resources by URL path', async () => {
 			expect(await registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
 			expect(await registry.getByResourcePath('/webhook/wf-1/mcp')).toBe(resourceB);
 			expect(await registry.getByResourcePath('/unknown')).toBeUndefined();
+		});
+
+		it('should not consult resolvers when matching alias-host resource URLs by path', async () => {
+			const resolverRegistry = new ProtectedResourceRegistry(mock<Logger>());
+			const resolver = mock<ProtectedResourceResolver>({ id: 'workflow-trigger', scopes: [] });
+			resolver.resolveByUrl.mockResolvedValue(undefined); // resolver only matches its own origin
+			resolver.resolveByPath.mockResolvedValue(resourceB);
+			resolverRegistry.registerResolver(resolver);
+
+			expect(
+				await resolverRegistry.getByResourceUrl('https://alias.example.com/webhook/wf-1/mcp'),
+			).toBeUndefined();
+			expect(resolver.resolveByPath).not.toHaveBeenCalled();
 		});
 
 		it('should resolve the default resource', () => {

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -58,6 +58,15 @@ export interface ProtectedResource {
 	 * @returns A promise that resolves to a boolean indicating whether the user is authorized
 	 **/
 	authorize(user: User): Promise<boolean>;
+
+	/**
+	 * Whether resource URLs for this resource may also match by URL path alone,
+	 * accepting any hostname that reaches this instance as an alias of the
+	 * canonical URL (split-hostname deployments, where clients reach the
+	 * backend at a hostname the config does not know about). Only the instance
+	 * MCP server opts in today.
+	 */
+	acceptsHostAliases?: boolean;
 }
 
 /**
@@ -121,7 +130,16 @@ export class ProtectedResourceRegistry {
 		return this.resources.get(id);
 	}
 
-	/** Look up a resource by its canonical URL (trailing slashes ignored). */
+	/**
+	 * Look up a resource by a resource URL (trailing slashes ignored).
+	 *
+	 * When no resource matches the full URL, resources that opt into host
+	 * aliases (`acceptsHostAliases`) are matched by URL path alone: deployments
+	 * may serve this instance at hostnames the config does not know about (e.g.
+	 * a dedicated MCP alias in front of the same backend), and clients build
+	 * their RFC 8707 resource indicator from the URL they connect to. The path
+	 * is matched exactly — no prefix or wildcard matching.
+	 */
 	async getByResourceUrl(resourceUrl: string): Promise<ProtectedResource | undefined> {
 		const normalized = trimTrailingSlash(resourceUrl);
 		for (const resource of this.resources.values()) {
@@ -133,6 +151,23 @@ export class ProtectedResourceRegistry {
 				if (resource) return resource;
 			} catch (error) {
 				this.logResolverFailure(resolver, error);
+			}
+		}
+
+		let pathname: string;
+		try {
+			pathname = trimTrailingSlash(new URL(normalized).pathname);
+		} catch {
+			return undefined;
+		}
+		for (const resource of this.resources.values()) {
+			if (!resource.acceptsHostAliases) continue;
+			try {
+				if (trimTrailingSlash(new URL(resource.getResourceUrl()).pathname) === pathname) {
+					return resource;
+				}
+			} catch {
+				continue;
 			}
 		}
 		return undefined;

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -2,6 +2,7 @@ import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
+import { UnexpectedError } from 'n8n-workflow';
 
 /**
  * Descriptor for an OAuth 2.1 protected resource served by this instance.
@@ -119,7 +120,39 @@ export class ProtectedResourceRegistry {
 	constructor(private readonly logger: Logger) {}
 
 	register(resource: ProtectedResource): void {
+		this.assertHostAliasPathIsUnique(resource);
 		this.resources.set(resource.id, resource);
+	}
+
+	/**
+	 * The alias-by-path match in `getByResourceUrl` is only unambiguous while at
+	 * most one alias-accepting resource owns a given URL path: two would let a
+	 * token minted for one pass the other's gate (the path resolves to both).
+	 * Guard against that drift at registration time rather than shipping a silent
+	 * cross-resource replay.
+	 */
+	private assertHostAliasPathIsUnique(resource: ProtectedResource): void {
+		if (!resource.acceptsHostAliases) return;
+
+		let path: string;
+		try {
+			path = trimTrailingSlash(new URL(resource.getResourceUrl()).pathname);
+		} catch {
+			return;
+		}
+
+		for (const existing of this.resources.values()) {
+			if (existing.id === resource.id || !existing.acceptsHostAliases) continue;
+			try {
+				if (trimTrailingSlash(new URL(existing.getResourceUrl()).pathname) === path) {
+					throw new UnexpectedError(
+						`Cannot register protected resource "${resource.id}": another alias-accepting resource ("${existing.id}") already owns the path "${path}"`,
+					);
+				}
+			} catch (error) {
+				if (error instanceof UnexpectedError) throw error;
+			}
+		}
 	}
 
 	registerResolver(resolver: ProtectedResourceResolver) {


### PR DESCRIPTION
## Summary

Self-hosted instances that serve the MCP endpoint at a hostname different from their configured base URL (split-hostname deployments) could not complete or refresh MCP OAuth on 2.29+. Spec-compliant clients (ChatGPT, Claude) send an RFC 8707 `resource` parameter built from the URL they connect to; the server validated it by exact-match against the config-derived canonical URL only, so an alias hostname was rejected with `400 invalid_target`. This broke both first-time authorization and token refresh, leaving clients permanently unable to reconnect.

Reported by a self-hoster who intentionally separates trust boundaries: the main UI hostname sits behind Cloudflare Access, while a narrow MCP-only hostname (`n8n-mcp.<domain>`) fronts the same backend for remote AI connectors. This topology worked before 2.29 and regressed after strict resource-indicator validation was added.

Community thread: https://community.n8n.io/t/instance-level-mcp-oauth-re-auth-fails-with-invalid-target-on-n8n-2-29-7-works-on-earlier-version/302460

## What changed

The instance MCP server now recognizes any hostname that reaches it as an alias of its canonical resource URL. Zero configuration — no new env var, no base-URL change.

- **Resource matching** (`ProtectedResourceRegistry.getByResourceUrl`): when the full URL doesn't match, resources that opt in via a new `acceptsHostAliases` flag are matched by exact URL **path**. Only the instance MCP server opts in; per-workflow MCP trigger resources keep strict origin matching. No prefix/wildcard matching, so path-traversal indicators still fail.
- **Token audience gate** (`OAuthTokenService.verifyAccessToken`): verifies the JWT signature, then accepts the token's `aud` if it belongs to the resolved resource (canonical URL, legacy `mcp-server-api`, or an alias resolving to the same resource id). Cross-resource replay is still rejected.
- **Discovery** (RFC 9728 protected-resource metadata): alias-accepting resources advertise the `resource` at the host the client used, so strict clients that compare metadata against the URL they queried succeed on the alias host. The RFC 8414 authorization-server metadata (issuer, endpoints) is unchanged.
- **Guardrail**: registering a second alias-accepting resource on the same URL path throws at startup, preserving the "single audience per path" property the audience gate relies on.

## Why this is safe

Access tokens are bound to the instance signing key and to a server-side token record, and represent the consenting user's own delegation — so a token only ever works against the issuing instance. The `aud` hostname is not a trust anchor; discovery pins `authorization_servers` to the canonical host, so clients are only ever directed back to the real instance. There is no second resource server that trusts these JWTs by `aud`, so no token-substitution/confused-deputy vector is opened. This was validated with an adversarial security review across token-substitution, consent-phishing, blast-radius, and RFC-compliance lenses.

## Testing

- Unit + integration suites for the OAuth server module, protected-resource registry, token service, and MCP protected resource (all green; lint + typecheck clean).
- Manual end-to-end against a running instance: drove discovery, DCR, authorize, consent, token exchange, MCP `initialize`, and refresh through an alias hostname (`mcp.localhost`) with `N8N_EDITOR_BASE_URL` set to a different host — the flow completes without `invalid_target`, and unknown-path / bogus-token requests are still rejected.

https://linear.app/n8n/issue/ADO-5561


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

