### PR TITLE
test(core): Cover vector store insert provider errors

### DIFF
--- a/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.test.ts
+++ b/packages/@n8n/ai-utilities/src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.test.ts
@@ -429,6 +429,49 @@ describe('createVectorStoreNode', () => {
 			includeDocumentMetadata: true,
 		};
 
+		it('normalizes provider errors thrown while inserting documents', async () => {
+			// AI-2626: provider upsert failures must cross the shared error-normalization boundary.
+			const parameters: Record<string, NodeParameterValueType> = {
+				...DEFAULT_PARAMETERS,
+				mode: 'insert',
+			};
+			const documents: DocumentInterface[] = [
+				{ pageContent: 'test document', metadata: { source: 'test' } },
+			];
+
+			executeContext.getNode.mockReturnValue({
+				id: 'testNode',
+				typeVersion: 1.1,
+				name: 'Test Vector Store',
+				type: 'testVectorStore',
+				parameters,
+				position: [0, 0],
+			});
+			executeContext.getNodeParameter.mockImplementation(
+				(parameterName: string): NodeParameterValueType | object => parameters[parameterName],
+			);
+			executeContext.getInputData.mockReturnValue([{ json: {} }]);
+			executeContext.getInputConnectionData
+				.mockResolvedValueOnce(embeddings)
+				.mockResolvedValueOnce(documents);
+			executeContext.getExecutionCancelSignal.mockReturnValue(undefined);
+
+			const providerError = new Error('Error');
+			vectorStoreNodeArgs.populateVectorStore.mockRejectedValueOnce(providerError);
+
+			const VectorStoreNodeType = createVectorStoreNode(vectorStoreNodeArgs);
+			const nodeType = new VectorStoreNodeType();
+			const thrown: unknown = await nodeType.execute
+				.call(executeContext)
+				.catch((error: unknown) => error);
+
+			expect(thrown).toBeInstanceOf(NodeApiError);
+			expect(thrown).toMatchObject({
+				level: 'warning',
+				message: 'Error',
+			});
+		});
+
 		it('wraps provider SDK errors thrown during execute in NodeApiError', async () => {
 			// ARRANGE
 			executeContext.getNodeParameter.mockImplementation(


### PR DESCRIPTION
## Summary

Add regression coverage for provider errors thrown while inserting documents into a vector store. The test verifies that an error from `populateVectorStore` crosses the shared execution error-normalization boundary and becomes a warning-level `NodeApiError`.

This complements the existing execute and supply-data normalization tests by covering the insert path directly. The test fails on the commit before the shared normalization fix and passes on current master.

## How to test

```sh
pushd packages/@n8n/ai-utilities
pnpm test src/utils/vector-store/createVectorStoreNode/createVectorStoreNode.test.ts
pnpm lint
pnpm typecheck
popd
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2626
- Related to https://github.com/n8n-io/n8n/pull/33508

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

