### PR TITLE
feat(Slack Node): Add advanced HITL one-click approval behind ENHANCED_HITL_SLACK flag

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/util.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ChatTrigger/__test__/util.test.ts
@@ -45,8 +45,8 @@ describe('util', () => {
 				title: '',
 				message: '',
 				options: [
-					{ label: 'Disapprove', url: 'https://no.com', style: 'secondary' },
-					{ label: 'Approve', url: 'https://yes.com', style: 'primary' },
+					{ label: 'Disapprove', url: 'https://no.com', style: 'secondary', approved: false },
+					{ label: 'Approve', url: 'https://yes.com', style: 'primary', approved: true },
 				],
 			});
 			ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1.1 }));

--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -17,6 +17,7 @@ import { bodyParser, corsMiddleware, rawBodyReader } from '@/middlewares';
 import { sendErrorResponse } from '@/response-helper';
 import { createHandlebarsEngine } from '@/utils/handlebars.util';
 import { LiveWebhooks } from '@/webhooks/live-webhooks';
+import { SlackInteractionWebhooks } from '@/webhooks/slack-interaction-webhooks';
 import { TestWebhooks } from '@/webhooks/test-webhooks';
 import { WaitingForms } from '@/webhooks/waiting-forms';
 import { WaitingWebhooks } from '@/webhooks/waiting-webhooks';
@@ -258,6 +259,13 @@ export abstract class AbstractServer {
 			this.app.all(
 				`/${this.endpointWebhookWaiting}/:path{/:suffix}`,
 				createWebhookHandlerFor(Container.get(WaitingWebhooks)),
+			);
+
+			// Slack posts all button clicks to one fixed URL, so the ids travel in the button
+			// value instead of the path.
+			this.app.all(
+				`/${this.endpointWebhookWaiting}-slack`,
+				createWebhookHandlerFor(Container.get(SlackInteractionWebhooks)),
 			);
 
 			// Register a handler for live MCP servers

--- a/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
@@ -1,6 +1,7 @@
 import type { IExecutionResponse } from '@n8n/db';
 import type express from 'express';
 import type { InstanceSettings } from 'n8n-core';
+import type { IWorkflowBase } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -45,12 +46,20 @@ describe('SlackInteractionWebhooks', () => {
 		slackInteractionWebhooks.getWebhookExecutionDataArgs = null;
 	});
 
-	/** Build a Slack interaction request whose button value carries the given ids. */
-	const createRequest = (value: unknown) => {
+	/**
+	 * Build a Slack interaction request. Defaults to a signed POST whose button value carries
+	 * the given ids; `opts` lets individual tests drop the signature/method or supply a raw body.
+	 */
+	const createRequest = (
+		value: unknown,
+		opts: { method?: string; hasSignature?: boolean; rawBody?: string } = {},
+	) => {
 		const payload = JSON.stringify({ actions: [{ value: JSON.stringify(value) }] });
 		const req = mock<WaitingWebhookRequest>({ readRawBody: vi.fn().mockResolvedValue(undefined) });
+		req.method = (opts.method ?? 'POST') as WaitingWebhookRequest['method'];
+		req.headers = opts.hasSignature === false ? {} : { 'x-slack-signature': 'v0=abc' };
 		// Assign the real Buffer after construction so the deep mock does not proxy it.
-		req.rawBody = Buffer.from(`payload=${encodeURIComponent(payload)}`);
+		req.rawBody = Buffer.from(opts.rawBody ?? `payload=${encodeURIComponent(payload)}`);
 		return req;
 	};
 
@@ -59,6 +68,57 @@ describe('SlackInteractionWebhooks', () => {
 		const send = vi.fn().mockReturnThis();
 		return { res: mock<express.Response>({ status, send }), status, send };
 	};
+
+	/** A waiting execution whose workflow contains a single node with the given id and type. */
+	const waitingExecutionWithNode = (nodeId: string, nodeType: string) =>
+		mock<IExecutionResponse>({
+			status: 'waiting',
+			finished: false,
+			data: { resultData: { lastNodeExecuted: 'SlackNode' } },
+			workflowData: {
+				id: 'workflow-1',
+				name: 'Test Workflow',
+				nodes: [
+					{
+						name: 'SlackNode',
+						type: nodeType,
+						typeVersion: 1,
+						parameters: {},
+						id: nodeId,
+						position: [0, 0],
+					},
+				],
+				connections: {},
+				active: false,
+				activeVersionId: null,
+				settings: {},
+				staticData: {},
+				isArchived: false,
+			} as unknown as IWorkflowBase,
+		});
+
+	it('responds 401 without resuming when the request has no Slack signature', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' }, { hasSignature: false });
+		const { res, status } = createResponse();
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 401 without resuming for a non-POST request', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' }, { method: 'GET' });
+		const { res, status } = createResponse();
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
+	});
 
 	it('responds 400 when the button value is missing the execution and node ids', async () => {
 		const req = createRequest({});
@@ -70,6 +130,31 @@ describe('SlackInteractionWebhooks', () => {
 		expect(result).toEqual({ noWebhookResponse: true });
 		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
 		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 400 when the request has no payload field', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' }, { rawBody: 'foo=bar' });
+		const { res, status } = createResponse();
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(400);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
+	});
+
+	it('responds 400 when the button value is not valid JSON', async () => {
+		const rawBody = `payload=${encodeURIComponent(
+			JSON.stringify({ actions: [{ value: 'not-json' }] }),
+		)}`;
+		const req = createRequest({}, { rawBody });
+		const { res, status } = createResponse();
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(400);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
 	});
 
 	it('throws NotFoundError when the referenced execution does not exist', async () => {
@@ -109,15 +194,142 @@ describe('SlackInteractionWebhooks', () => {
 		expect(result).toEqual({ noWebhookResponse: true });
 	});
 
-	it('routes the waiting execution into the shared resume with the parsed ids', async () => {
+	it('responds 404 without resuming when the target node is not a Slack node', async () => {
 		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
-		const { res } = createResponse();
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'n8n-nodes-base.httpRequest'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 404 without resuming when the target node is missing', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'missing-node' });
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'n8n-nodes-base.slack'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 404 without resuming when the referenced node is a Slack node but not the one awaiting resume', async () => {
+		// Attacker supplies the id of a real Slack node (`node-1`) while a different, non-Slack node
+		// (`node-2`) is the one actually waiting. The guard must key off lastNodeExecuted, not just
+		// "any Slack node in the workflow".
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res, status } = createResponse();
 		executionPersistence.findSingleExecution.mockResolvedValue(
 			mock<IExecutionResponse>({
 				status: 'waiting',
 				finished: false,
-				data: { resultData: { lastNodeExecuted: 'SlackNode' } },
+				data: { resultData: { lastNodeExecuted: 'WaitNode' } },
+				workflowData: {
+					id: 'workflow-1',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: 'SlackNode',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-1',
+							position: [0, 0],
+						},
+						{
+							name: 'WaitNode',
+							type: 'n8n-nodes-base.wait',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-2',
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					activeVersionId: null,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+				} as unknown as IWorkflowBase,
 			}),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 404 without resuming when no node has been recorded as last executed', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({
+				status: 'waiting',
+				finished: false,
+				data: { resultData: { lastNodeExecuted: undefined } },
+				workflowData: {
+					id: 'workflow-1',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							name: 'SlackNode',
+							type: 'n8n-nodes-base.slack',
+							typeVersion: 1,
+							parameters: {},
+							id: 'node-1',
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					activeVersionId: null,
+					settings: {},
+					staticData: {},
+					isArchived: false,
+				} as unknown as IWorkflowBase,
+			}),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(404);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('routes the waiting execution into the shared resume when the target is a Slack node', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'n8n-nodes-base.slack'),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toEqual({
+			executionId: 'exec-1',
+			suffix: 'node-1',
+		});
+	});
+
+	it('routes the waiting execution into the shared resume when the target is a Slack tool node', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			waitingExecutionWithNode('node-1', 'n8n-nodes-base.slackTool'),
 		);
 
 		const result = await slackInteractionWebhooks.executeWebhook(req, res);

--- a/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/slack-interaction-webhooks.test.ts
@@ -1,0 +1,131 @@
+import type { IExecutionResponse } from '@n8n/db';
+import type express from 'express';
+import type { InstanceSettings } from 'n8n-core';
+import { mock } from 'vitest-mock-extended';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { EventService } from '@/events/event.service';
+import type { ExecutionPersistence } from '@/executions/execution-persistence';
+import { SlackInteractionWebhooks } from '@/webhooks/slack-interaction-webhooks';
+import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from '@/webhooks/webhook.types';
+
+type GetWebhookExecutionDataArgs = {
+	executionId: string;
+	suffix?: string;
+};
+
+class TestSlackInteractionWebhooks extends SlackInteractionWebhooks {
+	getWebhookExecutionDataArgs: GetWebhookExecutionDataArgs | null = null;
+
+	// Isolate the endpoint's parse/route logic from the shared resume machinery, which is
+	// exercised by the WaitingWebhooks tests.
+	// eslint-disable-next-line @typescript-eslint/require-await
+	protected async getWebhookExecutionData(args: {
+		executionId: string;
+		suffix?: string;
+	}): Promise<IWebhookResponseCallbackData> {
+		this.getWebhookExecutionDataArgs = { executionId: args.executionId, suffix: args.suffix };
+		return { noWebhookResponse: true };
+	}
+}
+
+describe('SlackInteractionWebhooks', () => {
+	const executionPersistence = mock<ExecutionPersistence>();
+	const slackInteractionWebhooks = new TestSlackInteractionWebhooks(
+		mock(),
+		mock(),
+		executionPersistence,
+		mock(),
+		mock<InstanceSettings>(),
+		mock<EventService>(),
+	);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		slackInteractionWebhooks.getWebhookExecutionDataArgs = null;
+	});
+
+	/** Build a Slack interaction request whose button value carries the given ids. */
+	const createRequest = (value: unknown) => {
+		const payload = JSON.stringify({ actions: [{ value: JSON.stringify(value) }] });
+		const req = mock<WaitingWebhookRequest>({ readRawBody: vi.fn().mockResolvedValue(undefined) });
+		// Assign the real Buffer after construction so the deep mock does not proxy it.
+		req.rawBody = Buffer.from(`payload=${encodeURIComponent(payload)}`);
+		return req;
+	};
+
+	const createResponse = () => {
+		const status = vi.fn().mockReturnThis();
+		const send = vi.fn().mockReturnThis();
+		return { res: mock<express.Response>({ status, send }), status, send };
+	};
+
+	it('responds 400 when the button value is missing the execution and node ids', async () => {
+		const req = createRequest({});
+		const { res, status } = createResponse();
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(400);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(executionPersistence.findSingleExecution).not.toHaveBeenCalled();
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('throws NotFoundError when the referenced execution does not exist', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(undefined);
+
+		await expect(slackInteractionWebhooks.executeWebhook(req, res)).rejects.toThrowError(
+			NotFoundError,
+		);
+	});
+
+	it('responds 409 when the execution is already running', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({ status: 'running', finished: false }),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(409);
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toBeNull();
+	});
+
+	it('responds 409 when the execution has already finished', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res, status } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({ status: 'waiting', finished: true }),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(status).toHaveBeenCalledWith(409);
+		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('routes the waiting execution into the shared resume with the parsed ids', async () => {
+		const req = createRequest({ executionId: 'exec-1', nodeId: 'node-1' });
+		const { res } = createResponse();
+		executionPersistence.findSingleExecution.mockResolvedValue(
+			mock<IExecutionResponse>({
+				status: 'waiting',
+				finished: false,
+				data: { resultData: { lastNodeExecuted: 'SlackNode' } },
+			}),
+		);
+
+		const result = await slackInteractionWebhooks.executeWebhook(req, res);
+
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(slackInteractionWebhooks.getWebhookExecutionDataArgs).toEqual({
+			executionId: 'exec-1',
+			suffix: 'node-1',
+		});
+	});
+});

--- a/packages/cli/src/webhooks/slack-interaction-webhooks.ts
+++ b/packages/cli/src/webhooks/slack-interaction-webhooks.ts
@@ -1,0 +1,61 @@
+import { Service } from '@n8n/di';
+import type express from 'express';
+import { jsonParse } from 'n8n-workflow';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { WaitingWebhooks } from './waiting-webhooks';
+import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from './webhook.types';
+
+interface SlackInteractionValue {
+	executionId?: string;
+	nodeId?: string;
+}
+
+/**
+ * Receives Slack interactive button callbacks and resumes the matching Send-and-Wait execution.
+ */
+@Service()
+export class SlackInteractionWebhooks extends WaitingWebhooks {
+	async executeWebhook(
+		req: WaitingWebhookRequest,
+		res: express.Response,
+	): Promise<IWebhookResponseCallbackData> {
+		await req.readRawBody();
+		const payloadRaw = new URLSearchParams(req.rawBody?.toString() ?? '').get('payload');
+		const payload = payloadRaw
+			? jsonParse<{ actions?: Array<{ value?: string }> }>(payloadRaw, { fallbackValue: {} })
+			: {};
+		const value = jsonParse<SlackInteractionValue>(payload.actions?.[0]?.value ?? '', {
+			fallbackValue: {},
+		});
+
+		if (!value.executionId || !value.nodeId) {
+			res.status(400).send('');
+			return { noWebhookResponse: true };
+		}
+
+		// The ids drive webhook matching in the shared resume. The body is not set here: the
+		// resume path re-parses it from rawBody, so the Slack node reads the responder from
+		// the form-encoded `payload` field itself.
+		req.params = { path: value.executionId, suffix: value.nodeId };
+
+		const execution = await this.getExecution(value.executionId);
+		if (!execution) {
+			throw new NotFoundError(`The execution "${value.executionId}" does not exist.`);
+		}
+		if (execution.status === 'running' || execution.finished) {
+			res.status(409).send('');
+			return { noWebhookResponse: true };
+		}
+
+		return await this.getWebhookExecutionData({
+			execution,
+			req,
+			res,
+			lastNodeExecuted: execution.data.resultData.lastNodeExecuted as string,
+			executionId: value.executionId,
+			suffix: value.nodeId,
+		});
+	}
+}

--- a/packages/cli/src/webhooks/slack-interaction-webhooks.ts
+++ b/packages/cli/src/webhooks/slack-interaction-webhooks.ts
@@ -5,12 +5,16 @@ import { jsonParse } from 'n8n-workflow';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { WaitingWebhooks } from './waiting-webhooks';
+import { sanitizeWebhookRequest } from './webhook-request-sanitizer';
 import type { IWebhookResponseCallbackData, WaitingWebhookRequest } from './webhook.types';
 
 interface SlackInteractionValue {
 	executionId?: string;
 	nodeId?: string;
 }
+
+const SLACK_NODE_TYPE = 'n8n-nodes-base.slack';
+const SLACK_TOOL_NODE_TYPE = 'n8n-nodes-base.slackTool';
 
 /**
  * Receives Slack interactive button callbacks and resumes the matching Send-and-Wait execution.
@@ -21,6 +25,16 @@ export class SlackInteractionWebhooks extends WaitingWebhooks {
 		req: WaitingWebhookRequest,
 		res: express.Response,
 	): Promise<IWebhookResponseCallbackData> {
+		// Only a POST carrying an x-slack-signature header is accepted here; this check only
+		// asserts the header is present, not valid. Actual signature validity is enforced
+		// downstream in the node, where the signing secret lives on the node credential rather
+		// than at this layer. Rejecting header-less probes forces that node check to run on the
+		// resume.
+		if (req.method !== 'POST' || !req.headers['x-slack-signature']) {
+			res.status(401).send('');
+			return { noWebhookResponse: true };
+		}
+
 		await req.readRawBody();
 		const payloadRaw = new URLSearchParams(req.rawBody?.toString() ?? '').get('payload');
 		const payload = payloadRaw
@@ -35,10 +49,8 @@ export class SlackInteractionWebhooks extends WaitingWebhooks {
 			return { noWebhookResponse: true };
 		}
 
-		// The ids drive webhook matching in the shared resume. The body is not set here: the
-		// resume path re-parses it from rawBody, so the Slack node reads the responder from
-		// the form-encoded `payload` field itself.
-		req.params = { path: value.executionId, suffix: value.nodeId };
+		this.logReceivedWebhook(req.method, value.executionId);
+		sanitizeWebhookRequest(req);
 
 		const execution = await this.getExecution(value.executionId);
 		if (!execution) {
@@ -49,11 +61,30 @@ export class SlackInteractionWebhooks extends WaitingWebhooks {
 			return { noWebhookResponse: true };
 		}
 
+		// Restrict resume to a Slack send-and-wait node. Other waiting nodes run no Slack
+		// signature check, so they must not be resumable via this route. Guard the node that
+		// actually resumes (lastNodeExecuted), and assert its id matches the button's nodeId —
+		// the resume is coupled to it because the shared handler matches on webhook.path === suffix
+		// and the send-and-wait path is the node id. Respond 404 (not a descriptive error) so the
+		// response doesn't leak whether the node exists.
+		const lastNodeExecuted = execution.data.resultData.lastNodeExecuted;
+		const { nodes } = this.createWorkflow(execution.workflowData);
+		const targetNode = lastNodeExecuted ? nodes[lastNodeExecuted] : undefined;
+		if (
+			!lastNodeExecuted ||
+			!targetNode ||
+			targetNode.id !== value.nodeId ||
+			(targetNode.type !== SLACK_NODE_TYPE && targetNode.type !== SLACK_TOOL_NODE_TYPE)
+		) {
+			res.status(404).send('');
+			return { noWebhookResponse: true };
+		}
+
 		return await this.getWebhookExecutionData({
 			execution,
 			req,
 			res,
-			lastNodeExecuted: execution.data.resultData.lastNodeExecuted as string,
+			lastNodeExecuted,
 			executionId: value.executionId,
 			suffix: value.nodeId,
 		});

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.test.ts
@@ -9,6 +9,8 @@ import {
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { usePostHog } from '@/app/stores/posthog.store';
+import { SLACK_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { useNodeSettingsParameters } from './useNodeSettingsParameters';
 import * as nodeHelpers from '@/app/composables/useNodeHelpers';
 import * as workflowHelpers from '@/app/composables/useWorkflowHelpers';
@@ -275,6 +277,89 @@ describe('useNodeSettingsParameters', () => {
 
 		afterEach(() => {
 			vi.resetAllMocks();
+		});
+
+		describe('enhanced HITL Slack gating', () => {
+			const captureResponderParameter: INodeProperties = {
+				name: 'captureResponder',
+				type: 'boolean',
+				displayName: 'Capture Who Responded',
+				default: false,
+			};
+			const slackNode: INodeUi = {
+				id: '1',
+				name: 'Slack',
+				type: SLACK_NODE_TYPE,
+				typeVersion: 2.3,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			function setFlag(enabled: boolean) {
+				const posthog = mockedStore(usePostHog);
+				posthog.isFeatureEnabled = vi.fn().mockReturnValue(enabled);
+			}
+
+			it('hides captureResponder on the Slack node when the experiment is off', async () => {
+				mockNodeHelpers();
+				setFlag(false);
+
+				const { shouldDisplayNodeParameter } = useNodeSettingsParameters();
+
+				const result = await shouldDisplayNodeParameter({}, slackNode, captureResponderParameter);
+				expect(result).toBe(false);
+			});
+
+			it('shows captureResponder on the Slack node when the experiment is on', async () => {
+				mockNodeHelpers();
+				setFlag(true);
+
+				const { shouldDisplayNodeParameter } = useNodeSettingsParameters();
+
+				const result = await shouldDisplayNodeParameter({}, slackNode, captureResponderParameter);
+				expect(result).toBe(true);
+			});
+
+			it('hides captureResponder on the Slack tool variant when the experiment is off', async () => {
+				mockNodeHelpers();
+				setFlag(false);
+
+				const { shouldDisplayNodeParameter } = useNodeSettingsParameters();
+
+				const result = await shouldDisplayNodeParameter(
+					{},
+					{ ...slackNode, type: `${SLACK_NODE_TYPE}Tool` },
+					captureResponderParameter,
+				);
+				expect(result).toBe(false);
+			});
+
+			it('hides the approvers field on the Slack node when the experiment is off', async () => {
+				mockNodeHelpers();
+				setFlag(false);
+
+				const { shouldDisplayNodeParameter } = useNodeSettingsParameters();
+
+				const result = await shouldDisplayNodeParameter({}, slackNode, {
+					...captureResponderParameter,
+					name: 'approvers',
+					type: 'multiOptions',
+				});
+				expect(result).toBe(false);
+			});
+
+			it('does not gate unrelated parameters on the Slack node', async () => {
+				mockNodeHelpers();
+				setFlag(false);
+
+				const { shouldDisplayNodeParameter } = useNodeSettingsParameters();
+
+				const result = await shouldDisplayNodeParameter({}, slackNode, {
+					...mockParameter,
+					displayOptions: undefined,
+				});
+				expect(result).toBe(true);
+			});
 		});
 
 		describe('hidden parameter type', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -25,6 +25,8 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { CHAT_TRIGGER_NODE_TYPE, KEEP_AUTH_IN_NDV_FOR_NODES } from '@/app/constants';
+import { SLACK_NODE_TYPE } from '@/app/constants/nodeTypes';
+import { useEnhancedHitlSlackExperiment } from '@/experiments/enhancedHitlSlack';
 import {
 	getMainAuthField,
 	getNodeAuthFields,
@@ -54,11 +56,18 @@ const stripPublicDisplayCondition = (parameter: INodeProperties): INodePropertie
 	};
 };
 
+const ADVANCED_HITL_SLACK_PARAMETERS = ['captureResponder', 'approvers'];
+
+/** Tool variant of the Slack node (usableAsTool appends `Tool` to the node type). */
+const SLACK_TOOL_NODE_TYPE = `${SLACK_NODE_TYPE}Tool`;
+
 export function useNodeSettingsParameters() {
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const ndvStore = computed(() => useNDVStore(workflowDocumentStore.value.documentId));
 	const nodeTypesStore = useNodeTypesStore();
 	const settingsStore = useSettingsStore();
+
+	const { isFeatureEnabled: isEnhancedHitlSlackEnabled } = useEnhancedHitlSlackExperiment();
 	const telemetry = useTelemetry();
 	const nodeHelpers = useNodeHelpers();
 	const workflowHelpers = useWorkflowHelpers();
@@ -221,6 +230,15 @@ export function useNodeSettingsParameters() {
 			if (hasPublicDisplayCondition(effectiveParameter, false)) {
 				effectiveParameter = stripPublicDisplayCondition(effectiveParameter);
 			}
+		}
+
+		if (
+			displayKey === 'displayOptions' &&
+			(nodeTypeValue === SLACK_NODE_TYPE || nodeTypeValue === SLACK_TOOL_NODE_TYPE) &&
+			ADVANCED_HITL_SLACK_PARAMETERS.includes(effectiveParameter.name) &&
+			!isEnhancedHitlSlackEnabled.value
+		) {
+			return false;
 		}
 
 		// Fast path: hide parameters explicitly marked as cloud-only on cloud deployments

--- a/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
+++ b/packages/nodes-base/nodes/Slack/SlackTriggerHelpers.ts
@@ -81,8 +81,11 @@ export async function downloadFile(this: IWebhookFunctions, url: string): Promis
 	return response;
 }
 
-export async function verifySignature(this: IWebhookFunctions): Promise<boolean> {
-	const credential = await this.getCredentials('slackApi');
+export async function verifySignature(
+	this: IWebhookFunctions,
+	credentialType = 'slackApi',
+): Promise<boolean> {
+	const credential = await this.getCredentials(credentialType);
 	const req = this.getRequestObject();
 
 	const timestamp = req.header('x-slack-request-timestamp');

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -10,7 +10,11 @@ import type {
 } from 'n8n-workflow';
 import { NodeOperationError, sleep } from 'n8n-workflow';
 
-import type { SendAndWaitMessageBody } from './MessageInterface';
+import {
+	HITL_APPROVE_ACTION_ID,
+	HITL_DECLINE_ACTION_ID,
+	type SendAndWaitMessageBody,
+} from './MessageInterface';
 import { getSendAndWaitConfig } from '../../../utils/sendAndWait/utils';
 import { createUtmCampaignLink } from '../../../utils/utilities';
 
@@ -477,10 +481,7 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 					// the url so Slack treats it as interactive and POSTs the click to us instead.
 					...(captureResponder
 						? {
-								action_id:
-									new URL(option.url).searchParams.get('approved') === 'false'
-										? 'n8n_hitl_decline'
-										: 'n8n_hitl_approve',
+								action_id: option.approved ? HITL_APPROVE_ACTION_ID : HITL_DECLINE_ACTION_ID,
 								value: interactionValue,
 							}
 						: { url: option.url }),

--- a/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Slack/V2/GenericFunctions.ts
@@ -427,6 +427,18 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 
 	const config = getSendAndWaitConfig(context);
 
+	const responseType = context.getNodeParameter('responseType', 0, 'approval');
+
+	// Capture-responder only works with Approve/Reject buttons. Free-text and custom-form
+	// replies still use the plain link button.
+	const captureResponder =
+		context.getNodeParameter('captureResponder', 0, false) === true && responseType === 'approval';
+
+	// Sent back to us in the button click so we know which execution and node to resume.
+	const interactionValue = captureResponder
+		? JSON.stringify({ executionId: context.getExecutionId(), nodeId: context.getNode().id })
+		: undefined;
+
 	const body: SendAndWaitMessageBody = {
 		channel: target,
 		blocks: [
@@ -453,18 +465,26 @@ export function createSendAndWaitMessageBody(context: IExecuteFunctions) {
 			},
 			{
 				type: 'actions',
-				elements: config.options.map((option) => {
-					return {
-						type: 'button',
-						style: option.style === 'primary' ? 'primary' : undefined,
-						text: {
-							type: 'plain_text',
-							text: option.label,
-							emoji: true,
-						},
-						url: option.url,
-					};
-				}),
+				elements: config.options.map((option) => ({
+					type: 'button',
+					style: option.style === 'primary' ? 'primary' : undefined,
+					text: {
+						type: 'plain_text',
+						text: option.label,
+						emoji: true,
+					},
+					// A button with a `url` is a plain link. In capture-responder mode we drop
+					// the url so Slack treats it as interactive and POSTs the click to us instead.
+					...(captureResponder
+						? {
+								action_id:
+									new URL(option.url).searchParams.get('approved') === 'false'
+										? 'n8n_hitl_decline'
+										: 'n8n_hitl_approve',
+								value: interactionValue,
+							}
+						: { url: option.url }),
+				})),
 			},
 		],
 	};

--- a/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageDescription.ts
@@ -192,6 +192,43 @@ export const userRLC: INodeProperties = {
 	],
 };
 
+export const captureResponderField: INodeProperties = {
+	displayName: 'Capture Who Responded',
+	name: 'captureResponder',
+	type: 'boolean',
+	default: false,
+	// Approval only: the form response types need the plain link button. Both auth modes
+	// carry a signing secret, so either works for the interactive callback.
+	displayOptions: {
+		show: {
+			authentication: ['accessToken', 'oAuth2'],
+			responseType: ['approval'],
+		},
+	},
+	description:
+		"Whether to use Slack interactive buttons so the responder's identity (ID, name, email) is captured and returned with the response. Requires the Slack app to have Interactivity enabled (Request URL pointed at this n8n instance), a signing secret on the credential, and the users:read and users:read.email scopes.",
+};
+
+export const approversField: INodeProperties = {
+	displayName: 'Approver Names or IDs',
+	name: 'approvers',
+	type: 'multiOptions',
+	typeOptions: {
+		loadOptionsMethod: 'getUsers',
+	},
+	default: [],
+	// Only meaningful for the interactive-button flow (approval + capture responder).
+	displayOptions: {
+		show: {
+			authentication: ['accessToken', 'oAuth2'],
+			responseType: ['approval'],
+			captureResponder: [true],
+		},
+	},
+	description:
+		'Restrict who can approve or decline: a click from anyone not listed is ignored and they get a private notice. Leave empty to let anyone respond. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+};
+
 export const replyToMessageField: INodeProperties = {
 	displayName: 'Reply to a Message',
 	name: 'thread_ts',

--- a/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
@@ -24,7 +24,12 @@ export interface ButtonElement {
 	type: 'button';
 	style?: 'primary';
 	text: TextBlock;
-	url: string;
+	/** Present for plain link buttons (default HITL behaviour). */
+	url?: string;
+	/** Present for interactive buttons (capture-responder mode): the decision. */
+	action_id?: string;
+	/** Present for interactive buttons: which run/node to resume, echoed back by Slack. */
+	value?: string;
 }
 
 export interface ActionsBlock {

--- a/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
+++ b/packages/nodes-base/nodes/Slack/V2/MessageInterface.ts
@@ -4,6 +4,14 @@ export interface IAttachment {
 	};
 }
 
+/**
+ * `action_id` values for the interactive HITL approve/decline buttons. Shared by the
+ * button builder and the webhook consumer so a typo can't silently desync (which would
+ * fail closed to "declined").
+ */
+export const HITL_APPROVE_ACTION_ID = 'n8n_hitl_approve';
+export const HITL_DECLINE_ACTION_ID = 'n8n_hitl_decline';
+
 // Used for SendAndWaitMessage
 export interface TextBlock {
 	type: string;

--- a/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
@@ -1,0 +1,222 @@
+import { jsonParse, type IDataObject, type IWebhookFunctions } from 'n8n-workflow';
+
+import { slackApiRequest } from './GenericFunctions';
+import type { SectionBlock } from './MessageInterface';
+import type { SendAndWaitResponder } from '../../../utils/sendAndWait/interfaces';
+import { sendAndWaitWebhook } from '../../../utils/sendAndWait/utils';
+import { verifySignature } from '../SlackTriggerHelpers';
+
+interface SlackInteractionPayload {
+	user?: { id?: string; name?: string; username?: string };
+	actions?: Array<{ action_id?: string; value?: string; action_ts?: string }>;
+	channel?: { id?: string };
+	message?: { ts?: string; blocks?: IDataObject[] };
+	container?: { message_ts?: string };
+	response_url?: string;
+}
+
+/**
+ * Works out who clicked the button. Always returns their Slack id and name; the email is a
+ * bonus that only comes through if the app has the `users:read.email` scope.
+ */
+async function extractSlackResponder(
+	context: IWebhookFunctions,
+	payload: SlackInteractionPayload,
+): Promise<SendAndWaitResponder> {
+	const user = payload.user ?? {};
+	const responder: SendAndWaitResponder = {
+		id: user.id ?? '',
+		name: user.name ?? user.username,
+		source: 'slack',
+	};
+
+	if (user.id) {
+		try {
+			const info = (await slackApiRequest.call(
+				context,
+				'GET',
+				'/users.info',
+				{},
+				{ user: user.id },
+			)) as {
+				user?: { profile?: { email?: string } };
+			};
+			if (info?.user?.profile?.email) responder.email = info.user.profile.email;
+		} catch {
+			// No users:read.email scope? Just skip the email and keep id + name.
+		}
+	}
+
+	return responder;
+}
+
+/**
+ * When someone not on the approver list clicks a button, send them a private ("ephemeral")
+ * message so only they see that it was ignored. If this fails, we carry on regardless — it
+ * must never cause the execution to resume.
+ */
+async function notifyNotAuthorized(
+	context: IWebhookFunctions,
+	payload: SlackInteractionPayload,
+): Promise<void> {
+	const channel = payload.channel?.id;
+	const user = payload.user?.id;
+	if (!channel || !user) return;
+	try {
+		await slackApiRequest.call(context, 'POST', '/chat.postEphemeral', {
+			channel,
+			user,
+			text: 'You are not authorized to respond to this request.',
+		} as IDataObject);
+	} catch {
+		// Missing chat:write scope, or the user left the channel. Nothing more we can do.
+	}
+}
+
+/** Builds the "Approved/Declined by @user" line added under the message once someone decides. */
+function buildDecisionBlocks(approved: boolean, responder: SendAndWaitResponder): SectionBlock[] {
+	const who = responder.id ? `<@${responder.id}>` : (responder.name ?? 'a user');
+	const outcome = approved ? ':white_check_mark: *Approved*' : ':x: *Declined*';
+	return [{ type: 'section', text: { type: 'mrkdwn', text: `${outcome} by ${who}` } }];
+}
+
+/**
+ * Rewrites the original message so the decision is final: the buttons are gone and the
+ * outcome is shown. Tries Slack's `response_url` first (needs no token, but expires after
+ * ~30 min), then falls back to `chat.update`. If both fail we still let the execution
+ * resume — locking the message is nice-to-have, not required.
+ */
+async function lockSlackMessage(
+	context: IWebhookFunctions,
+	payload: SlackInteractionPayload,
+	blocks: IDataObject[],
+	text: string,
+): Promise<void> {
+	if (payload.response_url) {
+		try {
+			await context.helpers.httpRequest({
+				method: 'POST',
+				url: payload.response_url,
+				headers: { 'Content-Type': 'application/json' },
+				// response_url replies with a plain "ok", not JSON, so we stringify the body
+				// ourselves rather than letting the client try to parse the response.
+				body: JSON.stringify({ replace_original: true, text, blocks }),
+			});
+			return;
+		} catch (error) {
+			context.logger.warn(
+				`Slack HITL: response_url update failed (${(error as Error).message}); trying chat.update`,
+			);
+		}
+	}
+
+	const channel = payload.channel?.id;
+	const ts = payload.message?.ts ?? payload.container?.message_ts;
+	if (channel && ts) {
+		try {
+			await slackApiRequest.call(context, 'POST', '/chat.update', {
+				channel,
+				ts,
+				text,
+				blocks,
+			} as IDataObject);
+		} catch (error) {
+			// A missing chat:write scope shouldn't fail the resume, so leave the message as-is.
+			context.logger.warn(
+				`Slack HITL: chat.update failed (${(error as Error).message}); message left as-is`,
+			);
+		}
+	} else {
+		context.logger.warn('Slack HITL: cannot lock message — missing channel or message ts');
+	}
+}
+
+/**
+ * Entry point for the Slack webhook. If the request is an interactive button click (a signed
+ * POST from Slack), we verify the signature, figure out who responded, and lock the message.
+ * Anything else — plain-link approvals, form responses — is handed to the shared handler
+ * unchanged.
+ */
+export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
+	const req = this.getRequestObject();
+	const isInteraction = req.method === 'POST' && Boolean(req.headers['x-slack-signature']);
+
+	if (!isInteraction) {
+		return await sendAndWaitWebhook.call(this);
+	}
+
+	// Fail closed: this callback must have a signing secret to verify against. (The Slack
+	// trigger is more lenient and skips the check when no secret is set — we don't.)
+	// verifySignature also rejects old timestamps (replay protection) and compares in
+	// constant time. Both auth modes store the signing secret, so pick the credential that
+	// matches the node's authentication.
+	const authentication = this.getNodeParameter('authentication', 'accessToken') as string;
+	const credentialType = authentication === 'oAuth2' ? 'slackOAuth2Api' : 'slackApi';
+	const credential = await this.getCredentials(credentialType);
+	const signingSecret =
+		typeof credential.signatureSecret === 'string' ? credential.signatureSecret : '';
+	if (!signingSecret || !(await verifySignature.call(this, credentialType))) {
+		this.getResponseObject().status(401).send('');
+		return { noWebhookResponse: true };
+	}
+
+	// Slack sends interactions as form data, with the actual JSON inside a `payload` field.
+	const body = this.getBodyData();
+	const payload =
+		typeof body.payload === 'string'
+			? jsonParse<SlackInteractionPayload>(body.payload, { fallbackValue: {} })
+			: (body as SlackInteractionPayload);
+
+	// No approvers configured means anyone can respond (the original default). If a list is set,
+	// a click from anyone not on it is ignored: tell them privately and keep waiting.
+	const approvers = this.getNodeParameter('approvers', []) as string[];
+	if (approvers.length > 0 && !approvers.includes(payload.user?.id ?? '')) {
+		await notifyNotAuthorized(this, payload);
+		return { noWebhookResponse: true };
+	}
+
+	// Fail closed: treat as approved only when the click is explicitly the approve button.
+	// Anything else — the decline button, a missing or unexpected action_id — counts as declined.
+	const approved = payload.actions?.[0]?.action_id === 'n8n_hitl_approve';
+	const responder = await extractSlackResponder(this, payload);
+
+	// Slack tells us when the button was clicked via action_ts (epoch seconds). If it's
+	// missing, fall back to the time we received the request.
+	const actionTs = payload.actions?.[0]?.action_ts;
+	const actionMs = actionTs ? Number(actionTs) * 1000 : NaN;
+	const respondedAt = new Date(Number.isFinite(actionMs) ? actionMs : Date.now()).toISOString();
+
+	// Rebuild the message: keep everything except the buttons, then add the outcome line.
+	const keptBlocks = (payload.message?.blocks ?? []).filter(
+		(block) => (block as { type?: string }).type !== 'actions',
+	);
+	const lockedBlocks = [
+		...keptBlocks,
+		...buildDecisionBlocks(approved, responder),
+	] as IDataObject[];
+	await lockSlackMessage(
+		this,
+		payload,
+		lockedBlocks,
+		approved ? 'Request approved' : 'Request declined',
+	);
+
+	return {
+		webhookResponse: '',
+		workflowData: [
+			[
+				{
+					json: {
+						data: {
+							approved,
+							responder,
+							respondedAt,
+							channel: payload.channel?.id,
+							messageId: payload.message?.ts ?? payload.container?.message_ts,
+						},
+					},
+				},
+			],
+		],
+	};
+}

--- a/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
@@ -1,7 +1,7 @@
 import { jsonParse, type IDataObject, type IWebhookFunctions } from 'n8n-workflow';
 
 import { slackApiRequest } from './GenericFunctions';
-import type { SectionBlock } from './MessageInterface';
+import { HITL_APPROVE_ACTION_ID, type SectionBlock } from './MessageInterface';
 import type { SendAndWaitResponder } from '../../../utils/sendAndWait/interfaces';
 import { sendAndWaitWebhook } from '../../../utils/sendAndWait/utils';
 import { verifySignature } from '../SlackTriggerHelpers';
@@ -67,7 +67,7 @@ async function notifyNotAuthorized(
 			channel,
 			user,
 			text: 'You are not authorized to respond to this request.',
-		} as IDataObject);
+		});
 	} catch {
 		// Missing chat:write scope, or the user left the channel. Nothing more we can do.
 	}
@@ -105,7 +105,7 @@ async function lockSlackMessage(
 			return;
 		} catch (error) {
 			context.logger.warn(
-				`Slack HITL: response_url update failed (${(error as Error).message}); trying chat.update`,
+				`Slack HITL: response_url update failed (${error instanceof Error ? error.message : String(error)}); trying chat.update`,
 			);
 		}
 	}
@@ -119,11 +119,11 @@ async function lockSlackMessage(
 				ts,
 				text,
 				blocks,
-			} as IDataObject);
+			});
 		} catch (error) {
 			// A missing chat:write scope shouldn't fail the resume, so leave the message as-is.
 			context.logger.warn(
-				`Slack HITL: chat.update failed (${(error as Error).message}); message left as-is`,
+				`Slack HITL: chat.update failed (${error instanceof Error ? error.message : String(error)}); message left as-is`,
 			);
 		}
 	} else {
@@ -139,6 +139,12 @@ async function lockSlackMessage(
  */
 export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
 	const req = this.getRequestObject();
+	// Slack signs interactive button clicks with an x-slack-signature header. Gate on the header
+	// alone: the `-slack` CLI route hard-requires it (unsigned POSTs are rejected there with 401),
+	// so any header-less POST reaching the node arrived via the base HMAC-validated route and
+	// belongs to the shared handler (plain-link approvals, custom-form responses). Sniffing the
+	// body for a `payload` field would misclassify a form response whose user field is named
+	// `payload`, forcing it through Slack signature verification and wrongly rejecting it.
 	const isInteraction = req.method === 'POST' && Boolean(req.headers['x-slack-signature']);
 
 	if (!isInteraction) {
@@ -160,7 +166,7 @@ export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
 		return { noWebhookResponse: true };
 	}
 
-	// Slack sends interactions as form data, with the actual JSON inside a `payload` field.
+	// Slack sends interactions as form data with the JSON inside a `payload` field.
 	const body = this.getBodyData();
 	const payload =
 		typeof body.payload === 'string'
@@ -177,7 +183,7 @@ export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
 
 	// Fail closed: treat as approved only when the click is explicitly the approve button.
 	// Anything else — the decline button, a missing or unexpected action_id — counts as declined.
-	const approved = payload.actions?.[0]?.action_id === 'n8n_hitl_approve';
+	const approved = payload.actions?.[0]?.action_id === HITL_APPROVE_ACTION_ID;
 	const responder = await extractSlackResponder(this, payload);
 
 	// Slack tells us when the button was clicked via action_ts (epoch seconds). If it's

--- a/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackV2.node.ts
@@ -34,6 +34,8 @@ import {
 	toMultiOptionsCsv,
 } from './GenericFunctions';
 import {
+	approversField,
+	captureResponderField,
 	channelRLC,
 	messageFields,
 	messageOperations,
@@ -42,6 +44,7 @@ import {
 	userRLC,
 } from './MessageDescription';
 import { reactionFields, reactionOperations } from './ReactionDescription';
+import { slackSendAndWaitWebhook } from './SlackHitlWebhook';
 import { starFields, starOperations } from './StarDescription';
 import { userFields, userOperations } from './UserDescription';
 import { userGroupFields, userGroupOperations } from './UserGroupDescription';
@@ -50,7 +53,6 @@ import { sendAndWaitWebhooksDescription } from '../../../utils/sendAndWait/descr
 import {
 	getSendAndWaitProperties,
 	SEND_AND_WAIT_WAITING_TOOLTIP,
-	sendAndWaitWebhook,
 } from '../../../utils/sendAndWait/utils';
 
 export class SlackV2 implements INodeType {
@@ -169,7 +171,7 @@ export class SlackV2 implements INodeType {
 						},
 					],
 					undefined,
-					undefined,
+					[captureResponderField, approversField],
 					{ extraOptions: [replyToMessageField] },
 				).filter((p) => p.name !== 'subject'),
 				...starOperations,
@@ -365,7 +367,7 @@ export class SlackV2 implements INodeType {
 		},
 	};
 
-	webhook = sendAndWaitWebhook;
+	webhook = slackSendAndWaitWebhook;
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();

--- a/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
@@ -1,0 +1,268 @@
+import type { IWebhookFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import * as sendAndWaitUtils from '../../../../../utils/sendAndWait/utils';
+import * as SlackTriggerHelpers from '../../../SlackTriggerHelpers';
+import * as GenericFunctions from '../../../V2/GenericFunctions';
+import { slackSendAndWaitWebhook } from '../../../V2/SlackHitlWebhook';
+
+vi.mock('../../../V2/GenericFunctions', () => ({ slackApiRequest: vi.fn() }));
+vi.mock('../../../SlackTriggerHelpers', () => ({ verifySignature: vi.fn() }));
+vi.mock('../../../../../utils/sendAndWait/utils', () => ({ sendAndWaitWebhook: vi.fn() }));
+
+const slackApiRequest = vi.mocked(GenericFunctions.slackApiRequest);
+const verifySignature = vi.mocked(SlackTriggerHelpers.verifySignature);
+const sendAndWaitWebhook = vi.mocked(sendAndWaitUtils.sendAndWaitWebhook);
+
+interface ContextOptions {
+	method?: string;
+	hasSignature?: boolean;
+	signatureSecret?: string;
+	payload?: Record<string, unknown>;
+	approvers?: string[];
+	authentication?: string;
+}
+
+function createContext(opts: ContextOptions) {
+	const ctx = mock<IWebhookFunctions>();
+	ctx.getRequestObject.mockReturnValue({
+		method: opts.method ?? 'POST',
+		headers: opts.hasSignature ? { 'x-slack-signature': 'v0=abc' } : {},
+	} as unknown as ReturnType<IWebhookFunctions['getRequestObject']>);
+
+	const status = vi.fn().mockReturnThis();
+	const send = vi.fn().mockReturnThis();
+	ctx.getResponseObject.mockReturnValue({
+		status,
+		send,
+	} as unknown as ReturnType<IWebhookFunctions['getResponseObject']>);
+
+	ctx.getCredentials.mockResolvedValue({ signatureSecret: opts.signatureSecret });
+	ctx.getBodyData.mockReturnValue({ payload: JSON.stringify(opts.payload ?? {}) });
+	ctx.getNodeParameter.mockImplementation((name: string, fallback?: unknown) => {
+		if (name === 'approvers') return (opts.approvers ?? []) as never;
+		if (name === 'authentication') return (opts.authentication ?? fallback) as never;
+		return fallback as never;
+	});
+
+	const httpRequest = vi.fn();
+	ctx.helpers = { httpRequest } as unknown as IWebhookFunctions['helpers'];
+	ctx.logger = {
+		warn: vi.fn(),
+		error: vi.fn(),
+		info: vi.fn(),
+		debug: vi.fn(),
+	} as unknown as IWebhookFunctions['logger'];
+
+	return { ctx, status, send, httpRequest };
+}
+
+describe('slackSendAndWaitWebhook', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('delegates to the shared handler for non-interaction requests', async () => {
+		const { ctx } = createContext({ method: 'GET', hasSignature: false });
+		sendAndWaitWebhook.mockResolvedValue({ noWebhookResponse: true });
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+		expect(ctx.getCredentials).not.toHaveBeenCalled();
+	});
+
+	it('responds 401 without resuming when no signing secret is configured', async () => {
+		const { ctx, status } = createContext({ hasSignature: true, signatureSecret: undefined });
+		verifySignature.mockResolvedValue(true);
+
+		const result = await slackSendAndWaitWebhook.call(ctx);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('responds 401 without resuming when the signature is invalid', async () => {
+		const { ctx, status } = createContext({ hasSignature: true, signatureSecret: 'secret' });
+		verifySignature.mockResolvedValue(false);
+
+		const result = await slackSendAndWaitWebhook.call(ctx);
+
+		expect(status).toHaveBeenCalledWith(401);
+		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('resumes with the responder, channel and message id, and locks the message via response_url', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1', name: 'alice' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: {
+					ts: '111.222',
+					blocks: [
+						{ type: 'section', text: { type: 'mrkdwn', text: 'Please approve this request' } },
+						{ type: 'actions', elements: [{ type: 'button' }] },
+					],
+				},
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: { email: 'alice@example.com' } } });
+		httpRequest.mockResolvedValue({});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: Record<string, unknown> } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data).toEqual({
+			approved: true,
+			responder: { id: 'U1', name: 'alice', email: 'alice@example.com', source: 'slack' },
+			respondedAt: '2023-11-14T22:13:20.000Z',
+			channel: 'C1',
+			messageId: '111.222',
+		});
+		// Message locked via response_url, with the buttons removed. Body is a JSON string
+		// (Slack replies with plain "ok", so we don't parse the response as JSON).
+		expect(httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				method: 'POST',
+				url: 'https://hooks.slack.com/actions/xxx',
+				body: expect.stringContaining('"replace_original":true'),
+			}),
+		);
+		// The original message is preserved and only the actions block is dropped.
+		const lockBody = httpRequest.mock.calls[0][0].body as string;
+		expect(lockBody).toContain('Please approve this request');
+		expect(lockBody).not.toContain('"type":"actions"');
+		expect(lockBody).toContain('Approved');
+	});
+
+	it('verifies against the OAuth2 credential when the node uses OAuth2 auth', async () => {
+		const { ctx } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			authentication: 'oAuth2',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(ctx.getCredentials).toHaveBeenCalledWith('slackOAuth2Api');
+		expect(verifySignature).toHaveBeenCalledWith('slackOAuth2Api');
+	});
+
+	it('treats a decline action as not approved', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_decline', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(false);
+	});
+
+	it('ignores a click from someone not on the approver list and notifies them privately', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			approvers: ['U_ALLOWED'],
+			payload: {
+				user: { id: 'U_OTHER' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ ok: true });
+
+		const result = await slackSendAndWaitWebhook.call(ctx);
+
+		// Execution stays waiting: no workflowData returned, and the message is not locked.
+		expect(result).toEqual({ noWebhookResponse: true });
+		expect(httpRequest).not.toHaveBeenCalled();
+		expect(slackApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/chat.postEphemeral',
+			expect.objectContaining({ channel: 'C1', user: 'U_OTHER' }),
+		);
+	});
+
+	it('resumes when the responder is on the approver list', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			approvers: ['U1'],
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(true);
+	});
+
+	it('falls back to chat.update when response_url fails', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockImplementation(async (_method, resource) => {
+			if (resource === '/users.info') return { user: { profile: {} } };
+			return { ok: true };
+		});
+		httpRequest.mockRejectedValue(new Error('response_url expired'));
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(slackApiRequest).toHaveBeenCalledWith(
+			'POST',
+			'/chat.update',
+			expect.objectContaining({ channel: 'C1', ts: '111.222' }),
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
@@ -72,6 +72,24 @@ describe('slackSendAndWaitWebhook', () => {
 		expect(ctx.getCredentials).not.toHaveBeenCalled();
 	});
 
+	it('delegates a POST without an x-slack-signature header to the shared handler', async () => {
+		// The header-only gate: an unsigned POST is either HMAC-validated by the base route or
+		// rejected at the `-slack` CLI layer, so it must never be treated as a Slack interaction
+		// (which would force it through signature verification). A custom-form field named
+		// `payload` must not change this.
+		const { ctx } = createContext({
+			method: 'POST',
+			hasSignature: false,
+			payload: { payload: 'a user-defined form field' },
+		});
+		sendAndWaitWebhook.mockResolvedValue({ noWebhookResponse: true });
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(sendAndWaitWebhook).toHaveBeenCalledTimes(1);
+		expect(ctx.getCredentials).not.toHaveBeenCalled();
+	});
+
 	it('responds 401 without resuming when no signing secret is configured', async () => {
 		const { ctx, status } = createContext({ hasSignature: true, signatureSecret: undefined });
 		verifySignature.mockResolvedValue(true);
@@ -125,6 +143,8 @@ describe('slackSendAndWaitWebhook', () => {
 			channel: 'C1',
 			messageId: '111.222',
 		});
+		// A verified interaction resumes directly and never reaches the unauthenticated handler.
+		expect(sendAndWaitWebhook).not.toHaveBeenCalled();
 		// Message locked via response_url, with the buttons removed. Body is a JSON string
 		// (Slack replies with plain "ok", so we don't parse the response as JSON).
 		expect(httpRequest).toHaveBeenCalledWith(
@@ -264,5 +284,174 @@ describe('slackSendAndWaitWebhook', () => {
 			'/chat.update',
 			expect.objectContaining({ channel: 'C1', ts: '111.222' }),
 		);
+	});
+
+	it('resolves as not approved for an unknown action_id and still resumes', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'something_else', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(false);
+	});
+
+	it('resolves as not approved when the interaction carries no actions and still resumes', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(false);
+	});
+
+	it('still resumes when both response_url and chat.update fail to lock the message', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		httpRequest.mockRejectedValue(new Error('response_url expired'));
+		slackApiRequest.mockImplementation(async (_method, resource) => {
+			if (resource === '/users.info') return { user: { profile: {} } };
+			throw new Error('missing chat:write scope');
+		});
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(true);
+	});
+
+	it('still resumes when the message cannot be locked because channel and ts are missing', async () => {
+		const { ctx } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<Array<{ json: { data: { approved: boolean } } }>>;
+		};
+
+		expect(result.workflowData[0][0].json.data.approved).toBe(true);
+	});
+
+	it('resumes with id and name but no email when users.info fails', async () => {
+		const { ctx, httpRequest } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1', name: 'alice' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		httpRequest.mockResolvedValue({});
+		slackApiRequest.mockRejectedValue(new Error('missing users:read.email scope'));
+
+		const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+			workflowData: Array<
+				Array<{ json: { data: { responder: { id: string; name?: string; source: string } } } }>
+			>;
+		};
+
+		expect(result.workflowData[0][0].json.data.responder).toEqual({
+			id: 'U1',
+			name: 'alice',
+			source: 'slack',
+		});
+	});
+
+	it('keeps waiting when notifying an unauthorized responder fails', async () => {
+		const { ctx } = createContext({
+			hasSignature: true,
+			signatureSecret: 'secret',
+			approvers: ['U_ALLOWED'],
+			payload: {
+				user: { id: 'U_OTHER' },
+				actions: [{ action_id: 'n8n_hitl_approve', action_ts: '1700000000.000' }],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockRejectedValue(new Error('missing chat:write scope'));
+
+		const result = await slackSendAndWaitWebhook.call(ctx);
+
+		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('falls back to the receive time for respondedAt when action_ts is invalid', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-01-02T03:04:05.000Z'));
+		try {
+			const { ctx, httpRequest } = createContext({
+				hasSignature: true,
+				signatureSecret: 'secret',
+				payload: {
+					user: { id: 'U1' },
+					actions: [{ action_id: 'n8n_hitl_approve', action_ts: 'not-a-number' }],
+					channel: { id: 'C1' },
+					message: { ts: '111.222' },
+					response_url: 'https://hooks.slack.com/actions/xxx',
+				},
+			});
+			verifySignature.mockResolvedValue(true);
+			slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+			httpRequest.mockResolvedValue({});
+
+			const result = (await slackSendAndWaitWebhook.call(ctx)) as {
+				workflowData: Array<Array<{ json: { data: { respondedAt: string } } }>>;
+			};
+
+			expect(result.workflowData[0][0].json.data.respondedAt).toBe('2024-01-02T03:04:05.000Z');
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/sendAndWait.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/sendAndWait.test.ts
@@ -4,6 +4,7 @@ import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 
 import * as GenericFunctions from '../../../../V2/GenericFunctions';
+import { HITL_APPROVE_ACTION_ID, HITL_DECLINE_ACTION_ID } from '../../../../V2/MessageInterface';
 import { SlackV2 } from '../../../../V2/SlackV2.node';
 
 describe('Test SlackV2, message => sendAndWait', () => {
@@ -127,10 +128,41 @@ describe('Test SlackV2, message => sendAndWait', () => {
 		const [approveButton] = actionsBlock.elements;
 
 		expect(approveButton.url).toBeUndefined();
-		expect(approveButton.action_id).toBe('n8n_hitl_approve');
+		expect(approveButton.action_id).toBe(HITL_APPROVE_ACTION_ID);
 		expect(approveButton.value).toBe(
 			JSON.stringify({ executionId: 'exec-1', nodeId: 'test-node-id' }),
 		);
+	});
+
+	it('assigns the decline action_id to the disapprove button when capturing the responder', async () => {
+		slackApiRequestSpy.mockResolvedValue({ ok: true });
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'authentication') return 'accessToken';
+			if (key === 'resource') return 'message';
+			if (key === 'operation') return SEND_AND_WAIT_OPERATION;
+			if (key === 'select') return 'channel';
+			if (key === 'channelId') return 'C123456789';
+			if (key === 'message') return 'test message';
+			if (key === 'subject') return '';
+			if (key === 'approvalOptions.values') return { approvalType: 'double' };
+			if (key === 'options') return {};
+			if (key === 'options.limitWaitTime.values') return {};
+			if (key === 'responseType') return 'approval';
+			if (key === 'captureResponder') return true;
+			return undefined;
+		});
+
+		await slack.execute.call(mockExecuteFunctions);
+
+		const body = slackApiRequestSpy.mock.calls[0][2];
+		const actionsBlock = body.blocks.find(
+			(block: { type: string }) => block.type === 'actions',
+		) as { elements: Array<{ action_id?: string }> };
+		// getSendAndWaitConfig pushes the disapprove option first, then approve.
+		const [declineButton, approveButton] = actionsBlock.elements;
+
+		expect(declineButton.action_id).toBe(HITL_DECLINE_ACTION_ID);
+		expect(approveButton.action_id).toBe(HITL_APPROVE_ACTION_ID);
 	});
 
 	it('should route API errors to error output when continueOnFail is true', async () => {

--- a/packages/nodes-base/nodes/Slack/test/v2/node/message/sendAndWait.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/message/sendAndWait.test.ts
@@ -1,10 +1,10 @@
+import { type INode, SEND_AND_WAIT_OPERATION, type IExecuteFunctions } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
-import { type INode, SEND_AND_WAIT_OPERATION, type IExecuteFunctions } from 'n8n-workflow';
 
-import { SlackV2 } from '../../../../V2/SlackV2.node';
 import * as GenericFunctions from '../../../../V2/GenericFunctions';
-import type { MockInstance } from 'vitest';
+import { SlackV2 } from '../../../../V2/SlackV2.node';
 
 describe('Test SlackV2, message => sendAndWait', () => {
 	let slack: SlackV2;
@@ -32,6 +32,7 @@ describe('Test SlackV2, message => sendAndWait', () => {
 
 		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
 		mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+		mockExecuteFunctions.getExecutionId.mockReturnValue('exec-1');
 		mockExecuteFunctions.getInputData.mockReturnValue([{ json: { data: 'test' } }]);
 		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
 		mockExecuteFunctions.putExecutionToWait.mockImplementation(async () => {});
@@ -97,6 +98,39 @@ describe('Test SlackV2, message => sendAndWait', () => {
 				},
 			],
 		});
+	});
+
+	it('should render interactive buttons carrying the run and node ids when capturing the responder', async () => {
+		slackApiRequestSpy.mockResolvedValue({ ok: true });
+		mockExecuteFunctions.getNodeParameter.mockImplementation((key: string) => {
+			if (key === 'authentication') return 'accessToken';
+			if (key === 'resource') return 'message';
+			if (key === 'operation') return SEND_AND_WAIT_OPERATION;
+			if (key === 'select') return 'channel';
+			if (key === 'channelId') return 'C123456789';
+			if (key === 'message') return 'test message';
+			if (key === 'subject') return '';
+			if (key === 'approvalOptions.values') return {};
+			if (key === 'options') return {};
+			if (key === 'options.limitWaitTime.values') return {};
+			if (key === 'responseType') return 'approval';
+			if (key === 'captureResponder') return true;
+			return undefined;
+		});
+
+		await slack.execute.call(mockExecuteFunctions);
+
+		const body = slackApiRequestSpy.mock.calls[0][2];
+		const actionsBlock = body.blocks.find(
+			(block: { type: string }) => block.type === 'actions',
+		) as { elements: Array<{ url?: string; action_id?: string; value?: string }> };
+		const [approveButton] = actionsBlock.elements;
+
+		expect(approveButton.url).toBeUndefined();
+		expect(approveButton.action_id).toBe('n8n_hitl_approve');
+		expect(approveButton.value).toBe(
+			JSON.stringify({ executionId: 'exec-1', nodeId: 'test-node-id' }),
+		);
 	});
 
 	it('should route API errors to error output when continueOnFail is true', async () => {

--- a/packages/nodes-base/nodes/WhatsApp/tests/utils.test.ts
+++ b/packages/nodes-base/nodes/WhatsApp/tests/utils.test.ts
@@ -33,11 +33,13 @@ describe('createMessage', () => {
 				label: 'Yes',
 				style: 'primary',
 				url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+				approved: true,
 			},
 			{
 				label: 'No',
 				style: 'secondary',
 				url: 'http://localhost/waiting-webhook/nodeID?approved=false&signature=abc',
+				approved: false,
 			},
 		],
 	};
@@ -80,6 +82,7 @@ describe('createMessage', () => {
 					label: 'Confirm',
 					style: '',
 					url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+					approved: true,
 				},
 			],
 		};

--- a/packages/nodes-base/utils/sendAndWait/interfaces.ts
+++ b/packages/nodes-base/utils/sendAndWait/interfaces.ts
@@ -1,5 +1,17 @@
 import type { IDataObject } from 'n8n-workflow';
 
+/**
+ * Identity of the person who responded to a Send-and-Wait request from within the
+ * messaging app itself (e.g. a Slack button click). Kept app-agnostic so Telegram
+ * and Gmail can reuse it as their advanced HITL support lands.
+ */
+export interface SendAndWaitResponder {
+	id: string;
+	name?: string;
+	email?: string;
+	source: 'slack' | 'telegram' | 'discord' | 'whatsapp';
+}
+
 export interface IEmail {
 	from?: string;
 	to?: string;

--- a/packages/nodes-base/utils/sendAndWait/interfaces.ts
+++ b/packages/nodes-base/utils/sendAndWait/interfaces.ts
@@ -2,14 +2,13 @@ import type { IDataObject } from 'n8n-workflow';
 
 /**
  * Identity of the person who responded to a Send-and-Wait request from within the
- * messaging app itself (e.g. a Slack button click). Kept app-agnostic so Telegram
- * and Gmail can reuse it as their advanced HITL support lands.
+ * messaging app itself (currently only a Slack button click).
  */
 export interface SendAndWaitResponder {
 	id: string;
 	name?: string;
 	email?: string;
-	source: 'slack' | 'telegram' | 'discord' | 'whatsapp';
+	source: 'slack';
 }
 
 export interface IEmail {

--- a/packages/nodes-base/utils/sendAndWait/test/util.test.ts
+++ b/packages/nodes-base/utils/sendAndWait/test/util.test.ts
@@ -127,6 +127,7 @@ describe('Send and Wait utils tests', () => {
 						label: 'Approve',
 						style: 'primary',
 						url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+						approved: true,
 					},
 				],
 			});
@@ -164,11 +165,13 @@ describe('Send and Wait utils tests', () => {
 						label: 'Reject',
 						style: 'secondary',
 						url: 'http://localhost/waiting-webhook/nodeID?approved=false&signature=abc',
+						approved: false,
 					},
 					{
 						label: 'Approve',
 						style: 'primary',
 						url: 'http://localhost/waiting-webhook/nodeID?approved=true&signature=abc',
+						approved: true,
 					},
 				]),
 			);

--- a/packages/nodes-base/utils/sendAndWait/utils.ts
+++ b/packages/nodes-base/utils/sendAndWait/utils.ts
@@ -31,7 +31,7 @@ import type { IEmail } from './interfaces';
 export type SendAndWaitConfig = {
 	title: string;
 	message: string;
-	options: Array<{ label: string; url: string; style: string }>;
+	options: Array<{ label: string; url: string; style: string; approved: boolean }>;
 	appendAttribution?: boolean;
 };
 
@@ -524,6 +524,7 @@ export function getSendAndWaitConfig(context: IExecuteFunctions): SendAndWaitCon
 			label,
 			url: approvedSignedResumeUrl,
 			style: 'primary',
+			approved: true,
 		});
 	} else if (approvalOptions.approvalType === 'double') {
 		const approveLabel = escapeHtml(approvalOptions.approveLabel || 'Approve');
@@ -536,11 +537,13 @@ export function getSendAndWaitConfig(context: IExecuteFunctions): SendAndWaitCon
 			label: disapproveLabel,
 			url: disapprovedSignedResumeUrl,
 			style: buttonDisapprovalStyle,
+			approved: false,
 		});
 		config.options.push({
 			label: approveLabel,
 			url: approvedSignedResumeUrl,
 			style: buttonApprovalStyle,
+			approved: true,
 		});
 	} else {
 		const label = escapeHtml(approvalOptions.approveLabel || 'Approve');
@@ -549,6 +552,7 @@ export function getSendAndWaitConfig(context: IExecuteFunctions): SendAndWaitCon
 			label,
 			url: approvedSignedResumeUrl,
 			style,
+			approved: true,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Implements [ENT-160](https://linear.app/n8n/issue/ENT-160). Behind the
`ENHANCED_HITL_SLACK` experiment, the Slack **Send and Wait for Response**
operation gets an opt-in **Capture Who Responded** toggle. With it on, approval
becomes a one-click Slack interaction instead of a browser round-trip.

## What it does (with the toggle on)

- One click in Slack resolves the waiting execution — no browser.
- Output records the responder (`data.responder`: id, name, email) plus the
  `channel` and `messageId`.
- Optional **approver list** — a click from anyone not listed is ignored and
  they get a private "not authorized" note.
- After a decision the message is locked: the original text is kept, the buttons
  are removed, and the outcome + responder are appended. Uses `response_url`,
  falling back to `chat.update`.
- The callback endpoint verifies Slack's signing secret (replay window +
  constant-time compare) and rejects anything that fails.
- Works under both **Access Token** and **OAuth2** credentials.
- With the flag or the toggle off, the node behaves exactly as today. The
  AI-agent Slack HITL tool inherits the same behavior via `usableAsTool`.

## How it works

- **cli:** new `/webhook-waiting-slack` endpoint (`SlackInteractionWebhooks`)
  parses the Slack `block_actions` payload and routes it into the shared
  waiting-webhook resume. Registered before `bodyParser` so the raw body
  survives for signature verification.
- **nodes-base:** interactive buttons carry `{executionId, nodeId}`; the new
  `slackSendAndWaitWebhook` verifies the signature, captures the responder,
  enforces the approver list, and locks the message.
- **editor-ui:** `shouldDisplayNodeParameter` hides the advanced fields unless
  the experiment is on (covers the node and its tool variant).

## How to test

1. Enable the flag locally (`window.featureFlags.override('096_enhanced_hitl_slack', true)`).
2. Slack app with Interactivity → Request URL `<public-url>/webhook-waiting-slack`,
   bot scopes `chat:write`, `users:read`, `users:read.email`, signing secret on
   the credential.
3. Slack node → Send and Wait → Approval → enable **Capture Who Responded** →
   run → click Approve in Slack → execution resumes, responder captured, message
   locks.

## Notes

- Requires the PostHog flag `096_enhanced_hitl_slack` to be configured for
  rollout (UI stays hidden otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->