### PR TITLE
feat(editor): Remove preview label from Instance-level MCP settings

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3129,7 +3129,6 @@
 	"settings.opentelemetry.unsavedChanges.saveAndLeave": "Save and leave",
 	"settings.mcp": "Instance-level MCP",
 	"settings.mcp.description": "Connect MCP clients like Claude Code and Cursor to build, run, and iterate on workflows in your instance",
-	"settings.mcp.preview.tooltip": "This feature is in preview. Expect improvements and changes over time.",
 	"settings.mcp.header.toggle.enabled": "Enabled",
 	"settings.mcp.header.toggle.disabled": "Disabled",
 	"settings.mcp.actionBox.heading": "Connect AI assistants to build and run workflows",

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
@@ -26,7 +26,6 @@ import {
 	N8nLink,
 	N8nInputLabel,
 	N8nInput,
-	N8nPreviewTag,
 } from '@n8n/design-system';
 import type { TabOptions } from '@n8n/design-system';
 import { useMcp } from '@/features/ai/mcpAccess/composables/useMcp';
@@ -419,12 +418,7 @@ onMounted(async () => {
 	<div :class="$style.container">
 		<header :class="$style['main-header']" data-test-id="mcp-settings-header">
 			<div :class="$style.headings">
-				<div :class="$style['heading-row']">
-					<N8nHeading size="2xlarge">{{ i18n.baseText('settings.mcp') }}</N8nHeading>
-					<N8nTooltip :content="i18n.baseText('settings.mcp.preview.tooltip')">
-						<N8nPreviewTag size="medium" />
-					</N8nTooltip>
-				</div>
+				<N8nHeading size="2xlarge">{{ i18n.baseText('settings.mcp') }}</N8nHeading>
 				<div v-show="mcpStore.mcpAccessEnabled" data-test-id="mcp-settings-description">
 					<N8nText size="small" color="text-light">
 						{{ i18n.baseText('settings.mcp.description') }}.
@@ -572,13 +566,6 @@ onMounted(async () => {
 	display: flex;
 	flex-direction: column;
 	min-height: 60px;
-}
-
-.heading-row {
-	display: flex;
-	align-items: center;
-	gap: var(--spacing--2xs);
-	margin-bottom: var(--spacing--5xs);
 }
 
 .tabs-header {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/module.descriptor.ts
@@ -38,7 +38,6 @@ export const MCPModule: FrontendModuleDescription = {
 			label: i18n.baseText('settings.mcp'),
 			position: 'top',
 			route: { to: { name: MCP_SETTINGS_VIEW } },
-			preview: true,
 			get available() {
 				return hasPermission(['rbac'], {
 					rbac: { scope: ['mcp:oauth', 'mcpApiKey:create', 'mcpApiKey:rotate'] },


### PR DESCRIPTION
## Summary
Removes the "preview" label from the Instance-level MCP feature now that it's generally available. The preview tag was shown in two places:

- The **MCP settings sidebar item** (`preview: true` in the module descriptor)
- The **MCP settings page heading** (the `N8nPreviewTag` with its tooltip)

This also cleans up the now-unused `settings.mcp.preview.tooltip` i18n string, the `N8nPreviewTag` import, and the `.heading-row` CSS wrapper that only existed to lay out the heading alongside the tag.
<img width="1281" height="601" alt="Screenshot 2026-07-13 at 16 33 54" src="https://github.com/user-attachments/assets/e7662814-5092-4bbd-aa2c-33f1b1d48ede" />


<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts
https://n8nio.slack.com/archives/C092MKPJDK2/p1783527226254939
<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34084">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
