### PR TITLE
fix(Microsoft To Do Node): Resolve service principal target per input item

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/GenericFunctions.ts
@@ -1,5 +1,18 @@
 import type { INode } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeError, NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Stamps `context.itemIndex` on a `NodeError` that does not carry one yet, so a
+ * per-item failure (e.g. a bad Service Principal target resolved at item N) is
+ * attributed to the right item. Never overwrites an existing index. Returns the
+ * error for the caller to (re)throw.
+ */
+export function stampItemIndexOnError(error: unknown, itemIndex: number): unknown {
+	if (error instanceof NodeError && error.context?.itemIndex === undefined) {
+		error.context = { ...error.context, itemIndex };
+	}
+	return error;
+}
 
 /**
  * Overridable throw-site copy for {@link validateUserTargetId}. Messages are static

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -67,7 +67,7 @@ export function getServicePrincipalResourceRoot(rawId: string, node: INode): str
  */
 export function resolveScopeRoot(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
-	itemIndex = 0,
+	itemIndex: number,
 ): string | undefined {
 	if (getToDoCredentialType.call(this) !== 'microsoftEntraServicePrincipalApi') {
 		return undefined;
@@ -80,19 +80,19 @@ export function resolveScopeRoot(
 	return getServicePrincipalResourceRoot(id, this.getNode());
 }
 
-// `itemIndex` is REQUIRED so the compiler enforces the per-item contract: execute
-// call sites pass the loop index; loadOptions call sites pass a literal 0, where
-// `getNodeParameter`'s 2nd arg is a fallback, not an index.
+// `itemIndex` is REQUIRED (and placed before the defaulted params so call sites
+// need no positional padding): execute call sites pass the loop index; loadOptions
+// call sites pass a literal 0, where `getNodeParameter`'s 2nd arg is a fallback,
+// not an index.
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
+	itemIndex: number,
 	body: IDataObject = {},
 	qs: IDataObject = {},
-	uri: string | undefined,
-	_headers: IDataObject = {},
+	uri?: string,
 	option: IDataObject = { json: true },
-	itemIndex: number,
 ) {
 	const credentialType = getToDoCredentialType.call(this);
 	const isServicePrincipal = credentialType === 'microsoftEntraServicePrincipalApi';
@@ -150,9 +150,9 @@ export async function microsoftApiRequestAllItems(
 	propertyName: string,
 	method: IHttpRequestMethods,
 	endpoint: string,
+	itemIndex: number,
 	body: IDataObject = {},
 	query: IDataObject = {},
-	itemIndex: number,
 ) {
 	const returnData: IDataObject[] = [];
 
@@ -165,12 +165,10 @@ export async function microsoftApiRequestAllItems(
 			this,
 			method,
 			endpoint,
+			itemIndex,
 			body,
 			query,
 			uri,
-			undefined,
-			undefined,
-			itemIndex,
 		);
 		uri = responseData['@odata.nextLink'];
 		if (uri?.includes('$top')) {

--- a/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/GenericFunctions.ts
@@ -56,11 +56,14 @@ export function getServicePrincipalResourceRoot(rawId: string, node: INode): str
 
 /**
  * Resolves the app-only `/users/{id}` root for the current node context, or `undefined`
- * for the OAuth2 credentials (which use the `/me` path). The `userTarget` RLC value is
- * extracted manually (not via `{ extractValue: true }`) so the single call shape works in
- * both execute (`0` = itemIndex) and load-options (`0` = ignored fallback) contexts; an
+ * for the OAuth2 credentials (which use the `/me` path). The `userTarget` RLC accepts
+ * expressions and is resolved per item: execute call sites pass the loop's item index;
+ * load-options call sites pass a literal 0 — there `getNodeParameter`'s 2nd arg is a
+ * fallback, not an index. The RLC value is extracted manually (not via
+ * `{ extractValue: true }`) so the single call shape works in both contexts; an
  * unpersisted/empty target coalesces to `''`, which yields the intended "target ID
- * required" error rather than a malformed `/users/` URL.
+ * required" error rather than a malformed `/users/` URL. A validation error gets its
+ * item index stamped in the node's execute catch.
  */
 export function resolveScopeRoot(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
@@ -77,15 +80,19 @@ export function resolveScopeRoot(
 	return getServicePrincipalResourceRoot(id, this.getNode());
 }
 
+// `itemIndex` is REQUIRED so the compiler enforces the per-item contract: execute
+// call sites pass the loop index; loadOptions call sites pass a literal 0, where
+// `getNodeParameter`'s 2nd arg is a fallback, not an index.
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
 	body: IDataObject = {},
 	qs: IDataObject = {},
-	uri?: string,
+	uri: string | undefined,
 	_headers: IDataObject = {},
 	option: IDataObject = { json: true },
+	itemIndex: number,
 ) {
 	const credentialType = getToDoCredentialType.call(this);
 	const isServicePrincipal = credentialType === 'microsoftEntraServicePrincipalApi';
@@ -96,13 +103,13 @@ export async function microsoftApiRequest(
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
 
-	// App-only Service Principal has no `/me`; rebase the request onto the chosen user.
-	// `userTarget` is `noDataExpression` (a node-level value, identical for every item), so
-	// resolving it once here is correct. Only page-1 (relative) requests are scoped —
-	// paginated follow-ups pass an absolute `@odata.nextLink` as `uri`, used verbatim.
+	// App-only Service Principal has no `/me`; rebase the request onto the chosen user,
+	// resolved per item (`userTarget` accepts expressions). Only page-1 (relative)
+	// requests are scoped — paginated follow-ups pass an absolute `@odata.nextLink` as
+	// `uri`, used verbatim.
 	let uriToUse = uri || `${baseUrl}/v1.0/me${resource}`;
 	if (!uri && isServicePrincipal) {
-		const scopeRoot = resolveScopeRoot.call(this);
+		const scopeRoot = resolveScopeRoot.call(this, itemIndex);
 		if (scopeRoot) {
 			uriToUse = `${baseUrl}/v1.0${scopeRoot}${resource}`;
 		}
@@ -133,6 +140,7 @@ export async function microsoftApiRequest(
 		}
 		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
+		// The node's execute catch stamps the failing item's index.
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
 }
@@ -144,6 +152,7 @@ export async function microsoftApiRequestAllItems(
 	endpoint: string,
 	body: IDataObject = {},
 	query: IDataObject = {},
+	itemIndex: number,
 ) {
 	const returnData: IDataObject[] = [];
 
@@ -152,36 +161,23 @@ export async function microsoftApiRequestAllItems(
 	query.$top = 100;
 
 	do {
-		responseData = await microsoftApiRequest.call(this, method, endpoint, body, query, uri);
+		responseData = await microsoftApiRequest.call(
+			this,
+			method,
+			endpoint,
+			body,
+			query,
+			uri,
+			undefined,
+			undefined,
+			itemIndex,
+		);
 		uri = responseData['@odata.nextLink'];
 		if (uri?.includes('$top')) {
 			delete query.$top;
 		}
 		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
 	} while (responseData['@odata.nextLink'] !== undefined);
-
-	return returnData;
-}
-
-export async function microsoftApiRequestAllItemsSkip(
-	this: IExecuteFunctions,
-	propertyName: string,
-	method: IHttpRequestMethods,
-	endpoint: string,
-	body: IDataObject = {},
-	query: IDataObject = {},
-) {
-	const returnData: IDataObject[] = [];
-
-	let responseData;
-	query.$top = 100;
-	query.$skip = 0;
-
-	do {
-		responseData = await microsoftApiRequest.call(this, method, endpoint, body, query);
-		query.$skip += query.$top;
-		returnData.push.apply(returnData, responseData[propertyName] as IDataObject[]);
-	} while (responseData.value.length !== 0);
 
 	return returnData;
 }

--- a/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
@@ -10,6 +10,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
+import { stampItemIndexOnError } from '../GenericFunctions';
 import { targetDescription } from './descriptions/TargetDescription';
 import { microsoftApiRequest, microsoftApiRequestAllItems } from './GenericFunctions';
 import { linkedResourceFields, linkedResourceOperations } from './LinkedResourceDescription';
@@ -124,7 +125,16 @@ export class MicrosoftToDo implements INodeType {
 			// select them easily
 			async getTaskLists(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 				const returnData: INodePropertyOptions[] = [];
-				const lists = await microsoftApiRequestAllItems.call(this, 'value', 'GET', '/todo/lists');
+				// loadOptions context: 0 is the transport's fallback read, not an item index.
+				const lists = await microsoftApiRequestAllItems.call(
+					this,
+					'value',
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					0,
+				);
 				for (const list of lists) {
 					returnData.push({
 						name: list.displayName as string,
@@ -164,6 +174,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
 							body,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/linkedresource-delete?view=graph-rest-1.0&tabs=http
@@ -178,6 +192,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 						responseData = { success: true };
 
@@ -193,6 +211,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotask-list-linkedresources?view=graph-rest-1.0&tabs=http
@@ -209,6 +231,7 @@ export class MicrosoftToDo implements INodeType {
 								`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
 								undefined,
 								qs,
+								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -218,6 +241,10 @@ export class MicrosoftToDo implements INodeType {
 								`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
 								undefined,
 								qs,
+								undefined,
+								undefined,
+								undefined,
+								i,
 							);
 							responseData = responseData.value;
 						}
@@ -238,6 +265,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
 							body,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 					} else {
 						throw new NodeOperationError(
@@ -283,6 +314,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks`,
 							body,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotask-delete?view=graph-rest-1.0&tabs=http
@@ -296,6 +331,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 						responseData = { success: true };
 
@@ -310,6 +349,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotasklist-list-tasks?view=graph-rest-1.0&tabs=http
@@ -325,6 +368,7 @@ export class MicrosoftToDo implements INodeType {
 								`/todo/lists/${taskListId}/tasks/`,
 								undefined,
 								qs,
+								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -334,6 +378,10 @@ export class MicrosoftToDo implements INodeType {
 								`/todo/lists/${taskListId}/tasks/`,
 								undefined,
 								qs,
+								undefined,
+								undefined,
+								undefined,
+								i,
 							);
 							responseData = responseData.value;
 						}
@@ -376,6 +424,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
 							body,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 					} else {
 						throw new NodeOperationError(
@@ -391,7 +443,17 @@ export class MicrosoftToDo implements INodeType {
 							displayName: this.getNodeParameter('displayName', i) as string,
 						};
 
-						responseData = await microsoftApiRequest.call(this, 'POST', '/todo/lists/', body, qs);
+						responseData = await microsoftApiRequest.call(
+							this,
+							'POST',
+							'/todo/lists/',
+							body,
+							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
+						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotasklist-delete?view=graph-rest-1.0&tabs=http
 					} else if (operation === 'delete') {
@@ -402,6 +464,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${listId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 						responseData = { success: true };
 
@@ -414,6 +480,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${listId}`,
 							undefined,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0&tabs=http
@@ -427,6 +497,7 @@ export class MicrosoftToDo implements INodeType {
 								'/todo/lists',
 								undefined,
 								qs,
+								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -436,6 +507,10 @@ export class MicrosoftToDo implements INodeType {
 								'/todo/lists',
 								undefined,
 								qs,
+								undefined,
+								undefined,
+								undefined,
+								i,
 							);
 							responseData = responseData.value;
 						}
@@ -453,6 +528,10 @@ export class MicrosoftToDo implements INodeType {
 							`/todo/lists/${listId}`,
 							body,
 							qs,
+							undefined,
+							undefined,
+							undefined,
+							i,
 						);
 					} else {
 						throw new NodeOperationError(
@@ -471,7 +550,8 @@ export class MicrosoftToDo implements INodeType {
 					returnData.push(...executionErrorData);
 					continue;
 				}
-				throw error;
+				// A NodeError from the transport may be missing the itemIndex, add it
+				throw stampItemIndexOnError(error, i);
 			}
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/MicrosoftToDo.node.ts
@@ -131,8 +131,6 @@ export class MicrosoftToDo implements INodeType {
 					'value',
 					'GET',
 					'/todo/lists',
-					undefined,
-					undefined,
 					0,
 				);
 				for (const list of lists) {
@@ -172,12 +170,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'POST',
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/linkedresource-delete?view=graph-rest-1.0&tabs=http
@@ -190,12 +185,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'DELETE',
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 						responseData = { success: true };
 
@@ -209,12 +201,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'GET',
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotask-list-linkedresources?view=graph-rest-1.0&tabs=http
@@ -229,9 +218,9 @@ export class MicrosoftToDo implements INodeType {
 								'value',
 								'GET',
 								`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
+								i,
 								undefined,
 								qs,
-								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -239,12 +228,9 @@ export class MicrosoftToDo implements INodeType {
 								this,
 								'GET',
 								`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources`,
+								i,
 								undefined,
 								qs,
-								undefined,
-								undefined,
-								undefined,
-								i,
 							);
 							responseData = responseData.value;
 						}
@@ -263,12 +249,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'PATCH',
 							`/todo/lists/${taskListId}/tasks/${taskId}/linkedResources/${linkedResourceId}`,
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 					} else {
 						throw new NodeOperationError(
@@ -312,12 +295,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'POST',
 							`/todo/lists/${taskListId}/tasks`,
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotask-delete?view=graph-rest-1.0&tabs=http
@@ -329,12 +309,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'DELETE',
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 						responseData = { success: true };
 
@@ -347,12 +324,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'GET',
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotasklist-list-tasks?view=graph-rest-1.0&tabs=http
@@ -366,9 +340,9 @@ export class MicrosoftToDo implements INodeType {
 								'value',
 								'GET',
 								`/todo/lists/${taskListId}/tasks/`,
+								i,
 								undefined,
 								qs,
-								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -376,12 +350,9 @@ export class MicrosoftToDo implements INodeType {
 								this,
 								'GET',
 								`/todo/lists/${taskListId}/tasks/`,
+								i,
 								undefined,
 								qs,
-								undefined,
-								undefined,
-								undefined,
-								i,
 							);
 							responseData = responseData.value;
 						}
@@ -422,12 +393,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'PATCH',
 							`/todo/lists/${taskListId}/tasks/${taskId}`,
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 					} else {
 						throw new NodeOperationError(
@@ -447,12 +415,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'POST',
 							'/todo/lists/',
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todotasklist-delete?view=graph-rest-1.0&tabs=http
@@ -462,12 +427,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'DELETE',
 							`/todo/lists/${listId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 						responseData = { success: true };
 
@@ -478,12 +440,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'GET',
 							`/todo/lists/${listId}`,
+							i,
 							undefined,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 
 						// https://docs.microsoft.com/en-us/graph/api/todo-list-lists?view=graph-rest-1.0&tabs=http
@@ -495,9 +454,9 @@ export class MicrosoftToDo implements INodeType {
 								'value',
 								'GET',
 								'/todo/lists',
+								i,
 								undefined,
 								qs,
-								i,
 							);
 						} else {
 							qs.$top = this.getNodeParameter('limit', i);
@@ -505,12 +464,9 @@ export class MicrosoftToDo implements INodeType {
 								this,
 								'GET',
 								'/todo/lists',
+								i,
 								undefined,
 								qs,
-								undefined,
-								undefined,
-								undefined,
-								i,
 							);
 							responseData = responseData.value;
 						}
@@ -526,12 +482,9 @@ export class MicrosoftToDo implements INodeType {
 							this,
 							'PATCH',
 							`/todo/lists/${listId}`,
+							i,
 							body,
 							qs,
-							undefined,
-							undefined,
-							undefined,
-							i,
 						);
 					} else {
 						throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/descriptions/TargetDescription.ts
@@ -16,8 +16,7 @@ export const userTargetRLC: INodeProperties = {
 	displayName: 'User',
 	name: 'userTarget',
 	type: 'resourceLocator',
-	// Resolved once per run (from the first item) and reused for every item, so it accepts a fixed
-	// value or an expression; for per-item targeting, feed a single item or use Loop Over Items.
+	// Evaluated per input item, so an expression can target a different user for each item.
 	default: { mode: 'id', value: '' },
 	required: true,
 	modes: [
@@ -30,7 +29,7 @@ export const userTargetRLC: INodeProperties = {
 		},
 	],
 	description:
-		'The user whose To Do lists and tasks the Service Principal should act on. Applies to the whole node (every item in the execution).',
+		'The user whose To Do lists and tasks the Service Principal should act on. Evaluated per input item — an expression can target a different user for each item.',
 	displayOptions: {
 		show: {
 			authentication: ['microsoftEntraServicePrincipalApi'],

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -58,17 +58,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -90,17 +80,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: '',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -121,17 +101,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					},
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -153,17 +123,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.com/',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -185,17 +145,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.com///',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -217,17 +167,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -249,17 +189,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://dod-graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -281,17 +211,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://microsoftgraph.chinacloudapi.cn',
 				});
 
-				await microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				);
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -316,17 +236,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftToDoOAuth2Api when authentication is not set (backward compatibility)', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
@@ -335,17 +245,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftToDoOAuth2Api when explicitly selected', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
@@ -354,17 +254,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftOAuth2Api when the generic credential is selected', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
@@ -373,17 +263,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should resolve the credential name from the authentication parameter at index 0', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('authentication', 0);
 		});
@@ -391,17 +271,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should honor graphApiBaseUrl from the generic credential (sovereign cloud)', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockRequestOAuth2).toHaveBeenCalledWith(
 				'microsoftOAuth2Api',
@@ -464,17 +334,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		});
 
 		it('routes through requestWithAuthentication, never requestOAuth2', async () => {
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -487,17 +347,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		});
 
 		it('rebases /me onto /users/{id} for the user target', async () => {
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -510,17 +360,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				graphApiBaseUrl: 'https://graph.microsoft.us',
 			});
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -533,17 +373,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('carries a B2B guest (#EXT#) UPN end-to-end into an encoded /users/{id} uri', async () => {
 			setSpParams({ userTarget: { value: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' } });
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -556,17 +386,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('carries a "^"/"!" UPN end-to-end into an encoded /users/{id} uri', async () => {
 			setSpParams({ userTarget: { value: 'joe^smith@contoso.com' } });
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				0,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -584,12 +404,10 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				mockExecuteFunctions,
 				'GET',
 				'/todo/lists',
+				0,
 				{},
 				{},
 				nextLink,
-				undefined,
-				undefined,
-				0,
 			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
@@ -602,17 +420,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			setSpParams({ userTarget: { value: '' } });
 
 			await expect(
-				microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					undefined,
-					0,
-				),
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 0),
 			).rejects.toThrow('A target ID is required for the Service Principal');
 			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 		});
@@ -623,17 +431,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			mockRequestWithAuthentication.mockRejectedValue(new Error('boom'));
 
 			await expect(
-				microsoftApiRequest.call(
-					mockExecuteFunctions,
-					'GET',
-					'/todo/lists',
-					{},
-					{},
-					undefined,
-					{},
-					{ json: true },
-					2,
-				),
+				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 2),
 			).rejects.toThrow(NodeApiError);
 		});
 
@@ -647,17 +445,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				return fallback as never;
 			});
 
-			await microsoftApiRequest.call(
-				mockExecuteFunctions,
-				'GET',
-				'/todo/lists',
-				{},
-				{},
-				undefined,
-				{},
-				{ json: true },
-				1,
-			);
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', 1);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -680,8 +468,6 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				'value',
 				'GET',
 				'/todo/lists',
-				{},
-				{},
 				1,
 			);
 
@@ -709,8 +495,6 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				'value',
 				'GET',
 				'/todo/lists',
-				{},
-				{},
 				1,
 			);
 
@@ -826,7 +610,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('returns undefined for the OAuth2 credential', () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
 
-			expect(resolveScopeRoot.call(mockExecuteFunctions)).toBeUndefined();
+			expect(resolveScopeRoot.call(mockExecuteFunctions, 0)).toBeUndefined();
 		});
 
 		it('resolves the user root for the Service Principal credential', () => {
@@ -839,7 +623,7 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					(name in params ? params[name as string] : fallback) as never,
 			);
 
-			expect(resolveScopeRoot.call(mockExecuteFunctions)).toBe('/users/jane%40contoso.com');
+			expect(resolveScopeRoot.call(mockExecuteFunctions, 0)).toBe('/users/jane%40contoso.com');
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/GenericFunctions.test.ts
@@ -1,6 +1,7 @@
 import {
 	NodeApiError,
 	NodeOperationError,
+	type IDataObject,
 	type IExecuteFunctions,
 	type ILoadOptionsFunctions,
 	type INode,
@@ -13,6 +14,7 @@ import {
 	getServicePrincipalResourceRoot,
 	getToDoCredentialType,
 	microsoftApiRequest,
+	microsoftApiRequestAllItems,
 	resolveScopeRoot,
 } from '../GenericFunctions';
 import { MicrosoftToDo } from '../MicrosoftToDo.node';
@@ -56,7 +58,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -78,7 +90,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: '',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -99,7 +121,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					},
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -121,7 +153,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.com/',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -143,7 +185,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.com///',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -165,7 +217,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -187,7 +249,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://dod-graph.microsoft.us',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -209,7 +281,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 					graphApiBaseUrl: 'https://microsoftgraph.chinacloudapi.cn',
 				});
 
-				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				);
 
 				expect(mockRequestOAuth2).toHaveBeenCalledWith(
 					'microsoftToDoOAuth2Api',
@@ -234,7 +316,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftToDoOAuth2Api when authentication is not set (backward compatibility)', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
@@ -243,7 +335,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftToDoOAuth2Api when explicitly selected', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftToDoOAuth2Api');
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftToDoOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftToDoOAuth2Api', expect.anything());
@@ -252,7 +354,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should use microsoftOAuth2Api when the generic credential is selected', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
 			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
@@ -261,7 +373,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should resolve the credential name from the authentication parameter at index 0', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('authentication', 0);
 		});
@@ -269,7 +391,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('should honor graphApiBaseUrl from the generic credential (sovereign cloud)', async () => {
 			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestOAuth2).toHaveBeenCalledWith(
 				'microsoftOAuth2Api',
@@ -332,7 +464,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		});
 
 		it('routes through requestWithAuthentication, never requestOAuth2', async () => {
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -345,7 +487,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		});
 
 		it('rebases /me onto /users/{id} for the user target', async () => {
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -358,7 +510,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 				graphApiBaseUrl: 'https://graph.microsoft.us',
 			});
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -371,7 +533,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('carries a B2B guest (#EXT#) UPN end-to-end into an encoded /users/{id} uri', async () => {
 			setSpParams({ userTarget: { value: 'user_contoso.com#EXT#@tenant.onmicrosoft.com' } });
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -384,7 +556,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 		it('carries a "^"/"!" UPN end-to-end into an encoded /users/{id} uri', async () => {
 			setSpParams({ userTarget: { value: 'joe^smith@contoso.com' } });
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists');
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -398,7 +580,17 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			const nextLink =
 				'https://graph.microsoft.com/v1.0/users/jane%40contoso.com/todo/lists?$skiptoken=abc';
 
-			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists', {}, {}, nextLink);
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				{},
+				{},
+				nextLink,
+				undefined,
+				undefined,
+				0,
+			);
 
 			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
 				'microsoftEntraServicePrincipalApi',
@@ -410,17 +602,157 @@ describe('Microsoft ToDo GenericFunctions', () => {
 			setSpParams({ userTarget: { value: '' } });
 
 			await expect(
-				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists'),
+				microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					0,
+				),
 			).rejects.toThrow('A target ID is required for the Service Principal');
 			expect(mockRequestWithAuthentication).not.toHaveBeenCalled();
 		});
 
 		it('wraps a transport failure as NodeApiError', async () => {
+			// Item attribution happens in the node's execute catch, not here (see the
+			// 'execute error attribution' describe).
 			mockRequestWithAuthentication.mockRejectedValue(new Error('boom'));
 
 			await expect(
-				microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/todo/lists'),
+				microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/todo/lists',
+					{},
+					{},
+					undefined,
+					{},
+					{ json: true },
+					2,
+				),
 			).rejects.toThrow(NodeApiError);
+		});
+
+		it('resolves the user target at the passed itemIndex', async () => {
+			// The userTarget RLC accepts expressions, so execute call sites pass the loop
+			// index and the transport must read the target at exactly that index.
+			mockExecuteFunctions.getNodeParameter.mockImplementation((name, itemIndex, fallback) => {
+				if (name === 'authentication') return 'microsoftEntraServicePrincipalApi' as never;
+				if (name === 'userTarget')
+					return { value: itemIndex === 1 ? 'john@contoso.com' : 'jane@contoso.com' } as never;
+				return fallback as never;
+			});
+
+			await microsoftApiRequest.call(
+				mockExecuteFunctions,
+				'GET',
+				'/todo/lists',
+				{},
+				{},
+				undefined,
+				{},
+				{ json: true },
+				1,
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({ uri: `${baseUrl}/v1.0/users/john%40contoso.com/todo/lists` }),
+			);
+		});
+
+		it('forwards the itemIndex through microsoftApiRequestAllItems to the request', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((name, itemIndex, fallback) => {
+				if (name === 'authentication') return 'microsoftEntraServicePrincipalApi' as never;
+				if (name === 'userTarget')
+					return { value: itemIndex === 1 ? 'john@contoso.com' : 'jane@contoso.com' } as never;
+				return fallback as never;
+			});
+			// single page: no @odata.nextLink
+			mockRequestWithAuthentication.mockResolvedValue({ value: [{ id: 'list-1' }] });
+
+			await microsoftApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'value',
+				'GET',
+				'/todo/lists',
+				{},
+				{},
+				1,
+			);
+
+			expect(mockRequestWithAuthentication).toHaveBeenCalledWith(
+				'microsoftEntraServicePrincipalApi',
+				expect.objectContaining({ uri: `${baseUrl}/v1.0/users/john%40contoso.com/todo/lists` }),
+			);
+		});
+
+		it('paginates at the itemIndex root: page 1 scoped, page 2 via nextLink verbatim', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((name, itemIndex, fallback) => {
+				if (name === 'authentication') return 'microsoftEntraServicePrincipalApi' as never;
+				if (name === 'userTarget')
+					return { value: itemIndex === 1 ? 'john@contoso.com' : 'jane@contoso.com' } as never;
+				return fallback as never;
+			});
+			// The nextLink carries $top, which also exercises the $top-delete branch.
+			const nextLink = `${baseUrl}/v1.0/users/john%40contoso.com/todo/lists?$skiptoken=abc&$top=100`;
+			mockRequestWithAuthentication
+				.mockResolvedValueOnce({ value: [{ id: 'list-1' }], '@odata.nextLink': nextLink })
+				.mockResolvedValueOnce({ value: [{ id: 'list-2' }] });
+
+			const result = await microsoftApiRequestAllItems.call(
+				mockExecuteFunctions,
+				'value',
+				'GET',
+				'/todo/lists',
+				{},
+				{},
+				1,
+			);
+
+			const uris = mockRequestWithAuthentication.mock.calls.map(
+				(call) => (call[1] as IDataObject).uri,
+			);
+			expect(uris).toEqual([`${baseUrl}/v1.0/users/john%40contoso.com/todo/lists`, nextLink]);
+			expect(result).toEqual([{ id: 'list-1' }, { id: 'list-2' }]);
+		});
+	});
+
+	describe('execute error attribution', () => {
+		it('stamps context.itemIndex on a NodeError from the failing item', async () => {
+			const mockRequestWithAuthentication = vi.fn().mockResolvedValue({ value: [] });
+			mockExecuteFunctions.helpers.requestWithAuthentication = mockRequestWithAuthentication;
+			(mockExecuteFunctions.helpers.constructExecutionMetaData as Mock).mockReturnValue([]);
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }, { json: {} }]);
+			mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+			mockExecuteFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+			mockExecuteFunctions.getNodeParameter.mockImplementation((name, itemIndex, fallback) => {
+				const params: Record<string, unknown> = {
+					authentication: 'microsoftEntraServicePrincipalApi',
+					resource: 'list',
+					operation: 'getAll',
+					returnAll: false,
+					limit: 50,
+				};
+				if (name === 'userTarget')
+					return { value: itemIndex === 1 ? 'not a user' : 'jane@contoso.com' } as never;
+				return (name in params ? params[name as string] : fallback) as never;
+			});
+
+			let caught: unknown;
+			try {
+				await new MicrosoftToDo().execute.call(mockExecuteFunctions);
+			} catch (error) {
+				caught = error;
+			}
+
+			expect(caught).toBeInstanceOf(NodeOperationError);
+			expect((caught as NodeOperationError).message).toBe('The target ID is not valid');
+			expect((caught as NodeOperationError).context.itemIndex).toBe(1);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItem.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItem.test.ts
@@ -1,0 +1,29 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from './credentials';
+
+// The userTarget RLC accepts expressions, so it must be resolved per input item: the
+// Test Data node fans out to two users and each item's request must be rebased onto that
+// item's `/users/{id}` root (encoding pin preserved). Both interceptors are consume-once and
+// `pendingMocks` must be empty afterwards, so a run that sends both items to item 0's
+// user fails in either direction (unmatched second request AND an unconsumed mock).
+describe('Test MicrosoftToDo, Service Principal list:getAll per-item target', () => {
+	nock('https://graph.microsoft.com/v1.0')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get('/users/jane%40contoso.com/todo/lists')
+		.query({ $top: 50 })
+		.reply(200, { value: [{ id: 'list-jane', displayName: 'Jane Tasks' }] });
+
+	nock('https://graph.microsoft.com/v1.0')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get('/users/john%40contoso.com/todo/lists')
+		.query({ $top: 50 })
+		.reply(200, { value: [{ id: 'list-john', displayName: 'John Tasks' }] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['list.getAll.sp.perItem.workflow.json'],
+		customAssertions: () => expect(nock.pendingMocks()).toEqual([]),
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItem.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItem.workflow.json
@@ -1,0 +1,98 @@
+{
+	"name": "microsoft to do - list getAll (service principal, per-item target)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "2a000000-0000-4000-8000-000000000001",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"data": [
+					{
+						"user": "jane@contoso.com"
+					},
+					{
+						"user": "john@contoso.com"
+					}
+				]
+			},
+			"id": "2a000000-0000-4000-8000-000000000002",
+			"name": "Test Data",
+			"type": "n8n-nodes-testing.testData",
+			"typeVersion": 1,
+			"position": [200, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"userTarget": {
+					"__rl": true,
+					"value": "={{ $json.user }}",
+					"mode": "id"
+				},
+				"resource": "list",
+				"operation": "getAll",
+				"returnAll": false,
+				"limit": 50
+			},
+			"id": "2a000000-0000-4000-8000-000000000003",
+			"name": "Microsoft To Do",
+			"type": "n8n-nodes-base.microsoftToDo",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Microsoft To Do": [
+			{
+				"json": {
+					"id": "list-jane",
+					"displayName": "Jane Tasks"
+				}
+			},
+			{
+				"json": {
+					"id": "list-john",
+					"displayName": "John Tasks"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Test Data",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Test Data": {
+			"main": [
+				[
+					{
+						"node": "Microsoft To Do",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItemContinueOnFail.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItemContinueOnFail.test.ts
@@ -1,0 +1,22 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from './credentials';
+
+// Per-item error isolation under continueOnFail: item 0's bogus target ("not a user"
+// fails the shape validators) must produce an error item for item 0 only, while item 1
+// still hits its own user's root. Only jane is mocked; consume-once + empty pendingMocks
+// pin the exact request set.
+describe('Test MicrosoftToDo, Service Principal list:getAll fails only the bad item under continueOnFail', () => {
+	nock('https://graph.microsoft.com/v1.0')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get('/users/jane%40contoso.com/todo/lists')
+		.query({ $top: 50 })
+		.reply(200, { value: [{ id: 'list-jane', displayName: 'Jane Tasks' }] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['list.getAll.sp.perItemContinueOnFail.workflow.json'],
+		customAssertions: () => expect(nock.pendingMocks()).toEqual([]),
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItemContinueOnFail.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ToDo/test/list.getAll.sp.perItemContinueOnFail.workflow.json
@@ -1,0 +1,75 @@
+{
+	"name": "microsoft to do - list getAll (service principal, per-item target, continueOnFail)",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "3a000000-0000-4000-8000-000000000001",
+			"name": "When clicking 'Execute workflow'",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0]
+		},
+		{
+			"parameters": {
+				"data": [{ "user": "not a user" }, { "user": "jane@contoso.com" }]
+			},
+			"id": "3a000000-0000-4000-8000-000000000002",
+			"name": "Test Data",
+			"type": "n8n-nodes-testing.testData",
+			"typeVersion": 1,
+			"position": [200, 0]
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"userTarget": {
+					"__rl": true,
+					"value": "={{ $json.user }}",
+					"mode": "id"
+				},
+				"resource": "list",
+				"operation": "getAll",
+				"returnAll": false,
+				"limit": 50
+			},
+			"id": "3a000000-0000-4000-8000-000000000003",
+			"name": "Microsoft To Do",
+			"type": "n8n-nodes-base.microsoftToDo",
+			"typeVersion": 1,
+			"position": [400, 0],
+			"onError": "continueRegularOutput",
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Microsoft To Do": [
+			{
+				"json": {
+					"error": "The target ID is not valid"
+				}
+			},
+			{
+				"json": {
+					"id": "list-jane",
+					"displayName": "Jane Tasks"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [[{ "node": "Test Data", "type": "main", "index": 0 }]]
+		},
+		"Test Data": {
+			"main": [[{ "node": "Microsoft To Do", "type": "main", "index": 0 }]]
+		}
+	},
+	"active": false,
+	"settings": {},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
@@ -165,6 +165,15 @@ describe('Microsoft shared validateUserTargetId', () => {
 });
 
 describe('Microsoft shared stampItemIndexOnError', () => {
+	it('stamps context.itemIndex on a NodeError that lacks one, preserving other context keys', () => {
+		const error = new NodeOperationError(node, 'boom');
+		error.context.foo = 'bar';
+
+		expect(stampItemIndexOnError(error, 3)).toBe(error);
+		expect(error.context.itemIndex).toBe(3);
+		expect(error.context.foo).toBe('bar');
+	});
+
 	it('does not overwrite an already-set context.itemIndex', () => {
 		const error = new NodeOperationError(node, 'boom', { itemIndex: 5 });
 

--- a/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/test/GenericFunctions.test.ts
@@ -1,6 +1,10 @@
 import { NodeOperationError, type INode } from 'n8n-workflow';
 
-import { validateUserTargetId, type UserTargetMessages } from '../GenericFunctions';
+import {
+	stampItemIndexOnError,
+	validateUserTargetId,
+	type UserTargetMessages,
+} from '../GenericFunctions';
 
 const node: INode = {
 	id: 'test-node',
@@ -157,5 +161,21 @@ describe('Microsoft shared validateUserTargetId', () => {
 			expect(caught?.description).not.toContain('secret');
 			expect(caught?.description).not.toContain('%2');
 		});
+	});
+});
+
+describe('Microsoft shared stampItemIndexOnError', () => {
+	it('does not overwrite an already-set context.itemIndex', () => {
+		const error = new NodeOperationError(node, 'boom', { itemIndex: 5 });
+
+		expect(stampItemIndexOnError(error, 9)).toBe(error);
+		expect(error.context.itemIndex).toBe(5);
+	});
+
+	it('returns a plain (non-Node) Error as-is, unstamped', () => {
+		const error = new Error('boom');
+
+		expect(stampItemIndexOnError(error, 3)).toBe(error);
+		expect((error as { context?: unknown }).context).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

**Part 1 of 4** — splits #34020 per review feedback. This PR fixes Microsoft **To Do** and introduces the shared helper the three stacked sibling PRs reuse.

The Service Principal (app-only) target field (`userTarget`) accepts expressions (since #33343), but the transport resolved it **once at item 0** and reused the result for every input item — `={{ $json.user.id }}` over 5 items silently sent all 5 requests to item 0's user. This PR resolves the target **per input item**:

- A **required** `itemIndex` parameter is threaded through the To Do transports (the compiler enforces the contract at every call site); all 18 execute-loop call sites pass the loop index. The loadOptions call site passes a literal `0`, preserving today's behavior exactly (there the 2nd `getNodeParameter` arg is a fallback, not an index).
- New shared `stampItemIndexOnError` helper in `nodes/Microsoft/GenericFunctions.ts` stamps `context.itemIndex` on errors at the execute catch, so a bad target on item N fails item N (continueOnFail-compatible) with correct attribution. The stacked Outlook/OneDrive/Excel PRs reuse it.
- Removes the dead `microsoftApiRequestAllItemsSkip` export (zero callers; it embodied the exact resolve-at-0 shape this PR fixes).
- Field description updated from "resolves once per run" to per-item wording.

List/pagination rule: each input item's fan-out uses that item's resolved target for every page (`@odata.nextLink` followed verbatim). Validators, encoding, and URL shapes are unchanged — per-item resolution multiplies invocations of the existing validate-then-encode gate, not paths around it.

## How to test

1. Create a **Microsoft Entra Service Principal** credential and select it on a Microsoft To Do node.
2. Feed multiple input items with different users (e.g. Edit Fields emitting `[{ "user": "alice@tenant.com" }, { "user": "bob@tenant.com" }]`) and set **User to Act As** to `={{ $json.user }}`.
3. Run: each item's request goes to its own user (previously both went to alice). With **On Error → Continue**, an invalid target on one item produces an error item for that item only.

Covered by tests: per-item fan-out and continueOnFail error-isolation harness workflows (exact request sets pinned via consume-once nock + empty `pendingMocks` asserts), pagination-at-index and error-stamp unit tests, shared-helper no-overwrite/passthrough tests.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-149
Split from #34020 (part 1 of 4). Siblings (stacked on this PR): #34110 (Outlook), #34111 (OneDrive), #34112 (Excel).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


