### PR TITLE
feat(API): Add endpoint to retrieve SAML SSO configuration

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -76,6 +76,7 @@ export { SamlAcsDto } from './saml/saml-acs.dto';
 export { SamlPreferences } from './saml/saml-preferences.dto';
 export { SamlPreferencesAttributeMapping } from './saml/saml-preferences.dto';
 export { SamlToggleDto } from './saml/saml-toggle.dto';
+export { type SamlConfigurationResponse } from './saml/saml-configuration-response.dto';
 
 export { PasswordUpdateRequestDto } from './user/password-update-request.dto';
 export { RoleChangeRequestDto } from './user/role-change-request.dto';

--- a/packages/@n8n/api-types/src/dto/saml/saml-configuration-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/saml/saml-configuration-response.dto.ts
@@ -1,0 +1,9 @@
+import type { SamlPreferences } from './saml-preferences.dto';
+
+/**
+ * Public API response shape for the SAML SSO configuration group.
+ */
+export type SamlConfigurationResponse = SamlPreferences & {
+	entityID: string;
+	returnUrl: string;
+};

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -91,6 +91,7 @@ export const API_KEY_RESOURCES = {
 	variable: ['create', 'update', 'delete', 'list'] as const,
 	securityAudit: ['generate'] as const,
 	securitySettings: ['manage'] as const,
+	saml: ['manage'] as const,
 	project: ['create', 'update', 'delete', 'list', 'export'] as const,
 	user: ['read', 'list', 'create', 'changeRole', 'delete'] as const,
 	execution: ['delete', 'read', 'retry', 'list', 'stop'] as const,

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -15,6 +15,7 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'sourceControl:pull',
 	'securityAudit:generate',
 	'securitySettings:manage',
+	'saml:manage',
 	'project:create',
 	'project:update',
 	'project:delete',

--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -390,3 +390,11 @@ export declare namespace SecurityPolicyRequest {
 	type Get = AuthenticatedRequest;
 	type Update = AuthenticatedRequest<{}, {}, UpdateSecurityPolicyDto>;
 }
+
+// ----------------------------------
+//        /settings/sso/saml
+// ----------------------------------
+
+export declare namespace SsoSamlRequest {
+	type Get = AuthenticatedRequest;
+}

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/spec/paths/settings.sso.saml.yml
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/spec/paths/settings.sso.saml.yml
@@ -1,0 +1,22 @@
+get:
+  x-eov-operation-id: getSamlConfiguration
+  x-required-scope: saml:manage
+  x-eov-operation-handler: v1/handlers/sso-saml/sso-saml.handler
+  tags:
+    - SettingsSsoSaml
+  summary: Retrieve the SAML SSO configuration
+  description: >
+    Retrieve the current SAML SSO configuration, including every field exposed in the UI
+    plus the service provider entity ID and ACS return URL. Signing private keys are
+    redacted on read. Requires the `saml:manage` scope and the SAML feature to be licensed.
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/saml-configuration.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/spec/paths/settings.sso.saml.yml
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/spec/paths/settings.sso.saml.yml
@@ -7,8 +7,9 @@ get:
   summary: Retrieve the SAML SSO configuration
   description: >
     Retrieve the current SAML SSO configuration, including every field exposed in the UI
-    plus the service provider entity ID and ACS return URL. Signing private keys are
-    redacted on read. Requires the `saml:manage` scope and the SAML feature to be licensed.
+    plus the service provider entity ID and ACS return URL. Signing private keys, signing
+    certificates, and identity provider metadata are redacted on read. Requires the
+    `saml:manage` scope and the SAML feature to be licensed.
   responses:
     '200':
       description: Operation successful.

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/spec/schemas/saml-configuration.yml
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/spec/schemas/saml-configuration.yml
@@ -1,0 +1,121 @@
+type: object
+additionalProperties: false
+required:
+  - entityID
+  - returnUrl
+  - ignoreSSL
+  - loginBinding
+  - acsBinding
+  - authnRequestsSigned
+  - wantAssertionsSigned
+  - wantMessageSigned
+  - signatureConfig
+  - relayState
+properties:
+  entityID:
+    type: string
+    readOnly: true
+    description: Service provider entity ID (metadata URL).
+    example: https://n8n.example.com/rest/sso/saml/metadata
+  returnUrl:
+    type: string
+    readOnly: true
+    description: Assertion Consumer Service (ACS) return URL.
+    example: https://n8n.example.com/rest/sso/saml/acs
+  mapping:
+    type: object
+    description: Mapping of SAML attributes to n8n user fields.
+    additionalProperties: false
+    properties:
+      email:
+        type: string
+        description: SAML attribute mapped to the user's email.
+      firstName:
+        type: string
+        description: SAML attribute mapped to the user's first name.
+      lastName:
+        type: string
+        description: SAML attribute mapped to the user's last name.
+      userPrincipalName:
+        type: string
+        description: SAML attribute mapped to the user's principal name.
+      n8nInstanceRole:
+        type: string
+        description: SAML attribute mapped to the n8n instance role.
+      n8nProjectRoles:
+        type: array
+        items:
+          type: string
+        description: SAML attributes mapped to n8n project roles, formatted as `<projectId>:<role>`.
+  metadata:
+    type: string
+    description: Identity provider metadata in XML format.
+  metadataUrl:
+    type: string
+    description: URL to fetch identity provider metadata from.
+  ignoreSSL:
+    type: boolean
+    description: Whether to ignore SSL certificate errors when fetching metadata from a URL.
+    example: false
+  loginBinding:
+    type: string
+    enum: [redirect, post]
+    description: SAML login request binding.
+    example: redirect
+  loginEnabled:
+    type: boolean
+    description: Whether SAML login is enabled.
+    example: false
+  loginLabel:
+    type: string
+    description: Label shown on the SAML login button.
+    example: SAML
+  authnRequestsSigned:
+    type: boolean
+    description: Whether authentication requests are signed.
+    example: false
+  wantAssertionsSigned:
+    type: boolean
+    description: Whether signed assertions are required.
+    example: true
+  wantMessageSigned:
+    type: boolean
+    description: Whether signed SAML messages are required.
+    example: true
+  signingPrivateKey:
+    type: string
+    description: >
+      PEM-encoded private key for signing SAML AuthnRequests. Redacted on read when set;
+      never echoed back in plaintext.
+    example: '**hidden**'
+  signingCertificate:
+    type: string
+    description: PEM-encoded certificate containing the public key matching the signing private key.
+  acsBinding:
+    type: string
+    enum: [redirect, post]
+    description: Assertion Consumer Service binding.
+    example: post
+  signatureConfig:
+    type: object
+    description: Configuration for the signature in SAML requests and responses.
+    additionalProperties: false
+    properties:
+      prefix:
+        type: string
+        example: ds
+      location:
+        type: object
+        additionalProperties: false
+        properties:
+          reference:
+            type: string
+            example: /samlp:Response/saml:Issuer
+          action:
+            type: string
+            enum: [before, after, prepend, append]
+            example: after
+  relayState:
+    type: string
+    description: Default relay state value for SAML requests.
+    example: https://n8n.example.com

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/spec/schemas/saml-configuration.yml
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/spec/schemas/saml-configuration.yml
@@ -49,7 +49,10 @@ properties:
         description: SAML attributes mapped to n8n project roles, formatted as `<projectId>:<role>`.
   metadata:
     type: string
-    description: Identity provider metadata in XML format.
+    description: >
+      Identity provider metadata in XML format. Redacted on read when set because it
+      contains IdP certificates; never echoed back in plaintext.
+    example: '**hidden**'
   metadataUrl:
     type: string
     description: URL to fetch identity provider metadata from.
@@ -90,7 +93,10 @@ properties:
     example: '**hidden**'
   signingCertificate:
     type: string
-    description: PEM-encoded certificate containing the public key matching the signing private key.
+    description: >
+      PEM-encoded certificate containing the public key matching the signing private key.
+      Redacted on read when set; never echoed back in plaintext.
+    example: '**hidden**'
   acsBinding:
     type: string
     enum: [redirect, post]

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.handler.ts
@@ -1,0 +1,29 @@
+import { Container } from '@n8n/di';
+
+import { SamlService } from '@/modules/sso-saml/saml.service.ee';
+
+import type { SsoSamlRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import {
+	apiKeyHasScopeWithGlobalScopeFallback,
+	isLicensed,
+} from '../../shared/middlewares/global.middleware';
+import { toSamlConfigurationResponse } from './sso-saml.mapper';
+
+type SsoSamlHandlers = {
+	getSamlConfiguration: PublicAPIEndpoint<SsoSamlRequest.Get>;
+};
+
+const ssoSamlHandlers: SsoSamlHandlers = {
+	getSamlConfiguration: [
+		isLicensed('feat:saml'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'saml:manage' }),
+		async (_req, res) => {
+			const samlService = Container.get(SamlService);
+
+			return res.json(toSamlConfigurationResponse(samlService.samlPreferences));
+		},
+	],
+};
+
+export = ssoSamlHandlers;

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.mapper.ts
@@ -1,0 +1,16 @@
+import type { SamlConfigurationResponse, SamlPreferences } from '@n8n/api-types';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
+
+import {
+	getServiceProviderEntityId,
+	getServiceProviderReturnUrl,
+} from '@/modules/sso-saml/service-provider.ee';
+
+export function toSamlConfigurationResponse(prefs: SamlPreferences): SamlConfigurationResponse {
+	return {
+		...prefs,
+		signingPrivateKey: prefs.signingPrivateKey ? CREDENTIAL_BLANKING_VALUE : undefined,
+		entityID: getServiceProviderEntityId(),
+		returnUrl: getServiceProviderReturnUrl(),
+	};
+}

--- a/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/sso-saml/sso-saml.mapper.ts
@@ -9,7 +9,9 @@ import {
 export function toSamlConfigurationResponse(prefs: SamlPreferences): SamlConfigurationResponse {
 	return {
 		...prefs,
+		metadata: prefs.metadata ? CREDENTIAL_BLANKING_VALUE : undefined,
 		signingPrivateKey: prefs.signingPrivateKey ? CREDENTIAL_BLANKING_VALUE : undefined,
+		signingCertificate: prefs.signingCertificate ? CREDENTIAL_BLANKING_VALUE : undefined,
 		entityID: getServiceProviderEntityId(),
 		returnUrl: getServiceProviderReturnUrl(),
 	};

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -47,6 +47,8 @@ tags:
     description: Operations about projects
   - name: SecurityPolicy
     description: Operations about the instance security policy settings
+  - name: SettingsSsoSaml
+    description: Operations about SAML SSO settings
   - name: SourceControl
     description: Operations about source control
   - name: Tags
@@ -63,6 +65,8 @@ paths:
     $ref: './handlers/audit/spec/paths/audit.yml'
   /settings/security-policy:
     $ref: './handlers/security-policy/spec/paths/security-policy.yml'
+  /settings/sso/saml:
+    $ref: './handlers/sso-saml/spec/paths/settings.sso.saml.yml'
   /credentials:
     $ref: './handlers/credentials/spec/paths/credentials.yml'
   /credentials/{id}:

--- a/packages/cli/test/integration/public-api/sso-saml.test.ts
+++ b/packages/cli/test/integration/public-api/sso-saml.test.ts
@@ -55,7 +55,7 @@ describe('SAML SSO configuration in Public API', () => {
 			expect(response.body.returnUrl).toContain('/rest/sso/saml/acs');
 		});
 
-		it('redacts the signing private key on read', async () => {
+		it('redacts certificates and secrets on read', async () => {
 			testServer.license.enable('feat:saml');
 			process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS = 'true';
 
@@ -72,7 +72,10 @@ describe('SAML SSO configuration in Public API', () => {
 
 			expect(response.status).toBe(200);
 			expect(response.body.signingPrivateKey).toBe(CREDENTIAL_BLANKING_VALUE);
-			expect(response.body.signingCertificate).toBe(RSA_TEST_CERTIFICATE);
+			expect(response.body.signingCertificate).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(response.body.metadata).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(response.body.metadata).not.toContain('BEGIN CERTIFICATE');
+			expect(response.body.signingCertificate).not.toContain('BEGIN CERTIFICATE');
 		});
 
 		it('rejects with 403 when not licensed', async () => {

--- a/packages/cli/test/integration/public-api/sso-saml.test.ts
+++ b/packages/cli/test/integration/public-api/sso-saml.test.ts
@@ -1,0 +1,113 @@
+import { testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
+
+import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { SamlService } from '@/modules/sso-saml/saml.service.ee';
+import {
+	RSA_TEST_CERTIFICATE,
+	RSA_TEST_PRIVATE_KEY,
+} from '@/modules/sso-saml/__tests__/saml-signing-test-fixtures';
+import { createOwnerWithApiKey } from '@test-integration/db/users';
+import { sampleConfig } from '../saml/sample-metadata';
+import { setupTestServer } from '@test-integration/utils';
+
+describe('SAML SSO configuration in Public API', () => {
+	let owner: User;
+	const testServer = setupTestServer({
+		endpointGroups: ['publicApi', 'saml'],
+	});
+	const licenseErrorMessage = new FeatureNotLicensedError('feat:saml').message;
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+		owner = await createOwnerWithApiKey();
+	});
+
+	afterEach(() => {
+		delete process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS;
+	});
+
+	describe('GET /settings/sso/saml', () => {
+		it('returns the current SAML configuration when licensed', async () => {
+			testServer.license.enable('feat:saml');
+			const samlService = Container.get(SamlService);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/sso/saml');
+
+			expect(response.status).toBe(200);
+			expect(response.body).toMatchObject({
+				loginEnabled: samlService.samlPreferences.loginEnabled,
+				loginLabel: samlService.samlPreferences.loginLabel,
+				ignoreSSL: false,
+				loginBinding: 'redirect',
+				acsBinding: 'post',
+				authnRequestsSigned: false,
+				wantAssertionsSigned: true,
+				wantMessageSigned: true,
+			});
+			expect(response.body.entityID).toContain('/rest/sso/saml/metadata');
+			expect(response.body.returnUrl).toContain('/rest/sso/saml/acs');
+		});
+
+		it('redacts the signing private key on read', async () => {
+			testServer.license.enable('feat:saml');
+			process.env.N8N_ENV_FEAT_SIGNED_SAML_REQUESTS = 'true';
+
+			await testServer
+				.authAgentFor(owner)
+				.post('/sso/saml/config')
+				.send({
+					...sampleConfig,
+					signingPrivateKey: RSA_TEST_PRIVATE_KEY,
+					signingCertificate: RSA_TEST_CERTIFICATE,
+				});
+
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/sso/saml');
+
+			expect(response.status).toBe(200);
+			expect(response.body.signingPrivateKey).toBe(CREDENTIAL_BLANKING_VALUE);
+			expect(response.body.signingCertificate).toBe(RSA_TEST_CERTIFICATE);
+		});
+
+		it('rejects with 403 when not licensed', async () => {
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/sso/saml');
+
+			expect(response.status).toBe(403);
+			expect(response.body).toHaveProperty('message', licenseErrorMessage);
+		});
+
+		it('rejects with 403 when the API key lacks the saml:manage scope', async () => {
+			testServer.license.enable('feat:saml');
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
+
+			const response = await testServer.publicApiAgentFor(scopedOwner).get('/settings/sso/saml');
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects with 401 without a valid API key', async () => {
+			testServer.license.enable('feat:saml');
+
+			const response = await testServer.publicApiAgentWithoutApiKey().get('/settings/sso/saml');
+
+			expect(response.status).toBe(401);
+		});
+
+		it('reads through the SAML service without reimplementing preferences', async () => {
+			testServer.license.enable('feat:saml');
+			const samlService = Container.get(SamlService);
+
+			const response = await testServer.publicApiAgentFor(owner).get('/settings/sso/saml');
+
+			expect(response.status).toBe(200);
+			expect(response.body.loginEnabled).toBe(samlService.samlPreferences.loginEnabled);
+			expect(response.body.loginLabel).toBe(samlService.samlPreferences.loginLabel);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -181,6 +181,9 @@
 		"PUT /settings/security-policy": {
 			"status": "gap"
 		},
+		"GET /settings/sso/saml": {
+			"status": "gap"
+		},
 		"POST /variables": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

Adds `GET /settings/sso/saml` to the public API v1, returning the current SAML SSO configuration.

<img width="888" height="517" alt="image" src="https://github.com/user-attachments/assets/25d9f785-9ca6-46d3-9925-c22c80b67cbb" />

The response includes every field exposed in the UI plus the service provider `entityID` and ACS `returnUrl`. The signing private key is redacted (returned as the credential blanking value) on read. The handler reads through `SamlService` rather than reimplementing preference resolution.

The endpoint is gated behind:
- the licensed `feat:saml` feature (returns `403` when unlicensed)
- the `saml:manage` API key scope, with a global-scope fallback (returns `403` when the scope is missing, `401` without a valid API key)

Changes:
- New handler, mapper, and OpenAPI path/schema specs under `public-api/v1/handlers/sso-saml`
- New `SamlConfigurationResponse` DTO in `@n8n/api-types`
- Registers the path and `SettingsSsoSaml` tag in `openapi.yml`
- Marks `GET /settings/sso/saml` in the n8n node API coverage manifest
- Integration test coverage for the licensed, redaction, scope, and auth cases

## How to test

This endpoint requires the **SAML feature to be licensed** (enterprise) and an API key with the `saml:manage` scope.

1. Start an instance with a license that enables `feat:saml`.
2. Configure SAML SSO in the UI (or seed SAML preferences).
3. Call `GET /api/v1/settings/sso/saml` with an API key that has the `saml:manage` scope.
4. Verify the response returns the current configuration, the `entityID` and `returnUrl` fields, and that `signingPrivateKey` is redacted.
5. Verify a `403` when the feature is unlicensed or the key lacks `saml:manage`, and a `401` without a valid API key.

Automated coverage: `packages/cli/test/integration/public-api/sso-saml.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-55

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

