### PR TITLE
feat(AWS Bedrock Chat Model Node): Add Timeout option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/LmChatAwsBedrock.node.ts
@@ -245,6 +245,14 @@ export class LmChatAwsBedrock implements INodeType {
 						type: 'number',
 					},
 					{
+						displayName: 'Timeout',
+						name: 'timeout',
+						default: 60000,
+						description:
+							'Maximum amount of time a request is allowed to take in milliseconds. Increase this for long generations; set to 0 to disable.',
+						type: 'number',
+					},
+					{
 						displayName: 'Additional Model Request Fields',
 						name: 'additionalModelRequestFields',
 						default: '{}',
@@ -323,6 +331,7 @@ export class LmChatAwsBedrock implements INodeType {
 			maxTokensToSample?: number;
 			topP?: number;
 			maxRetries?: number;
+			timeout?: number;
 			additionalModelRequestFields?: string;
 			latency?: PerformanceConfigLatency;
 			guardrail?: {
@@ -346,8 +355,13 @@ export class LmChatAwsBedrock implements INodeType {
 			region = arnRegion;
 		}
 
-		// Pass the pre-configured client to avoid credential resolution proxy issues
-		const client = createBedrockRuntimeClient({ region, credentials, bedrockRuntimeEndpoint });
+		const client = createBedrockRuntimeClient({
+			region,
+			credentials,
+			bedrockRuntimeEndpoint,
+			maxRetries: options.maxRetries,
+			timeout: options.timeout,
+		});
 
 		// Forward only user-set options; unset ones are omitted so model defaults are preserved.
 		const modelConfig: ChatBedrockConverseInput = {
@@ -361,7 +375,6 @@ export class LmChatAwsBedrock implements INodeType {
 		if (options.temperature !== undefined) modelConfig.temperature = options.temperature;
 		if (options.maxTokensToSample !== undefined) modelConfig.maxTokens = options.maxTokensToSample;
 		if (options.topP !== undefined) modelConfig.topP = options.topP;
-		if (options.maxRetries !== undefined) modelConfig.maxRetries = options.maxRetries;
 		if (options.latency !== undefined) modelConfig.performanceConfig = { latency: options.latency };
 
 		const guardrail = options.guardrail?.values;

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAwsBedrock/test/LmChatAwsBedrock.test.ts
@@ -1,10 +1,12 @@
 import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { ChatBedrockConverse } from '@langchain/aws';
 import { makeN8nLlmFailedAttemptHandler, getNodeProxyAgent } from '@n8n/ai-utilities';
-import { resolveAwsCredentials } from '@utils/aws/resolveAwsCredentials';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
 import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
 import { UserError, type INode, type ISupplyDataFunctions } from 'n8n-workflow';
 import type { Mocked } from 'vitest';
+
+import { resolveAwsCredentials } from '@utils/aws/resolveAwsCredentials';
 
 import { LmChatAwsBedrock } from '../LmChatAwsBedrock.node';
 
@@ -25,7 +27,12 @@ vi.mock('@utils/aws/resolveAwsCredentials', () => ({
 vi.mock('@aws-sdk/client-bedrock-runtime', () => ({
 	BedrockRuntimeClient: vi.fn(),
 }));
+vi.mock('@smithy/node-http-handler', () => ({
+	NodeHttpHandler: vi.fn(),
+}));
+
 const MockedBedrockRuntimeClient = vi.mocked(BedrockRuntimeClient);
+const MockedNodeHttpHandler = vi.mocked(NodeHttpHandler);
 const MockedChatBedrockConverse = vi.mocked(ChatBedrockConverse);
 const mockedMakeN8nLlmFailedAttemptHandler = vi.mocked(makeN8nLlmFailedAttemptHandler);
 const mockedGetNodeProxyAgent = vi.mocked(getNodeProxyAgent);
@@ -269,7 +276,6 @@ describe('LmChatAwsBedrock', () => {
 				expect(MockedChatBedrockConverse).toHaveBeenCalledWith(
 					expect.objectContaining({
 						topP: 0.9,
-						maxRetries: 5,
 						performanceConfig: { latency: 'optimized' },
 						guardrailConfig: {
 							guardrailIdentifier: 'gr-123',
@@ -278,6 +284,26 @@ describe('LmChatAwsBedrock', () => {
 						},
 						additionalModelRequestFields: { top_k: 50 },
 					}),
+				);
+				// Retries are configured on the SDK client, since ChatBedrockConverse
+				// bypasses LangChain's retrying caller.
+				expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+					expect.objectContaining({ maxAttempts: 6 }),
+				);
+			});
+
+			it('maps Max Retries 0 to a single SDK attempt', async () => {
+				const ctx = setupMockContext();
+				ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+					if (paramName === 'model') return 'amazon.nova-pro-v1:0';
+					if (paramName === 'options') return { maxRetries: 0 };
+					return undefined;
+				});
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedBedrockRuntimeClient).toHaveBeenCalledWith(
+					expect.objectContaining({ maxAttempts: 1 }),
 				);
 			});
 
@@ -297,6 +323,9 @@ describe('LmChatAwsBedrock', () => {
 				expect(config).not.toHaveProperty('performanceConfig');
 				expect(config).not.toHaveProperty('guardrailConfig');
 				expect(config).not.toHaveProperty('additionalModelRequestFields');
+				// Unset Max Retries keeps the SDK's default retry strategy.
+				const clientConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0] ?? {};
+				expect(clientConfig).not.toHaveProperty('maxAttempts');
 			});
 
 			it('throws a UserError when additionalModelRequestFields is invalid JSON', async () => {
@@ -363,6 +392,85 @@ describe('LmChatAwsBedrock', () => {
 				expect(mockedGetNodeProxyAgent).toHaveBeenCalledWith(
 					'https://bedrock-runtime.eu-west-3.amazonaws.com',
 				);
+			});
+		});
+
+		describe('request handler (timeout & proxy)', () => {
+			const setNodeParameters = (options: Record<string, unknown>) => {
+				mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+					if (paramName === 'model') return 'amazon.nova-pro-v1:0';
+					if (paramName === 'options') return options;
+					return undefined;
+				});
+			};
+
+			it('creates a handler with requestTimeout when timeout is set and no proxy is configured', async () => {
+				const ctx = setupMockContext();
+				setNodeParameters({ timeout: 120000 });
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
+					requestTimeout: 120000,
+					throwOnRequestTimeout: true,
+				});
+				const clientConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0];
+				expect(clientConfig?.requestHandler).toBe(MockedNodeHttpHandler.mock.instances.at(-1));
+			});
+
+			it('merges timeout and proxy agents into a single handler', async () => {
+				const ctx = setupMockContext();
+				const fakeAgent = { fake: 'agent' } as unknown as ReturnType<typeof getNodeProxyAgent>;
+				mockedGetNodeProxyAgent.mockReturnValue(fakeAgent);
+				setNodeParameters({ timeout: 30000 });
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedNodeHttpHandler).toHaveBeenCalledTimes(1);
+				expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
+					httpAgent: fakeAgent,
+					httpsAgent: fakeAgent,
+					requestTimeout: 30000,
+					throwOnRequestTimeout: true,
+				});
+			});
+
+			it('creates a proxy-only handler without timeout keys when timeout is unset', async () => {
+				const ctx = setupMockContext();
+				const fakeAgent = { fake: 'agent' } as unknown as ReturnType<typeof getNodeProxyAgent>;
+				mockedGetNodeProxyAgent.mockReturnValue(fakeAgent);
+				setNodeParameters({});
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedNodeHttpHandler).toHaveBeenCalledTimes(1);
+				const handlerOptions = MockedNodeHttpHandler.mock.calls.at(-1)?.[0] ?? {};
+				expect(handlerOptions).toEqual({ httpAgent: fakeAgent, httpsAgent: fakeAgent });
+				expect(handlerOptions).not.toHaveProperty('requestTimeout');
+				expect(handlerOptions).not.toHaveProperty('throwOnRequestTimeout');
+			});
+
+			it('creates no handler at all when neither timeout nor proxy is configured', async () => {
+				const ctx = setupMockContext();
+				setNodeParameters({});
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedNodeHttpHandler).not.toHaveBeenCalled();
+				const clientConfig = MockedBedrockRuntimeClient.mock.calls.at(-1)?.[0] ?? {};
+				expect(clientConfig).not.toHaveProperty('requestHandler');
+			});
+
+			it('passes timeout 0 through as a disabled requestTimeout', async () => {
+				const ctx = setupMockContext();
+				setNodeParameters({ timeout: 0 });
+
+				await node.supplyData.call(ctx, 0);
+
+				expect(MockedNodeHttpHandler).toHaveBeenCalledWith({
+					requestTimeout: 0,
+					throwOnRequestTimeout: true,
+				});
 			});
 		});
 

--- a/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
@@ -50,7 +50,9 @@ export function createBedrockRuntimeClient(params: {
 	}
 	if (timeout !== undefined) {
 		requestHandlerOptions.requestTimeout = timeout;
-		// Without this flag smithy only logs a warning on breach instead of failing the request.
+		// requestTimeout alone is a no-op. When the timeout is exceeded,
+		// smithy only prints a warning to the console and keeps waiting;
+		// only this flag makes it destroy the request and reject with a TimeoutError.
 		requestHandlerOptions.throwOnRequestTimeout = true;
 	}
 	if (Object.keys(requestHandlerOptions).length > 0) {

--- a/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
+++ b/packages/@n8n/nodes-langchain/utils/aws/createBedrockRuntimeClient.ts
@@ -3,7 +3,7 @@ import {
 	type BedrockRuntimeClientConfig,
 } from '@aws-sdk/client-bedrock-runtime';
 import { getNodeProxyAgent } from '@n8n/ai-utilities';
-import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { NodeHttpHandler, type NodeHttpHandlerOptions } from '@smithy/node-http-handler';
 import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smithy/types';
 import {
 	getAwsDomain,
@@ -15,13 +15,17 @@ import {
  * Builds a Bedrock runtime SDK client shared by the chat and embeddings nodes.
  * The runtime plane bypasses n8n's credential `authenticate()` (the SDK does its own
  * signing/transport), so the endpoint override is injected into the client config here.
+ * Retries (`maxRetries`) and request `timeout` are also applied on the SDK client because
+ * ChatBedrockConverse calls `client.send()` directly, bypassing LangChain's retrying AsyncCaller.
  */
 export function createBedrockRuntimeClient(params: {
 	region: AWSRegion;
 	credentials: AwsCredentialIdentity | AwsCredentialIdentityProvider;
 	bedrockRuntimeEndpoint?: string;
+	maxRetries?: number;
+	timeout?: number;
 }): BedrockRuntimeClient {
-	const { region, credentials, bedrockRuntimeEndpoint } = params;
+	const { region, credentials, bedrockRuntimeEndpoint, maxRetries, timeout } = params;
 
 	// getAwsDomain keeps China (amazonaws.com.cn) / GovCloud endpoints correct.
 	const endpoint = bedrockRuntimeEndpoint
@@ -35,11 +39,22 @@ export function createBedrockRuntimeClient(params: {
 		// Set endpoint only for overrides; otherwise let the SDK derive its default.
 		...(bedrockRuntimeEndpoint ? { endpoint } : {}),
 	};
+
+	// maxAttempts counts the initial try, so it's maxRetries + 1.
+	if (maxRetries !== undefined) clientConfig.maxAttempts = maxRetries + 1;
+
+	const requestHandlerOptions: NodeHttpHandlerOptions = {};
 	if (proxyAgent) {
-		clientConfig.requestHandler = new NodeHttpHandler({
-			httpAgent: proxyAgent,
-			httpsAgent: proxyAgent,
-		});
+		requestHandlerOptions.httpAgent = proxyAgent;
+		requestHandlerOptions.httpsAgent = proxyAgent;
+	}
+	if (timeout !== undefined) {
+		requestHandlerOptions.requestTimeout = timeout;
+		// Without this flag smithy only logs a warning on breach instead of failing the request.
+		requestHandlerOptions.throwOnRequestTimeout = true;
+	}
+	if (Object.keys(requestHandlerOptions).length > 0) {
+		clientConfig.requestHandler = new NodeHttpHandler(requestHandlerOptions);
 	}
 
 	return new BedrockRuntimeClient(clientConfig);


### PR DESCRIPTION
## Summary

The AWS Bedrock Chat Model node had no way to bound how long a request may take: its `BedrockRuntimeClient` was created without any request deadline, so a silently dropped TCP connection (e.g. a NAT gateway idle-timeout killing the connection mid-generation) left AI Agent executions hanging indefinitely, with no error and therefore no retries.

This PR:

- **Adds a `Timeout` option** to the node's Options collection (default 60000 ms when added, `0` = disabled), matching the OpenAI Chat Model node. It is threaded into the Bedrock client via `NodeHttpHandler`'s `requestTimeout`. The handler construction is merged with the existing proxy-agent handler so proxy and timeout compose instead of one clobbering the other. When the option is unset, no custom handler is created and behavior is unchanged. `throwOnRequestTimeout: true` is important. Only with this flag the request get destroyed and rejected with a `TimeoutError`. 
- **Makes `Max Retries` actually work.** `ChatBedrockConverse` calls `client.send()` directly and bypasses LangChain's retrying `AsyncCaller`, so the existing `maxRetries` pass-through was dead code — retries were always governed by the AWS SDK's default (3 attempts) regardless of the option. The option is now mapped to the SDK client's `maxAttempts` (`maxRetries + 1`); unset keeps the SDK default.

Notes for reviewers:
- With a timeout and retries configured, total wall time before failure is up to `(maxRetries + 1) × timeout`.

## How to test

Without burning tokens, using a local mock:

1. Run a local HTTP server that accepts requests and never responds (a "blackhole", simulating a dead connection).
2. Start n8n with `AWS_ENDPOINT_URL_BEDROCK_RUNTIME=<created server>` and create an AWS credential with dummy keys (ignore the failed credential test).
3. Build a workflow: Manual Trigger → Basic LLM Chain with an AWS Bedrock Chat Model attached.
   - **Timeout 5000, Max Retries 0** → fails after ~5 s with a `TimeoutError` (`ETIMEDOUT`)
   - **Timeout 5000, Max Retries 2** → fails after ~15 s
   - **No Timeout set** → hangs indefinitely (pre-existing behavior, preserved intentionally since the option is opt-in).

<img width="1083" height="685" alt="mockTimeout" src="https://github.com/user-attachments/assets/83fc83fe-3c3c-4315-8f06-9e4a6e473339" />



With real credentials: set Timeout to small value (e.g. `100`) and observe a fast `TimeoutError` instead of a completed request; unset it and the request completes.

<img width="1142" height="615" alt="realTimeout1s" src="https://github.com/user-attachments/assets/9e89d219-3944-46fe-b72e-285fd6cd68e8" />

<img width="1241" height="634" alt="realTimeout100ms" src="https://github.com/user-attachments/assets/67253d42-f1d2-48f4-96d4-f6f264553350" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-195

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


