### PR TITLE
fix(API): Fix broken public API playground server selection

### DIFF
--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -301,6 +301,9 @@ function createApiRouter(
 	}
 
 	apiController.get(`/${publicApiEndpoint}/${version}/openapi.yml`, (_, res) => {
+		// Public, read-only spec with no auth or sensitive data - safe to expose
+		// cross-origin for documentation playgrounds
+		res.header('Access-Control-Allow-Origin', '*');
 		res.sendFile(openApiSpecPath);
 	});
 

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -1,5 +1,6 @@
 ---
 openapi: 3.0.0
+x-enable-proxy: false
 info:
   title: n8n Public API
   description: n8n Public API
@@ -15,6 +16,12 @@ externalDocs:
   url: https://docs.n8n.io/api/
 servers:
   - url: /api/v1
+    description: Current n8n instance (self-hosted built-in playground)
+  - url: '{url}/api/v1'
+    description: Self-hosted n8n instance
+    variables:
+      url:
+        default: https://example.com
 tags:
   - name: User
     description: Operations about users


### PR DESCRIPTION
## Summary

The Public API documentation playground on docs.n8n.io, powered by GitBook, previously exposed only a single relative server URL (`/api/v1`). As a result, the "Test it" functionality was disabled.

This PR adds server definitions with variables for self-hosted n8n instances.

Here is a screenshot of my self-hosted n8n instance
<img width="1928" height="887" alt="image" src="https://github.com/user-attachments/assets/708ab37d-755c-426d-8b8b-a89185b11ddc" />


### Current limitations

```mermaid
sequenceDiagram
    participant Browser as Visitor's browser<br>on docs.n8n.io
    participant GBBack as GitBook backend
    participant Proxy as GitBook proxy
    participant N8N as n8n instance

    rect rgb(219, 234, 254)
    Note over GBBack,N8N: Step 0 — publish/refresh, decides x-enable-proxy for everyone downstream
    GBBack->>N8N: GET /openapi.yml
    N8N-->>GBBack: 200: checking specification and also if proxy is needed via x-enable-proxy
    end

    rect rgb(254, 226, 226)
    Note over Browser,N8N: A · proxy ON (original)
    Browser->>Proxy: fetch spec (spec's own origin is<br/>auto-added to the allow-list for this)
    Proxy->>N8N: GET /openapi.yml (server-to-server)
    N8N-->>Proxy: 200 · spec
    Proxy-->>Browser: 200 → panel opens ✅
    Browser->>Proxy: Send → target = whatever the visitor typed
    Proxy->>Proxy: check target vs. allow-list — not found, <br>because allow-list filled only with default values <br>instead of real user instance
    Proxy-->>Browser: ❌ "Target URL is not in the allowed origins"
    end

    rect rgb(254, 240, 199)
    Note over Browser,N8N: B · proxy OFF, nothing else changed
    Browser->>N8N: GET /openapi.yml
    N8N-->>Browser: ❌ blocked, no CORS header — panel never opens
    end

    rect rgb(220, 252, 231)
    Note over Browser,N8N: C · proxy OFF + CORS header on /openapi.yml (this PR)
    Browser->>N8N: GET /openapi.yml
    N8N-->>Browser: 200 + Access-Control-Allow-Origin: * → panel opens ✅
    Browser->>N8N: Send → direct request
    N8N-->>Browser: ✅ if your instance's own CORS allows it, otherwise blocked
    end
```

There are currently two limitations affecting requests to dynamically configured n8n instances:

1. GitBook's proxy cannot be used with arbitrary instance URLs.
The proxy validates target origins against the server URLs defined in the OpenAPI specification using their default variable values. Because user-provided instance URLs are not part of that allowlist, requests will fail with: 
```
Target URL is not in the allowed origins
```
Relevant implementation details:
* https://github.com/GitbookIO/gitbook/blob/a69a307de2c6d90e3bae8afa13f3a773494f81e9/packages/gitbook/src/lib/openapi/proxy-token.ts#L80
* https://github.com/GitbookIO/gitbook/blob/a69a307de2c6d90e3bae8afa13f3a773494f81e9/packages/react-openapi/src/util/server.ts#L72

2. Since the GitBook proxy cannot be used for dynamically configured instance URLs, requests would need to be sent directly from the browser. n8n instances do not currently return the required CORS headers for this flow, so these requests are blocked by the browser.

As a result, this PR only adds the self-hosted server option and does not include n8n Cloud instances. While users cannot change the CORS configuration of Cloud instances, self-hosted deployments can be configured to support requests from the documentation playground.

## How to test

1. Rebuild `cli` and restart, or check the deployed spec.
3. Open `http://localhost:5678/api/v1/openapi.yml` — should show 2 servers and `x-enable-proxy: false`.
4. Open `http://localhost:5678/api/v1/docs` — server dropdown defaults to `/api/v1` (unaffected) with self-hosted as extra option.
5. On docs.n8n.io (after deploy), the GitBook playground shows a self-hosted server selector with fillable variables.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-58

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

