### PR TITLE
chore(core): Make dockerized schema-docs independent of container-to-host networking (no-changelog)

### DIFF
--- a/packages/@n8n/db/scripts/schema-docs.mjs
+++ b/packages/@n8n/db/scripts/schema-docs.mjs
@@ -144,6 +144,7 @@ async function provision(dbType) {
 	process.env.DB_TABLE_PREFIX = '';
 	return {
 		dataSourceOptions: { type: 'postgres', ...conn },
+		containerId: container.getId(),
 		cleanup: () => container.stop(),
 	};
 }
@@ -156,10 +157,14 @@ function buildDsn(dbType, provisioned, docker) {
 		return `sqlite://${filePath}`;
 	}
 	const conn = provisioned.dataSourceOptions;
-	// Under Docker, tbls runs in its own container and reaches the host-mapped
-	// Postgres port via host.docker.internal (added below with --add-host).
-	const host = docker ? 'host.docker.internal' : conn.host;
-	return `postgres://${conn.username}:${conn.password}@${host}:${conn.port}/${conn.database}?sslmode=disable&search_path=public`;
+	// Under Docker, tbls shares the Postgres container's network namespace
+	// (--network container:<id> below), so it connects to the unmapped port on
+	// localhost. Going through the host-mapped port instead would break on
+	// hosts whose firewall drops container→host traffic (e.g. nftables setups).
+	if (docker) {
+		return `postgres://${conn.username}:${conn.password}@127.0.0.1:5432/${conn.database}?sslmode=disable&search_path=public`;
+	}
+	return `postgres://${conn.username}:${conn.password}@${conn.host}:${conn.port}/${conn.database}?sslmode=disable&search_path=public`;
 }
 
 /** Pre-pulls the tbls image, retrying on transient registry/network errors. */
@@ -181,7 +186,7 @@ async function pullImageWithRetry(image, env, attempts = 3) {
 }
 
 /** Invokes tbls (binary locally, Docker image in CI). */
-async function tbls(command, dbType, dsn, docker) {
+async function tbls(command, dbType, dsn, docker, networkContainerId) {
 	const config = `.tbls.${dbType}.yml`;
 	const env = { ...process.env, TBLS_DSN: dsn };
 	const args = command === 'diff' ? ['diff'] : ['doc', '--force'];
@@ -195,8 +200,9 @@ async function tbls(command, dbType, dsn, docker) {
 		const dockerArgs = [
 			'run',
 			'--rm',
-			'--add-host',
-			'host.docker.internal:host-gateway',
+			// Join the DB container's network namespace so the DSN's localhost port
+			// resolves inside it — no dependency on container→host connectivity.
+			...(networkContainerId ? ['--network', `container:${networkContainerId}`] : []),
 			'-e',
 			`TBLS_DSN=${dsn}`,
 			'-v',
@@ -282,7 +288,7 @@ async function main() {
 		await dataSource.destroy();
 
 		const dsn = buildDsn(dbType, provisioned, docker);
-		const { code, stdout } = await tbls(command, dbType, dsn, docker);
+		const { code, stdout } = await tbls(command, dbType, dsn, docker, provisioned.containerId);
 
 		if (command === 'diff') {
 			// `tbls diff` prints the unified diff to stdout and exits non-zero when


### PR DESCRIPTION
## Summary

`pnpm db:schema:docs` / `db:schema:check` with `--docker` (the CI path, and the local fallback when no `tbls` binary is installed) ran the tbls container against the throwaway Postgres container's **host-mapped port** via `host.docker.internal:host-gateway`. That requires container→host traffic to published ports, which some host firewalls drop (e.g. nftables-based setups on Arch) — the check then fails with a connection timeout even though Docker itself is healthy.

tbls now joins the Postgres container's network namespace (`docker run --network container:<id>`) and connects to the unmapped port on `127.0.0.1`. Container→container networking never touches the host firewall, so this works everywhere Docker runs, including CI. The SQLite path is unaffected (tbls reads the database file from the repo mount; the `--add-host` flag it never needed is gone).

The local-binary path (`tbls` installed, no `--docker`) is unchanged.

## How to test

On any machine with Docker (no local `tbls` needed):

```sh
pnpm build > build.log 2>&1  # or just: pnpm turbo run build --filter=@n8n/db
pnpm --filter=@n8n/db exec node scripts/schema-docs.mjs diff --db=postgres --docker
pnpm --filter=@n8n/db exec node scripts/schema-docs.mjs diff --db=sqlite --docker
```

Both print `✓ … schema docs are up to date`. Before this change, the postgres run timed out on hosts whose firewall blocks docker-bridge→host traffic. The `schema-docs-check` CI job on this PR exercises the same code path.

## Related Linear tickets, Github issues, and Community forum posts

—

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34146">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

