### PR TITLE
feat(Microsoft Excel SharePoint Node): Add the shared Graph request code (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
@@ -1,5 +1,7 @@
 export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
 
+export type ExcelSharePointCredentialType = 'microsoftOAuth2Api' | typeof SERVICE_PRINCIPAL_AUTH;
+
 export const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com';
 
 // Consulted on 403s so the error names the missing permission; each action adds its row.

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
@@ -1,0 +1,16 @@
+export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
+
+export const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com';
+
+// Consulted on 403s so the error names the missing permission; each action adds its row.
+export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; application: string }> = {
+	'worksheet:readRows': {
+		delegated: 'Sites.Read.All',
+		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
+	},
+};
+
+// A 404 can come from any of the location segments, so the message must not
+// single one out
+export const NOT_FOUND_MESSAGE =
+	'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.';

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/converters.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/converters.ts
@@ -1,7 +1,14 @@
 import type { IDataObject, IHttpRequestMethods, IHttpRequestOptions } from 'n8n-workflow';
 
 import { DEFAULT_GRAPH_BASE_URL } from './constants';
-import type { GraphRequestError } from './interfaces';
+
+export type GraphRequestError = {
+	httpCode?: string | number | null;
+	statusCode?: string | number | null;
+	message?: string;
+	code?: string;
+	error?: { error?: GraphRequestError };
+};
 
 /** Normalizes Graph's inconsistent status-code fields (string, number, or absent) into a clean number. */
 export function toHttpCode(raw: string | number | null | undefined): number | undefined {

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/converters.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/converters.ts
@@ -1,0 +1,62 @@
+import type { IDataObject, IHttpRequestMethods, IHttpRequestOptions } from 'n8n-workflow';
+
+import { DEFAULT_GRAPH_BASE_URL } from './constants';
+import type { GraphRequestError } from './interfaces';
+
+/** Normalizes Graph's inconsistent status-code fields (string, number, or absent) into a clean number. */
+export function toHttpCode(raw: string | number | null | undefined): number | undefined {
+	if (raw === undefined || raw === null) return undefined;
+	const code = Number(raw);
+	return Number.isNaN(code) ? undefined : code;
+}
+
+/** Resolves the credential's Graph base URL, defaulting to the public cloud and trimming trailing slashes. */
+export function toGraphBaseUrl(graphApiBaseUrl: unknown): string {
+	const base =
+		typeof graphApiBaseUrl === 'string' && graphApiBaseUrl !== ''
+			? graphApiBaseUrl
+			: DEFAULT_GRAPH_BASE_URL;
+	return base.replace(/\/+$/, '');
+}
+
+/** Graph nests its real error one level under `error.error`; unwraps it while preserving the outer status code. */
+export function unwrapGraphError(error: GraphRequestError): GraphRequestError {
+	if (!error.error?.error) return error;
+	return { ...error.error.error, statusCode: error.statusCode };
+}
+
+/** Builds the `REQUIRED_PERMISSIONS` lookup key for a resource/operation pair. */
+export function toPermissionKey(resource: string, operation: string): string {
+	return `${resource}:${operation}`;
+}
+
+export type RequestOptionsParams = {
+	method: IHttpRequestMethods;
+	resource: string;
+	body: IDataObject;
+	qs: IDataObject;
+	uri?: string;
+	headers: IDataObject;
+	graphApiBaseUrl: unknown;
+};
+
+/** Shapes the raw call args into Graph request options, resolving the base URL and merging in any extra headers. */
+export function buildRequestOptions(params: RequestOptionsParams): IHttpRequestOptions {
+	const baseUrl = toGraphBaseUrl(params.graphApiBaseUrl);
+	const options: IHttpRequestOptions = {
+		headers: {
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			'Content-Type': 'application/json',
+		},
+		method: params.method,
+		body: params.body,
+		qs: params.qs,
+		// An explicit `uri` (e.g. a next-page link from Graph) is used verbatim
+		url: params.uri ?? `${baseUrl}${params.resource}`,
+		json: true,
+	};
+	if (Object.keys(params.headers).length !== 0) {
+		options.headers = Object.assign({}, options.headers, params.headers);
+	}
+	return options;
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/credentials.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/credentials.ts
@@ -1,0 +1,8 @@
+import { SERVICE_PRINCIPAL_AUTH } from './constants';
+import type { AuthContext, ExcelSharePointCredentialType } from './interfaces';
+
+export function getExcelSharePointCredentialType(this: AuthContext): ExcelSharePointCredentialType {
+	// In load-options contexts the 2nd arg is the fallback, not an item index — keep the 2-arg form
+	const selected = this.getNodeParameter('authentication', 0);
+	return selected === SERVICE_PRINCIPAL_AUTH ? SERVICE_PRINCIPAL_AUTH : 'microsoftOAuth2Api';
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/credentials.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/credentials.ts
@@ -1,8 +1,0 @@
-import { SERVICE_PRINCIPAL_AUTH } from './constants';
-import type { AuthContext, ExcelSharePointCredentialType } from './interfaces';
-
-export function getExcelSharePointCredentialType(this: AuthContext): ExcelSharePointCredentialType {
-	// In load-options contexts the 2nd arg is the fallback, not an item index — keep the 2-arg form
-	const selected = this.getNodeParameter('authentication', 0);
-	return selected === SERVICE_PRINCIPAL_AUTH ? SERVICE_PRINCIPAL_AUTH : 'microsoftOAuth2Api';
-}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorHandler.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorHandler.ts
@@ -2,8 +2,13 @@ import type { IDataObject, JsonObject } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
 import { NOT_FOUND_MESSAGE, REQUIRED_PERMISSIONS } from './constants';
-import { toHttpCode, toPermissionKey, unwrapGraphError } from './converters';
-import type { AuthContext, GraphRequestError } from './interfaces';
+import {
+	toHttpCode,
+	toPermissionKey,
+	unwrapGraphError,
+	type GraphRequestError,
+} from './converters';
+import type { AuthContext } from './interfaces';
 
 /** Best-effort lookup; load-options contexts may not expose resource/operation. */
 function lookupRequiredPermissions(

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorHandler.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorHandler.ts
@@ -1,0 +1,94 @@
+import type { IDataObject, JsonObject } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+
+import { NOT_FOUND_MESSAGE, REQUIRED_PERMISSIONS } from './constants';
+import { toHttpCode, toPermissionKey, unwrapGraphError } from './converters';
+import type { AuthContext, GraphRequestError } from './interfaces';
+
+/** Best-effort lookup; load-options contexts may not expose resource/operation. */
+function lookupRequiredPermissions(
+	this: AuthContext,
+): { delegated: string; application: string } | undefined {
+	try {
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
+		if (typeof resource === 'string' && typeof operation === 'string') {
+			return REQUIRED_PERMISSIONS[toPermissionKey(resource, operation)];
+		}
+	} catch {}
+	return undefined;
+}
+
+// App-only error bodies can include internal identifiers — surface only a
+// fixed message + status (which lives on `httpCode` as a string when wrapped)
+export function servicePrincipalApiError(
+	this: AuthContext,
+	error: GraphRequestError,
+): NodeApiError {
+	const httpCode = toHttpCode(error.httpCode ?? error.statusCode);
+
+	let message: string;
+	if (httpCode === undefined) {
+		// No HTTP status means the request never got an answer — don't blame
+		// inputs or permissions
+		message = 'Could not reach Microsoft Graph. Check your network connection and try again.';
+	} else if (httpCode === 404) {
+		message = NOT_FOUND_MESSAGE;
+	} else if (httpCode === 401) {
+		message =
+			"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
+	} else if (httpCode === 403) {
+		const permissions = lookupRequiredPermissions.call(this);
+		message = permissions
+			? `The app registration is missing a consented application permission for this operation: ${permissions.application}. Grant it and admin consent, then retry.`
+			: 'The app registration is missing a consented application permission for this operation. Grant the required Microsoft Graph application permission and admin consent, then retry.';
+	} else {
+		message = `Microsoft Graph rejected the request (HTTP ${httpCode}). Check the operation's inputs and the app registration's permissions.`;
+	}
+
+	const sanitizedError: JsonObject = { message };
+	const errorOptions: IDataObject = { message };
+	if (httpCode !== undefined) {
+		sanitizedError.httpStatusCode = httpCode;
+		errorOptions.httpCode = `${httpCode}`;
+	}
+	return new NodeApiError(this.getNode(), sanitizedError, errorOptions);
+}
+
+// Always builds a fresh error object (never re-wraps `error` itself): once the
+// underlying request goes through `httpRequestWithAuthentication`, `error` may
+// already be a NodeApiError, and NodeApiError's constructor short-circuits
+// (returns the same instance untouched) when re-wrapping one of its own, which
+// would silently discard the message/description built below.
+export function delegatedApiError(this: AuthContext, error: GraphRequestError): NodeApiError {
+	const statusCode = toHttpCode(error.statusCode ?? error.httpCode);
+
+	let message: string | undefined;
+	let description: string | undefined;
+	if (statusCode === 403) {
+		// Missing scope OR no access to the site; callers key off httpCode '403'
+		const permissions = lookupRequiredPermissions.call(this);
+		message = permissions
+			? `Microsoft Graph refused this request. The credential may be missing the ${permissions.delegated} permission, or the signed-in account may not have access to this resource`
+			: 'Microsoft Graph refused this request. The credential may be missing a required permission, or the signed-in account may not have access to this resource';
+		description =
+			"Check the credential's scopes (with admin consent if your tenant requires it) and that the signed-in account can access the site, then try again.";
+	} else if (error.error?.error) {
+		const unwrapped = unwrapGraphError(error);
+		message =
+			unwrapped.code === 'NotFound' && unwrapped.message === 'Resource not found'
+				? NOT_FOUND_MESSAGE
+				: unwrapped.message;
+	}
+
+	const sanitizedError: JsonObject = message ? { message } : {};
+	const errorOptions: IDataObject = message ? { message } : {};
+	if (description) {
+		errorOptions.description = description;
+	}
+	if (statusCode !== undefined) {
+		sanitizedError.httpStatusCode = statusCode;
+		errorOptions.httpCode = `${statusCode}`;
+	}
+	return new NodeApiError(this.getNode(), sanitizedError, errorOptions);
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorMappers.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorMappers.ts
@@ -1,0 +1,12 @@
+import { SERVICE_PRINCIPAL_AUTH } from './constants';
+import { delegatedApiError, servicePrincipalApiError } from './errorHandler';
+import type { ErrorMapper, ExcelSharePointCredentialType } from './interfaces';
+
+const ERROR_MAPPERS: Record<ExcelSharePointCredentialType, ErrorMapper> = {
+	microsoftOAuth2Api: delegatedApiError,
+	[SERVICE_PRINCIPAL_AUTH]: servicePrincipalApiError,
+};
+
+export function getErrorMapper(credentialType: ExcelSharePointCredentialType): ErrorMapper {
+	return ERROR_MAPPERS[credentialType];
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorMappers.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/errorMappers.ts
@@ -1,6 +1,13 @@
-import { SERVICE_PRINCIPAL_AUTH } from './constants';
+import type { NodeApiError } from 'n8n-workflow';
+
+import { SERVICE_PRINCIPAL_AUTH, type ExcelSharePointCredentialType } from './constants';
+import type { GraphRequestError } from './converters';
 import { delegatedApiError, servicePrincipalApiError } from './errorHandler';
-import type { ErrorMapper, ExcelSharePointCredentialType } from './interfaces';
+import type { AuthContext } from './interfaces';
+
+// Both sign-in methods now go through the same httpRequestWithAuthentication
+// call; only the shape of the resulting error still differs by credential type.
+export type ErrorMapper = (this: AuthContext, error: GraphRequestError) => NodeApiError;
 
 const ERROR_MAPPERS: Record<ExcelSharePointCredentialType, ErrorMapper> = {
 	microsoftOAuth2Api: delegatedApiError,

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/interfaces.ts
@@ -1,19 +1,6 @@
-import type { IExecuteFunctions, ILoadOptionsFunctions, NodeApiError } from 'n8n-workflow';
+import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
 
-import type { SERVICE_PRINCIPAL_AUTH } from './constants';
-
-export type ExcelSharePointCredentialType = 'microsoftOAuth2Api' | typeof SERVICE_PRINCIPAL_AUTH;
-
-export type GraphRequestError = {
-	httpCode?: string | number | null;
-	statusCode?: string | number | null;
-	message?: string;
-	code?: string;
-	error?: { error?: GraphRequestError };
-};
-
+// Used as `this` by every helper in this node (credential resolution, error
+// mapping, the request itself), so it earns a shared home unlike the other
+// types here, which each live next to their one real consumer.
 export type AuthContext = IExecuteFunctions | ILoadOptionsFunctions;
-
-// Both sign-in methods now go through the same httpRequestWithAuthentication
-// call; only the shape of the resulting error still differs by credential type.
-export type ErrorMapper = (this: AuthContext, error: GraphRequestError) => NodeApiError;

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/interfaces.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/interfaces.ts
@@ -1,0 +1,19 @@
+import type { IExecuteFunctions, ILoadOptionsFunctions, NodeApiError } from 'n8n-workflow';
+
+import type { SERVICE_PRINCIPAL_AUTH } from './constants';
+
+export type ExcelSharePointCredentialType = 'microsoftOAuth2Api' | typeof SERVICE_PRINCIPAL_AUTH;
+
+export type GraphRequestError = {
+	httpCode?: string | number | null;
+	statusCode?: string | number | null;
+	message?: string;
+	code?: string;
+	error?: { error?: GraphRequestError };
+};
+
+export type AuthContext = IExecuteFunctions | ILoadOptionsFunctions;
+
+// Both sign-in methods now go through the same httpRequestWithAuthentication
+// call; only the shape of the resulting error still differs by credential type.
+export type ErrorMapper = (this: AuthContext, error: GraphRequestError) => NodeApiError;

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/MicrosoftExcelSharePoint.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/MicrosoftExcelSharePoint.node.test.ts
@@ -1,8 +1,8 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
-import { MicrosoftExcelSharePoint } from '../MicrosoftExcelSharePoint.node';
 import { MicrosoftExcel } from '../../Excel/MicrosoftExcel.node';
+import { MicrosoftExcelSharePoint } from '../MicrosoftExcelSharePoint.node';
 
 describe('MicrosoftExcelSharePoint (hidden shell)', () => {
 	const node = new MicrosoftExcelSharePoint();

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/converters.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/converters.test.ts
@@ -1,0 +1,128 @@
+import {
+	buildRequestOptions,
+	toGraphBaseUrl,
+	toHttpCode,
+	toPermissionKey,
+	unwrapGraphError,
+} from '../helpers/converters';
+
+describe('Microsoft Excel (SharePoint) Converters', () => {
+	describe('toHttpCode', () => {
+		it('passes a number through unchanged', () => {
+			expect(toHttpCode(404)).toBe(404);
+		});
+
+		it('parses a numeric string', () => {
+			expect(toHttpCode('403')).toBe(403);
+		});
+
+		it('returns undefined for undefined', () => {
+			expect(toHttpCode(undefined)).toBeUndefined();
+		});
+
+		it('returns undefined for null', () => {
+			expect(toHttpCode(null)).toBeUndefined();
+		});
+
+		it('returns undefined for a non-numeric string', () => {
+			expect(toHttpCode('oops')).toBeUndefined();
+		});
+	});
+
+	describe('toGraphBaseUrl', () => {
+		it('returns an explicit URL unchanged', () => {
+			expect(toGraphBaseUrl('https://graph.microsoft.us')).toBe('https://graph.microsoft.us');
+		});
+
+		it('trims trailing slashes', () => {
+			expect(toGraphBaseUrl('https://graph.microsoft.com//')).toBe('https://graph.microsoft.com');
+		});
+
+		it('defaults to the public cloud when undefined', () => {
+			expect(toGraphBaseUrl(undefined)).toBe('https://graph.microsoft.com');
+		});
+
+		it('defaults to the public cloud when an empty string', () => {
+			expect(toGraphBaseUrl('')).toBe('https://graph.microsoft.com');
+		});
+	});
+
+	describe('unwrapGraphError', () => {
+		it('unwraps the nested error while preserving the outer status code', () => {
+			const error = {
+				statusCode: 404,
+				error: { error: { code: 'NotFound', message: 'Resource not found' } },
+			};
+
+			expect(unwrapGraphError(error)).toEqual({
+				code: 'NotFound',
+				message: 'Resource not found',
+				statusCode: 404,
+			});
+		});
+
+		it('leaves a non-nested error untouched', () => {
+			const error = { statusCode: 403, message: 'Access denied' };
+
+			expect(unwrapGraphError(error)).toBe(error);
+		});
+	});
+
+	describe('toPermissionKey', () => {
+		it('joins resource and operation into the lookup key format', () => {
+			expect(toPermissionKey('worksheet', 'readRows')).toBe('worksheet:readRows');
+		});
+	});
+
+	describe('buildRequestOptions', () => {
+		it('builds the url from the base URL and resource with the default Content-Type header', () => {
+			const options = buildRequestOptions({
+				method: 'GET',
+				resource: '/v1.0/sites/s',
+				body: {},
+				qs: {},
+				headers: {},
+				graphApiBaseUrl: 'https://graph.microsoft.com',
+			});
+
+			expect(options).toEqual({
+				headers: { 'Content-Type': 'application/json' },
+				method: 'GET',
+				body: {},
+				qs: {},
+				url: 'https://graph.microsoft.com/v1.0/sites/s',
+				json: true,
+			});
+		});
+
+		it('uses an explicit uri verbatim over the base URL and resource', () => {
+			const options = buildRequestOptions({
+				method: 'GET',
+				resource: '/ignored',
+				body: {},
+				qs: {},
+				uri: 'https://graph.microsoft.com/v1.0/sites?$skiptoken=abc',
+				headers: {},
+				graphApiBaseUrl: 'https://graph.microsoft.com',
+			});
+
+			expect(options.url).toBe('https://graph.microsoft.com/v1.0/sites?$skiptoken=abc');
+		});
+
+		it('merges extra headers into the default Content-Type header', () => {
+			const options = buildRequestOptions({
+				method: 'GET',
+				resource: '/v1.0/sites/s',
+				body: {},
+				qs: {},
+				headers: { 'If-Match': '*' },
+				graphApiBaseUrl: 'https://graph.microsoft.com',
+			});
+
+			expect(options.headers).toEqual({
+				'Content-Type': 'application/json',
+				'If-Match': '*',
+			});
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/credentials.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/credentials.test.ts
@@ -1,0 +1,26 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { SERVICE_PRINCIPAL_AUTH } from '../helpers/constants';
+import { getExcelSharePointCredentialType } from '../helpers/credentials';
+
+describe('Microsoft Excel (SharePoint) Credentials', () => {
+	let ctx: Mocked<IExecuteFunctions>;
+
+	beforeEach(() => {
+		ctx = mockDeep<IExecuteFunctions>();
+	});
+
+	it('returns the Service Principal type when selected', () => {
+		ctx.getNodeParameter.mockReturnValue(SERVICE_PRINCIPAL_AUTH);
+
+		expect(getExcelSharePointCredentialType.call(ctx)).toBe(SERVICE_PRINCIPAL_AUTH);
+	});
+
+	it('defaults to the generic OAuth2 type for any other selection', () => {
+		ctx.getNodeParameter.mockReturnValue(undefined);
+
+		expect(getExcelSharePointCredentialType.call(ctx)).toBe('microsoftOAuth2Api');
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/credentials.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/credentials.test.ts
@@ -3,7 +3,7 @@ import type { Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
 import { SERVICE_PRINCIPAL_AUTH } from '../helpers/constants';
-import { getExcelSharePointCredentialType } from '../helpers/credentials';
+import { getExcelSharePointCredentialType } from '../transport';
 
 describe('Microsoft Excel (SharePoint) Credentials', () => {
 	let ctx: Mocked<IExecuteFunctions>;

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/errorHandler.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/errorHandler.test.ts
@@ -1,0 +1,106 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { delegatedApiError, servicePrincipalApiError } from '../helpers/errorHandler';
+
+describe('Microsoft Excel (SharePoint) Error Handler', () => {
+	let ctx: Mocked<IExecuteFunctions>;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	beforeEach(() => {
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getNode.mockReturnValue({
+			id: 'test-node',
+			name: 'Test Node',
+			type: 'n8n-nodes-base.microsoftExcelSharePoint',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		} as INode);
+		setParams({});
+	});
+
+	describe('servicePrincipalApiError', () => {
+		it('reports a rejected token on a 401', () => {
+			const error = servicePrincipalApiError.call(ctx, { httpCode: '401' });
+
+			expect(error.message).toContain('Service Principal token was rejected');
+		});
+
+		it('falls back to a generic message when the permission is not in the lookup table', () => {
+			setParams({ resource: 'worksheet', operation: 'unknownOperation' });
+
+			const error = servicePrincipalApiError.call(ctx, { httpCode: '403' });
+
+			expect(error.message).toBe(
+				'The app registration is missing a consented application permission for this operation. Grant the required Microsoft Graph application permission and admin consent, then retry.',
+			);
+		});
+	});
+
+	describe('delegatedApiError', () => {
+		it('falls back to a generic message when the permission is not in the lookup table', () => {
+			setParams({ resource: 'worksheet', operation: 'unknownOperation' });
+
+			const error = delegatedApiError.call(ctx, { statusCode: 403 });
+
+			expect(error.message).toBe(
+				'Microsoft Graph refused this request. The credential may be missing a required permission, or the signed-in account may not have access to this resource',
+			);
+		});
+
+		it('replaces a nested NotFound error with the not-found message', () => {
+			const error = delegatedApiError.call(ctx, {
+				statusCode: 404,
+				error: { error: { code: 'NotFound', message: 'Resource not found' } },
+			});
+
+			expect(error.message).toBe(
+				'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.',
+			);
+		});
+
+		it('passes through a nested error message for a non-NotFound code', () => {
+			const error = delegatedApiError.call(ctx, {
+				statusCode: 400,
+				error: { error: { code: 'BadRequest', message: 'The request is malformed' } },
+			});
+
+			expect(error.message).toBe('The request is malformed');
+		});
+
+		it('passes the status code through with no custom message when neither 403 nor nested', () => {
+			const error = delegatedApiError.call(ctx, { statusCode: 500 });
+
+			expect(error.httpCode).toBe('500');
+			expect(error.message).not.toContain('Sites.Read.All');
+			expect(error.message).not.toBe(
+				'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.',
+			);
+		});
+
+		it('still builds its own message when the incoming error is already a NodeApiError', () => {
+			// httpRequestWithAuthentication wraps any failure in a NodeApiError before this
+			// function ever sees it. NodeApiError's constructor returns the same instance
+			// untouched when asked to re-wrap one of its own, so this proves delegatedApiError
+			// never passes that instance back in as the thing being wrapped.
+			const alreadyWrapped = new NodeApiError(ctx.getNode(), { response: { status: 403 } });
+			expect(alreadyWrapped.httpCode).toBe('403');
+
+			const error = delegatedApiError.call(ctx, alreadyWrapped);
+
+			expect(error).not.toBe(alreadyWrapped);
+			expect(error.message).toBe(
+				'Microsoft Graph refused this request. The credential may be missing a required permission, or the signed-in account may not have access to this resource',
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/errorMappers.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/errorMappers.test.ts
@@ -1,0 +1,13 @@
+import { SERVICE_PRINCIPAL_AUTH } from '../helpers/constants';
+import { delegatedApiError, servicePrincipalApiError } from '../helpers/errorHandler';
+import { getErrorMapper } from '../helpers/errorMappers';
+
+describe('Microsoft Excel (SharePoint) Error Mappers', () => {
+	it('returns the delegated mapper for the generic OAuth2 credential', () => {
+		expect(getErrorMapper('microsoftOAuth2Api')).toBe(delegatedApiError);
+	});
+
+	it('returns the Service Principal mapper for the Service Principal credential', () => {
+		expect(getErrorMapper(SERVICE_PRINCIPAL_AUTH)).toBe(servicePrincipalApiError);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/transport.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/transport.test.ts
@@ -3,12 +3,12 @@ import { NodeApiError } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 
-import { microsoftApiRequest, SERVICE_PRINCIPAL_AUTH } from '../transport';
+import { SERVICE_PRINCIPAL_AUTH } from '../helpers/constants';
+import { microsoftApiRequest } from '../transport';
 
 describe('Microsoft Excel (SharePoint) Transport', () => {
 	let ctx: Mocked<IExecuteFunctions>;
-	let mockRequestOAuth2: Mock;
-	let mockRequestWithAuthentication: Mock;
+	let mockHttpRequestWithAuthentication: Mock;
 
 	const setParams = (params: Record<string, unknown>) => {
 		ctx.getNodeParameter.mockImplementation(
@@ -20,10 +20,8 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		ctx = mockDeep<IExecuteFunctions>();
-		mockRequestOAuth2 = vi.fn().mockResolvedValue({ values: [] });
-		mockRequestWithAuthentication = vi.fn().mockResolvedValue({ values: [] });
-		ctx.helpers.requestOAuth2 = mockRequestOAuth2;
-		ctx.helpers.requestWithAuthentication = mockRequestWithAuthentication;
+		mockHttpRequestWithAuthentication = vi.fn().mockResolvedValue({ values: [] });
+		ctx.helpers.httpRequestWithAuthentication = mockHttpRequestWithAuthentication;
 		ctx.getNode.mockReturnValue({
 			id: 'test-node',
 			name: 'Test Node',
@@ -46,9 +44,9 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 
 		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s/drives/d/items/i');
 
-		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+		expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
 			'microsoftOAuth2Api',
-			expect.objectContaining({ uri: `${baseUrl}/v1.0/sites/s/drives/d/items/i` }),
+			expect.objectContaining({ url: `${baseUrl}/v1.0/sites/s/drives/d/items/i` }),
 		);
 	});
 
@@ -57,20 +55,22 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 
 		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s');
 
-		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+		expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
 			'microsoftOAuth2Api',
-			expect.objectContaining({ uri: 'https://graph.microsoft.com/v1.0/sites/s' }),
+			expect.objectContaining({ url: 'https://graph.microsoft.com/v1.0/sites/s' }),
 		);
 	});
 
-	it('routes Service Principal requests through requestWithAuthentication', async () => {
+	it('sends Service Principal requests with its own credential type', async () => {
 		setParams({ authentication: SERVICE_PRINCIPAL_AUTH });
 
 		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s');
 
 		expect(ctx.getCredentials).toHaveBeenCalledWith(SERVICE_PRINCIPAL_AUTH);
-		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
-		expect(mockRequestOAuth2).not.toHaveBeenCalled();
+		expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
+			SERVICE_PRINCIPAL_AUTH,
+			expect.anything(),
+		);
 	});
 
 	it('uses an explicit uri verbatim', async () => {
@@ -78,9 +78,9 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 
 		await microsoftApiRequest.call(ctx, 'GET', '/ignored', {}, {}, nextLink);
 
-		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+		expect(mockHttpRequestWithAuthentication).toHaveBeenCalledWith(
 			'microsoftOAuth2Api',
-			expect.objectContaining({ uri: nextLink }),
+			expect.objectContaining({ url: nextLink }),
 		);
 	});
 
@@ -90,7 +90,7 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 			resource: 'worksheet',
 			operation: 'readRows',
 		});
-		mockRequestOAuth2.mockRejectedValue({
+		mockHttpRequestWithAuthentication.mockRejectedValue({
 			statusCode: 403,
 			error: { error: { code: 'accessDenied', message: 'Access denied' } },
 		});
@@ -106,7 +106,7 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 			resource: 'worksheet',
 			operation: 'readRows',
 		});
-		mockRequestWithAuthentication.mockRejectedValue({ httpCode: '403' });
+		mockHttpRequestWithAuthentication.mockRejectedValue({ httpCode: '403' });
 
 		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
 			/Sites\.Read\.All \(or Sites\.Selected/,
@@ -119,7 +119,7 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 			resource: 'worksheet',
 			operation: 'readRows',
 		});
-		mockRequestWithAuthentication.mockRejectedValue({ httpCode: '404' });
+		mockHttpRequestWithAuthentication.mockRejectedValue({ httpCode: '404' });
 
 		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
 			'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.',
@@ -128,7 +128,7 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 
 	it('reports a network failure as unreachable, not as a rejection', async () => {
 		setParams({ authentication: SERVICE_PRINCIPAL_AUTH });
-		mockRequestWithAuthentication.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+		mockHttpRequestWithAuthentication.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
 
 		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
 			'Could not reach Microsoft Graph. Check your network connection and try again.',
@@ -141,7 +141,7 @@ describe('Microsoft Excel (SharePoint) Transport', () => {
 			resource: 'worksheet',
 			operation: 'readRows',
 		});
-		mockRequestWithAuthentication.mockRejectedValue({
+		mockHttpRequestWithAuthentication.mockRejectedValue({
 			httpCode: '500',
 			message: 'MARKER-do-not-leak',
 			error: { error: { message: 'MARKER-do-not-leak' } },

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/transport.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/transport.test.ts
@@ -1,0 +1,160 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { microsoftApiRequest, SERVICE_PRINCIPAL_AUTH } from '../transport';
+
+describe('Microsoft Excel (SharePoint) Transport', () => {
+	let ctx: Mocked<IExecuteFunctions>;
+	let mockRequestOAuth2: Mock;
+	let mockRequestWithAuthentication: Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<IExecuteFunctions>();
+		mockRequestOAuth2 = vi.fn().mockResolvedValue({ values: [] });
+		mockRequestWithAuthentication = vi.fn().mockResolvedValue({ values: [] });
+		ctx.helpers.requestOAuth2 = mockRequestOAuth2;
+		ctx.helpers.requestWithAuthentication = mockRequestWithAuthentication;
+		ctx.getNode.mockReturnValue({
+			id: 'test-node',
+			name: 'Test Node',
+			type: 'n8n-nodes-base.microsoftExcelSharePoint',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		} as INode);
+		setParams({ authentication: 'microsoftOAuth2Api' });
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: 'https://graph.microsoft.com' });
+	});
+
+	it.each([
+		['US Government', 'https://graph.microsoft.us'],
+		['US Government DOD', 'https://dod-graph.microsoft.us'],
+		['China', 'https://microsoftgraph.chinacloudapi.cn'],
+		['Global', 'https://graph.microsoft.com'],
+	])('targets the %s cloud from the credential', async (_name, baseUrl) => {
+		ctx.getCredentials.mockResolvedValue({ graphApiBaseUrl: baseUrl });
+
+		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s/drives/d/items/i');
+
+		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+			'microsoftOAuth2Api',
+			expect.objectContaining({ uri: `${baseUrl}/v1.0/sites/s/drives/d/items/i` }),
+		);
+	});
+
+	it('falls back to the global cloud when the credential does not say', async () => {
+		ctx.getCredentials.mockResolvedValue({});
+
+		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s');
+
+		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+			'microsoftOAuth2Api',
+			expect.objectContaining({ uri: 'https://graph.microsoft.com/v1.0/sites/s' }),
+		);
+	});
+
+	it('routes Service Principal requests through requestWithAuthentication', async () => {
+		setParams({ authentication: SERVICE_PRINCIPAL_AUTH });
+
+		await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s');
+
+		expect(ctx.getCredentials).toHaveBeenCalledWith(SERVICE_PRINCIPAL_AUTH);
+		expect(mockRequestWithAuthentication).toHaveBeenCalledTimes(1);
+		expect(mockRequestOAuth2).not.toHaveBeenCalled();
+	});
+
+	it('uses an explicit uri verbatim', async () => {
+		const nextLink = 'https://graph.microsoft.com/v1.0/sites?$skiptoken=abc';
+
+		await microsoftApiRequest.call(ctx, 'GET', '/ignored', {}, {}, nextLink);
+
+		expect(mockRequestOAuth2).toHaveBeenCalledWith(
+			'microsoftOAuth2Api',
+			expect.objectContaining({ uri: nextLink }),
+		);
+	});
+
+	it('names the missing delegated permission on a refusal', async () => {
+		setParams({
+			authentication: 'microsoftOAuth2Api',
+			resource: 'worksheet',
+			operation: 'readRows',
+		});
+		mockRequestOAuth2.mockRejectedValue({
+			statusCode: 403,
+			error: { error: { code: 'accessDenied', message: 'Access denied' } },
+		});
+
+		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
+			/Sites\.Read\.All/,
+		);
+	});
+
+	it('names the missing application permission on a refusal under the Service Principal', async () => {
+		setParams({
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'worksheet',
+			operation: 'readRows',
+		});
+		mockRequestWithAuthentication.mockRejectedValue({ httpCode: '403' });
+
+		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
+			/Sites\.Read\.All \(or Sites\.Selected/,
+		);
+	});
+
+	it('reports a plain not-found under the Service Principal without blaming one field', async () => {
+		setParams({
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'worksheet',
+			operation: 'readRows',
+		});
+		mockRequestWithAuthentication.mockRejectedValue({ httpCode: '404' });
+
+		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
+			'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.',
+		);
+	});
+
+	it('reports a network failure as unreachable, not as a rejection', async () => {
+		setParams({ authentication: SERVICE_PRINCIPAL_AUTH });
+		mockRequestWithAuthentication.mockRejectedValue(new Error('getaddrinfo ENOTFOUND'));
+
+		await expect(microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s')).rejects.toThrow(
+			'Could not reach Microsoft Graph. Check your network connection and try again.',
+		);
+	});
+
+	it('keeps a fixed message for other Service Principal errors', async () => {
+		setParams({
+			authentication: SERVICE_PRINCIPAL_AUTH,
+			resource: 'worksheet',
+			operation: 'readRows',
+		});
+		mockRequestWithAuthentication.mockRejectedValue({
+			httpCode: '500',
+			message: 'MARKER-do-not-leak',
+			error: { error: { message: 'MARKER-do-not-leak' } },
+		});
+
+		let thrown: NodeApiError | undefined;
+		try {
+			await microsoftApiRequest.call(ctx, 'GET', '/v1.0/sites/s');
+		} catch (error) {
+			thrown = error as NodeApiError;
+		}
+
+		expect(thrown).toBeInstanceOf(NodeApiError);
+		expect(thrown?.message).not.toContain('MARKER-do-not-leak');
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
@@ -1,168 +1,38 @@
-import type {
-	IDataObject,
-	IExecuteFunctions,
-	IHttpRequestMethods,
-	ILoadOptionsFunctions,
-	IRequestOptions,
-	JsonObject,
-} from 'n8n-workflow';
-import { NodeApiError } from 'n8n-workflow';
+import type { IDataObject, IHttpRequestMethods, IHttpRequestOptions } from 'n8n-workflow';
 
-export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
+import { buildRequestOptions } from '../helpers/converters';
+import { getExcelSharePointCredentialType } from '../helpers/credentials';
+import { getErrorMapper } from '../helpers/errorMappers';
+import type { AuthContext } from '../helpers/interfaces';
 
-export type ExcelSharePointCredentialType = 'microsoftOAuth2Api' | typeof SERVICE_PRINCIPAL_AUTH;
-
-export const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com';
-
-// Consulted on 403s so the error names the missing permission; each action adds its row.
-export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; application: string }> = {
-	'worksheet:readRows': {
-		delegated: 'Sites.Read.All',
-		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
-	},
-};
-
-export function getExcelSharePointCredentialType(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
-): ExcelSharePointCredentialType {
-	// In load-options contexts the 2nd arg is the fallback, not an item index — keep the 2-arg form
-	const selected = this.getNodeParameter('authentication', 0);
-	return selected === SERVICE_PRINCIPAL_AUTH ? SERVICE_PRINCIPAL_AUTH : 'microsoftOAuth2Api';
-}
-
-/** Best-effort lookup; load-options contexts may not expose resource/operation. */
-function lookupRequiredPermissions(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
-): { delegated: string; application: string } | undefined {
-	try {
-		const resource = this.getNodeParameter('resource', 0);
-		const operation = this.getNodeParameter('operation', 0);
-		if (typeof resource === 'string' && typeof operation === 'string') {
-			return REQUIRED_PERMISSIONS[`${resource}:${operation}`];
-		}
-	} catch {}
-	return undefined;
-}
-
-type GraphRequestError = {
-	httpCode?: string | number | null;
-	statusCode?: string | number | null;
-	message?: string;
-	code?: string;
-	error?: { error?: GraphRequestError };
-};
-
-// A 404 can come from any of the location segments, so the message must not
-// single one out
-const NOT_FOUND_MESSAGE =
-	'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.';
-
-// App-only error bodies can include internal identifiers — surface only a
-// fixed message + status (which lives on `httpCode` as a string when wrapped)
-function servicePrincipalApiError(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
-	error: GraphRequestError,
-): NodeApiError {
-	const rawCode = error.httpCode ?? error.statusCode;
-	const httpCode: number | undefined =
-		rawCode === undefined || rawCode === null ? undefined : Number(rawCode);
-
-	let message: string;
-	if (httpCode === undefined || Number.isNaN(httpCode)) {
-		// No HTTP status means the request never got an answer — don't blame
-		// inputs or permissions
-		message = 'Could not reach Microsoft Graph. Check your network connection and try again.';
-	} else if (httpCode === 404) {
-		message = NOT_FOUND_MESSAGE;
-	} else if (httpCode === 401) {
-		message =
-			"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
-	} else if (httpCode === 403) {
-		const permissions = lookupRequiredPermissions.call(this);
-		message = permissions
-			? `The app registration is missing a consented application permission for this operation: ${permissions.application}. Grant it and admin consent, then retry.`
-			: 'The app registration is missing a consented application permission for this operation. Grant the required Microsoft Graph application permission and admin consent, then retry.';
-	} else {
-		message = `Microsoft Graph rejected the request (HTTP ${httpCode ?? 'unknown'}). Check the operation's inputs and the app registration's permissions.`;
-	}
-
-	const sanitizedError: JsonObject = { message };
-	const errorOptions: IDataObject = { message };
-	if (httpCode !== undefined && !Number.isNaN(httpCode)) {
-		sanitizedError.httpStatusCode = httpCode;
-		errorOptions.httpCode = `${httpCode}`;
-	}
-	return new NodeApiError(this.getNode(), sanitizedError, errorOptions);
-}
-
-function delegatedApiError(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
-	error: GraphRequestError,
-): NodeApiError {
-	const errorOptions: IDataObject = {};
-	const statusCode = Number(error.statusCode ?? error.httpCode);
-	if (statusCode === 403) {
-		// Missing scope OR no access to the site; callers key off httpCode '403'
-		const permissions = lookupRequiredPermissions.call(this);
-		errorOptions.message = permissions
-			? `Microsoft Graph refused this request. The credential may be missing the ${permissions.delegated} permission, or the signed-in account may not have access to this resource`
-			: 'Microsoft Graph refused this request. The credential may be missing a required permission, or the signed-in account may not have access to this resource';
-		errorOptions.description =
-			"Check the credential's scopes (with admin consent if your tenant requires it) and that the signed-in account can access the site, then try again.";
-		errorOptions.httpCode = '403';
-	} else if (error.error?.error) {
-		const httpCode = error.statusCode;
-		error = error.error.error;
-		error.statusCode = httpCode;
-		errorOptions.message = error.message;
-
-		if (error.code === 'NotFound' && error.message === 'Resource not found') {
-			errorOptions.message = NOT_FOUND_MESSAGE;
-		}
-	}
-	return new NodeApiError(this.getNode(), error as JsonObject, errorOptions);
-}
-
-export async function microsoftApiRequest(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
+export async function microsoftApiRequest<T extends IDataObject = IDataObject>(
+	this: AuthContext,
 	method: IHttpRequestMethods,
 	resource: string,
 	body: IDataObject = {},
 	qs: IDataObject = {},
 	uri?: string,
 	headers: IDataObject = {},
-): Promise<IDataObject> {
+): Promise<T> {
 	const credentialType = getExcelSharePointCredentialType.call(this);
-	const isServicePrincipal = credentialType === SERVICE_PRINCIPAL_AUTH;
+	const mapError = getErrorMapper(credentialType);
 	const credentials = await this.getCredentials(credentialType);
-	const baseUrl = (
-		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
-			? credentials.graphApiBaseUrl
-			: DEFAULT_GRAPH_BASE_URL
-	).replace(/\/+$/, '');
-	const options: IRequestOptions = {
-		headers: {
-			'Content-Type': 'application/json',
-		},
+	const options = buildRequestOptions({
 		method,
+		resource,
 		body,
 		qs,
-		// An explicit `uri` (e.g. a next-page link from Graph) is used verbatim
-		uri: uri ?? `${baseUrl}${resource}`,
-		json: true,
-	};
+		uri,
+		headers,
+		graphApiBaseUrl: credentials.graphApiBaseUrl,
+	});
 	try {
-		if (Object.keys(headers).length !== 0) {
-			options.headers = Object.assign({}, options.headers, headers);
-		}
-		// The SP credential is not an oAuth2Api type, so it can't go through requestOAuth2
-		if (isServicePrincipal) {
-			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
-		}
-		return await this.helpers.requestOAuth2.call(this, credentialType, options);
+		return await this.helpers.httpRequestWithAuthentication.call<
+			AuthContext,
+			[string, IHttpRequestOptions],
+			Promise<T>
+		>(this, credentialType, options);
 	} catch (error) {
-		throw isServicePrincipal
-			? servicePrincipalApiError.call(this, error)
-			: delegatedApiError.call(this, error);
+		throw mapError.call(this, error);
 	}
 }

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
@@ -1,9 +1,17 @@
 import type { IDataObject, IHttpRequestMethods, IHttpRequestOptions } from 'n8n-workflow';
 
+import { SERVICE_PRINCIPAL_AUTH, type ExcelSharePointCredentialType } from '../helpers/constants';
 import { buildRequestOptions } from '../helpers/converters';
-import { getExcelSharePointCredentialType } from '../helpers/credentials';
 import { getErrorMapper } from '../helpers/errorMappers';
 import type { AuthContext } from '../helpers/interfaces';
+
+// Not expected to be reused outside this file yet; move it back to its own
+// helpers/credentials.ts if a second consumer (e.g. a load-options dropdown) needs it.
+export function getExcelSharePointCredentialType(this: AuthContext): ExcelSharePointCredentialType {
+	// In load-options contexts the 2nd arg is the fallback, not an item index — keep the 2-arg form
+	const selected = this.getNodeParameter('authentication', 0);
+	return selected === SERVICE_PRINCIPAL_AUTH ? SERVICE_PRINCIPAL_AUTH : 'microsoftOAuth2Api';
+}
 
 export async function microsoftApiRequest<T extends IDataObject = IDataObject>(
 	this: AuthContext,

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/transport/index.ts
@@ -1,0 +1,168 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	IHttpRequestMethods,
+	ILoadOptionsFunctions,
+	IRequestOptions,
+	JsonObject,
+} from 'n8n-workflow';
+import { NodeApiError } from 'n8n-workflow';
+
+export const SERVICE_PRINCIPAL_AUTH = 'microsoftEntraServicePrincipalApi';
+
+export type ExcelSharePointCredentialType = 'microsoftOAuth2Api' | typeof SERVICE_PRINCIPAL_AUTH;
+
+export const DEFAULT_GRAPH_BASE_URL = 'https://graph.microsoft.com';
+
+// Consulted on 403s so the error names the missing permission; each action adds its row.
+export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; application: string }> = {
+	'worksheet:readRows': {
+		delegated: 'Sites.Read.All',
+		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
+	},
+};
+
+export function getExcelSharePointCredentialType(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+): ExcelSharePointCredentialType {
+	// In load-options contexts the 2nd arg is the fallback, not an item index — keep the 2-arg form
+	const selected = this.getNodeParameter('authentication', 0);
+	return selected === SERVICE_PRINCIPAL_AUTH ? SERVICE_PRINCIPAL_AUTH : 'microsoftOAuth2Api';
+}
+
+/** Best-effort lookup; load-options contexts may not expose resource/operation. */
+function lookupRequiredPermissions(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+): { delegated: string; application: string } | undefined {
+	try {
+		const resource = this.getNodeParameter('resource', 0);
+		const operation = this.getNodeParameter('operation', 0);
+		if (typeof resource === 'string' && typeof operation === 'string') {
+			return REQUIRED_PERMISSIONS[`${resource}:${operation}`];
+		}
+	} catch {}
+	return undefined;
+}
+
+type GraphRequestError = {
+	httpCode?: string | number | null;
+	statusCode?: string | number | null;
+	message?: string;
+	code?: string;
+	error?: { error?: GraphRequestError };
+};
+
+// A 404 can come from any of the location segments, so the message must not
+// single one out
+const NOT_FOUND_MESSAGE =
+	'The requested resource was not found. Check the Site, Library, Workbook, and Sheet values.';
+
+// App-only error bodies can include internal identifiers — surface only a
+// fixed message + status (which lives on `httpCode` as a string when wrapped)
+function servicePrincipalApiError(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	error: GraphRequestError,
+): NodeApiError {
+	const rawCode = error.httpCode ?? error.statusCode;
+	const httpCode: number | undefined =
+		rawCode === undefined || rawCode === null ? undefined : Number(rawCode);
+
+	let message: string;
+	if (httpCode === undefined || Number.isNaN(httpCode)) {
+		// No HTTP status means the request never got an answer — don't blame
+		// inputs or permissions
+		message = 'Could not reach Microsoft Graph. Check your network connection and try again.';
+	} else if (httpCode === 404) {
+		message = NOT_FOUND_MESSAGE;
+	} else if (httpCode === 401) {
+		message =
+			"The Service Principal token was rejected. Check the app registration's client secret and that admin consent is granted.";
+	} else if (httpCode === 403) {
+		const permissions = lookupRequiredPermissions.call(this);
+		message = permissions
+			? `The app registration is missing a consented application permission for this operation: ${permissions.application}. Grant it and admin consent, then retry.`
+			: 'The app registration is missing a consented application permission for this operation. Grant the required Microsoft Graph application permission and admin consent, then retry.';
+	} else {
+		message = `Microsoft Graph rejected the request (HTTP ${httpCode ?? 'unknown'}). Check the operation's inputs and the app registration's permissions.`;
+	}
+
+	const sanitizedError: JsonObject = { message };
+	const errorOptions: IDataObject = { message };
+	if (httpCode !== undefined && !Number.isNaN(httpCode)) {
+		sanitizedError.httpStatusCode = httpCode;
+		errorOptions.httpCode = `${httpCode}`;
+	}
+	return new NodeApiError(this.getNode(), sanitizedError, errorOptions);
+}
+
+function delegatedApiError(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	error: GraphRequestError,
+): NodeApiError {
+	const errorOptions: IDataObject = {};
+	const statusCode = Number(error.statusCode ?? error.httpCode);
+	if (statusCode === 403) {
+		// Missing scope OR no access to the site; callers key off httpCode '403'
+		const permissions = lookupRequiredPermissions.call(this);
+		errorOptions.message = permissions
+			? `Microsoft Graph refused this request. The credential may be missing the ${permissions.delegated} permission, or the signed-in account may not have access to this resource`
+			: 'Microsoft Graph refused this request. The credential may be missing a required permission, or the signed-in account may not have access to this resource';
+		errorOptions.description =
+			"Check the credential's scopes (with admin consent if your tenant requires it) and that the signed-in account can access the site, then try again.";
+		errorOptions.httpCode = '403';
+	} else if (error.error?.error) {
+		const httpCode = error.statusCode;
+		error = error.error.error;
+		error.statusCode = httpCode;
+		errorOptions.message = error.message;
+
+		if (error.code === 'NotFound' && error.message === 'Resource not found') {
+			errorOptions.message = NOT_FOUND_MESSAGE;
+		}
+	}
+	return new NodeApiError(this.getNode(), error as JsonObject, errorOptions);
+}
+
+export async function microsoftApiRequest(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	method: IHttpRequestMethods,
+	resource: string,
+	body: IDataObject = {},
+	qs: IDataObject = {},
+	uri?: string,
+	headers: IDataObject = {},
+): Promise<IDataObject> {
+	const credentialType = getExcelSharePointCredentialType.call(this);
+	const isServicePrincipal = credentialType === SERVICE_PRINCIPAL_AUTH;
+	const credentials = await this.getCredentials(credentialType);
+	const baseUrl = (
+		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
+			? credentials.graphApiBaseUrl
+			: DEFAULT_GRAPH_BASE_URL
+	).replace(/\/+$/, '');
+	const options: IRequestOptions = {
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		method,
+		body,
+		qs,
+		// An explicit `uri` (e.g. a next-page link from Graph) is used verbatim
+		uri: uri ?? `${baseUrl}${resource}`,
+		json: true,
+	};
+	try {
+		if (Object.keys(headers).length !== 0) {
+			options.headers = Object.assign({}, options.headers, headers);
+		}
+		// The SP credential is not an oAuth2Api type, so it can't go through requestOAuth2
+		if (isServicePrincipal) {
+			return await this.helpers.requestWithAuthentication.call(this, credentialType, options);
+		}
+		return await this.helpers.requestOAuth2.call(this, credentialType, options);
+	} catch (error) {
+		throw isServicePrincipal
+			? servicePrincipalApiError.call(this, error)
+			: delegatedApiError.call(this, error);
+	}
+}


### PR DESCRIPTION
## Summary

First half of ENT-198, split to keep each review a manageable size (stacked on #34089; the base switches as the stack merges). This adds **the shared request code** every action of the Microsoft Excel (SharePoint) node will use to call Microsoft's API (Graph). Nothing user-visible: the node is still hidden and gains no operations here — the first action arrives in the second half.

What the helper does:

- **Sends the request as whoever signed in.** The node's Authentication choice picks the credential — a person (Microsoft OAuth2) or an app (Service Principal) — and the matching sign-in machinery.
- **Calls the right copy of Microsoft's service.** The credential says which cloud the tenant lives in (public, US government, US government DOD, or China); the public cloud is used when it doesn't say.
- **Turns a refusal into an error naming the missing permission.** On a refusal the helper looks up what the current operation needs (`Sites.Read.All` for reading rows) and says so. The wording allows for both causes: a missing permission, or a signed-in person without access to that site.
- **Explains failures honestly.** A "not found" doesn't blame one field (it could be the site, library, workbook, or sheet), and a network failure says the service couldn't be reached — it doesn't send anyone auditing permissions.
- **Keeps app-credential errors short and fixed**, because app-only error responses can include internal identifiers that don't belong in a workflow error.
- **Uses "next page" links exactly as Microsoft hands them out** — locked in by a test before anything pages.

The shape is copied from the SharePoint v2 transport (#34063, still unmerged — the ticket says copy rather than wait). Converging the Microsoft nodes on one shared request module is an open question on the project.

## How to test

Code plus tests only. The 12 tests in `test/transport.test.ts` cover: credential routing for both sign-in methods, the four cloud addresses plus the fallback, "next page" links used untouched, permission-naming refusals under both sign-in methods, the plain not-found and network-failure messages, and that nothing from an app-credential error body leaks through. Run with `pnpm test ExcelSharePoint` in `packages/nodes-base`. The first real use is the second half of this split, where Sheet — Get Rows calls this code.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-198

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34097">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

