### PR TITLE
fix(core): Preserve node aliases when generating AI tool variants

### DIFF
--- a/packages/cli/src/tool-generation/__tests__/ai-tools.test.ts
+++ b/packages/cli/src/tool-generation/__tests__/ai-tools.test.ts
@@ -213,6 +213,31 @@ describe('ai-tools', () => {
 			});
 		});
 
+		it('should preserve codex alias so tool variants stay searchable by alias', () => {
+			fullNodeWrapper.description.codex = {
+				categories: ['Existing'],
+				subcategories: {
+					Existing: ['Category'],
+				},
+				alias: ['scrape', 'crawl'],
+			};
+			const result = convertNodeToAiTool(fullNodeWrapper);
+			expect(result.description.codex).toEqual({
+				categories: ['AI'],
+				subcategories: {
+					AI: ['Tools'],
+					Tools: ['Other Tools'],
+				},
+				resources: {},
+				alias: ['scrape', 'crawl'],
+			});
+		});
+
+		it('should not add an alias key when the source node has none', () => {
+			const result = convertNodeToAiTool(fullNodeWrapper);
+			expect(result.description.codex).not.toHaveProperty('alias');
+		});
+
 		it('should handle nodes with very long names', () => {
 			fullNodeWrapper.description.name = 'veryLongNodeNameThatExceedsNormalLimits'.repeat(10);
 			fullNodeWrapper.description.displayName =

--- a/packages/cli/src/tool-generation/utils.ts
+++ b/packages/cli/src/tool-generation/utils.ts
@@ -40,6 +40,8 @@ export function setToolCodex(
 ): void {
 	const resources = description.codex?.resources ?? {};
 	const existingToolsSubcategory = description.codex?.subcategories?.Tools;
+	// Keep the original node's search aliases so tool variants stay discoverable
+	const alias = description.codex?.alias;
 
 	description.codex = {
 		categories: ['AI'],
@@ -49,5 +51,6 @@ export function setToolCodex(
 				preserveExisting && existingToolsSubcategory ? existingToolsSubcategory : [toolSubcategory],
 		},
 		resources,
+		...(alias && { alias }),
 	};
 }


### PR DESCRIPTION
## Summary

Follow-up to #33832. The n8n Connect search boost (and alias-based matching in general) worked in the regular nodes panel but **not** when searching the **Tools** section to add a tool to an agent.

Root cause: when a node is converted to its AI-tool variant, `setToolCodex` rebuilds the `codex` object from scratch and dropped the source node's `codex.alias`. The tools panel lists these tool variants, so:

- `sublimeSearch` (which matches on `properties.codex.alias`) could no longer find tool variants by alias.
- `getAiGatewaySearchBoosts` reads `codex.alias`, so eligible Connect tools never received the `+75` boost.

The fix carries the original `alias` over when rebuilding the codex, consistent with how `resources` is already preserved. Applies to both AI tool and HITL tool variants.

## How to test

1. Open an AI Agent and click the `+` on the **Tools** input to open the tools panel.
2. Type an alias of an n8n Connect service (e.g. `scrape`, `serp`, `pdf`, `ocr`).
3. The eligible Connect tool should now appear and rank at/near the top (previously it wouldn't match by alias at all).
4. Confirm the regular nodes panel search still behaves as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-182

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->