### PR TITLE
fix(core): Keep database connection monitor ping loop alive through recovery windows

### DIFF
--- a/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.test.ts
+++ b/packages/@n8n/db/src/connection/__tests__/db-connection-monitor.test.ts
@@ -310,6 +310,36 @@ describe('DbConnectionMonitor', () => {
 			expect(pool.connect).not.toHaveBeenCalled();
 		});
 
+		it('should reschedule the next ping when the data source is not initialized', async () => {
+			// Recovery leaves isInitialized=false from destroy() until a successful
+			// initialize() — a window that spans every failed attempt plus backoff during
+			// an outage. A ping tick landing in that window must keep the loop alive:
+			// returning without rescheduling kills the monitor permanently, freezing
+			// `connected` at its last value with no pings, no future recovery and no logs.
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = false;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const scheduleNextPingSpy = vi.spyOn(monitor as any, 'scheduleNextPing');
+
+			// @ts-expect-error private property
+			await monitor.ping();
+
+			expect(scheduleNextPingSpy).toHaveBeenCalled();
+		});
+
+		it('should not reschedule pings once the monitor is stopped', async () => {
+			// @ts-expect-error readonly property
+			dataSource.isInitialized = true;
+			void monitor.stop();
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const scheduleNextPingSpy = vi.spyOn(monitor as any, 'scheduleNextPing');
+
+			// @ts-expect-error private property
+			await monitor.ping();
+
+			expect(scheduleNextPingSpy).not.toHaveBeenCalled();
+		});
+
 		it('should not query if monitor is stopped', async () => {
 			// @ts-expect-error readonly property
 			dataSource.isInitialized = true;

--- a/packages/@n8n/db/src/connection/db-connection-monitor.ts
+++ b/packages/@n8n/db/src/connection/db-connection-monitor.ts
@@ -147,11 +147,16 @@ export class DbConnectionMonitor {
 	}
 
 	private async ping() {
-		if (this.stopped || !this.dataSource.isInitialized) {
+		if (this.stopped) {
 			return;
 		}
 
-		if (this.recovering) {
+		// Recovery leaves `isInitialized === false` from `destroy()` until a successful
+		// `initialize()` — a window that spans every failed attempt plus backoff. Skip
+		// the ping but keep the loop alive: returning without rescheduling would kill
+		// the monitor permanently, freezing `connected` at its last value with no
+		// pings, no future recovery and no logs.
+		if (this.recovering || !this.dataSource.isInitialized) {
 			this.scheduleNextPing();
 			return;
 		}


### PR DESCRIPTION
Fixes #34115

## Summary

`DbConnectionMonitor.ping()` can permanently kill its own loop, leaving the instance with no connection monitoring, no future recovery, and `connected` frozen at its last value — all silently.

During recovery, `dataSource.isInitialized` is `false` from the moment `destroy()` completes until an `initialize()` attempt succeeds. That window spans every failed attempt plus the backoff between attempts — i.e. potentially the whole outage. A ping tick that fires inside it hits this guard:

```ts
if (this.stopped || !this.dataSource.isInitialized) {
	return; // ← returns WITHOUT scheduleNextPing()
}
```

and returns without rescheduling. With the default `DB_PING_INTERVAL_SECONDS=2`, effectively any recovery that needs more than one attempt loses the ping loop. From then on:

- no pings, no failure counting, no future recovery, and no monitor log output;
- `connected` freezes at its last value. If it froze at `true`, `/healthz/readiness` keeps returning 200 while every query that touches the pool hangs — so container orchestrator healthchecks never restart the wedged instance.

We hit this twice in production (n8n 2.27.4, queue mode, multi-main, Postgres behind HAProxy/Patroni where failovers are routine): after a Redis+Postgres double failover, the monitor logged `Database connection recovered after 1 attempt(s)` and then went completely silent for 8+ hours — readiness 200, Docker healthcheck healthy, and every `/rest/*` endpoint touching the DB hanging until the container was replaced manually. Detailed logs available on request.

This PR reorders the guards: `stopped` still exits without rescheduling (that is `stop()`'s job), while `recovering || !isInitialized` skips the ping body but keeps the loop alive — matching the intent already documented for the `recovering` branch.

## How to test

Unit: `pnpm --filter @n8n/db test db-connection-monitor`. Includes a new test asserting that a ping tick landing in the `isInitialized === false` window reschedules itself (fails on current master), plus a guard test that `stop()` still ends the loop.

Manual: run n8n against Postgres and stop Postgres long enough for recovery to need more than one attempt (longer than the destroy timeout plus the first backoff), then bring it back. On master, once recovery eventually succeeds, the monitor never logs again — stop Postgres a second time and there are no ping failures, no recovery, and readiness stays ok. With this fix, pings resume after recovery and the second outage is detected and recovered normally.

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created — not applicable (bug fix, no user-facing docs impact).
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34113">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


