### PR TITLE
feat(editor): Improve sub workflow extraction

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowExtractionNameModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowExtractionNameModal.vue
@@ -38,10 +38,10 @@ const onSubmit = async () => {
 	if (initiatedExtraction.value) return;
 
 	initiatedExtraction.value = true;
-	const { selection, subGraph } = props.data;
+	const { selection: extractionBoundary, subGraph } = props.data;
 	try {
 		await workflowExtraction.extractNodesIntoSubworkflow(
-			selection,
+			extractionBoundary,
 			subGraph,
 			workflowNameOrDefault.value,
 		);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
@@ -12,6 +12,7 @@ const {
 	mockCanvasOperations,
 	mockTelemetry,
 	mockHistoryStore,
+	mockUIStore,
 } = vi.hoisted(() => ({
 	mockWorkflowsStore: {
 		workflowId: 'parent-workflow-id',
@@ -25,16 +26,24 @@ const {
 		parentFolder: null as { id: string } | null,
 		getNodeById: vi.fn(),
 		getNodeByName: vi.fn(),
+		getParentNodes: vi.fn().mockReturnValue([]),
 		getChildNodes: vi.fn().mockReturnValue([]),
-		getExpressionHandler: vi.fn().mockReturnValue({}),
+		getExpressionHandler: vi.fn().mockReturnValue(undefined),
 		getGroupForNode: vi.fn(),
 		getGroupById: vi.fn(),
 		addNodesToGroup: vi.fn(),
 	},
 	mockNodeTypesStore: {
 		getNodeType: vi.fn().mockReturnValue({
+			displayName: 'Set',
+			name: 'n8n-nodes-base.set',
+			group: ['transform'],
+			version: 1,
+			description: '',
+			defaults: { name: 'Set' },
 			inputs: ['main'],
 			outputs: ['main'],
+			properties: [],
 		}),
 	},
 	mockCanvasOperations: {
@@ -50,6 +59,11 @@ const {
 		startRecordingUndo: vi.fn(),
 		stopRecordingUndo: vi.fn(),
 		pushCommandToUndo: vi.fn(),
+	},
+	mockUIStore: {
+		resetLastInteractedWith: vi.fn(),
+		markStateDirty: vi.fn(),
+		openModalWithData: vi.fn(),
 	},
 }));
 
@@ -70,11 +84,7 @@ vi.mock('@/app/composables/useCanvasOperations', () => ({
 }));
 
 vi.mock('@/app/stores/ui.store', () => ({
-	useUIStore: vi.fn().mockReturnValue({
-		resetLastInteractedWith: vi.fn(),
-		markStateDirty: vi.fn(),
-		openModalWithData: vi.fn(),
-	}),
+	useUIStore: vi.fn().mockReturnValue(mockUIStore),
 }));
 
 vi.mock('@/app/stores/history.store', () => ({
@@ -121,6 +131,22 @@ function makeNode(name: string, position: [number, number] = [0, 0]): INodeUi {
 	} as INodeUi;
 }
 
+function setWorkflowNodes(nodes: INodeUi[]) {
+	mockWorkflowDocumentStore.allNodes = nodes;
+	const nodesById = new Map(nodes.map((node) => [node.id, node]));
+	const nodesByName = new Map(nodes.map((node) => [node.name, node]));
+
+	mockWorkflowDocumentStore.getNodeById.mockImplementation((id: string) => nodesById.get(id));
+	mockWorkflowDocumentStore.getNodeByName.mockImplementation(
+		(name: string) => nodesByName.get(name) ?? null,
+	);
+}
+
+function mockSuccessfulWorkflowCreation() {
+	mockWorkflowsStore.createNewWorkflow.mockResolvedValue({ id: 'new-id', versionId: 'v1' });
+	mockWorkflowsStore.publishWorkflow.mockResolvedValue(undefined);
+}
+
 describe('useWorkflowExtraction', () => {
 	beforeEach(() => {
 		const pinia = createTestingPinia({ stubActions: false });
@@ -133,10 +159,21 @@ describe('useWorkflowExtraction', () => {
 		mockCanvasOperations.deleteNodes.mockClear();
 		mockCanvasOperations.replaceNodeParameters.mockClear();
 		mockTelemetry.track.mockClear();
+		mockUIStore.resetLastInteractedWith.mockClear();
+		mockUIStore.markStateDirty.mockClear();
+		mockUIStore.openModalWithData.mockClear();
+		mockWorkflowDocumentStore.getNodeById.mockReset();
+		mockWorkflowDocumentStore.getNodeByName.mockReset();
+		mockWorkflowDocumentStore.getParentNodes.mockReset();
+		mockWorkflowDocumentStore.getParentNodes.mockReturnValue([]);
+		mockWorkflowDocumentStore.getChildNodes.mockReset();
 		mockWorkflowDocumentStore.getChildNodes.mockReturnValue([]);
+		mockWorkflowDocumentStore.getExpressionHandler.mockReset();
+		mockWorkflowDocumentStore.getExpressionHandler.mockReturnValue(undefined);
 		mockWorkflowDocumentStore.getGroupForNode.mockReset();
 		mockWorkflowDocumentStore.getGroupById.mockReset();
 		mockWorkflowDocumentStore.addNodesToGroup.mockReset();
+		mockNodeTypesStore.getNodeType.mockClear();
 		mockHistoryStore.startRecordingUndo.mockClear();
 		mockHistoryStore.stopRecordingUndo.mockClear();
 		mockHistoryStore.pushCommandToUndo.mockClear();
@@ -152,6 +189,50 @@ describe('useWorkflowExtraction', () => {
 
 			expect(mockTelemetry.track).not.toHaveBeenCalled();
 		});
+
+		it('includes attached sub-nodes when starting extraction', () => {
+			const nodeA = makeNode('A', [0, 0]);
+			const agentB = makeNode('Agent B', [200, 0]);
+			const agentC = makeNode('Agent C', [400, 0]);
+			const model = makeNode('Model', [200, 120]);
+
+			setWorkflowNodes([nodeA, agentB, agentC, model]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent B', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				'Agent B': {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent C', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				Model: {
+					[NodeConnectionTypes.AiLanguageModel]: [
+						[{ node: 'Agent B', type: NodeConnectionTypes.AiLanguageModel, index: 0 }],
+					],
+				},
+			};
+			mockWorkflowDocumentStore.getParentNodes.mockImplementation((nodeName, type) => {
+				if (nodeName === 'Agent B' && type === 'ALL_NON_MAIN') return ['Model'];
+				return [];
+			});
+
+			const { extractWorkflow } = useWorkflowExtraction();
+
+			extractWorkflow([agentB.id]);
+
+			expect(mockUIStore.openModalWithData).toHaveBeenCalledTimes(1);
+			const modalData = mockUIStore.openModalWithData.mock.calls[0][0].data as {
+				subGraph: INodeUi[];
+				selection: { start?: string; end?: string };
+			};
+			expect(modalData.subGraph.map((node) => node.name).sort()).toEqual(
+				['Agent B', 'Model'].sort(),
+			);
+			expect(modalData.selection).toEqual({ start: 'Agent B', end: 'Agent B' });
+		});
 	});
 
 	describe('extractNodesIntoSubworkflow', () => {
@@ -160,7 +241,7 @@ describe('useWorkflowExtraction', () => {
 			const nodeB = makeNode('B', [200, 0]);
 			const nodeC = makeNode('C', [400, 0]); // outside the extracted selection
 
-			mockWorkflowDocumentStore.allNodes = [nodeA, nodeB, nodeC];
+			setWorkflowNodes([nodeA, nodeB, nodeC]);
 			mockWorkflowDocumentStore.connectionsBySourceNode = {
 				A: {
 					[NodeConnectionTypes.Main]: [
@@ -172,11 +253,7 @@ describe('useWorkflowExtraction', () => {
 				},
 			};
 
-			mockWorkflowsStore.createNewWorkflow.mockResolvedValue({
-				id: 'new-id',
-				versionId: 'v1',
-			});
-			mockWorkflowsStore.publishWorkflow.mockResolvedValue(undefined);
+			mockSuccessfulWorkflowCreation();
 
 			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
 
@@ -211,7 +288,7 @@ describe('useWorkflowExtraction', () => {
 			const nodeB = makeNode('B', [200, 0]);
 			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id] };
 
-			mockWorkflowDocumentStore.allNodes = [nodeA, nodeB];
+			setWorkflowNodes([nodeA, nodeB]);
 			mockWorkflowDocumentStore.getGroupForNode.mockImplementation((nodeId: string) =>
 				group.nodeIds.includes(nodeId) ? group : undefined,
 			);
@@ -219,8 +296,7 @@ describe('useWorkflowExtraction', () => {
 				.mockReturnValueOnce({ ...group })
 				.mockReturnValueOnce({ ...group, nodeIds: [...group.nodeIds, 'execute-node-id'] });
 
-			mockWorkflowsStore.createNewWorkflow.mockResolvedValue({ id: 'new-id', versionId: 'v1' });
-			mockWorkflowsStore.publishWorkflow.mockResolvedValue(undefined);
+			mockSuccessfulWorkflowCreation();
 
 			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
 
@@ -238,6 +314,158 @@ describe('useWorkflowExtraction', () => {
 			expect(groupCommand).toBeInstanceOf(UpdateNodeGroupCommand);
 			expect(groupCommand?.before.nodeIds).toEqual([nodeA.id, nodeB.id]);
 			expect(groupCommand?.after.nodeIds).toEqual([nodeA.id, nodeB.id, 'execute-node-id']);
+		});
+
+		it('copies shared sub-nodes into the sub-workflow but keeps them in the parent', async () => {
+			const nodeA = makeNode('A', [0, 0]);
+			const agentB = makeNode('Agent B', [200, 0]);
+			const agentC = makeNode('Agent C', [400, 0]);
+			agentC.parameters = { value: '={{ $("Model").item.json.foo }}' };
+			const model = makeNode('Model', [200, 120]);
+			const agentGroup = { id: 'agents', name: 'Agents', nodeIds: [agentB.id, agentC.id] };
+			const modelGroup = { id: 'models', name: 'Models', nodeIds: [model.id] };
+
+			setWorkflowNodes([nodeA, agentB, agentC, model]);
+			mockWorkflowDocumentStore.getGroupForNode.mockImplementation((nodeId: string) => {
+				if (agentGroup.nodeIds.includes(nodeId)) return agentGroup;
+				if (modelGroup.nodeIds.includes(nodeId)) return modelGroup;
+				return undefined;
+			});
+			mockWorkflowDocumentStore.getGroupById
+				.mockReturnValueOnce({ ...agentGroup })
+				.mockReturnValueOnce({
+					...agentGroup,
+					nodeIds: [...agentGroup.nodeIds, 'execute-node-id'],
+				});
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent B', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				'Agent B': {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent C', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				Model: {
+					[NodeConnectionTypes.AiLanguageModel]: [
+						[
+							{ node: 'Agent B', type: NodeConnectionTypes.AiLanguageModel, index: 0 },
+							{ node: 'Agent C', type: NodeConnectionTypes.AiLanguageModel, index: 0 },
+						],
+					],
+				},
+			};
+			mockWorkflowDocumentStore.getChildNodes.mockImplementation((nodeName, type) => {
+				if (nodeName === 'Agent B' && type === NodeConnectionTypes.Main) return ['Agent C'];
+				if (nodeName === 'Agent B' && type === 'ALL') return ['Agent C'];
+				return [];
+			});
+			mockSuccessfulWorkflowCreation();
+
+			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
+
+			await extractNodesIntoSubworkflow(
+				{ start: 'Agent B', end: 'Agent B' },
+				[agentB, model],
+				'Sub',
+			);
+
+			const created = mockWorkflowsStore.createNewWorkflow.mock.calls[0][0] as WorkflowDataCreate;
+			expect((created.nodes ?? []).map((node: INode) => node.name)).toEqual(
+				expect.arrayContaining(['Agent B', 'Model']),
+			);
+
+			const modelConnections =
+				created.connections?.Model?.[NodeConnectionTypes.AiLanguageModel]?.[0] ?? [];
+			expect(modelConnections.map((connection) => connection.node)).toEqual(['Agent B']);
+			expect(mockCanvasOperations.deleteNodes.mock.calls[0][0]).toEqual([agentB.id]);
+			expect(mockWorkflowDocumentStore.addNodesToGroup).toHaveBeenCalledWith(agentGroup.id, [
+				'execute-node-id',
+			]);
+			expect(mockCanvasOperations.replaceNodeParameters).not.toHaveBeenCalled();
+		});
+
+		it('removes unshared extracted sub-nodes from the parent', async () => {
+			const nodeA = makeNode('A', [0, 0]);
+			const agentB = makeNode('Agent B', [200, 0]);
+			const agentC = makeNode('Agent C', [400, 0]);
+			const memory = makeNode('Memory', [200, 120]);
+
+			setWorkflowNodes([nodeA, agentB, agentC, memory]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent B', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				'Agent B': {
+					[NodeConnectionTypes.Main]: [
+						[{ node: 'Agent C', type: NodeConnectionTypes.Main, index: 0 }],
+					],
+				},
+				Memory: {
+					[NodeConnectionTypes.AiMemory]: [
+						[{ node: 'Agent B', type: NodeConnectionTypes.AiMemory, index: 0 }],
+					],
+				},
+			};
+			mockWorkflowDocumentStore.getChildNodes.mockImplementation((nodeName, type) => {
+				if (nodeName === 'Agent B' && type === NodeConnectionTypes.Main) return ['Agent C'];
+				if (nodeName === 'Agent B' && type === 'ALL') return ['Agent C'];
+				return [];
+			});
+			mockSuccessfulWorkflowCreation();
+
+			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
+
+			await extractNodesIntoSubworkflow(
+				{ start: 'Agent B', end: 'Agent B' },
+				[agentB, memory],
+				'Sub',
+			);
+
+			const created = mockWorkflowsStore.createNewWorkflow.mock.calls[0][0] as WorkflowDataCreate;
+			const memoryConnections =
+				created.connections?.Memory?.[NodeConnectionTypes.AiMemory]?.[0] ?? [];
+			expect(memoryConnections.map((connection) => connection.node)).toEqual(['Agent B']);
+			expect(mockCanvasOperations.deleteNodes.mock.calls[0][0]).toEqual([agentB.id, memory.id]);
+		});
+
+		it('keeps sub-nodes that feed preserved shared sub-nodes in the parent', async () => {
+			const agentB = makeNode('Agent B', [200, 0]);
+			const agentC = makeNode('Agent C', [400, 0]);
+			const model = makeNode('Model', [200, 120]);
+			const parser = makeNode('Parser', [200, 240]);
+
+			setWorkflowNodes([agentB, agentC, model, parser]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				Model: {
+					[NodeConnectionTypes.AiLanguageModel]: [
+						[
+							{ node: 'Agent B', type: NodeConnectionTypes.AiLanguageModel, index: 0 },
+							{ node: 'Agent C', type: NodeConnectionTypes.AiLanguageModel, index: 0 },
+						],
+					],
+				},
+				Parser: {
+					[NodeConnectionTypes.AiOutputParser]: [
+						[{ node: 'Model', type: NodeConnectionTypes.AiOutputParser, index: 0 }],
+					],
+				},
+			};
+			mockSuccessfulWorkflowCreation();
+
+			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
+
+			await extractNodesIntoSubworkflow(
+				{ start: undefined, end: undefined },
+				[agentB, model, parser],
+				'Sub',
+			);
+
+			expect(mockCanvasOperations.deleteNodes.mock.calls[0][0]).toEqual([agentB.id]);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -3,6 +3,7 @@ import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store
 import {
 	extractReferencesInNodeExpressions,
 	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	NodeConnectionTypes,
 	NodeHelpers,
 } from 'n8n-workflow';
 import type {
@@ -48,7 +49,7 @@ export function useWorkflowExtraction() {
 	const canvasOperations = useCanvasOperations();
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
-	const { isSelectionExtractable } = useSelectionValidation();
+	const { expandSelectionWithSubNodes, isSelectionExtractable } = useSelectionValidation();
 
 	function showError(message: string) {
 		toast.showMessage({
@@ -91,6 +92,9 @@ export function useWorkflowExtraction() {
 		position: [number, number],
 		variables: Map<string, string>,
 	): Omit<INode, 'id'> {
+		const variableEntries = [...variables.entries()];
+		const variableNames = [...variables.keys()];
+
 		return {
 			parameters: {
 				workflowId: {
@@ -100,20 +104,18 @@ export function useWorkflowExtraction() {
 				},
 				workflowInputs: {
 					mappingMode: 'defineBelow',
-					value: Object.fromEntries(variables.entries().map(([k, v]) => [k, `={{ ${v} }}`])),
-					matchingColumns: [...variables.keys()],
-					schema: [
-						...variables.keys().map((x) => ({
-							id: x,
-							displayName: x,
-							required: false,
-							defaultMatch: false,
-							display: true,
-							canBeUsedToMatch: true,
-							removed: false,
-							// omitted type implicitly uses our `any` type
-						})),
-					],
+					value: Object.fromEntries(variableEntries.map(([k, v]) => [k, `={{ ${v} }}`])),
+					matchingColumns: variableNames,
+					schema: variableNames.map((x) => ({
+						id: x,
+						displayName: x,
+						required: false,
+						defaultMatch: false,
+						display: true,
+						canBeUsedToMatch: true,
+						removed: false,
+						// omitted type implicitly uses our `any` type
+					})),
 					attemptToConvertTypes: false,
 					convertFieldsToString: true,
 				},
@@ -272,6 +274,61 @@ export function useWorkflowExtraction() {
 		return [summedUp[0] / summedUp[2], summedUp[1] / summedUp[2]];
 	}
 
+	function getNonMainConnectionTargets(nodeName: string, connections: IConnections): string[] {
+		const nodeConnections = connections[nodeName];
+		if (!nodeConnections) return [];
+
+		const targets: string[] = [];
+		for (const [type, connectionsByOutputIndex] of Object.entries(nodeConnections)) {
+			if (type === NodeConnectionTypes.Main) continue;
+
+			for (const outputConnections of connectionsByOutputIndex) {
+				for (const connection of outputConnections ?? []) {
+					targets.push(connection.node);
+				}
+			}
+		}
+
+		return targets;
+	}
+
+	function getNodesToDeleteFromParent(subGraph: INodeUi[], connections: IConnections): INodeUi[] {
+		const subGraphNames = new Set(subGraph.map((node) => node.name));
+		const nonMainTargetsByNodeName = new Map(
+			subGraph.map((node) => [node.name, getNonMainConnectionTargets(node.name, connections)]),
+		);
+		const subNodeNames = new Set(
+			[...nonMainTargetsByNodeName.entries()]
+				.filter(([, targets]) => targets.some((target) => subGraphNames.has(target)))
+				.map(([nodeName]) => nodeName),
+		);
+
+		const preservedNodeNames = new Set(
+			[...subNodeNames].filter((nodeName) =>
+				(nonMainTargetsByNodeName.get(nodeName) ?? []).some((target) => !subGraphNames.has(target)),
+			),
+		);
+
+		let didAddPreservedNode = true;
+		while (didAddPreservedNode) {
+			didAddPreservedNode = false;
+
+			for (const nodeName of subNodeNames) {
+				if (preservedNodeNames.has(nodeName)) continue;
+
+				const shouldPreserve = (nonMainTargetsByNodeName.get(nodeName) ?? []).some((target) =>
+					preservedNodeNames.has(target),
+				);
+				if (!shouldPreserve) continue;
+
+				preservedNodeNames.add(nodeName);
+				didAddPreservedNode = true;
+			}
+		}
+
+		return subGraph.filter((node) => !preservedNodeNames.has(node.name));
+	}
+
 	async function tryCreateWorkflow(workflowData: WorkflowDataCreate): Promise<IWorkflowDb | null> {
 		try {
 			const createdWorkflow = await workflowsStore.createNewWorkflow(workflowData);
@@ -310,7 +367,7 @@ export function useWorkflowExtraction() {
 		executeWorkflowNodeData: AddedNode,
 		startId: string | undefined,
 		endId: string | undefined,
-		selection: INode[],
+		nodesToDelete: INode[],
 		selectionChildNodes: INode[],
 	) {
 		historyStore.startRecordingUndo();
@@ -325,7 +382,7 @@ export function useWorkflowExtraction() {
 		)[0];
 
 		addReplacementNodeToSelectionGroup(
-			selection.map((node) => node.id),
+			nodesToDelete.map((node) => node.id),
 			executeWorkflowNode.id,
 		);
 
@@ -344,7 +401,7 @@ export function useWorkflowExtraction() {
 			});
 
 		canvasOperations.deleteNodes(
-			selection.map((x) => x.id),
+			nodesToDelete.map((x) => x.id),
 			CANVAS_HISTORY_OPTIONS,
 		);
 
@@ -390,7 +447,8 @@ export function useWorkflowExtraction() {
 	}
 
 	function tryExtractNodesIntoSubworkflow(nodeIds: string[]): boolean {
-		const result = isSelectionExtractable(nodeIds);
+		const expandedNodeIds = expandSelectionWithSubNodes(nodeIds);
+		const result = isSelectionExtractable(expandedNodeIds);
 
 		if (!result.valid) {
 			switch (result.reason) {
@@ -453,6 +511,11 @@ export function useWorkflowExtraction() {
 
 		let startNodeName = 'Start';
 		const subGraphNames = subGraph.map((x) => x.name);
+		const nodesToDelete = getNodesToDeleteFromParent(
+			subGraph,
+			workflowDocumentStore.value.connectionsBySourceNode,
+		);
+		const deletedNodeNames = nodesToDelete.map((node) => node.name);
 		while (subGraphNames.includes(startNodeName)) startNodeName += '_1';
 
 		let returnNodeName = 'Return';
@@ -484,9 +547,7 @@ export function useWorkflowExtraction() {
 
 		const { nodes: afterNodes, variables: afterVariables } = extractReferencesInNodeExpressions(
 			allAfterEndNodes,
-			allAfterEndNodes
-				.map((x) => x.name)
-				.concat(subGraphNames), // this excludes nodes that will remain in the parent workflow
+			allAfterEndNodes.map((x) => x.name).concat(deletedNodeNames),
 			executeWorkflowNodeName,
 			directAfterEndNodeNames,
 		);
@@ -504,7 +565,9 @@ export function useWorkflowExtraction() {
 		const createdWorkflow = await tryCreateWorkflow(workflowData);
 		if (createdWorkflow === null) return false;
 
-		const executeWorkflowPosition = computeAveragePosition(subGraph);
+		const executeWorkflowPosition = computeAveragePosition(
+			nodesToDelete.length > 0 ? nodesToDelete : subGraph,
+		);
 		const executeWorkflowNode = makeExecuteWorkflowNode(
 			createdWorkflow.id,
 			executeWorkflowNodeName,
@@ -513,9 +576,9 @@ export function useWorkflowExtraction() {
 		);
 		await replaceSelectionWithNode(
 			executeWorkflowNode,
-			subGraph.find((x) => x.name === start)?.id,
-			subGraph.find((x) => x.name === end)?.id,
-			subGraph,
+			nodesToDelete.find((x) => x.name === start)?.id,
+			nodesToDelete.find((x) => x.name === end)?.id,
+			nodesToDelete,
 			afterNodes,
 		);
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -292,20 +292,28 @@ export function useWorkflowExtraction() {
 		return targets;
 	}
 
-	function getNodesToDeleteFromParent(subGraph: INodeUi[], connections: IConnections): INodeUi[] {
-		const subGraphNames = new Set(subGraph.map((node) => node.name));
+	function getNodesToRemoveFromParent(
+		extractedNodes: INodeUi[],
+		connections: IConnections,
+	): INodeUi[] {
+		const extractedNodeNames = new Set(extractedNodes.map((node) => node.name));
 		const nonMainTargetsByNodeName = new Map(
-			subGraph.map((node) => [node.name, getNonMainConnectionTargets(node.name, connections)]),
+			extractedNodes.map((node) => [
+				node.name,
+				getNonMainConnectionTargets(node.name, connections),
+			]),
 		);
 		const subNodeNames = new Set(
 			[...nonMainTargetsByNodeName.entries()]
-				.filter(([, targets]) => targets.some((target) => subGraphNames.has(target)))
+				.filter(([, targets]) => targets.some((target) => extractedNodeNames.has(target)))
 				.map(([nodeName]) => nodeName),
 		);
 
 		const preservedNodeNames = new Set(
 			[...subNodeNames].filter((nodeName) =>
-				(nonMainTargetsByNodeName.get(nodeName) ?? []).some((target) => !subGraphNames.has(target)),
+				(nonMainTargetsByNodeName.get(nodeName) ?? []).some(
+					(target) => !extractedNodeNames.has(target),
+				),
 			),
 		);
 
@@ -326,7 +334,7 @@ export function useWorkflowExtraction() {
 			}
 		}
 
-		return subGraph.filter((node) => !preservedNodeNames.has(node.name));
+		return extractedNodes.filter((node) => !preservedNodeNames.has(node.name));
 	}
 
 	async function tryCreateWorkflow(workflowData: WorkflowDataCreate): Promise<IWorkflowDb | null> {
@@ -363,12 +371,12 @@ export function useWorkflowExtraction() {
 		}
 	}
 
-	async function replaceSelectionWithNode(
+	async function replaceParentSelectionWithSubworkflowNode(
 		executeWorkflowNodeData: AddedNode,
 		startId: string | undefined,
 		endId: string | undefined,
-		nodesToDelete: INode[],
-		selectionChildNodes: INode[],
+		nodesToRemoveFromParent: INode[],
+		rewrittenDownstreamNodes: INode[],
 	) {
 		historyStore.startRecordingUndo();
 
@@ -382,7 +390,7 @@ export function useWorkflowExtraction() {
 		)[0];
 
 		addReplacementNodeToSelectionGroup(
-			nodesToDelete.map((node) => node.id),
+			nodesToRemoveFromParent.map((node) => node.id),
 			executeWorkflowNode.id,
 		);
 
@@ -401,11 +409,11 @@ export function useWorkflowExtraction() {
 			});
 
 		canvasOperations.deleteNodes(
-			nodesToDelete.map((x) => x.id),
+			nodesToRemoveFromParent.map((x) => x.id),
 			CANVAS_HISTORY_OPTIONS,
 		);
 
-		for (const node of selectionChildNodes) {
+		for (const node of rewrittenDownstreamNodes) {
 			const currentNode = workflowDocumentStore.value.allNodes.find((x) => x.id === node.id);
 
 			if (isEqual(node, currentNode)) continue;
@@ -501,25 +509,25 @@ export function useWorkflowExtraction() {
 	}
 
 	async function doExtractNodesIntoSubworkflow(
-		selection: ExtractableSubgraphData,
-		subGraph: INodeUi[],
+		extractionBoundary: ExtractableSubgraphData,
+		extractedNodes: INodeUi[],
 		newWorkflowName: string,
 	) {
-		const { start, end } = selection;
+		const { start, end } = extractionBoundary;
 
 		const allNodeNames = workflowDocumentStore.value.allNodes.map((x) => x.name) ?? [];
 
 		let startNodeName = 'Start';
-		const subGraphNames = subGraph.map((x) => x.name);
-		const nodesToDelete = getNodesToDeleteFromParent(
-			subGraph,
+		const extractedNodeNames = extractedNodes.map((x) => x.name);
+		const nodesToRemoveFromParent = getNodesToRemoveFromParent(
+			extractedNodes,
 			workflowDocumentStore.value.connectionsBySourceNode,
 		);
-		const deletedNodeNames = nodesToDelete.map((node) => node.name);
-		while (subGraphNames.includes(startNodeName)) startNodeName += '_1';
+		const removedParentNodeNames = nodesToRemoveFromParent.map((node) => node.name);
+		while (extractedNodeNames.includes(startNodeName)) startNodeName += '_1';
 
 		let returnNodeName = 'Return';
-		while (subGraphNames.includes(returnNodeName)) returnNodeName += '_1';
+		while (extractedNodeNames.includes(returnNodeName)) returnNodeName += '_1';
 
 		const directAfterEndNodeNames = end
 			? (workflowDocumentStore.value
@@ -536,7 +544,7 @@ export function useWorkflowExtraction() {
 			: [];
 
 		const { nodes, variables } = extractReferencesInNodeExpressions(
-			subGraph,
+			extractedNodes,
 			allNodeNames,
 			startNodeName,
 			start ? [start] : undefined,
@@ -547,14 +555,14 @@ export function useWorkflowExtraction() {
 
 		const { nodes: afterNodes, variables: afterVariables } = extractReferencesInNodeExpressions(
 			allAfterEndNodes,
-			allAfterEndNodes.map((x) => x.name).concat(deletedNodeNames),
+			allAfterEndNodes.map((x) => x.name).concat(removedParentNodeNames),
 			executeWorkflowNodeName,
 			directAfterEndNodeNames,
 		);
 
 		const workflowData = makeSubworkflow(
 			newWorkflowName,
-			selection,
+			extractionBoundary,
 			nodes,
 			workflowDocumentStore.value?.connectionsBySourceNode,
 			variables,
@@ -566,7 +574,7 @@ export function useWorkflowExtraction() {
 		if (createdWorkflow === null) return false;
 
 		const executeWorkflowPosition = computeAveragePosition(
-			nodesToDelete.length > 0 ? nodesToDelete : subGraph,
+			nodesToRemoveFromParent.length > 0 ? nodesToRemoveFromParent : extractedNodes,
 		);
 		const executeWorkflowNode = makeExecuteWorkflowNode(
 			createdWorkflow.id,
@@ -574,11 +582,11 @@ export function useWorkflowExtraction() {
 			executeWorkflowPosition,
 			variables,
 		);
-		await replaceSelectionWithNode(
+		await replaceParentSelectionWithSubworkflowNode(
 			executeWorkflowNode,
-			nodesToDelete.find((x) => x.name === start)?.id,
-			nodesToDelete.find((x) => x.name === end)?.id,
-			nodesToDelete,
+			nodesToRemoveFromParent.find((x) => x.name === start)?.id,
+			nodesToRemoveFromParent.find((x) => x.name === end)?.id,
+			nodesToRemoveFromParent,
 			afterNodes,
 		);
 
@@ -605,12 +613,16 @@ export function useWorkflowExtraction() {
 	 * by @tryExtractNodesIntoSubworkflow
 	 */
 	async function extractNodesIntoSubworkflow(
-		selection: ExtractableSubgraphData,
-		subGraph: INodeUi[],
+		extractionBoundary: ExtractableSubgraphData,
+		extractedNodes: INodeUi[],
 		newWorkflowName: string,
 	) {
-		const success = await doExtractNodesIntoSubworkflow(selection, subGraph, newWorkflowName);
-		trackExtractWorkflow(subGraph.length, success);
+		const success = await doExtractNodesIntoSubworkflow(
+			extractionBoundary,
+			extractedNodes,
+			newWorkflowName,
+		);
+		trackExtractWorkflow(extractedNodes.length, success);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Automatically include attached AI sub-nodes when extracting nodes to a sub-workflow
- Copy shared AI sub-nodes into the new sub-workflow while preserving them in the parent workflow
- Remove extracted sub-nodes from the parent only when they have no remaining non-main consumers
- Clarify workflow extraction variable naming around extracted nodes vs parent removal

## How to test

  1. Create a workflow: Manual Trigger → Agent B → Agent C.
  2. Add one Chat Model and connect it to both Agent B and Agent C.
  3. Select Agent B only and use Convert to sub-workflow.
  4. Confirm the extraction.
  5. Verify the new sub-workflow contains Agent B and a copied Chat Model connected to Agent B.
  6. Verify the parent workflow still contains the original Chat Model connected to Agent C.
  7. Run the parent workflow and confirm Agent C no longer loses its required Chat Model connection.

  Optional extra case:

  1. Create Agent B with a Memory sub-node used only by Agent B.
  2. Convert Agent B to a sub-workflow.
  3. Verify Memory is copied into the sub-workflow and removed from the parent workflow.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-3603](https://linear.app/n8n/issue/ADO-3603/feature-automatically-extract-sub-nodes-of-a-selected-node)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

