### PR TITLE
fix(editor): Remove extra top spacing in sticky note markdown

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -361,6 +361,11 @@ input[type='checkbox'] + label {
 	color: var(--sticky--color--text);
 	overflow-wrap: break-word;
 
+	// First rendered block sits flush with the top; container padding supplies the gap.
+	> :first-child {
+		margin-top: 0;
+	}
+
 	h1,
 	h2,
 	h3,


### PR DESCRIPTION
## Summary

Fixes uneven vertical spacing in sticky-note markdown. 

<img width="1152" height="617" alt="Screenshot 2026-07-14 at 08 57 39" src="https://github.com/user-attachments/assets/b5601b33-95fa-4a54-be6f-c12d0d86ea59" />


## How to test

1. Open a workflow and add a sticky note.
2. Enter multi-paragraph markdown, e.g.:

   ```
   First line

   Second line
   ```
3. Confirm the note content sits flush against the top padding (no extra gap above the first line) and paragraph spacing is compact.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5423

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

