### PR TITLE
fix(editor): Wrap long keyboard shortcut tooltip labels within max-width

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/KeyboardShortcutTooltip.vue
+++ b/packages/frontend/editor-ui/src/app/components/KeyboardShortcutTooltip.vue
@@ -37,6 +37,6 @@ withDefaults(defineProps<Props>(), { placement: 'top', shortcut: undefined });
 }
 
 .label {
-	flex-shrink: 0;
+	min-width: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

The tooltip on the "Convert to sub-workflow" button (shown above a multi-node selection on the canvas) was truncated mid-word, e.g. "Convert 4 nodes to sub-workf" instead of the full "Convert 4 nodes to sub-workflow".

Changing `flex-shrink: 0` to `min-width: 0` lets the flex item shrink below its content width, so the inherited `overflow-wrap: anywhere` can wrap the label within the tooltip's `max-width`.

<img width="353" height="155" alt="Screenshot 2026-07-14 at 11 52 51" src="https://github.com/user-attachments/assets/a30ef8ae-0ff7-46f4-908d-d5bd8ea2792f" />
<img width="609" height="259" alt="Screenshot 2026-07-14 at 11 53 01" src="https://github.com/user-attachments/assets/25f0093c-c926-47a6-910d-c18d6eed34cb" />


## How to test

1. Open a workflow on the canvas.
2. Select several nodes (e.g. 4).
3. Hover over the "Convert to sub-workflow" button that appears above the selection.
4. The tooltip should show the full text ("Convert 4 nodes to sub-workflow"), wrapping onto multiple lines instead of being cut off.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5582

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->