### PR TITLE
fix(core): Preserve local credential fields absent from source contro…

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-helper.ee.test.ts
@@ -1188,7 +1188,7 @@ describe('Source Control Helper', () => {
 			expect(result.port).toBe(5000); // Number from remote
 		});
 
-		it('should only include fields present in remote', () => {
+		it('should keep local fields that are absent from remote', () => {
 			const local = {
 				apiKey: 'secret',
 				port: 3000,
@@ -1197,14 +1197,32 @@ describe('Source Control Helper', () => {
 			const remote = {
 				port: 8080,
 				apiKey: '', // Plain string sanitized to empty
-				// extraField is NOT in remote, so won't be in result
+				// extraField is NOT in remote (e.g. left at its default when pushed)
 			};
 
 			const result = mergeRemoteCrendetialDataIntoLocalCredentialData({ local, remote });
 
 			expect(result.apiKey).toBe('secret'); // Local preserved (empty skipped)
 			expect(result.port).toBe(8080); // Merged from remote
-			expect(result.extraField).toBeUndefined(); // Not in remote, not in result
+			expect(result.extraField).toBe('local-only'); // Absent from remote, local retained
+		});
+
+		it('should not reset a locally selected option field the remote stub omits', () => {
+			// A stub pushed from an instance where the option was left at its default
+			// omits that field entirely. Pulling it must not reset a different local selection.
+			const local = {
+				apikey: 'prod-secret',
+				environment: 'https://api.example.com', // non-default selection on this instance
+			};
+			const remote = {
+				apikey: '', // secret blanked in the stub
+				// environment omitted because the pushing instance used the default
+			} as ICredentialDataDecryptedObject;
+
+			const result = mergeRemoteCrendetialDataIntoLocalCredentialData({ local, remote });
+
+			expect(result.apikey).toBe('prod-secret');
+			expect(result.environment).toBe('https://api.example.com');
 		});
 
 		it('should handle empty local object', () => {
@@ -1229,8 +1247,8 @@ describe('Source Control Helper', () => {
 
 			const result = mergeRemoteCrendetialDataIntoLocalCredentialData({ local, remote });
 
-			// Remote is empty, so result is empty (remote is source of truth for which fields exist)
-			expect(result).toEqual({});
+			// Remote carries no fields, so every local field is retained rather than wiped
+			expect(result).toEqual({ apiKey: 'secret', port: 3000 });
 		});
 
 		it('should handle both empty objects', () => {

--- a/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-helper.ee.ts
@@ -141,11 +141,15 @@ export function mergeRemoteCrendetialDataIntoLocalCredentialData({
 		}
 	}
 
-	// Because oauthTokenData is explicitly stripped from the remote data during sanitization,
-	// it will never exist in the sanitizedRemote object. Therefore, it is skipped in the loop above.
-	// We manually merge it back from local to prevent OAuth credentials being wiped out on pull.
-	if (local.oauthTokenData) {
-		merged.oauthTokenData = local.oauthTokenData;
+	// Keep local fields the remote stub does not carry. A field left at its default value
+	// is not persisted, so it never reaches the stub; an absent field carries the same
+	// "no value to give" meaning as a present-but-blank one, which is already preserved
+	// above. Without this it would be dropped on pull and reset to its default. This also
+	// covers oauthTokenData, which sanitization always strips from the remote.
+	for (const [key, localValue] of Object.entries(local)) {
+		if (!(key in sanitizedRemote)) {
+			merged[key] = localValue;
+		}
 	}
 
 	return merged;


### PR DESCRIPTION
## Summary

On Git pull, merging remote credentials into local credentials built the merged credential only from keys present in the remote stub. A credential set to its default value isn't persisted in Git, so it never reaches the stub. This leads to local credentials being overwritten and reset to defaults if they're missing in remote.

The case of an existing stub with empty value is already handled, merge preserves it:

> source-control-helper.ee.ts:78-80 — when the stub carries the key as an empty string (a blanked secret) and a local value exists, mergeSingleValue returns the local value. That's the "present-but-blank" case being preserved.


This fix preserves local fields including oauthTokenData that are not present in the remote. This prevents deletion of local data.

## Video

https://www.loom.com/share/a37ddb367b744577abf6f7c8e7f693fd

## How to test

1. Use a credential with default values
2. Push workflow/credential to source control
3. Set values other than default in the credential
4. Pull the credential again

## Related Linear tickets, Github issues, and Community forum posts

[LIGO-405](https://linear.app/n8n/issue/LIGO-405/community-issue-git-integration-resets-non-default-credential-option)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

