### PR TITLE
fix(editor): Restore hosted chat Markdown styles

### DIFF
--- a/packages/frontend/@n8n/chat/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/chat/src/css/_tokens.scss
@@ -21,6 +21,7 @@
 	--chat--font-family:
 		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
+	--chat--font-family--monospace: ui-monospace, Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 
 	/* Window Dimensions */
 	--chat--window--width: 400px;
@@ -136,4 +137,39 @@
 	--chat--footer--background: var(--chat--color-light);
 	--chat--footer--color: var(--chat--color-dark);
 	--chat--footer--border-top: 1px solid var(--chat--color-light-shade-100);
+}
+
+.n8n-chat {
+	/* Keep the shared Markdown styles self-contained when chat is embedded outside the n8n app. */
+	--spacing--5xs: calc(var(--chat--spacing) / 8);
+	--spacing--4xs: calc(var(--chat--spacing) / 4);
+	--spacing--2xs: calc(var(--chat--spacing) / 2);
+	--font-family--monospace: var(--chat--font-family--monospace);
+	--font-size--3xs: calc(var(--chat--message--font-size) * 5 / 8);
+	--font-size--xs: calc(var(--chat--message--font-size) * 13 / 16);
+	--font-size--sm: calc(var(--chat--message--font-size) * 7 / 8);
+	--font-size--md: var(--chat--message--font-size);
+	--font-size--lg: calc(var(--chat--message--font-size) * 9 / 8);
+	--font-size--xl: calc(var(--chat--message--font-size) * 5 / 4);
+	--font-weight--regular: 400;
+	--font-weight--medium: 500;
+	--font-weight--bold: 600;
+	--line-height--md: 1.3;
+	--line-height--lg: 1.35;
+	--line-height--xl: var(--chat--message-line-height);
+	--radius--sm: calc(var(--chat--border-radius) / 2);
+	--radius--lg: calc(var(--chat--border-radius) * 2);
+	--radius--xl: calc(var(--chat--border-radius) * 3);
+	--border-width: 1px;
+	--border-style: solid;
+	--color--primary: var(--chat--color--primary);
+	--color--background: var(--chat--color-light);
+	--color--foreground: var(--chat--color-light-shade-50);
+	--color--foreground--shade-1: var(--chat--color-light-shade-100);
+	--color--foreground--tint-1: var(--chat--color-light);
+	--color--neutral-200: var(--chat--color-light-shade-50);
+	--color--neutral-300: var(--chat--color-light-shade-100);
+	--color--text: currentColor;
+	--color--text--shade-1: currentColor;
+	--color--text--tint-1: currentColor;
 }


### PR DESCRIPTION
## Summary

- define the design-system tokens used by shared Markdown styles inside the standalone `.n8n-chat` scope
- derive spacing, typography, radii, borders, and colors from the existing public `--chat--*` customization contract
- add a customizable monospace font token for rendered code

This restores Markdown formatting when `@n8n/chat` is embedded without the full n8n application theme. Exact CDN pinning remains a follow-up after a package version containing this fix is published; pinning a currently published version would preserve the regression.

## How to test

1. Build the standalone package with `pnpm --filter @n8n/chat... build`.
2. Run `pnpm test`, `pnpm lint`, `pnpm lint:styles`, and `pnpm typecheck` from `packages/frontend/@n8n/chat`.
3. Open a hosted Chat Trigger page and render a response containing headings, nested lists, inline and block code, a blockquote, and a table.
4. Confirm spacing, hierarchy, list indentation, code styling, and table borders render without loading the n8n application theme.

Validation completed locally:

- 12 test files passed, 124 tests passed
- standalone package build passed
- ESLint, stylelint, and typecheck passed
- all external variables referenced by the Markdown stylesheet are defined in the generated standalone CSS

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2625
- Fixes #33121
- Related community proposal: https://github.com/n8n-io/n8n/pull/33149

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34176">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Image of the fix and the workflow i tested with
<img width="1843" height="1224" alt="image" src="https://github.com/user-attachments/assets/a415e454-681d-4112-82a8-3d507c60ebab" />
[My workflow.json](https://github.com/user-attachments/files/30024002/My.workflow.json)

