### PR TITLE
fix(core): Bind dynamic credential tokens to a user ID

### DIFF
--- a/packages/cli/src/auth/__tests__/auth-service-browser-id-whitelist.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-service-browser-id-whitelist.test.ts
@@ -49,5 +49,11 @@ describe('AuthService Browser ID Whitelist', () => {
 			expect(skipEndpoints).toContain('/rest/oauth1-credential/callback');
 			expect(skipEndpoints).toContain('/rest/oauth2-credential/callback');
 		});
+
+		it('should include the dynamic-credential authorize link in the skip browser ID check endpoints', () => {
+			const skipEndpoints = (authService as any).skipBrowserIdCheckEndpoints;
+
+			expect(skipEndpoints).toContain('/rest/credentials/:id/authorize');
+		});
 	});
 });

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -84,6 +84,11 @@ export class AuthService {
 			`/${restEndpoint}/oauth1-credential/callback`,
 			`/${restEndpoint}/oauth2-credential/callback`,
 
+			// The dynamic-credential authorize link is a top-level browser navigation
+			// (link click / redirect), so it can't carry the browser-id header. The
+			// GET method guard below keeps this GET-only; POST authorize is unaffected.
+			`/${restEndpoint}/credentials/:id/authorize`,
+
 			// Skip browser ID check for type files
 			'/types/nodes.json',
 			'/types/credentials.json',

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -137,6 +137,7 @@ export const eventNamesAudit = [
 	'n8n.audit.cluster.instance-joined',
 	'n8n.audit.cluster.instance-left',
 	'n8n.audit.oauth.callback.binding.rejected',
+	'n8n.audit.credentials.authorize.rejected',
 ] as const;
 
 export type EventNamesWorkflowType = (typeof eventNamesWorkflow)[number];

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -483,6 +483,11 @@ export type RelayEventMap = {
 		origin?: 'static-credential' | 'dynamic-credential';
 	};
 
+	'dynamic-credential-authorize-rejected': {
+		reason: 'unauthenticated' | 'user-mismatch';
+		credentialId?: string;
+	};
+
 	'private-credential-created': {
 		user: UserLike;
 		credentialType: string;

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -80,6 +80,8 @@ export class LogStreamingEventRelay extends EventRelay {
 			'credentials-shared': (event) => this.credentialsShared(event),
 			'credentials-updated': (event) => this.credentialsUpdated(event),
 			'oauth-callback-binding-rejected': (event) => this.oauthCallbackBindingRejected(event),
+			'dynamic-credential-authorize-rejected': (event) =>
+				this.dynamicCredentialAuthorizeRejected(event),
 			'variable-created': (event) => this.variableCreated(event),
 			'variable-updated': (event) => this.variableUpdated(event),
 			'variable-deleted': (event) => this.variableDeleted(event),
@@ -671,6 +673,15 @@ export class LogStreamingEventRelay extends EventRelay {
 	) {
 		void this.eventBus.sendAuditEvent({
 			eventName: 'n8n.audit.oauth.callback.binding.rejected',
+			payload: event,
+		});
+	}
+
+	private dynamicCredentialAuthorizeRejected(
+		event: RelayEventMap['dynamic-credential-authorize-rejected'] /* no user context: clicker is unauthenticated or mismatched */,
+	) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.credentials.authorize.rejected',
 			payload: event,
 		});
 	}

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -16,8 +16,10 @@ import {
 	AuthorizeIntentService,
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
+	DynamicCredentialService,
 } from '@/modules/dynamic-credentials.ee/services';
 import { OauthService } from '@/oauth/oauth.service';
+import { UrlService } from '@/services/url.service';
 
 import { DynamicCredentialWebService } from '../services/dynamic-credential-web.service';
 
@@ -36,8 +38,10 @@ describe('DynamicCredentialsController', () => {
 	const cipher = mockInstance(Cipher);
 	const authorizeIntentService = mockInstance(AuthorizeIntentService);
 	const credentialsFinderService = mockInstance(CredentialsFinderService);
+	const dynamicCredentialService = mockInstance(DynamicCredentialService);
+	const urlService = mockInstance(UrlService);
+	const eventService = mockInstance(EventService);
 	mockInstance(CredentialConnectionStatusService);
-	mockInstance(EventService);
 
 	mockInstance(Logger);
 
@@ -56,6 +60,12 @@ describe('DynamicCredentialsController', () => {
 			version: 1 as const,
 			metadata: {},
 		});
+
+		// Default: resolver does not map the link to an n8n user (link stays unbound).
+		dynamicCredentialService.resolveOwningUserIdForAuthorization.mockResolvedValue({
+			status: 'unbound',
+		});
+		urlService.getInstanceBaseUrl.mockReturnValue('http://localhost:5678');
 
 		// Default: caller can access the credential
 		credentialsFinderService.findCredentialForUser.mockResolvedValue(mock<CredentialsEntity>());
@@ -354,6 +364,62 @@ describe('DynamicCredentialsController', () => {
 
 			expect(cipher.decryptV2).not.toHaveBeenCalled();
 		});
+
+		it('sets the state userId when the resolver binds the link to a user', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			dynamicCredentialService.resolveOwningUserIdForAuthorization.mockResolvedValue({
+				status: 'bound',
+				userId: 'user-1',
+			});
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(oauthService.generateAOauth2AuthUri).toHaveBeenCalledWith(
+				mockCredential,
+				expect.objectContaining({ userId: 'user-1' }),
+				req,
+				res,
+			);
+		});
+
+		it('leaves the state userId unset when the link is unbound', async () => {
+			const mockCredential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
+			const req = mock<Request>({
+				params: { id: '1' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			resolverRepository.findOneBy.mockResolvedValue(mockResolverEntity);
+			resolverRegistry.getResolverByTypename.mockReturnValue(mockResolver);
+			oauthService.generateAOauth2AuthUri.mockResolvedValueOnce(
+				'https://example.domain/oauth2/auth',
+			);
+
+			await controller.authorizeCredential(req, res);
+
+			expect(oauthService.generateAOauth2AuthUri).toHaveBeenCalledWith(
+				mockCredential,
+				expect.objectContaining({ userId: undefined }),
+				req,
+				res,
+			);
+		});
 	});
 
 	describe('authorizeCredentialRedirect', () => {
@@ -474,6 +540,122 @@ describe('DynamicCredentialsController', () => {
 
 			expect(oauthService.renderCallbackError).toHaveBeenCalledWith(res, 'discovery failed');
 			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
+		it('proceeds when a bound link is opened by the intended user', async () => {
+			const req = mock<AuthenticatedRequest>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-1' }),
+			});
+			const res = mock<Response>();
+			const mockCredential = mock<CredentialsEntity>({ id: 'cred-1', type: 'googleOAuth2Api' });
+
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				userId: 'user-1',
+				metadata: {},
+			});
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			oauthService.generateAOauth2AuthUri.mockResolvedValue('https://accounts.google.com/auth?x=1');
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(oauthService.generateAOauth2AuthUri).toHaveBeenCalledWith(
+				mockCredential,
+				expect.objectContaining({ userId: 'user-1' }),
+				req,
+				res,
+			);
+			expect(res.redirect).toHaveBeenCalledWith('https://accounts.google.com/auth?x=1');
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('redirects an anonymous clicker of a bound link to sign in', async () => {
+			const req = mock<Request>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				originalUrl: '/rest/credentials/cred-1/authorize?token=tok',
+			});
+			const res = mock<Response>();
+
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				userId: 'user-1',
+				metadata: {},
+			});
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(eventService.emit).toHaveBeenCalledWith('dynamic-credential-authorize-rejected', {
+				reason: 'unauthenticated',
+				credentialId: 'cred-1',
+			});
+			expect(res.redirect).toHaveBeenCalledWith(
+				`http://localhost:5678/signin?redirect=${encodeURIComponent(
+					'http://localhost:5678/rest/credentials/cred-1/authorize?token=tok',
+				)}`,
+			);
+			expect(oauthService.generateAOauth2AuthUri).not.toHaveBeenCalled();
+		});
+
+		it('rejects a bound link opened by a different account', async () => {
+			const req = mock<AuthenticatedRequest>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-2' }),
+			});
+			const res = mock<Response>();
+
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				userId: 'user-1',
+				metadata: {},
+			});
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(eventService.emit).toHaveBeenCalledWith('dynamic-credential-authorize-rejected', {
+				reason: 'user-mismatch',
+				credentialId: 'cred-1',
+			});
+			expect(oauthService.renderCallbackError).toHaveBeenCalledWith(
+				res,
+				'This authorization link was issued for a different account. Sign in as the intended user and open the link again.',
+			);
+			expect(res.redirect).not.toHaveBeenCalled();
+			expect(oauthService.generateAOauth2AuthUri).not.toHaveBeenCalled();
+		});
+
+		it('proceeds unchanged for an unbound intent regardless of clicker', async () => {
+			const req = mock<AuthenticatedRequest>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				user: mock<AuthenticatedRequest['user']>({ id: 'some-other-user' }),
+			});
+			const res = mock<Response>();
+			const mockCredential = mock<CredentialsEntity>({ id: 'cred-1', type: 'googleOAuth2Api' });
+
+			// No userId on the intent → link is unbound.
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				metadata: {},
+			});
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			oauthService.generateAOauth2AuthUri.mockResolvedValue('https://accounts.google.com/auth?x=1');
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(res.redirect).toHaveBeenCalledWith('https://accounts.google.com/auth?x=1');
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -573,6 +573,66 @@ describe('DynamicCredentialsController', () => {
 			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
+		it('proceeds through the OAuth1 flow when a bound link is opened by the intended user', async () => {
+			const req = mock<AuthenticatedRequest>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-1' }),
+			});
+			const res = mock<Response>();
+			const mockCredential = mock<CredentialsEntity>({ id: 'cred-1', type: 'twitterOAuth1Api' });
+
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				userId: 'user-1',
+				metadata: {},
+			});
+			enterpriseCredentialsService.getOne.mockResolvedValue(mockCredential);
+			oauthService.generateAOauth1AuthUri.mockResolvedValue(
+				'https://api.twitter.com/oauth/authorize?x=1',
+			);
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(oauthService.generateAOauth1AuthUri).toHaveBeenCalledWith(
+				mockCredential,
+				expect.objectContaining({ userId: 'user-1' }),
+				req,
+				res,
+			);
+			expect(oauthService.generateAOauth2AuthUri).not.toHaveBeenCalled();
+			expect(res.redirect).toHaveBeenCalledWith('https://api.twitter.com/oauth/authorize?x=1');
+			expect(eventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('rejects a bound OAuth1 link opened by a different account before materializing the flow', async () => {
+			const req = mock<AuthenticatedRequest>({
+				params: { id: 'cred-1' },
+				query: { token: 'tok' },
+				user: mock<AuthenticatedRequest['user']>({ id: 'user-2' }),
+			});
+			const res = mock<Response>();
+
+			authorizeIntentService.get.mockResolvedValue({
+				credentialId: 'cred-1',
+				resolverId: 'resolver-123',
+				identity: 'bearer-jwt',
+				userId: 'user-1',
+				metadata: {},
+			});
+
+			await controller.authorizeCredentialRedirect(req, res);
+
+			expect(eventService.emit).toHaveBeenCalledWith('dynamic-credential-authorize-rejected', {
+				reason: 'user-mismatch',
+				credentialId: 'cred-1',
+			});
+			expect(oauthService.generateAOauth1AuthUri).not.toHaveBeenCalled();
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
 		it('redirects an anonymous clicker of a bound link to sign in', async () => {
 			const req = mock<Request>({
 				params: { id: 'cred-1' },

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -1,11 +1,11 @@
 import { Time } from '@n8n/constants';
-import { Delete, Get, Options, Param, Post, RestController } from '@n8n/decorators';
 import { CredentialsEntity, AuthenticatedRequest, isAuthenticatedRequest, User } from '@n8n/db';
-import type { Scope } from '@n8n/permissions';
+import { Delete, Get, Options, Param, Post, RestController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import type { Scope } from '@n8n/permissions';
+import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { Request, Response } from 'express';
 import { Cipher } from 'n8n-core';
-import { ensureError } from '@n8n/utils/errors/ensure-error';
 import { jsonParse } from 'n8n-workflow';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
@@ -177,7 +177,6 @@ export class DynamicCredentialsController {
 			});
 		}
 
-		console.log('SECURITY_DEBUG: authorizeCredential called');
 		// Best-effort: bind the callback to the intended n8n user when the resolver
 		// names one, so `decodeCsrfState` rejects a mismatched session. External
 		// machine callers legitimately have no n8n user, so this never fails the POST.
@@ -185,7 +184,6 @@ export class DynamicCredentialsController {
 			credentialContext,
 			resolverEntity.id,
 		);
-		console.log('SECURITY_DEBUG: authorizeCredential ownership:', ownership);
 
 		const csrfData: CreateCsrfStateData = {
 			cid: credential.id,
@@ -242,7 +240,6 @@ export class DynamicCredentialsController {
 			return;
 		}
 
-		console.log('SECURITY_DEBUG: authorizeCredentialRedirect called');
 		// When the link is bound to an n8n user, the clicker must be that user.
 		if (intent.userId) {
 			const user = isAuthenticatedRequest(req) ? req.user : undefined;

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -14,6 +14,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { EventService } from '@/events/event.service';
 import { CreateCsrfStateData, OauthService } from '@/oauth/oauth.service';
+import { UrlService } from '@/services/url.service';
 
 import { DynamicCredentialResolverRepository } from './database/repositories/credential-resolver.repository';
 import { DynamicCredentialsConfig } from './dynamic-credentials.config';
@@ -21,6 +22,7 @@ import {
 	AuthorizeIntentService,
 	CredentialConnectionStatusService,
 	DynamicCredentialResolverRegistry,
+	DynamicCredentialService,
 } from './services';
 import { DynamicCredentialCorsService } from './services/dynamic-credential-cors.service';
 import { DynamicCredentialWebService } from './services/dynamic-credential-web.service';
@@ -42,6 +44,8 @@ export class DynamicCredentialsController {
 		private readonly credentialConnectionStatusService: CredentialConnectionStatusService,
 		private readonly eventService: EventService,
 		private readonly authorizeIntentService: AuthorizeIntentService,
+		private readonly dynamicCredentialService: DynamicCredentialService,
+		private readonly urlService: UrlService,
 	) {}
 
 	private async findCredentialToUse(
@@ -173,12 +177,23 @@ export class DynamicCredentialsController {
 			});
 		}
 
+		console.log('SECURITY_DEBUG: authorizeCredential called');
+		// Best-effort: bind the callback to the intended n8n user when the resolver
+		// names one, so `decodeCsrfState` rejects a mismatched session. External
+		// machine callers legitimately have no n8n user, so this never fails the POST.
+		const ownership = await this.dynamicCredentialService.resolveOwningUserIdForAuthorization(
+			credentialContext,
+			resolverEntity.id,
+		);
+		console.log('SECURITY_DEBUG: authorizeCredential ownership:', ownership);
+
 		const csrfData: CreateCsrfStateData = {
 			cid: credential.id,
 			origin: 'dynamic-credential',
 			authorizationHeader: req.headers.authorization ?? `Bearer ${credentialContext.identity}`,
 			authMetadata: credentialContext.metadata,
 			credentialResolverId: req.query.resolverId,
+			userId: ownership.status === 'bound' ? ownership.userId : undefined,
 		};
 
 		if (credential.type.toLowerCase().includes('oauth2')) {
@@ -227,6 +242,37 @@ export class DynamicCredentialsController {
 			return;
 		}
 
+		console.log('SECURITY_DEBUG: authorizeCredentialRedirect called');
+		// When the link is bound to an n8n user, the clicker must be that user.
+		if (intent.userId) {
+			const user = isAuthenticatedRequest(req) ? req.user : undefined;
+
+			if (!user) {
+				this.eventService.emit('dynamic-credential-authorize-rejected', {
+					reason: 'unauthenticated',
+					credentialId: intent.credentialId,
+				});
+				// Absolute, same-origin http(s) URL so SigninView returns here after login.
+				const returnUrl = `${this.urlService.getInstanceBaseUrl()}${req.originalUrl}`;
+				res.redirect(
+					`${this.urlService.getInstanceBaseUrl()}/signin?redirect=${encodeURIComponent(returnUrl)}`,
+				);
+				return;
+			}
+
+			if (user.id !== intent.userId) {
+				this.eventService.emit('dynamic-credential-authorize-rejected', {
+					reason: 'user-mismatch',
+					credentialId: intent.credentialId,
+				});
+				this.oauthService.renderCallbackError(
+					res,
+					'This authorization link was issued for a different account. Sign in as the intended user and open the link again.',
+				);
+				return;
+			}
+		}
+
 		try {
 			const credential = await this.findCredentialToUse(intent.credentialId);
 
@@ -236,6 +282,7 @@ export class DynamicCredentialsController {
 				authorizationHeader: intent.identity ? `Bearer ${intent.identity}` : '',
 				authMetadata: intent.metadata,
 				credentialResolverId: intent.resolverId,
+				userId: intent.userId,
 			};
 
 			const authorizationUrl = credential.type.toLowerCase().includes('oauth2')

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -1,8 +1,9 @@
-import { TriggerAuthIdentitySeederProxy } from '@/services/trigger-auth-identity-seeder-proxy.service';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+
+import { TriggerAuthIdentitySeederProxy } from '@/services/trigger-auth-identity-seeder-proxy.service';
 
 /**
  * Superset capability: external/custom credential resolvers (OAuth/Slack) plus

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-check-proxy.service.test.ts
@@ -10,6 +10,7 @@ import { CredentialsEntity } from '@n8n/db';
 import type { AuthorizeIntentService } from '../authorize-intent.service';
 import type { CredentialResolverWorkflowService } from '../credential-resolver-workflow.service';
 import { CredentialCheckProxyService } from '../credential-check-proxy.service';
+import type { DynamicCredentialService } from '../dynamic-credential.service';
 
 const createMockCredentialEntity = (
 	overrides: Partial<CredentialsEntity> = {},
@@ -37,6 +38,7 @@ describe('CredentialCheckProxyService', () => {
 	let mockExecutionContextService: Mocked<ExecutionContextService>;
 	let mockEnterpriseCredentialsService: Mocked<EnterpriseCredentialsService>;
 	let mockAuthorizeIntentService: Mocked<AuthorizeIntentService>;
+	let mockDynamicCredentialService: Mocked<DynamicCredentialService>;
 	let mockUrlService: Mocked<UrlService>;
 
 	const executionContext: IExecutionContext = {
@@ -76,6 +78,10 @@ describe('CredentialCheckProxyService', () => {
 			create: vi.fn().mockResolvedValue('intent-token'),
 		} as unknown as Mocked<AuthorizeIntentService>;
 
+		mockDynamicCredentialService = {
+			resolveOwningUserIdForAuthorization: vi.fn().mockResolvedValue({ status: 'unbound' }),
+		} as unknown as Mocked<DynamicCredentialService>;
+
 		mockUrlService = {
 			getInstanceBaseUrl: vi.fn().mockReturnValue('http://localhost:5678'),
 		} as unknown as Mocked<UrlService>;
@@ -87,6 +93,7 @@ describe('CredentialCheckProxyService', () => {
 			mockExecutionContextService,
 			mockEnterpriseCredentialsService,
 			mockAuthorizeIntentService,
+			mockDynamicCredentialService,
 			mockUrlService,
 			globalConfig,
 		);
@@ -285,6 +292,81 @@ describe('CredentialCheckProxyService', () => {
 
 			expect(result.credentials[0].authorizationUrl).toBeUndefined();
 			expect(mockAuthorizeIntentService.create).not.toHaveBeenCalled();
+		});
+
+		it('should bind the intent to the resolved user when the resolver names one', async () => {
+			mockDynamicCredentialService.resolveOwningUserIdForAuthorization.mockResolvedValue({
+				status: 'bound',
+				userId: 'user-1',
+			});
+			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'OAuth2 API',
+					credentialType: 'oauth2Api',
+					resolverId: 'resolver-1',
+					status: 'missing',
+				},
+			]);
+			mockEnterpriseCredentialsService.getOne.mockResolvedValue(
+				createMockCredentialEntity({ id: 'cred-1', type: 'oauth2Api' }),
+			);
+
+			await service.checkCredentialStatus('workflow-1', executionContext);
+
+			expect(mockAuthorizeIntentService.create).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: 'user-1' }),
+			);
+		});
+
+		it('should not issue a link when the owning user cannot be resolved', async () => {
+			mockDynamicCredentialService.resolveOwningUserIdForAuthorization.mockResolvedValue({
+				status: 'unresolved',
+			});
+			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'OAuth2 API',
+					credentialType: 'oauth2Api',
+					resolverId: 'resolver-1',
+					status: 'missing',
+				},
+			]);
+			mockEnterpriseCredentialsService.getOne.mockResolvedValue(
+				createMockCredentialEntity({ id: 'cred-1', type: 'oauth2Api' }),
+			);
+
+			const result = await service.checkCredentialStatus('workflow-1', executionContext);
+
+			expect(result.credentials[0].authorizationUrl).toBeUndefined();
+			expect(mockAuthorizeIntentService.create).not.toHaveBeenCalled();
+		});
+
+		it('should issue an unbound link when the resolver does not map to a user', async () => {
+			mockDynamicCredentialService.resolveOwningUserIdForAuthorization.mockResolvedValue({
+				status: 'unbound',
+			});
+			mockCredentialResolverWorkflowService.getWorkflowStatus.mockResolvedValue([
+				{
+					credentialId: 'cred-1',
+					credentialName: 'OAuth2 API',
+					credentialType: 'oauth2Api',
+					resolverId: 'resolver-1',
+					status: 'missing',
+				},
+			]);
+			mockEnterpriseCredentialsService.getOne.mockResolvedValue(
+				createMockCredentialEntity({ id: 'cred-1', type: 'oauth2Api' }),
+			);
+
+			const result = await service.checkCredentialStatus('workflow-1', executionContext);
+
+			expect(result.credentials[0].authorizationUrl).toBe(
+				'http://localhost:5678/rest/credentials/cred-1/authorize?token=intent-token',
+			);
+			expect(mockAuthorizeIntentService.create).toHaveBeenCalledWith(
+				expect.objectContaining({ userId: undefined }),
+			);
 		});
 
 		it('should return readyToExecute:true for empty credentials list', async () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential.service.test.ts
@@ -1269,4 +1269,78 @@ describe('DynamicCredentialService', () => {
 			expect(service.getSystemResolverId()).toBe('system-n8n');
 		});
 	});
+
+	describe('resolveOwningUserIdForAuthorization', () => {
+		it('returns unbound when the resolver does not map to an n8n user', async () => {
+			mockResolverRepository.findOneBy.mockResolvedValue(createMockResolverEntity());
+			// External-identity resolvers (Slack, OAuth) do not implement resolveOwningUserId.
+			mockResolverRegistry.getResolverByTypename.mockReturnValue(createMockResolver());
+
+			const result = await service.resolveOwningUserIdForAuthorization(
+				createMockCredentialContext(),
+				'resolver-456',
+			);
+
+			expect(result).toEqual({ status: 'unbound' });
+		});
+
+		it('returns unbound when the resolver entity is missing', async () => {
+			mockResolverRepository.findOneBy.mockResolvedValue(null);
+
+			const result = await service.resolveOwningUserIdForAuthorization(
+				createMockCredentialContext(),
+				'resolver-456',
+			);
+
+			expect(result).toEqual({ status: 'unbound' });
+		});
+
+		it('returns bound with the user id when the resolver maps to an n8n user', async () => {
+			mockResolverRepository.findOneBy.mockResolvedValue(createMockResolverEntity());
+			mockCipher.decryptV2.mockResolvedValue('{}');
+			mockResolverRegistry.getResolverByTypename.mockReturnValue({
+				...createMockResolver(),
+				resolveOwningUserId: vi.fn().mockResolvedValue('user-789'),
+			});
+
+			const result = await service.resolveOwningUserIdForAuthorization(
+				createMockCredentialContext(),
+				'resolver-456',
+			);
+
+			expect(result).toEqual({ status: 'bound', userId: 'user-789' });
+		});
+
+		it('returns unresolved when the resolver maps to a user but returns nothing', async () => {
+			mockResolverRepository.findOneBy.mockResolvedValue(createMockResolverEntity());
+			mockCipher.decryptV2.mockResolvedValue('{}');
+			mockResolverRegistry.getResolverByTypename.mockReturnValue({
+				...createMockResolver(),
+				resolveOwningUserId: vi.fn().mockResolvedValue(undefined),
+			});
+
+			const result = await service.resolveOwningUserIdForAuthorization(
+				createMockCredentialContext(),
+				'resolver-456',
+			);
+
+			expect(result).toEqual({ status: 'unresolved' });
+		});
+
+		it('returns unresolved when resolving the owning user throws', async () => {
+			mockResolverRepository.findOneBy.mockResolvedValue(createMockResolverEntity());
+			mockCipher.decryptV2.mockResolvedValue('{}');
+			mockResolverRegistry.getResolverByTypename.mockReturnValue({
+				...createMockResolver(),
+				resolveOwningUserId: vi.fn().mockRejectedValue(new Error('token expired')),
+			});
+
+			const result = await service.resolveOwningUserIdForAuthorization(
+				createMockCredentialContext(),
+				'resolver-456',
+			);
+
+			expect(result).toEqual({ status: 'unresolved' });
+		});
+	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/authorize-intent.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/authorize-intent.service.ts
@@ -15,6 +15,12 @@ export type AuthorizeIntent = {
 	resolverId: string;
 	/** Caller identity (the bearer/subject) the credential connection must be bound to. */
 	identity: string;
+	/**
+	 * The n8n user the link was issued for, when the resolver maps to one. Set only
+	 * for resolvers implementing `resolveOwningUserId`; absent for external-subject
+	 * resolvers, which leaves the link unbound (any clicker with the token proceeds).
+	 */
+	userId?: string;
 	metadata?: Record<string, unknown>;
 };
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
@@ -4,6 +4,7 @@ import type {
 	CredentialCheckResult,
 	CredentialCheckStatus,
 	DynamicCredentialCheckProxyProvider,
+	ICredentialContext,
 	IExecutionContext,
 } from 'n8n-workflow';
 
@@ -13,6 +14,7 @@ import { UrlService } from '@/services/url.service';
 import { ExecutionContextService } from 'n8n-core';
 import { AuthorizeIntentService } from './authorize-intent.service';
 import { CredentialResolverWorkflowService } from './credential-resolver-workflow.service';
+import { DynamicCredentialService } from './dynamic-credential.service';
 
 @Service()
 export class CredentialCheckProxyService implements DynamicCredentialCheckProxyProvider {
@@ -21,6 +23,7 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 		private readonly executionContextService: ExecutionContextService,
 		private readonly enterpriseCredentialsService: EnterpriseCredentialsService,
 		private readonly authorizeIntentService: AuthorizeIntentService,
+		private readonly dynamicCredentialService: DynamicCredentialService,
 		private readonly urlService: UrlService,
 		private readonly globalConfig: GlobalConfig,
 	) {}
@@ -79,18 +82,29 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 	private async generateAuthorizationUrl(
 		credentialId: string,
 		resolverId: string,
-		credentialContext: { identity?: string; metadata?: Record<string, unknown> },
+		credentialContext: ICredentialContext,
 	): Promise<string | undefined> {
+		console.log('SECURITY_DEBUG: generateAuthorizationUrl called');
 		const credential = await this.enterpriseCredentialsService.getOne(credentialId);
 		if (!credential) return undefined;
 
 		const type = credential.type.toLowerCase();
 		if (!type.includes('oauth2') && !type.includes('oauth1')) return undefined;
 
+		// Bind the link to the intended n8n user when the resolver names one. Fail
+		// closed if the resolver maps to a user but can't resolve one right now —
+		// issuing an unbindable link would let any clicker complete the connection.
+		const ownership = await this.dynamicCredentialService.resolveOwningUserIdForAuthorization(
+			credentialContext,
+			resolverId,
+		);
+		if (ownership.status === 'unresolved') return undefined;
+
 		const token = await this.authorizeIntentService.create({
 			credentialId: credential.id,
 			resolverId,
 			identity: credentialContext.identity ?? '',
+			userId: ownership.status === 'bound' ? ownership.userId : undefined,
 			metadata: credentialContext.metadata,
 		});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-check-proxy.service.ts
@@ -84,7 +84,6 @@ export class CredentialCheckProxyService implements DynamicCredentialCheckProxyP
 		resolverId: string,
 		credentialContext: ICredentialContext,
 	): Promise<string | undefined> {
-		console.log('SECURITY_DEBUG: generateAuthorizationUrl called');
 		const credential = await this.enterpriseCredentialsService.getOne(credentialId);
 		if (!credential) return undefined;
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -193,7 +193,6 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 	): Promise<
 		{ status: 'unbound' } | { status: 'bound'; userId: string } | { status: 'unresolved' }
 	> {
-		console.log('SECURITY_DEBUG: resolveOwningUserIdForAuthorization called');
 		const resolverEntity = await this.resolverRepository.findOneBy({ id: resolverId });
 		const resolver =
 			resolverEntity && this.resolverRegistry.getResolverByTypename(resolverEntity.type);

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential.service.ts
@@ -5,6 +5,7 @@ import { Service } from '@n8n/di';
 import type { NextFunction, Response } from 'express';
 import { Cipher } from 'n8n-core';
 import type {
+	ICredentialContext,
 	ICredentialDataDecryptedObject,
 	IExecutionContext,
 	IWorkflowSettings,
@@ -171,6 +172,49 @@ export class DynamicCredentialService implements ICredentialResolutionProvider {
 
 	getSystemResolverId(): string {
 		return SYSTEM_RESOLVER_ID;
+	}
+
+	/**
+	 * Resolves the n8n user a pending authorization link should be bound to, when
+	 * the resolver maps its context to an n8n user (`resolveOwningUserId`).
+	 *
+	 * - `unbound`: resolver doesn't map to an n8n user (external-subject resolvers
+	 *   like Slack / OAuth introspection) — the link stays unbound and works as today.
+	 * - `bound`: resolver named a user — bind the link to it.
+	 * - `unresolved`: resolver implements the mapping but threw or returned nothing —
+	 *   callers fail closed rather than issue an unbindable link.
+	 *
+	 * Self-contained (reuses the resolver-loading idiom of `resolveIfNeeded` without
+	 * touching that hot path).
+	 */
+	async resolveOwningUserIdForAuthorization(
+		credentialContext: ICredentialContext,
+		resolverId: string,
+	): Promise<
+		{ status: 'unbound' } | { status: 'bound'; userId: string } | { status: 'unresolved' }
+	> {
+		console.log('SECURITY_DEBUG: resolveOwningUserIdForAuthorization called');
+		const resolverEntity = await this.resolverRepository.findOneBy({ id: resolverId });
+		const resolver =
+			resolverEntity && this.resolverRegistry.getResolverByTypename(resolverEntity.type);
+		if (!resolverEntity || !resolver?.resolveOwningUserId) {
+			return { status: 'unbound' };
+		}
+
+		try {
+			const parsedConfig = jsonParse<Record<string, unknown>>(
+				await this.cipher.decryptV2(resolverEntity.config),
+			);
+			const resolverConfig = await this.expressionService.resolve(parsedConfig);
+			const userId = await resolver.resolveOwningUserId(credentialContext, {
+				resolverId: resolverEntity.id,
+				resolverName: resolverEntity.type,
+				configuration: resolverConfig,
+			});
+			return userId ? { status: 'bound', userId } : { status: 'unresolved' };
+		} catch {
+			return { status: 'unresolved' };
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
When generating a dynamic credential URL, for example to authorise with Google OAuth when using an MCP node tool, the credentials are not associated to a user meaning technically they can be activated by another user allowing them to store their credential in the initiators account. This change associates the user ID of the user who triggered the authorisation with the token that is generated. This allows us to check whether the user authenticating with the generated URL is the same one who created it and reject if not.

The `authorize` endpoint had to be added to the skip-list for the `skipBrowserIdCheckEndpoints` array as it does not set the required headers - that means that it requires the user to have the authentication cookie in the browser they're attempting to authorise in. If they do not have authentication then they will be required to log in first.

If a user tries to connect using an auth URL that they did not create, they will see this message:

<img width="946" height="114" alt="Screenshot 2026-07-13 at 13 53 53" src="https://github.com/user-attachments/assets/f03960ee-1ae1-49fc-9189-b7be12b2f4f4" />

There is also a new audit event `n8n.audit.credentials.authorize.rejected'` for logging purposes.

If a token does not have a user ID bound to it, for example one that was created before this update was applied, or one created from an automated system that has no user, then the new checks are skipped entirely and the old behaviour is preserved.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
1. have 2 accounts in n8n, 'A' and 'B'
2. with account A, create an MCP node with a tool that uses Google OAuth (using end-user credentials)
3. connect the MCP to claude code or your harness of choice and authorise it
4. ask it to use the tool - it should return an authorisation link
5. paste that link into a browser signed into account B - you should see the error
6. paste that link into a browser signed into account A - it should work as expected and authorise the account (and because of end-user credentials it should be assigned to the correct user)
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/IAM-982/bind-dynamic-credential-authorize-link-to-the-initiating-user#comment-7421bd30
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->