### PR TITLE
fix(core): Resolve task runner execution timeouts in task broker

### DIFF
--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker-ws-server.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker-ws-server.test.ts
@@ -19,6 +19,30 @@ describe('TaskBrokerWsServer', () => {
 
 			expect(ws.close).toHaveBeenCalledWith(WsStatusCodes.CloseNormal);
 		});
+
+		it('should close and delete if connectionToRemove matches active connection', async () => {
+			const server = new TaskBrokerWsServer(mock(), mock(), mock(), mock(), mock(), globalConfig);
+			const ws = mock<WebSocket>();
+			server.runnerConnections.set('test-runner', ws);
+
+			await server.removeConnection('test-runner', 'unknown', WsStatusCodes.CloseNormal, ws);
+
+			expect(ws.close).toHaveBeenCalledWith(WsStatusCodes.CloseNormal);
+			expect(server.runnerConnections.has('test-runner')).toBe(false);
+		});
+
+		it('should not close or delete if connectionToRemove does not match active connection', async () => {
+			const server = new TaskBrokerWsServer(mock(), mock(), mock(), mock(), mock(), globalConfig);
+			const wsActive = mock<WebSocket>();
+			const wsOld = mock<WebSocket>();
+			server.runnerConnections.set('test-runner', wsActive);
+
+			await server.removeConnection('test-runner', 'unknown', WsStatusCodes.CloseNormal, wsOld);
+
+			expect(wsOld.close).not.toHaveBeenCalled();
+			expect(wsActive.close).not.toHaveBeenCalled();
+			expect(server.runnerConnections.get('test-runner')).toBe(wsActive);
+		});
 	});
 
 	describe('heartbeat timer', () => {
@@ -85,6 +109,41 @@ describe('TaskBrokerWsServer', () => {
 			await Promise.resolve();
 
 			expect(ws.close).toHaveBeenCalledWith(WsStatusCodes.CloseProtocolError);
+
+			await server.stop();
+			vi.useRealTimers();
+		});
+
+		it('should continue checking remaining connections even if one fails the heartbeat check', async () => {
+			vi.useFakeTimers();
+			const server = new TaskBrokerWsServer(
+				mock(),
+				mock(),
+				mock(),
+				mock<TaskRunnersConfig>({ path: '/runners', heartbeatInterval: 30 }),
+				mock(),
+				globalConfig,
+			);
+
+			const ws1 = mock<WebSocket>();
+			ws1.isAlive = false;
+			const ws2 = mock<WebSocket>();
+			ws2.isAlive = true;
+
+			server.runnerConnections.set('runner1', ws1);
+			server.runnerConnections.set('runner2', ws2);
+
+			server.start();
+
+			vi.advanceTimersByTime(30 * Time.seconds.toMilliseconds);
+
+			await Promise.resolve();
+
+			// ws1 should be closed due to failed heartbeat
+			expect(ws1.close).toHaveBeenCalledWith(WsStatusCodes.CloseProtocolError);
+			// ws2 should be pinged and set to isAlive = false
+			expect(ws2.ping).toHaveBeenCalled();
+			expect(ws2.isAlive).toBe(false);
 
 			await server.stop();
 			vi.useRealTimers();

--- a/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
+++ b/packages/cli/src/task-runners/task-broker/__tests__/task-broker.service.test.ts
@@ -1161,5 +1161,43 @@ describe('TaskBroker', () => {
 			handleTimeoutSpy.mockRestore();
 			vi.useRealTimers();
 		});
+
+		it('should re-settle tasks if offer accept fails due to accept timeout', async () => {
+			vi.useFakeTimers();
+			const settleTasksSpy = vi.spyOn(taskBroker, 'settleTasks');
+
+			// Register a runner
+			const runnerId = 'runner1';
+			const runner = mock<TaskRunner>({ id: runnerId });
+			const messageCallback = vi.fn();
+			taskBroker.registerRunner(runner, messageCallback);
+
+			const offer: TaskOffer = {
+				offerId: 'offer1',
+				runnerId,
+				taskType: 'taskType1',
+				validFor: 1000,
+				validUntil: createValidUntil(1000),
+			};
+
+			const request: TaskRequest = {
+				requestId: 'request1',
+				requesterId: 'requester1',
+				taskType: 'taskType1',
+			};
+
+			taskBroker.setPendingTaskOffers([offer]);
+			taskBroker.setPendingTaskRequests([request]);
+
+			taskBroker.settleTasks();
+
+			// Advance timers by 2 seconds to trigger the TaskRunnerAcceptTimeoutError and resolve async microtasks
+			await vi.advanceTimersByTimeAsync(2000);
+
+			// settleTasks is called first for settling, then in the catch block on failure
+			expect(settleTasksSpy).toHaveBeenCalledTimes(2);
+			settleTasksSpy.mockRestore();
+			vi.useRealTimers();
+		});
 	});
 });

--- a/packages/cli/src/task-runners/task-broker/task-broker-ws-server.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker-ws-server.ts
@@ -61,9 +61,10 @@ export class TaskBrokerWsServer {
 						runnerId,
 						'failed-heartbeat-check',
 						WsStatusCodes.CloseProtocolError,
+						connection,
 					);
 					this.runnerLifecycleEvents.emit('runner:failed-heartbeat-check');
-					return;
+					continue;
 				}
 				connection.isAlive = false;
 				connection.ping();
@@ -146,7 +147,7 @@ export class TaskBrokerWsServer {
 		connection.once('close', async () => {
 			connection.off('pong', heartbeat);
 			connection.off('message', onMessage);
-			await this.removeConnection(id);
+			await this.removeConnection(id, 'unknown', WsStatusCodes.CloseNormal, connection);
 		});
 
 		connection.on('message', onMessage);
@@ -159,9 +160,13 @@ export class TaskBrokerWsServer {
 		id: TaskRunner['id'],
 		reason: DisconnectReason = 'unknown',
 		code: WsStatusCode = WsStatusCodes.CloseNormal,
+		connectionToRemove?: WebSocket,
 	) {
 		const connection = this.runnerConnections.get(id);
 		if (connection) {
+			if (connectionToRemove && connection !== connectionToRemove) {
+				return;
+			}
 			const disconnectError = await this.disconnectAnalyzer.toDisconnectError({
 				runnerId: id,
 				reason,

--- a/packages/cli/src/task-runners/task-broker/task-broker.service.ts
+++ b/packages/cli/src/task-runners/task-broker/task-broker.service.ts
@@ -563,6 +563,7 @@ export class TaskBroker {
 			await acceptPromise;
 		} catch (e) {
 			request.acceptInProgress = false;
+			this.settleTasks();
 			if (e instanceof TaskRejectError) {
 				this.logger.info(`Task (${taskId}) rejected by Runner with reason "${e.reason}"`);
 				return;


### PR DESCRIPTION
## Summary

Fixes #34051 
This PR addresses the task runner timeouts where Code node executions fail with `Task request timed out after 60 seconds Your Code node task was not matched to a runner`. 

We resolved three distinct bugs in the task broker:
1. **WebSocket Close Race Condition:** In `TaskBrokerWsServer.add`, when a runner reconnects and the old connection is terminated asynchronously, the old socket's `close` handler was firing after the new connection was registered. This caused the old handler to erroneously get and close the *new* connection. We fixed this by passing the specific `connection` object to `removeConnection` to guarantee only the target socket gets closed/deleted.
2. **Heartbeat Timer Early Return:** Corrected a bug in `startHeartbeatChecks` where detecting a single dead connection immediately exited the heartbeat callback via a `return` statement, preventing subsequent runner connections from being checked or pinged. We changed `return` to `continue`.
3. **Offer Acceptance Failure Re-settling:** Added `this.settleTasks()` to the `catch` block of `acceptOffer` in `TaskBroker`. If the runner rejects or times out on offer acceptance, the broker immediately re-evaluates the matching queue rather than leaving the request hanging.

## How to test

1. Run the existing and newly added automated tests in `packages/cli`:
   ```bash
   pnpm test task-broker.service.test.ts task-broker-ws-server.test.ts
   
Review / Merge checklist
[x] I have seen this code, I have run this code, and I take responsibility for this code.
[x] PR title and summary are descriptive.
[ ] Docs updated or follow-up ticket created. (N/A)
[x] Tests included.
[ ] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

