### PR TITLE
fix(editor): Refresh editor checksum on workflow activation while editing

### DIFF
--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -4535,6 +4535,79 @@ describe('POST /workflows/:workflowId/activate', () => {
 	});
 });
 
+describe('workflow conflict detection when a version is activated mid-edit (INS-859)', () => {
+	// `activeVersionId` is one of WORKFLOW_CHECKSUM_FIELDS, so activating a workflow shifts its
+	// server-side checksum even though no editable content changed. An editor that captured its
+	// checksum before the activation push therefore autosaves with a stale checksum and gets a
+	// (correct) 409 — the false "changed by someone else" conflict from INS-859. These tests pin
+	// that backend contract: a 409 on the pre-activation checksum, a clean save on the refreshed
+	// one. The frontend fix (refresh the checksum on the `workflowActivated` push) relies on it.
+
+	test('changes the workflow checksum when a version is activated', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const beforeActivation = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
+		expect(beforeActivation.body.data.activeVersionId).toBeNull();
+		const checksumBeforeActivation = beforeActivation.body.data.checksum;
+
+		const activated = await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: workflow.versionId })
+			.expect(200);
+
+		// Only activeVersionId changed, yet the checksum moves — the root cause of the conflict.
+		expect(activated.body.data.activeVersionId).toBe(workflow.versionId);
+		expect(activated.body.data.checksum).not.toBe(checksumBeforeActivation);
+	});
+
+	test('rejects an autosave whose checksum was captured before activation', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		// The editor loads the workflow and holds its checksum while the user keeps editing.
+		const loaded = await authOwnerAgent.get(`/workflows/${workflow.id}`).expect(200);
+		const checksumHeldByEditor = loaded.body.data.checksum;
+
+		// A server-side activation lands while the canvas is still dirty.
+		await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: workflow.versionId })
+			.expect(200);
+
+		// The debounced autosave ships with the now-stale pre-activation checksum (the edit here
+		// stands in for the node drag in the original report — the conflict is checksum-driven,
+		// not content-driven).
+		const autosave = await authOwnerAgent.patch(`/workflows/${workflow.id}`).send({
+			name: 'Edited while activation landed',
+			expectedChecksum: checksumHeldByEditor,
+		});
+
+		expect(autosave.statusCode).toBe(409);
+		expect(autosave.body.code).toBe(409);
+	});
+
+	test('accepts the autosave once the checksum is refreshed after activation, preserving the edit', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const activated = await authOwnerAgent
+			.post(`/workflows/${workflow.id}/activate`)
+			.send({ versionId: workflow.versionId })
+			.expect(200);
+
+		// The fix: on the `workflowActivated` push the editor refreshes its checksum to the
+		// post-activation value before the autosave fires.
+		const refreshedChecksum = activated.body.data.checksum;
+
+		const autosave = await authOwnerAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({ name: 'Edited while activation landed', expectedChecksum: refreshedChecksum })
+			.expect(200);
+
+		// The in-progress edit is persisted and the activation state is preserved.
+		expect(autosave.body.data.name).toBe('Edited while activation landed');
+		expect(autosave.body.data.activeVersionId).toBe(workflow.versionId);
+	});
+});
+
 describe('POST /workflows/:workflowId/deactivate', () => {
 	test('should deactivate active workflow', async () => {
 		const addRecordSpy = vi.spyOn(workflowPublishHistoryRepository, 'addRecord');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
@@ -156,5 +156,7 @@ describe('workflowActivated', () => {
 		// The stored expectedChecksum must be the post-publish value; otherwise the next
 		// autosave of the position change 409s with "Workflow was changed by someone else".
 		expect(workflowDocumentStore.checksum).toBe('checksum-after-publish');
+		// The in-progress edits must survive: reconcile the checksum, never re-hydrate.
+		expect(mockCanvasOperations.initializeWorkspace).not.toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.test.ts
@@ -119,4 +119,42 @@ describe('workflowActivated', () => {
 		expect(workflowDocumentStore.publicationStatus).toBe('idle');
 		expect(mockBannersStore.removeBannerFromStack).not.toHaveBeenCalled();
 	});
+
+	// Regression: INS-859 — "Workflow was changed by someone else" on dragging a node.
+	//
+	// `activeVersionId` is part of the conflict checksum (WORKFLOW_CHECKSUM_FIELDS in
+	// packages/workflow/src/workflow-checksum.ts), so publishing/activating a workflow
+	// changes its server-side checksum. When an AI-assistant artifact is published (the
+	// builder calls WorkflowService.activateWorkflow, which emits a `workflowActivated`
+	// push), the editor that is currently open must refresh its stored `expectedChecksum`
+	// — otherwise the next autosave sends the pre-publish checksum and the backend's
+	// `_detectConflicts` (workflow.service.ts) rejects it with a false 409.
+	//
+	// The sibling `workflowSettingsUpdated` handler already does exactly this
+	// (`setChecksum(checksum)` with a comment "so the next normal save doesn't 409").
+	// `workflowActivated` only refreshes when the workspace is clean, so a user who has an
+	// unsaved position change (dirty state) when the publication lands is left holding a
+	// stale checksum. This test pins that gap.
+	it('refreshes the editor checksum on activation even when there are unsaved changes', async () => {
+		// Editor opened before publication: draft checksum captured, workflow not yet published.
+		workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
+		workflowDocumentStore.setChecksum('checksum-before-publish');
+
+		// User dragged a node → workspace is dirty, autosave pending.
+		mockUIStore.stateIsDirty = true;
+
+		// Publication lands (e.g. AI builder publishes the artifact): server checksum now
+		// reflects the new activeVersionId.
+		mockWorkflowsListStore.fetchWorkflow.mockResolvedValue({
+			id: 'wf-123',
+			activeVersionId: 'v1',
+			checksum: 'checksum-after-publish',
+		});
+
+		await workflowActivated(makeEvent('wf-123', 'v1'), options);
+
+		// The stored expectedChecksum must be the post-publish value; otherwise the next
+		// autosave of the position change 409s with "Workflow was changed by someone else".
+		expect(workflowDocumentStore.checksum).toBe('checksum-after-publish');
+	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -22,12 +22,16 @@ export async function workflowActivated(
 	const workflowIsBeingViewed = workflowDocumentStore.workflowId === workflowId;
 	const activeVersionChanged = workflowDocumentStore.activeVersionId !== activeVersionId;
 	if (workflowIsBeingViewed && activeVersionChanged) {
-		// Only update workflow if there are no unsaved changes
-		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
-			if (!updatedWorkflow.checksum) {
-				throw new Error('Failed to fetch workflow');
-			}
+		const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to fetch workflow');
+		}
+
+		if (uiStore.stateIsDirty) {
+			// Unsaved changes in the editor: refresh the expectedChecksum so the next save
+			// doesn't 409, but don't re-hydrate — that would discard the in-progress edits.
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
+		} else {
 			await initializeWorkspace(updatedWorkflow);
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.test.ts
@@ -168,4 +168,32 @@ describe('workflowPartiallyActivated', () => {
 		expect(workflowDocumentStore.publicationFailures).toEqual([]);
 		expect(mockToast.showError).not.toHaveBeenCalled();
 	});
+
+	// Regression: INS-859 — same latent defect as workflowActivated. `activeVersionId` is part
+	// of the conflict checksum (WORKFLOW_CHECKSUM_FIELDS in packages/workflow), so a partial
+	// activation also changes the server-side checksum. An editor with unsaved changes must
+	// refresh its stored `expectedChecksum` instead of being left holding the pre-publish value,
+	// which would 409 the next autosave with "Workflow was changed by someone else".
+	it('refreshes the editor checksum on partial activation even when there are unsaved changes', async () => {
+		// Editor opened before publication: draft checksum captured, workflow not yet published.
+		workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
+		workflowDocumentStore.setChecksum('checksum-before-publish');
+
+		// User dragged a node → workspace is dirty, autosave pending.
+		mockUIStore.stateIsDirty = true;
+
+		// Publication lands with a partial result: server checksum now reflects the new
+		// activeVersionId.
+		mockWorkflowsListStore.fetchWorkflow.mockResolvedValue({
+			id: 'wf-123',
+			activeVersionId: 'v2',
+			checksum: 'checksum-after-publish',
+		});
+
+		await workflowPartiallyActivated(makeEvent(), options);
+
+		expect(workflowDocumentStore.checksum).toBe('checksum-after-publish');
+		// The in-progress edits must survive: reconcile the checksum, never re-hydrate.
+		expect(mockCanvasOperations.initializeWorkspace).not.toHaveBeenCalled();
+	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.ts
@@ -33,13 +33,19 @@ export async function workflowPartiallyActivated(
 	);
 
 	const activeVersionChanged = workflowDocumentStore.activeVersionId !== activeVersionId;
-	if (activeVersionChanged && !uiStore.stateIsDirty) {
-		// Only update workflow if there are no unsaved changes
+	if (activeVersionChanged) {
 		const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
 		if (!updatedWorkflow.checksum) {
 			throw new Error('Failed to fetch workflow');
 		}
-		await initializeWorkspace(updatedWorkflow);
+
+		if (uiStore.stateIsDirty) {
+			// Unsaved changes in the editor: refresh the expectedChecksum so the next save
+			// doesn't 409, but don't re-hydrate — that would discard the in-progress edits.
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
+		} else {
+			await initializeWorkspace(updatedWorkflow);
+		}
 	}
 
 	if (useSettingsStore().isWorkflowPublicationServiceEnabled) {


### PR DESCRIPTION
## Summary

Editing a published workflow could surface a false **"Workflow was changed by someone else"** error on the next autosave — most reliably on AI-assistant artifacts, where the builder auto-publishes.

Root cause: `activeVersionId` is part of the server-side conflict checksum (`WORKFLOW_CHECKSUM_FIELDS`), so activating/publishing a workflow changes that checksum even when no node or connection changed. The editor's activation push handlers only refreshed the stored `expectedChecksum` when the workspace was **clean**. If a user had an unsaved change (e.g. a dragged node) when an activation landed, the stored checksum went stale and the next autosave was rejected with a false 409.

The fix mirrors the sibling `workflowSettingsUpdated` handler: on `workflowActivated` and `workflowPartiallyActivated`, reconcile `expectedChecksum` **even when there are unsaved changes**. The activation push does not carry the new checksum, so the handler fetches the workflow and updates only the checksum — it does **not** re-hydrate the workspace, which would discard the in-progress edits.

Scope is limited to the two editor push handlers; no backend or `packages/workflow` changes.

**Changes**
- `workflowActivated.ts` / `workflowPartiallyActivated.ts`: refresh the stored checksum on activation when the workspace is dirty, without re-hydrating.
- Regression tests for both handlers, asserting the checksum is refreshed and the workspace is not re-hydrated when there are unsaved changes.

## How to test

Automated (deterministic):

```
cd packages/frontend/editor-ui
pnpm test src/app/composables/usePushConnection/handlers/workflowActivated.test.ts src/app/composables/usePushConnection/handlers/workflowPartiallyActivated.test.ts
```

Both regression tests — *"refreshes the editor checksum on (partial) activation even when there are unsaved changes"* — pass.

Manual:
1. Open a published workflow in the editor.
2. Make an unsaved change (e.g. drag a node) so the workspace is dirty.
3. Trigger an activation/publication of the same workflow (e.g. the AI builder publishing the artifact, or activating it from another session).
4. Save the pending change. Before this fix it failed with "Workflow was changed by someone else"; now it saves and the edit is preserved.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-859

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34095">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

