### PR TITLE
feat(editor): Export `CommandBarItem` type from `@n8n/design-system` package index (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -142,5 +142,6 @@ export { default as N8nInlineTextEdit } from './N8nInlineTextEdit';
 export { default as N8nScrollArea } from './N8nScrollArea';
 export * from './DateRangePicker';
 export { default as N8nCommandBar } from './N8nCommandBar';
+export type { CommandBarItem } from './N8nCommandBar/types';
 export * from './N8nDialog';
 export * from './N8nAlertDialog';


### PR DESCRIPTION
## Summary

Adds a public, top-level re-export of the `CommandBarItem` type from the `@n8n/design-system` package index. Previously `CommandBarItem` was reachable only via the deep path `@n8n/design-system/components/N8nCommandBar/types`, which consumer packages cannot import under the `no-internal-package-import` lint rule (error-level for module packages).

This is a contract-first enabler for the `@n8n/module-sdk` descriptor v2 `commands` field: the SDK grounds `CommandBarContribution` on the canonical `CommandBarItem` rather than forking a parallel command type, so the L1 export lands before the L2 consumer.

Type-only re-export — no runtime, behavior, or component-API change.

```diff
 export { default as N8nCommandBar } from './N8nCommandBar';
+export type { CommandBarItem } from './N8nCommandBar/types';
```

## How to test

Type-only change, no runtime surface. Verified locally:

- `pnpm --filter @n8n/design-system typecheck` — green
- `pnpm --filter @n8n/design-system lint` — clean
- `import type { CommandBarItem } from '@n8n/design-system'` now resolves from a consumer package (flows up through `export * from './components'` in the package index) with no deep path.

## Related

Enabler for module-sdk descriptor v2 (`CommandBarContribution`). No GitHub/Linear ticket.

## Checklist

- [ ] The human author of the PR has checked the "I have seen this code, I have run this code, and I take responsibility for this code." checkbox
- [x] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)
- [x] Tests: type-only change, covered by existing typecheck
- [ ] `release/backport` label if urgent

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34138">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

