### PR TITLE
fix(editor): Allow scrolling the AI Assistant empty view when content overflows (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -669,7 +669,8 @@ function handleShelfSuggestionInsert(payload: {
 	gap: var(--spacing--lg);
 	padding: var(--spacing--lg);
 	padding-top: 20vh;
-	overflow: hidden;
+	overflow-y: auto;
+	overflow-x: hidden;
 }
 
 .centeredInput {


### PR DESCRIPTION
## Summary

On the AI Assistant empty view (`/assistant`), the personalized prompt suggestions experiment (`093_instance_ai_personalized_prompt_suggestions`, `v4-personalized` catalog) renders a 4-suggestion shelf below the composer. On smaller screens (≲800px viewport height at 100% zoom) the last suggestion lands below the fold and could not be reached: the view's entire layout chain (`InstanceAiView .container` → `.chatArea` → `.emptyLayout`) clips overflow with `overflow: hidden`, so there was no scroll container anywhere. The control empty state is short enough to always fit, which is why this was never visible before the experiment.

This makes `.emptyLayout` the scroll container: `overflow-y: auto` + `overflow-x: hidden`. The empty view now scrolls vertically when its content exceeds the viewport (the `20vh` top padding scrolls away first), matching what the split empty state experiment already does in its chat column.

`overflow-x` stays `hidden` deliberately: `TemplateExamplesCatalog` (`093`'s sibling experiment from #33244) walks up the DOM looking for the nearest ancestor with `overflow: hidden` / `overflow-x: hidden` to position its lateral nav buttons, so `.emptyLayout` keeps matching that check.

## How to test

1. Run n8n with the experiment forced: set localStorage `N8N_EXPERIMENT_OVERRIDES` to `{"093_instance_ai_personalized_prompt_suggestions":"variant-list"}`.
2. Open `/assistant` in a window ~640–750px tall (or zoom in until the shelf overflows). You can force a deterministic suggestion segment with `/assistant?instanceAiPersonalizedPromptProfile=marketing:market-research`.
3. Before this change: the 4th suggestion is clipped below the fold and mouse-wheel scrolling does nothing (it only becomes visible when zooming the browser out, see the recording in the Linear ticket).
4. With this change: the view scrolls with the wheel/trackpad and the 4th suggestion is fully reachable. No horizontal scrollbar appears.

Verified with a local Playwright run at a 1470×640 viewport: precondition (last suggestion clipped) reproduced, then a real wheel gesture brought it fully into view; a geometry probe confirmed `.emptyLayout` is the vertical scroll container with `overflow-x: hidden` and no horizontal overflow. Not covered by a committed test: jsdom can't exercise CSS layout/scrolling, and an e2e spec for a temporary experiment surface didn't seem worth the container-lane cost — happy to add one if preferred.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GROP-57

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

