### PR TITLE
fix(Microsoft Teams Node): List all joined teams in the Task resource Team picker

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/methods/listSearch.ts
@@ -186,25 +186,17 @@ export async function getGroups(
 	filter?: string,
 ): Promise<INodeListSearchResult> {
 	const returnData: INodeListSearchItems[] = [];
-	// const groupSource = this.getCurrentNodeParameter('groupSource') as string;
-	const requestUrl = '/v1.0/groups' as string;
+	const value = await microsoftApiRequestAllItems.call(
+		this,
+		'value',
+		'GET',
+		joinedTeamsEndpoint.call(this),
+	);
 
-	// if (groupSource === 'mine') {
-	// 	requestUrl = '/v1.0/me/transitiveMemberOf';
-	// }
-
-	const { value } = await microsoftApiRequest.call(this, 'GET', requestUrl);
-
-	for (const group of value) {
-		if (group.displayName === 'All Company') continue;
-
-		const name = group.displayName || group.mail;
-
-		if (name === undefined) continue;
-
+	for (const team of value) {
 		returnData.push({
-			name,
-			value: group.id,
+			name: team.displayName,
+			value: team.id,
 		});
 	}
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -14,6 +14,7 @@ import {
 	getBuckets,
 	getChannels,
 	getChats,
+	getGroups,
 	getMembers,
 	getPlans,
 	getTeams,
@@ -764,6 +765,46 @@ describe('Microsoft Teams Transport', () => {
 				}),
 			);
 			expect(results.map((r) => r.value)).toEqual(['t1', 't2']);
+		});
+
+		it('getGroups lists the joined teams (/v1.0/me/joinedTeams), not tenant groups (/v1.0/groups)', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(undefined);
+			loadOptionsRequestOAuth2.mockResolvedValue({
+				value: [
+					{ id: 'g1', displayName: 'Team 1' },
+					{ id: 'g2', displayName: 'Team 2' },
+				],
+			});
+
+			const { results } = await getGroups.call(mockLoadOptions);
+
+			const calledUri = loadOptionsRequestOAuth2.mock.calls[0][1].uri as string;
+			expect(calledUri).toContain('/v1.0/me/joinedTeams');
+			expect(calledUri).not.toContain('/v1.0/groups');
+			expect(results.map((r) => r.value)).toEqual(['g1', 'g2']);
+		});
+
+		it('getGroups pages through @odata.nextLink (teams past the first page are found)', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(undefined);
+			// page 1 carries @odata.nextLink → the paginator must follow it to page 2.
+			loadOptionsRequestOAuth2
+				.mockResolvedValueOnce({
+					value: [{ id: 'g1', displayName: 'Team 1' }],
+					'@odata.nextLink': 'https://graph.microsoft.com/v1.0/me/joinedTeams?$skiptoken=p2',
+				})
+				.mockResolvedValueOnce({ value: [{ id: 'g2', displayName: 'Team 2' }] });
+
+			const { results } = await getGroups.call(mockLoadOptions);
+
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledTimes(2);
+			expect(loadOptionsRequestOAuth2).toHaveBeenNthCalledWith(
+				2,
+				'microsoftTeamsOAuth2Api',
+				expect.objectContaining({
+					uri: 'https://graph.microsoft.com/v1.0/me/joinedTeams?$skiptoken=p2',
+				}),
+			);
+			expect(results.map((r) => r.value)).toEqual(['g1', 'g2']);
 		});
 
 		it('getChats throws a static error under SP and never issues a request', async () => {


### PR DESCRIPTION
## Summary

The Microsoft Teams node's **Task** resource has a "Team" picker (`groupId` resource locator, backed by the `getGroups` list-search method) that failed to list many teams a user belongs to. It issued a single unpaginated `GET /v1.0/groups`, so:

- **No pagination** — it never followed `@odata.nextLink`, returning only Graph's first ~100 results.
- **Wrong scope** — `/v1.0/groups` returns *all* tenant groups, not the user's teams, so on large tenants the user's teams fell past the first page.
- **No Teams filter** — non-Teams M365 groups consumed slots in that first page.

Because filtering happened client-side over the already-truncated page, the search box couldn't find the missing teams either.

`getGroups` now mirrors the Channel resource's working team picker (`getTeams`): it pages through `microsoftApiRequestAllItems` scoped to `joinedTeamsEndpoint()` (`/v1.0/me/joinedTeams` under OAuth2, `/v1.0/teams` under the Service Principal credential). This lists exactly the teams the user is a member of — matching what the customer asked for. A team's Graph `id` equals its backing group `id`, so the selected value stays valid for the downstream Planner calls (`getPlans`, `getBuckets`, `getMembers`).

**Compatibility:** `groupId` is used only in the editor to scope the Plan/Member dropdowns — it is not part of the execution payload (Task Create sends `planId`/`bucketId`; Task Update deletes `groupId`). Existing saved workflows execute unchanged. The only edge case is a non-Team M365 group that was previously picked from the list; it remains reachable via the picker's **By ID** mode.

## How to test

On test instance: https://test-pr-34043.stage-app.n8n.cloud/workflow/OODP8WcGCd3Kefma DM me for login info

Open the **Team** dropdown → it now lists **only the teams you're a member of**, and typing in the search box finds any of them. (right now that should be n8n GmbH + Teams 1-7)

To test pagination (I did not want to create >100 Teams by hand, so you have to check it locally) change the pagination param in the code to limit like 3. so the pagination kicks in. Credential in bitwarden.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5397

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34043">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

