### PR TITLE
fix(Microsoft Teams Node): Validate Graph path IDs under all credential types

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -337,11 +337,25 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(result).toBe('/chats/chat123/messages');
 		});
 
-		it('should return the correct resource path for newChatMessage event with chatId missing', async () => {
+		it('should reject a missing chatId for the newChatMessage event', async () => {
 			setParams({ watchAllChats: false, chatId: undefined });
 
-			const result = await getResourcePath.call(mockHookFunctions, 'newChatMessage');
-			expect(result).toBe('/chats/undefined/messages');
+			await expect(getResourcePath.call(mockHookFunctions, 'newChatMessage')).rejects.toThrow(
+				'A required ID is empty',
+			);
+		});
+
+		it('should reject a missing channelId for the newChannelMessage event', async () => {
+			setParams({
+				watchAllTeams: false,
+				teamId: 'team123',
+				watchAllChannels: false,
+				channelId: undefined,
+			});
+
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannelMessage')).rejects.toThrow(
+				'A required ID is empty',
+			);
 		});
 		it('should return the correct resource path for newChannel event', async () => {
 			setParams({ watchAllTeams: false, teamId: 'team123' });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -350,11 +350,12 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(result).toBe('/teams/team123/channels');
 		});
 
-		it('should return the correct resource path for newChannel event with teamId missing', async () => {
+		it('should reject a missing teamId for the newChannel event', async () => {
 			setParams({ watchAllTeams: false, teamId: undefined });
 
-			const result = await getResourcePath.call(mockHookFunctions, 'newChannel');
-			expect(result).toBe('/teams/undefined/channels');
+			await expect(getResourcePath.call(mockHookFunctions, 'newChannel')).rejects.toThrow(
+				'A required ID is empty',
+			);
 		});
 
 		it('should return the correct resource path for newChannelMessage event with a specific team and channel', async () => {
@@ -376,11 +377,12 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(result).toBe('/teams/team123/members');
 		});
 
-		it('should return the correct resource path for newTeamMember event with teamId missing', async () => {
+		it('should reject a missing teamId for the newTeamMember event', async () => {
 			setParams({ watchAllTeams: false, teamId: undefined });
 
-			const result = await getResourcePath.call(mockHookFunctions, 'newTeamMember');
-			expect(result).toBe('/teams/undefined/members');
+			await expect(getResourcePath.call(mockHookFunctions, 'newTeamMember')).rejects.toThrow(
+				'A required ID is empty',
+			);
 		});
 
 		it('should return the correct resource path for newTeamMember event with watchAllTeams', async () => {

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.validation.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/v2/node/chatMessage/get.validation.test.ts
@@ -1,0 +1,70 @@
+import type { IExecuteFunctions, INode, NodeParameterValueType } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { MockProxy } from 'vitest-mock-extended';
+import { mock } from 'vitest-mock-extended';
+
+import { versionDescription } from '../../../../v2/actions/versionDescription';
+import { MicrosoftTeamsV2 } from '../../../../v2/MicrosoftTeamsV2.node';
+import * as transport from '../../../../v2/transport';
+import type * as _importType0 from '../../../../v2/transport';
+
+// Real transport except the network helper, so buildTeamsPath/validateTeamsId
+// run for real; only microsoftApiRequest is stubbed.
+vi.mock('../../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+describe('Microsoft Teams V2 — chatMessage:get error surfacing', () => {
+	let node: MicrosoftTeamsV2;
+	let ctx: MockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown): NodeParameterValueType =>
+				(name in params ? params[name] : fallback) as NodeParameterValueType,
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftTeamsV2(versionDescription);
+		ctx = mock<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getInstanceId.mockReturnValue('instanceId');
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		ctx.continueOnFail.mockReturnValue(false);
+	});
+
+	it('surfaces the validation error for a malformed message ID', async () => {
+		setParams({
+			authentication: 'microsoftTeamsOAuth2Api',
+			resource: 'chatMessage',
+			operation: 'get',
+			chatId: '19:abc@thread.v2',
+			messageId: 'a/b',
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('The ID is not valid');
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('keeps the not-found message for request failures', async () => {
+		setParams({
+			authentication: 'microsoftTeamsOAuth2Api',
+			resource: 'chatMessage',
+			operation: 'get',
+			chatId: '19:abc@thread.v2',
+			messageId: '1698378560692',
+		});
+		apiRequest.mockRejectedValueOnce(new Error('404'));
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			"The message you are trying to get doesn't exist",
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
@@ -91,8 +91,6 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 		instanceId,
 	);
 
-	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
-	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
 	return await microsoftApiRequest.call(
 		this,
 		'POST',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/create.operation.ts
@@ -4,7 +4,7 @@ import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
 import { prepareMessage } from '../../helpers/utils';
-import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest, SP_HIDE } from '../../transport';
 import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [
@@ -93,5 +93,10 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 
 	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
 	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
-	return await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
+	return await microsoftApiRequest.call(
+		this,
+		'POST',
+		buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages']),
+		body,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
@@ -38,17 +38,19 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	// catch below, so the static SP message is surfaced, not the generic one).
 	throwIfChatUnsupported.call(this);
 
-	try {
-		const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
-		const messageId = this.getNodeParameter('messageId', i) as string;
+	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
+	const messageId = this.getNodeParameter('messageId', i) as string;
+	// Built outside the try so an invalid id surfaces as its own validation
+	// error instead of being replaced by the not-found message below
+	const endpoint = buildTeamsPath.call(this, [
+		'/v1.0/chats/',
+		{ id: chatId },
+		'/messages/',
+		{ id: messageId },
+	]);
 
-		// OAuth2-only path (chat is hidden + guarded under SP), so `chatId` is
-		// interpolated raw without buildTeamsPath by design.
-		return await microsoftApiRequest.call(
-			this,
-			'GET',
-			buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages/', { id: messageId }]),
-		);
+	try {
+		return await microsoftApiRequest.call(this, 'GET', endpoint);
 	} catch (error) {
 		throw new NodeOperationError(
 			this.getNode(),

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/get.operation.ts
@@ -3,7 +3,7 @@ import { type INodeProperties, type IExecuteFunctions, NodeOperationError } from
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest, SP_HIDE } from '../../transport';
 import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [
@@ -47,7 +47,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 		return await microsoftApiRequest.call(
 			this,
 			'GET',
-			`/v1.0/chats/${chatId}/messages/${messageId}`,
+			buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages/', { id: messageId }]),
 		);
 	} catch (error) {
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -27,8 +27,6 @@ export async function execute(this: IExecuteFunctions, i: number) {
 	// App-only Graph cannot read chats; fail before any request.
 	throwIfChatUnsupported.call(this);
 
-	// OAuth2-only path (chat is hidden + guarded under SP), so `chatId` below is
-	// interpolated raw without buildTeamsPath by design.
 	const chatId = this.getNodeParameter('chatId', i, '', { extractValue: true }) as string;
 	const returnAll = this.getNodeParameter('returnAll', i);
 

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/getAll.operation.ts
@@ -4,7 +4,7 @@ import { returnAllOrLimit } from '@utils/descriptions';
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequestAllItems, SP_HIDE } from '../../transport';
+import { buildTeamsPath, microsoftApiRequestAllItems, SP_HIDE } from '../../transport';
 import { throwIfChatUnsupported } from './sharedGuard';
 
 const properties: INodeProperties[] = [chatRLC, ...returnAllOrLimit];
@@ -37,7 +37,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			'value',
 			'GET',
-			`/v1.0/chats/${chatId}/messages`,
+			buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages']),
 		);
 	} else {
 		const limit = this.getNodeParameter('limit', i);
@@ -45,7 +45,7 @@ export async function execute(this: IExecuteFunctions, i: number) {
 			this,
 			'value',
 			'GET',
-			`/v1.0/chats/${chatId}/messages`,
+			buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages']),
 			{},
 		);
 		return responseData.splice(0, limit);

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../../../utils/sendAndWait/utils';
 import { createUtmCampaignLink } from '../../../../../../utils/utilities';
 import { chatRLC } from '../../descriptions';
-import { microsoftApiRequest, SP_HIDE } from '../../transport';
+import { buildTeamsPath, microsoftApiRequest, SP_HIDE } from '../../transport';
 import { throwIfChatUnsupported } from './sharedGuard';
 
 export const description: INodeProperties[] = getSendAndWaitProperties(
@@ -59,5 +59,10 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 
 	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
 	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
-	return await microsoftApiRequest.call(this, 'POST', `/v1.0/chats/${chatId}/messages`, body);
+	return await microsoftApiRequest.call(
+		this,
+		'POST',
+		buildTeamsPath.call(this, ['/v1.0/chats/', { id: chatId }, '/messages']),
+		body,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/chatMessage/sendAndWait.operation.ts
@@ -57,8 +57,6 @@ export async function execute(this: IExecuteFunctions, i: number, instanceId: st
 		},
 	};
 
-	// OAuth2-only path (chatMessage is hidden + guarded under SP by throwIfChatUnsupported
-	// above), so `chatId` is interpolated raw without buildTeamsPath by design.
 	return await microsoftApiRequest.call(
 		this,
 		'POST',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -29,8 +29,8 @@ export async function fetchAllChannels(
 	this: IHookFunctions,
 	teamId: string,
 ): Promise<ChannelResponse[]> {
-	// Route through buildTeamsPath so `teamId` is validated under SP (non-bypassable
-	// defense-in-depth — watch-all is also guarded in getResourcePath); verbatim under OAuth2.
+	// Route through buildTeamsPath so `teamId` is validated before interpolation
+	// (watch-all is also guarded in getResourcePath).
 	const { value: channels } = (await microsoftApiRequest.call(
 		this,
 		'GET',
@@ -99,12 +99,12 @@ export async function getResourcePath(
 	this: IHookFunctions,
 	event: string,
 ): Promise<string | string[]> {
-	// App-only Graph has no signed-in user. On the SP-reachable branches the
-	// path-interpolated ids are validated + interpolated via buildTeamsPath. A By-URL
-	// channel id arrives percent-encoded, so newChannelMessage decodes it first (parity
-	// with the OAuth2 path) so validation runs on the decoded value. Watch-all is disabled
-	// under SP (UI-hidden + the runtime guards below, since fetchAllTeams/fetchAllChannels
-	// fan out an org-wide-token request). The OAuth2 branches are byte-for-byte unchanged.
+	// Path-interpolated ids are validated + interpolated via buildTeamsPath under
+	// both credential types. A By-URL channel/chat id arrives percent-encoded, so it
+	// is decoded first (guarded helper) so validation runs on the decoded value.
+	// App-only Graph has no signed-in user: chat events and watch-all are disabled
+	// under SP (UI-hidden + the runtime guards below, since fetchAllTeams/
+	// fetchAllChannels fan out an org-wide-token request).
 	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
 
 	switch (event) {
@@ -122,7 +122,11 @@ export async function getResourcePath(
 				return '/me/chats/getAllMessages';
 			} else {
 				const chatId = this.getNodeParameter('chatId', undefined, { extractValue: true }) as string;
-				return `/chats/${decodeURIComponent(chatId)}/messages`;
+				return buildTeamsPath.call(this, [
+					'/chats/',
+					{ id: decodeSelectedId.call(this, chatId) },
+					'/messages',
+				]);
 			}
 		}
 
@@ -139,10 +143,7 @@ export async function getResourcePath(
 				return teams.map((team) => `/teams/${team.id}/channels`);
 			} else {
 				const teamId = this.getNodeParameter('teamId', undefined, { extractValue: true }) as string;
-				if (isServicePrincipal) {
-					return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/channels']);
-				}
-				return `/teams/${teamId}/channels`;
+				return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/channels']);
 			}
 		}
 
@@ -176,20 +177,13 @@ export async function getResourcePath(
 					const channelId = this.getNodeParameter('channelId', undefined, {
 						extractValue: true,
 					}) as string;
-					if (isServicePrincipal) {
-						// `channelId` is percent-encoded when selected By URL; decode it first (via the
-						// guarded helper, so a malformed `%` yields a NodeOperationError not a raw
-						// URIError) so validation runs on the decoded value and the subscription resource
-						// carries the raw channel id Graph matches against (parity with the OAuth2 path).
-						return buildTeamsPath.call(this, [
-							'/teams/',
-							{ id: teamId },
-							'/channels/',
-							{ id: decodeChannelId.call(this, channelId) },
-							'/messages',
-						]);
-					}
-					return `/teams/${teamId}/channels/${decodeURIComponent(channelId)}/messages`;
+					return buildTeamsPath.call(this, [
+						'/teams/',
+						{ id: teamId },
+						'/channels/',
+						{ id: decodeSelectedId.call(this, channelId) },
+						'/messages',
+					]);
 				}
 			}
 		}
@@ -207,10 +201,7 @@ export async function getResourcePath(
 				return teams.map((team) => `/teams/${team.id}/members`);
 			} else {
 				const teamId = this.getNodeParameter('teamId', undefined, { extractValue: true }) as string;
-				if (isServicePrincipal) {
-					return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/members']);
-				}
-				return `/teams/${teamId}/members`;
+				return buildTeamsPath.call(this, ['/teams/', { id: teamId }, '/members']);
 			}
 		}
 
@@ -257,18 +248,16 @@ function throwWatchAllUnsupported(this: IHookFunctions): never {
 }
 
 /**
- * Decodes a By-URL channel id (percent-encoded, e.g. `19%3A...%40thread.tacv2`) before it is
- * validated and interpolated under SP. A malformed `%` sequence makes `decodeURIComponent` throw a
- * raw `URIError`; convert it to a static `NodeOperationError` so the SP path never surfaces a raw
- * decode error (the OAuth2 path keeps its pre-existing unguarded decode).
+ * Decodes a By-URL id (percent-encoded, e.g. `19%3A...%40thread.tacv2`) before it is
+ * validated and interpolated. A malformed `%` sequence makes `decodeURIComponent`
+ * throw a raw `URIError`; convert it to a static `NodeOperationError`.
  */
-function decodeChannelId(this: IHookFunctions, channelId: string): string {
+function decodeSelectedId(this: IHookFunctions, id: string): string {
 	try {
-		return decodeURIComponent(channelId);
+		return decodeURIComponent(id);
 	} catch {
 		throw new NodeOperationError(this.getNode(), 'The ID is not valid', {
-			description:
-				'The channel ID could not be decoded. Re-select the channel from the list or by URL.',
+			description: 'The ID could not be decoded. Re-select it from the list or by URL.',
 		});
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -254,7 +254,9 @@ function throwWatchAllUnsupported(this: IHookFunctions): never {
  */
 function decodeSelectedId(this: IHookFunctions, id: string): string {
 	try {
-		return decodeURIComponent(id);
+		// A missing selection arrives as a non-string — keep it empty (not the
+		// string "undefined") so validation raises the required-ID error
+		return decodeURIComponent(String(id ?? ''));
 	} catch {
 		throw new NodeOperationError(this.getNode(), 'The ID is not valid', {
 			description: 'The ID could not be decoded. Re-select it from the list or by URL.',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -529,7 +529,7 @@ describe('Microsoft Teams Transport', () => {
 		});
 
 		it.each(['a/b', 'a\\b', 'a?b', 'a#b', 'x/../../groups/abc', 'abc?$expand=foo'])(
-			'rejects path-escape / query-injection ids (%s)',
+			'rejects ids containing separators or query characters (%s)',
 			(id) => {
 				expect(() => validateTeamsId(id, mockNode)).toThrow();
 			},
@@ -553,7 +553,7 @@ describe('Microsoft Teams Transport', () => {
 	});
 
 	describe('buildTeamsPath', () => {
-		it('passes ids verbatim under OAuth2 (no validate, no encode)', () => {
+		it('validates and interpolates a valid id RAW under OAuth2 (no encoding)', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
 
 			const path = buildTeamsPath.call(mockExecuteFunctions, [
@@ -594,53 +594,72 @@ describe('Microsoft Teams Transport', () => {
 		});
 
 		// A node expression like `={{ 123 }}` resolves to a non-string at runtime; the
-		// call sites' `as string` is compile-time only. The SP path must coerce before
-		// `.trim()` or it throws a raw `TypeError` (regression guard).
-		it('coerces a non-string id under SP without throwing', () => {
-			mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+		// call sites' `as string` is compile-time only — ids must be coerced before
+		// trimming or the build throws a raw `TypeError` (regression guard).
+		it.each(['microsoftTeamsOAuth2Api', SERVICE_PRINCIPAL_AUTH])(
+			'coerces a non-string id under %s without throwing',
+			(credential) => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(credential);
 
-			const path = buildTeamsPath.call(mockExecuteFunctions, [
-				'/v1.0/planner/tasks/',
-				{ id: 123 as unknown as string },
-			]);
+				const path = buildTeamsPath.call(mockExecuteFunctions, [
+					'/v1.0/planner/tasks/',
+					{ id: 123 as unknown as string },
+				]);
 
-			expect(path).toBe('/v1.0/planner/tasks/123');
+				expect(path).toBe('/v1.0/planner/tasks/123');
+			},
+		);
+
+		it.each(['microsoftTeamsOAuth2Api', SERVICE_PRINCIPAL_AUTH])(
+			'trims surrounding whitespace from a valid id under %s',
+			(credential) => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(credential);
+
+				const path = buildTeamsPath.call(mockExecuteFunctions, [
+					'/v1.0/teams/',
+					{ id: '  19:abc@thread.tacv2  ' },
+					'/channels',
+				]);
+
+				expect(path).toBe('/v1.0/teams/19:abc@thread.tacv2/channels');
+			},
+		);
+
+		const malformedIds = ['x/../../groups/abc', 'abc?$expand=foo', 'a\\b', 'a#frag'];
+		it.each(
+			['microsoftTeamsOAuth2Api', SERVICE_PRINCIPAL_AUTH].flatMap((credential) =>
+				malformedIds.map((id) => [credential, id]),
+			),
+		)('rejects an id containing separators under %s (%s)', (credential, malformedId) => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(credential);
+
+			expect(() =>
+				buildTeamsPath.call(mockExecuteFunctions, [
+					'/v1.0/teams/',
+					{ id: malformedId },
+					'/channels',
+				]),
+			).toThrow('The ID is not valid');
 		});
 
-		it('stringifies a non-string id under OAuth2 (join coercion, no throw)', () => {
-			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
-
-			const path = buildTeamsPath.call(mockExecuteFunctions, [
-				'/v1.0/planner/tasks/',
-				{ id: 123 as unknown as string },
-			]);
-
-			expect(path).toBe('/v1.0/planner/tasks/123');
-		});
-
-		it.each(['x/../../groups/abc', 'abc?$expand=foo', 'a\\b', 'a#frag'])(
-			'throws on a crafted separator/injection id (%s) under the Service Principal credential',
-			(craftedId) => {
-				mockExecuteFunctions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+		it.each(['microsoftTeamsOAuth2Api', SERVICE_PRINCIPAL_AUTH])(
+			'rejects an empty id under %s',
+			(credential) => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(credential);
 
 				expect(() =>
-					buildTeamsPath.call(mockExecuteFunctions, [
-						'/v1.0/teams/',
-						{ id: craftedId },
-						'/channels',
-					]),
-				).toThrow();
+					buildTeamsPath.call(mockExecuteFunctions, ['/v1.0/teams/', { id: '' }, '/channels']),
+				).toThrow('A required ID is empty');
 			},
 		);
 	});
 
-	describe('OAuth2 back-compat lock (byte-for-byte unchanged)', () => {
+	describe('OAuth2 back-compat lock (valid ids byte-for-byte unchanged)', () => {
 		it('composes the legacy raw uri for a colon-bearing channelId', async () => {
 			// Default OAuth2 selected. A realistic colon-bearing channel id flows through
-			// buildTeamsPath verbatim — no throw, no encoding — proving OAuth2 URL shapes
-			// are unchanged. SP composes the SAME raw shape for this valid id (see the
-			// buildTeamsPath SP test); the two paths differ only in that SP rejects the
-			// separator/query-injection vectors.
+			// buildTeamsPath unmodified — validated but never encoded — proving OAuth2
+			// URL shapes for valid ids are unchanged. SP composes the SAME raw shape for
+			// this valid id (see the buildTeamsPath SP test).
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
 			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
 			mockExecuteFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
@@ -777,9 +796,9 @@ describe('Microsoft Teams Transport', () => {
 		});
 
 		// MAJOR B hard gate: every SP-reachable listSearch method that interpolates an id
-		// must reject a crafted traversal id via buildTeamsPath, before any request.
-		describe('SP id-injection gate (enumerated)', () => {
-			const craftedId = 'x/../../groups/abc';
+		// must reject a malformed id via buildTeamsPath, before any request.
+		describe('SP id validation gate (enumerated)', () => {
+			const malformedId = 'x/../../groups/abc';
 
 			beforeEach(() => {
 				mockLoadOptions.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
@@ -789,29 +808,29 @@ describe('Microsoft Teams Transport', () => {
 				});
 			});
 
-			it('getChannels rejects a crafted teamId', async () => {
-				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+			it('getChannels rejects a malformed teamId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
 
 				await expect(getChannels.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
 				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
-			it('getPlans rejects a crafted groupId', async () => {
-				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+			it('getPlans rejects a malformed groupId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
 
 				await expect(getPlans.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
 				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
-			it('getBuckets rejects a crafted (unvalidated) planId', async () => {
-				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+			it('getBuckets rejects a malformed planId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
 
 				await expect(getBuckets.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
 				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();
 			});
 
-			it('getMembers rejects a crafted groupId', async () => {
-				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(craftedId);
+			it('getMembers rejects a malformed groupId', async () => {
+				mockLoadOptions.getCurrentNodeParameter.mockReturnValue(malformedId);
 
 				await expect(getMembers.call(mockLoadOptions)).rejects.toThrow('The ID is not valid');
 				expect(loadOptionsRequestWithAuthentication).not.toHaveBeenCalled();

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -80,7 +80,7 @@ export function joinedTeamsEndpoint(
 // path separators (`/` `\`), query/fragment starters (`?` `#`), and control chars
 // (0x00–0x1F). `:` and `@` are ALLOWED — they are structure-neutral inside a single
 // Teams id segment (real channel ids look like `19:...@thread.tacv2`), and the proven
-// OAuth2 URL shape interpolates them raw. Validating the shape (not encoding) is what
+// Graph URL shape interpolates them raw. Validating the shape (not encoding) is what
 // keeps a value safe to interpolate raw. Messages are static so a rejected id is
 // never echoed back.
 // eslint-disable-next-line no-control-regex
@@ -88,11 +88,11 @@ const TEAMS_ID_REJECT = /[\x00-\x1f\/\\?#]/;
 
 /**
  * Validates a user-supplied Graph id (already `extractValue`-resolved) before it is
- * interpolated RAW into a Graph path. Throws a `NodeOperationError` with a fully
- * static message (never echoing the id) on a bad shape. Reused for both path IDs and
- * `task:create` body IDs (the latter validate-only — see `buildTeamsPath`).
+ * interpolated RAW into a Graph path, and returns the coerced + trimmed value.
+ * Throws a `NodeOperationError` with a fully static message (never echoing the id)
+ * on a bad shape. Reused for both path IDs and `task:create` body IDs.
  */
-export function validateTeamsId(id: string, node: INode): void {
+export function validateTeamsId(id: string, node: INode): string {
 	const value = String(id ?? '').trim();
 	if (value === '') {
 		throw new NodeOperationError(node, 'A required ID is empty', {
@@ -109,6 +109,7 @@ export function validateTeamsId(id: string, node: INode): void {
 			description: 'Remove any slashes, backslashes, question marks or hashes and try again.',
 		});
 	}
+	return value;
 }
 
 type TeamsPathSegment = string | { id: string };
@@ -116,25 +117,21 @@ type TeamsPathSegment = string | { id: string };
 /**
  * Single, non-bypassable path builder for every Graph path that interpolates a
  * user-supplied id. `segments` is an ordered mix of literal strings and id parts
- * (`{ id: value }`). Under SP each `{ id }` is validated then interpolated RAW;
- * under OAuth2 it is passed through verbatim. See `validateTeamsId` /
- * `TEAMS_ID_REJECT` for why validation (not encoding) is the guard.
+ * (`{ id: value }`). Every `{ id }` is validated then interpolated RAW, under
+ * both credential types. See `validateTeamsId` / `TEAMS_ID_REJECT` for why
+ * validation (not encoding) is the guard.
  */
 export function buildTeamsPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 	segments: TeamsPathSegment[],
 ): string {
-	const isServicePrincipal = getTeamsCredentialType.call(this) === SERVICE_PRINCIPAL_AUTH;
 	const node = this.getNode();
 	return segments
 		.map((segment) => {
 			if (typeof segment === 'string') return segment;
-			// `as string` at the call sites is compile-time only — an expression can resolve an
-			// id to a non-string (e.g. `={{ 123 }}` → number). OAuth2 passes through and is
-			// stringified by `join()`; the SP path must coerce before `.trim()` or it throws.
-			if (!isServicePrincipal) return segment.id;
-			validateTeamsId(segment.id, node);
-			return String(segment.id).trim();
+			// validateTeamsId coerces + trims — `as string` at the call sites is
+			// compile-time only, so an expression can resolve an id to a non-string.
+			return validateTeamsId(segment.id, node);
 		})
 		.join('');
 }
@@ -142,8 +139,8 @@ export function buildTeamsPath(
 /**
  * Shape-validates Planner body IDs (`planId`/`bucketId`) under SP for `task:create`
  * and `task:update`. These go into the JSON body (not a path), so this is
- * defense-in-depth — a malformed id is a bad request — NOT the path-injection fix
- * (that is `buildTeamsPath` on path-interpolated ids). No-op under OAuth2.
+ * defense-in-depth — a malformed id is a bad request; path-interpolated ids are
+ * guarded by `buildTeamsPath`. No-op under OAuth2.
  */
 export function validateTaskBodyIdsUnderSp(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,


### PR DESCRIPTION
## Summary

The Microsoft Teams node checks user-supplied IDs (team, channel, chat, plan, and so on) before putting them into a request address — but until now only when signed in as an app (Service Principal). When signed in as a person (OAuth2), IDs went into the address exactly as typed. This PR applies the same checking everywhere, under both sign-in methods:

- Every ID that goes into a request address is checked and trimmed first, whichever credential is in use.
- The trigger previously kept two copies of its address-building code, one per sign-in method — those collapse into one. A By-URL ID that can't be decoded now produces a clear error instead of a raw `URIError`.
- The chat message operations now build their addresses the same way as every other operation.

## Will existing workflows still work?

Yes.

- **IDs of the normal shape behave exactly as before.** Team and channel IDs, message numbers, planner IDs, and email addresses contain none of the characters the check rejects. Existing tests lock this in, and none of the node's 223 test fixtures needed an ID changed.
- **What changes:** an ID that is empty, only dots, or contains slashes, question marks or hashes now fails straight away with a plain message — the same one app sign-in users already get. Those values never produced a working request before; they built a malformed address that failed at Microsoft's end with a confusing error (a missing trigger team ID literally built the address `/teams/undefined/channels`). Failures now happen sooner and explain themselves.
- IDs with spaces around them are tidied up before use (they used to fail at Microsoft's end).
- Opening a dropdown before choosing its parent (for example Plan before Group) now shows "A required ID is empty" instead of an error from Microsoft.
- **Conclusion: no version bump needed.** No input that used to work behaves differently.

## How to test

1. Run existing Teams workflows with teams, channels, or chats chosen from the list or by URL, under both sign-in methods — no change.
2. Set an ID field to an expression that produces an empty value, or one containing `/` — the node fails immediately with a clear message instead of a remote API error.
3. Activate a Teams Trigger with a By-URL channel whose value contains a broken `%` sequence — a clear error instead of a `URIError`.

All 223 Teams tests pass; the ID-checking tests now cover the malformed, empty, non-text, and space-padded cases under both sign-in methods.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-120

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)