### PR TITLE
test(core): Add Schedule Trigger durable scheduler e2e (single- and multi-main) (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
@@ -51,11 +51,11 @@ test.describe(
 		test('should not fire once per sweep when the tick is slower than the sweep', async ({
 			api,
 		}) => {
-			// Sweep and executor run every 1s but the schedule ticks every 5s. The
+			// Sweep and executor run every 1s but the schedule ticks every 2s. The
 			// dedupe guards (row claim + guarded fire-time write) must collapse the
-			// intervening sweeps so a single 5s tick yields a single execution, not
-			// one per second.
-			const wf = makeScheduleTriggerWorkflow(5);
+			// intervening sweeps so a single tick yields a single execution, not one
+			// per second.
+			const wf = makeScheduleTriggerWorkflow();
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,
 			);
@@ -63,18 +63,18 @@ test.describe(
 			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
 			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
 
-			// Observe a fixed window of roughly four 5s ticks.
-			await sleep(22_000);
+			// Observe a fixed window of roughly five 2s ticks.
+			await sleep(10_000);
 			const executions = await api.workflows.getExecutions(workflowId, 50);
 
-			// ~4 expected over 22s at a 5s tick. A per-sweep double-fire would land
-			// near ~20. Tolerant band absorbs scheduling jitter either side.
+			// ~6 expected over 10s at a 2s tick. A per-sweep double-fire (once every
+			// 1s) would land near ~11. Tolerant band absorbs scheduling jitter.
 			expect(executions.length).toBeGreaterThanOrEqual(2);
 			expect(executions.length).toBeLessThanOrEqual(8);
 		});
 
 		test('should stop firing after the workflow is deactivated', async ({ api }) => {
-			const wf = makeScheduleTriggerWorkflow(5);
+			const wf = makeScheduleTriggerWorkflow();
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,
 			);
@@ -87,17 +87,17 @@ test.describe(
 			// Let any in-flight tick settle, then snapshot and hold across several
 			// intervals. Deactivation removes the scheduled job (no read path exists,
 			// so this is proven indirectly by the count staying flat).
-			await sleep(3_000);
+			await sleep(2_000);
 			const countAfterDeactivate = (await api.workflows.getExecutions(workflowId, 50)).length;
 
-			await sleep(12_000);
+			await sleep(6_000);
 			const countAtEnd = (await api.workflows.getExecutions(workflowId, 50)).length;
 
 			expect(countAtEnd).toBe(countAfterDeactivate);
 		});
 
 		test('should fire a Schedule Trigger driven by a raw cron expression', async ({ api }) => {
-			const wf = makeCronScheduleTriggerWorkflow('*/5 * * * * *');
+			const wf = makeCronScheduleTriggerWorkflow();
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,
 			);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
@@ -1,5 +1,4 @@
-import type { IWorkflowBase } from 'n8n-workflow';
-
+import { expectScheduleTriggerFires } from './schedule-trigger-helpers';
 import {
 	makeScheduleTriggerWorkflow,
 	makeCronScheduleTriggerWorkflow,
@@ -36,16 +35,7 @@ test.describe(
 		test('should fire an activated Schedule Trigger through the durable scheduler', async ({
 			api,
 		}) => {
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-
-			// Generous budget: depends on sweep + executor cadence plus the interval.
-			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
-			expect(execution.status).toBe('success');
+			await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 		});
 
 		test('should not fire once per sweep when the tick is slower than the sweep', async ({
@@ -55,13 +45,7 @@ test.describe(
 			// dedupe guards (row claim + guarded fire-time write) must collapse the
 			// intervening sweeps so a single tick yields a single execution, not one
 			// per second.
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
 			// Observe a fixed window of roughly five 2s ticks.
 			await sleep(10_000);
@@ -74,13 +58,7 @@ test.describe(
 		});
 
 		test('should stop firing after the workflow is deactivated', async ({ api }) => {
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
 			await api.workflows.deactivate(workflowId);
 
@@ -97,15 +75,8 @@ test.describe(
 		});
 
 		test('should fire a Schedule Trigger driven by a raw cron expression', async ({ api }) => {
-			const wf = makeCronScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-
-			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
-			expect(execution.status).toBe('success');
+			// Cron variant: exercises the cronExpression provisioning branch.
+			await expectScheduleTriggerFires(api, makeCronScheduleTriggerWorkflow());
 		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
@@ -1,0 +1,111 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import {
+	makeScheduleTriggerWorkflow,
+	makeCronScheduleTriggerWorkflow,
+} from './schedule-trigger-workflow';
+import { test, expect } from '../../../fixtures/base';
+
+const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+
+// Durable scheduler path. Both flags are required: N8N_SCHEDULER_ENABLED alone
+// leaves activation on the legacy in-memory timer, so without
+// N8N_USE_WORKFLOW_PUBLICATION_SERVICE the schedule-trigger job registrar
+// early-returns and activation falls back to the legacy path. With both set the
+// registrar intercepts and the in-memory schedule is discarded, so these tests
+// exercise the durable path. Note: a successful trigger-mode execution does not
+// by itself prove durable-vs-legacy (both emit mode:trigger); the restart-
+// continuity spec is what actually distinguishes the two engines.
+test.use({
+	capability: {
+		env: {
+			N8N_SCHEDULER_ENABLED: 'true',
+			N8N_USE_WORKFLOW_PUBLICATION_SERVICE: 'true',
+			N8N_SCHEDULER_SWEEP_INTERVAL: '1',
+			N8N_SCHEDULER_EXECUTOR_INTERVAL: '1',
+		},
+	},
+});
+
+test.describe(
+	'Schedule Trigger (durable scheduler)',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should fire an activated Schedule Trigger through the durable scheduler', async ({
+			api,
+		}) => {
+			const wf = makeScheduleTriggerWorkflow();
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			// Generous budget: depends on sweep + executor cadence plus the interval.
+			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			expect(execution.status).toBe('success');
+		});
+
+		test('should not fire once per sweep when the tick is slower than the sweep', async ({
+			api,
+		}) => {
+			// Sweep and executor run every 1s but the schedule ticks every 5s. The
+			// dedupe guards (row claim + guarded fire-time write) must collapse the
+			// intervening sweeps so a single 5s tick yields a single execution, not
+			// one per second.
+			const wf = makeScheduleTriggerWorkflow(5);
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+
+			// Observe a fixed window of roughly four 5s ticks.
+			await sleep(22_000);
+			const executions = await api.workflows.getExecutions(workflowId, 50);
+
+			// ~4 expected over 22s at a 5s tick. A per-sweep double-fire would land
+			// near ~20. Tolerant band absorbs scheduling jitter either side.
+			expect(executions.length).toBeGreaterThanOrEqual(2);
+			expect(executions.length).toBeLessThanOrEqual(8);
+		});
+
+		test('should stop firing after the workflow is deactivated', async ({ api }) => {
+			const wf = makeScheduleTriggerWorkflow(5);
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+
+			await api.workflows.deactivate(workflowId);
+
+			// Let any in-flight tick settle, then snapshot and hold across several
+			// intervals. Deactivation removes the scheduled job (no read path exists,
+			// so this is proven indirectly by the count staying flat).
+			await sleep(3_000);
+			const countAfterDeactivate = (await api.workflows.getExecutions(workflowId, 50)).length;
+
+			await sleep(12_000);
+			const countAtEnd = (await api.workflows.getExecutions(workflowId, 50)).length;
+
+			expect(countAtEnd).toBe(countAfterDeactivate);
+		});
+
+		test('should fire a Schedule Trigger driven by a raw cron expression', async ({ api }) => {
+			const wf = makeCronScheduleTriggerWorkflow('*/5 * * * * *');
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			expect(execution.status).toBe('success');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-durable.spec.ts
@@ -7,14 +7,13 @@ import { test, expect } from '../../../fixtures/base';
 
 const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
 
-// Durable scheduler path. Both flags are required: N8N_SCHEDULER_ENABLED alone
-// leaves activation on the legacy in-memory timer, so without
-// N8N_USE_WORKFLOW_PUBLICATION_SERVICE the schedule-trigger job registrar
-// early-returns and activation falls back to the legacy path. With both set the
-// registrar intercepts and the in-memory schedule is discarded, so these tests
-// exercise the durable path. Note: a successful trigger-mode execution does not
-// by itself prove durable-vs-legacy (both emit mode:trigger); the restart-
-// continuity spec is what actually distinguishes the two engines.
+// Durable scheduler path. Both flags are required: with only
+// `N8N_SCHEDULER_ENABLED` the job registrar early-returns and activation falls
+// back to the legacy in-memory timer. With both set the registrar intercepts and
+// the in-memory schedule is discarded.
+//
+// A successful trigger-mode execution does not by itself prove durable-vs-legacy
+// (both emit `mode:trigger`); the restart-continuity spec distinguishes them.
 test.use({
 	capability: {
 		env: {
@@ -47,14 +46,18 @@ test.describe(
 			// per second.
 			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
-			// Observe a fixed window of roughly five 2s ticks.
+			// Count the delta over a fixed window rather than the absolute total:
+			// expectScheduleTriggerFires already polled for up to 60s, so ticks
+			// accrued during detection must not count against the window's budget.
+			const countBefore = (await api.workflows.getExecutions(workflowId, 100)).length;
 			await sleep(10_000);
-			const executions = await api.workflows.getExecutions(workflowId, 50);
+			const countAfter = (await api.workflows.getExecutions(workflowId, 100)).length;
+			const fired = countAfter - countBefore;
 
-			// ~6 expected over 10s at a 2s tick. A per-sweep double-fire (once every
-			// 1s) would land near ~11. Tolerant band absorbs scheduling jitter.
-			expect(executions.length).toBeGreaterThanOrEqual(2);
-			expect(executions.length).toBeLessThanOrEqual(8);
+			// ~5 expected over 10s at a 2s tick. A per-sweep double-fire (once every
+			// 1s) would land near ~10. Tolerant band absorbs scheduling jitter.
+			expect(fired).toBeGreaterThanOrEqual(2);
+			expect(fired).toBeLessThanOrEqual(8);
 		});
 
 		test('should stop firing after the workflow is deactivated', async ({ api }) => {
@@ -75,7 +78,7 @@ test.describe(
 		});
 
 		test('should fire a Schedule Trigger driven by a raw cron expression', async ({ api }) => {
-			// Cron variant: exercises the cronExpression provisioning branch.
+			// Cron variant: exercises the `cronExpression` provisioning branch.
 			await expectScheduleTriggerFires(api, makeCronScheduleTriggerWorkflow());
 		});
 	},

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-helpers.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-helpers.ts
@@ -1,0 +1,28 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import type { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
+import { expect } from '../../../fixtures/base';
+import type { ApiHelpers } from '../../../services/api-helper';
+
+type ScheduleTriggerWorkflow = ReturnType<typeof makeScheduleTriggerWorkflow>;
+
+// Shared happy-path assertion: create + activate a Schedule Trigger workflow and
+// assert it produces a successful trigger-mode execution. The fire tests differ
+// only in the rule kind (seconds vs cron) and the scheduler flags, so the flow
+// lives here once rather than being copy-pasted across specs. Returns the created
+// workflow id for callers that go on to inspect further executions.
+export async function expectScheduleTriggerFires(
+	api: ApiHelpers,
+	wf: ScheduleTriggerWorkflow,
+): Promise<string> {
+	const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+		wf.toJSON() as IWorkflowBase,
+	);
+
+	await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+	const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+	expect(execution.status).toBe('success');
+
+	return workflowId;
+}

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-helpers.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-helpers.ts
@@ -6,11 +6,10 @@ import type { ApiHelpers } from '../../../services/api-helper';
 
 type ScheduleTriggerWorkflow = ReturnType<typeof makeScheduleTriggerWorkflow>;
 
-// Shared happy-path assertion: create + activate a Schedule Trigger workflow and
-// assert it produces a successful trigger-mode execution. The fire tests differ
-// only in the rule kind (seconds vs cron) and the scheduler flags, so the flow
-// lives here once rather than being copy-pasted across specs. Returns the created
-// workflow id for callers that go on to inspect further executions.
+// Shared happy-path assertion: create and activate a Schedule Trigger workflow and
+// assert it produces a successful trigger-mode execution. Extracted because the
+// fire tests differ only in rule kind (seconds vs cron) and scheduler flags.
+// Returns the workflow id for callers that inspect further executions.
 export async function expectScheduleTriggerFires(
 	api: ApiHelpers,
 	wf: ScheduleTriggerWorkflow,

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-legacy.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-legacy.spec.ts
@@ -1,7 +1,6 @@
-import type { IWorkflowBase } from 'n8n-workflow';
-
+import { expectScheduleTriggerFires } from './schedule-trigger-helpers';
 import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
-import { test, expect } from '../../../fixtures/base';
+import { test } from '../../../fixtures/base';
 
 // Flag-off parity control: with the durable scheduler disabled (default), the
 // same workflow must still fire via the legacy in-memory path. Guards against the
@@ -15,15 +14,7 @@ test.describe(
 		test('should fire an activated Schedule Trigger through the legacy in-memory path', async ({
 			api,
 		}) => {
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-
-			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
-			expect(execution.status).toBe('success');
+			await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-legacy.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-legacy.spec.ts
@@ -1,0 +1,29 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
+import { test, expect } from '../../../fixtures/base';
+
+// Flag-off parity control: with the durable scheduler disabled (default), the
+// same workflow must still fire via the legacy in-memory path. Guards against the
+// durable work regressing the common case.
+test.describe(
+	'Schedule Trigger (legacy in-memory scheduler)',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should fire an activated Schedule Trigger through the legacy in-memory path', async ({
+			api,
+		}) => {
+			const wf = makeScheduleTriggerWorkflow();
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			expect(execution.status).toBe('success');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
@@ -1,5 +1,4 @@
-import type { IWorkflowBase } from 'n8n-workflow';
-
+import { expectScheduleTriggerFires } from './schedule-trigger-helpers';
 import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
 import { test, expect } from '../../../fixtures/base';
 
@@ -44,13 +43,7 @@ test.describe(
 			// eslint-disable-next-line playwright/no-skipped-test -- runtime topology guard, not a disabled test
 			test.skip(mainUrls.length < 2, 'requires a multi-main cluster (2+ mains)');
 
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
 			// Observe a fixed window of roughly five 2s ticks. Both mains run the
 			// sweep + executor every 1s, so a broken claim would let each main fire
@@ -68,6 +61,7 @@ test.describe(
 			api,
 			mainUrls,
 			n8nContainer,
+			createApiForMain,
 		}) => {
 			// eslint-disable-next-line playwright/no-skipped-test -- runtime topology guard, not a disabled test
 			test.skip(mainUrls.length < 2, 'requires a multi-main cluster (2+ mains)');
@@ -75,13 +69,7 @@ test.describe(
 			// eslint-disable-next-line playwright/no-skipped-test -- container-only guard, not a disabled test
 			test.skip(!n8nContainer, 'container-only: requires stoppable n8n containers');
 
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
 			// Snapshot what fired before the stop. Continuity is only proven by an
 			// execution whose id is not in this set appearing afterwards.
@@ -89,25 +77,32 @@ test.describe(
 				(await api.workflows.getExecutions(workflowId, 50)).map((execution) => execution.id),
 			);
 
-			// Stop one main. There is no leader, so the survivor is already competing
-			// for the same ticks and its sweep/executor keep going; any tick the
-			// stopped main had claimed but not completed is reclaimed once its lease
-			// expires. The api fixture talks through the load balancer, which routes
-			// to the surviving main.
+			// Stop main-1. There is no leader, so the survivor (main-2) is already
+			// competing for the same ticks and its sweep/executor keep going; any tick
+			// main-1 had claimed but not completed is reclaimed once its lease expires.
 			const [stopped] = n8nContainer.findContainers(/-n8n-main-1$/);
 			expect(stopped, 'main-1 container should be found').toBeDefined();
 			await n8nContainer.stopContainer(/-n8n-main-1$/);
 
+			// Query the survivor directly rather than via the load balancer, which
+			// keeps routing a share of requests to the stopped main until it drops it.
+			const survivor = await createApiForMain(1);
+
 			// A brand-new trigger execution (not in the pre-stop set) fires without
-			// re-activation and succeeds. Generous budget: covers load-balancer
-			// re-routing plus, in the worst case, a lease-expiry reclaim.
+			// re-activation and succeeds. Generous budget: covers, worst case, a
+			// lease-expiry reclaim. Transient errors while the survivor settles are
+			// swallowed so the poll keeps trying.
 			await expect
 				.poll(
 					async () => {
-						const fresh = (await api.workflows.getExecutions(workflowId, 50)).find(
-							(execution) => !idsBeforeStop.has(execution.id) && execution.mode === 'trigger',
-						);
-						return fresh?.status ?? null;
+						try {
+							const fresh = (await survivor.workflows.getExecutions(workflowId, 50)).find(
+								(execution) => !idsBeforeStop.has(execution.id) && execution.mode === 'trigger',
+							);
+							return fresh?.status ?? null;
+						} catch {
+							return null;
+						}
 					},
 					{ timeout: 90_000, intervals: [2_000] },
 				)

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
@@ -5,19 +5,17 @@ import { test, expect } from '../../../fixtures/base';
 const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
 
 // Durable scheduler under a multi-main cluster. The scheduler has no leader: the
-// sweep, executor and reaper loops run on EVERY main, and correctness comes from
-// the DB claim (`FOR UPDATE SKIP LOCKED` + a `claimedBy`/`leaseEpoch` fence), not
-// from electing one main to fire. These tests prove the two properties that the
+// sweep, executor and reaper loops run on every main, and correctness comes from
+// the DB claim (`FOR UPDATE SKIP LOCKED` plus a `claimedBy`/`leaseEpoch` fence)
+// rather than electing one main to fire. These tests prove the two properties the
 // legacy in-memory timer cannot offer across a cluster: a tick fires exactly once
 // (not once per main), and firing survives losing a main (lease-expiry reclaim).
 //
-// Topology is inherited from the running project, NOT pinned here: the
-// `multi-main` project supplies 2 mains + a worker (queue mode, Postgres, load
-// balancer, licensed), while every other e2e project supplies a single main and
-// the tests skip via `mainUrls.length < 2`. Pinning `mains: 2` in `test.use`
-// would force a licensed 2-main stack under the sqlite project too, which throws
-// at startup without a license. Only the scheduler env is added here; it merges
-// with the project's container config.
+// Topology is inherited from the running project, not pinned here. Pinning
+// `mains: 2` in `test.use` would force a licensed 2-main stack under the sqlite
+// project too, which throws at startup without a license; instead the tests skip
+// via `mainUrls.length < 2` on single-main projects. Only the scheduler env is
+// added here, merged with the project's container config.
 test.use({
 	capability: {
 		env: {
@@ -45,16 +43,19 @@ test.describe(
 
 			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
-			// Observe a fixed window of roughly five 2s ticks. Both mains run the
-			// sweep + executor every 1s, so a broken claim would let each main fire
-			// the same tick, doubling the count towards ~12. A correct atomic claim
-			// keeps it to one execution per tick (~6). The band separates the two
-			// while absorbing scheduling jitter.
+			// Count the delta over a fixed window of roughly five 2s ticks. Both mains
+			// run the sweep + executor every 1s, so a broken claim would let each main
+			// fire the same tick, doubling the count towards ~10. A correct atomic
+			// claim keeps it to one execution per tick (~5). Measuring the delta (not
+			// the absolute total) keeps ticks accrued during the up-to-60s detection
+			// in expectScheduleTriggerFires out of the window's budget.
+			const countBefore = (await api.workflows.getExecutions(workflowId, 100)).length;
 			await sleep(10_000);
-			const executions = await api.workflows.getExecutions(workflowId, 50);
+			const countAfter = (await api.workflows.getExecutions(workflowId, 100)).length;
+			const fired = countAfter - countBefore;
 
-			expect(executions.length).toBeGreaterThanOrEqual(2);
-			expect(executions.length).toBeLessThanOrEqual(8);
+			expect(fired).toBeGreaterThanOrEqual(2);
+			expect(fired).toBeLessThanOrEqual(8);
 		});
 
 		test('should keep firing after one main is stopped', async ({

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-multimain.spec.ts
@@ -1,0 +1,117 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
+import { test, expect } from '../../../fixtures/base';
+
+const sleep = async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms));
+
+// Durable scheduler under a multi-main cluster. The scheduler has no leader: the
+// sweep, executor and reaper loops run on EVERY main, and correctness comes from
+// the DB claim (`FOR UPDATE SKIP LOCKED` + a `claimedBy`/`leaseEpoch` fence), not
+// from electing one main to fire. These tests prove the two properties that the
+// legacy in-memory timer cannot offer across a cluster: a tick fires exactly once
+// (not once per main), and firing survives losing a main (lease-expiry reclaim).
+//
+// Topology is inherited from the running project, NOT pinned here: the
+// `multi-main` project supplies 2 mains + a worker (queue mode, Postgres, load
+// balancer, licensed), while every other e2e project supplies a single main and
+// the tests skip via `mainUrls.length < 2`. Pinning `mains: 2` in `test.use`
+// would force a licensed 2-main stack under the sqlite project too, which throws
+// at startup without a license. Only the scheduler env is added here; it merges
+// with the project's container config.
+test.use({
+	capability: {
+		env: {
+			N8N_SCHEDULER_ENABLED: 'true',
+			N8N_USE_WORKFLOW_PUBLICATION_SERVICE: 'true',
+			N8N_SCHEDULER_SWEEP_INTERVAL: '1',
+			N8N_SCHEDULER_EXECUTOR_INTERVAL: '1',
+		},
+	},
+});
+
+test.describe(
+	'Schedule Trigger multi-main (durable scheduler) @mode:multi-main',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should fire an activated Schedule Trigger exactly once across the cluster', async ({
+			api,
+			mainUrls,
+		}) => {
+			// Only meaningful with more than one main competing for the same tick.
+			// eslint-disable-next-line playwright/no-skipped-test -- runtime topology guard, not a disabled test
+			test.skip(mainUrls.length < 2, 'requires a multi-main cluster (2+ mains)');
+
+			const wf = makeScheduleTriggerWorkflow();
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+
+			// Observe a fixed window of roughly five 2s ticks. Both mains run the
+			// sweep + executor every 1s, so a broken claim would let each main fire
+			// the same tick, doubling the count towards ~12. A correct atomic claim
+			// keeps it to one execution per tick (~6). The band separates the two
+			// while absorbing scheduling jitter.
+			await sleep(10_000);
+			const executions = await api.workflows.getExecutions(workflowId, 50);
+
+			expect(executions.length).toBeGreaterThanOrEqual(2);
+			expect(executions.length).toBeLessThanOrEqual(8);
+		});
+
+		test('should keep firing after one main is stopped', async ({
+			api,
+			mainUrls,
+			n8nContainer,
+		}) => {
+			// eslint-disable-next-line playwright/no-skipped-test -- runtime topology guard, not a disabled test
+			test.skip(mainUrls.length < 2, 'requires a multi-main cluster (2+ mains)');
+			// Needs real containers to stop one; skipped against a local instance.
+			// eslint-disable-next-line playwright/no-skipped-test -- container-only guard, not a disabled test
+			test.skip(!n8nContainer, 'container-only: requires stoppable n8n containers');
+
+			const wf = makeScheduleTriggerWorkflow();
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+
+			// Snapshot what fired before the stop. Continuity is only proven by an
+			// execution whose id is not in this set appearing afterwards.
+			const idsBeforeStop = new Set(
+				(await api.workflows.getExecutions(workflowId, 50)).map((execution) => execution.id),
+			);
+
+			// Stop one main. There is no leader, so the survivor is already competing
+			// for the same ticks and its sweep/executor keep going; any tick the
+			// stopped main had claimed but not completed is reclaimed once its lease
+			// expires. The api fixture talks through the load balancer, which routes
+			// to the surviving main.
+			const [stopped] = n8nContainer.findContainers(/-n8n-main-1$/);
+			expect(stopped, 'main-1 container should be found').toBeDefined();
+			await n8nContainer.stopContainer(/-n8n-main-1$/);
+
+			// A brand-new trigger execution (not in the pre-stop set) fires without
+			// re-activation and succeeds. Generous budget: covers load-balancer
+			// re-routing plus, in the worst case, a lease-expiry reclaim.
+			await expect
+				.poll(
+					async () => {
+						const fresh = (await api.workflows.getExecutions(workflowId, 50)).find(
+							(execution) => !idsBeforeStop.has(execution.id) && execution.mode === 'trigger',
+						);
+						return fresh?.status ?? null;
+					},
+					{ timeout: 90_000, intervals: [2_000] },
+				)
+				.toBe('success');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
@@ -1,0 +1,87 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
+import { test, expect } from '../../../fixtures/base';
+
+// The durable job is DB state, written on activation and independent of process
+// lifetime. After a main restart the sweep reclaims it and keeps firing with no
+// re-activation. This is the property the legacy in-memory timer cannot offer,
+// and it is only observable in container mode (needs a real process restart).
+test.use({
+	capability: {
+		env: {
+			N8N_SCHEDULER_ENABLED: 'true',
+			N8N_USE_WORKFLOW_PUBLICATION_SERVICE: 'true',
+			N8N_SCHEDULER_SWEEP_INTERVAL: '1',
+			N8N_SCHEDULER_EXECUTOR_INTERVAL: '1',
+		},
+	},
+});
+
+test.describe(
+	'Schedule Trigger restart continuity (durable scheduler)',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test('should keep firing after a main restart without re-activation', async ({
+			api,
+			n8nContainer,
+		}) => {
+			// Needs a real container to restart; skipped when running against a
+			// pre-started local instance (n8nContainer is null there).
+			// eslint-disable-next-line playwright/no-skipped-test -- runtime guard, not a disabled test
+			test.skip(!n8nContainer, 'container-only: requires a restartable n8n container');
+
+			const wf = makeScheduleTriggerWorkflow(5);
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
+				wf.toJSON() as IWorkflowBase,
+			);
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+
+			// Snapshot the executions that exist BEFORE the restart. Continuity is
+			// only proven by an execution whose id is not in this set firing after
+			// the restart — waitForExecution's recency fallback would otherwise
+			// re-match a pre-restart execution when recovery takes under 5s.
+			const idsBeforeRestart = new Set(
+				(await api.workflows.getExecutions(workflowId, 50)).map((execution) => execution.id),
+			);
+
+			// Restart the single main container in place (same writable layer + DB).
+			const [main] = n8nContainer.findContainers(/-n8n$/);
+			expect(main, 'main n8n container should be found').toBeDefined();
+			await main.restart();
+
+			// Wait until the API is serving again after the restart.
+			await expect
+				.poll(
+					async () => {
+						try {
+							const response = await api.request.get('/healthz/readiness');
+							return response.status();
+						} catch {
+							return 0;
+						}
+					},
+					{ timeout: 60_000, intervals: [1_000] },
+				)
+				.toBe(200);
+
+			// A brand-new trigger execution (not in the pre-restart set) appears
+			// without re-activating the workflow, and it succeeds.
+			await expect
+				.poll(
+					async () => {
+						const fresh = (await api.workflows.getExecutions(workflowId, 50)).find(
+							(execution) => !idsBeforeRestart.has(execution.id) && execution.mode === 'trigger',
+						);
+						return fresh?.status ?? null;
+					},
+					{ timeout: 60_000, intervals: [1_000] },
+				)
+				.toBe('success');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
@@ -33,7 +33,7 @@ test.describe(
 			// eslint-disable-next-line playwright/no-skipped-test -- runtime guard, not a disabled test
 			test.skip(!n8nContainer, 'container-only: requires a restartable n8n container');
 
-			const wf = makeScheduleTriggerWorkflow(5);
+			const wf = makeScheduleTriggerWorkflow();
 			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
 				wf.toJSON() as IWorkflowBase,
 			);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
@@ -25,8 +25,15 @@ test.describe(
 	() => {
 		test('should keep firing after a main restart without re-activation', async ({
 			api,
+			mainUrls,
 			n8nContainer,
 		}) => {
+			// Single-main only. Under a cluster a surviving main keeps ticking while
+			// one restarts, so the fresh execution would appear regardless of whether
+			// restart recovery works, making the test pass vacuously. Cluster
+			// crash-continuity is covered by the multi-main spec instead.
+			// eslint-disable-next-line playwright/no-skipped-test -- runtime topology guard, not a disabled test
+			test.skip(mainUrls.length >= 2, 'single-main only: cluster continuity is covered elsewhere');
 			// Needs a real container to restart; skipped when running against a
 			// pre-started local instance (n8nContainer is null there).
 			// eslint-disable-next-line playwright/no-skipped-test -- runtime guard, not a disabled test
@@ -36,15 +43,13 @@ test.describe(
 
 			// Snapshot the executions that exist BEFORE the restart. Continuity is
 			// only proven by an execution whose id is not in this set firing after
-			// the restart — waitForExecution's recency fallback would otherwise
+			// the restart; `waitForExecution`'s recency fallback would otherwise
 			// re-match a pre-restart execution when recovery takes under 5s.
 			const idsBeforeRestart = new Set(
 				(await api.workflows.getExecutions(workflowId, 50)).map((execution) => execution.id),
 			);
 
-			// Restart a main container in place (same writable layer + DB). The
-			// naming differs by topology: `-n8n` single-main, `-n8n-main-N` in a
-			// cluster; match either and take the first.
+			// Restart the main container in place (same writable layer + DB).
 			const [main] = n8nContainer.findContainers(/-n8n(-main-\d+)?$/);
 			expect(main, 'main n8n container should be found').toBeDefined();
 			await main.restart();

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-restart.spec.ts
@@ -1,5 +1,4 @@
-import type { IWorkflowBase } from 'n8n-workflow';
-
+import { expectScheduleTriggerFires } from './schedule-trigger-helpers';
 import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
 import { test, expect } from '../../../fixtures/base';
 
@@ -33,13 +32,7 @@ test.describe(
 			// eslint-disable-next-line playwright/no-skipped-test -- runtime guard, not a disabled test
 			test.skip(!n8nContainer, 'container-only: requires a restartable n8n container');
 
-			const wf = makeScheduleTriggerWorkflow();
-			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition(
-				wf.toJSON() as IWorkflowBase,
-			);
-
-			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
-			await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			const workflowId = await expectScheduleTriggerFires(api, makeScheduleTriggerWorkflow());
 
 			// Snapshot the executions that exist BEFORE the restart. Continuity is
 			// only proven by an execution whose id is not in this set firing after
@@ -49,8 +42,10 @@ test.describe(
 				(await api.workflows.getExecutions(workflowId, 50)).map((execution) => execution.id),
 			);
 
-			// Restart the single main container in place (same writable layer + DB).
-			const [main] = n8nContainer.findContainers(/-n8n$/);
+			// Restart a main container in place (same writable layer + DB). The
+			// naming differs by topology: `-n8n` single-main, `-n8n-main-N` in a
+			// cluster; match either and take the first.
+			const [main] = n8nContainer.findContainers(/-n8n(-main-\d+)?$/);
 			expect(main, 'main n8n container should be found').toBeDefined();
 			await main.restart();
 
@@ -59,15 +54,14 @@ test.describe(
 				.poll(
 					async () => {
 						try {
-							const response = await api.request.get('/healthz/readiness');
-							return response.status();
+							return await api.isHealthy('readiness');
 						} catch {
-							return 0;
+							return false;
 						}
 					},
 					{ timeout: 60_000, intervals: [1_000] },
 				)
-				.toBe(200);
+				.toBe(true);
 
 			// A brand-new trigger execution (not in the pre-restart set) appears
 			// without re-activating the workflow, and it succeeds.

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-timezone.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-timezone.spec.ts
@@ -1,0 +1,56 @@
+import type { IWorkflowBase } from 'n8n-workflow';
+
+import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
+import { test, expect } from '../../../fixtures/base';
+
+// Instance timezone set to a non-UTC zone. A workflow that leaves its timezone on
+// the 'DEFAULT' sentinel must have that resolved to the instance timezone when the
+// durable path builds the trigger item; the bug was 'DEFAULT' leaking straight
+// into moment.tz(...), which silently resolves an unknown zone to UTC.
+const INSTANCE_TIMEZONE = 'America/New_York';
+
+test.use({
+	capability: {
+		env: {
+			N8N_SCHEDULER_ENABLED: 'true',
+			N8N_USE_WORKFLOW_PUBLICATION_SERVICE: 'true',
+			N8N_SCHEDULER_SWEEP_INTERVAL: '1',
+			N8N_SCHEDULER_EXECUTOR_INTERVAL: '1',
+			GENERIC_TIMEZONE: INSTANCE_TIMEZONE,
+		},
+	},
+});
+
+test.describe(
+	'Schedule Trigger timezone (durable scheduler)',
+	{
+		annotation: [{ type: 'owner', description: 'Catalysts' }],
+	},
+	() => {
+		test("should resolve the workflow's DEFAULT timezone to the instance timezone", async ({
+			api,
+		}) => {
+			const wf = makeScheduleTriggerWorkflow();
+			const { workflowId, createdWorkflow } = await api.workflows.createWorkflowFromDefinition({
+				...(wf.toJSON() as IWorkflowBase),
+				settings: { timezone: 'DEFAULT' },
+			});
+
+			await api.workflows.activate(workflowId, createdWorkflow.versionId!);
+
+			const execution = await api.workflows.waitForExecution(workflowId, 60_000, 'trigger');
+			expect(execution.status).toBe('success');
+
+			const full = await api.workflows.getExecution(execution.id, { redactExecutionData: false });
+
+			// The emitted item's Timezone field is `<zone> (UTC<offset>)`. Resolved
+			// correctly it names the instance zone; the pre-fix leak emitted the
+			// literal 'DEFAULT' sentinel resolved to UTC instead. America/New_York is
+			// never UTC+00:00 in any season, so the offset assertion is DST-proof and
+			// catches a resolve-to-UTC regression without hardcoding -04:00/-05:00.
+			expect(full.data).toContain(INSTANCE_TIMEZONE);
+			expect(full.data).not.toContain('DEFAULT (UTC');
+			expect(full.data).not.toContain('(UTC+00:00)');
+		});
+	},
+);

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-timezone.spec.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-timezone.spec.ts
@@ -4,9 +4,9 @@ import { makeScheduleTriggerWorkflow } from './schedule-trigger-workflow';
 import { test, expect } from '../../../fixtures/base';
 
 // Instance timezone set to a non-UTC zone. A workflow that leaves its timezone on
-// the 'DEFAULT' sentinel must have that resolved to the instance timezone when the
-// durable path builds the trigger item; the bug was 'DEFAULT' leaking straight
-// into moment.tz(...), which silently resolves an unknown zone to UTC.
+// the `'DEFAULT'` sentinel must have it resolved to the instance timezone when the
+// durable path builds the trigger item; the bug was `'DEFAULT'` leaking straight
+// into `moment.tz`, which silently resolves an unknown zone to UTC.
 const INSTANCE_TIMEZONE = 'America/New_York';
 
 test.use({
@@ -44,10 +44,10 @@ test.describe(
 			const full = await api.workflows.getExecution(execution.id, { redactExecutionData: false });
 
 			// The emitted item's Timezone field is `<zone> (UTC<offset>)`. Resolved
-			// correctly it names the instance zone; the pre-fix leak emitted the
-			// literal 'DEFAULT' sentinel resolved to UTC instead. America/New_York is
-			// never UTC+00:00 in any season, so the offset assertion is DST-proof and
-			// catches a resolve-to-UTC regression without hardcoding -04:00/-05:00.
+			// correctly it names the instance zone; the pre-fix leak resolved the
+			// `'DEFAULT'` sentinel to UTC. America/New_York is never UTC+00:00 in any
+			// season, so asserting the zone name and a non-UTC offset is DST-proof
+			// without hardcoding -04:00/-05:00.
 			expect(full.data).toContain(INSTANCE_TIMEZONE);
 			expect(full.data).not.toContain('DEFAULT (UTC');
 			expect(full.data).not.toContain('(UTC+00:00)');

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
@@ -1,9 +1,10 @@
 import { workflow, trigger, node } from '@n8n/workflow-sdk';
 import { nanoid } from 'nanoid';
 
-// Builds a Schedule Trigger -> NoOp workflow that fires every few seconds, so a
-// trigger-mode execution appears well within the test's wait budget.
-export const makeScheduleTriggerWorkflow = (secondsInterval = 5) => {
+// Builds a Schedule Trigger -> NoOp workflow that fires every couple of seconds,
+// so a trigger-mode execution appears quickly and the observation windows stay
+// short (keeps the CI cost down).
+export const makeScheduleTriggerWorkflow = (secondsInterval = 2) => {
 	const scheduleTrigger = trigger({
 		type: 'n8n-nodes-base.scheduleTrigger',
 		version: 1.3,
@@ -30,7 +31,7 @@ export const makeScheduleTriggerWorkflow = (secondsInterval = 5) => {
 
 // Same shape but driven by a raw cron expression (the `cronExpression` field
 // takes a separate provisioning branch from the fixed-interval fields).
-export const makeCronScheduleTriggerWorkflow = (expression = '*/5 * * * * *') => {
+export const makeCronScheduleTriggerWorkflow = (expression = '*/2 * * * * *') => {
 	const scheduleTrigger = trigger({
 		type: 'n8n-nodes-base.scheduleTrigger',
 		version: 1.3,

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
@@ -1,0 +1,56 @@
+import { workflow, trigger, node } from '@n8n/workflow-sdk';
+import { nanoid } from 'nanoid';
+
+// Builds a Schedule Trigger -> NoOp workflow that fires every few seconds, so a
+// trigger-mode execution appears well within the test's wait budget.
+export const makeScheduleTriggerWorkflow = (secondsInterval = 5) => {
+	const scheduleTrigger = trigger({
+		type: 'n8n-nodes-base.scheduleTrigger',
+		version: 1.3,
+		config: {
+			name: 'Schedule Trigger',
+			parameters: {
+				rule: {
+					interval: [{ field: 'seconds', secondsInterval }],
+				},
+			},
+		},
+	});
+
+	const noOp = node({
+		type: 'n8n-nodes-base.noOp',
+		version: 1,
+		config: {
+			name: 'NoOp',
+		},
+	});
+
+	return workflow(nanoid(), `Schedule Trigger Test ${nanoid()}`).add(scheduleTrigger.to(noOp));
+};
+
+// Same shape but driven by a raw cron expression (the `cronExpression` field
+// takes a separate provisioning branch from the fixed-interval fields).
+export const makeCronScheduleTriggerWorkflow = (expression = '*/5 * * * * *') => {
+	const scheduleTrigger = trigger({
+		type: 'n8n-nodes-base.scheduleTrigger',
+		version: 1.3,
+		config: {
+			name: 'Schedule Trigger',
+			parameters: {
+				rule: {
+					interval: [{ field: 'cronExpression', expression }],
+				},
+			},
+		},
+	});
+
+	const noOp = node({
+		type: 'n8n-nodes-base.noOp',
+		version: 1,
+		config: {
+			name: 'NoOp',
+		},
+	});
+
+	return workflow(nanoid(), `Schedule Trigger Cron Test ${nanoid()}`).add(scheduleTrigger.to(noOp));
+};

--- a/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
+++ b/packages/testing/playwright/tests/e2e/scheduling/schedule-trigger-workflow.ts
@@ -1,9 +1,8 @@
 import { workflow, trigger, node } from '@n8n/workflow-sdk';
 import { nanoid } from 'nanoid';
 
-// Builds a Schedule Trigger -> NoOp workflow that fires every couple of seconds,
-// so a trigger-mode execution appears quickly and the observation windows stay
-// short (keeps the CI cost down).
+// Builds a Schedule Trigger -> NoOp workflow firing every couple of seconds, so a
+// trigger-mode execution appears quickly and the observation windows stay short.
 export const makeScheduleTriggerWorkflow = (secondsInterval = 2) => {
 	const scheduleTrigger = trigger({
 		type: 'n8n-nodes-base.scheduleTrigger',


### PR DESCRIPTION
## Summary

Playwright container e2e for the durable scheduler behind
`N8N_SCHEDULER_ENABLED` + `N8N_USE_WORKFLOW_PUBLICATION_SERVICE`, covering both
single-main and multi-main topologies (CAT-3733, follow-on to C2 node wiring).

Test-only; no product code changes. All under
`packages/testing/playwright/tests/e2e/scheduling/`.

## Single-main scenarios

- **durable path** fires an activated Schedule Trigger (seconds + raw cron rules)
- **flag-off legacy parity** control (durable path must not regress the common case)
- **fires once per due tick, not once per sweep** (1s sweep vs 2s tick; guards the dedupe claim/fire-time guards)
- **stops firing after deactivation** (indirect: execution count flat over a quiet window)
- **timezone**: a workflow left on the `DEFAULT` sentinel resolves to the instance timezone, not a leaked Moment zone (guards the tz sentinel fix)
- **restart continuity**: the durable job survives a main-container restart and keeps firing with no re-activation, the property the legacy in-memory timer cannot offer (container-only)

## Multi-main scenarios

There is no leader: the sweep, executor and reaper loops run on every main and
correctness comes from the DB claim, not from electing one main to fire. The new
`schedule-trigger-multimain.spec.ts` proves the two properties the legacy
in-memory timer cannot offer across a cluster:

- **fires exactly once across the cluster** (not once per main), via the atomic
  `FOR UPDATE SKIP LOCKED` claim + `claimedBy`/`leaseEpoch` fence
- **keeps firing after one main is stopped** (lease-expiry reclaim on a surviving
  main)

The spec inherits the running project's topology instead of pinning `mains`, so
it runs 2-main under the `multi-main` project (`@mode:multi-main`) and skips
elsewhere via `mainUrls.length < 2`. A licensed 2-main stack is required, so
these two run in CI (internal-PR `multi-main:e2e` job) rather than locally.

## Notes

Both flags are required for the durable path: `N8N_SCHEDULER_ENABLED` alone leaves
activation on the legacy in-memory timer. A plain trigger-mode success does not by
itself distinguish durable from legacy (both emit `mode: trigger`); the
restart-continuity and multi-main specs are what actually separate the two engines.

The schedule tick is 2s (sweep/executor 1s) and observation windows are kept
short to limit the CI wall-clock cost.

Out of scope: multi-main failover / chaos matrix beyond the two smoke properties
above (R2, CAT-3624).

Run:
- single-main: `pnpm --filter=n8n-playwright test:container:sqlite tests/e2e/scheduling/` (6 passed + 2 multi-main skipped locally)
- multi-main: `pnpm --filter=n8n-playwright test:container:multi-main:e2e --grep "Schedule Trigger multi-main"` (needs a license; CI-verified)

https://linear.app/n8n/issue/CAT-3733

🤖 Generated with [Claude Code](https://claude.com/claude-code)