### PR TITLE
feat(ai-builder): Count scenario executions in eval lane load and fail fast on lane death (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -355,8 +355,9 @@ jobs:
             URLS+=("http://localhost:$port")
           done
           BASE_URLS=$(IFS=,; printf '%s' "${URLS[*]}")
-          # 44 over 14 lanes ≈ 3 per lane (burst 4 per MAX_CONCURRENT_BUILDS).
-          ARGS=(--base-url "$BASE_URLS" --concurrency 44 --verbose --iterations "${ITERATIONS:-3}")
+          # Per-lane cap on concurrent work (builds + scenario executions);
+          # the CLI derives the total in-flight cap from lane count × this.
+          ARGS=(--base-url "$BASE_URLS" --lane-concurrency 4 --verbose --iterations "${ITERATIONS:-3}")
           [ -n "$FILTER" ] && ARGS+=(--filter "$FILTER")
           [ -n "$TIER" ] && ARGS+=(--tier "$TIER")
           [ -n "$EXPERIMENT_NAME" ] && ARGS+=(--experiment-name "$EXPERIMENT_NAME")

--- a/.github/workflows/test-evals-mcp.yml
+++ b/.github/workflows/test-evals-mcp.yml
@@ -41,7 +41,7 @@ on:
         type: string
         default: '3'
       eval-concurrency:
-        description: 'Concurrent scenario executions in the verifier (empty = lanes * 2). Raise it to push throughput, but too high starves the shared Anthropic budget and causes verifier/MCP timeouts.'
+        description: 'Concurrent work units per lane in the verifier — builds + scenario executions (empty = 2). Raise it to push throughput, but too high starves the shared Anthropic budget and causes verifier/MCP timeouts.'
         required: false
         type: string
         default: ''
@@ -99,7 +99,7 @@ on:
           - '5'
         default: '3'
       eval-concurrency:
-        description: 'Concurrent scenario executions in the verifier (empty = lanes * 2). Raise it to push throughput, but too high starves the shared Anthropic budget and causes verifier/MCP timeouts.'
+        description: 'Concurrent work units per lane in the verifier — builds + scenario executions (empty = 2). Raise it to push throughput, but too high starves the shared Anthropic budget and causes verifier/MCP timeouts.'
         required: false
         default: ''
       build-model:
@@ -259,12 +259,12 @@ jobs:
           EVAL_CONCURRENCY: ${{ inputs.eval-concurrency }}
           EXPERIMENT_NAME: ${{ inputs.experiment-name }}
         run: |
-          # Default concurrency to lanes * 2. Each lane already caps builds at 4,
-          # but running all lanes flat-out (lanes * 4) floods the shared Anthropic
-          # budget — builds, verifier checks, and AI-node mocks all contend — which
-          # surfaces as verifier/MCP timeouts. lanes * 2 keeps that in check.
-          CONCURRENCY="${EVAL_CONCURRENCY:-$((LANES * 2))}"
-          echo "Lanes: $LANES | eval concurrency: $CONCURRENCY"
+          # 2 work units per lane (half the CLI default of 4): builds, verifier
+          # checks, and AI-node mocks all draw on the shared Anthropic budget, and
+          # running lanes flat-out surfaces as verifier/MCP timeouts. The CLI
+          # derives the total in-flight cap from lane count x this.
+          LANE_CONCURRENCY="${EVAL_CONCURRENCY:-2}"
+          echo "Lanes: $LANES | lane concurrency: $LANE_CONCURRENCY"
 
           # --dataset + --baseline-prefix keep the MCP cohort isolated from the
           # Instance AI dataset/baseline in LangSmith (both halves required).
@@ -278,7 +278,7 @@ jobs:
             --build-via-mcp
             --tier "${TIER:-mcp}"
             --iterations "${ITERATIONS:-3}"
-            --concurrency "$CONCURRENCY"
+            --lane-concurrency "$LANE_CONCURRENCY"
             --timeout-ms 1500000
             --dataset mcp-workflow-evals
             --baseline-prefix mcp-baseline-

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -145,7 +145,7 @@ dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --iterations 3
 | `--output-dir` | cwd | Where to write `eval-results.json` |
 | `--dataset` | `instance-ai-workflow-evals` | LangSmith dataset name. Synced from the JSON test cases (honoring `--filter`/`--exclude`/`--tier`) before each run — point an isolated cohort (e.g. MCP) at its own dataset to avoid writing to the shared one |
 | `--baseline-prefix` | `instance-ai-baseline-` | Experiment-name prefix the regression comparison uses to find the baseline. Override (e.g. `mcp-baseline-`) so a cohort compares against its own baselines instead of the Instance AI one |
-| `--concurrency` | `16` | Max concurrent scenarios (builds are separately capped at 4) |
+| `--lane-concurrency` | `4` | Max concurrent work on one lane — builds and scenario executions both count. The global in-flight cap is derived (lanes × (this + 1)), so there is no second number to keep in sync with the lane count |
 | `--experiment-name` | auto | LangSmith experiment prefix (defaults to `{branch}-{sha}` in CI or `local-{branch}-{sha}-dirty?` locally) |
 | `--iterations` | `1` | Run each test case N times with fresh builds |
 | `--tier` | — | Filter to test cases whose `datasets` array contains this value (e.g. `--tier pr` for the PR-time set). Combines with `--filter`/`--exclude`. |
@@ -425,8 +425,8 @@ which starts + seeds the lanes and forwards everything after `--`):
 
 ```bash
 # 6 lanes; build via MCP + verify the mcp tier, one experiment.
-# --concurrency 12 = lanes * 2 (the script's own default is lanes * 4).
-./scripts/run-eval-lanes.sh --instance-count 6 --tier mcp --concurrency 12 -- \
+# --lane-concurrency 2 halves the default per-lane load (see budget note below).
+./scripts/run-eval-lanes.sh --instance-count 6 --tier mcp --lane-concurrency 2 -- \
   --build-via-mcp \
   --dataset mcp-workflow-evals \
   --baseline-prefix mcp-baseline-
@@ -440,18 +440,18 @@ dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai \
   --build-via-mcp \
   --tier mcp \
   --iterations 3 \
-  --concurrency 4 \
+  --lane-concurrency 2 \
   --dataset mcp-workflow-evals \
   --baseline-prefix mcp-baseline-
 ```
 
 In CI this is what `ci-mcp-evals.yml` runs (see `test-evals-mcp.yml`): a single
-job starts `lanes` containers and runs one `--build-via-mcp` process, defaulting
-`--concurrency` to `lanes * 2`. Use the same ratio locally: `claude` builds,
-mock generation, and the verifier all draw on one Anthropic budget, and running
-lanes flat-out at `lanes * 4` (each lane's per-lane build cap) starves it,
-surfacing as verifier/MCP timeouts. Treat `lanes * 4` as an aggressive upper
-bound for keys with rate-limit headroom, not the starting point.
+job starts `lanes` containers and runs one `--build-via-mcp` process with
+`--lane-concurrency 2` (half the CLI default). Use the same setting locally:
+`claude` builds, mock generation, and the verifier all draw on one Anthropic
+budget, and running lanes flat-out at the default of 4 starves it, surfacing as
+verifier/MCP timeouts. Treat 4 as an aggressive upper bound for keys with
+rate-limit headroom, not the starting point.
 
 ## Discovery evals
 
@@ -794,7 +794,7 @@ Suite pass rates typically sit between 40–65%; most failures are `builder_issu
 
 **`Wrong username or password` on login.** Your instance has no owner. Run the `rest/e2e/reset` curl from [Quick start](#quick-start) (needs `E2E_TESTS=true` on the server).
 
-**`Have reached end of quota` mid-run.** You're hitting the hosted AI proxy's per-tenant quota. Set `N8N_AI_ASSISTANT_BASE_URL=""` to hit Anthropic directly with your `N8N_INSTANCE_AI_MODEL_API_KEY`. Also consider lowering `--concurrency`.
+**`Have reached end of quota` mid-run.** You're hitting the hosted AI proxy's per-tenant quota. Set `N8N_AI_ASSISTANT_BASE_URL=""` to hit Anthropic directly with your `N8N_INSTANCE_AI_MODEL_API_KEY`. Also consider lowering `--lane-concurrency`.
 
 **All scenarios timing out.** Check that the server is up (`curl localhost:5678/healthz`) and that `N8N_INSTANCE_AI_MODEL_API_KEY` is set. A full build is ~60–180s; timeouts past `--timeout-ms` usually mean the agent is looping.
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/args.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/args.test.ts
@@ -296,3 +296,17 @@ describe('parseCliArgs --build-via-mcp', () => {
 		expect(() => parseCliArgs(['--build-max-attempts', 'lots'])).toThrow();
 	});
 });
+
+describe('parseCliArgs --lane-concurrency', () => {
+	it('defaults to 4 work units per lane', () => {
+		expect(parseCliArgs([]).laneConcurrency).toBe(4);
+	});
+
+	it('parses an explicit per-lane cap', () => {
+		expect(parseCliArgs(['--lane-concurrency', '2']).laneConcurrency).toBe(2);
+	});
+
+	it('rejects the removed --concurrency flag with a migration hint', () => {
+		expect(() => parseCliArgs(['--concurrency', '32'])).toThrow(/--lane-concurrency/);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
@@ -7,7 +7,7 @@ interface TestLane extends AllocatableLane {
 function newLanes(count: number): TestLane[] {
 	return Array.from({ length: count }, (_, i) => ({
 		id: i,
-		activeBuilds: 0,
+		activeWork: 0,
 		inflightKeys: new Set<string>(),
 	}));
 }
@@ -20,7 +20,7 @@ describe('LaneAllocator', () => {
 		const l2 = await a.acquire('p2');
 		const l3 = await a.acquire('p3');
 		expect([l1.id, l2.id, l3.id]).toEqual([0, 1, 2]);
-		expect(lanes.map((l) => l.activeBuilds)).toEqual([1, 1, 1]);
+		expect(lanes.map((l) => l.activeWork)).toEqual([1, 1, 1]);
 	});
 
 	it('skips a lane already running the same prompt', async () => {
@@ -51,7 +51,7 @@ describe('LaneAllocator', () => {
 		expect(lanes[0].inflightKeys.has('p1')).toBe(true);
 	});
 
-	it('respects maxConcurrentBuilds per lane', async () => {
+	it('respects the per-lane work cap', async () => {
 		const lanes = newLanes(1);
 		const a = new LaneAllocator(lanes, 2);
 		await a.acquire('p1');
@@ -92,6 +92,91 @@ describe('LaneAllocator', () => {
 		expect(order).toEqual(['p3', 'p1']);
 	});
 
+	describe('pinned work slots (scenario executions)', () => {
+		it('counts pinned work toward the lane cap so a backlogged lane stops winning builds', async () => {
+			const lanes = newLanes(2);
+			const a = new LaneAllocator(lanes, 2);
+			await a.acquireOn(lanes[0]);
+			await a.acquireOn(lanes[0]);
+			// Lane 0 is full of scenario work — every build must land on lane 1.
+			const b1 = await a.acquire('p1');
+			const b2 = await a.acquire('p2');
+			expect([b1.id, b2.id]).toEqual([1, 1]);
+			a.release(lanes[0]);
+			const b3 = await a.acquire('p3');
+			expect(b3.id).toBe(0);
+		});
+
+		it('waits for the pinned lane even when other lanes are free', async () => {
+			const lanes = newLanes(2);
+			const a = new LaneAllocator(lanes, 1);
+			await a.acquire('p1'); // fills lane 0
+			let resolved = false;
+			const pinned = a.acquireOn(lanes[0]).then(() => {
+				resolved = true;
+			});
+			await new Promise((r) => setImmediate(r));
+			expect(resolved).toBe(false); // lane 1 being free must not unblock it
+			a.release(lanes[0], 'p1');
+			await pinned;
+			expect(resolved).toBe(true);
+		});
+
+		it('rejects a pinned wait at its deadline with the lane state in the message', async () => {
+			vi.useFakeTimers();
+			const lanes = newLanes(1);
+			const a = new LaneAllocator(lanes, 1);
+			await a.acquire('p1');
+			const pinned = a.acquireOn(lanes[0], { deadlineMs: 1000 });
+			const rejection = expect(pinned).rejects.toThrow('no lane slot within 1000ms');
+			await vi.advanceTimersByTimeAsync(1000);
+			await rejection;
+			vi.useRealTimers();
+		});
+
+		it('keeps pinned waiters queued through quarantine and serves them on re-admission', async () => {
+			vi.useFakeTimers();
+			const lanes = newLanes(2);
+			let healthy = false;
+			const a = new LaneAllocator(lanes, 4, {
+				probe: async () => await Promise.resolve(healthy),
+				probeIntervalMs: 1000,
+				quarantineThreshold: 1,
+			});
+			a.reportOutcome(lanes[0], 'transient-failure');
+			expect(a.isQuarantined(lanes[0])).toBe(true);
+			let resolved = false;
+			const pinned = a.acquireOn(lanes[0]).then(() => {
+				resolved = true;
+			});
+			await vi.advanceTimersByTimeAsync(1000);
+			expect(resolved).toBe(false);
+			healthy = true;
+			await vi.advanceTimersByTimeAsync(1000);
+			await pinned;
+			expect(resolved).toBe(true);
+			expect(lanes[0].activeWork).toBe(1);
+			vi.useRealTimers();
+		});
+
+		it('does not hand a freed slot on another lane to a pinned waiter', async () => {
+			const lanes = newLanes(2);
+			const a = new LaneAllocator(lanes, 1);
+			await a.acquire('p1'); // lane 0
+			await a.acquire('p2'); // lane 1
+			let resolved = false;
+			void a.acquireOn(lanes[0]).then(() => {
+				resolved = true;
+			});
+			a.release(lanes[1], 'p2');
+			await new Promise((r) => setImmediate(r));
+			expect(resolved).toBe(false);
+			a.release(lanes[0], 'p1');
+			await new Promise((r) => setImmediate(r));
+			expect(resolved).toBe(true);
+		});
+	});
+
 	describe('lane health', () => {
 		afterEach(() => {
 			vi.useRealTimers();
@@ -105,7 +190,7 @@ describe('LaneAllocator', () => {
 				quarantineThreshold: 3,
 				onQuarantine,
 			});
-			for (let i = 0; i < 3; i++) a.reportBuildOutcome(lanes[0], 'transient-failure');
+			for (let i = 0; i < 3; i++) a.reportOutcome(lanes[0], 'transient-failure');
 			expect(a.isQuarantined(lanes[0])).toBe(true);
 			expect(onQuarantine).toHaveBeenCalledWith(lanes[0]);
 			const l1 = await a.acquire('p1');
@@ -119,11 +204,11 @@ describe('LaneAllocator', () => {
 				probe: async () => await Promise.resolve(false),
 				quarantineThreshold: 3,
 			});
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
-			a.reportBuildOutcome(lanes[0], 'ok');
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'ok');
+			a.reportOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
 			expect(a.isQuarantined(lanes[0])).toBe(false);
 		});
 
@@ -139,7 +224,7 @@ describe('LaneAllocator', () => {
 				allQuarantinedGraceMs: 60_000,
 				onReadmit,
 			});
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
 			expect(a.isQuarantined(lanes[0])).toBe(true);
 			const waiter = a.acquire('p1');
 			await vi.advanceTimersByTimeAsync(1000);
@@ -173,7 +258,7 @@ describe('LaneAllocator', () => {
 				quarantineThreshold: 1,
 			});
 			expect(a.wasQuarantinedSince(lanes[0], before)).toBe(false);
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
 			expect(a.wasQuarantinedSince(lanes[0], before)).toBe(true);
 			expect(a.wasQuarantinedSince(lanes[0], Date.now() + 1000)).toBe(false);
 		});
@@ -187,8 +272,8 @@ describe('LaneAllocator', () => {
 				quarantineThreshold: 1,
 				allQuarantinedGraceMs: 5000,
 			});
-			a.reportBuildOutcome(lanes[0], 'transient-failure');
-			a.reportBuildOutcome(lanes[1], 'transient-failure');
+			a.reportOutcome(lanes[0], 'transient-failure');
+			a.reportOutcome(lanes[1], 'transient-failure');
 			const pending = a.acquire('p1');
 			const rejection = expect(pending).rejects.toThrow('All 2 lanes quarantined');
 			await vi.advanceTimersByTimeAsync(5000);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/lane-allocator.test.ts
@@ -93,6 +93,10 @@ describe('LaneAllocator', () => {
 	});
 
 	describe('pinned work slots (scenario executions)', () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
 		it('counts pinned work toward the lane cap so a backlogged lane stops winning builds', async () => {
 			const lanes = newLanes(2);
 			const a = new LaneAllocator(lanes, 2);
@@ -157,6 +161,48 @@ describe('LaneAllocator', () => {
 			expect(resolved).toBe(true);
 			expect(lanes[0].activeWork).toBe(1);
 			vi.useRealTimers();
+		});
+
+		it('serves a queued pinned waiter before an earlier-queued build waiter', async () => {
+			const lanes = newLanes(1);
+			const a = new LaneAllocator(lanes, 1);
+			await a.acquire('p1'); // fills the lane
+			const order: string[] = [];
+			void a.acquire('p2').then(() => order.push('build'));
+			void a.acquireOn(lanes[0]).then(() => order.push('pinned'));
+			a.release(lanes[0], 'p1');
+			await new Promise((r) => setImmediate(r));
+			// The build queued first, but it could run on any lane — the pinned
+			// scenario can only run here, so it wins the freed slot.
+			expect(order).toEqual(['pinned']);
+			a.release(lanes[0]);
+			await new Promise((r) => setImmediate(r));
+			expect(order).toEqual(['pinned', 'build']);
+		});
+
+		it('hands a re-admitted lane to its pinned backlog before queued builds', async () => {
+			vi.useFakeTimers();
+			const lanes = newLanes(1);
+			let healthy = false;
+			const a = new LaneAllocator(lanes, 2, {
+				probe: async () => await Promise.resolve(healthy),
+				probeIntervalMs: 1000,
+				quarantineThreshold: 1,
+				allQuarantinedGraceMs: 60_000,
+			});
+			a.reportOutcome(lanes[0], 'transient-failure');
+			const order: string[] = [];
+			void a.acquire('p1').then(() => order.push('build'));
+			void a.acquireOn(lanes[0]).then(() => order.push('pinned-1'));
+			void a.acquireOn(lanes[0]).then(() => order.push('pinned-2'));
+			healthy = true;
+			await vi.advanceTimersByTimeAsync(1000);
+			// Two slots on re-admission: the pinned backlog (which waited through
+			// the outage) fills them; the build — queued first — stays behind.
+			expect(order).toEqual(['pinned-1', 'pinned-2']);
+			a.release(lanes[0]);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(order).toEqual(['pinned-1', 'pinned-2', 'build']);
 		});
 
 		it('does not hand a freed slot on another lane to a pinned waiter', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/transient-error.test.ts
@@ -1,7 +1,10 @@
 import {
 	extractErrorMessage,
+	isExecutionTimeout,
 	isTransientNetworkError,
+	LANE_QUARANTINED_ABORT,
 	MAX_EXEC_ATTEMPTS,
+	shouldRetryScenarioExecution,
 } from '../harness/transient-error';
 
 describe('transient-error', () => {
@@ -59,5 +62,24 @@ describe('transient-error', () => {
 	it('caps retries at a small positive number', () => {
 		expect(MAX_EXEC_ATTEMPTS).toBeGreaterThan(1);
 		expect(MAX_EXEC_ATTEMPTS).toBeLessThanOrEqual(5);
+	});
+
+	describe('lane-quarantine aborts', () => {
+		const message = `${LANE_QUARANTINED_ABORT} (lane 3)`;
+
+		it('classifies the abort as transient so builds fail over', () => {
+			expect(isTransientNetworkError(message)).toBe(true);
+		});
+
+		it('does not mistake the abort for a client-side timeout', () => {
+			// Timeouts get MAX_TIMEOUT_ATTEMPTS (2); the fail-fast abort is cheap
+			// and must keep the full network-retry budget.
+			expect(isExecutionTimeout(message)).toBe(false);
+		});
+
+		it('retries the aborted execution up to the network-retry budget', () => {
+			expect(shouldRetryScenarioExecution(message, MAX_EXEC_ATTEMPTS - 1)).toBe(true);
+			expect(shouldRetryScenarioExecution(message, MAX_EXEC_ATTEMPTS)).toBe(false);
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/cli/args.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/args.ts
@@ -38,7 +38,7 @@ export interface CliArgs {
 	timeoutMs: number;
 	/** One or more n8n base URLs. Multi-lane runs use a work-stealing allocator
 	 *  that dispatches each build to a lane that isn't already running its
-	 *  prompt, capped per-lane at MAX_CONCURRENT_BUILDS=4. Pass comma-separated
+	 *  prompt, capped per-lane by `--lane-concurrency`. Pass comma-separated
 	 *  to `--base-url`. */
 	baseUrls: string[];
 	email?: string;
@@ -63,9 +63,13 @@ export interface CliArgs {
 	outputDir?: string;
 	/** LangSmith dataset name (synced from JSON test cases before each run) */
 	dataset: string;
-	/** Max concurrent target() calls in LangSmith evaluate(). Build concurrency is
-	 *  enforced separately by the LaneAllocator (cap=4 per lane). */
-	concurrency: number;
+	/** Max concurrent work units (builds + scenario executions) on one lane —
+	 *  the one concurrency knob. Lanes come from `--base-url`; the global
+	 *  in-flight cap is derived as lanes × (laneConcurrency + 1), so it never
+	 *  needs to be kept in sync with the lane count by hand. With a single
+	 *  base URL this is simply "how much runs at once on my instance". The
+	 *  default reflects that an n8n backend degrades above ~4 concurrent builds. */
+	laneConcurrency: number;
 	/** LangSmith experiment name prefix (auto-generated if not set) */
 	experimentName?: string;
 	/** Number of iterations to run each test case (default: 1). Each iteration
@@ -138,7 +142,7 @@ const cliArgsSchema = z.object({
 	deletePrebuiltWorkflows: z.boolean().default(false),
 	outputDir: z.string().optional(),
 	dataset: z.string().default(DEFAULT_DATASET),
-	concurrency: z.number().int().positive().default(16),
+	laneConcurrency: z.number().int().positive().default(4),
 	experimentName: z.string().optional(),
 	iterations: z.number().int().positive().default(1),
 	pinAiRoots: z.array(z.string().min(1)).optional(),
@@ -235,7 +239,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
 		deletePrebuiltWorkflows: validated.deletePrebuiltWorkflows,
 		outputDir: validated.outputDir,
 		dataset,
-		concurrency: validated.concurrency,
+		laneConcurrency: validated.laneConcurrency,
 		experimentName: validated.experimentName,
 		iterations: validated.iterations,
 		pinAiRoots: validated.pinAiRoots,
@@ -295,7 +299,7 @@ interface RawArgs {
 	deletePrebuiltWorkflows: boolean;
 	outputDir?: string;
 	dataset: string;
-	concurrency: number;
+	laneConcurrency: number;
 	experimentName?: string;
 	iterations: number;
 	pinAiRoots?: string[];
@@ -328,7 +332,7 @@ function parseRawArgs(argv: string[]): RawArgs {
 		deletePrebuiltWorkflows: false,
 		outputDir: undefined,
 		dataset: DEFAULT_DATASET,
-		concurrency: 16,
+		laneConcurrency: 4,
 		experimentName: undefined,
 		iterations: 1,
 		pinAiRoots: undefined,
@@ -417,10 +421,18 @@ function parseRawArgs(argv: string[]): RawArgs {
 				i++;
 				break;
 
-			case '--concurrency':
-				result.concurrency = parseIntArg(argv, i, '--concurrency');
+			case '--lane-concurrency':
+				result.laneConcurrency = parseIntArg(argv, i, '--lane-concurrency');
 				i++;
 				break;
+
+			case '--concurrency':
+				throw new Error(
+					'--concurrency was replaced by --lane-concurrency: the cap is per lane now ' +
+						'(concurrent builds + scenario executions on one lane, default 4), and the ' +
+						'global in-flight cap is derived as lanes × (lane-concurrency + 1). With a ' +
+						'single --base-url the two flags mean the same thing.',
+				);
 
 			case '--experiment-name':
 				result.experimentName = nextArg(argv, i, '--experiment-name');

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -1092,8 +1092,10 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				// so they take one of its work slots — that's what makes scenario
 				// backlog visible to the build allocator. A quarantined lane keeps
 				// the slot request queued until re-admission (the workflow survives
-				// the container restart), bounded by the scenario's own budget.
-				await allocator.acquireOn(builtOnLane, { deadlineMs: scenarioTimeoutMs });
+				// the container restart). Waiting burns no compute, so the deadline
+				// is 2× the scenario budget: enough to outlast in-flight builds
+				// ahead of it, while still bounding a truly wedged lane.
+				await allocator.acquireOn(builtOnLane, { deadlineMs: scenarioTimeoutMs * 2 });
 				try {
 					result = await builtOnLane.tracedExecute({
 						workflowId: build.workflowId,

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -81,6 +81,7 @@ import {
 import {
 	extractErrorMessage,
 	isTransientNetworkError,
+	LANE_QUARANTINED_ABORT,
 	MAX_EXEC_ATTEMPTS,
 	shouldRetryScenarioExecution,
 } from '../harness/transient-error';
@@ -102,9 +103,6 @@ import type {
 	WorkflowTestCaseResult,
 } from '../types';
 import { caseDisplayPrompt, conversationUserTurnsAsText } from '../utils/conversation-text';
-
-// n8n degrades above ~4 concurrent builds.
-const MAX_CONCURRENT_BUILDS = 4;
 
 /** Attempts (initial + retries) for a build hitting transient network errors. */
 const MAX_BUILD_ATTEMPTS = 3;
@@ -596,7 +594,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		testCaseByFileSlug.set(fileSlug, testCase);
 	}
 
-	// LaneState carries the allocator-managed counters (activeBuilds,
+	// LaneState carries the allocator-managed counters (activeWork,
 	// inflightKeys) plus the lane's traced LangSmith wrappers. `runner` is
 	// the underlying Lane (n8n client, credential state) — named distinctly so
 	// it doesn't shadow the iteration variable `lane` in lanes.map().
@@ -614,8 +612,11 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	interface LaneState {
 		runner: Lane;
 		laneNum: number;
-		activeBuilds: number;
+		activeWork: number;
 		inflightKeys: Set<string>;
+		/** Armed per quarantine: aborts the lane's in-flight HTTP work so it
+		 *  fails fast instead of running out its timeouts against a dead backend. */
+		failFast: AbortController;
 		tracedBuild: (buildArgs: BuildArgs) => Promise<BuildResult>;
 		tracedExecute: (execArgs: {
 			workflowId: string;
@@ -632,8 +633,9 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		return {
 			runner: lane,
 			laneNum,
-			activeBuilds: 0,
+			activeWork: 0,
 			inflightKeys: new Set<string>(),
+			failFast: new AbortController(),
 			tracedBuild: traceable(
 				async (buildArgs: BuildArgs) =>
 					await buildWorkflow({
@@ -709,19 +711,30 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 	}
 
 	// Work-stealing: each build acquires a lane that isn't already running its
-	// fileSlug, runs there (capped per-lane), then releases. Scenarios re-use
-	// the lane that built their workflow. Health options quarantine a dead lane
-	// instead of letting its instant failures attract the whole queue.
-	const allocator = new LaneAllocator(laneStates, MAX_CONCURRENT_BUILDS, {
+	// fileSlug, runs there, then releases. Scenario executions re-acquire the
+	// lane that built their workflow, so builds and scenarios share the same
+	// per-lane cap — a lane whose scenarios back up stops winning new builds
+	// until it drains. Health options quarantine a dead lane instead of letting
+	// its instant failures attract the whole queue.
+	const allocator = new LaneAllocator(laneStates, args.laneConcurrency, {
 		probe: laneHealthy,
-		onQuarantine: (lane) =>
+		onQuarantine: (lane) => {
 			logger.error(
 				`[lane ${String(lane.laneNum)}] quarantined after consecutive transport failures; probing ${lane.runner.baseUrl} for recovery`,
-			),
+			);
+			// Fail the lane's in-flight HTTP work now — those requests can only
+			// run out their timeouts against a dead backend, and each burnt
+			// timeout books a framework row. A fresh controller arms retries.
+			lane.failFast.abort(new Error(`${LANE_QUARANTINED_ABORT} (lane ${String(lane.laneNum)})`));
+			lane.failFast = new AbortController();
+		},
 		onReadmit: (lane) => logger.info(`[lane ${String(lane.laneNum)}] healthy again — re-admitted`),
 		onAllQuarantined: () =>
 			logger.error('All lanes quarantined — builds paused pending lane recovery'),
 	});
+	for (const state of laneStates) {
+		state.runner.client.laneSignal = () => state.failFast.signal;
+	}
 	const buildCache = new Map<
 		string,
 		Promise<{ build: BuildResult; lane: LaneState; buildDurationMs: number }>
@@ -773,7 +786,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				{
 					const transient = await isTransportFailure(build, lane);
 					if (!build.success) build.transportFailure = transient;
-					allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
+					allocator.reportOutcome(lane, transient ? 'transient-failure' : 'ok');
 				}
 				const buildDurationMs = Date.now() - start;
 				// Cleanup registration happens inside buildWorkflowViaMcpOnLane (as soon
@@ -861,7 +874,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					(await isTransportFailure(build, lane)) ||
 					(!build.success && allocator.wasQuarantinedSince(lane, start));
 				if (!build.success) build.transportFailure = transient;
-				allocator.reportBuildOutcome(lane, transient ? 'transient-failure' : 'ok');
+				allocator.reportOutcome(lane, transient ? 'transient-failure' : 'ok');
 				if (!transient || attempt >= MAX_BUILD_ATTEMPTS) break;
 				logger.warn(
 					`Build ${fileSlug} attempt ${String(attempt)}/${String(MAX_BUILD_ATTEMPTS)} failed transiently on lane ${String(lane.laneNum)} (${build.error ?? 'unknown'}); retrying on another lane`,
@@ -1068,22 +1081,40 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 
 		const execStart = Date.now();
 		const nodeCount = build.workflowJsons[0]?.nodes.length ?? 0;
+		const scenarioTimeoutMs = effectiveTimeoutMs(
+			testCaseByFileSlug.get(inputs.testCaseFile)?.complexity,
+			args.timeoutMs,
+		);
 		let result;
 		for (let attempt = 1; ; attempt++) {
 			try {
-				result = await builtOnLane.tracedExecute({
-					workflowId: build.workflowId,
-					scenario,
-					workflowJsons: build.workflowJsons,
-					buildTrace: build.buildTrace,
-					timeoutMs: effectiveTimeoutMs(
-						testCaseByFileSlug.get(inputs.testCaseFile)?.complexity,
-						args.timeoutMs,
-					),
-				});
+				// Scenario executions are pinned to the lane that built the workflow,
+				// so they take one of its work slots — that's what makes scenario
+				// backlog visible to the build allocator. A quarantined lane keeps
+				// the slot request queued until re-admission (the workflow survives
+				// the container restart), bounded by the scenario's own budget.
+				await allocator.acquireOn(builtOnLane, { deadlineMs: scenarioTimeoutMs });
+				try {
+					result = await builtOnLane.tracedExecute({
+						workflowId: build.workflowId,
+						scenario,
+						workflowJsons: build.workflowJsons,
+						buildTrace: build.buildTrace,
+						timeoutMs: scenarioTimeoutMs,
+					});
+				} finally {
+					allocator.release(builtOnLane);
+				}
+				allocator.reportOutcome(builtOnLane, 'ok');
 				break;
 			} catch (error: unknown) {
 				const errorMessage = extractErrorMessage(error);
+				// In a scenario-only phase (a run's tail) these are the only signal
+				// that a lane died — without them quarantine, and with it fail-fast
+				// and wait-for-recovery, would never engage after the last build.
+				if (isTransientNetworkError(errorMessage)) {
+					allocator.reportOutcome(builtOnLane, 'transient-failure');
+				}
 				if (shouldRetryScenarioExecution(errorMessage, attempt)) {
 					logger.warn(
 						`    [${scenario.name}] execution attempt ${attempt}/${MAX_EXEC_ATTEMPTS} failed (${errorMessage}); retrying`,
@@ -1200,8 +1231,11 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 
 	const experimentPrefix = args.experimentName ?? computeExperimentPrefix();
 
+	// One in-flight case-iteration per lane work slot, plus one spare per lane
+	// so a lane isn't idle while an example sits in a judge phase (no lane work).
+	const evaluateConcurrency = lanes.length * (args.laneConcurrency + 1);
 	logger.info(
-		`Starting evaluate() with concurrency=${String(args.concurrency)}, ${String(lanes.length)} lane(s) × ${String(MAX_CONCURRENT_BUILDS)} concurrent builds, iterations=${String(args.iterations)}`,
+		`Starting evaluate() with ${String(lanes.length)} lane(s) × lane-concurrency ${String(args.laneConcurrency)} (builds + scenario executions) → ${String(evaluateConcurrency)} in-flight case-iterations, iterations=${String(args.iterations)}`,
 	);
 
 	// Filter the dataset to the selected slugs — the sync is additive, so orphans
@@ -1223,7 +1257,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			data: evaluateData,
 			evaluators: [feedbackExtractor],
 			experimentPrefix,
-			maxConcurrency: args.concurrency,
+			maxConcurrency: evaluateConcurrency,
 			client: lsClient,
 			metadata: {
 				filter: args.filter ?? 'all',
@@ -1231,8 +1265,8 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				tier: args.tier ?? null,
 				prebuilt: prebuiltManifest !== undefined,
 				baselinePrefix: args.baselinePrefix,
-				concurrency: args.concurrency,
-				maxBuilds: MAX_CONCURRENT_BUILDS,
+				concurrency: evaluateConcurrency,
+				laneConcurrency: args.laneConcurrency,
 				lanes: lanes.length,
 				iterations: args.iterations,
 				...buildCIMetadata(),
@@ -1582,7 +1616,7 @@ async function runDirectLoop(config: RunConfig): Promise<{
 							}
 							return result;
 						},
-						MAX_CONCURRENT_BUILDS,
+						args.laneConcurrency,
 					);
 					return bucket.map((b, i) => ({ origIdx: b.origIdx, result: results[i] }));
 				}),

--- a/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
@@ -1,6 +1,10 @@
-// Pull-based lane allocator. Each lane caps at `maxConcurrentBuilds` and never
-// runs the same key twice concurrently — pairing those rules eliminates the
-// same-key concentration that breaks the agent under load.
+// Pull-based lane allocator. Lane load counts every work unit — builds and
+// scenario executions alike — capped at `laneConcurrency`, and a lane never
+// runs the same build key twice concurrently. Builds may run on any lane
+// (least-loaded wins); scenario executions are pinned to the lane holding
+// their workflow and wait for a slot there via `acquireOn`. Counting both
+// kinds of work is what stops a lane that falls behind on scenario
+// executions from continuing to win new builds while its backlog grows.
 //
 // A dead lane fails builds in milliseconds, making it permanently the
 // least-loaded lane — it would swallow the whole remaining queue. Consecutive
@@ -8,14 +12,18 @@
 // once its backend responds; all-lanes-quarantined aborts after a grace period.
 
 export interface AllocatableLane {
-	activeBuilds: number;
+	activeWork: number;
 	inflightKeys: Set<string>;
 }
 
 interface Waiter<L> {
-	key: string;
+	/** Build waiters carry a same-key exclusion key; pinned waiters carry none. */
+	key?: string;
+	/** Pinned waiters (scenario executions) can only run on this lane. */
+	lane?: L;
 	resolve: (lane: L) => void;
 	reject: (error: Error) => void;
+	deadline?: NodeJS.Timeout;
 }
 
 export interface LaneHealthOptions<L> {
@@ -23,7 +31,8 @@ export interface LaneHealthOptions<L> {
 	probe: (lane: L) => Promise<boolean>;
 	/** Delay between health probes of a quarantined lane. */
 	probeIntervalMs?: number;
-	/** Consecutive transient build failures before a lane is quarantined. */
+	/** Consecutive transient failures (builds or scenario executions) before a
+	 *  lane is quarantined. */
 	quarantineThreshold?: number;
 	/** How long ALL lanes may stay quarantined before acquires abort. */
 	allQuarantinedGraceMs?: number;
@@ -51,7 +60,7 @@ export class LaneAllocator<L extends AllocatableLane> {
 
 	constructor(
 		private readonly lanes: L[],
-		private readonly maxConcurrentBuilds: number,
+		private readonly laneConcurrency: number,
 		private readonly health?: LaneHealthOptions<L>,
 	) {}
 
@@ -69,15 +78,46 @@ export class LaneAllocator<L extends AllocatableLane> {
 		});
 	}
 
-	release(lane: L, key: string): void {
-		lane.activeBuilds--;
-		lane.inflightKeys.delete(key);
+	/** Waits for a work slot on this specific lane (scenario executions are
+	 *  pinned to the lane that built their workflow). A quarantined lane keeps
+	 *  its pinned waiters queued until re-admission — the workflow survives a
+	 *  container restart — bounded by `deadlineMs`. */
+	async acquireOn(lane: L, opts?: { deadlineMs?: number }): Promise<void> {
+		if (this.aborted) throw this.aborted;
+		if (this.canServe(lane, undefined)) {
+			this.markBusy(lane, undefined);
+			return;
+		}
+		await new Promise<L>((resolve, reject) => {
+			const waiter: Waiter<L> = { lane, resolve, reject };
+			if (opts?.deadlineMs !== undefined) {
+				const deadlineMs = opts.deadlineMs;
+				waiter.deadline = setTimeout(() => {
+					const i = this.waiters.indexOf(waiter);
+					if (i !== -1) this.waiters.splice(i, 1);
+					reject(
+						new Error(
+							`no lane slot within ${String(deadlineMs)}ms (${this.quarantined.has(lane) ? 'lane quarantined' : 'lane at capacity'})`,
+						),
+					);
+				}, deadlineMs);
+				waiter.deadline.unref?.();
+			}
+			this.waiters.push(waiter);
+		});
+	}
+
+	release(lane: L, key?: string): void {
+		lane.activeWork--;
+		if (key !== undefined) lane.inflightKeys.delete(key);
 		this.wakeNext(lane);
 	}
 
-	/** A completed build — even one the agent failed — is 'ok'; only
-	 *  network-level failures count toward quarantine. */
-	reportBuildOutcome(lane: L, outcome: 'ok' | 'transient-failure'): void {
+	/** A completed build or scenario execution — even one the agent failed —
+	 *  is 'ok'; only network-level failures count toward quarantine. Scenario
+	 *  executions must report too: in a scenario-only phase (e.g. a run's
+	 *  tail) they are the only signal left that a lane has died. */
+	reportOutcome(lane: L, outcome: 'ok' | 'transient-failure'): void {
 		if (outcome === 'ok') {
 			this.consecutiveFailures.delete(lane);
 			return;
@@ -146,14 +186,19 @@ export class LaneAllocator<L extends AllocatableLane> {
 			this.allQuarantinedTimer = undefined;
 		}
 		this.health?.onReadmit?.(lane);
-		// A re-admitted lane is idle — wake every waiter it can serve.
+		// A re-admitted lane starts with its queued pinned work counted, so the
+		// least-loaded policy sees the backlog instead of dogpiling fresh builds
+		// onto the lane that just died. Wake every waiter it can serve.
 		let woke = true;
 		while (woke) woke = this.wakeNext(lane);
 	}
 
 	private abort(error: Error): void {
 		this.aborted = error;
-		for (const w of this.waiters.splice(0)) w.reject(error);
+		for (const w of this.waiters.splice(0)) {
+			if (w.deadline) clearTimeout(w.deadline);
+			w.reject(error);
+		}
 	}
 
 	private findFree(key: string, not?: L): L | undefined {
@@ -161,31 +206,33 @@ export class LaneAllocator<L extends AllocatableLane> {
 		// filling lane 0 to cap before touching lane 1. Avoids hot-spotting.
 		let best: L | undefined;
 		for (const lane of this.lanes) {
-			if (lane === not || !this.canRun(lane, key)) continue;
-			if (best === undefined || lane.activeBuilds < best.activeBuilds) best = lane;
+			if (lane === not || !this.canServe(lane, key)) continue;
+			if (best === undefined || lane.activeWork < best.activeWork) best = lane;
 		}
 		return best;
 	}
 
-	private canRun(lane: L, key: string): boolean {
+	private canServe(lane: L, key: string | undefined): boolean {
 		return (
 			!this.quarantined.has(lane) &&
-			lane.activeBuilds < this.maxConcurrentBuilds &&
-			!lane.inflightKeys.has(key)
+			lane.activeWork < this.laneConcurrency &&
+			(key === undefined || !lane.inflightKeys.has(key))
 		);
 	}
 
-	private markBusy(lane: L, key: string): void {
-		lane.activeBuilds++;
-		lane.inflightKeys.add(key);
+	private markBusy(lane: L, key: string | undefined): void {
+		lane.activeWork++;
+		if (key !== undefined) lane.inflightKeys.add(key);
 	}
 
 	private wakeNext(lane: L): boolean {
 		// Wake the first waiter this lane can now serve. FIFO ordering.
 		for (let i = 0; i < this.waiters.length; i++) {
 			const w = this.waiters[i];
-			if (this.canRun(lane, w.key)) {
+			if (w.lane !== undefined && w.lane !== lane) continue;
+			if (this.canServe(lane, w.key)) {
 				this.waiters.splice(i, 1);
+				if (w.deadline) clearTimeout(w.deadline);
 				this.markBusy(lane, w.key);
 				w.resolve(lane);
 				return true;

--- a/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/lane-allocator.ts
@@ -2,9 +2,11 @@
 // scenario executions alike — capped at `laneConcurrency`, and a lane never
 // runs the same build key twice concurrently. Builds may run on any lane
 // (least-loaded wins); scenario executions are pinned to the lane holding
-// their workflow and wait for a slot there via `acquireOn`. Counting both
-// kinds of work is what stops a lane that falls behind on scenario
-// executions from continuing to win new builds while its backlog grows.
+// their workflow and wait for a slot there via `acquireOn`. Two rules keep
+// the pinned work from starving behind builds: a freed slot serves pinned
+// waiters before build waiters (builds have other lanes to go to), and build
+// placement counts a lane's queued pinned work as load, steering new builds
+// away from a backlog instead of piling more work in front of it.
 //
 // A dead lane fails builds in milliseconds, making it permanently the
 // least-loaded lane — it would swallow the whole remaining queue. Consecutive
@@ -47,6 +49,11 @@ const DEFAULT_ALL_QUARANTINED_GRACE_MS = 5 * 60_000;
 
 export class LaneAllocator<L extends AllocatableLane> {
 	private readonly waiters: Array<Waiter<L>> = [];
+
+	/** Queued pinned waiters per lane. Build placement counts these as load so
+	 *  new builds route away from a lane whose scenario backlog is growing —
+	 *  builds can run anywhere, the queued scenarios can't. */
+	private readonly pinnedQueued = new Map<L, number>();
 
 	private readonly consecutiveFailures = new Map<L, number>();
 
@@ -94,7 +101,10 @@ export class LaneAllocator<L extends AllocatableLane> {
 				const deadlineMs = opts.deadlineMs;
 				waiter.deadline = setTimeout(() => {
 					const i = this.waiters.indexOf(waiter);
-					if (i !== -1) this.waiters.splice(i, 1);
+					if (i !== -1) {
+						this.waiters.splice(i, 1);
+						this.trackPinned(lane, -1);
+					}
 					reject(
 						new Error(
 							`no lane slot within ${String(deadlineMs)}ms (${this.quarantined.has(lane) ? 'lane quarantined' : 'lane at capacity'})`,
@@ -104,6 +114,7 @@ export class LaneAllocator<L extends AllocatableLane> {
 				waiter.deadline.unref?.();
 			}
 			this.waiters.push(waiter);
+			this.trackPinned(lane, +1);
 		});
 	}
 
@@ -199,15 +210,28 @@ export class LaneAllocator<L extends AllocatableLane> {
 			if (w.deadline) clearTimeout(w.deadline);
 			w.reject(error);
 		}
+		this.pinnedQueued.clear();
+	}
+
+	private trackPinned(lane: L, delta: number): void {
+		const next = (this.pinnedQueued.get(lane) ?? 0) + delta;
+		if (next > 0) this.pinnedQueued.set(lane, next);
+		else this.pinnedQueued.delete(lane);
 	}
 
 	private findFree(key: string, not?: L): L | undefined {
 		// Least-loaded policy: spread builds evenly across lanes rather than
-		// filling lane 0 to cap before touching lane 1. Avoids hot-spotting.
+		// filling lane 0 to cap before touching lane 1. Queued pinned scenario
+		// work counts as load so builds route away from a growing backlog.
 		let best: L | undefined;
+		let bestLoad = Number.POSITIVE_INFINITY;
 		for (const lane of this.lanes) {
 			if (lane === not || !this.canServe(lane, key)) continue;
-			if (best === undefined || lane.activeWork < best.activeWork) best = lane;
+			const load = lane.activeWork + (this.pinnedQueued.get(lane) ?? 0);
+			if (load < bestLoad) {
+				best = lane;
+				bestLoad = load;
+			}
 		}
 		return best;
 	}
@@ -226,13 +250,16 @@ export class LaneAllocator<L extends AllocatableLane> {
 	}
 
 	private wakeNext(lane: L): boolean {
-		// Wake the first waiter this lane can now serve. FIFO ordering.
-		for (let i = 0; i < this.waiters.length; i++) {
-			const w = this.waiters[i];
-			if (w.lane !== undefined && w.lane !== lane) continue;
-			if (this.canServe(lane, w.key)) {
+		// Pinned waiters win a freed slot over builds — a queued build can run
+		// on any lane, the pinned scenario only here. FIFO within each class.
+		for (const pinnedPass of [true, false]) {
+			for (let i = 0; i < this.waiters.length; i++) {
+				const w = this.waiters[i];
+				if (pinnedPass ? w.lane !== lane : w.lane !== undefined) continue;
+				if (!this.canServe(lane, w.key)) continue;
 				this.waiters.splice(i, 1);
 				if (w.deadline) clearTimeout(w.deadline);
+				if (w.lane !== undefined) this.trackPinned(w.lane, -1);
 				this.markBusy(lane, w.key);
 				w.resolve(lane);
 				return true;

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -129,6 +129,11 @@ export class N8nApiError extends Error {
 export class N8nClient {
 	private sessionCookie?: string;
 
+	/** When set (per-lane clients), every request also aborts on this signal —
+	 *  quarantining a lane fails its in-flight HTTP work immediately instead of
+	 *  letting each request run out its own timeout against a dead backend. */
+	laneSignal?: () => AbortSignal;
+
 	constructor(private readonly baseUrl: string) {}
 
 	// -- Auth ----------------------------------------------------------------
@@ -697,11 +702,18 @@ export class N8nClient {
 
 		const method = options.method ?? 'GET';
 
+		const signals: AbortSignal[] = [];
+		if (options.timeoutMs) signals.push(AbortSignal.timeout(options.timeoutMs));
+		const laneSignal = this.laneSignal?.();
+		if (laneSignal) signals.push(laneSignal);
+
 		const res = await fetch(`${this.baseUrl}${path}`, {
 			method,
 			headers,
 			body: options.body ? JSON.stringify(options.body) : undefined,
-			...(options.timeoutMs ? { signal: AbortSignal.timeout(options.timeoutMs) } : {}),
+			...(signals.length > 0
+				? { signal: signals.length === 1 ? signals[0] : AbortSignal.any(signals) }
+				: {}),
 		});
 
 		if (!res.ok) {

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -30,9 +30,17 @@ export function extractErrorMessage(error: unknown): string {
 		: baseError.message;
 }
 
+/** Abort reason for a lane's in-flight HTTP work when the lane is quarantined.
+ *  Distinct wording matters: it must not look like a client-side timeout
+ *  (`isExecutionTimeout`), and it must classify as transient so builds fail
+ *  over and scenario executions retry after the lane recovers. */
+export const LANE_QUARANTINED_ABORT = 'lane quarantined mid-request';
+
 /** Network-level failures worth retrying — none indicate a builder or mock defect. */
 export function isTransientNetworkError(message: string): boolean {
-	return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up/i.test(message);
+	return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang up|lane quarantined/i.test(
+		message,
+	);
 }
 
 /**

--- a/packages/@n8n/instance-ai/scripts/run-eval-lanes.sh
+++ b/packages/@n8n/instance-ai/scripts/run-eval-lanes.sh
@@ -26,7 +26,7 @@ IMAGE="n8nio/n8n:local"
 BUILD_IMAGE=false
 SKIP_EVAL=false
 KEEP_CONTAINERS=false
-EVAL_CONCURRENCY="" # auto = instance-count * 4
+LANE_CONCURRENCY="" # empty = CLI default (4 work units per lane)
 EVAL_ITERATIONS=1
 EVAL_TIER=""
 ENV_FILE=".env.local"
@@ -47,7 +47,7 @@ Options:
   --image NAME        Docker image (default: n8nio/n8n:local)
   --build             Build docker image before starting lanes
   --env-file PATH     Env file relative to repo root (default: .env.local)
-  --concurrency N     Eval scenario concurrency (default: instance-count * 4)
+  --lane-concurrency N  Concurrent work per lane, builds + scenario executions (default: CLI default 4)
   --iterations N      Eval iterations per case (default: 3)
   --tier NAME         Eval tier filter (default: none; use "pr" for PR suite)
   --skip-eval         Only start + seed lanes; do not run evals
@@ -224,9 +224,12 @@ while [[ $# -gt 0 ]]; do
 			ENV_FILE="${2:-}"
 			shift 2
 			;;
-		--concurrency)
-			EVAL_CONCURRENCY="${2:-}"
+		--lane-concurrency)
+			LANE_CONCURRENCY="${2:-}"
 			shift 2
+			;;
+		--concurrency)
+			die "--concurrency was replaced by --lane-concurrency (per lane; the CLI derives the global cap from lane count)"
 			;;
 		--iterations)
 			EVAL_ITERATIONS="${2:-}"
@@ -272,10 +275,6 @@ done
 ((INSTANCE_COUNT >= 1)) || die "--instance-count must be >= 1"
 [[ "$START_PORT" =~ ^[0-9]+$ ]] || die "--start-port must be a number"
 ((START_PORT >= 1 && START_PORT <= 65535)) || die "invalid --start-port"
-
-if [[ -z "$EVAL_CONCURRENCY" ]]; then
-	EVAL_CONCURRENCY=$((INSTANCE_COUNT * 4))
-fi
 
 ENV_FILE_PATH="${REPO_ROOT}/${ENV_FILE}"
 EVAL_PKG_DIR="${REPO_ROOT}/packages/@n8n/instance-ai"
@@ -383,7 +382,7 @@ fi
 log "running eval:instance-ai"
 log "  lanes:       ${INSTANCE_COUNT}"
 log "  base-url:    ${BASE_URL_CSV}"
-log "  concurrency: ${EVAL_CONCURRENCY}"
+log "  lane-concurrency: ${LANE_CONCURRENCY:-4 (default)}"
 log "  iterations:  ${EVAL_ITERATIONS}"
 log "  tier:        ${EVAL_TIER:-<none>}"
 
@@ -392,10 +391,13 @@ cd "$EVAL_PKG_DIR"
 ARGS=(
 	pnpm eval:instance-ai
 	--base-url "$BASE_URL_CSV"
-	--concurrency "$EVAL_CONCURRENCY"
 	--iterations "$EVAL_ITERATIONS"
 	--verbose
 )
+
+if [[ -n "$LANE_CONCURRENCY" ]]; then
+	ARGS+=(--lane-concurrency "$LANE_CONCURRENCY")
+fi
 
 if [[ -n "$EVAL_TIER" ]]; then
 	ARGS+=(--tier "$EVAL_TIER")


### PR DESCRIPTION
## Summary

Stacked on #34103 (which stacks on #33903). Closes the two mechanics behind the July-13 baseline's framework-noise cluster: the scenario pile-up loop and the burnt-timeout row spray on lane death.

**Root cause (from the baseline forensics):** builds were capped per lane, but scenario executions — pinned to the lane that built their workflow — were invisible to the allocator. A lane whose scenarios ran slow kept winning new builds, each adding more scenarios to its own pile (17 concurrent at the moment of death). When the lane died, every in-flight scenario burned its full timeout budget and booked a framework row (~31 of the run's 43).

## What changed

- **One concurrency knob, end to end.** `--lane-concurrency` (default 4 — the same per-lane ceiling as the old hardcoded `MAX_CONCURRENT_BUILDS`) caps concurrent work units on one lane, where builds and scenario executions both count. The global evaluate() cap is derived (`lanes × (lane-concurrency + 1)`), so the workflow no longer carries a second number that must track lane count. `--concurrency` now errors with a migration hint.
- **Scenario executions take lane slots** (`allocator.acquireOn`, pinned, FIFO, deadline-bounded). A lane that falls behind stops attracting builds until it drains — the pile-up loop can't form.
- **Fail-fast on quarantine.** Quarantining a lane aborts its in-flight HTTP work (`AbortSignal` composed into the lane client) instead of letting each request run out its timeout against a dead backend. Aborted scenario executions classify as transient, wait for re-admission via the slot queue (the workflow survives the container restart), and retry.
- **Scenario outcomes feed the quarantine counter.** In a scenario-only phase (a run's tail) they are the only death signal left; without this, fail-fast never engages after the last build.
- Callers migrated: eval workflow (`--lane-concurrency 4`), MCP workflow (`2`, replacing the `lanes × 2` derivation), `run-eval-lanes.sh`, README.

## Validation

- 995 unit tests pass (new coverage: pinned slots block builds, pinned waiters survive quarantine and resolve on re-admission, deadline rejection, flag parsing + migration error, abort-reason classification).
- Live 2-lane smoke run (2 iterations × 5 scenarios, `--lane-concurrency 2`): completed clean — 10/10 scenarios judged, zero framework rows, builds shared via cache, banner shows the derived model (`2 lane(s) × lane-concurrency 2 → 6 in-flight`).
- An N=10 validation run against this branch is queued; results will be linked here.

- [x] I have read the [contributing guidelines](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) and my PR follows them


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34106">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

