### PR TITLE
fix: Raise community stale workflow operations-per-run so it reaches recent PRs

### DIFF
--- a/.github/workflows/community-pr-close-stale.yml
+++ b/.github/workflows/community-pr-close-stale.yml
@@ -37,6 +37,7 @@ jobs:
           days-before-pr-close: 14
           stale-pr-label: 'Stale'
           close-pr-label: 'status:internal-closed'
+          operations-per-run: 1000 # default 30 exhausts on page fetches before reaching recent PRs
           # contributor activity resets the clock (remove-stale-when-updated defaults to true)
           ascending: true # oldest first
           debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}


### PR DESCRIPTION
## Summary

The `Community: Close Stale PRs` workflow never reaches recent PRs because it exhausts its `operations-per-run` budget (default **30**) on page-fetch operations before getting past the oldest end of the open-items list.

Today's scheduled run processed only 700 items before exiting:

```
##[warning] No more operations left! Exiting...
Statistics:
  Processed items: 700
  Operations performed: 30
```

With `ascending: true`, every run burns its 30 ops fetching events/comments for ancient issues and PRs (#4539, #5178, ...) and never reaches candidates further down the list (e.g. #31433).

## Changes

- Set `operations-per-run: 1000` on the `actions/stale` step. The actual write-op count stays low because only PRs with `triage:needs-info` / `triage:tests-needed` / `Needs Feedback` are acted on — the budget is mostly consumed by paging through all open items, which the action always does.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34070">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

