### PR TITLE
fix(Code Node): External modules not working even when allowed in n8n version 1.x

### DIFF
--- a/packages/nodes-base/nodes/Code/JavaScriptSandbox.ts
+++ b/packages/nodes-base/nodes/Code/JavaScriptSandbox.ts
@@ -10,7 +10,7 @@ import {
 import type { SandboxContext } from './Sandbox';
 import { Sandbox } from './Sandbox';
 import { ValidationError } from './ValidationError';
-import { generateScript } from './utils';
+import { generateScript, resolveExternalModule } from './utils';
 
 const { NODE_FUNCTION_ALLOW_BUILTIN: builtIn, NODE_FUNCTION_ALLOW_EXTERNAL: external } =
 	process.env;
@@ -23,6 +23,7 @@ export const vmResolver = makeResolverFromLegacyOptions({
 			}
 		: false,
 	builtin: builtIn?.split(',') ?? [],
+	resolve: resolveExternalModule,
 });
 
 export class JavaScriptSandbox extends Sandbox {

--- a/packages/nodes-base/nodes/Code/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Code/test/utils.test.ts
@@ -1,7 +1,34 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { makeResolverFromLegacyOptions, NodeVM } from 'vm2';
 
-import { addPostExecutionWarning } from '../utils';
+import { addPostExecutionWarning, generateScript } from '../utils';
+
+it('should resolve external modules outside the process working directory', async () => {
+	const originalCwd = process.cwd();
+	const isolatedCwd = mkdtempSync(join(tmpdir(), 'n8n-code-node-'));
+
+	try {
+		process.chdir(isolatedCwd);
+
+		const resolver = makeResolverFromLegacyOptions({
+			external: { modules: ['lodash'], transitive: false },
+			builtin: [],
+		});
+		const vm = new NodeVM({ require: resolver });
+
+		await expect(vm.run(generateScript("return typeof require('lodash').chunk"))).resolves.toBe(
+			'function',
+		);
+	} finally {
+		process.chdir(originalCwd);
+		rmSync(isolatedCwd, { recursive: true, force: true });
+	}
+});
 
 describe('addPostExecutionWarning', () => {
 	const context = mock<IExecuteFunctions>();

--- a/packages/nodes-base/nodes/Code/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Code/test/utils.test.ts
@@ -6,7 +6,7 @@ import { mock } from 'jest-mock-extended';
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { makeResolverFromLegacyOptions, NodeVM } from 'vm2';
 
-import { addPostExecutionWarning, generateScript } from '../utils';
+import { addPostExecutionWarning, generateScript, resolveExternalModule } from '../utils';
 
 it('should resolve external modules outside the process working directory', async () => {
 	const originalCwd = process.cwd();
@@ -18,6 +18,7 @@ it('should resolve external modules outside the process working directory', asyn
 		const resolver = makeResolverFromLegacyOptions({
 			external: { modules: ['lodash'], transitive: false },
 			builtin: [],
+			resolve: resolveExternalModule,
 		});
 		const vm = new NodeVM({ require: resolver });
 

--- a/packages/nodes-base/nodes/Code/utils.ts
+++ b/packages/nodes-base/nodes/Code/utils.ts
@@ -1,5 +1,3 @@
-import { join } from 'node:path';
-
 import type { INodeExecutionData, IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import { VMScript } from 'vm2';
 
@@ -68,18 +66,24 @@ Error.prepareStackTrace = (err, structuredStackTrace) => {
 };
 `;
 
-const SCRIPT_FILENAME = join(__dirname, 'Code');
+export function resolveExternalModule(moduleName: string) {
+	try {
+		return require.resolve(moduleName);
+	} catch {
+		return undefined;
+	}
+}
 
 export function generateScript(jsCode: string) {
 	return new VMScript(
 		`module.exports = async function() {${jsCode}\n}() ${PREPARE_STACKTRACE}`,
-		SCRIPT_FILENAME,
+		'Code',
 	);
 }
 
 export function generateSortingScript(jsCode: string) {
 	return new VMScript(
 		`module.exports = items.sort((a, b) => { ${jsCode} }) ${PREPARE_STACKTRACE}`,
-		SCRIPT_FILENAME,
+		'Code',
 	);
 }

--- a/packages/nodes-base/nodes/Code/utils.ts
+++ b/packages/nodes-base/nodes/Code/utils.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import type { INodeExecutionData, IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import { VMScript } from 'vm2';
 
@@ -66,16 +68,18 @@ Error.prepareStackTrace = (err, structuredStackTrace) => {
 };
 `;
 
+const SCRIPT_FILENAME = join(__dirname, 'Code');
+
 export function generateScript(jsCode: string) {
 	return new VMScript(
 		`module.exports = async function() {${jsCode}\n}() ${PREPARE_STACKTRACE}`,
-		'Code',
+		SCRIPT_FILENAME,
 	);
 }
 
 export function generateSortingScript(jsCode: string) {
 	return new VMScript(
 		`module.exports = items.sort((a, b) => { ${jsCode} }) ${PREPARE_STACKTRACE}`,
-		'Code',
+		SCRIPT_FILENAME,
 	);
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

Allowed external modules could not be resolved in Docker in `1.x`, even when specified in `NODE_FUNCTION_ALLOW_EXTERNAL` env var, which caused an error if the Code node tries to `require()` a package

This occurred because if an instance of `VMScript` was provided to `.run` function, it would use the `filename` that is passed as a second argument in the `VMScript` constructor (see [here](https://github.com/n8n-io/n8n/blob/81ade1aff7c23a8e2bd738741c9b19cf996989d8/packages/nodes-base/nodes/Code/utils.ts#L72)), instead of the second arg to `.run` itself (see [here](https://github.com/n8n-io/n8n/blob/2a6119ea3169e929be60c60a8ea5a6fcf74c42e0/packages/nodes-base/nodes/Code/JavaScriptSandbox.ts#L58)). Also here is the [`vm2` code](https://github.com/patriksimek/vm2/blob/7a1f5100b96f48d34e0fe104ab37c0acc5944f92/lib/nodevm.js#L531) where that check occurs. Before, we'd pass a string instead of a `VMScript` which is why this issue didn't occur then, see [this PR with the change](https://github.com/n8n-io/n8n/pull/29828/changes#diff-db8569b9edbf17dd1ee5d81714d59eb2d569ddd86cffc03a0286065aaa0d5898L58)

This PR fixes it by providing a custom `resolve` function to the VM resolver

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

1. Build and run the Docker image with `NODE_FUNCTION_ALLOW_EXTERNAL=lodash`:
    1. `pnpm i && pnpm build:docker`
    2. `docker run -p 5678:5678 -e NODE_FUNCTION_ALLOW_EXTERNAL=lodash n8nio/n8n:local`
3. Create a workflow containing a Code node.
4. In that Code node, use this code:
```javascript
const { chunk } = require('lodash');

return [{ json: { result: chunk([1, 2, 3], 2) } }];
```
6. Confirm the node returns:
```javascript
{ result: [[1, 2], [3]] }
```
Before the fix, an error occurred: `Cannot find module 'lodash'`. The issue generally does not reproduce when running n8n locally from the repository.

7. Update the code in the node to confirm that for modules that are not allowed (e.g. `prom-client`) you still get an error when you try to `require` it
```javascript
const client = require('prom-client');

return [{ json: { result: client } }];
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/NODE-5457/code-node-external-modules-eg-prom-client-fail-to-load-after-112342
https://community.n8n.io/t/update-from-1-123-6-to-1-123-61-using-prom-client-in-code-node-broken/302275

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34093">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->