### PR TITLE
test: Track security-policy endpoints in n8n node API coverage (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -5,6 +5,12 @@
 			"status": "covered",
 			"nodeOperation": "audit:generate"
 		},
+		"GET /settings/security-policy": {
+			"status": "gap"
+		},
+		"PUT /settings/security-policy": {
+			"status": "gap"
+		},
 		"GET /credentials": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

The `N8n.api-coverage` contract test (`packages/nodes-base/nodes/N8n/test/N8n.api-coverage.test.ts`) checks that every endpoint in the public-API OpenAPI spec is registered in the n8n node's coverage manifest. A recent change added the `/settings/security-policy` endpoints (`GET`, `PUT`) to `openapi.yml` without adding matching manifest entries, so the "every spec endpoint is tracked in the manifest" test now fails on `master`.

It slipped through on the originating PR (likely a stale Turbo cache — the test file itself warns about keeping Turbo inputs in sync) and surfaces on any PR that forces the test to re-run against current `master`.

This adds the two missing entries, marked `gap` to match the manifest's existing convention for endpoints the node doesn't implement yet (there are no `excluded` entries in the file today).

## How to test

```
cd packages/nodes-base && pnpm vitest run nodes/N8n/test/N8n.api-coverage.test.ts
```

All 3 tests pass. (Before this change, "every spec endpoint is tracked in the manifest" fails with the two `/settings/security-policy` endpoints untracked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34079">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

