### PR TITLE
fix(core): Require row read scope for data table CSV export

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
@@ -10,6 +10,7 @@ import type { Project, User } from '@n8n/db';
 import { Container } from '@n8n/di';
 
 import { createDataTable } from '@test-integration/db/data-tables';
+import { createCustomRoleWithScopeSlugs } from '@test-integration/db/roles';
 import { createOwner, createMember } from '@test-integration/db/users';
 import type { SuperAgentTest } from '@test-integration/types';
 import * as utils from '@test-integration/utils';
@@ -509,5 +510,69 @@ describe('GET /projects/:projectId/data-tables/:dataTableId/download-csv', () =>
 		expect(csvContent).not.toContain('id');
 		expect(csvContent).not.toContain('createdAt');
 		expect(csvContent).not.toContain('updatedAt');
+	});
+
+	describe('row-level authorization', () => {
+		test('should not expose row data via CSV if custom role lacks dataTable:readRow scope', async () => {
+			const project = await createTeamProject('test project', owner);
+			const metadataOnlyRole = await createCustomRoleWithScopeSlugs(
+				['dataTable:listProject', 'dataTable:read'],
+				{ roleType: 'project' },
+			);
+			const metadataOnlyUser = await createMember();
+			await linkUserToProject(metadataOnlyUser, project, metadataOnlyRole.slug);
+			const metadataOnlyAgent = testServer.authAgentFor(metadataOnlyUser);
+
+			const dataTable = await createDataTable(project, {
+				name: 'Sensitive Table',
+				columns: [{ name: 'secret', type: 'string' }],
+			});
+			const columns = await dataTableColumnRepository.getColumns(dataTable.id);
+			await dataTableRowsRepository.insertRows(
+				dataTable.id,
+				[{ secret: 'payroll-token-123' }],
+				columns,
+				'id',
+			);
+
+			// The row listing endpoint already rejects the metadata-only role
+			await metadataOnlyAgent
+				.get(`/projects/${project.id}/data-tables/${dataTable.id}/rows`)
+				.expect(403);
+
+			// The CSV export endpoint must reject it too, since it also returns row data
+			await metadataOnlyAgent
+				.get(`/projects/${project.id}/data-tables/${dataTable.id}/download-csv`)
+				.expect(403);
+		});
+
+		test('should allow CSV download if custom role has dataTable:readRow scope', async () => {
+			const project = await createTeamProject('test project', owner);
+			const rowReaderRole = await createCustomRoleWithScopeSlugs(
+				['dataTable:listProject', 'dataTable:read', 'dataTable:readRow'],
+				{ roleType: 'project' },
+			);
+			const rowReaderUser = await createMember();
+			await linkUserToProject(rowReaderUser, project, rowReaderRole.slug);
+			const rowReaderAgent = testServer.authAgentFor(rowReaderUser);
+
+			const dataTable = await createDataTable(project, {
+				name: 'Readable Table',
+				columns: [{ name: 'secret', type: 'string' }],
+			});
+			const columns = await dataTableColumnRepository.getColumns(dataTable.id);
+			await dataTableRowsRepository.insertRows(
+				dataTable.id,
+				[{ secret: 'payroll-token-123' }],
+				columns,
+				'id',
+			);
+
+			const response = await rowReaderAgent
+				.get(`/projects/${project.id}/data-tables/${dataTable.id}/download-csv`)
+				.expect(200);
+
+			expect(response.body.data.csvContent).toContain('payroll-token-123');
+		});
 	});
 });

--- a/packages/cli/src/modules/data-table/data-table.controller.ts
+++ b/packages/cli/src/modules/data-table/data-table.controller.ts
@@ -308,7 +308,7 @@ export class DataTableController {
 	}
 
 	@Get('/:dataTableId/download-csv')
-	@ProjectScope('dataTable:read')
+	@ProjectScope('dataTable:readRow')
 	async downloadDataTableCsv(
 		req: AuthenticatedRequest<{ projectId: string; dataTableId: string }>,
 		_res: Response,

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableActions.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableActions.test.ts
@@ -24,6 +24,13 @@ const mockToast = {
 
 const mockDeleteDataTable = vi.fn();
 
+const mockDataTablePermissions = {
+	delete: true,
+	update: true,
+	readRow: true,
+	writeRow: true,
+};
+
 vi.mock('@/app/composables/useMessage', () => ({
 	useMessage: () => mockMessage,
 }));
@@ -36,10 +43,7 @@ vi.mock('@/features/core/dataTable/dataTable.store', () => ({
 	useDataTableStore: () => ({
 		deleteDataTable: mockDeleteDataTable,
 		projectPermissions: {
-			dataTable: {
-				delete: true,
-				update: true,
-			},
+			dataTable: mockDataTablePermissions,
 		},
 	}),
 }));
@@ -96,6 +100,10 @@ describe('DataTableActions', () => {
 		uiStore = mockedStore(useUIStore);
 		dataTableStore.deleteDataTable.mockResolvedValue(true);
 		mockMessage.confirm.mockResolvedValue(MODAL_CONFIRM);
+		mockDataTablePermissions.delete = true;
+		mockDataTablePermissions.update = true;
+		mockDataTablePermissions.readRow = true;
+		mockDataTablePermissions.writeRow = true;
 	});
 
 	it('should render N8nActionToggle with correct props', () => {
@@ -232,6 +240,23 @@ describe('DataTableActions', () => {
 			expect(uiStore.openModal).toHaveBeenCalledWith(
 				`${DOWNLOAD_DATA_TABLE_MODAL_KEY}-${mockDataTable.id}`,
 			);
+		});
+
+		it('should not open modal when user lacks dataTable:readRow permission', async () => {
+			mockDataTablePermissions.readRow = false;
+
+			const { getByTestId } = renderComponent({
+				props: {
+					dataTable: mockDataTable,
+					isReadOnly: false,
+					location: 'card',
+				},
+			});
+
+			await openActionsDropdown(getByTestId);
+			await userEvent.click(getByTestId(`action-${DATA_TABLE_CARD_ACTIONS.DOWNLOAD_CSV}`));
+
+			expect(uiStore.openModal).not.toHaveBeenCalled();
 		});
 
 		it('should use different modal keys for different data tables', async () => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableActions.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/DataTableActions.vue
@@ -63,7 +63,7 @@ const actions = computed<Array<UserAction<IUser>>>(() => {
 		{
 			label: i18n.baseText('dataTable.download.csv'),
 			value: DATA_TABLE_CARD_ACTIONS.DOWNLOAD_CSV,
-			disabled: false,
+			disabled: !dataTableStore.projectPermissions.dataTable.readRow,
 		},
 		{
 			label: favoritesStore.isFavorite(props.dataTable.id, 'dataTable')


### PR DESCRIPTION
## Summary

The data table CSV export endpoint (`GET /projects/:projectId/data-tables/:dataTableId/download-csv`) returns full row contents but was guarded by the `dataTable:read` scope, which is documented as metadata/structure access only. The equivalent row-listing endpoint (`/rows`) already requires `dataTable:readRow`.

## How to test

1. Create a team project with a data table containing some rows.
2. Create a custom project role with `dataTable:listProject` and `dataTable:read` but **not** `dataTable:readRow`.
3. Add a user to the project with that custom role.
4. Verify that the user cannot download the data table rows

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5558

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34127">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

