### PR TITLE
fix(Postgres Node): Return DATE and date/time array columns as strings (v2.7)

### DIFF
--- a/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
+++ b/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
@@ -7,6 +7,8 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import pgPromise from 'pg-promise';
 
+import { getDateAsStringTypeParsers } from '@utils/postgres';
+
 import {
 	generateReturning,
 	getItemCopy,
@@ -15,13 +17,12 @@ import {
 	pgQueryV2,
 	pgUpdate,
 } from '../Postgres/v1/genericFunctions';
-import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class CrateDb implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'CrateDB',
 		name: 'crateDb',
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
+
 		icon: 'file:cratedb.png',
 		group: ['input'],
 		version: [1, 1.1],

--- a/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
+++ b/packages/nodes-base/nodes/CrateDb/CrateDb.node.ts
@@ -15,6 +15,7 @@ import {
 	pgQueryV2,
 	pgUpdate,
 } from '../Postgres/v1/genericFunctions';
+import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class CrateDb implements INodeType {
 	description: INodeTypeDescription = {
@@ -23,7 +24,7 @@ export class CrateDb implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:cratedb.png',
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Add and update data in CrateDB',
 		defaults: {
 			name: 'CrateDB',
@@ -273,7 +274,11 @@ export class CrateDb implements INodeType {
 			sslmode: (credentials.ssl as string) || 'disable',
 		};
 
-		const db = pgp(config);
+		const db = pgp({
+			...config,
+			// Return date/timestamp columns as strings so node output stays JSON-safe
+			...(this.getNode().typeVersion >= 1.1 ? { types: getDateAsStringTypeParsers(pgp) } : {}),
+		});
 
 		let returnItems: INodeExecutionData[] = [];
 

--- a/packages/nodes-base/nodes/Postgres/Postgres.node.ts
+++ b/packages/nodes-base/nodes/Postgres/Postgres.node.ts
@@ -11,7 +11,7 @@ export class Postgres extends VersionedNodeType {
 			name: 'postgres',
 			icon: 'file:postgres.svg',
 			group: ['input'],
-			defaultVersion: 2.6,
+			defaultVersion: 2.7,
 			description: 'Get, add and update data in Postgres',
 			parameterPane: 'wide',
 		};
@@ -25,6 +25,7 @@ export class Postgres extends VersionedNodeType {
 			2.4: new PostgresV2(baseDescription),
 			2.5: new PostgresV2(baseDescription),
 			2.6: new PostgresV2(baseDescription),
+			2.7: new PostgresV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Postgres/test/transport/receive.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/transport/receive.test.ts
@@ -1,11 +1,4 @@
-import pgPromise from 'pg-promise';
-
-import {
-	applyLargeNumbersReceive,
-	createReceiveHandler,
-	getDateAsStringTypeParsers,
-	parseDateToISO,
-} from '../../transport';
+import { applyLargeNumbersReceive, createReceiveHandler } from '../../transport';
 
 const BIGINT_TYPE_ID = 20;
 const NUMERIC_TYPE_ID = 1700;
@@ -106,64 +99,5 @@ describe('createReceiveHandler', () => {
 		const data = [{ id: '9007199254740993' }];
 		handler({ data, result: bigintResult });
 		expect(data[0].id).toBe('9007199254740993');
-	});
-});
-
-describe('parseDateToISO', () => {
-	it('should convert a UTC timestamp string to an ISO string', () => {
-		expect(parseDateToISO('2020-01-01 12:00:00+00')).toBe('2020-01-01T12:00:00.000Z');
-	});
-
-	it('should normalize a timezone-qualified string to an ISO string', () => {
-		expect(parseDateToISO('2020-01-01T05:30:00+05:30')).toBe('2020-01-01T00:00:00.000Z');
-	});
-
-	it('should return the original value when the date is invalid', () => {
-		expect(parseDateToISO('not-a-date')).toBe('not-a-date');
-	});
-
-	it('should return the original value for an empty string', () => {
-		expect(parseDateToISO('')).toBe('');
-	});
-});
-
-describe('getDateAsStringTypeParsers', () => {
-	const pgp = pgPromise({ noWarnings: true });
-	const { builtins } = pgp.pg.types;
-	const DATE_ARRAY_TYPE_ID = 1182;
-	const TIMESTAMP_ARRAY_TYPE_ID = 1115;
-
-	const parse = (oid: number, value: string) =>
-		getDateAsStringTypeParsers(pgp).getTypeParser(oid, 'text')(value);
-
-	it('should keep DATE columns as their raw YYYY-MM-DD string', () => {
-		expect(parse(builtins.DATE, '2020-01-01')).toBe('2020-01-01');
-	});
-
-	it('should normalize TIMESTAMP and TIMESTAMPTZ columns to ISO strings', () => {
-		expect(parse(builtins.TIMESTAMP, '2020-01-01 12:00:00')).toBe(
-			new Date('2020-01-01 12:00:00').toISOString(),
-		);
-		expect(parse(builtins.TIMESTAMPTZ, '2020-01-01 12:00:00+00')).toBe('2020-01-01T12:00:00.000Z');
-	});
-
-	it('should return date array elements as strings', () => {
-		expect(parse(DATE_ARRAY_TYPE_ID, '{2020-01-01,2020-01-02}')).toEqual([
-			'2020-01-01',
-			'2020-01-02',
-		]);
-	});
-
-	it('should return timestamp array elements as ISO strings', () => {
-		expect(parse(TIMESTAMP_ARRAY_TYPE_ID, '{"2020-01-01 12:00:00"}')).toEqual([
-			new Date('2020-01-01 12:00:00').toISOString(),
-		]);
-	});
-
-	it('should delegate non-date types to the default parser', () => {
-		// int4 default parser returns a JS number
-		expect(parse(OTHER_TYPE_ID, '42')).toBe(42);
-		// numeric default parser preserves precision as a string
-		expect(parse(NUMERIC_TYPE_ID, '99.99')).toBe('99.99');
 	});
 });

--- a/packages/nodes-base/nodes/Postgres/test/transport/receive.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/transport/receive.test.ts
@@ -1,4 +1,11 @@
-import { applyLargeNumbersReceive, createReceiveHandler, parseDateToISO } from '../../transport';
+import pgPromise from 'pg-promise';
+
+import {
+	applyLargeNumbersReceive,
+	createReceiveHandler,
+	getDateAsStringTypeParsers,
+	parseDateToISO,
+} from '../../transport';
 
 const BIGINT_TYPE_ID = 20;
 const NUMERIC_TYPE_ID = 1700;
@@ -117,5 +124,46 @@ describe('parseDateToISO', () => {
 
 	it('should return the original value for an empty string', () => {
 		expect(parseDateToISO('')).toBe('');
+	});
+});
+
+describe('getDateAsStringTypeParsers', () => {
+	const pgp = pgPromise({ noWarnings: true });
+	const { builtins } = pgp.pg.types;
+	const DATE_ARRAY_TYPE_ID = 1182;
+	const TIMESTAMP_ARRAY_TYPE_ID = 1115;
+
+	const parse = (oid: number, value: string) =>
+		getDateAsStringTypeParsers(pgp).getTypeParser(oid, 'text')(value);
+
+	it('should keep DATE columns as their raw YYYY-MM-DD string', () => {
+		expect(parse(builtins.DATE, '2020-01-01')).toBe('2020-01-01');
+	});
+
+	it('should normalize TIMESTAMP and TIMESTAMPTZ columns to ISO strings', () => {
+		expect(parse(builtins.TIMESTAMP, '2020-01-01 12:00:00')).toBe(
+			new Date('2020-01-01 12:00:00').toISOString(),
+		);
+		expect(parse(builtins.TIMESTAMPTZ, '2020-01-01 12:00:00+00')).toBe('2020-01-01T12:00:00.000Z');
+	});
+
+	it('should return date array elements as strings', () => {
+		expect(parse(DATE_ARRAY_TYPE_ID, '{2020-01-01,2020-01-02}')).toEqual([
+			'2020-01-01',
+			'2020-01-02',
+		]);
+	});
+
+	it('should return timestamp array elements as ISO strings', () => {
+		expect(parse(TIMESTAMP_ARRAY_TYPE_ID, '{"2020-01-01 12:00:00"}')).toEqual([
+			new Date('2020-01-01 12:00:00').toISOString(),
+		]);
+	});
+
+	it('should delegate non-date types to the default parser', () => {
+		// int4 default parser returns a JS number
+		expect(parse(OTHER_TYPE_ID, '42')).toBe(42);
+		// numeric default parser preserves precision as a string
+		expect(parse(NUMERIC_TYPE_ID, '99.99')).toBe('99.99');
 	});
 });

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -1,6 +1,4 @@
 import { formatPemBlock } from '@n8n/utils/format-pem-block';
-import { ConnectionPoolManager } from '@utils/connection-pool-manager';
-import { LOCALHOST } from '@utils/constants';
 import type {
 	IExecuteFunctions,
 	ICredentialTestFunctions,
@@ -11,9 +9,12 @@ import type {
 import { createServer, type AddressInfo, type Server } from 'node:net';
 import pgPromise from 'pg-promise';
 
+import { ConnectionPoolManager } from '@utils/connection-pool-manager';
+import { LOCALHOST } from '@utils/constants';
+import { getDateAsStringTypeParsers, parseDateToISO } from '@utils/postgres';
+
 import type {
 	ConnectionsData,
-	PgpClient,
 	PgpConnectionParameters,
 	PostgresNodeCredentials,
 	PostgresNodeOptions,
@@ -22,11 +23,6 @@ import type {
 // dataTypeIDs for bigint (int8) and numeric types in PostgreSQL
 const BIGINT_TYPE_ID = 20;
 const NUMERIC_TYPE_ID = 1700;
-
-// Array type OIDs, not exposed via pg-types `builtins`
-const DATE_ARRAY_TYPE_ID = 1182; // _date
-const TIMESTAMP_ARRAY_TYPE_ID = 1115; // _timestamp
-const TIMESTAMPTZ_ARRAY_TYPE_ID = 1185; // _timestamptz
 
 export function applyLargeNumbersReceive(e: {
 	data: Array<Record<string, unknown>>;
@@ -54,62 +50,6 @@ export function createReceiveHandler(
 	return (e: unknown) => {
 		if (largeNumbersOutput !== 'numbers') return;
 		applyLargeNumbersReceive(e as Parameters<typeof applyLargeNumbersReceive>[0]);
-	};
-}
-
-export function parseDateToISO(value: string) {
-	const parsedDate = new Date(value);
-
-	if (isNaN(parsedDate.getTime())) {
-		return value;
-	}
-	return parsedDate.toISOString();
-}
-
-// pg-promise's bundled pg-types exposes `arrayParser.create(source, transform)`,
-// but the published typings type `arrayParser` as a plain function.
-type ArrayParser = {
-	create: (source: string, transform: (entry: string) => unknown) => { parse: () => unknown[] };
-};
-
-/**
- * Per-connection type parsers that return date/timestamp columns (and their array
- * variants) as JSON-safe strings, so node output never contains live `Date` objects.
- * DATE stays as its `YYYY-MM-DD` wire value; timestamps are normalized to ISO. Every
- * other OID falls back to the default parser. Applied via the pg `types` connection
- * option so we don't mutate global pg-types state shared across all pools.
- */
-export function getDateAsStringTypeParsers(
-	pgp: PgpClient,
-): NonNullable<PgpConnectionParameters['types']> {
-	const { builtins } = pgp.pg.types;
-	const arrayParser = pgp.pg.types.arrayParser as unknown as ArrayParser;
-	const parseElements = (transform: (entry: string) => unknown) => (value: string) =>
-		arrayParser.create(value, transform).parse();
-
-	const overrides = new Map<number, (value: string) => unknown>([
-		[builtins.DATE, (value) => value],
-		[builtins.TIMESTAMP, parseDateToISO],
-		[builtins.TIMESTAMPTZ, parseDateToISO],
-		[DATE_ARRAY_TYPE_ID, parseElements((value) => value)],
-		[TIMESTAMP_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
-		[TIMESTAMPTZ_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
-	]);
-
-	return {
-		setTypeParser(
-			id: number,
-			formatOrParseFn: string | ((value: string) => unknown),
-			parseFn?: string | ((value: string) => unknown),
-		) {
-			const fn = parseFn ?? formatOrParseFn;
-			if (typeof fn === 'function') overrides.set(id, fn);
-		},
-		getTypeParser(id: number, format?: 'text' | 'binary') {
-			const override = overrides.get(id);
-			if (override && (format === undefined || format === 'text')) return override;
-			return pgp.pg.types.getTypeParser(id, format);
-		},
 	};
 }
 
@@ -191,11 +131,10 @@ export async function configurePostgres(
 		const dbConfig = getPostgresConfig(credentials, options);
 
 		if (typeof options.nodeVersion === 'number' && options.nodeVersion >= 2.7) {
-			// Return DATE, TIME and array date/timestamp columns as strings too, via a
-			// per-connection type config that leaves global pg-types state untouched.
+			// Also return DATE and date/timestamp array columns as strings
 			dbConfig.types = getDateAsStringTypeParsers(pgp);
 		} else if (typeof options.nodeVersion === 'number' && options.nodeVersion >= 2.1) {
-			// Return TIMESTAMP columns as ISO strings (DATE columns still return Date objects)
+			// DATE columns still return Date objects on these versions
 			[pgp.pg.types.builtins.TIMESTAMP, pgp.pg.types.builtins.TIMESTAMPTZ].forEach((type) => {
 				pgp.pg.types.setTypeParser(type, parseDateToISO);
 			});

--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -13,6 +13,7 @@ import pgPromise from 'pg-promise';
 
 import type {
 	ConnectionsData,
+	PgpClient,
 	PgpConnectionParameters,
 	PostgresNodeCredentials,
 	PostgresNodeOptions,
@@ -21,6 +22,11 @@ import type {
 // dataTypeIDs for bigint (int8) and numeric types in PostgreSQL
 const BIGINT_TYPE_ID = 20;
 const NUMERIC_TYPE_ID = 1700;
+
+// Array type OIDs, not exposed via pg-types `builtins`
+const DATE_ARRAY_TYPE_ID = 1182; // _date
+const TIMESTAMP_ARRAY_TYPE_ID = 1115; // _timestamp
+const TIMESTAMPTZ_ARRAY_TYPE_ID = 1185; // _timestamptz
 
 export function applyLargeNumbersReceive(e: {
 	data: Array<Record<string, unknown>>;
@@ -58,6 +64,53 @@ export function parseDateToISO(value: string) {
 		return value;
 	}
 	return parsedDate.toISOString();
+}
+
+// pg-promise's bundled pg-types exposes `arrayParser.create(source, transform)`,
+// but the published typings type `arrayParser` as a plain function.
+type ArrayParser = {
+	create: (source: string, transform: (entry: string) => unknown) => { parse: () => unknown[] };
+};
+
+/**
+ * Per-connection type parsers that return date/timestamp columns (and their array
+ * variants) as JSON-safe strings, so node output never contains live `Date` objects.
+ * DATE stays as its `YYYY-MM-DD` wire value; timestamps are normalized to ISO. Every
+ * other OID falls back to the default parser. Applied via the pg `types` connection
+ * option so we don't mutate global pg-types state shared across all pools.
+ */
+export function getDateAsStringTypeParsers(
+	pgp: PgpClient,
+): NonNullable<PgpConnectionParameters['types']> {
+	const { builtins } = pgp.pg.types;
+	const arrayParser = pgp.pg.types.arrayParser as unknown as ArrayParser;
+	const parseElements = (transform: (entry: string) => unknown) => (value: string) =>
+		arrayParser.create(value, transform).parse();
+
+	const overrides = new Map<number, (value: string) => unknown>([
+		[builtins.DATE, (value) => value],
+		[builtins.TIMESTAMP, parseDateToISO],
+		[builtins.TIMESTAMPTZ, parseDateToISO],
+		[DATE_ARRAY_TYPE_ID, parseElements((value) => value)],
+		[TIMESTAMP_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
+		[TIMESTAMPTZ_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
+	]);
+
+	return {
+		setTypeParser(
+			id: number,
+			formatOrParseFn: string | ((value: string) => unknown),
+			parseFn?: string | ((value: string) => unknown),
+		) {
+			const fn = parseFn ?? formatOrParseFn;
+			if (typeof fn === 'function') overrides.set(id, fn);
+		},
+		getTypeParser(id: number, format?: 'text' | 'binary') {
+			const override = overrides.get(id);
+			if (override && (format === undefined || format === 'text')) return override;
+			return pgp.pg.types.getTypeParser(id, format);
+		},
+	};
 }
 
 const getPostgresConfig = (
@@ -135,14 +188,18 @@ export async function configurePostgres(
 			receive: createReceiveHandler(options.largeNumbersOutput),
 		});
 
-		if (typeof options.nodeVersion === 'number' && options.nodeVersion >= 2.1) {
-			// Always return dates as ISO strings
+		const dbConfig = getPostgresConfig(credentials, options);
+
+		if (typeof options.nodeVersion === 'number' && options.nodeVersion >= 2.7) {
+			// Return DATE, TIME and array date/timestamp columns as strings too, via a
+			// per-connection type config that leaves global pg-types state untouched.
+			dbConfig.types = getDateAsStringTypeParsers(pgp);
+		} else if (typeof options.nodeVersion === 'number' && options.nodeVersion >= 2.1) {
+			// Return TIMESTAMP columns as ISO strings (DATE columns still return Date objects)
 			[pgp.pg.types.builtins.TIMESTAMP, pgp.pg.types.builtins.TIMESTAMPTZ].forEach((type) => {
 				pgp.pg.types.setTypeParser(type, parseDateToISO);
 			});
 		}
-
-		const dbConfig = getPostgresConfig(credentials, options);
 
 		if (!credentials.sshTunnel) {
 			const db = pgp(dbConfig);

--- a/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/versionDescription.ts
@@ -8,7 +8,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'postgres',
 	icon: 'file:postgres.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6],
+	version: [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7],
 	subtitle: '={{ $parameter["operation"] }}',
 	description: 'Get, add and update data in Postgres',
 	defaults: {

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -7,14 +7,15 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import pgPromise from 'pg-promise';
 
+import { getDateAsStringTypeParsers } from '@utils/postgres';
+
 import { pgInsert, pgQueryV2 } from '../Postgres/v1/genericFunctions';
-import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class QuestDb implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'QuestDB',
 		name: 'questDb',
-		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
+
 		icon: 'file:questdb.png',
 		group: ['input'],
 		version: [1, 1.1],

--- a/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
+++ b/packages/nodes-base/nodes/QuestDb/QuestDb.node.ts
@@ -8,6 +8,7 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import pgPromise from 'pg-promise';
 
 import { pgInsert, pgQueryV2 } from '../Postgres/v1/genericFunctions';
+import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class QuestDb implements INodeType {
 	description: INodeTypeDescription = {
@@ -16,7 +17,7 @@ export class QuestDb implements INodeType {
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:questdb.png',
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Get, add and update data in QuestDB',
 		defaults: {
 			name: 'QuestDB',
@@ -212,7 +213,11 @@ export class QuestDb implements INodeType {
 			sslmode: (credentials.ssl as string) || 'disable',
 		};
 
-		const db = pgp(config);
+		const db = pgp({
+			...config,
+			// Return date/timestamp columns as strings so node output stays JSON-safe
+			...(this.getNode().typeVersion >= 1.1 ? { types: getDateAsStringTypeParsers(pgp) } : {}),
+		});
 
 		let returnItems: INodeExecutionData[] = [];
 

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -8,6 +8,7 @@ import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import pgPromise from 'pg-promise';
 
 import { pgInsert, pgQueryV2, pgUpdate } from '../Postgres/v1/genericFunctions';
+import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class TimescaleDb implements INodeType {
 	description: INodeTypeDescription = {
@@ -15,7 +16,7 @@ export class TimescaleDb implements INodeType {
 		name: 'timescaleDb',
 		icon: { light: 'file:timescaleDb.svg', dark: 'file:timescaleDb.dark.svg' },
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		description: 'Add and update data in TimescaleDB',
 		defaults: {
 			name: 'TimescaleDB',
@@ -269,7 +270,11 @@ export class TimescaleDb implements INodeType {
 			sslmode: (credentials.ssl as string) || 'disable',
 		};
 
-		const db = pgp(config);
+		const db = pgp({
+			...config,
+			// Return date/timestamp columns as strings so node output stays JSON-safe
+			...(this.getNode().typeVersion >= 1.1 ? { types: getDateAsStringTypeParsers(pgp) } : {}),
+		});
 
 		let returnItems = [];
 

--- a/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
+++ b/packages/nodes-base/nodes/TimescaleDb/TimescaleDb.node.ts
@@ -7,8 +7,9 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import pgPromise from 'pg-promise';
 
+import { getDateAsStringTypeParsers } from '@utils/postgres';
+
 import { pgInsert, pgQueryV2, pgUpdate } from '../Postgres/v1/genericFunctions';
-import { getDateAsStringTypeParsers } from '../Postgres/transport';
 
 export class TimescaleDb implements INodeType {
 	description: INodeTypeDescription = {

--- a/packages/nodes-base/utils/postgres.test.ts
+++ b/packages/nodes-base/utils/postgres.test.ts
@@ -1,0 +1,65 @@
+import pgPromise from 'pg-promise';
+
+import { getDateAsStringTypeParsers, parseDateToISO } from './postgres';
+
+const NUMERIC_TYPE_ID = 1700;
+const OTHER_TYPE_ID = 23; // int4
+
+describe('parseDateToISO', () => {
+	it('should convert a UTC timestamp string to an ISO string', () => {
+		expect(parseDateToISO('2020-01-01 12:00:00+00')).toBe('2020-01-01T12:00:00.000Z');
+	});
+
+	it('should normalize a timezone-qualified string to an ISO string', () => {
+		expect(parseDateToISO('2020-01-01T05:30:00+05:30')).toBe('2020-01-01T00:00:00.000Z');
+	});
+
+	it('should return the original value when the date is invalid', () => {
+		expect(parseDateToISO('not-a-date')).toBe('not-a-date');
+	});
+
+	it('should return the original value for an empty string', () => {
+		expect(parseDateToISO('')).toBe('');
+	});
+});
+
+describe('getDateAsStringTypeParsers', () => {
+	const pgp = pgPromise({ noWarnings: true });
+	const { builtins } = pgp.pg.types;
+	const DATE_ARRAY_TYPE_ID = 1182;
+	const TIMESTAMP_ARRAY_TYPE_ID = 1115;
+
+	const parse = (oid: number, value: string) =>
+		getDateAsStringTypeParsers(pgp).getTypeParser(oid, 'text')(value);
+
+	it('should keep DATE columns as their raw YYYY-MM-DD string', () => {
+		expect(parse(builtins.DATE, '2020-01-01')).toBe('2020-01-01');
+	});
+
+	it('should normalize TIMESTAMP and TIMESTAMPTZ columns to ISO strings', () => {
+		expect(parse(builtins.TIMESTAMP, '2020-01-01 12:00:00')).toBe(
+			new Date('2020-01-01 12:00:00').toISOString(),
+		);
+		expect(parse(builtins.TIMESTAMPTZ, '2020-01-01 12:00:00+00')).toBe('2020-01-01T12:00:00.000Z');
+	});
+
+	it('should return date array elements as strings', () => {
+		expect(parse(DATE_ARRAY_TYPE_ID, '{2020-01-01,2020-01-02}')).toEqual([
+			'2020-01-01',
+			'2020-01-02',
+		]);
+	});
+
+	it('should return timestamp array elements as ISO strings', () => {
+		expect(parse(TIMESTAMP_ARRAY_TYPE_ID, '{"2020-01-01 12:00:00"}')).toEqual([
+			new Date('2020-01-01 12:00:00').toISOString(),
+		]);
+	});
+
+	it('should delegate non-date types to the default parser', () => {
+		// int4 default parser returns a JS number
+		expect(parse(OTHER_TYPE_ID, '42')).toBe(42);
+		// numeric default parser preserves precision as a string
+		expect(parse(NUMERIC_TYPE_ID, '99.99')).toBe('99.99');
+	});
+});

--- a/packages/nodes-base/utils/postgres.ts
+++ b/packages/nodes-base/utils/postgres.ts
@@ -1,0 +1,61 @@
+import type pgPromise from 'pg-promise';
+import type pg from 'pg-promise/typescript/pg-subset';
+
+type PgpClient = pgPromise.IMain;
+type PgTypesConfig = NonNullable<pg.IConnectionParameters<pg.IClient>['types']>;
+
+// Array type OIDs, not exposed via pg-types `builtins`
+const DATE_ARRAY_TYPE_ID = 1182; // _date
+const TIMESTAMP_ARRAY_TYPE_ID = 1115; // _timestamp
+const TIMESTAMPTZ_ARRAY_TYPE_ID = 1185; // _timestamptz
+
+export function parseDateToISO(value: string) {
+	const parsedDate = new Date(value);
+
+	if (isNaN(parsedDate.getTime())) {
+		return value;
+	}
+	return parsedDate.toISOString();
+}
+
+// pg-promise's bundled pg-types exposes `arrayParser.create`, but its published typings don't.
+type ArrayParser = {
+	create: (source: string, transform: (entry: string) => unknown) => { parse: () => unknown[] };
+};
+
+/**
+ * Per-connection type parsers that return date/timestamp columns (and their array variants) as
+ * JSON-safe strings rather than live `Date` objects: DATE keeps its `YYYY-MM-DD` wire value,
+ * timestamps are normalized to ISO, every other OID falls back to the default parser. Applied via
+ * the pg `types` connection option so the global pg-types state shared across pools stays untouched.
+ */
+export function getDateAsStringTypeParsers(pgp: PgpClient): PgTypesConfig {
+	const { builtins } = pgp.pg.types;
+	const parseElements = (transform: (entry: string) => unknown) => (value: string) =>
+		(pgp.pg.types.arrayParser as unknown as ArrayParser).create(value, transform).parse();
+
+	const overrides = new Map<number, (value: string) => unknown>([
+		[builtins.DATE, (value) => value],
+		[builtins.TIMESTAMP, parseDateToISO],
+		[builtins.TIMESTAMPTZ, parseDateToISO],
+		[DATE_ARRAY_TYPE_ID, parseElements((value) => value)],
+		[TIMESTAMP_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
+		[TIMESTAMPTZ_ARRAY_TYPE_ID, parseElements(parseDateToISO)],
+	]);
+
+	return {
+		setTypeParser(
+			id: number,
+			formatOrParseFn: string | ((value: string) => unknown),
+			parseFn?: string | ((value: string) => unknown),
+		) {
+			const fn = parseFn ?? formatOrParseFn;
+			if (typeof fn === 'function') overrides.set(id, fn);
+		},
+		getTypeParser(id: number, format?: 'text' | 'binary') {
+			const override = overrides.get(id);
+			if (override && (format === undefined || format === 'text')) return override;
+			return pgp.pg.types.getTypeParser(id, format);
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Postgres v2.1 started returning TIMESTAMP columns as ISO strings, but `DATE`, `TIME` and date/timestamp **array** columns still leaked live JS `Date` objects. That's inconsistent (a value is a `Date` in a full run but a string after any serialization boundary).

v2.7 returns all of them as strings. Same fix applied to CrateDB/QuestDB/TimescaleDB (v1.1), which reuse the Postgres v1 code path and leaked unconditionally.

All behind new node versions.

## How to test

See Linear

## Related tickets

https://linear.app/n8n/issue/NODE-5424
Parent: https://linear.app/n8n/issue/NODE-3077

## Checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title follows conventions
- [x] Tests included

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

