### PR TITLE
fix(editor): Prevent multiple nodes showing as executing in manual runs

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
@@ -1,56 +1,146 @@
 import { useExecutingNode } from './useExecutingNode';
 
+/** Topology stub for plain main-flow nodes: they enclose nothing. */
+const noEnclosing = () => [];
+
 describe('useExecutingNode composable', () => {
 	it('should initialize with an empty executingNode queue', () => {
-		const { executingNode } = useExecutingNode();
+		const { executingNode } = useExecutingNode(noEnclosing);
 		expect(executingNode.value).toEqual([]);
 	});
 
 	it('should add a node to the executing queue', () => {
-		const { executingNode, addExecutingNode } = useExecutingNode();
+		const { executingNode, addExecutingNode } = useExecutingNode(noEnclosing);
 		addExecutingNode('node1');
-		expect(executingNode.value).toEqual(['node1']);
-	});
-
-	it('should remove an executing node from the queue (removes one occurrence at a time)', () => {
-		const { executingNode, addExecutingNode, removeExecutingNode } = useExecutingNode();
-
-		// Add nodes, including duplicates.
-		addExecutingNode('node1');
-		addExecutingNode('node2');
-		addExecutingNode('node1');
-
-		// After removal, only the first occurrence of "node1" should be removed.
-		removeExecutingNode('node1');
-		expect(executingNode.value).toEqual(['node2', 'node1']);
-	});
-
-	it('should not remove a node that does not exist', () => {
-		const { executingNode, removeExecutingNode } = useExecutingNode();
-
-		// Manually set the state for testing.
-		executingNode.value = ['node1'];
-		removeExecutingNode('node2'); // Trying to remove a non-existent node.
 		expect(executingNode.value).toEqual(['node1']);
 	});
 
 	it('should return true if a node is executing', () => {
-		const { addExecutingNode, isNodeExecuting } = useExecutingNode();
+		const { addExecutingNode, isNodeExecuting } = useExecutingNode(noEnclosing);
 		addExecutingNode('node1');
 		expect(isNodeExecuting('node1')).toBe(true);
 	});
 
 	it('should return false if a node is not executing', () => {
-		const { isNodeExecuting } = useExecutingNode();
+		const { isNodeExecuting } = useExecutingNode(noEnclosing);
 		expect(isNodeExecuting('node1')).toBe(false);
 	});
 
-	it('should clear the node execution queue', () => {
-		const { executingNode, addExecutingNode, clearNodeExecutionQueue } = useExecutingNode();
+	it('should not remove a node that does not exist', () => {
+		const { executingNode, addExecutingNode, removeExecutingNode } = useExecutingNode(noEnclosing);
 		addExecutingNode('node1');
-		addExecutingNode('node2');
-		expect(executingNode.value).toEqual(['node1', 'node2']);
+		removeExecutingNode('node2');
+		expect(executingNode.value).toEqual(['node1']);
+	});
+
+	it('should clear the node execution queue', () => {
+		const { executingNode, addExecutingNode, clearNodeExecutionQueue } =
+			useExecutingNode(noEnclosing);
+		addExecutingNode('node1');
+		addExecutingNode('node1');
+		expect(executingNode.value).toEqual(['node1', 'node1']);
 		clearNodeExecutionQueue();
 		expect(executingNode.value).toEqual([]);
+	});
+
+	describe('same-node quick succession', () => {
+		it('keeps one queue entry per concurrent run so the spinner survives the first nodeExecuteAfter', () => {
+			const { executingNode, addExecutingNode, removeExecutingNode, isNodeExecuting } =
+				useExecutingNode(noEnclosing);
+
+			// The same node starts twice before either run finishes.
+			addExecutingNode('node1');
+			addExecutingNode('node1');
+			expect(executingNode.value).toEqual(['node1', 'node1']);
+
+			// The first nodeExecuteAfter must not drop the spinner while the second run is in flight.
+			removeExecutingNode('node1');
+			expect(isNodeExecuting('node1')).toBe(true);
+			expect(executingNode.value).toEqual(['node1']);
+
+			removeExecutingNode('node1');
+			expect(isNodeExecuting('node1')).toBe(false);
+		});
+	});
+
+	describe('scope-aware supersede', () => {
+		it('supersedes a stale sibling whose nodeExecuteAfter was lost when the next node starts', () => {
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode(noEnclosing);
+
+			addExecutingNode('nodeA');
+			// nodeA's nodeExecuteAfter is dropped (suspended tab); nodeB then starts.
+			addExecutingNode('nodeB');
+
+			expect(isNodeExecuting('nodeA')).toBe(false);
+			expect(isNodeExecuting('nodeB')).toBe(true);
+			expect(executingNode.value).toEqual(['nodeB']);
+		});
+	});
+
+	describe('parent + sub-node nesting', () => {
+		// Agent runs a Tool and a Model as sub-nodes; both connect into the Agent
+		// via non-main connections, so the Agent encloses their execution.
+		const enclosing = (nodeName: string) =>
+			nodeName === 'Tool' || nodeName === 'Model' ? ['Agent'] : [];
+
+		it('keeps an enclosing consumer spinning while its sub-node runs', () => {
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode(enclosing);
+
+			addExecutingNode('Agent');
+			addExecutingNode('Tool');
+
+			expect(isNodeExecuting('Agent')).toBe(true);
+			expect(isNodeExecuting('Tool')).toBe(true);
+			expect(executingNode.value).toEqual(['Agent', 'Tool']);
+		});
+
+		it('supersedes a stale sibling sub-node but keeps the shared enclosing consumer', () => {
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode(enclosing);
+
+			addExecutingNode('Agent');
+			addExecutingNode('Tool'); // Tool's nodeExecuteAfter is dropped
+			addExecutingNode('Model');
+
+			expect(isNodeExecuting('Agent')).toBe(true);
+			expect(isNodeExecuting('Tool')).toBe(false);
+			expect(isNodeExecuting('Model')).toBe(true);
+			expect(executingNode.value).toEqual(['Agent', 'Model']);
+		});
+
+		it('preserves the full enclosing chain for deeply nested sub-nodes', () => {
+			// Embeddings → VectorStore → Agent: each is enclosed by the ones below it.
+			const chain: Record<string, string[]> = {
+				Embeddings: ['VectorStore', 'Agent'],
+				VectorStore: ['Agent'],
+			};
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode(
+				(nodeName) => chain[nodeName] ?? [],
+			);
+
+			addExecutingNode('Agent');
+			addExecutingNode('VectorStore');
+			addExecutingNode('Embeddings');
+
+			expect(isNodeExecuting('Agent')).toBe(true);
+			expect(isNodeExecuting('VectorStore')).toBe(true);
+			expect(isNodeExecuting('Embeddings')).toBe(true);
+			expect(executingNode.value).toEqual(['Agent', 'VectorStore', 'Embeddings']);
+		});
+	});
+
+	describe('identity-guarded clear', () => {
+		it('ignores a late nodeExecuteAfter for a node the next start already superseded', () => {
+			const { executingNode, addExecutingNode, removeExecutingNode, isNodeExecuting } =
+				useExecutingNode(noEnclosing);
+
+			addExecutingNode('nodeA');
+			addExecutingNode('nodeB'); // supersedes stale nodeA → ['nodeB']
+
+			// A late / reordered nodeExecuteAfter(nodeA) arrives after nodeB has started.
+			removeExecutingNode('nodeA');
+
+			expect(isNodeExecuting('nodeB')).toBe(true);
+			expect(executingNode.value).toEqual(['nodeB']);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
@@ -1,27 +1,43 @@
 import { ref } from 'vue';
 
 /**
- * Composable to keep track of the currently executing node.
- * The queue is used to keep track of the order in which nodes are executed and to ensure that
- * the UI reflects the correct execution status.
+ * Composable to keep track of the currently executing node(s), driving the
+ * per-node loading spinner. A node can appear multiple times in the queue so
+ * the spinner does not flicker when a node runs several times in quick
+ * succession — each `nodeExecuteBefore` adds one entry, each `nodeExecuteAfter`
+ * removes one.
  *
- * Once a node is added to the queue, it will be removed after a short delay
- * to allow the running spinner to show for a small amount of time.
- *
- * The number of additions and removals from the queue should always be equal.
- * A node can exist multiple times in the queue, in order to prevent the loading spinner from
- * disappearing when a node is executed multiple times in quick succession.
+ * Scope-aware collapse: the backend relays node events fire-and-forget with no
+ * sequence numbers, so a browser tab suspended to save memory can miss a
+ * `nodeExecuteAfter` and leave a node stuck in the queue — surfacing as several
+ * nodes spinning at once (CAT-2895). The main runner executes one node at a
+ * time, so when a node starts we drop every other queued node except the ones
+ * that legitimately enclose it: a sub-node (an AI Agent's tool/model/memory,
+ * a vector store's embeddings, …) runs nested inside its consumer's execution,
+ * so that consumer keeps spinning. `getEnclosingNodeNames` returns those
+ * enclosing consumers (transitively) for a given node; same-node entries are
+ * kept regardless, to preserve the quick-succession refcount above.
  */
-export function useExecutingNode() {
+export function useExecutingNode(getEnclosingNodeNames: (nodeName: string) => string[]) {
 	const executingNode = ref<string[]>([]);
 	const lastAddedExecutingNode = ref<string | null>(null);
 
 	function addExecutingNode(nodeName: string) {
-		executingNode.value.push(nodeName);
+		// Supersede stale same-scope siblings (their `nodeExecuteAfter` was lost)
+		// while keeping this node's own entries and its enclosing consumers, so
+		// genuine parent+sub-node nesting still shows both spinners.
+		const enclosingNodeNames = new Set(getEnclosingNodeNames(nodeName));
+		executingNode.value = [
+			...executingNode.value.filter((name) => name === nodeName || enclosingNodeNames.has(name)),
+			nodeName,
+		];
 		lastAddedExecutingNode.value = nodeName;
 	}
 
 	function removeExecutingNode(nodeName: string) {
+		// Identity-scoped: only an entry matching `nodeName` is dropped, so a
+		// late or reordered `nodeExecuteAfter` for an already-superseded node is a
+		// no-op and can never clear a different node's spinner.
 		const executionIndex = executingNode.value.indexOf(nodeName);
 		if (executionIndex === -1) {
 			return;

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
@@ -27,6 +27,7 @@ import { createTestTaskData, createTestWorkflowExecutionResponse } from '@/__tes
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import {
 	createRunExecutionData,
+	NodeConnectionTypes,
 	TRIMMED_TASK_DATA_CONNECTIONS_KEY,
 	type ExecutionSummary,
 } from 'n8n-workflow';
@@ -1445,6 +1446,87 @@ describe('workflowExecutionState.store', () => {
 			expect(a.executingNode.isNodeExecuting('Node A')).toBe(true);
 			expect(b.executingNode.isNodeExecuting('Node A')).toBe(false);
 			expect(b.executingNode.executingNode).toEqual([]);
+		});
+
+		// Scope-aware collapse (CAT-2895): a suspended tab can drop a
+		// `nodeExecuteAfter`, leaving stale nodes stuck in the queue and
+		// surfacing as several nodes spinning at once. The store feeds the
+		// workflow topology into `useExecutingNode` so it collapses stale
+		// same-scope siblings while preserving genuine parent+sub-node nesting.
+		describe('scope-aware collapse', () => {
+			// AI Agent → (main) Set, with a Calculator tool nested into the Agent
+			// via a non-main (ai_tool) connection.
+			function seedAgentToolWorkflow(documentId: ReturnType<typeof createWorkflowDocumentId>) {
+				const documentStore = useWorkflowDocumentStore(documentId);
+				documentStore.addNode({
+					id: 'agent-id',
+					name: 'AI Agent',
+					type: '@n8n/n8n-nodes-langchain.agent',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				});
+				documentStore.addNode({
+					id: 'tool-id',
+					name: 'Calculator',
+					type: '@n8n/n8n-nodes-langchain.toolCalculator',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				});
+				documentStore.addNode({
+					id: 'set-id',
+					name: 'Set',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				});
+				documentStore.setConnections({
+					'AI Agent': {
+						main: [[{ node: 'Set', type: NodeConnectionTypes.Main, index: 0 }]],
+					},
+					Calculator: {
+						[NodeConnectionTypes.AiTool]: [
+							[{ node: 'AI Agent', type: NodeConnectionTypes.AiTool, index: 0 }],
+						],
+					},
+				});
+			}
+
+			it('keeps an AI Agent and its sub-node both spinning (nested pair)', () => {
+				const documentId = createWorkflowDocumentId('wf-nesting');
+				seedAgentToolWorkflow(documentId);
+				const executionStateStore = useWorkflowExecutionStateStore(documentId);
+
+				// Engine emits before(Agent) then before(Calculator) nested inside it.
+				executionStateStore.executingNode.addExecutingNode('AI Agent');
+				executionStateStore.executingNode.addExecutingNode('Calculator');
+
+				expect(executionStateStore.executingNode.isNodeExecuting('AI Agent')).toBe(true);
+				expect(executionStateStore.executingNode.isNodeExecuting('Calculator')).toBe(true);
+				// The per-node canvas projection sees both spinners.
+				expect(executionStateStore.executionRunningByNodeId.get('agent-id')?.value).toBe(true);
+				expect(executionStateStore.executionRunningByNodeId.get('tool-id')?.value).toBe(true);
+			});
+
+			it('supersedes stale sibling spinners when the next main node starts', () => {
+				const documentId = createWorkflowDocumentId('wf-supersede');
+				seedAgentToolWorkflow(documentId);
+				const executionStateStore = useWorkflowExecutionStateStore(documentId);
+
+				// Agent + tool are mid-run, then both nodeExecuteAfter events are lost.
+				executionStateStore.executingNode.addExecutingNode('AI Agent');
+				executionStateStore.executingNode.addExecutingNode('Calculator');
+
+				// The next main node starts — a main-connection sibling, not enclosed.
+				executionStateStore.executingNode.addExecutingNode('Set');
+
+				expect(executionStateStore.executingNode.isNodeExecuting('AI Agent')).toBe(false);
+				expect(executionStateStore.executingNode.isNodeExecuting('Calculator')).toBe(false);
+				expect(executionStateStore.executingNode.isNodeExecuting('Set')).toBe(true);
+				expect(executionStateStore.executingNode.executingNode).toEqual(['Set']);
+			});
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -150,13 +150,22 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		 */
 		const trackedExecutionIds = ref<Set<string>>(new Set());
 
+		const documentStore = useWorkflowDocumentStore(documentId);
+
 		/**
 		 * Queue of currently-executing node names driving per-node loading
 		 * spinners. Owned by the per-document store so spinner state stays
 		 * isolated per workflow document. Read purely via Vue reactivity; it is
 		 * intentionally not wired into the change-event mechanism below.
+		 *
+		 * `getEnclosingNodeNames` gives `useExecutingNode` the scope topology it
+		 * needs to collapse stale spinners: a node's non-main consumers (an AI
+		 * Agent for its tool/model, a vector store for its embeddings, …), which
+		 * keep executing while the node runs nested inside them.
 		 */
-		const executingNode = useExecutingNode();
+		const executingNode = useExecutingNode((nodeName) =>
+			documentStore.getChildNodes(nodeName, 'ALL_NON_MAIN', -1),
+		);
 
 		const onWorkflowExecutionStateChange = createEventHook<WorkflowExecutionStateChangeEvent>();
 
@@ -372,8 +381,6 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		// reactively, so add/remove calls invalidate only that entry — and only
 		// when the *value* changes (gated by structural equality).
 		// ---------------------------------------------------------------------
-
-		const documentStore = useWorkflowDocumentStore(documentId);
 
 		const executionRunningByNodeId = shallowReactive(new Map<string, ComputedRef<boolean>>());
 		const executionWaitingForNextByNodeId = shallowReactive(


### PR DESCRIPTION
## Summary

Manual executions could show **several nodes spinning as "executing" at once** (CAT-2895). The backend relays `nodeExecuteBefore` / `nodeExecuteAfter` fire-and-forget with no sequence numbers, so a browser tab suspended to save memory can miss a `nodeExecuteAfter`. The missed event leaves a node stuck in the executing-node queue, and because the main runner executes one node at a time, that leftover spinner piles up on top of the node that is actually running.

This makes `useExecutingNode` **scope-aware**. When a node starts, it now supersedes stale entries from other execution scopes while preserving the cases that are legitimately concurrent:

- **Scope-aware collapse** — a stale main-connection sibling (whose `nodeExecuteAfter` was lost) is dropped when the next node starts.
- **Parent + sub-node nesting preserved** — a sub-node (an AI Agent's tool/model/memory, a vector store's embeddings, …) runs *nested inside* its consumer's execution, so that consumer keeps spinning. The store feeds the workflow topology — `getChildNodes(node, 'ALL_NON_MAIN', -1)`, a node's non-main consumers, transitively — into the composable to tell genuine nesting apart from stale siblings.
- **Identity-guarded clear** — removal only drops an entry matching that node name, so a late or reordered `nodeExecuteAfter` can never wipe a different node's spinner.
- **Quick-succession refcount kept** — a node run twice in quick succession still keeps one queue entry per run, so its spinner doesn't drop mid-flight.

The corrected answer lives in `isNodeExecuting`, so every consumer (canvas spinner, NDV input/output, focus panel, `useNodeExecution`, `computeExecutionRunning`) sees it with no further changes. FE-only; does **not** touch `pushConnection.store.ts`.

> **Out of scope** (tracked as the reconcile-on-reconnect follow-up): if a `nodeExecuteBefore` itself is dropped, or the terminal event is missed, a **single** stale spinner can still linger until `executionFinished`. This PR shrinks the symptom from "N stuck spinners" to "at most one," which is exactly CAT-2895's reported complaint.

## How to test

**Deterministic (unit + store integration, included in this PR):**

```
pnpm --filter n8n-editor-ui test \
  src/app/composables/useExecutingNode.test.ts \
  src/app/stores/workflowExecutionState.store.test.ts
```

Covers: a dropped mid-run `nodeExecuteAfter` followed by the next node starting → single correct spinner; an AI Agent + sub-node → both keep spinning; a deep nesting chain (embeddings → vector store → agent); the quick-succession refcount; and the identity-guarded clear.

**Manual (the original repro, intermittent):**

1. Open a long-running workflow in two browser tabs and start both in parallel.
2. Switch away for 10+ seconds so the tabs suspend, then return to them.
3. Before: multiple nodes show the running spinner. After: only the genuinely-executing node (plus any of its active sub-nodes) spins.

**AI-agent sanity check (no nesting regression):**

1. Run a workflow with an AI Agent and a tool/model sub-node.
2. While a sub-node runs, both the Agent and the sub-node keep their spinner.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2895

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- No user-facing docs affected. -->
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34136">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

