### PR TITLE
test: Skip Instance AI approval-panel e2e tests with stale replay recordings (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-confirmations.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-confirmations.spec.ts
@@ -235,7 +235,11 @@ test.describe(
 			}
 		});
 
-		test(
+		// Skipped: the replay recording predates the create-tasks load_tool
+		// deferral (#33815), so the recorded direct create-tasks call fails as an
+		// unloaded tool and the approval panel never appears. Unskip once the
+		// recordings are updated (#34055 or a re-record).
+		test.skip(
 			'should show approval panel and approve workflow execution',
 			{
 				annotation: [
@@ -269,7 +273,8 @@ test.describe(
 			},
 		);
 
-		test(
+		// Skipped: same broken recording as the approve variant above (#33815).
+		test.skip(
 			'should show approval panel and deny workflow execution',
 			{
 				annotation: [


### PR DESCRIPTION
## Summary

Skips the two Instance AI approval-panel e2e tests to unblock PR CI, which they have been failing consistently since July 10 (internal Slack thread; 13 failures in 14 days per Currents):

- `should show approval panel and deny workflow execution` (fails on every internal PR branch that runs the instance-ai specs)
- `should show approval panel and approve workflow execution` (skips multi-main already, but fails the same way on sqlite/postgres runs, e.g. fork PRs and nightlies)

**Root cause:** [#33815](https://github.com/n8n-io/n8n/pull/33815) made `create-tasks` a deferred tool that must be loaded via `load_tool` before it can be called. The replay recordings for these two tests were made on July 6 in [#33693](https://github.com/n8n-io/n8n/pull/33693), when `create-tasks` was always loaded, so the recorded conversation calls it directly. On replay the tool call fails as unloaded, the plan-review suspension never happens, and the test times out waiting for the approval panel. These are the only two recordings that call `create-tasks`. #33815 itself merged with E2E skipped because the e2e impact map has no entries for `packages/@n8n/instance-ai/**` (being looked at separately).

**Unskip path:** [#34055](https://github.com/n8n-io/n8n/pull/34055) patches the recordings with the missing `load_tool` turn (replay-verified locally), or the tests can be re-recorded with a real `ANTHROPIC_API_KEY`. Whichever lands should revert this skip.

## How to test

```bash
cd packages/testing/playwright
pnpm test:container:sqlite tests/e2e/instance-ai/instance-ai-confirmations.spec.ts --grep "approval panel"
```

Both tests report as skipped without booting the container stack; the other three tests in the spec still run.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

