### PR TITLE
fix(core): Count AI assistant workflow test runs as manual executions in statistics

### DIFF
--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -139,6 +139,7 @@ type HooksSetupParameters = {
 	pushRef?: string;
 	retryOf?: string;
 	parentExecution?: RelatedExecution;
+	source?: IWorkflowExecutionDataProcess['source'];
 };
 
 function hookFunctionsWorkflowEvents(
@@ -485,10 +486,13 @@ function hookFunctionsFinalizeExecutionStatus(hooks: ExecutionLifecycleHooks) {
 	});
 }
 
-function hookFunctionsStatistics(hooks: ExecutionLifecycleHooks) {
+function hookFunctionsStatistics(
+	hooks: ExecutionLifecycleHooks,
+	source?: IWorkflowExecutionDataProcess['source'],
+) {
 	const workflowStatisticsService = Container.get(WorkflowStatisticsService);
 	hooks.addHandler('nodeFetchedData', (workflowId, node) => {
-		workflowStatisticsService.emit('nodeFetchedData', { workflowId, node });
+		workflowStatisticsService.emit('nodeFetchedData', { workflowId, node, source });
 	});
 }
 
@@ -519,7 +523,7 @@ async function duplicateBinaryDataToParent(
  */
 function hookFunctionsSave(
 	hooks: ExecutionLifecycleHooks,
-	{ pushRef, retryOf, saveSettings, parentExecution }: HooksSetupParameters,
+	{ pushRef, retryOf, saveSettings, parentExecution, source }: HooksSetupParameters,
 ) {
 	const logger = Container.get(Logger);
 	const errorReporter = Container.get(ErrorReporter);
@@ -633,6 +637,7 @@ function hookFunctionsSave(
 			workflowStatisticsService.emit('workflowExecutionCompleted', {
 				workflowData: this.workflowData,
 				fullRunData,
+				source,
 			});
 		}
 	});
@@ -647,7 +652,7 @@ const DISCARDABLE_DATA_MODES: WorkflowExecuteMode[] = ['trigger', 'cli', 'error'
  */
 function hookFunctionsSaveWorker(
 	hooks: ExecutionLifecycleHooks,
-	{ pushRef, retryOf, saveSettings }: HooksSetupParameters,
+	{ pushRef, retryOf, saveSettings, source }: HooksSetupParameters,
 ) {
 	const logger = Container.get(Logger);
 	const errorReporter = Container.get(ErrorReporter);
@@ -722,6 +727,7 @@ function hookFunctionsSaveWorker(
 			workflowStatisticsService.emit('workflowExecutionCompleted', {
 				workflowData: this.workflowData,
 				fullRunData,
+				source,
 			});
 		}
 	});
@@ -760,7 +766,7 @@ export function getLifecycleHooksForScalingWorker(
 	data: IWorkflowExecutionDataProcess,
 	executionId: string,
 ): ExecutionLifecycleHooks {
-	const { pushRef, retryOf, executionMode, workflowData } = data;
+	const { pushRef, retryOf, executionMode, workflowData, source } = data;
 	const hooks = new ExecutionLifecycleHooks(
 		executionMode,
 		executionId,
@@ -768,12 +774,12 @@ export function getLifecycleHooksForScalingWorker(
 		retryOf ?? undefined,
 	);
 	const saveSettings = toSaveSettings(workflowData.settings);
-	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
+	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings, source };
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSaveWorker(hooks, optionalParameters);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
-	hookFunctionsStatistics(hooks);
+	hookFunctionsStatistics(hooks, source);
 	hookFunctionsExternalHooks(hooks);
 
 	if (executionMode === 'manual' && Container.get(InstanceSettings).isWorker) {
@@ -898,14 +904,14 @@ export function getLifecycleHooksForRegularMain(
 		retryOf ?? undefined,
 	);
 	const saveSettings = toSaveSettings(workflowData.settings);
-	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
+	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings, source };
 	hookFunctionsWorkflowEvents(hooks, userId, projectId, projectName, source, telemetryMetadata);
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSave(hooks, optionalParameters);
 	hookFunctionsPush(hooks, optionalParameters, userId, source);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
-	hookFunctionsStatistics(hooks);
+	hookFunctionsStatistics(hooks, source);
 	hookFunctionsExternalHooks(hooks);
 	Container.get(ModulesHooksRegistry).addHooks(hooks);
 	return hooks;

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -1121,6 +1121,17 @@ export class InstanceAiAdapterService {
 					mockDataSources: pinDataPlan.mockDataSources,
 				};
 
+				// In queue mode the worker rebuilds the run from persisted `execution.data`,
+				// where top-level `runData.source` doesn't survive. Persist it in
+				// `manualData` so worker-side statistics can classify IAI runs.
+				if (runData.executionData) {
+					runData.executionData.manualData = {
+						...runData.executionData.manualData,
+						userId: user.id,
+						source: runData.source,
+					};
+				}
+
 				// When manual executions are offloaded to workers (queue mode), the worker
 				// rebuilds the run from the persisted `execution.data`. The adapter's manual
 				// run details otherwise live in transient top-level fields that don't survive
@@ -1141,6 +1152,7 @@ export class InstanceAiAdapterService {
 						manualData: {
 							userId: runData.userId,
 							triggerToStartFrom: runData.triggerToStartFrom,
+							source: runData.source,
 						},
 						executionData: null,
 					});

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -183,6 +183,7 @@ export class JobProcessor {
 				retryOf: execution.retryOf,
 				pushRef,
 				userId: execution.data.manualData?.userId,
+				source: execution.data.manualData?.source,
 			},
 			executionId,
 		);

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -24,6 +24,7 @@ import {
 	type INode,
 	type IRun,
 	type WorkflowExecuteMode,
+	type WorkflowExecutionSource,
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
@@ -81,8 +82,9 @@ describe('WorkflowStatisticsService', () => {
 			service: WorkflowStatisticsService,
 			workflowData: IWorkflowDb & WorkflowEntity,
 			runData: IRun,
+			source?: WorkflowExecutionSource,
 		) => {
-			await service.workflowExecutionCompleted(workflowData, runData);
+			await service.workflowExecutionCompleted(workflowData, runData, source);
 			await flushStats(service);
 		};
 
@@ -181,6 +183,113 @@ describe('WorkflowStatisticsService', () => {
 				const statistics = await workflowStatisticsRepository.find();
 				expect(statistics).toHaveLength(0);
 			}
+		});
+
+		test.each<WorkflowExecuteMode>(['trigger', 'webhook'])(
+			'should count successful instance_ai-sourced execution with mode %s as manual, not production',
+			async (mode) => {
+				// ARRANGE
+				const runData: IRun = {
+					finished: true,
+					status: 'success',
+					data: createEmptyRunExecutionData(),
+					mode,
+					startedAt: new Date(),
+					storedAt: 'db',
+				};
+
+				// ACT
+				await completeAndFlush(workflowStatisticsService, workflow, runData, 'instance_ai');
+
+				// ASSERT
+				const statistics = await workflowStatisticsRepository.find();
+				expect(statistics).toHaveLength(1);
+				expect(statistics[0]).toMatchObject({
+					count: 1,
+					rootCount: 0,
+					name: 'manual_success',
+					workflowId: workflow.id,
+				});
+			},
+		);
+
+		test('should count failing instance_ai-sourced execution as manual error and not emit instance-first-production-workflow-failed', async () => {
+			// ARRANGE
+			const runData: IRun = {
+				finished: false,
+				status: 'error',
+				data: createEmptyRunExecutionData(),
+				mode: 'trigger',
+				startedAt: new Date(),
+				storedAt: 'db',
+			};
+			const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+
+			// ACT
+			await completeAndFlush(workflowStatisticsService, workflow, runData, 'instance_ai');
+
+			// ASSERT
+			const statistics = await workflowStatisticsRepository.find();
+			expect(statistics).toHaveLength(1);
+			expect(statistics[0]).toMatchObject({
+				count: 1,
+				rootCount: 0,
+				name: 'manual_error',
+				workflowId: workflow.id,
+			});
+			expect(emitSpy).not.toHaveBeenCalledWith(
+				'instance-first-production-workflow-failed',
+				expect.anything(),
+			);
+		});
+
+		test('should not update user settings or emit first-production-workflow-succeeded for instance_ai-sourced executions', async () => {
+			// ARRANGE
+			const runData: IRun = {
+				finished: true,
+				status: 'success',
+				data: createEmptyRunExecutionData(),
+				mode: 'trigger',
+				startedAt: new Date(),
+				storedAt: 'db',
+			};
+			const emitSpy = vi.spyOn(Container.get(EventService), 'emit');
+			const updateSettingsSpy = vi.spyOn(userService, 'updateSettings');
+
+			// ACT
+			await completeAndFlush(workflowStatisticsService, workflow, runData, 'instance_ai');
+
+			// ASSERT
+			expect(updateSettingsSpy).not.toHaveBeenCalled();
+			expect(emitSpy).not.toHaveBeenCalledWith(
+				'first-production-workflow-succeeded',
+				expect.anything(),
+			);
+		});
+
+		test('should count user-sourced executions as production', async () => {
+			// ARRANGE
+			const runData: IRun = {
+				finished: true,
+				status: 'success',
+				data: createEmptyRunExecutionData(),
+				mode: 'trigger',
+				startedAt: new Date(),
+				storedAt: 'db',
+			};
+
+			// ACT
+			await completeAndFlush(workflowStatisticsService, workflow, runData, 'user');
+
+			// ASSERT
+			const statistics = await workflowStatisticsRepository.find();
+			expect(statistics).toHaveLength(1);
+			expect(statistics[0]).toMatchObject({
+				count: 1,
+				rootCount: 1,
+				name: 'production_success',
+				workflowId: workflow.id,
+			});
 		});
 
 		test.each<ExecutionStatus>(['success', 'crashed', 'error'])(
@@ -876,6 +985,21 @@ describe('WorkflowStatisticsService', () => {
 				nodeType: node.type,
 				nodeId: node.id,
 			});
+		});
+
+		test('should not record data-loaded statistics for instance_ai-sourced executions', async () => {
+			const workflowId = '1';
+			const node = {
+				id: 'abcde',
+				name: 'test node',
+				typeVersion: 1,
+				type: '',
+				position: [0, 0] as [number, number],
+				parameters: {},
+			};
+			await workflowStatisticsService.nodeFetchedData(workflowId, node, 'instance_ai');
+			expect(entityManager.insert).not.toHaveBeenCalled();
+			expect(eventService.emit).not.toHaveBeenCalled();
 		});
 
 		test('should emit event with no `userId` if workflow is owned by team project', async () => {

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -15,6 +15,7 @@ import {
 	type IRun,
 	type IWorkflowBase,
 	type WorkflowExecuteMode,
+	type WorkflowExecutionSource,
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
@@ -58,13 +59,19 @@ const isModeRootExecution = {
 	agent: false,
 } satisfies Record<WorkflowExecuteMode, boolean>;
 
-function getStatisticsNameForCompletedRun(runData: IRun): StatisticsNames | null {
+function getStatisticsNameForCompletedRun(
+	runData: IRun,
+	source?: WorkflowExecutionSource,
+): StatisticsNames | null {
 	const isChatExecution = runData.mode === 'chat';
 	if (isChatExecution || !isCompletedExecutionStatus(runData.status)) {
 		return null;
 	}
 
-	const isManualExecution = runData.mode === 'manual';
+	// Instance AI verification runs mimic the trigger's execution mode, but they
+	// are test runs on the user's behalf — count them as manual so they never
+	// land in production stats or fire first-production milestones.
+	const isManualExecution = runData.mode === 'manual' || source === 'instance_ai';
 	if (isManualExecution) {
 		return runData.status === 'success'
 			? StatisticsNames.manualSuccess
@@ -81,8 +88,12 @@ function isRootExecutionForRun(runData: IRun): boolean {
 }
 
 type WorkflowStatisticsEvents = {
-	nodeFetchedData: { workflowId: string; node: INode };
-	workflowExecutionCompleted: { workflowData: IWorkflowBase; fullRunData: IRun };
+	nodeFetchedData: { workflowId: string; node: INode; source?: WorkflowExecutionSource };
+	workflowExecutionCompleted: {
+		workflowData: IWorkflowBase;
+		fullRunData: IRun;
+		source?: WorkflowExecutionSource;
+	};
 };
 
 @Service()
@@ -102,23 +113,29 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 
 		this.on(
 			'nodeFetchedData',
-			async ({ workflowId, node }) => await this.nodeFetchedData(workflowId, node),
+			async ({ workflowId, node, source }) => await this.nodeFetchedData(workflowId, node, source),
 		);
 		this.on(
 			'workflowExecutionCompleted',
-			async ({ workflowData, fullRunData }) =>
-				await this.workflowExecutionCompleted(workflowData, fullRunData),
+			async ({ workflowData, fullRunData, source }) =>
+				await this.workflowExecutionCompleted(workflowData, fullRunData, source),
 		);
 	}
 
-	async workflowExecutionCompleted(workflowData: IWorkflowBase, runData: IRun): Promise<void> {
-		const statisticsName = getStatisticsNameForCompletedRun(runData);
+	async workflowExecutionCompleted(
+		workflowData: IWorkflowBase,
+		runData: IRun,
+		source?: WorkflowExecutionSource,
+	): Promise<void> {
+		const statisticsName = getStatisticsNameForCompletedRun(runData, source);
+
+		// Instance AI runs mimic trigger modes but are not root production runs.
+		const isRoot = source !== 'instance_ai' && isRootExecutionForRun(runData);
+
 		if (!statisticsName) return;
 
 		const workflowId = workflowData.id;
 		if (!workflowId) return;
-
-		const isRoot = isRootExecutionForRun(runData);
 
 		let upsertResult: Awaited<ReturnType<WorkflowStatisticsRepository['upsertWorkflowStatistics']>>;
 
@@ -256,8 +273,16 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 		});
 	}
 
-	async nodeFetchedData(workflowId: string | undefined | null, node: INode): Promise<void> {
+	async nodeFetchedData(
+		workflowId: string | undefined | null,
+		node: INode,
+		source?: WorkflowExecutionSource,
+	): Promise<void> {
 		if (!workflowId) return;
+
+		// Instance AI verification runs must not claim a workflow's
+		// first-data-loaded milestone on the user's behalf.
+		if (source === 'instance_ai') return;
 
 		const insertResult = await this.repository.insertWorkflowStatistics(
 			StatisticsNames.dataLoaded,

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -264,6 +264,7 @@ export class WorkflowExecutionService {
 						userId: data.userId,
 						dirtyNodeNames: data.dirtyNodeNames,
 						triggerToStartFrom: data.triggerToStartFrom,
+						source: data.source,
 					},
 					// Set this to null so `createRunExecutionData` doesn't initialize it.
 					// Otherwise this would be treated as a resumed execution after waiting.

--- a/packages/workflow/src/run-execution-data/run-execution-data.v0.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v0.ts
@@ -51,6 +51,6 @@ export interface IRunExecutionDataV0 {
 	/** Data needed for a worker to run a manual execution. */
 	manualData?: Pick<
 		IWorkflowExecutionDataProcess,
-		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId'
+		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId' | 'source'
 	>;
 }

--- a/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
+++ b/packages/workflow/src/run-execution-data/run-execution-data.v1.ts
@@ -66,7 +66,7 @@ export interface IRunExecutionDataV1 {
 	/** Data needed for a worker to run a manual execution. */
 	manualData?: Pick<
 		IWorkflowExecutionDataProcess,
-		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId'
+		'dirtyNodeNames' | 'triggerToStartFrom' | 'userId' | 'evaluationRunId' | 'source'
 	>;
 
 	/** Metadata about whether and how this execution's data was redacted. */


### PR DESCRIPTION
## Summary

When Instance AI verifies a workflow it built (via `verify-built-workflow` or `executions(run)`), the run mimics the trigger's execution mode (`trigger`/`webhook`) so the test behaves like production. The workflow statistics service classifies every non-manual mode as production, so these AI self-tests were:

- counted as `production_success`/`production_error` in `workflow_statistics` (and license metrics, including `rootCount`),
- claiming the `Workflow first prod success` milestone and setting `userActivated`/`userActivatedAt`/`firstSuccessfulWorkflowId` on users who never ran anything themselves,
- able to claim the once-per-instance `Instance first prod failure` event (permanently suppressing it for the real first user failure) and trigger its owner notification email,
- claiming the `Workflow first data fetched` milestone.

This PR propagates the existing `source: 'instance_ai'` run tag into the statistics layer and classifies AI-sourced runs as **manual** executions regardless of mode. The runs are still fully tracked (execution records, manual stats bucket, all telemetry). The execution mode itself is unchanged, since editor behavior and verification fidelity depend on it.

Changes:

- `execution-lifecycle-hooks.ts`: pass `source` into the `workflowExecutionCompleted` and `nodeFetchedData` statistics emits (regular main + scaling worker paths).
- `workflow-statistics.service.ts`: classify `instance_ai`-sourced completed runs into the manual buckets, never as root executions; skip data-loaded statistics for them.
- `run-execution-data` (v0/v1): allow `manualData` to carry `source`, so it survives serialization to queue-mode workers.
- `instance-ai.adapter.service.ts` / `workflow-execution.service.ts`: persist `source` into `executionData.manualData`.
- `job-processor.ts`: restore `source` from the persisted execution data on the worker.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34145">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

