### PR TITLE
feat(API): Add workflow dependency export policy (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
@@ -85,4 +85,36 @@ describe('ExportPackageRequestDto', () => {
 			expect(ExportPackageRequestDto.safeParse(request).success).toBe(false);
 		});
 	});
+
+	describe('workflowsRequirementMissingPolicy', () => {
+		it.each(['fail', 'reference-only', 'include-in-package'])(
+			'accepts %s',
+			(workflowsRequirementMissingPolicy) => {
+				const result = ExportPackageRequestDto.safeParse({
+					workflowIds: ['wf-1'],
+					workflowsRequirementMissingPolicy,
+				});
+
+				expect(result.success).toBe(true);
+			},
+		);
+
+		it('defaults to fail', () => {
+			const result = ExportPackageRequestDto.safeParse({ workflowIds: ['wf-1'] });
+
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.workflowsRequirementMissingPolicy).toBe('fail');
+			}
+		});
+
+		it('rejects unknown values', () => {
+			const result = ExportPackageRequestDto.safeParse({
+				workflowIds: ['wf-1'],
+				workflowsRequirementMissingPolicy: 'skip',
+			});
+
+			expect(result.success).toBe(false);
+		});
+	});
 });

--- a/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/export-package-request.dto.test.ts
@@ -86,13 +86,13 @@ describe('ExportPackageRequestDto', () => {
 		});
 	});
 
-	describe('workflowsRequirementMissingPolicy', () => {
+	describe('missingWorkflowDependencyPolicy', () => {
 		it.each(['fail', 'reference-only', 'include-in-package'])(
 			'accepts %s',
-			(workflowsRequirementMissingPolicy) => {
+			(missingWorkflowDependencyPolicy) => {
 				const result = ExportPackageRequestDto.safeParse({
 					workflowIds: ['wf-1'],
-					workflowsRequirementMissingPolicy,
+					missingWorkflowDependencyPolicy,
 				});
 
 				expect(result.success).toBe(true);
@@ -104,14 +104,14 @@ describe('ExportPackageRequestDto', () => {
 
 			expect(result.success).toBe(true);
 			if (result.success) {
-				expect(result.data.workflowsRequirementMissingPolicy).toBe('fail');
+				expect(result.data.missingWorkflowDependencyPolicy).toBe('fail');
 			}
 		});
 
 		it('rejects unknown values', () => {
 			const result = ExportPackageRequestDto.safeParse({
 				workflowIds: ['wf-1'],
-				workflowsRequirementMissingPolicy: 'skip',
+				missingWorkflowDependencyPolicy: 'skip',
 			});
 
 			expect(result.success).toBe(false);

--- a/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
@@ -6,4 +6,8 @@ export class ExportPackageRequestDto extends Z.class({
 	workflowIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	folderIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	projectIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
+	workflowsRequirementMissingPolicy: z
+		.enum(['fail', 'reference-only', 'include-in-package'])
+		.optional()
+		.default('fail'),
 }) {}

--- a/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/export-package-request.dto.ts
@@ -6,7 +6,7 @@ export class ExportPackageRequestDto extends Z.class({
 	workflowIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	folderIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
 	projectIds: z.array(z.string().trim().min(1)).min(1).max(300).optional(),
-	workflowsRequirementMissingPolicy: z
+	missingWorkflowDependencyPolicy: z
 		.enum(['fail', 'reference-only', 'include-in-package'])
 		.optional()
 		.default('fail'),

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -24,6 +24,7 @@ n8n-cli package export -p abc -p def -o projects.n8np
 | `-f, --folder-id` | Folder ID to include with its nested folders. Repeat the flag to export several. |
 | `-p, --project-id` | Project ID to include. Repeat the flag to export several. |
 | `-o, --output` | File to write the package to. Defaults to `export.n8np`. |
+| `--missing-workflow-dependency-policy` | Policy for missing static sub-workflow dependencies: `fail`, `reference-only`, or `include-in-package`. Currently only `fail` is supported. |
 
 Provide at least one `--workflow-id`, `--folder-id`, or `--project-id`. Requires
 the API key to hold `workflow:export` when exporting workflows or folders, or

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -78,6 +78,23 @@ describe('N8nClient packages', () => {
 			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a'], folderIds: ['f1'] }));
 		});
 
+		it('includes the missing workflow dependency policy when provided', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
+
+			await client.exportPackage({
+				projectIds: ['proj-1'],
+				missingWorkflowDependencyPolicy: 'include-in-package',
+			});
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.body).toBe(
+				JSON.stringify({
+					projectIds: ['proj-1'],
+					missingWorkflowDependencyPolicy: 'include-in-package',
+				}),
+			);
+		});
+
 		it('omits an empty collection from the body', async () => {
 			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1])));
 

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -12,7 +12,13 @@ const mockedWriteFileSync = vi.mocked(fs.writeFileSync);
 /** The command methods we stub to isolate behaviour from oclif/networking. */
 interface ExportInternals {
 	parse: () => Promise<{
-		flags: { workflowId?: string[]; folderId?: string[]; projectId?: string[]; output: string };
+		flags: {
+			workflowId?: string[];
+			folderId?: string[];
+			projectId?: string[];
+			output: string;
+			missingWorkflowDependencyPolicy: string;
+		};
 	}>;
 	getClient: () => N8nClient;
 	succeed: () => void;
@@ -20,13 +26,21 @@ interface ExportInternals {
 }
 
 function stubCommand(
-	flags: { workflowId?: string[]; folderId?: string[]; projectId?: string[]; output: string },
+	flags: {
+		workflowId?: string[];
+		folderId?: string[];
+		projectId?: string[];
+		output: string;
+		missingWorkflowDependencyPolicy?: string;
+	},
 	exportPackage = vi.fn().mockResolvedValue(Buffer.from([1, 2, 3])),
 ) {
 	const command = new PackageExport([], {} as Config);
 	const internals = command as unknown as ExportInternals;
 	// Bypass oclif arg parsing, connection setup, and the success/exit path.
-	vi.spyOn(internals, 'parse').mockResolvedValue({ flags });
+	vi.spyOn(internals, 'parse').mockResolvedValue({
+		flags: { missingWorkflowDependencyPolicy: 'fail', ...flags },
+	});
 	vi.spyOn(internals, 'getClient').mockReturnValue({ exportPackage } as unknown as N8nClient);
 	vi.spyOn(internals, 'succeed').mockImplementation(() => {});
 	vi.spyOn(internals, 'error').mockImplementation((message: string) => {
@@ -48,7 +62,11 @@ describe('package export command', () => {
 
 		await command.run();
 
-		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: ['wf-1', 'wf-2'], folderIds: [] });
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: ['wf-1', 'wf-2'],
+			folderIds: [],
+			missingWorkflowDependencyPolicy: 'fail',
+		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/team.n8np', Buffer.from([1, 2, 3]));
 	});
 
@@ -60,7 +78,11 @@ describe('package export command', () => {
 
 		await command.run();
 
-		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: [], folderIds: ['fld-1'] });
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: [],
+			folderIds: ['fld-1'],
+			missingWorkflowDependencyPolicy: 'fail',
+		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/folders.n8np', Buffer.from([1, 2, 3]));
 	});
 
@@ -73,7 +95,28 @@ describe('package export command', () => {
 
 		await command.run();
 
-		expect(exportPackage).toHaveBeenCalledWith({ workflowIds: ['wf-1'], folderIds: ['fld-1'] });
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: ['wf-1'],
+			folderIds: ['fld-1'],
+			missingWorkflowDependencyPolicy: 'fail',
+		});
+	});
+
+	it('forwards a non-default missing workflow dependency policy for workflows and folders', async () => {
+		const { command, exportPackage } = stubCommand({
+			workflowId: ['wf-1'],
+			folderId: ['fld-1'],
+			output: '/tmp/mixed.n8np',
+			missingWorkflowDependencyPolicy: 'reference-only',
+		});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({
+			workflowIds: ['wf-1'],
+			folderIds: ['fld-1'],
+			missingWorkflowDependencyPolicy: 'reference-only',
+		});
 	});
 
 	it('forwards project ids and writes the archive', async () => {
@@ -84,8 +127,26 @@ describe('package export command', () => {
 
 		await command.run();
 
-		expect(exportPackage).toHaveBeenCalledWith({ projectIds: ['proj-1', 'proj-2'] });
+		expect(exportPackage).toHaveBeenCalledWith({
+			projectIds: ['proj-1', 'proj-2'],
+			missingWorkflowDependencyPolicy: 'fail',
+		});
 		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/projects.n8np', Buffer.from([1, 2, 3]));
+	});
+
+	it('forwards a non-default missing workflow dependency policy for projects', async () => {
+		const { command, exportPackage } = stubCommand({
+			projectId: ['proj-1'],
+			output: '/tmp/projects.n8np',
+			missingWorkflowDependencyPolicy: 'include-in-package',
+		});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith({
+			projectIds: ['proj-1'],
+			missingWorkflowDependencyPolicy: 'include-in-package',
+		});
 	});
 
 	it('rejects providing both workflow and project IDs', async () => {

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -427,12 +427,20 @@ export class N8nClient {
 		workflowIds?: string[];
 		folderIds?: string[];
 		projectIds?: string[];
+		missingWorkflowDependencyPolicy?: string;
 	}): Promise<Buffer> {
 		// Empty collections are dropped so the API's per-field "at least one" rule isn't tripped.
-		const body: { workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] } = {};
+		const body: {
+			workflowIds?: string[];
+			folderIds?: string[];
+			projectIds?: string[];
+			missingWorkflowDependencyPolicy?: string;
+		} = {};
 		if (fields.workflowIds?.length) body.workflowIds = fields.workflowIds;
 		if (fields.folderIds?.length) body.folderIds = fields.folderIds;
 		if (fields.projectIds?.length) body.projectIds = fields.projectIds;
+		if (fields.missingWorkflowDependencyPolicy)
+			body.missingWorkflowDependencyPolicy = fields.missingWorkflowDependencyPolicy;
 
 		return await this.request<Buffer>('POST', '/n8n-packages/export', {
 			body,

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -20,6 +20,13 @@ export interface ImportPackageFields {
 	folderConflictPolicy?: string;
 }
 
+export interface ExportPackageFields {
+	workflowIds?: string[];
+	folderIds?: string[];
+	projectIds?: string[];
+	missingWorkflowDependencyPolicy?: string;
+}
+
 export class ApiError extends Error {
 	constructor(
 		readonly statusCode: number,
@@ -423,12 +430,7 @@ export class N8nClient {
 
 	// ─── Packages (beta) ───────────────────────────────────────────
 
-	async exportPackage(fields: {
-		workflowIds?: string[];
-		folderIds?: string[];
-		projectIds?: string[];
-		missingWorkflowDependencyPolicy?: string;
-	}): Promise<Buffer> {
+	async exportPackage(fields: ExportPackageFields): Promise<Buffer> {
 		// Empty collections are dropped so the API's per-field "at least one" rule isn't tripped.
 		const body: {
 			workflowIds?: string[];

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -44,7 +44,7 @@ export default class PackageExport extends BaseCommand {
 			options: ['fail', 'reference-only', 'include-in-package'],
 			default: 'fail',
 			description:
-				'What to do when a dependency workflow (sub-workflow) is not explicitely included in the package target',
+				'What to do when a dependency workflow (sub-workflow) is not explicitly included in the package target',
 			aliases: ['missing-workflow-dependency-policy'],
 		}),
 	};

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -40,6 +40,13 @@ export default class PackageExport extends BaseCommand {
 			description: 'File to write the package to',
 			default: 'export.n8np',
 		}),
+		missingWorkflowDependencyPolicy: Flags.string({
+			options: ['fail', 'reference-only', 'include-in-package'],
+			default: 'fail',
+			description:
+				'What to do when a dependency workflow (sub-workflow) is not explicitely included in the package target',
+			aliases: ['missing-workflow-dependency-policy'],
+		}),
 	};
 
 	async run(): Promise<void> {
@@ -47,6 +54,7 @@ export default class PackageExport extends BaseCommand {
 		const workflowIds = flags.workflowId ?? [];
 		const folderIds = flags.folderId ?? [];
 		const projectIds = flags.projectId ?? [];
+		const missingWorkflowDependencyPolicy = flags.missingWorkflowDependencyPolicy;
 
 		// A package is either loose workflows/folders or whole projects, not both.
 		if (projectIds.length > 0 && (workflowIds.length > 0 || folderIds.length > 0)) {
@@ -61,7 +69,9 @@ export default class PackageExport extends BaseCommand {
 			let archive: Buffer;
 			try {
 				archive = await client.exportPackage(
-					projectIds.length > 0 ? { projectIds } : { workflowIds, folderIds },
+					projectIds.length > 0
+						? { projectIds, missingWorkflowDependencyPolicy }
+						: { workflowIds, folderIds, missingWorkflowDependencyPolicy },
 				);
 			} catch (error) {
 				throw toPackagesError(error);

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.service.ts
@@ -11,6 +11,7 @@ import { WorkflowPackageImporter } from './engine/workflow-package-importer';
 import { CredentialExporter } from './entities/credential/credential.exporter';
 import { DataTableExporter } from './entities/data-table/data-table.exporter';
 import { FolderExporter } from './entities/folder/folder.exporter';
+import { PackageExportBlockedError } from './entities/package-export.errors';
 import { ProjectExporter } from './entities/project/project.exporter';
 import { mergeRequirements } from './entities/requirements.types';
 import { PackageWorkflowRequirementValidator } from './entities/workflow/package-workflow-requirement.validator';
@@ -18,10 +19,11 @@ import { WorkflowExporter } from './entities/workflow/workflow.exporter';
 import { TarPackageReader } from './io/tar/tar-package-reader';
 import { TarPackageWriter } from './io/tar/tar-package-writer';
 import { PackageImportConfig } from './n8n-packages.config';
-import type {
-	ExportPackageRequest,
-	ImportPackageRequest,
-	ImportResult,
+import {
+	MissingWorkflowDependencyPolicy,
+	type ExportPackageRequest,
+	type ImportPackageRequest,
+	type ImportResult,
 } from './n8n-packages.types';
 import { FORMAT_VERSION } from './spec/constants';
 import {
@@ -49,6 +51,16 @@ export class N8nPackagesService {
 	) {}
 
 	async exportPackage(request: ExportPackageRequest): Promise<Readable> {
+		// TODO: remove this once the other options are implemented
+		const missingWorkflowDependencyPolicy =
+			request.missingWorkflowDependencyPolicy ?? MissingWorkflowDependencyPolicy.Fail;
+
+		if (missingWorkflowDependencyPolicy !== MissingWorkflowDependencyPolicy.Fail) {
+			throw new PackageExportBlockedError(
+				`missingWorkflowDependencyPolicy="${missingWorkflowDependencyPolicy}" is not supported yet. Only "fail" is currently supported.`,
+			);
+		}
+
 		const writer = new TarPackageWriter();
 		const workflowIds = request.workflowIds ?? [];
 		const folderIds = request.folderIds ?? [];

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -42,6 +42,15 @@ export const FolderConflictPolicy = {
 	/** Fails the import if any package folder already exists in the target project. */
 	Fail: 'fail',
 } as const;
+
+export const MissingWorkflowDependencyPolicy = {
+	/** Fails the export when a static sub-workflow dependency is not included. */
+	Fail: 'fail',
+	/** Reserved for exporting missing static sub-workflows as requirements only. */
+	ReferenceOnly: 'reference-only',
+	/** Reserved for automatically adding missing static sub-workflows to the package. */
+	IncludeInPackage: 'include-in-package',
+} as const;
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export type WorkflowConflictPolicy =
@@ -51,11 +60,15 @@ export type WorkflowIdPolicy = (typeof WorkflowIdPolicy)[keyof typeof WorkflowId
 
 export type FolderConflictPolicy = (typeof FolderConflictPolicy)[keyof typeof FolderConflictPolicy];
 
+export type MissingWorkflowDependencyPolicy =
+	(typeof MissingWorkflowDependencyPolicy)[keyof typeof MissingWorkflowDependencyPolicy];
+
 export interface ExportPackageRequest {
 	user: User;
 	workflowIds?: string[];
 	folderIds?: string[];
 	projectIds?: string[];
+	missingWorkflowDependencyPolicy?: MissingWorkflowDependencyPolicy;
 }
 
 export type ImportPackageRequest = {

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -48,7 +48,7 @@ describe('n8n-packages handler', () => {
 			workflowIds?: string[];
 			folderIds?: string[];
 			projectIds?: string[];
-			workflowsRequirementMissingPolicy?: string;
+			missingWorkflowDependencyPolicy?: string;
 		},
 		apiKeyScopes?: string[],
 	) {
@@ -300,7 +300,7 @@ describe('n8n-packages handler', () => {
 			expect(mockEventService.emit).not.toHaveBeenCalled();
 		});
 
-		it('accepts a workflows requirement missing policy without changing the export request', async () => {
+		it('accepts a missing workflow dependency policy without changing the export request', async () => {
 			const stream = new PassThrough();
 			mockService.exportPackage.mockResolvedValue(stream);
 			const res = makeResponse();
@@ -309,7 +309,7 @@ describe('n8n-packages handler', () => {
 				makeRequest(
 					{
 						workflowIds: ['wf-1'],
-						workflowsRequirementMissingPolicy: 'reference-only',
+						missingWorkflowDependencyPolicy: 'reference-only',
 					},
 					['workflow:export'],
 				),

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -44,7 +44,12 @@ describe('n8n-packages handler', () => {
 	let mockEventService: Mocked<EventService>;
 
 	function makeRequest(
-		body: { workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] },
+		body: {
+			workflowIds?: string[];
+			folderIds?: string[];
+			projectIds?: string[];
+			workflowsRequirementMissingPolicy?: string;
+		},
 		apiKeyScopes?: string[],
 	) {
 		return {
@@ -293,6 +298,33 @@ describe('n8n-packages handler', () => {
 				'attachment; filename="export.n8np"',
 			);
 			expect(mockEventService.emit).not.toHaveBeenCalled();
+		});
+
+		it('accepts a workflows requirement missing policy without changing the export request', async () => {
+			const stream = new PassThrough();
+			mockService.exportPackage.mockResolvedValue(stream);
+			const res = makeResponse();
+
+			const resultPromise = run(
+				makeRequest(
+					{
+						workflowIds: ['wf-1'],
+						workflowsRequirementMissingPolicy: 'reference-only',
+					},
+					['workflow:export'],
+				),
+				res,
+			);
+			stream.end(Buffer.from('package-bytes'));
+			const caught = await resultPromise;
+
+			expect(caught).toBeUndefined();
+			expect(mockService.exportPackage).toHaveBeenCalledWith({
+				user: { id: 'user-1' },
+				workflowIds: ['wf-1'],
+				folderIds: [],
+				projectIds: [],
+			});
 		});
 
 		it('streams the export for a valid project request', async () => {

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/__tests__/n8n-packages.handler.test.ts
@@ -291,6 +291,7 @@ describe('n8n-packages handler', () => {
 				workflowIds: ['wf-1', 'wf-2'],
 				folderIds: [],
 				projectIds: [],
+				missingWorkflowDependencyPolicy: 'fail',
 			});
 			expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/gzip');
 			expect(res.setHeader).toHaveBeenCalledWith(
@@ -300,7 +301,7 @@ describe('n8n-packages handler', () => {
 			expect(mockEventService.emit).not.toHaveBeenCalled();
 		});
 
-		it('accepts a missing workflow dependency policy without changing the export request', async () => {
+		it('forwards a non-default missing workflow dependency policy', async () => {
 			const stream = new PassThrough();
 			mockService.exportPackage.mockResolvedValue(stream);
 			const res = makeResponse();
@@ -324,6 +325,7 @@ describe('n8n-packages handler', () => {
 				workflowIds: ['wf-1'],
 				folderIds: [],
 				projectIds: [],
+				missingWorkflowDependencyPolicy: 'reference-only',
 			});
 		});
 
@@ -345,6 +347,7 @@ describe('n8n-packages handler', () => {
 				workflowIds: [],
 				folderIds: [],
 				projectIds: ['project-1'],
+				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
 
@@ -363,6 +366,7 @@ describe('n8n-packages handler', () => {
 				workflowIds: [],
 				folderIds: ['fld-1'],
 				projectIds: [],
+				missingWorkflowDependencyPolicy: 'fail',
 			});
 		});
 	});

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -26,7 +26,12 @@ const PACKAGE_EXPORT_SCOPES = 'project:export,workflow:export';
 type ExportPackageRequest = AuthenticatedRequest<
 	{},
 	{},
-	{ workflowIds?: string[]; folderIds?: string[]; projectIds?: string[] }
+	{
+		workflowIds?: string[];
+		folderIds?: string[];
+		projectIds?: string[];
+		workflowsRequirementMissingPolicy?: 'fail' | 'reference-only' | 'include-in-package';
+	}
 >;
 
 type ImportPackageRequest = PackageRequest.Import & {
@@ -100,10 +105,6 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 				if (!payload.success) {
 					throw new BadRequestError(payload.error.errors.map(({ message }) => message).join('; '));
 				}
-
-				console.log({
-					data: payload.data,
-				});
 
 				workflowIds = payload.data.workflowIds ?? [];
 				folderIds = payload.data.folderIds ?? [];

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -126,6 +126,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 					workflowIds,
 					folderIds,
 					projectIds,
+					missingWorkflowDependencyPolicy: payload.data.missingWorkflowDependencyPolicy,
 				});
 
 				return await streamPackageExport(res, stream);

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -30,7 +30,7 @@ type ExportPackageRequest = AuthenticatedRequest<
 		workflowIds?: string[];
 		folderIds?: string[];
 		projectIds?: string[];
-		workflowsRequirementMissingPolicy?: 'fail' | 'reference-only' | 'include-in-package';
+		missingWorkflowDependencyPolicy?: 'fail' | 'reference-only' | 'include-in-package';
 	}
 >;
 

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -101,6 +101,10 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 					throw new BadRequestError(payload.error.errors.map(({ message }) => message).join('; '));
 				}
 
+				console.log({
+					data: payload.data,
+				});
+
 				workflowIds = payload.data.workflowIds ?? [];
 				folderIds = payload.data.folderIds ?? [];
 				projectIds = payload.data.projectIds ?? [];

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -40,7 +40,8 @@ properties:
       - reference-only
       - include-in-package
     description: >-
-      What to do when a dependency workflow (sub-workflow) is not explicitly
-      included in the package target.
+      Policy for missing static sub-workflow dependencies. Currently only
+      `fail` is supported; `reference-only` and `include-in-package` are
+      reserved for upcoming export modes.
     example: fail
     default: fail

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -40,6 +40,7 @@ properties:
       - reference-only
       - include-in-package
     description: >-
-      What to do when a dependency workflow (sub-workflow) is not explicitely included in the package target.
+      What to do when a dependency workflow (sub-workflow) is not explicitly
+      included in the package target.
     example: fail
     default: fail

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -33,3 +33,13 @@ properties:
       minLength: 1
     example:
       - Ox8O54VQrmBrb4qL
+  workflowsRequirementMissingPolicy:
+    type: string
+    enum:
+      - fail
+      - reference-only
+      - include-in-package
+    description: >-
+      What to do when a dependency workflow (sub-workflow) is not explicitely included in the package target.
+    example: fail
+    default: fail

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/exportPackageRequest.yml
@@ -33,7 +33,7 @@ properties:
       minLength: 1
     example:
       - Ox8O54VQrmBrb4qL
-  workflowsRequirementMissingPolicy:
+  missingWorkflowDependencyPolicy:
     type: string
     enum:
       - fail


### PR DESCRIPTION
## Summary

Adds `missingWorkflowDependencyPolicy` to the package export public API and n8n CLI contracts, with validation for `fail`, `reference-only`, and `include-in-package`.
Currently only `fail` is supported, so non-default policies are explicitly blocked and documented as reserved for upcoming export modes.
Updates CLI/public API docs and tests for DTO validation, API handler forwarding, and CLI request serialization.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-823

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34175">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

