### PR TITLE
fix(API): Sort tags alphabetically in the public API manifest (no-changelog)

### DIFF
--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -18,6 +18,12 @@ each handler's `spec/` directory.
    - Export middleware arrays keyed by `x-eov-operation-id`.
    - Tag the first middleware with `__apiKeyScope` and add `x-required-scope` in
      the path YAML (see `scope-parity.test.ts`).
+   - **Delegate to the same service/controller layer as the internal REST API.**
+     Parse input with `@n8n/api-types` DTOs, call `Container.get(SomeService)` or
+     `Container.get(SomeController)`, map errors — do not reach into repositories
+     or duplicate business logic in the handler. Older handlers like
+     `handlers/credentials/` and `handlers/workflows/` predate this pattern;
+     follow them only for middleware/OpenAPI wiring, not for data access.
 2. **OpenAPI path spec** — `handlers/<feature>/spec/paths/<path>.yml`
    - Set `tags: [<TagName>]` matching a top-level tag in `openapi.yml`.
 3. **Register path** — add a `$ref` entry under `paths:` in `openapi.yml`.
@@ -46,7 +52,8 @@ sort order.
 
 ## Reference handlers
 
-- Simple GET: `handlers/insights/`
-- CRUD: `handlers/credentials/`, `handlers/workflows/`
+- Simple GET via service: `handlers/insights/`
+- CRUD via service/controller: `handlers/variables/`, `handlers/folders/`,
+  `handlers/projects/`, `handlers/data-tables/`
 - Multipart: `handlers/n8n-packages/` (see also
   `packages/cli/src/modules/n8n-packages/CLAUDE.md`)

--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -16,8 +16,11 @@ each handler's `spec/` directory.
 
 1. **Handler** — `handlers/<feature>/<feature>.handler.ts`
    - Export middleware arrays keyed by `x-eov-operation-id`.
-   - Tag the first middleware with `__apiKeyScope` and add `x-required-scope` in
-     the path YAML (see `scope-parity.test.ts`).
+   - For scope-protected endpoints, use `publicApiScope()` or
+     `apiKeyHasScopeWithGlobalScopeFallback()` (they tag the scope-enforcement
+     middleware with `__apiKeyScope`) and add matching `x-required-scope` in the
+     path YAML; use `none` for endpoints without an API-key scope (see
+     `scope-parity.test.ts`).
    - **Delegate to the same service/controller layer as the internal REST API.**
      Parse input with `@n8n/api-types` DTOs, call `Container.get(SomeService)` or
      `Container.get(SomeController)`, map errors — do not reach into repositories
@@ -29,7 +32,7 @@ each handler's `spec/` directory.
 3. **Register path** — add a `$ref` entry under `paths:` in `openapi.yml`.
 4. **Request types** — add a namespace in `packages/cli/src/public-api/types.ts`
    when the handler needs typed query/body params.
-5. **Coverage manifest** — if the endpoint is user-facing, add it to
+5. **Coverage manifest** — add every new OpenAPI endpoint to
    `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
 
 ## `tags` array in `openapi.yml`

--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: n8n:public-api
+description: >-
+  Adds or updates n8n Public API v1 endpoints, OpenAPI specs, and handler wiring.
+  Use when creating public API handlers, registering paths in openapi.yml, or
+  adding OpenAPI tags.
+---
+
+# Public API v1
+
+Public API lives under `packages/cli/src/public-api/v1/`. Handlers are
+`express-openapi-validator` route modules; OpenAPI path specs are YAML under
+each handler's `spec/` directory.
+
+## Adding an endpoint
+
+1. **Handler** — `handlers/<feature>/<feature>.handler.ts`
+   - Export middleware arrays keyed by `x-eov-operation-id`.
+   - Tag the first middleware with `__apiKeyScope` and add `x-required-scope` in
+     the path YAML (see `scope-parity.test.ts`).
+2. **OpenAPI path spec** — `handlers/<feature>/spec/paths/<path>.yml`
+   - Set `tags: [<TagName>]` matching a top-level tag in `openapi.yml`.
+3. **Register path** — add a `$ref` entry under `paths:` in `openapi.yml`.
+4. **Request types** — add a namespace in `packages/cli/src/public-api/types.ts`
+   when the handler needs typed query/body params.
+5. **Coverage manifest** — if the endpoint is user-facing, add it to
+   `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
+
+## `tags` array in `openapi.yml`
+
+When adding or editing the top-level `tags:` array in
+`packages/cli/src/public-api/v1/openapi.yml`, **keep entries sorted
+alphabetically by `name`**. Insert the new tag in order; do not append to the end.
+
+```yaml
+tags:
+  - name: Audit
+    description: Operations about security audit
+  - name: CommunityPackage
+    description: Operations about community packages
+  # … remaining tags in A→Z order by name
+```
+
+`scope-parity.test.ts` asserts this ordering — CI fails if tags drift out of
+sort order.
+
+## Reference handlers
+
+- Simple GET: `handlers/insights/`
+- CRUD: `handlers/credentials/`, `handlers/workflows/`
+- Multipart: `handlers/n8n-packages/` (see also
+  `packages/cli/src/modules/n8n-packages/CLAUDE.md`)

--- a/.claude/plugins/n8n/skills/public-api
+++ b/.claude/plugins/n8n/skills/public-api
@@ -1,0 +1,1 @@
+../../../../.agents/skills/public-api

--- a/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
@@ -1,6 +1,8 @@
 import RefParser from '@apidevtools/json-schema-ref-parser';
 import { API_KEY_RESOURCES, type ApiKeyScope } from '@n8n/permissions';
+import fs from 'node:fs';
 import path from 'node:path';
+import yaml from 'yaml';
 
 import type { ScopeTaggedMiddleware } from '../shared/middlewares/global.middleware';
 
@@ -73,6 +75,15 @@ describe('Public API scope parity', () => {
 
 	beforeAll(async () => {
 		ops = await loadOperations();
+	});
+
+	test('openapi.yml tags are sorted alphabetically by name', () => {
+		const spec = yaml.parse(fs.readFileSync(OPENAPI_SPEC_PATH, 'utf8')) as {
+			tags?: Array<{ name: string }>;
+		};
+		const tagNames = (spec.tags ?? []).map((tag) => tag.name);
+		const sorted = [...tagNames].sort((a, b) => (a < b ? -1 : 1));
+		expect(tagNames).toEqual(sorted);
 	});
 
 	test('every operation declares x-required-scope', () => {

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -16,40 +16,40 @@ externalDocs:
 servers:
   - url: /api/v1
 tags:
-  - name: User
-    description: Operations about users
   - name: Audit
     description: Operations about security audit
-  - name: SecurityPolicy
-    description: Operations about the instance security policy settings
-  - name: Execution
-    description: Operations about executions
-  - name: Workflow
-    description: Operations about workflows
-  - name: Evaluation
-    description: Operations about evaluation test runs
-  - name: Credential
-    description: Operations about credentials
-  - name: Tags
-    description: Operations about tags
-  - name: SourceControl
-    description: Operations about source control
-  - name: Variables
-    description: Operations about variables
-  - name: DataTable
-    description: Operations about data tables and their rows
-  - name: Projects
-    description: Operations about projects
   - name: CommunityPackage
     description: Operations about community packages
+  - name: Credential
+    description: Operations about credentials
+  - name: DataTable
+    description: Operations about data tables and their rows
   - name: Discover
     description: API capability discovery
-  - name: Insights
-    description: Operations about insights
+  - name: Evaluation
+    description: Operations about evaluation test runs
+  - name: Execution
+    description: Operations about executions
   - name: Folders
     description: Operations about folders
+  - name: Insights
+    description: Operations about insights
   - name: N8nPackage
     description: Beta — breaking changes may still occur without major version bump.
+  - name: Projects
+    description: Operations about projects
+  - name: SecurityPolicy
+    description: Operations about the instance security policy settings
+  - name: SourceControl
+    description: Operations about source control
+  - name: Tags
+    description: Operations about tags
+  - name: User
+    description: Operations about users
+  - name: Variables
+    description: Operations about variables
+  - name: Workflow
+    description: Operations about workflows
 
 paths:
   /audit:


### PR DESCRIPTION
## Summary

The public API tags in `openapi.yml` were listed in an arbitrary order, so the
endpoint groups rendered out of order at https://docs.n8n.io/connect/n8n-api.

This PR:
- Reorders the top-level `tags` array in `openapi.yml` alphabetically by `name`.
- Adds a scope-parity test that enforces the ordering going forward, so newly
  added tags have to be inserted in the correct place.
- Adds the `n8n:public-api` skill, which documents the public API v1 authoring
  flow and codifies the alphabetical `tags` ordering convention the test enforces.

## How to test

```bash
cd packages/cli
pnpm test src/public-api/v1/__tests__/scope-parity.test.ts
```

The new `openapi.yml tags are sorted alphabetically by name` test passes; the
rest of the scope-parity suite is unaffected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-61

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.