### PR TITLE
fix(core): Resolve sub-workflow repository get returning null

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -706,7 +706,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			expect(result.connections).toEqual(activeVersionConnections);
 			expect(workflowRepository.get).toHaveBeenCalledWith(
 				{ id: 'workflow-123' },
-				{ relations: ['activeVersion', 'tags'] },
+				{ relations: { activeVersion: true, tags: true } },
 			);
 		});
 
@@ -762,7 +762,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 			expect(workflowRepository.get).toHaveBeenCalledWith(
 				{ id: 'workflow-123' },
-				{ relations: ['activeVersion'] },
+				{ relations: { activeVersion: true } },
 			);
 
 			globalConfig.tags.disabled = false;

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -5,7 +5,8 @@ import { Logger, ModuleRegistry } from '@n8n/backend-common';
 import { SsrfProtectionService } from '@n8n/backend-network';
 import { ExecutionsConfig, GlobalConfig, SsrfProtectionConfig, WorkflowsConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
-import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
+import type { FindOptionsRelations } from '@n8n/typeorm';
+import { ExecutionRepository, WorkflowRepository, WorkflowEntity } from '@n8n/db';
 import type { ServiceIdentifier } from '@n8n/di';
 import { Container } from '@n8n/di';
 import type { JSONSchema7 } from 'json-schema';
@@ -110,8 +111,7 @@ export function getRunData(
 }
 
 /**
- * Fetches workflow from database or returns provided code.
- * Shared helper for getDraftWorkflowData and getPublishedWorkflowData.
+ * Clean up fetchWorkflowData to query with object-based relations
  */
 async function fetchWorkflowData(
 	workflowInfo: IExecuteWorkflowInfo,
@@ -125,10 +125,10 @@ async function fetchWorkflowData(
 	}
 
 	if (workflowInfo.id !== undefined) {
-		const baseRelations = ['activeVersion'];
-		const relations = Container.get(GlobalConfig).tags.disabled
-			? [...baseRelations]
-			: [...baseRelations, 'tags'];
+		const relations: FindOptionsRelations<WorkflowEntity> = {
+			activeVersion: true,
+			...(!Container.get(GlobalConfig).tags.disabled ? { tags: true } : {}),
+		};
 
 		const workflowFromDb = await Container.get(WorkflowRepository).get(
 			{ id: workflowInfo.id },


### PR DESCRIPTION
Fixes #34037
Linear Ticket: https://linear.app/n8n/issue/GHC-8834

## What this PR does
Resolves an issue where executing a sub-workflow in manual mode throws a `"Workflow does not exist"` error despite the workflow record existing in the database with a matching active version.

The root cause was that `WorkflowRepository.get` was queried using the legacy array syntax for relations (`relations: ['activeVersion']`). In TypeORM 0.3.x, when a ManyToOne relation shares a column name convention with another column in the entity (`activeVersionId`), result mapping with array relations can fail silently and return `null` for the entire entity. 

We updated `fetchWorkflowData` to use TypeORM's preferred object syntax (`relations: { activeVersion: true }`), resolving this mapping bug. We also updated the corresponding test mocks in `workflow-execute-additional-data.test.ts` to expect the object relations instead of array strings.

## How to test
1. Create a workflow (A) containing an `Execute Workflow` node set to `mode: 'uuid'`, pointing to another workflow (B) which has an active version.
2. Execute workflow A.
3. Verify that the sub-workflow B executes successfully instead of throwing a `"Workflow does not exist"` error.
4. Run the unit tests locally to confirm they pass:
   ```bash
   pnpm test:win src/__tests__/workflow-execute-additional-data.test.ts
   
 ## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (N/A)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34054">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

