### PR TITLE
refactor(core)!: Remove BinaryHelperFunctions.copyBinaryFile

### DIFF
--- a/packages/@n8n/task-runner/src/runner-types.ts
+++ b/packages/@n8n/task-runner/src/runner-types.ts
@@ -134,9 +134,6 @@ export const UNSUPPORTED_HELPER_FUNCTIONS = [
 	'helpers.httpRequestWithAuthentication',
 	'helpers.requestWithAuthenticationPaginated',
 
-	// This has been removed
-	'helpers.copyBinaryFile',
-
 	// We can't support streams over RPC without implementing it ourselves
 	'helpers.createReadStream',
 	'helpers.getBinaryStream',

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -1320,17 +1320,12 @@ describe('getBinaryHelperFunctions', () => {
 			'binaryToString',
 			'prepareBinaryData',
 			'setBinaryDataBuffer',
-			'copyBinaryFile',
 		] as const;
 
 		expectedMethods.forEach((method) => {
 			expect(helperFunctions).toHaveProperty(method);
 			expect(typeof helperFunctions[method]).toBe('function');
 		});
-
-		await expect(async () => await helperFunctions.copyBinaryFile()).rejects.toThrow(
-			'`copyBinaryFile` has been removed',
-		);
 	});
 });
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -16,7 +16,6 @@ import type {
 import {
 	NodeOperationError,
 	fileTypeFromMimeType,
-	UserError,
 	UnexpectedError,
 	isBinaryValue,
 	BINARY_MODE_COMBINED,
@@ -356,7 +355,4 @@ export const getBinaryHelperFunctions = (
 		await prepareBinaryData(binaryData, executionId!, workflowId, filePath, mimeType),
 	setBinaryDataBuffer: async (data, binaryData) =>
 		await setBinaryDataBuffer(data, binaryData, workflowId, executionId!),
-	copyBinaryFile: async () => {
-		throw new UserError('`copyBinaryFile` has been removed. Please upgrade this node.');
-	},
 });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -846,8 +846,6 @@ export interface BinaryHelperFunctions {
 		mimeType?: string,
 	): Promise<IBinaryData>;
 	setBinaryDataBuffer(data: IBinaryData, binaryData: Buffer): Promise<IBinaryData>;
-	/** @deprecated */
-	copyBinaryFile(): Promise<never>;
 	binaryToBuffer(body: Buffer | Readable): Promise<Buffer>;
 	binaryToString(body: Buffer | Readable, encoding?: BufferEncoding): Promise<string>;
 	getBinaryPath(binaryDataId: string): string;


### PR DESCRIPTION
## Summary

Part of the v3 legacy cleanup. Removes the deprecated `BinaryHelperFunctions.copyBinaryFile` helper (`this.helpers.copyBinaryFile`), which had already been gutted to a throwing stub during its deprecation window on `master`.

This targets `3.x` as a breaking change, per [DEVELOPING_V3.md](https://github.com/n8n-io/n8n/blob/master/.github/DEVELOPING_V3.md) — the deprecation notice (throwing stub + `@deprecated` + community-nodes ESLint rule) already shipped on `master`.

What's removed:
- `copyBinaryFile()` from the `BinaryHelperFunctions` interface (`packages/workflow`).
- The throwing stub from `getBinaryHelperFunctions` and its now-unused `UserError` import (`packages/core`).
- The stale `'helpers.copyBinaryFile'` entry from the task-runner `UNSUPPORTED_HELPER_FUNCTIONS` denylist.
- The matching unit-test expectations.

**Not touched:** the separate, still-functional `NodeHelperFunctions.copyBinaryFile` (`this.nodeHelpers.copyBinaryFile`), which Webhook, FTP, SSH, Form and Chat Trigger nodes rely on. That's a distinct API and is unaffected.

The community-nodes ESLint rule (`no-deprecated-workflow-functions`) is intentionally kept so authors still get a clear static warning.

## How to test

Backend/type-only change; no UI. The stub already threw at runtime, so there's no behavioural change for working code — the check is that the still-live path is intact.

**Functional path unaffected (main check):** run a node that uses `nodeHelpers.copyBinaryFile` — e.g. a **Form Trigger** with a **File** field, submit a file, and confirm the upload still appears as binary data on the output. (Webhook with binary, or FTP/SSH download, exercise the same helper.)n.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5414

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34160">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

