### PR TITLE
fix(editor): Debounce the node search input

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/NodesListPanel.test.ts
@@ -1,7 +1,7 @@
 import { defineComponent, nextTick, watch } from 'vue';
 import type { PropType } from 'vue';
 import { createPinia } from 'pinia';
-import { screen, fireEvent } from '@testing-library/vue';
+import { screen, fireEvent, waitFor } from '@testing-library/vue';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useViewStacks } from '@/features/shared/nodeCreator/composables/useViewStacks';
@@ -246,19 +246,17 @@ describe('NodesListPanel', () => {
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: 'Ninth' },
 			});
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+			// Search is debounced, so wait for the filtered results.
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1));
 
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: 'Non sense' },
 			});
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(0);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(0));
 			expect(screen.queryByText("We didn't make that... yet")).toBeInTheDocument();
 
 			await fireEvent.click(container.querySelector('svg[data-icon=circle-x]')!);
-			await nextTick();
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9);
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(9));
 		});
 
 		it('should trim search input before emitting update', async () => {
@@ -269,9 +267,9 @@ describe('NodesListPanel', () => {
 			await fireEvent.input(screen.getByTestId('node-creator-search-bar'), {
 				target: { value: '    Node 1' },
 			});
-			await nextTick();
 
-			expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1);
+			// Search is debounced, so wait for the filtered results.
+			await waitFor(() => expect(screen.queryAllByTestId('item-iterator-item')).toHaveLength(1));
 			expect(screen.queryByText('Node 1')).toBeInTheDocument();
 
 			expect(screen.getByTestId('node-creator-search-bar')).toHaveValue('Node 1');

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/SearchBar.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/SearchBar.test.ts
@@ -1,0 +1,82 @@
+import { fireEvent } from '@testing-library/vue';
+import { nextTick } from 'vue';
+
+import { createComponentRenderer } from '@/__tests__/render';
+import { DEBOUNCE_TIME } from '@/app/constants';
+
+import SearchBar from './SearchBar.vue';
+
+const renderComponent = createComponentRenderer(SearchBar, {
+	global: {
+		stubs: {
+			N8nIcon: { template: '<span />', props: ['icon', 'size'] },
+		},
+	},
+});
+
+const getInput = (container: HTMLElement) =>
+	container.querySelector<HTMLInputElement>('[data-test-id="node-creator-search-bar"]')!;
+
+describe('SearchBar', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('emits the search value once the user stops typing', async () => {
+		const { container, emitted } = renderComponent();
+		const input = getInput(container);
+
+		await fireEvent.update(input, 'http');
+		// Nothing is emitted while the user is still typing.
+		expect(emitted()['update:modelValue']).toBeUndefined();
+
+		vi.advanceTimersByTime(DEBOUNCE_TIME.INPUT.SEARCH);
+		expect(emitted()['update:modelValue']).toEqual([['http']]);
+	});
+
+	it('collapses rapid typing into a single search', async () => {
+		const { container, emitted } = renderComponent();
+		const input = getInput(container);
+
+		await fireEvent.update(input, 'h');
+		await fireEvent.update(input, 'ht');
+		await fireEvent.update(input, 'htt');
+		await fireEvent.update(input, 'http');
+
+		vi.advanceTimersByTime(DEBOUNCE_TIME.INPUT.SEARCH);
+		expect(emitted()['update:modelValue']).toEqual([['http']]);
+	});
+
+	it('keeps the typed text visible before the search runs', async () => {
+		const { container, emitted } = renderComponent();
+		const input = getInput(container);
+
+		await fireEvent.update(input, 'http');
+		await nextTick();
+
+		// The field shows the text immediately, even though the search has not run yet.
+		expect(input.value).toBe('http');
+		expect(emitted()['update:modelValue']).toBeUndefined();
+	});
+
+	it('clears immediately and cancels a pending search when cleared', async () => {
+		const { container, emitted, getByTestId } = renderComponent();
+		const input = getInput(container);
+
+		await fireEvent.update(input, 'http');
+		await nextTick();
+
+		await fireEvent.click(getByTestId('node-creator-search-clear'));
+		// Clearing emits an empty value right away, without waiting for the debounce.
+		expect(emitted()['update:modelValue']).toEqual([['']]);
+
+		// The pending search from the earlier typing must not fire afterwards.
+		vi.advanceTimersByTime(DEBOUNCE_TIME.INPUT.SEARCH);
+		expect(emitted()['update:modelValue']).toEqual([['']]);
+		expect(input.value).toBe('');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/SearchBar.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Panel/SearchBar.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { onMounted, reactive, toRefs, onBeforeUnmount } from 'vue';
+import { onMounted, reactive, ref, toRefs, onBeforeUnmount, watch } from 'vue';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
+import { useDebounce } from '@/app/composables/useDebounce';
+import { DEBOUNCE_TIME } from '@/app/constants';
 
 import { N8nIcon } from '@n8n/design-system';
 export interface Props {
@@ -8,7 +10,7 @@ export interface Props {
 	modelValue?: string;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
 	placeholder: '',
 	modelValue: '',
 });
@@ -21,18 +23,37 @@ const state = reactive({
 	inputRef: null as HTMLInputElement | null,
 });
 
+// Local copy so the field and clear button react instantly, while the search
+// itself only runs once the user stops typing.
+const searchValue = ref(props.modelValue);
+
 const externalHooks = useExternalHooks();
+const { debounce } = useDebounce();
+
+const emitSearch = debounce((value: string) => emit('update:modelValue', value), {
+	debounceTime: DEBOUNCE_TIME.INPUT.SEARCH,
+	trailing: true,
+});
+
+watch(
+	() => props.modelValue,
+	(value) => {
+		if (value !== searchValue.value.trim()) searchValue.value = value;
+	},
+);
 
 function focus() {
 	state.inputRef?.focus();
 }
 
 function onInput(event: Event) {
-	const input = event.target as HTMLInputElement;
-	emit('update:modelValue', input.value.trim());
+	searchValue.value = (event.target as HTMLInputElement).value.trim();
+	emitSearch(searchValue.value);
 }
 
 function clear() {
+	emitSearch.cancel();
+	searchValue.value = '';
 	emit('update:modelValue', '');
 }
 
@@ -53,14 +74,14 @@ defineExpose({
 
 <template>
 	<div :class="$style.searchContainer" data-test-id="search-bar">
-		<div :class="{ [$style.prefix]: true, [$style.active]: modelValue.length > 0 }">
+		<div :class="{ [$style.prefix]: true, [$style.active]: searchValue.length > 0 }">
 			<N8nIcon icon="search" size="small" />
 		</div>
 		<div :class="$style.text">
 			<input
 				ref="inputRef"
 				:placeholder="placeholder"
-				:value="modelValue"
+				:value="searchValue"
 				:class="$style.input"
 				autofocus
 				data-test-id="node-creator-search-bar"
@@ -68,7 +89,12 @@ defineExpose({
 				@input="onInput"
 			/>
 		</div>
-		<div v-if="modelValue.length > 0" :class="[$style.suffix, $style.clickable]" @click="clear">
+		<div
+			v-if="searchValue.length > 0"
+			:class="[$style.suffix, $style.clickable]"
+			data-test-id="node-creator-search-clear"
+			@click="clear"
+		>
 			<N8nIcon size="small" icon="circle-x" />
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

When you open the "Add node" panel and type in the search box, the search runs on
every single keystroke. On slower setups this makes typing feel laggy — the text and
results can show up a second or two after you type.

This change debounces the search so it only runs once you stop typing (300ms), the
same pattern n8n already uses for other search inputs (`useDebounce` +
`DEBOUNCE_TIME.INPUT.SEARCH`). The text you type still appears instantly, because the
field keeps its own local value and only the search waits. The clear (X) button still
clears everything right away and cancels any pending search.

## How to test

1. Open a workflow and click "+" to open the node search panel.
2. Type a node name quickly (for example "http request").
3. The typed text appears instantly, and the results update once you pause typing
   instead of on every keystroke.
4. Click the clear (X) button — the field and results clear immediately.

## Related Linear tickets, Github issues, and Community forum posts

Closes #33955

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34039">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

