### PR TITLE
fix(credentials): prevent preAuthentication from overwriting expression fields

### DIFF
--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -1829,5 +1829,90 @@ describe('CredentialsHelper', () => {
 			expect(mockTokenRequest).toHaveBeenCalledTimes(2);
 			expect(refreshed).toMatchObject({ accessToken: 'TOKEN_2' });
 		});
+
+		// Regression: GitHub App's `preAuthentication` hook used to return the entire
+		// resolved credentials object (including the freshly-resolved value of an
+		// `{{ ... }}` expression in the Installation ID field). The resolver was
+		// persisting that whole object back to the DB, permanently overwriting the
+		// stored expression with the test-run's static value. The fix persists only
+		// keys that the hook actually introduced — keys that were not in the input
+		// or that were empty/undefined. This test reproduces the bug shape (a hook
+		// that spreads `...credentials`) and asserts the expression survives.
+		test('does not persist values for keys that were already populated in the input', async () => {
+			class SpreadingPreAuthCredential implements ICredentialType {
+				name = 'spreadingPreAuthCredential';
+				displayName = 'Spreading PreAuth';
+				properties: INodeProperties[] = [
+					{
+						displayName: 'Dynamic ID',
+						name: 'dynamicId',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Access Token',
+						name: 'accessToken',
+						type: 'hidden',
+						typeOptions: { expirable: true },
+						default: '',
+					},
+				];
+				async preAuthentication(
+					this: IHttpRequestHelper,
+					credentials: ICredentialDataDecryptedObject,
+				) {
+					// Buggy hook shape: spreads the input back, including any
+					// expressions that the resolver just resolved.
+					return { ...credentials, accessToken: 'NEW_TOKEN' };
+				}
+			}
+
+			const spreading = new SpreadingPreAuthCredential();
+			mockNodesAndCredentials.getCredential
+				.calledWith('spreadingPreAuthCredential')
+				.mockReturnValue({ type: spreading, sourcePath: '' });
+
+			const spreadingNode: INode = {
+				id: 'uuid-spread',
+				name: 'Spread',
+				type: 'n8n-nodes-base.noOp',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+				credentials: { spreadingPreAuthCredential: { id: 'spread-cred', name: 'Spread' } },
+			};
+
+			const expressionText = "{{ $('Webhook').item.json.body.installation.id }}";
+			const inputCredentials: ICredentialDataDecryptedObject = {
+				// Resolver has already turned the expression into a static number —
+				// the in-memory shape that the hook actually sees.
+				dynamicId: 12345,
+				// The user-entered expression, as it lives in the DB. The fix
+				// guarantees this is what stays in the DB after the run.
+				originalDynamicId: expressionText,
+				accessToken: '',
+			};
+
+			const result = await credentialsHelper.preAuthentication(
+				helpers,
+				inputCredentials,
+				'spreadingPreAuthCredential',
+				spreadingNode,
+				false,
+			);
+
+			// The in-memory return must include the new token so the request
+			// can proceed.
+			expect(result).toMatchObject({ accessToken: 'NEW_TOKEN' });
+
+			// Only one persistence call, and it must NOT carry `dynamicId`
+			// (which had a non-empty value in the input — the expression
+			// is already resolved to 12345 in memory, and we must not write
+			// that back over the original expression).
+			expect(updateSpy).toHaveBeenCalledTimes(1);
+			const persisted = updateSpy.mock.calls[0][2];
+			expect(persisted).not.toHaveProperty('dynamicId');
+			expect(persisted).toEqual({ accessToken: 'NEW_TOKEN' });
+		});
 	});
 });

--- a/packages/cli/src/__tests__/credentials-helper.test.ts
+++ b/packages/cli/src/__tests__/credentials-helper.test.ts
@@ -1887,32 +1887,47 @@ describe('CredentialsHelper', () => {
 				// Resolver has already turned the expression into a static number —
 				// the in-memory shape that the hook actually sees.
 				dynamicId: 12345,
-				// The user-entered expression, as it lives in the DB. The fix
-				// guarantees this is what stays in the DB after the run.
-				originalDynamicId: expressionText,
 				accessToken: '',
 			};
 
-			const result = await credentialsHelper.preAuthentication(
-				helpers,
-				inputCredentials,
-				'spreadingPreAuthCredential',
-				spreadingNode,
-				false,
-			);
+			// Mock getCredentials to return a credential entity with the original
+			// expression string in the DB
+			const mockCredentialEntity = {
+				getData: vi.fn().mockResolvedValue({
+					dynamicId: expressionText,
+					accessToken: '',
+				}),
+			};
+			const getCredentialsSpy = vi
+				.spyOn(credentialsHelper, 'getCredentials')
+				.mockResolvedValue(mockCredentialEntity as any);
 
-			// The in-memory return must include the new token so the request
-			// can proceed.
-			expect(result).toMatchObject({ accessToken: 'NEW_TOKEN' });
+			try {
+				const result = await credentialsHelper.preAuthentication(
+					helpers,
+					inputCredentials,
+					'spreadingPreAuthCredential',
+					spreadingNode,
+					false,
+				);
 
-			// Only one persistence call, and it must NOT carry `dynamicId`
-			// (which had a non-empty value in the input — the expression
-			// is already resolved to 12345 in memory, and we must not write
-			// that back over the original expression).
-			expect(updateSpy).toHaveBeenCalledTimes(1);
-			const persisted = updateSpy.mock.calls[0][2];
-			expect(persisted).not.toHaveProperty('dynamicId');
-			expect(persisted).toEqual({ accessToken: 'NEW_TOKEN' });
+				// The in-memory return must include the new token so the request
+				// can proceed.
+				expect(result).toMatchObject({ accessToken: 'NEW_TOKEN' });
+
+				// Only one persistence call
+				expect(updateSpy).toHaveBeenCalledTimes(1);
+				const persisted = updateSpy.mock.calls[0][2];
+
+				// The persisted data must include the original expression string
+				// (not the resolved value 12345) and the new token
+				expect(persisted).toEqual({
+					dynamicId: expressionText,
+					accessToken: 'NEW_TOKEN',
+				});
+			} finally {
+				getCredentialsSpy.mockRestore();
+			}
 		});
 	});
 });

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -199,11 +199,31 @@ export class CredentialsHelper extends ICredentialsHelper {
 					}
 
 					if (node.credentials) {
-						await this.updateCredentials(
-							node.credentials[credentialType.name],
-							credentialType.name,
-							Object.assign(credentials, output),
-						);
+						// Only persist the keys the hook actually changed: keys that were not
+						// present in the input credentials, or that were empty/undefined. This
+						// prevents resolved {{ ... }} expressions (which have a non-empty string
+						// value in the input) from being written back over the original
+						// expression text. Keys that were already populated in the input —
+						// including expressions — are left intact on disk.
+						const dataToPersist: ICredentialDataDecryptedObject = {};
+						for (const [key, value] of Object.entries(output)) {
+							if (
+								!(key in credentials) ||
+								credentials[key] === '' ||
+								credentials[key] === undefined ||
+								credentials[key] === null
+							) {
+								dataToPersist[key] = value;
+							}
+						}
+
+						if (Object.keys(dataToPersist).length > 0) {
+							await this.updateCredentials(
+								node.credentials[credentialType.name],
+								credentialType.name,
+								dataToPersist,
+							);
+						}
 						return Object.assign(credentials, output);
 					}
 				}

--- a/packages/cli/src/credentials-helper.ts
+++ b/packages/cli/src/credentials-helper.ts
@@ -199,31 +199,39 @@ export class CredentialsHelper extends ICredentialsHelper {
 					}
 
 					if (node.credentials) {
-						// Only persist the keys the hook actually changed: keys that were not
-						// present in the input credentials, or that were empty/undefined. This
-						// prevents resolved {{ ... }} expressions (which have a non-empty string
-						// value in the input) from being written back over the original
-						// expression text. Keys that were already populated in the input —
-						// including expressions — are left intact on disk.
-						const dataToPersist: ICredentialDataDecryptedObject = {};
+						// Build the data to persist by merging the hook's output with the
+						// current credential data. We only include keys from the output that
+						// are either:
+						// 1. The expirable property (always persist token refreshes)
+						// 2. Keys that were not in the input, or were empty/undefined
+						// This prevents resolved {{ ... }} expressions from being written
+						// back over the original expression text, while ensuring token
+						// refreshes are persisted.
+						const currentCredentials = await this.getCredentials(
+							node.credentials[credentialType.name],
+							credentialType.name,
+						);
+						const currentData = await currentCredentials.getData();
+						const dataToPersist: ICredentialDataDecryptedObject = { ...currentData };
+
 						for (const [key, value] of Object.entries(output)) {
-							if (
+							const shouldPersist =
+								key === expirableProperty.name ||
 								!(key in credentials) ||
 								credentials[key] === '' ||
 								credentials[key] === undefined ||
-								credentials[key] === null
-							) {
+								credentials[key] === null;
+
+							if (shouldPersist) {
 								dataToPersist[key] = value;
 							}
 						}
 
-						if (Object.keys(dataToPersist).length > 0) {
-							await this.updateCredentials(
-								node.credentials[credentialType.name],
-								credentialType.name,
-								dataToPersist,
-							);
-						}
+						await this.updateCredentials(
+							node.credentials[credentialType.name],
+							credentialType.name,
+							dataToPersist,
+						);
 						return Object.assign(credentials, output);
 					}
 				}

--- a/packages/nodes-base/credentials/GithubAppApi.credentials.ts
+++ b/packages/nodes-base/credentials/GithubAppApi.credentials.ts
@@ -111,7 +111,6 @@ export class GithubAppApi implements ICredentialType {
 		}
 
 		return {
-			...credentials,
 			accessToken: response.token,
 		};
 	}


### PR DESCRIPTION
This PR fixes a regression where resolved credential values overwritten user-entered expressions during persistence. The logic now only saves new or empty fields, protecting existing expression data from being lost. 

- Updated persistence logic to skip keys with existing input values
- Added regression test covering expression preservation after hooks
- Simplified GithubAppApi preAuthentication to return only access tokens
- Prevents database from storing resolved values over original expressions

- fixes issue #34107