### PR TITLE
fix: Resolve modules on windows

### DIFF
--- a/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
@@ -19,7 +19,7 @@ export type BreakingChangeVersion = z.infer<typeof breakingChangeVersionSchema>;
  * When a new major version is released, update this value and add the
  * corresponding breaking-change rules on the backend.
  */
-export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = 'v3';
+export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = null;
 
 // Common schemas
 const recommendationSchema = z.object({

--- a/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/breaking-changes.schema.ts
@@ -19,7 +19,7 @@ export type BreakingChangeVersion = z.infer<typeof breakingChangeVersionSchema>;
  * When a new major version is released, update this value and add the
  * corresponding breaking-change rules on the backend.
  */
-export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = null;
+export const MIGRATION_REPORT_TARGET_VERSION: BreakingChangeVersion | null = 'v3';
 
 // Common schemas
 const recommendationSchema = z.object({

--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -1,15 +1,30 @@
 import type { ModuleInterface, ModuleMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import path from 'path';
 import { mock } from 'vitest-mock-extended';
 
 import type { LicenseState } from '../../license-state';
 import { ModuleConfusionError } from '../errors/module-confusion.error';
-import { ModuleRegistry } from '../module-registry';
+import { getModuleEntryUrl, ModuleRegistry } from '../module-registry';
 
 beforeEach(() => {
 	vi.resetAllMocks();
 	process.env = {};
 	Container.reset();
+});
+
+describe('getModuleEntryUrl', () => {
+	it.each([
+		['community module', false, '/insights/insights.module.js'],
+		['enterprise module', true, '/insights.ee/insights.module.js'],
+	])('should return a file URL for a %s', (_, isEnterprise, expectedPathSuffix) => {
+		const url = new URL(
+			getModuleEntryUrl(path.join(process.cwd(), 'dist', 'modules'), 'insights', isEnterprise),
+		);
+
+		expect(url.protocol).toBe('file:');
+		expect(url.pathname.endsWith(expectedPathSuffix)).toBe(true);
+	});
 });
 
 describe('eligibleModules', () => {

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -5,6 +5,7 @@ import { Container, Service } from '@n8n/di';
 import { existsSync } from 'fs';
 import type { NodeLoader } from 'n8n-workflow';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import { MissingModuleError } from './errors/missing-module.error';
 import { ModuleConfusionError } from './errors/module-confusion.error';
@@ -12,6 +13,15 @@ import { ModulesConfig } from './modules.config';
 import type { ModuleName } from './modules.config';
 import { LicenseState } from '../license-state';
 import { Logger } from '../logging/logger';
+
+export const getModuleEntryUrl = (modulesDir: string, moduleName: string, isEnterprise = false) =>
+	pathToFileURL(
+		path.join(
+			modulesDir,
+			isEnterprise ? `${moduleName}.ee` : moduleName,
+			`${moduleName}.module.js`,
+		),
+	).href;
 
 @Service()
 export class ModuleRegistry {
@@ -103,10 +113,10 @@ export class ModuleRegistry {
 
 		for (const moduleName of modules ?? this.eligibleModules) {
 			try {
-				await import(`${modulesDir}/${moduleName}/${moduleName}.module.js`);
+				await import(getModuleEntryUrl(modulesDir, moduleName));
 			} catch (primaryError) {
 				try {
-					await import(`${modulesDir}/${moduleName}.ee/${moduleName}.module.js`);
+					await import(getModuleEntryUrl(modulesDir, moduleName, true));
 				} catch (error) {
 					const loggedError =
 						primaryError instanceof Error &&


### PR DESCRIPTION
## Summary

Fix for an issue that started occurring on Windows after recent migration https://github.com/n8n-io/n8n/pull/34131

On windows the path of module can look like `import('C:\\…\\insights.module.js')` which leads to Error: `Failed to load module "insights": Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`

The fix changes imports to `import('file:///C:/…/insights.module.js')` format


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

