### PR TITLE
feat(core): Add durable scheduler rollout docs and observability warnings (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/scheduler.config.test.ts
@@ -23,7 +23,7 @@ describe('SchedulerConfig', () => {
 			const { scheduler } = Container.get(GlobalConfig);
 
 			expect(scheduler.materializationWindowSeconds).toBe(60);
-			expect(scheduler.sweepIntervalSeconds).toBe(10);
+			expect(scheduler.materializationIntervalSeconds).toBe(10);
 			expect(scheduler.executorIntervalSeconds).toBe(5);
 			expect(scheduler.claimBatchSize).toBe(100);
 			expect(scheduler.reaperIntervalSeconds).toBe(30);
@@ -34,7 +34,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.retentionIntervalSeconds).toBe(60 * 60);
 			expect(scheduler.minIntervalSeconds).toBe(0);
 			expect(scheduler.jitterRatio).toBe(0.1);
-			expect(scheduler.sweepTimeoutSeconds).toBe(60);
+			expect(scheduler.materializationTimeoutSeconds).toBe(60);
 			expect(scheduler.executorTimeoutSeconds).toBe(60);
 			expect(scheduler.reaperTimeoutSeconds).toBe(60);
 			expect(scheduler.retentionTimeoutSeconds).toBe(5 * 60);
@@ -53,7 +53,7 @@ describe('SchedulerConfig', () => {
 
 		it('should override each tunable from env', () => {
 			vi.stubEnv('N8N_SCHEDULER_MATERIALIZATION_WINDOW', '120');
-			vi.stubEnv('N8N_SCHEDULER_SWEEP_INTERVAL', '20');
+			vi.stubEnv('N8N_SCHEDULER_MATERIALIZATION_INTERVAL', '20');
 			vi.stubEnv('N8N_SCHEDULER_EXECUTOR_INTERVAL', '2');
 			vi.stubEnv('N8N_SCHEDULER_REAPER_INTERVAL', '45');
 			vi.stubEnv('N8N_SCHEDULER_LEASE_DURATION', '90');
@@ -62,7 +62,7 @@ describe('SchedulerConfig', () => {
 			vi.stubEnv('N8N_SCHEDULER_RETENTION_INTERVAL', '600');
 			vi.stubEnv('N8N_SCHEDULER_MIN_INTERVAL', '15');
 			vi.stubEnv('N8N_SCHEDULER_JITTER_RATIO', '0.25');
-			vi.stubEnv('N8N_SCHEDULER_SWEEP_TIMEOUT', '30');
+			vi.stubEnv('N8N_SCHEDULER_MATERIALIZATION_TIMEOUT', '30');
 			vi.stubEnv('N8N_SCHEDULER_EXECUTOR_TIMEOUT', '15');
 			vi.stubEnv('N8N_SCHEDULER_REAPER_TIMEOUT', '45');
 			vi.stubEnv('N8N_SCHEDULER_RETENTION_TIMEOUT', '120');
@@ -71,7 +71,7 @@ describe('SchedulerConfig', () => {
 			const { scheduler } = Container.get(GlobalConfig);
 
 			expect(scheduler.materializationWindowSeconds).toBe(120);
-			expect(scheduler.sweepIntervalSeconds).toBe(20);
+			expect(scheduler.materializationIntervalSeconds).toBe(20);
 			expect(scheduler.executorIntervalSeconds).toBe(2);
 			expect(scheduler.reaperIntervalSeconds).toBe(45);
 			expect(scheduler.leaseDurationSeconds).toBe(90);
@@ -80,7 +80,7 @@ describe('SchedulerConfig', () => {
 			expect(scheduler.retentionIntervalSeconds).toBe(600);
 			expect(scheduler.minIntervalSeconds).toBe(15);
 			expect(scheduler.jitterRatio).toBe(0.25);
-			expect(scheduler.sweepTimeoutSeconds).toBe(30);
+			expect(scheduler.materializationTimeoutSeconds).toBe(30);
 			expect(scheduler.executorTimeoutSeconds).toBe(15);
 			expect(scheduler.reaperTimeoutSeconds).toBe(45);
 			expect(scheduler.retentionTimeoutSeconds).toBe(120);

--- a/packages/@n8n/config/src/configs/scheduler.config.ts
+++ b/packages/@n8n/config/src/configs/scheduler.config.ts
@@ -58,8 +58,8 @@ export class SchedulerConfig {
 	 * upcoming runs (those falling within the window above). Defaults to 10 seconds.
 	 * Must be greater than 0.
 	 */
-	@Env('N8N_SCHEDULER_SWEEP_INTERVAL', positiveIntSchema)
-	sweepIntervalSeconds: number = 10;
+	@Env('N8N_SCHEDULER_MATERIALIZATION_INTERVAL', positiveIntSchema)
+	materializationIntervalSeconds: number = 10;
 
 	/**
 	 * How long, in seconds, a single scan for upcoming runs may take before it is
@@ -68,8 +68,8 @@ export class SchedulerConfig {
 	 * Defaults to 60 seconds.
 	 * Must be greater than 0.
 	 */
-	@Env('N8N_SCHEDULER_SWEEP_TIMEOUT', positiveIntSchema)
-	sweepTimeoutSeconds: number = Time.minutes.toSeconds;
+	@Env('N8N_SCHEDULER_MATERIALIZATION_TIMEOUT', positiveIntSchema)
+	materializationTimeoutSeconds: number = Time.minutes.toSeconds;
 
 	/**
 	 * How often, in seconds, the scheduler checks for recorded runs whose time has

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -444,8 +444,8 @@ describe('GlobalConfig', () => {
 		scheduler: {
 			enabled: false,
 			materializationWindowSeconds: 60,
-			sweepIntervalSeconds: 10,
-			sweepTimeoutSeconds: 60,
+			materializationIntervalSeconds: 10,
+			materializationTimeoutSeconds: 60,
 			executorIntervalSeconds: 5,
 			executorTimeoutSeconds: 60,
 			claimBatchSize: 100,

--- a/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
@@ -425,6 +425,16 @@ export class ScheduledTaskRepository extends Repository<ScheduledTask> {
 	}
 
 	/**
+	 * @returns database clock.
+	 */
+	async readDbTime(): Promise<Date> {
+		const [row]: Array<{ dbNow: Date | string }> = await this.query(
+			`SELECT ${dbNowLiteral(this.isPostgres)} AS "dbNow"`,
+		);
+		return parseDbTime(row.dbNow);
+	}
+
+	/**
 	 * Reaper reclaim: an expired-lease `running` task back to `pending`, counting the
 	 * attempt, pushing `runAt` out by the backoff, and bumping the lease epoch.
 	 * Clears the claim and lease. Guarded on the epoch read during the sweep and a

--- a/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-task.repository.ts
@@ -424,9 +424,7 @@ export class ScheduledTaskRepository extends Repository<ScheduledTask> {
 		};
 	}
 
-	/**
-	 * @returns database clock.
-	 */
+	/** Current time on the database clock, used to check this instance's clock for skew. */
 	async readDbTime(): Promise<Date> {
 		const [row]: Array<{ dbNow: Date | string }> = await this.query(
 			`SELECT ${dbNowLiteral(this.isPostgres)} AS "dbNow"`,

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -352,8 +352,8 @@ A few things that are not obvious from the code but save a lot of confusion.
   provisioning does).
 
 - **Each background pass runs on its own timer, with jitter.** The four passes are
-  independent and slightly randomised, so several servers do not all sweep in
-  lockstep, and one slow pass does not stall the others.
+  independent and slightly randomised, so several servers do not all run their
+  passes in lockstep, and one slow pass does not stall the others.
 
 ## Future ideas
 

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -1,65 +1,369 @@
 # @n8n/scheduler
 
-Durable, multi-main scheduling for n8n. Upcoming work is recorded in storage
-before it runs, then claimed, fired and recovered under leases and epoch
-fencing, so each occurrence executes once across the cluster and survives
-restarts and failovers. Occurrences are dispatched to handlers by `taskType`;
-the Schedule Trigger node is the first consumer. Everything sits behind
-`N8N_SCHEDULER_ENABLED` (default off) while the legacy engine stays in place.
+A durable, cluster-safe scheduler. You give it rules like "run this every Monday
+at 09:00" or "run this once at midnight on New Year's Eve", and it makes sure the
+work actually runs, at the right time, and (as close as a distributed system can
+get) exactly once, even when n8n is running on several servers at once and even
+across restarts and crashes.
 
-## Surface
+## TL;DR
 
-The package is pure logic, with no DI and no database. It exposes exactly two
-things (plus the types their signatures reach):
+**The principle.** Most schedulers keep their timers in memory: the process holds
+a `setTimeout` for each upcoming run. That is simple but fragile. If the process
+restarts, the timers are gone. If you run several copies of the server for high
+availability, every copy fires the same timer and the work runs many times.
 
-- **`Scheduler`**: `registerTaskHandler` plus one accessor per pass
-  (`materialize`, `execute`, `reap`, `prune`, `stop`). The host drives each
-  pass on its own cadence.
-- **`createScheduler(deps)`**: composes the internal algorithms (materializer,
-  executor, reaper, retention) into a `Scheduler`.
+This package takes a different approach: **write the work down before running it.**
+Every upcoming run is recorded in the database first, then picked up and fired from
+there. Because the source of truth lives in storage and not in one process's memory:
 
-The host binds `deps`: a task store and a transaction runner (the `@n8n/db`
-repositories satisfy the store contracts structurally, so no adapters are
-needed), optional per-pass tuning, and an `onEvent` sink for described
-incidents. In n8n that host is the cli's `DurableScheduler`
-(`packages/cli/src/scheduling/`), which wires DI, config and instance identity,
-and routes events to the logger.
+- a restart or crash loses nothing (the run is still recorded and gets picked up
+  again),
+- any server in the cluster can pick up any run, and
+- coordination in the database drives each run toward firing on **exactly one**
+  server, with safety mechanisms (claims, leases, recovery) to fall back on when a
+  server crashes mid-run.
+
+**Two things you work with.**
+
+- A **job** is a *rule*: it says *when* something should happen (the cron
+  expression, the interval, the one-off instant). Think of it as a recurring
+  calendar event.
+- A **task** is *one concrete run* produced from that rule, scheduled for one
+  specific instant. Think of it as a single occurrence of that calendar event on a
+  specific date. Tasks are the unit that actually gets claimed, run, retried and
+  cleaned up.
+
+**The functionality surface.** You register a *handler* (a function that does the
+actual work) for a given task type, hand the scheduler your rules, and start it.
+From then on it:
+
+- turns each rule into concrete upcoming runs, ahead of time,
+- claims each due run on one server and calls your handler at the right moment,
+- retries a run that fails, with a growing backoff between attempts,
+- recovers runs that were stranded by a crashed server,
+- cleans up finished runs after a retention window.
+
+**How it is built.** The package is **pure logic**. It talks to no database and
+uses no dependency injection directly. Instead the host (in n8n, the `cli`
+package) hands it a small set of storage functions and configuration, and the
+scheduler composes its algorithms over them. This keeps every algorithm easy to
+test in isolation with a fake store. The work is split into a few focused
+submodules, described below.
+
+Everything sits behind the `N8N_SCHEDULER_ENABLED` flag (off by default). Turning
+it off reverts n8n to its previous in-memory scheduling, which is the rollback
+path during rollout.
+
+## The moving parts
+
+The scheduler runs four small background routines, each on its own repeating
+timer. Each one is a separate submodule with a single responsibility. Their code
+names are in parentheses; the rest of this document uses the plain names.
+
+```mermaid
+flowchart TD
+    P["Provisioning<br/><i>define & update rules</i>"] --> J[("Jobs<br/><i>the rules: when to run</i>")]
+
+    J -->|"claims rules whose<br/>next run is due"| M["Planner<br/><i>(materializer)</i>"]
+    M -->|"records upcoming<br/>runs, ahead of time"| T[("Tasks<br/><i>concrete queued runs</i>")]
+
+    T -->|"claims due runs<br/>for this server"| E["Runner<br/><i>(executor)</i>"]
+    E -->|"fires at the right<br/>instant"| H["Your handler<br/><i>does the actual work</i>"]
+    E -.->|"on failure: retry<br/>later with backoff"| T
+
+    RE["Recovery<br/><i>(reaper)</i>"] -.->|"rescues runs stranded<br/>by a crashed server"| T
+    T -.->|"finished runs,<br/>past their window"| C["Cleanup<br/><i>(retention)</i>"]
+    C -.->|deletes| T
+
+    classDef store fill:#2d3748,stroke:#4a5568,color:#fff;
+    class J,T store;
+```
+
+### Planner (materializer)
+
+Turns rules into concrete runs. On each pass it claims the jobs whose next run is
+due, computes their upcoming occurrences a little way into the future, records
+those as tasks, and advances each job's clock to its next run. Recording runs
+*ahead of time* means a frequent schedule doesn't need one planning pass per fire.
+
+Failures are isolated: if one rule cannot be planned (for example a timezone this
+server's runtime doesn't know about), that single job is set aside and retried
+later, while every other job in the batch still gets planned. One broken rule
+never wedges scheduling for everyone.
+
+### Runner (executor)
+
+Runs the concrete tasks. On each pass it claims the tasks that are due for this
+server and arms a precise in-memory timer for each, so it fires at its exact
+instant. When the timer fires it calls your registered handler for that task type.
+If the handler succeeds the task is marked done; if it throws and attempts remain,
+the task is rescheduled a bit later (backoff); if it throws with no attempts left,
+the task fails for good (a "dead letter").
+
+### Recovery (reaper)
+
+Rescues stranded runs. When a server claims a task it takes a time-limited *lease*
+on it. If that server crashes or stalls, the lease eventually expires and the task
+is left stuck in the "running" state. The recovery pass finds those expired-lease
+tasks and puts them back in line for another attempt (or fails them for good if
+they are out of attempts). This is what makes a mid-run crash safe.
+
+### Cleanup (retention)
+
+Deletes finished tasks once they are older than a retention window, oldest first,
+in small bounded batches so it never holds long locks or monopolises a pass.
+Successful and failed runs can be kept for different lengths of time.
+
+### Supporting submodules
+
+- **Provisioning** keeps the stored set of rules in sync with what a scope
+  (for example a workflow) currently wants: it inserts new rules, rewrites changed
+  ones, and removes rules that are gone. Unchanged rules keep their identity, so
+  re-publishing a workflow never double-fires runs that were already queued.
+- **Recurrence** is the pure date math: given a rule and a starting instant, what
+  is the next run? It handles cron expressions, intervals, one-offs, and the
+  "every N periods" variant described below, including timezone and daylight-saving
+  behaviour.
+- **Lifecycle** is the set of repeating loops that drive the four passes above,
+  each on its own interval with a little randomness ("jitter") so multiple servers
+  don't all fire their passes in lockstep.
 
 ## Schedule kinds
 
-A scheduled job says *when* something should run. There are four kinds:
+A job says *when* to run. There are four kinds:
 
 | Kind | Meaning | Example |
 |---|---|---|
 | `cron` | Fires at fixed clock times, written as a cron expression. | `0 0 9 * * 1` = every Monday at 09:00 |
 | `interval` | Fires every N seconds of elapsed time. | every 3600s = once an hour |
 | `one_off` | Fires once, at a single instant, then never again. | fire at 2026-01-01 00:00 |
-| `recurring_cron` | A cron *anchor* thinned by an "every N periods" gate, for cadences plain cron cannot express. | every 3 weeks on Monday |
+| `recurring_cron` | A cron pattern thinned by an "every N periods" filter, for cadences plain cron cannot express. | every 5 hours; every 3 weeks on Monday |
+
+A `cron` schedule is evaluated as *wall-clock* time in a timezone, so it follows
+daylight-saving shifts (09:00 stays 09:00). An `interval` schedule counts *elapsed*
+time, so daylight saving never moves it.
 
 ### Why `recurring_cron`?
 
-Plain cron can say "every Monday", but not "every *third* Monday".
-`recurring_cron` builds that from two parts:
+A cron expression can only pick times *within* a repeating calendar (which minute,
+hour, day-of-week, and so on). It cannot count across those cycles. So it can say
+"every Monday", but not "every *third* Monday", and it can say "at minute 0 of some
+hours", but not "every 5 hours" starting from a fixed point (the day has 24 hours,
+which 5 does not divide evenly, so no fixed set of hour values repeats cleanly).
 
-- an **anchor**: a normal cron that lists candidate dates (often too many),
-- a **gate**: keeps a candidate only once at least `recurrenceSize` periods of
-  `recurrenceUnit` (`hours` / `days` / `weeks` / `months`) have passed since the
-  last kept fire.
+`recurring_cron` covers exactly those cases by combining two parts:
 
-"Every 3 weeks on Monday" = anchor "every Monday" + gate "1 per 3 weeks":
+- an **anchor**: a normal cron pattern that lists candidate times (often too many),
+- a **filter**: keeps a candidate only once at least N periods (hours, days, weeks
+  or months) have passed since the last kept run.
+
+The most common case is a plain "every N hours". "Every 5 hours" = anchor "every
+hour" + filter "1 per 5 hours":
+
+```
+Anchor (every hour):    H  H  H  H  H  H  H  H  H  H  H
+Filter (1 per 5 hours): ✓  ✗  ✗  ✗  ✗  ✓  ✗  ✗  ✗  ✗  ✓
+Fires:                  H              H              H
+```
+
+The same shape expresses calendar cadences too. "Every 3 weeks on Monday" = anchor
+"every Monday" + filter "1 per 3 weeks":
 
 ```
 Anchor (every Monday):  M   M   M   M   M   M   M
-Gate (1 per 3 weeks):   ✓   ✗   ✗   ✓   ✗   ✗   ✓
+Filter (1 per 3 weeks): ✓   ✗   ✗   ✓   ✗   ✗   ✓
 Fires:                  M           M           M
 ```
 
-The gate looks only at the previous fire, with no stored counter. So any
-instance in the cluster can compute the next run, and a restart never loses the
+The filter looks only at the *previous* run, with no stored counter. So any server
+in the cluster can compute the next run on its own, and a restart never loses the
 cadence.
 
-## Status
+## Durable and distributed
 
-Early foundation. The algorithms, schedule math and composition surface are in
-place; the driver that runs the passes on their cadences in the main process
-lands in later milestones.
+Two properties describe the whole design, and everything else follows from them.
+
+**Durable** means nothing important lives only in memory. The rules, every upcoming
+run, and each run's current state all live in the database. A process can restart
+or crash at any moment and the scheduler simply picks up where the stored state left
+off. Compare an in-memory scheduler, where a restart forgets every pending timer.
+
+**Distributed and leaderless** means there is no elected "scheduler node" that the
+others depend on. Every server runs the same passes over the same shared state, and
+they coordinate purely through the database. There is no leader to elect, fail over,
+or lose. Adding or removing a server changes throughput, not correctness: any server
+can plan any rule and run any due task.
+
+## Aiming for exactly-once across a cluster
+
+In a distributed system, servers crash mid-run, clocks drift, and network calls
+time out. A scheduler cannot make those failures impossible, so this one is built to
+**target exactly-once and, when something does go wrong, to prefer not losing work
+over never repeating it.** In rare recovery situations that can mean a run executes
+more than once, so handlers should tolerate being called again for the same run.
+The design leans on a few ideas working together.
+
+- **Claim.** A run is only ever picked up through an atomic database claim: a
+  single statement that flips exactly one waiting row to "running" and stamps it
+  with the server that claimed it. Because the database resolves the race, only one
+  server can win a given run, no matter how many try at once.
+- **Lease.** A claim comes with an expiry (a *lease*). While the lease is valid the
+  run belongs to that server. If the server dies, the lease lapses and the recovery
+  pass can safely take the run back. Without leases a crashed server would strand
+  its runs forever.
+- **Fencing.** Each claim carries a version number (an *epoch*) that increases every
+  time a run is claimed. Every final write ("mark succeeded", "mark failed") is
+  guarded by that number. So if a slow server comes back from the dead after its
+  run was already recovered and re-run elsewhere, its late write matches nothing and
+  is harmlessly ignored. It cannot overwrite the newer result.
+
+The claim, the lease and the recovery pass are the safety net: a crash at any point
+is recoverable rather than silently lost. A few supporting choices reinforce it:
+
+- **Identity and idempotency.** Each concrete run is unique on its
+  `(job, instant)` pair, so the same instant can never be queued twice, even if two
+  planning passes race.
+- **Recomputable recurrence.** The next run is derived from the last one, never from
+  a counter held in memory, so any server can compute it and a restart never drifts.
+- **Shared backoff.** A retry after a handler failure and a retry after a crash use
+  the same backoff curve, so recovery behaves consistently however a run failed.
+
+## Lifecycle of a job (a rule)
+
+A job carries a "clock" (its next-run time). The planner keeps advancing that clock
+as it queues runs.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: rule provisioned
+    Active --> Active: planner queues upcoming runs, advances the clock
+    Active --> Deferred: schedule can't be planned<br/>(unknown timezone, corrupt row)
+    Deferred --> Active: retried on a later pass
+    Active --> Active: rule edited<br/>(queued runs withdrawn, clock reset)
+    Active --> Exhausted: last run queued (a one-off that fired)
+    Active --> [*]: rule removed
+    Exhausted --> [*]: rule removed
+```
+
+- **Active**: has a next-run time; the planner keeps materialising it.
+- **Deferred**: planning failed for now; the clock is pushed out and retried later,
+  so a transient cause (a fixed timezone, updated timezone data) heals on its own.
+- **Exhausted**: no future runs left (a one-off that has fired); the clock is empty.
+- Editing or removing a rule is handled by provisioning, which withdraws any runs
+  that were queued under the old definition.
+
+## Lifecycle of a task (a concrete run)
+
+A task is created by the planner and moves through claim, run, and a final outcome.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: planner queues the run
+
+    Pending --> Running: a server claims it (takes a lease)
+
+    Running --> Succeeded: handler finished
+    Running --> Pending: handler failed, attempts left<br/>(retry after backoff)
+    Running --> Failed: handler failed, no attempts left
+
+    Running --> Pending: server crashed, lease expired,<br/>attempts left (recovery)
+    Running --> Failed: server crashed, lease expired,<br/>no attempts left (recovery)
+
+    Pending --> Cancelled: its rule was edited or removed
+    Pending --> Missed: too stale to run (host policy)
+
+    Succeeded --> [*]: deleted by cleanup
+    Failed --> [*]: deleted by cleanup
+    Cancelled --> [*]: deleted by cleanup
+    Missed --> [*]: deleted by cleanup
+```
+
+- **Pending**: queued and waiting for its instant.
+- **Running**: claimed and owned by one server for the duration of its lease.
+- **Succeeded / Failed**: the two normal final outcomes. "Failed" means all attempts
+  were used up, whether from repeated handler errors or repeated crashes.
+- **Cancelled**: the run's rule changed or was removed before it fired, so the
+  queued run is withdrawn.
+- **Missed**: a run so old it is no longer worth firing; whether a stale run still
+  runs or is marked missed is the host's policy, not the scheduler's.
+- Finished runs (the four final states) are eventually deleted by the cleanup pass.
+
+## What this package is (and is not)
+
+It is a **library of scheduling logic**, not a running service on its own. It owns
+the algorithms and the schedule math; it does not own a database connection, a DI
+container, or a configuration source. A **host** provides those and drives it.
+
+The public surface is small:
+
+- **`createScheduler(deps)`** composes the submodules into a scheduler. `deps` is
+  the host's contribution: a task store and a transaction runner (the `@n8n/db`
+  repositories fit these shapes directly, so no adapter layer is needed), an
+  instance identity, optional per-pass tuning, and optional sinks for events,
+  tracing and metrics.
+- The resulting **`Scheduler`** exposes `registerTaskHandler` (bind a handler to a
+  task type), `start` (begin the repeating passes) and `stop` (drain them
+  gracefully). Individual passes can also be triggered one at a time, which is used
+  mainly for tests and manual driving.
+- A few pure helpers are exported too: schedule validation, next-run computation,
+  and the provisioning entry points.
+
+In n8n, that host is the `cli` package's durable-scheduler module, which wires up
+DI, configuration and instance identity, and routes the scheduler's events to the
+logger. While `N8N_SCHEDULER_ENABLED` is off, the previous in-memory engine stays
+in place; turning the flag off again is the rollback.
+
+## Good to know
+
+A few things that are not obvious from the code but save a lot of confusion.
+
+- **"Processing a task" is *scheduling* it, not doing the work.** From the
+  scheduler's point of view, handling a due task means claiming it and arming a
+  precise timer so it fires at its exact instant. The actual work is whatever your
+  registered handler does; the scheduler only hands the task to it at the right
+  moment and records the outcome. So a fast scheduler pass does not mean the work is
+  fast, and a slow handler does not block the passes that queue and claim other
+  tasks.
+
+- **A plain cron expression cannot count across cycles.** It selects times within a
+  repeating calendar (minutes, hours, days-of-week), so cadences like "every third
+  Monday" or "every 5 hours" are simply not expressible in cron. That is the whole
+  reason `recurring_cron` exists: it wraps a cron anchor with an "every N periods"
+  filter to cover those cases. If a schedule fits plain cron, use `cron`; reach for
+  `recurring_cron` only when the cadence spans cycles.
+
+- **The package never logs, traces or measures on its own.** Instead it reports
+  through optional hooks the host supplies, so observability is entirely the host's
+  choice:
+  - an **event sink** (`onEvent`) receives already-handled milestones and incidents
+    as plain, described messages, which the host typically routes to its logger;
+  - a **tracer** wraps each pass and each handler run in a span;
+  - a **metrics** sink records counts and timings (dispatches, retries, dead
+    letters, and so on).
+
+  All three default to no-ops, and a throwing hook is swallowed so a broken logger
+  or exporter can never break the scheduling it was only meant to observe.
+
+- **Runs are recorded ahead of time, within a window.** Because upcoming runs are
+  queued in advance, a frequent schedule does not need one planning pass per fire.
+  The flip side: disabling or editing a rule may take until the end of that window
+  to stop already-queued runs, unless the rule-writing path withdraws them (which
+  provisioning does).
+
+- **Each background pass runs on its own timer, with jitter.** The four passes are
+  independent and slightly randomised, so several servers do not all sweep in
+  lockstep, and one slow pass does not stall the others.
+
+## Future ideas
+
+- **A dedicated host module.** Today the wiring that turns this pure library into a
+  running scheduler (DI, configuration, instance identity, event routing) lives
+  inside the large `cli` package. Extracting it into its own module, for example
+  `@n8n/scheduler-cli` or `@n8n/scheduler-features`, would keep the integration
+  concerns together and out of `cli`, and mirror the clean split this package
+  already draws between algorithm and host.
+- **Lease renewal for long handlers.** A claim's lease is fixed for now, so a
+  handler that runs longer than its lease risks being recovered and re-run. A
+  heartbeat that extends the lease while a handler is genuinely still working would
+  lift that constraint.

--- a/packages/@n8n/scheduler/README.md
+++ b/packages/@n8n/scheduler/README.md
@@ -345,6 +345,22 @@ A few things that are not obvious from the code but save a lot of confusion.
   All three default to no-ops, and a throwing hook is swallowed so a broken logger
   or exporter can never break the scheduling it was only meant to observe.
 
+- **Two warnings tell an operator their timing is off.** Both arrive through the
+  event sink at `warn` level, so they land in the host's logs:
+  - a **clock-skew warning** at start-up. Due-ness and leases are judged on the
+    clock the scheduler coordinates on (the host supplies it via `now`, e.g. the
+    database clock), but fire timers are armed on this instance's own clock. When
+    `start` samples the two and they differ by more than the threshold (default
+    `1s`, `CLOCK_SKEW_WARN_THRESHOLD_MS`), it warns: tasks may fire early or late,
+    and the instance clock should be synchronised (e.g. via NTP). The sample runs
+    detached, so it never delays the loops, and a slow read cannot trip it on its
+    own (the offset must also exceed half the round-trip). Skipped entirely when no
+    `now` is supplied.
+  - a **dispatch-lag warning** when a task fires at least
+    `DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS` (default `30s`) past its scheduled
+    time, once per late fire. This flags a genuinely late dispatch (a blocked event
+    loop, a skewed clock), not routine sub-second jitter.
+
 - **Runs are recorded ahead of time, within a window.** Because upcoming runs are
   queued in advance, a frequent schedule does not need one planning pass per fire.
   The flip side: disabling or editing a rule may take until the end of that window

--- a/packages/@n8n/scheduler/package.json
+++ b/packages/@n8n/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n8n/scheduler",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "scripts": {
     "clean": "rimraf dist .turbo",
     "dev": "pnpm watch",

--- a/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
@@ -37,6 +37,18 @@ describe('isClockSkewSignificant', () => {
 		).toBe(false);
 	});
 
+	it('is false for an offset exactly at the threshold (strict comparison)', () => {
+		expect(
+			isClockSkewSignificant({ offsetMs: CLOCK_SKEW_WARN_THRESHOLD_MS, roundTripMs: 20 }),
+		).toBe(false);
+	});
+
+	it('is false for an offset exactly at half the round-trip', () => {
+		// Round-trip 4_000 gives a 2_000 ms bound; an offset of exactly 2_000 (above the
+		// fixed threshold) must not warn, since the comparison is strict.
+		expect(isClockSkewSignificant({ offsetMs: 2_000, roundTripMs: 4_000 })).toBe(false);
+	});
+
 	it('is true for an offset beyond the threshold, in either direction', () => {
 		expect(isClockSkewSignificant({ offsetMs: 5_000, roundTripMs: 20 })).toBe(true);
 		expect(isClockSkewSignificant({ offsetMs: -5_000, roundTripMs: 20 })).toBe(true);

--- a/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
@@ -54,11 +54,10 @@ describe('isClockSkewSignificant', () => {
 		expect(isClockSkewSignificant({ offsetMs: -5_000, roundTripMs: 20 })).toBe(true);
 	});
 
-	it('does not trip on a slow read alone: the offset must exceed half the round-trip', () => {
+	it('requires the offset to exceed half the round-trip', () => {
 		// A 4s round-trip gives ±2s of measurement uncertainty, so a 1.5s offset (above
 		// the fixed threshold) is still within the noise and must not warn.
 		expect(isClockSkewSignificant({ offsetMs: 1_500, roundTripMs: 4_000 })).toBe(false);
-		// The same round-trip with a clearly larger offset does warn.
 		expect(isClockSkewSignificant({ offsetMs: 3_000, roundTripMs: 4_000 })).toBe(true);
 	});
 

--- a/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/clock-skew.test.ts
@@ -1,0 +1,57 @@
+import {
+	CLOCK_SKEW_WARN_THRESHOLD_MS,
+	isClockSkewSignificant,
+	measureClockSkew,
+} from '../clock-skew';
+
+describe('measureClockSkew', () => {
+	it('reports no offset when the coordination clock matches the round-trip midpoint', () => {
+		const skew = measureClockSkew({ before: 1_000, referenceNow: 1_050, after: 1_100 });
+
+		expect(skew.offsetMs).toBe(0);
+		expect(skew.roundTripMs).toBe(100);
+	});
+
+	it('reports a positive offset when the coordination clock is ahead of the instance', () => {
+		// Midpoint is 1_050; the coordination clock read 5_000 ms later.
+		const skew = measureClockSkew({ before: 1_000, referenceNow: 6_050, after: 1_100 });
+
+		expect(skew.offsetMs).toBe(5_000);
+	});
+
+	it('reports a negative offset when the coordination clock is behind the instance', () => {
+		const skew = measureClockSkew({ before: 10_000, referenceNow: 7_000, after: 10_000 });
+
+		expect(skew.offsetMs).toBe(-3_000);
+	});
+});
+
+describe('isClockSkewSignificant', () => {
+	it('is false for an in-sync clock', () => {
+		expect(isClockSkewSignificant({ offsetMs: 0, roundTripMs: 20 })).toBe(false);
+	});
+
+	it('is false for an offset within the threshold', () => {
+		expect(
+			isClockSkewSignificant({ offsetMs: CLOCK_SKEW_WARN_THRESHOLD_MS - 1, roundTripMs: 20 }),
+		).toBe(false);
+	});
+
+	it('is true for an offset beyond the threshold, in either direction', () => {
+		expect(isClockSkewSignificant({ offsetMs: 5_000, roundTripMs: 20 })).toBe(true);
+		expect(isClockSkewSignificant({ offsetMs: -5_000, roundTripMs: 20 })).toBe(true);
+	});
+
+	it('does not trip on a slow read alone: the offset must exceed half the round-trip', () => {
+		// A 4s round-trip gives ±2s of measurement uncertainty, so a 1.5s offset (above
+		// the fixed threshold) is still within the noise and must not warn.
+		expect(isClockSkewSignificant({ offsetMs: 1_500, roundTripMs: 4_000 })).toBe(false);
+		// The same round-trip with a clearly larger offset does warn.
+		expect(isClockSkewSignificant({ offsetMs: 3_000, roundTripMs: 4_000 })).toBe(true);
+	});
+
+	it('honours a custom threshold', () => {
+		expect(isClockSkewSignificant({ offsetMs: 200, roundTripMs: 20 }, 100)).toBe(true);
+		expect(isClockSkewSignificant({ offsetMs: 200, roundTripMs: 20 }, 500)).toBe(false);
+	});
+});

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -7,7 +7,7 @@ import type { SchedulerMetrics } from '../../observability/metrics';
 import { SpanStatus, type Span, type Tracer } from '../../observability/tracer';
 import { InvalidLifecycleOptionsError } from '../errors';
 import { createScheduler } from '../factory';
-import type { SchedulerDeps, SchedulerTaskStore } from '../factory';
+import type { SchedulerDeps, SchedulerEvent, SchedulerTaskStore } from '../factory';
 import { PASS_TIMED_OUT } from '../lifecycle';
 import type { MaterializerTransaction, RunInTransaction } from '../materializer';
 import { DEFAULT_RETENTION_OPTIONS } from '../retention';
@@ -36,7 +36,7 @@ const makeTracer = () => {
 /** Compose a scheduler over mocks, with non-default retention windows. */
 function makeScheduler(deps: Partial<SchedulerDeps> = {}) {
 	const taskStore = mock<SchedulerTaskStore>();
-	const onEvent = vi.fn();
+	const onEvent = vi.fn<(event: SchedulerEvent) => void>();
 	const materializerTransaction: RunInTransaction = vi.fn();
 	const scheduler = createScheduler({
 		hostId: 'main-test',
@@ -496,6 +496,94 @@ describe('createScheduler lifecycle', () => {
 
 		// The loops are one-shot; a restart claim over dead loops would be a lie.
 		expect(onEvent).not.toHaveBeenCalled();
+	});
+});
+
+describe('createScheduler clock skew', () => {
+	const CLOCK_DIFFERENCE_WARNING =
+		'Scheduler detected a clock difference between this instance and the clock it coordinates on; scheduled tasks may fire slightly early or late. Synchronise this instance clock (e.g. via NTP).';
+
+	/** The events the sink received, filtered by level. */
+	const eventsAt = (
+		onEvent: ReturnType<typeof makeScheduler>['onEvent'],
+		level: SchedulerEvent['level'],
+	) => onEvent.mock.calls.map((call) => call[0]).filter((event) => event.level === level);
+
+	it('warns through the event sink when the instance and coordination clocks differ', async () => {
+		// The coordination clock reads 5s ahead of the instance, far past the threshold.
+		const now = vi.fn<() => Promise<Date>>().mockResolvedValue(new Date(Date.now() + 5_000));
+		const { scheduler, onEvent } = makeScheduler({ now });
+
+		scheduler.start();
+
+		// The check is detached from start; wait for it to report.
+		await vi.waitFor(() => {
+			expect(onEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ level: 'warn', message: CLOCK_DIFFERENCE_WARNING }),
+			);
+		});
+		expect(now).toHaveBeenCalledTimes(1);
+		const [warning] = eventsAt(onEvent, 'warn');
+		expect(typeof warning.context.offsetMs).toBe('number');
+		expect(typeof warning.context.roundTripMs).toBe('number');
+
+		await scheduler.stop();
+	});
+
+	it('stays silent when the clocks are in sync', async () => {
+		const now = vi.fn<() => Promise<Date>>().mockResolvedValue(new Date());
+		const { scheduler, onEvent } = makeScheduler({ now });
+
+		scheduler.start();
+		await vi.waitFor(() => expect(now).toHaveBeenCalledTimes(1));
+
+		expect(eventsAt(onEvent, 'warn')).toHaveLength(0);
+
+		await scheduler.stop();
+	});
+
+	it('reports a failed clock read at debug and never breaks start', async () => {
+		const now = vi.fn<() => Promise<Date>>().mockRejectedValue(new Error('clock unavailable'));
+		const { scheduler, onEvent } = makeScheduler({ now });
+
+		scheduler.start();
+
+		await vi.waitFor(() => {
+			expect(onEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					level: 'debug',
+					message: 'Scheduler could not check the clock difference',
+					context: { error: 'clock unavailable' },
+				}),
+			);
+		});
+
+		await scheduler.stop();
+	});
+
+	it('honours a custom warn threshold', async () => {
+		// A 5s offset would warn at the default threshold; a 10s threshold silences it.
+		const now = vi.fn<() => Promise<Date>>().mockResolvedValue(new Date(Date.now() + 5_000));
+		const { scheduler, onEvent } = makeScheduler({ now, clockSkew: { warnThresholdMs: 10_000 } });
+
+		scheduler.start();
+		await vi.waitFor(() => expect(now).toHaveBeenCalledTimes(1));
+
+		expect(eventsAt(onEvent, 'warn')).toHaveLength(0);
+
+		await scheduler.stop();
+	});
+
+	it('skips the check when no clock reader is supplied', async () => {
+		const { scheduler, onEvent } = makeScheduler();
+
+		scheduler.start();
+		// Let any detached work run.
+		await Promise.resolve();
+
+		expect(eventsAt(onEvent, 'warn')).toHaveLength(0);
+
+		await scheduler.stop();
 	});
 });
 

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -6,7 +6,7 @@ import { SCHEDULER_ATTRIBUTES, SCHEDULER_FIRE_OUTCOME } from '../../observabilit
 import type { SchedulerMetrics } from '../../observability/metrics';
 import { SpanStatus, type Span, type Tracer } from '../../observability/tracer';
 import { InvalidLifecycleOptionsError } from '../errors';
-import { createScheduler } from '../factory';
+import { createScheduler, DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS } from '../factory';
 import type { SchedulerDeps, SchedulerEvent, SchedulerTaskStore } from '../factory';
 import { PASS_TIMED_OUT } from '../lifecycle';
 import type { MaterializerTransaction, RunInTransaction } from '../materializer';
@@ -606,9 +606,21 @@ describe('createScheduler late dispatch', () => {
 				expect.objectContaining({
 					level: 'warn',
 					message: 'Scheduler fired a task later than its scheduled time',
+					context: expect.objectContaining({
+						taskType: 'test-task',
+						// A 2020 runAt is years past, so the reported lag is a large whole number.
+						lagSeconds: expect.any(Number),
+					}),
 				}),
 			);
 		});
+		const warned = onEvent.mock.calls
+			.map(([event]) => event)
+			.find((event) => event.message === 'Scheduler fired a task later than its scheduled time');
+		expect(warned?.context?.lagSeconds).toBeGreaterThan(
+			DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS,
+		);
+		expect(Number.isInteger(warned?.context?.lagSeconds)).toBe(true);
 	});
 
 	it('stays silent within the configured lag threshold', async () => {

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -606,16 +606,13 @@ describe('createScheduler late dispatch', () => {
 				expect.objectContaining({
 					level: 'warn',
 					message: 'Scheduler fired a task later than its scheduled time',
-					context: expect.objectContaining({
-						taskType: 'test-task',
-						lagSeconds: expect.any(Number),
-					}),
 				}),
 			);
 		});
 		const warned = onEvent.mock.calls
 			.map(([event]) => event)
 			.find((event) => event.message === 'Scheduler fired a task later than its scheduled time');
+		expect(warned?.context?.taskType).toBe('test-task');
 		expect(warned?.context?.lagSeconds).toBeGreaterThan(
 			DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS,
 		);

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -608,7 +608,6 @@ describe('createScheduler late dispatch', () => {
 					message: 'Scheduler fired a task later than its scheduled time',
 					context: expect.objectContaining({
 						taskType: 'test-task',
-						// A 2020 runAt is years past, so the reported lag is a large whole number.
 						lagSeconds: expect.any(Number),
 					}),
 				}),

--- a/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
+++ b/packages/@n8n/scheduler/src/core/__tests__/factory.test.ts
@@ -587,6 +587,53 @@ describe('createScheduler clock skew', () => {
 	});
 });
 
+describe('createScheduler late dispatch', () => {
+	it('warns when a task fires well past its scheduled time', async () => {
+		const { scheduler, taskStore, onEvent } = makeScheduler();
+		scheduler.registerTaskHandler('test-task', { execute: vi.fn().mockResolvedValue(undefined) });
+		// A long-past runAt makes the dispatch lag far exceed the default threshold.
+		taskStore.claimDueTasks.mockResolvedValue([
+			claimedTask({ runAt: new Date('2020-01-01T00:00:00.000Z') }),
+		]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.completeTask.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		// The fire is detached from the claim: wait for the timer to deliver it.
+		await vi.waitFor(() => {
+			expect(onEvent).toHaveBeenCalledWith(
+				expect.objectContaining({
+					level: 'warn',
+					message: 'Scheduler fired a task later than its scheduled time',
+				}),
+			);
+		});
+	});
+
+	it('stays silent within the configured lag threshold', async () => {
+		// A threshold no real lag can reach: even a long-past runAt is not reported.
+		const { scheduler, taskStore, onEvent } = makeScheduler({
+			dispatchLagWarnThresholdSeconds: Number.MAX_SAFE_INTEGER,
+		});
+		scheduler.registerTaskHandler('test-task', { execute: vi.fn().mockResolvedValue(undefined) });
+		taskStore.claimDueTasks.mockResolvedValue([
+			claimedTask({ runAt: new Date('2020-01-01T00:00:00.000Z') }),
+		]);
+		taskStore.markStarted.mockResolvedValue(1);
+		taskStore.completeTask.mockResolvedValue(1);
+
+		await scheduler.execute();
+
+		await vi.waitFor(() => expect(taskStore.completeTask).toHaveBeenCalledTimes(1));
+		expect(onEvent).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: 'Scheduler fired a task later than its scheduled time',
+			}),
+		);
+	});
+});
+
 describe('createScheduler lifecycle config', () => {
 	it('rejects a jitter ratio that would allow a zero or negative delay', () => {
 		expect(() => makeScheduler({ lifecycle: { jitterRatio: 1 } })).toThrow(

--- a/packages/@n8n/scheduler/src/core/clock-skew.ts
+++ b/packages/@n8n/scheduler/src/core/clock-skew.ts
@@ -11,7 +11,7 @@
 export interface ClockSkew {
 	/** Coordination clock minus instance clock, in ms. Positive means it is ahead. */
 	offsetMs: number;
-	/** The round-trip of the sampling read, in ms. Bounds the estimate's own error (±half). */
+	/** Round-trip of the sampling read, in ms; bounds the estimate's error (±half). */
 	roundTripMs: number;
 }
 
@@ -34,10 +34,9 @@ export const DEFAULT_CLOCK_SKEW_OPTIONS: ClockSkewOptions = {
 };
 
 /**
- * Estimate the clock offset from a single round-trip. The coordination clock was
- * read at some instant between `before` and `after` (both instance-clock readings
- * taken around the read), so that instant maps to their midpoint on the instance
- * clock; the offset is `referenceNow - midpoint`.
+ * Estimate the clock offset from a single round-trip: the coordination clock was
+ * read at some instant between `before` and `after`, so that instant maps to their
+ * midpoint on the instance clock, giving offset = `referenceNow - midpoint`.
  */
 export function measureClockSkew(sample: {
 	/** Instance clock immediately before reading the coordination clock. */

--- a/packages/@n8n/scheduler/src/core/clock-skew.ts
+++ b/packages/@n8n/scheduler/src/core/clock-skew.ts
@@ -1,0 +1,67 @@
+/**
+ * Compares this instance's clock against the clock the scheduler coordinates on.
+ * Coordination (due-ness, leases) runs on that shared clock, but fire timers are
+ * armed on the instance's own clock, so a difference between the two makes tasks
+ * fire early or late. The host supplies a way to read the shared clock; `start`
+ * samples it once and reports a meaningful skew through the event sink. The math
+ * here is pure so it is tested on its own.
+ */
+
+/** One estimate of how far the coordination clock leads (or trails) the instance clock. */
+export interface ClockSkew {
+	/** Coordination clock minus instance clock, in ms. Positive means it is ahead. */
+	offsetMs: number;
+	/** The round-trip of the sampling read, in ms. Bounds the estimate's own error (±half). */
+	roundTripMs: number;
+}
+
+/**
+ * Offset, in ms, above which the two clocks count as meaningfully out of sync.
+ * Below this, ordinary round-trip jitter and sub-second drift are not worth
+ * reporting; above it, fire timing is noticeably off and an operator should check
+ * that this instance's clock is synchronised (e.g. via NTP).
+ */
+export const CLOCK_SKEW_WARN_THRESHOLD_MS = 1_000;
+
+/** Tuning for the start-time clock-skew check. */
+export interface ClockSkewOptions {
+	/** {@link CLOCK_SKEW_WARN_THRESHOLD_MS} */
+	warnThresholdMs: number;
+}
+
+export const DEFAULT_CLOCK_SKEW_OPTIONS: ClockSkewOptions = {
+	warnThresholdMs: CLOCK_SKEW_WARN_THRESHOLD_MS,
+};
+
+/**
+ * Estimate the clock offset from a single round-trip. The coordination clock was
+ * read at some instant between `before` and `after` (both instance-clock readings
+ * taken around the read), so that instant maps to their midpoint on the instance
+ * clock; the offset is `referenceNow - midpoint`.
+ */
+export function measureClockSkew(sample: {
+	/** Instance clock immediately before reading the coordination clock. */
+	before: number;
+	/** The coordination clock that was read. */
+	referenceNow: number;
+	/** Instance clock immediately after reading the coordination clock. */
+	after: number;
+}): ClockSkew {
+	const midpoint = sample.before + (sample.after - sample.before) / 2;
+	return {
+		offsetMs: sample.referenceNow - midpoint,
+		roundTripMs: sample.after - sample.before,
+	};
+}
+
+/**
+ * Whether a measured skew is worth reporting: the offset must exceed both the
+ * threshold and the measurement's own uncertainty (half the round-trip), so a slow
+ * read (e.g. a cold connection) can never trip the warning on its own.
+ */
+export function isClockSkewSignificant(
+	skew: ClockSkew,
+	thresholdMs: number = CLOCK_SKEW_WARN_THRESHOLD_MS,
+): boolean {
+	return Math.abs(skew.offsetMs) > Math.max(thresholdMs, skew.roundTripMs / 2);
+}

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -1,6 +1,12 @@
 import { Time } from '@n8n/constants';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
 
+import {
+	DEFAULT_CLOCK_SKEW_OPTIONS,
+	isClockSkewSignificant,
+	measureClockSkew,
+	type ClockSkewOptions,
+} from './clock-skew';
 import { InvalidLifecycleOptionsError } from './errors';
 import {
 	DEFAULT_EXECUTOR_OPTIONS,
@@ -61,8 +67,20 @@ export interface SchedulerDeps {
 	reaper?: Partial<ReaperOptions>;
 	retention?: Partial<RetentionOptions>;
 
+	/** Tuning for the start-time clock-skew check (only used when {@link now} is set). */
+	clockSkew?: Partial<ClockSkewOptions>;
+
 	/** Cadences of the loops `start` runs, one per pass. */
 	lifecycle?: Partial<LifecycleOptions>;
+
+	/**
+	 * Reads the current time from the clock the scheduler coordinates on, the same
+	 * clock due-ness and leases are judged against. Optional: when given, `start`
+	 * samples it once and reports a warning through {@link onEvent} if it differs
+	 * from this instance's own clock enough to fire tasks early or late. How the
+	 * time is read is the host's concern; left out, the check is skipped.
+	 */
+	now?: () => Promise<Date>;
 
 	onEvent?: (event: SchedulerEvent) => void;
 
@@ -105,6 +123,7 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 	const reaperOptions = withDefaults(DEFAULT_REAPER_OPTIONS, deps.reaper);
 	const retentionOptions = withDefaults(DEFAULT_RETENTION_OPTIONS, deps.retention);
 	const lifecycleOptions = withDefaults(DEFAULT_LIFECYCLE_OPTIONS, deps.lifecycle);
+	const clockSkewOptions = withDefaults(DEFAULT_CLOCK_SKEW_OPTIONS, deps.clockSkew);
 
 	if (!(lifecycleOptions.jitterRatio >= 0 && lifecycleOptions.jitterRatio < 1)) {
 		throw new InvalidLifecycleOptionsError(
@@ -419,6 +438,27 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 		),
 	];
 
+	const checkClockSkew = async () => {
+		if (deps.now === undefined) return;
+		try {
+			const before = Date.now();
+			const referenceNow = await deps.now();
+			const after = Date.now();
+			const skew = measureClockSkew({ before, referenceNow: referenceNow.getTime(), after });
+			if (isClockSkewSignificant(skew, clockSkewOptions.warnThresholdMs)) {
+				emit(
+					'warn',
+					'Scheduler detected a clock difference between this instance and the clock it coordinates on; scheduled tasks may fire slightly early or late. Synchronise this instance clock (e.g. via NTP).',
+					{ offsetMs: Math.round(skew.offsetMs), roundTripMs: Math.round(skew.roundTripMs) },
+				);
+			}
+		} catch (error) {
+			emit('debug', 'Scheduler could not check the clock difference', {
+				error: described(error),
+			});
+		}
+	};
+
 	let started = false;
 	let stopping: Promise<void> | undefined;
 
@@ -444,6 +484,9 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 					loop.start();
 				}
 				emit('info', 'Scheduler started', { hostId });
+				// Detached: the clock check reports through the event sink and must
+				// never delay the loops that are already running.
+				void checkClockSkew();
 			}
 		},
 

--- a/packages/@n8n/scheduler/src/core/factory.ts
+++ b/packages/@n8n/scheduler/src/core/factory.ts
@@ -34,6 +34,13 @@ import { noopTracer, type Tracer } from '../observability/tracer';
 export type SchedulerEventLevel = 'debug' | 'info' | 'warn' | 'error';
 
 /**
+ * A task firing this far past its scheduled time is reported once, per fire. Kept
+ * well above normal sub-second dispatch jitter so the warning flags a genuinely
+ * late fire (a blocked event loop, a skewed clock) rather than routine load.
+ */
+export const DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS = 30;
+
+/**
  * A lifecycle milestone, incident or notable outcome the scheduler reports,
  * already handled where it fired. The host only decides how to report it
  * (typically: route to its logger).
@@ -69,6 +76,13 @@ export interface SchedulerDeps {
 
 	/** Tuning for the start-time clock-skew check (only used when {@link now} is set). */
 	clockSkew?: Partial<ClockSkewOptions>;
+
+	/**
+	 * Warn through {@link onEvent} when a task fires at least this many seconds after
+	 * its scheduled time (a blocked event loop or a skewed clock). Defaults to
+	 * {@link DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS}.
+	 */
+	dispatchLagWarnThresholdSeconds?: number;
 
 	/** Cadences of the loops `start` runs, one per pass. */
 	lifecycle?: Partial<LifecycleOptions>;
@@ -124,6 +138,8 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 	const retentionOptions = withDefaults(DEFAULT_RETENTION_OPTIONS, deps.retention);
 	const lifecycleOptions = withDefaults(DEFAULT_LIFECYCLE_OPTIONS, deps.lifecycle);
 	const clockSkewOptions = withDefaults(DEFAULT_CLOCK_SKEW_OPTIONS, deps.clockSkew);
+	const dispatchLagWarnThresholdSeconds =
+		deps.dispatchLagWarnThresholdSeconds ?? DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS;
 
 	if (!(lifecycleOptions.jitterRatio >= 0 && lifecycleOptions.jitterRatio < 1)) {
 		throw new InvalidLifecycleOptionsError(
@@ -224,11 +240,18 @@ export function createScheduler(deps: SchedulerDeps): Scheduler & SchedulerPasse
 					error: described(error),
 				});
 			},
-			onDispatch: (taskType, lagSeconds) =>
+			onDispatch: (taskType, lagSeconds) => {
 				recordMetric(() => {
 					metrics.recordDispatch(taskType);
 					metrics.observeDispatchLagSeconds(taskType, lagSeconds);
-				}),
+				});
+				if (lagSeconds >= dispatchLagWarnThresholdSeconds) {
+					emit('warn', 'Scheduler fired a task later than its scheduled time', {
+						taskType,
+						lagSeconds: Math.round(lagSeconds),
+					});
+				}
+			},
 			onFire: (taskType, result) =>
 				recordMetric(() => {
 					metrics.recordFireOutcome(taskType, result);

--- a/packages/@n8n/scheduler/src/core/index.ts
+++ b/packages/@n8n/scheduler/src/core/index.ts
@@ -18,6 +18,14 @@ export type {
 export { computeFirstRunAt, computeNextRunAt } from './recurrence/next-run';
 export { validateSchedule } from './recurrence/validate';
 
+export {
+	CLOCK_SKEW_WARN_THRESHOLD_MS,
+	DEFAULT_CLOCK_SKEW_OPTIONS,
+	isClockSkewSignificant,
+	measureClockSkew,
+} from './clock-skew';
+export type { ClockSkew, ClockSkewOptions } from './clock-skew';
+
 export { provision, deprovision, createJobProvisioner, scheduleFingerprint } from './provisioning';
 export type {
 	JobProvisioner,

--- a/packages/@n8n/scheduler/src/core/index.ts
+++ b/packages/@n8n/scheduler/src/core/index.ts
@@ -1,5 +1,5 @@
 export type { Scheduler, SchedulerPasses } from './scheduler';
-export { createScheduler } from './factory';
+export { createScheduler, DEFAULT_DISPATCH_LAG_WARN_THRESHOLD_SECONDS } from './factory';
 export type {
 	SchedulerDeps,
 	SchedulerEvent,

--- a/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-scheduler.test.ts
@@ -28,11 +28,13 @@ describe('DurableScheduler', () => {
 			taskType: SCHEDULE_TRIGGER_TASK_TYPE,
 		});
 		const tracing = mock<Tracing>();
+		const tasks = mock<ScheduledTaskRepository>();
+		tasks.readDbTime.mockResolvedValue(new Date());
 		const scheduler = new DurableScheduler(
 			logger,
 			mock<DataSource>(),
 			mock<ScheduledJobRepository>(),
-			mock<ScheduledTaskRepository>(),
+			tasks,
 			mock<InstanceSettings>({ instanceType: instanceType as 'main' | 'worker' | 'webhook' }),
 			mock<GlobalConfig>({
 				generic: { timezone: 'UTC' },
@@ -43,7 +45,7 @@ describe('DurableScheduler', () => {
 			scheduleTriggerTaskHandler,
 			mock<PrometheusSchedulerMetricsService>(),
 		);
-		return { scheduler, inner, logger, tracing };
+		return { scheduler, inner, logger, tracing, tasks };
 	}
 
 	describe('composition', () => {
@@ -133,6 +135,17 @@ describe('DurableScheduler', () => {
 			scheduler.start();
 
 			expect(inner.start).not.toHaveBeenCalled();
+		});
+
+		// The skew detection itself lives in the scheduler package (behind the event
+		// sink); the host only supplies the clock read, which here is the database.
+		it('wires the coordination clock reader to the repository', async () => {
+			const { tasks } = makeScheduler();
+			const deps = vi.mocked(createScheduler).mock.calls.at(-1)?.[0];
+
+			await deps?.now?.();
+
+			expect(tasks.readDbTime).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -64,11 +64,11 @@ export class DurableScheduler implements Scheduler {
 						failedRetentionSeconds: config.failedRetentionSeconds,
 					},
 					lifecycle: {
-						materializerIntervalSeconds: config.sweepIntervalSeconds,
+						materializerIntervalSeconds: config.materializationIntervalSeconds,
 						executorIntervalSeconds: config.executorIntervalSeconds,
 						reaperIntervalSeconds: config.reaperIntervalSeconds,
 						retentionIntervalSeconds: config.retentionIntervalSeconds,
-						materializerTimeoutSeconds: config.sweepTimeoutSeconds,
+						materializerTimeoutSeconds: config.materializationTimeoutSeconds,
 						executorTimeoutSeconds: config.executorTimeoutSeconds,
 						reaperTimeoutSeconds: config.reaperTimeoutSeconds,
 						retentionTimeoutSeconds: config.retentionTimeoutSeconds,

--- a/packages/cli/src/scheduling/durable-scheduler.ts
+++ b/packages/cli/src/scheduling/durable-scheduler.ts
@@ -77,6 +77,7 @@ export class DurableScheduler implements Scheduler {
 							globalConfig.database.type === 'postgresdb' ? 'concurrent' : 'sequential',
 						maxConcurrentPasses: config.maxConcurrentPasses,
 					},
+					now: async () => await tasks.readDbTime(),
 					onEvent: ({ level, message, context }) => logger[level](message, context),
 					tracer,
 				})

--- a/packages/cli/test/integration/scheduling/durable-scheduler-lifecycle.test.ts
+++ b/packages/cli/test/integration/scheduling/durable-scheduler-lifecycle.test.ts
@@ -55,7 +55,7 @@ describe('durable scheduler process lifecycle and flag gating', () => {
 	const buildScheduler = (opts: { enabled: boolean; instanceType?: 'main' | 'worker' }) => {
 		const globalConfig = Container.get(GlobalConfig);
 		globalConfig.scheduler.enabled = opts.enabled;
-		globalConfig.scheduler.sweepIntervalSeconds = 1;
+		globalConfig.scheduler.materializationIntervalSeconds = 1;
 		globalConfig.scheduler.executorIntervalSeconds = 1;
 		globalConfig.scheduler.reaperIntervalSeconds = 1;
 		globalConfig.scheduler.retentionIntervalSeconds = 1;


### PR DESCRIPTION
## Summary

Advances the durable scheduler (`@n8n/scheduler`) toward production rollout (Linear CAT-3625, "R3"). This is documentation, observability, and naming polish. Everything stays behind the default-off `N8N_SCHEDULER_ENABLED` flag, so there is no behaviour change for existing instances and no changelog impact.

- **Docs.** Rewrote the package README as an educational guide for a developer new to the package
- **Config naming.** Renamed the materializer's public env vars from `SWEEP` to `MATERIALIZATION`.
  **Breaking, no alias:** `N8N_SCHEDULER_SWEEP_INTERVAL` / `_TIMEOUT` fall back to defaults
  (10s / 60s) after upgrade. Fine to break: the scheduler is off by default and unreleased.
- **Clock-skew check.** On start, the scheduler compares this instance's clock against the clock it coordinates on and warns
- **Late-dispatch warning.** 
- Bumped `@n8n/scheduler` to `1.0.0`.

The documentation is part of https://github.com/n8n-io/n8n-docs/pull/4936 

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3625

Env var documentation: https://github.com/n8n-io/n8n-docs/pull/4936

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34170">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


