### PR TITLE
feat(core): Fold Instance AI history from the durable event log behind N8N_INSTANCE_AI_DURABLE_LOG (no-changelog)

### DIFF
--- a/packages/cli/src/events/maps/instance-ai.event-map.ts
+++ b/packages/cli/src/events/maps/instance-ai.event-map.ts
@@ -21,6 +21,12 @@ export type InstanceAiEventMap = {
 		events: number;
 		cursorAgeEvents: number;
 	};
+	/** A getRichMessages read derived agent trees by folding the durable log. */
+	'instance-ai-history-folded': {
+		latencyMs: number;
+		snapshotTreesReplaced: number;
+		treesSynthesized: number;
+	};
 	/** History rendered from the message-derived fallback ladder instead of a renderable snapshot tree. */
 	'instance-ai-parser-fallback': {
 		count: number;

--- a/packages/cli/src/events/maps/instance-ai.event-map.ts
+++ b/packages/cli/src/events/maps/instance-ai.event-map.ts
@@ -24,8 +24,7 @@ export type InstanceAiEventMap = {
 	/** A getRichMessages read derived agent trees by folding the durable log. */
 	'instance-ai-history-folded': {
 		latencyMs: number;
-		snapshotTreesReplaced: number;
-		treesSynthesized: number;
+		trees: number;
 	};
 	/** History rendered from the message-derived fallback ladder instead of a renderable snapshot tree. */
 	'instance-ai-parser-fallback': {

--- a/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
@@ -118,6 +118,12 @@ export class PrometheusInstanceAiMetricsService implements PrometheusMetricsColl
 			buckets: [1, 5, 25, 100, 500],
 		});
 
+		const historyFoldDuration = new promClient.Histogram({
+			name: `${this.config.prefix}instance_ai_history_fold_duration_seconds`,
+			help: 'Latency of deriving history agent trees by folding the durable log.',
+			buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5],
+		});
+
 		const parserFallbacksTotal = new promClient.Counter({
 			name: `${this.config.prefix}instance_ai_parser_fallbacks_total`,
 			help: 'History messages rendered from the message-derived fallback ladder instead of a renderable snapshot tree.',
@@ -140,6 +146,9 @@ export class PrometheusInstanceAiMetricsService implements PrometheusMetricsColl
 		this.eventService.on('instance-ai-durable-log-replayed', ({ cursorAgeEvents }) => {
 			durableLogReplaysTotal.inc(1);
 			durableLogReplayCursorAge.observe(cursorAgeEvents);
+		});
+		this.eventService.on('instance-ai-history-folded', ({ latencyMs }) => {
+			historyFoldDuration.observe(latencyMs / 1000);
 		});
 		this.eventService.on('instance-ai-parser-fallback', ({ count }) => {
 			parserFallbacksTotal.inc(count);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -567,6 +567,46 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[0].role).toBe('user');
 	});
 
+	it('excludes a group via live group ids when the excluded run has no persisted rows yet', async () => {
+		// The active run_b just started: its run-start is still in the drain
+		// queue, so the log alone cannot map it to 'mg-1'. The controller passes
+		// the live group id, and the completed sibling run_a must not derive a
+		// partial group entry.
+		mockListMessages.mockResolvedValue({ messages: [userMessage] });
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_a', 1),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1', {
+			excludeRunIds: ['run_b'],
+			excludeMessageGroupIds: ['mg-1'],
+		});
+
+		expect(mockDurableLogMetrics.recordFoldRead).not.toHaveBeenCalled();
+		expect(mockDbSnapshotStorage.getAll).not.toHaveBeenCalled();
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0].role).toBe('user');
+	});
+
 	it('keeps interleaved runs of one group in thread order', async () => {
 		// Background runs execute concurrently with their parent, so a group's
 		// facts interleave in the log. The fold must feed the reducer in seq

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -439,9 +439,11 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
 	});
 
-	it('prefers the log-derived tree over a rich stored snapshot', async () => {
-		// The defining rule of fold-on-read: when the log has renderable rows,
-		// stored snapshot trees are not read at all — not even renderable ones.
+	it('ignores the stored snapshot once the thread has log rows', async () => {
+		// There is no source competition — the flag picks the source. But
+		// snapshot rows keep being written while the flag is on (they are the
+		// flag-off/rollback path until Gate B), so a flag-on read always sees
+		// both; the tree must come from the log, never the stored row.
 		mockDbSnapshotStorage.getAll.mockResolvedValue([
 			{
 				tree: makeTree({ textContent: 'From the snapshot' }),

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -405,6 +405,9 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		]);
 		expect(assistant.agentTree?.status).toBe('completed');
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
+		// The stored rows are not even loaded: the snapshot query only runs when
+		// the fold needs its fallback.
+		expect(mockDbSnapshotStorage.getAll).not.toHaveBeenCalled();
 	});
 
 	it('renders a run that crashed before its snapshot was written', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -440,6 +440,79 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
 	});
 
+	it('excludes the whole message group while any of its runs is active', async () => {
+		// Group 'mg-2' has a completed run and an in-flight one (excluded by the
+		// controller). Deriving a partial group tree from the completed run
+		// would pair against a turn with no assistant message yet, so the whole
+		// group stays out of history until the turn completes.
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_done',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_done', 1),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_done',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-2', messageGroupId: 'mg-2' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'text-block',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { text: 'first segment of the in-flight turn' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_b',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-2', messageGroupId: 'mg-2' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1', {
+			excludeRunIds: ['run_b'],
+		});
+
+		// Only run_done's entry is derived; no partial 'mg-2' entry exists.
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
+		expect(result.messages[1].agentTree?.toolCalls).toHaveLength(1);
+	});
+
 	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {
 		const tree = makeTree();
 		mockDbSnapshotStorage.getAll.mockResolvedValue([

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -513,6 +513,66 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[1].agentTree?.toolCalls).toHaveLength(1);
 	});
 
+	it('keeps interleaved runs of one group in thread order', async () => {
+		// Background runs execute concurrently with their parent, so a group's
+		// facts interleave in the log. The fold must feed the reducer in seq
+		// order — the order the run-sync bootstrap and snapshot writer use —
+		// not run-by-run concatenation.
+		const block = (runId: string, text: string, responseId: string) =>
+			eventRow(
+				{ type: 'text-block', runId, agentId: 'agent-001', responseId, payload: { text } },
+				at,
+			);
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_b',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			block('run_a', 'one', 'r-1'),
+			block('run_b', 'two', 'r-2'),
+			block('run_a', 'three', 'r-3'),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_b',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		const timeline = result.messages[1].agentTree?.timeline ?? [];
+		const texts = timeline.map((entry) => ('content' in entry ? entry.content : ''));
+		expect(texts).toEqual(['one', 'two', 'three']);
+	});
+
 	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {
 		const tree = makeTree();
 		mockDbSnapshotStorage.getAll.mockResolvedValue([

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -402,7 +402,7 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 			'tool-3',
 		]);
 		expect(assistant.agentTree?.status).toBe('completed');
-		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1, 0);
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
 	});
 
 	it('synthesizes a tree for a run that has log rows but no snapshot', async () => {
@@ -435,7 +435,7 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(assistant.agentTree).toBeDefined();
 		expect(assistant.agentTree?.toolCalls).toHaveLength(1);
 		expect(assistant.runId).toBe('run_abc');
-		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 0, 1);
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
 	});
 
 	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {
@@ -464,13 +464,13 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[1].agentTree).toStrictEqual(tree);
 	});
 
-	it('does not synthesize entries for lifecycle-only runs', async () => {
+	it('falls back to stored snapshots when the log derives nothing renderable', async () => {
 		const tree = makeTree();
 		mockDbSnapshotStorage.getAll.mockResolvedValue([
 			{ tree, runId: 'run_abc', createdAt: at, updatedAt: at },
 		]);
-		// A second run left only its lifecycle facts — no renderable work, so no
-		// orphan card is synthesized (matches today's behavior).
+		// The log holds only lifecycle facts — no renderable work, so no orphan
+		// card is derived and the stored snapshots keep rendering.
 		mockEventLogRepository.getForThread.mockResolvedValue([
 			eventRow(
 				{
@@ -493,9 +493,10 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		]);
 
 		const service = createService({ durableLog: true });
-		await service.getRichMessages('user-1', 'thread-1');
+		const result = await service.getRichMessages('user-1', 'thread-1');
 
-		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 0, 0);
+		expect(result.messages[1].agentTree).toStrictEqual(tree);
+		expect(mockDurableLogMetrics.recordFoldRead).not.toHaveBeenCalled();
 	});
 
 	it('never reads the log when the flag is off', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -28,11 +28,16 @@ const mockAgentMemory = {
 // Mock GlobalConfig
 const mockDbSnapshotStorage = { getAll: vi.fn().mockResolvedValue([]) };
 const mockCheckpointRepository = { findActiveByThreadId: vi.fn().mockResolvedValue([]) };
+const mockEventLogRepository = { getForThread: vi.fn().mockResolvedValue([]) };
+const mockDurableLogMetrics = { recordFoldRead: vi.fn(), notifyParserFallbacks: vi.fn() };
 
-function createService(options: { threadTtlDays?: number } = {}): InstanceAiMemoryService {
+function createService(
+	options: { threadTtlDays?: number; durableLog?: boolean } = {},
+): InstanceAiMemoryService {
 	const mockConfig = {
 		instanceAi: {
 			threadTtlDays: options.threadTtlDays ?? 0,
+			durableLog: options.durableLog ?? false,
 		},
 		database: {
 			type: 'postgresdb',
@@ -46,8 +51,6 @@ function createService(options: { threadTtlDays?: number } = {}): InstanceAiMemo
 		},
 	};
 	const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-	// Flag off: the durable-log metrics forwarder only fires on parser fallbacks.
-	const mockDurableLogMetrics = { notifyParserFallbacks: vi.fn() };
 	return new InstanceAiMemoryService(
 		mockLogger as never,
 		mockConfig as never,
@@ -55,6 +58,7 @@ function createService(options: { threadTtlDays?: number } = {}): InstanceAiMemo
 		mockDbSnapshotStorage as never,
 		mockCheckpointRepository as never,
 		mockPendingConfirmationRepository as never,
+		mockEventLogRepository as never,
 		mockDurableLogMetrics as never,
 	);
 }
@@ -298,6 +302,207 @@ describe('InstanceAiMemoryService.getRichMessages', () => {
 
 		expect(result.messages).toHaveLength(1);
 		expect(result.messages[0].role).toBe('user');
+	});
+});
+
+describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read', () => {
+	function eventRow(event: { runId: string; [key: string]: unknown }, createdAt: Date) {
+		return { runId: event.runId, createdAt, event };
+	}
+
+	const userMessage = {
+		id: 'msg-u',
+		role: 'user',
+		content: 'Hello',
+		createdAt: new Date('2026-01-01T00:00:00.000Z'),
+	};
+	const assistantMessage = {
+		id: 'msg-a',
+		role: 'assistant',
+		content: [{ type: 'text', text: 'Done!' }],
+		createdAt: new Date('2026-01-01T00:00:01.000Z'),
+	};
+	const at = new Date('2026-01-01T00:00:01.000Z');
+
+	function toolCallRows(runId: string, count: number) {
+		const rows = [];
+		for (let i = 1; i <= count; i++) {
+			rows.push(
+				eventRow(
+					{
+						type: 'tool-call',
+						runId,
+						agentId: 'agent-001',
+						payload: { toolCallId: `tc-${i}`, toolName: `tool-${i}`, args: {} },
+					},
+					at,
+				),
+				eventRow(
+					{
+						type: 'tool-result',
+						runId,
+						agentId: 'agent-001',
+						payload: { toolCallId: `tc-${i}`, result: {} },
+					},
+					at,
+				),
+			);
+		}
+		return rows;
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDbSnapshotStorage.getAll.mockResolvedValue([]);
+		mockEventLogRepository.getForThread.mockResolvedValue([]);
+		mockListMessages.mockResolvedValue({ messages: [userMessage, assistantMessage] });
+	});
+
+	it('supersedes a degenerate stored snapshot with the tree folded from the log', async () => {
+		// The stored snapshot was built over an evicted buffer: an empty
+		// cancelled tree with none of the run's work (the INS-595 bug family).
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{
+				tree: makeTree({ status: 'cancelled', textContent: '', timeline: [], toolCalls: [] }),
+				runId: 'run_abc',
+				createdAt: at,
+				updatedAt: at,
+			},
+		]);
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_abc', 3),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		const assistant = result.messages[1];
+		expect(assistant.agentTree?.toolCalls).toHaveLength(3);
+		expect(assistant.agentTree?.toolCalls.map((tc) => tc.toolName)).toEqual([
+			'tool-1',
+			'tool-2',
+			'tool-3',
+		]);
+		expect(assistant.agentTree?.status).toBe('completed');
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1, 0);
+	});
+
+	it('synthesizes a tree for a run that has log rows but no snapshot', async () => {
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_abc', 1),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		const assistant = result.messages[1];
+		expect(assistant.agentTree).toBeDefined();
+		expect(assistant.agentTree?.toolCalls).toHaveLength(1);
+		expect(assistant.runId).toBe('run_abc');
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 0, 1);
+	});
+
+	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {
+		const tree = makeTree();
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{ tree, runId: 'run_abc', createdAt: at, updatedAt: at },
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages[1].agentTree).toStrictEqual(tree);
+		expect(mockDurableLogMetrics.recordFoldRead).not.toHaveBeenCalled();
+	});
+
+	it('falls back to stored snapshots when the log read fails', async () => {
+		const tree = makeTree();
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{ tree, runId: 'run_abc', createdAt: at, updatedAt: at },
+		]);
+		mockEventLogRepository.getForThread.mockRejectedValue(new Error('db down'));
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages[1].agentTree).toStrictEqual(tree);
+	});
+
+	it('does not synthesize entries for lifecycle-only runs', async () => {
+		const tree = makeTree();
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{ tree, runId: 'run_abc', createdAt: at, updatedAt: at },
+		]);
+		// A second run left only its lifecycle facts — no renderable work, so no
+		// orphan card is synthesized (matches today's behavior).
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_empty',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-2' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_empty',
+					agentId: 'agent-001',
+					payload: { status: 'cancelled' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		await service.getRichMessages('user-1', 'thread-1');
+
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 0, 0);
+	});
+
+	it('never reads the log when the flag is off', async () => {
+		const service = createService();
+		await service.getRichMessages('user-1', 'thread-1');
+
+		expect(mockEventLogRepository.getForThread).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -607,6 +607,126 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[0].role).toBe('user');
 	});
 
+	it('anchors a group at its parent run so late background completions do not shift pairing', async () => {
+		// Turn 1's group has a background run that finishes AFTER turn 2. A
+		// stored snapshot's createdAt is stamped at parent-run end and never
+		// moves; the fold entry must anchor the same way, or the parser's
+		// next-message guard rejects it for turn 1 and the tree becomes a
+		// trailing orphan card.
+		// Assistant message createdAt is stamped when the response starts, so it
+		// precedes the run's final rows; the entry's anchor must land between it
+		// and the next user message.
+		const t = (seconds: number) => new Date(2026, 0, 1, 0, 0, seconds);
+		mockListMessages.mockResolvedValue({
+			messages: [
+				{ id: 'msg-u1', role: 'user', content: 'first', createdAt: t(0) },
+				{
+					id: 'msg-a1',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'answer one' }],
+					createdAt: t(8),
+				},
+				{ id: 'msg-u2', role: 'user', content: 'second', createdAt: t(20) },
+				{
+					id: 'msg-a2',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'answer two' }],
+					createdAt: t(26),
+				},
+			],
+		});
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			// Turn 1: parent run answers at ~t10, spawns a background sibling.
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_parent',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				t(5),
+			),
+			eventRow(
+				{
+					type: 'text-block',
+					runId: 'run_parent',
+					agentId: 'agent-001',
+					payload: { text: 'answer one' },
+				},
+				t(9),
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_bg',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				t(9),
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_parent',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				t(10),
+			),
+			// Turn 2 completes while the background run is still going.
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_2',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-2' },
+				},
+				t(25),
+			),
+			...toolCallRows('run_2', 1).map((row) => ({ ...row, createdAt: t(26) })),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_2',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				t(29),
+			),
+			// The background sibling finishes LAST, after turn 2.
+			eventRow(
+				{
+					type: 'tool-call',
+					runId: 'run_bg',
+					agentId: 'agent-001',
+					payload: { toolCallId: 'tc-bg', toolName: 'bg-tool', args: {} },
+				},
+				t(40),
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_bg',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				t(41),
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		// Four messages, no trailing orphan card.
+		expect(result.messages).toHaveLength(4);
+		// Turn 1 pairs with its group's tree (parent text + background tool call).
+		const turn1 = result.messages[1];
+		expect(turn1.agentTree?.textContent).toBe('answer one');
+		expect(turn1.agentTree?.toolCalls.map((tc) => tc.toolName)).toContain('bg-tool');
+		// Turn 2 pairs with its own run.
+		expect(result.messages[3].agentTree?.toolCalls.map((tc) => tc.toolName)).toEqual(['tool-1']);
+	});
+
 	it('keeps interleaved runs of one group in thread order', async () => {
 		// Background runs execute concurrently with their parent, so a group's
 		// facts interleave in the log. The fold must feed the reducer in seq

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -361,7 +361,8 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 	it('derives the tree from the log even when the stored snapshot is degenerate', async () => {
 		// The stored snapshot was built over an evicted buffer: an empty
 		// cancelled tree with none of the run's work (the INS-595 bug family).
-		// Flag on, it is simply never read — the log is authoritative.
+		// Snapshot rows keep being written flag-on (the rollback path until Gate
+		// B), but they are never read once the thread has log rows.
 		mockDbSnapshotStorage.getAll.mockResolvedValue([
 			{
 				tree: makeTree({ status: 'cancelled', textContent: '', timeline: [], toolCalls: [] }),
@@ -437,55 +438,6 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(assistant.agentTree?.toolCalls).toHaveLength(1);
 		expect(assistant.runId).toBe('run_abc');
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
-	});
-
-	it('ignores the stored snapshot once the thread has log rows', async () => {
-		// There is no source competition — the flag picks the source. But
-		// snapshot rows keep being written while the flag is on (they are the
-		// flag-off/rollback path until Gate B), so a flag-on read always sees
-		// both; the tree must come from the log, never the stored row.
-		mockDbSnapshotStorage.getAll.mockResolvedValue([
-			{
-				tree: makeTree({ textContent: 'From the snapshot' }),
-				runId: 'run_abc',
-				createdAt: at,
-				updatedAt: at,
-			},
-		]);
-		mockEventLogRepository.getForThread.mockResolvedValue([
-			eventRow(
-				{
-					type: 'run-start',
-					runId: 'run_abc',
-					agentId: 'agent-001',
-					payload: { messageId: 'm-1' },
-				},
-				at,
-			),
-			eventRow(
-				{
-					type: 'text-block',
-					runId: 'run_abc',
-					agentId: 'agent-001',
-					payload: { text: 'From the log' },
-				},
-				at,
-			),
-			eventRow(
-				{
-					type: 'run-finish',
-					runId: 'run_abc',
-					agentId: 'agent-001',
-					payload: { status: 'completed' },
-				},
-				at,
-			),
-		]);
-
-		const service = createService({ durableLog: true });
-		const result = await service.getRichMessages('user-1', 'thread-1');
-
-		expect(result.messages[1].agentTree?.textContent).toBe('From the log');
 	});
 
 	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -358,9 +358,10 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		mockListMessages.mockResolvedValue({ messages: [userMessage, assistantMessage] });
 	});
 
-	it('supersedes a degenerate stored snapshot with the tree folded from the log', async () => {
+	it('derives the tree from the log even when the stored snapshot is degenerate', async () => {
 		// The stored snapshot was built over an evicted buffer: an empty
 		// cancelled tree with none of the run's work (the INS-595 bug family).
+		// Flag on, it is simply never read — the log is authoritative.
 		mockDbSnapshotStorage.getAll.mockResolvedValue([
 			{
 				tree: makeTree({ status: 'cancelled', textContent: '', timeline: [], toolCalls: [] }),
@@ -405,7 +406,7 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
 	});
 
-	it('synthesizes a tree for a run that has log rows but no snapshot', async () => {
+	it('renders a run that crashed before its snapshot was written', async () => {
 		mockEventLogRepository.getForThread.mockResolvedValue([
 			eventRow(
 				{
@@ -436,6 +437,53 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(assistant.agentTree?.toolCalls).toHaveLength(1);
 		expect(assistant.runId).toBe('run_abc');
 		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
+	});
+
+	it('prefers the log-derived tree over a rich stored snapshot', async () => {
+		// The defining rule of fold-on-read: when the log has renderable rows,
+		// stored snapshot trees are not read at all — not even renderable ones.
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{
+				tree: makeTree({ textContent: 'From the snapshot' }),
+				runId: 'run_abc',
+				createdAt: at,
+				updatedAt: at,
+			},
+		]);
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'text-block',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { text: 'From the log' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_abc',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages[1].agentTree?.textContent).toBe('From the log');
 	});
 
 	it('keeps the stored snapshot tree for pre-log threads (no log rows)', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -516,6 +516,57 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[1].agentTree?.toolCalls).toHaveLength(1);
 	});
 
+	it('renders nothing for a fold emptied by exclusion instead of falling back to stored snapshots', async () => {
+		// The in-flight group is the thread's ONLY log content. Its completed
+		// sibling run_a has a stored snapshot that would survive the loader's
+		// exact-runId filter (only run_b is excluded) — falling back would
+		// resurrect exactly the in-flight group state the exclusion keeps out
+		// of history.
+		mockListMessages.mockResolvedValue({ messages: [userMessage] });
+		mockDbSnapshotStorage.getAll.mockResolvedValue([
+			{ tree: makeTree(), runId: 'run_a', createdAt: at, updatedAt: at },
+		]);
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_a', 1),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_a',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_b',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1', {
+			excludeRunIds: ['run_b'],
+		});
+
+		expect(mockDbSnapshotStorage.getAll).not.toHaveBeenCalled();
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0].role).toBe('user');
+	});
+
 	it('keeps interleaved runs of one group in thread order', async () => {
 		// Background runs execute concurrently with their parent, so a group's
 		// facts interleave in the log. The fold must feed the reducer in seq

--- a/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
@@ -44,13 +44,11 @@ export class DurableLogMetrics {
 
 	/** History read counters (fold-on-read path). */
 	history = {
-		/** getRichMessages reads that folded trees from the durable log. */
+		/** getRichMessages reads that derived trees from the durable log. */
 		foldReads: 0,
 		foldLatencyMsTotal: 0,
-		/** Stored snapshot trees superseded by a log-derived tree. */
-		snapshotTreesReplaced: 0,
-		/** Trees synthesized for runs that had log rows but no snapshot. */
-		treesSynthesized: 0,
+		/** Agent trees derived from the log across those reads. */
+		treesDerived: 0,
 	};
 
 	constructor(private readonly eventService: EventService) {}
@@ -90,16 +88,11 @@ export class DurableLogMetrics {
 		});
 	}
 
-	recordFoldRead(latencyMs: number, replaced: number, synthesized: number): void {
+	recordFoldRead(latencyMs: number, trees: number): void {
 		this.history.foldReads++;
 		this.history.foldLatencyMsTotal += latencyMs;
-		this.history.snapshotTreesReplaced += replaced;
-		this.history.treesSynthesized += synthesized;
-		this.eventService.emit('instance-ai-history-folded', {
-			latencyMs,
-			snapshotTreesReplaced: replaced,
-			treesSynthesized: synthesized,
-		});
+		this.history.treesDerived += trees;
+		this.eventService.emit('instance-ai-history-folded', { latencyMs, trees });
 	}
 
 	/**

--- a/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
@@ -42,6 +42,17 @@ export class DurableLogMetrics {
 		cursorAgeEventsMax: 0,
 	};
 
+	/** History read counters (fold-on-read path). */
+	history = {
+		/** getRichMessages reads that folded trees from the durable log. */
+		foldReads: 0,
+		foldLatencyMsTotal: 0,
+		/** Stored snapshot trees superseded by a log-derived tree. */
+		snapshotTreesReplaced: 0,
+		/** Trees synthesized for runs that had log rows but no snapshot. */
+		treesSynthesized: 0,
+	};
+
 	constructor(private readonly eventService: EventService) {}
 
 	recordDrainBatch(rows: number, bytes: number): void {
@@ -76,6 +87,18 @@ export class DurableLogMetrics {
 		this.eventService.emit('instance-ai-durable-log-replayed', {
 			events: eventsServed,
 			cursorAgeEvents,
+		});
+	}
+
+	recordFoldRead(latencyMs: number, replaced: number, synthesized: number): void {
+		this.history.foldReads++;
+		this.history.foldLatencyMsTotal += latencyMs;
+		this.history.snapshotTreesReplaced += replaced;
+		this.history.treesSynthesized += synthesized;
+		this.eventService.emit('instance-ai-history-folded', {
+			latencyMs,
+			snapshotTreesReplaced: replaced,
+			treesSynthesized: synthesized,
 		});
 	}
 

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -90,6 +90,80 @@ function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): 
 	return [...byId.values()].sort((a, b) => messageCreatedAtMs(a) - messageCreatedAtMs(b));
 }
 
+type LogRun = { events: InstanceAiEvent[]; messageGroupId?: string; lastAt: Date };
+
+/** Group a thread's log rows (already in seq order) by run: the run's events,
+ *  its message group (from run-start), and its last-write time (mimics the
+ *  snapshot row's write-at-run-end timestamp, which the parser aligns
+ *  messages by). */
+function indexLogRuns(
+	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
+): Map<string, LogRun> {
+	const runs = new Map<string, LogRun>();
+	for (const row of rows) {
+		if (!row.runId) continue;
+		let run = runs.get(row.runId);
+		if (!run) {
+			run = { events: [], lastAt: row.createdAt };
+			runs.set(row.runId, run);
+		}
+		run.events.push(row.event);
+		run.lastAt = row.createdAt;
+		if (row.event.type === 'run-start') {
+			const groupId = row.event.payload.messageGroupId;
+			if (typeof groupId === 'string' && groupId) run.messageGroupId = groupId;
+		}
+	}
+	return runs;
+}
+
+/** Snapshot-shaped entries derived from the log, grouped the way the snapshot
+ *  writer groups its rows: by run-start messageGroupId, else one entry per
+ *  run. The parser pairs these to assistant messages positionally, so the
+ *  entry's createdAt is the run's last fact time (≈ the write-at-run-end
+ *  timestamp a stored snapshot would carry). */
+function buildLogDerivedSnapshots(
+	runs: Map<string, LogRun>,
+	skipRunIds: Set<string>,
+): AgentTreeSnapshot[] {
+	type Group = {
+		runIds: string[];
+		events: InstanceAiEvent[];
+		messageGroupId?: string;
+		lastAt: Date;
+	};
+	const groups = new Map<string, Group>();
+	for (const [runId, run] of runs) {
+		if (skipRunIds.has(runId)) continue;
+		const key = run.messageGroupId ?? runId;
+		let group = groups.get(key);
+		if (!group) {
+			group = { runIds: [], events: [], messageGroupId: run.messageGroupId, lastAt: run.lastAt };
+			groups.set(key, group);
+		}
+		group.runIds.push(runId);
+		group.events.push(...run.events);
+		if (run.lastAt > group.lastAt) group.lastAt = run.lastAt;
+	}
+
+	const entries: AgentTreeSnapshot[] = [];
+	for (const group of groups.values()) {
+		// Nothing renderable beyond the run lifecycle — skip, matching today's
+		// behavior of not surfacing empty orphan cards.
+		const hasContent = group.events.some((e) => e.type !== 'run-start' && e.type !== 'run-finish');
+		if (!hasContent) continue;
+		entries.push({
+			tree: buildAgentTreeFromEvents(group.events),
+			runId: group.runIds[group.runIds.length - 1],
+			messageGroupId: group.messageGroupId,
+			runIds: group.runIds,
+			createdAt: group.lastAt,
+			updatedAt: group.lastAt,
+		});
+	}
+	return entries;
+}
+
 @Service()
 export class InstanceAiMemoryService {
 	private readonly instanceAiConfig: InstanceAiConfig;
@@ -241,12 +315,11 @@ export class InstanceAiMemoryService {
 			snapshots = snapshots.filter((s) => !excluded.has(s.runId));
 		}
 
-		// Durable-log flag (fold-on-read): for post-log threads, the agent tree
-		// is derived by folding the durable event log — the persisted snapshot
-		// tree is written but no longer read. Pre-log threads (no log rows) keep
-		// the legacy snapshot path untouched until the Gate B backfill (INS-851).
+		// Durable-log flag (fold-on-read): history trees derive from the event
+		// log; the stored snapshots above only serve as the pre-log/failure
+		// fallback (they remain the flag-off and rollback path).
 		if (this.instanceAiConfig.durableLog) {
-			snapshots = await this.overlayLogDerivedTrees(threadId, snapshots, options?.excludeRunIds);
+			snapshots = await this.foldSnapshotsFromLog(threadId, snapshots, options?.excludeRunIds);
 		}
 
 		// Surface the in-flight messages from any suspended checkpoint. The
@@ -271,17 +344,15 @@ export class InstanceAiMemoryService {
 	}
 
 	/**
-	 * Durable-log fold-on-read: supersede each snapshot's stored tree with a
-	 * fold of the durable log over the snapshot's runIds, and synthesize
-	 * snapshot entries for runs that have log rows but no snapshot row at all
-	 * (e.g. the snapshot write failed or the process died first). Snapshot rows
-	 * keep providing the message alignment metadata
-	 * (createdAt/messageGroupId/runIds); only the tree content is derived.
-	 * Threads with no log rows are returned unchanged (legacy path).
+	 * Durable-log fold-on-read: with the flag on, history agent trees derive
+	 * from the event log. Stored snapshot rows keep being written (they are the
+	 * flag-off and rollback path) but are not read here; they only serve as the
+	 * fallback when the thread has no log rows or the read fails/derives
+	 * nothing.
 	 */
-	private async overlayLogDerivedTrees(
+	private async foldSnapshotsFromLog(
 		threadId: string,
-		snapshots: AgentTreeSnapshot[],
+		storedSnapshots: AgentTreeSnapshot[],
 		excludeRunIds?: string[],
 	): Promise<AgentTreeSnapshot[]> {
 		const start = Date.now();
@@ -293,83 +364,19 @@ export class InstanceAiMemoryService {
 				threadId,
 				error: error instanceof Error ? error.message : String(error),
 			});
-			return snapshots;
+			return storedSnapshots;
 		}
-		if (rows.length === 0) return snapshots;
+		// Pre-log thread (instance ran before the flag): stored snapshots still
+		// render. Production flips the flag together with the backfill migration
+		// (INS-851), so this branch is a dev-instance safety, not a design.
+		if (rows.length === 0) return storedSnapshots;
 
-		// Per-run bookkeeping in seq order: events, group id (from run-start),
-		// and last-write time (mimics the snapshot row's write-at-run-finish
-		// timestamp, which the parser aligns messages by).
-		const runs = new Map<
-			string,
-			{ events: InstanceAiEvent[]; messageGroupId?: string; lastAt: Date }
-		>();
-		for (const row of rows) {
-			if (!row.runId) continue;
-			let run = runs.get(row.runId);
-			if (!run) {
-				run = { events: [], lastAt: row.createdAt };
-				runs.set(row.runId, run);
-			}
-			run.events.push(row.event);
-			run.lastAt = row.createdAt;
-			if (row.event.type === 'run-start') {
-				const groupId = row.event.payload.messageGroupId;
-				if (typeof groupId === 'string' && groupId) run.messageGroupId = groupId;
-			}
-		}
+		const entries = buildLogDerivedSnapshots(indexLogRuns(rows), new Set(excludeRunIds ?? []));
+		if (entries.length === 0) return storedSnapshots;
+		entries.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
 
-		let replaced = 0;
-		const covered = new Set<string>();
-		const result = snapshots.map((snapshot) => {
-			const runIds = snapshot.runIds?.length ? snapshot.runIds : [snapshot.runId];
-			const events = runIds.flatMap((runId) => runs.get(runId)?.events ?? []);
-			for (const runId of runIds) covered.add(runId);
-			if (events.length === 0) return snapshot; // pre-log run — legacy tree
-			replaced++;
-			return { ...snapshot, tree: buildAgentTreeFromEvents(events) };
-		});
-
-		// Runs recorded in the log but never snapshotted: group them the way the
-		// snapshot writer would have (by run-start messageGroupId, else alone).
-		const excluded = new Set(excludeRunIds ?? []);
-		const groups = new Map<string, { runIds: string[]; events: InstanceAiEvent[]; lastAt: Date }>();
-		for (const [runId, run] of runs) {
-			if (covered.has(runId) || excluded.has(runId)) continue;
-			const key = run.messageGroupId ?? runId;
-			let group = groups.get(key);
-			if (!group) {
-				group = { runIds: [], events: [], lastAt: run.lastAt };
-				groups.set(key, group);
-			}
-			group.runIds.push(runId);
-			group.events.push(...run.events);
-			if (run.lastAt > group.lastAt) group.lastAt = run.lastAt;
-		}
-
-		let synthesized = 0;
-		for (const [key, group] of groups) {
-			// Nothing renderable beyond the run lifecycle — skip, matching today's
-			// behavior of not surfacing empty orphan cards.
-			const hasContent = group.events.some(
-				(e) => e.type !== 'run-start' && e.type !== 'run-finish',
-			);
-			if (!hasContent) continue;
-			synthesized++;
-			const lastRunId = group.runIds[group.runIds.length - 1];
-			result.push({
-				tree: buildAgentTreeFromEvents(group.events),
-				runId: lastRunId,
-				messageGroupId: key === lastRunId ? undefined : key,
-				runIds: group.runIds,
-				createdAt: group.lastAt,
-				updatedAt: group.lastAt,
-			});
-		}
-		result.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
-
-		this.durableLogMetrics.recordFoldRead(Date.now() - start, replaced, synthesized);
-		return result;
+		this.durableLogMetrics.recordFoldRead(Date.now() - start, entries.length);
+		return entries;
 	}
 
 	/** Cross-check every confirmation card against `instance_ai_pending_confirmations`

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -96,11 +96,11 @@ function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): 
  *  group can interleave (background tasks run concurrently with their parent)
  *  and the reducer must see facts in the order they happened, exactly as the
  *  run-sync bootstrap and the snapshot writer feed it. The parser pairs
- *  entries to assistant messages positionally, so the entry's createdAt is
- *  the group's last fact time (≈ the write-at-run-end timestamp a stored
- *  snapshot would carry). `skippedInFlight` reports whether run/group
- *  exclusion dropped any rows, so the caller can tell an exclusion-emptied
- *  fold apart from a thread with nothing renderable. */
+ *  entries to assistant messages positionally by createdAt, so the entry is
+ *  anchored at the FIRST run's last fact time (≈ parent-run end, the moment
+ *  a stored snapshot row would have been created). `skippedInFlight` reports
+ *  whether run/group exclusion dropped any rows, so the caller can tell an
+ *  exclusion-emptied fold apart from a thread with nothing renderable. */
 function buildLogDerivedSnapshots(
 	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
 	skipRunIds: Set<string>,
@@ -132,6 +132,11 @@ function buildLogDerivedSnapshots(
 		runIds: string[];
 		events: InstanceAiEvent[];
 		messageGroupId?: string;
+		/** Last fact time of the group's FIRST run — the parent-run-end moment a
+		 *  stored snapshot's createdAt would carry. Background runs can finish
+		 *  after LATER turns, so anchoring on the group's last fact would push
+		 *  the entry past the next message and break positional pairing. */
+		anchorAt: Date;
 		lastAt: Date;
 	};
 	const groups = new Map<string, Group>();
@@ -146,11 +151,20 @@ function buildLogDerivedSnapshots(
 		}
 		let group = groups.get(key);
 		if (!group) {
-			group = { runIds: [], events: [], messageGroupId, lastAt: row.createdAt };
+			group = {
+				runIds: [],
+				events: [],
+				messageGroupId,
+				anchorAt: row.createdAt,
+				lastAt: row.createdAt,
+			};
 			groups.set(key, group);
 		}
 		if (!group.runIds.includes(row.runId)) group.runIds.push(row.runId);
 		group.events.push(row.event);
+		if (row.runId === group.runIds[0] && row.createdAt > group.anchorAt) {
+			group.anchorAt = row.createdAt;
+		}
 		if (row.createdAt > group.lastAt) group.lastAt = row.createdAt;
 	}
 
@@ -165,7 +179,9 @@ function buildLogDerivedSnapshots(
 			runId: group.runIds[group.runIds.length - 1],
 			messageGroupId: group.messageGroupId,
 			runIds: group.runIds,
-			createdAt: group.lastAt,
+			// Mirror the stored-snapshot row: created at parent-run end (save),
+			// only updatedAt advances as later group runs complete (updateLast).
+			createdAt: group.anchorAt,
 			updatedAt: group.lastAt,
 		});
 	}

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -104,6 +104,7 @@ function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): 
 function buildLogDerivedSnapshots(
 	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
 	skipRunIds: Set<string>,
+	skipGroupIds: Set<string>,
 ): { entries: AgentTreeSnapshot[]; skippedInFlight: boolean } {
 	// A run's run-start is its first fact, so the run-to-group mapping is
 	// complete before any grouping decision needs it.
@@ -118,8 +119,10 @@ function buildLogDerivedSnapshots(
 	// from the group's completed runs would pair it against a turn whose
 	// assistant message does not exist yet — the misalignment excludeRunIds
 	// exists to prevent. The in-flight turn renders via the SSE bootstrap, not
-	// history.
-	const skipGroupKeys = new Set<string>();
+	// history. Seeded from the caller's live group ids first: an excluded run
+	// whose run-start row is still in the drain queue has no mapping here, so
+	// persisted rows alone cannot be trusted to identify its group.
+	const skipGroupKeys = new Set<string>(skipGroupIds);
 	for (const runId of skipRunIds) {
 		const groupId = groupKeyByRun.get(runId);
 		if (groupId) skipGroupKeys.add(groupId);
@@ -296,7 +299,15 @@ export class InstanceAiMemoryService {
 	async getRichMessages(
 		_userId: string,
 		threadId: string,
-		options?: { limit?: number; page?: number; excludeRunIds?: string[] },
+		options?: {
+			limit?: number;
+			page?: number;
+			excludeRunIds?: string[];
+			/** Live in-flight group ids from run state — the durable-log fold
+			 *  cannot rely on persisted run-start rows alone to map an excluded
+			 *  run to its group (the row may still be in the drain queue). */
+			excludeMessageGroupIds?: string[];
+		},
 	): Promise<Omit<InstanceAiRichMessagesResponse, 'nextEventId'>> {
 		const result = await this.agentMemory.listMessages({
 			threadId,
@@ -327,7 +338,12 @@ export class InstanceAiMemoryService {
 		// loaded when the fold needs its pre-log/failure fallback, keeping the
 		// heaviest instance-ai table out of the flag-on hot path.
 		const snapshots = this.instanceAiConfig.durableLog
-			? await this.foldSnapshotsFromLog(threadId, loadStoredSnapshots, options?.excludeRunIds)
+			? await this.foldSnapshotsFromLog(
+					threadId,
+					loadStoredSnapshots,
+					options?.excludeRunIds,
+					options?.excludeMessageGroupIds,
+				)
 			: await loadStoredSnapshots();
 
 		// Surface the in-flight messages from any suspended checkpoint. The
@@ -362,6 +378,7 @@ export class InstanceAiMemoryService {
 		threadId: string,
 		loadStoredSnapshots: () => Promise<AgentTreeSnapshot[]>,
 		excludeRunIds?: string[],
+		excludeMessageGroupIds?: string[],
 	): Promise<AgentTreeSnapshot[]> {
 		const start = Date.now();
 		let rows;
@@ -382,6 +399,7 @@ export class InstanceAiMemoryService {
 		const { entries, skippedInFlight } = buildLogDerivedSnapshots(
 			rows,
 			new Set(excludeRunIds ?? []),
+			new Set(excludeMessageGroupIds ?? []),
 		);
 		if (entries.length === 0) {
 			// Emptied by exclusion: the thread's only renderable content is the

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -1,5 +1,6 @@
 import type {
 	InstanceAiEnsureThreadResponse,
+	InstanceAiEvent,
 	InstanceAiRichMessagesResponse,
 	InstanceAiThreadInfo,
 	InstanceAiThreadListResponse,
@@ -12,6 +13,7 @@ import { GlobalConfig } from '@n8n/config';
 import type { InstanceAiConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import {
+	buildAgentTreeFromEvents,
 	createSubAgentResourceIdPrefix,
 	patchThread,
 	type AgentDbMessage,
@@ -31,6 +33,7 @@ import {
 	parseStoredMessages,
 } from './message-parser';
 import { InstanceAiCheckpointRepository } from './repositories/instance-ai-checkpoint.repository';
+import { InstanceAiEventLogRepository } from './repositories/instance-ai-event-log.repository';
 import { InstanceAiPendingConfirmationRepository } from './repositories/instance-ai-pending-confirmation.repository';
 import { TypeORMAgentMemory } from './storage/typeorm-agent-memory';
 
@@ -98,6 +101,7 @@ export class InstanceAiMemoryService {
 		private readonly dbSnapshotStorage: DbSnapshotStorage,
 		private readonly checkpointRepository: InstanceAiCheckpointRepository,
 		private readonly pendingConfirmationRepository: InstanceAiPendingConfirmationRepository,
+		private readonly eventLogRepository: InstanceAiEventLogRepository,
 		private readonly durableLogMetrics: DurableLogMetrics,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
@@ -237,6 +241,14 @@ export class InstanceAiMemoryService {
 			snapshots = snapshots.filter((s) => !excluded.has(s.runId));
 		}
 
+		// Durable-log flag (fold-on-read): for post-log threads, the agent tree
+		// is derived by folding the durable event log — the persisted snapshot
+		// tree is written but no longer read. Pre-log threads (no log rows) keep
+		// the legacy snapshot path untouched until the Gate B backfill (INS-851).
+		if (this.instanceAiConfig.durableLog) {
+			snapshots = await this.overlayLogDerivedTrees(threadId, snapshots, options?.excludeRunIds);
+		}
+
 		// Surface the in-flight messages from any suspended checkpoint. The
 		// user's prompt is persisted to memory on receipt, but the intermediate
 		// assistant responses and pending tool-call from a turn suspended at HITL
@@ -256,6 +268,108 @@ export class InstanceAiMemoryService {
 
 		const projectId = await this.agentMemory.getThreadProjectId(threadId);
 		return { threadId, projectId: projectId ?? undefined, messages };
+	}
+
+	/**
+	 * Durable-log fold-on-read: supersede each snapshot's stored tree with a
+	 * fold of the durable log over the snapshot's runIds, and synthesize
+	 * snapshot entries for runs that have log rows but no snapshot row at all
+	 * (e.g. the snapshot write failed or the process died first). Snapshot rows
+	 * keep providing the message alignment metadata
+	 * (createdAt/messageGroupId/runIds); only the tree content is derived.
+	 * Threads with no log rows are returned unchanged (legacy path).
+	 */
+	private async overlayLogDerivedTrees(
+		threadId: string,
+		snapshots: AgentTreeSnapshot[],
+		excludeRunIds?: string[],
+	): Promise<AgentTreeSnapshot[]> {
+		const start = Date.now();
+		let rows;
+		try {
+			rows = await this.eventLogRepository.getForThread(threadId);
+		} catch (error) {
+			this.logger.warn('Failed to read Instance AI event log for history', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return snapshots;
+		}
+		if (rows.length === 0) return snapshots;
+
+		// Per-run bookkeeping in seq order: events, group id (from run-start),
+		// and last-write time (mimics the snapshot row's write-at-run-finish
+		// timestamp, which the parser aligns messages by).
+		const runs = new Map<
+			string,
+			{ events: InstanceAiEvent[]; messageGroupId?: string; lastAt: Date }
+		>();
+		for (const row of rows) {
+			if (!row.runId) continue;
+			let run = runs.get(row.runId);
+			if (!run) {
+				run = { events: [], lastAt: row.createdAt };
+				runs.set(row.runId, run);
+			}
+			run.events.push(row.event);
+			run.lastAt = row.createdAt;
+			if (row.event.type === 'run-start') {
+				const groupId = row.event.payload.messageGroupId;
+				if (typeof groupId === 'string' && groupId) run.messageGroupId = groupId;
+			}
+		}
+
+		let replaced = 0;
+		const covered = new Set<string>();
+		const result = snapshots.map((snapshot) => {
+			const runIds = snapshot.runIds?.length ? snapshot.runIds : [snapshot.runId];
+			const events = runIds.flatMap((runId) => runs.get(runId)?.events ?? []);
+			for (const runId of runIds) covered.add(runId);
+			if (events.length === 0) return snapshot; // pre-log run — legacy tree
+			replaced++;
+			return { ...snapshot, tree: buildAgentTreeFromEvents(events) };
+		});
+
+		// Runs recorded in the log but never snapshotted: group them the way the
+		// snapshot writer would have (by run-start messageGroupId, else alone).
+		const excluded = new Set(excludeRunIds ?? []);
+		const groups = new Map<string, { runIds: string[]; events: InstanceAiEvent[]; lastAt: Date }>();
+		for (const [runId, run] of runs) {
+			if (covered.has(runId) || excluded.has(runId)) continue;
+			const key = run.messageGroupId ?? runId;
+			let group = groups.get(key);
+			if (!group) {
+				group = { runIds: [], events: [], lastAt: run.lastAt };
+				groups.set(key, group);
+			}
+			group.runIds.push(runId);
+			group.events.push(...run.events);
+			if (run.lastAt > group.lastAt) group.lastAt = run.lastAt;
+		}
+
+		let synthesized = 0;
+		for (const [key, group] of groups) {
+			// Nothing renderable beyond the run lifecycle — skip, matching today's
+			// behavior of not surfacing empty orphan cards.
+			const hasContent = group.events.some(
+				(e) => e.type !== 'run-start' && e.type !== 'run-finish',
+			);
+			if (!hasContent) continue;
+			synthesized++;
+			const lastRunId = group.runIds[group.runIds.length - 1];
+			result.push({
+				tree: buildAgentTreeFromEvents(group.events),
+				runId: lastRunId,
+				messageGroupId: key === lastRunId ? undefined : key,
+				runIds: group.runIds,
+				createdAt: group.lastAt,
+				updatedAt: group.lastAt,
+			});
+		}
+		result.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
+
+		this.durableLogMetrics.recordFoldRead(Date.now() - start, replaced, synthesized);
+		return result;
 	}
 
 	/** Cross-check every confirmation card against `instance_ai_pending_confirmations`

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -298,28 +298,31 @@ export class InstanceAiMemoryService {
 			page: options?.page ?? 0,
 		});
 
-		let snapshots = await this.dbSnapshotStorage.getAll(threadId).catch((error) => {
-			this.logger.warn('Failed to load agent tree snapshots', {
-				threadId,
-				error: error instanceof Error ? error.message : String(error),
+		const loadStoredSnapshots = async (): Promise<AgentTreeSnapshot[]> => {
+			let snapshots = await this.dbSnapshotStorage.getAll(threadId).catch((error) => {
+				this.logger.warn('Failed to load agent tree snapshots', {
+					threadId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return [] as AgentTreeSnapshot[];
 			});
-			return [] as AgentTreeSnapshot[];
-		});
-
-		// Exclude snapshots for active runs — they have no matching assistant
-		// message in memory yet and would misalign the positional
-		// snapshot-to-message matching in parseStoredMessages.
-		if (options?.excludeRunIds?.length) {
-			const excluded = new Set(options.excludeRunIds);
-			snapshots = snapshots.filter((s) => !excluded.has(s.runId));
-		}
+			// Exclude snapshots for active runs — they have no matching assistant
+			// message in memory yet and would misalign the positional
+			// snapshot-to-message matching in parseStoredMessages.
+			if (options?.excludeRunIds?.length) {
+				const excluded = new Set(options.excludeRunIds);
+				snapshots = snapshots.filter((s) => !excluded.has(s.runId));
+			}
+			return snapshots;
+		};
 
 		// Durable-log flag (fold-on-read): history trees derive from the event
-		// log; the stored snapshots above only serve as the pre-log/failure
-		// fallback (they remain the flag-off and rollback path).
-		if (this.instanceAiConfig.durableLog) {
-			snapshots = await this.foldSnapshotsFromLog(threadId, snapshots, options?.excludeRunIds);
-		}
+		// log; the stored snapshots (the flag-off and rollback path) are only
+		// loaded when the fold needs its pre-log/failure fallback, keeping the
+		// heaviest instance-ai table out of the flag-on hot path.
+		const snapshots = this.instanceAiConfig.durableLog
+			? await this.foldSnapshotsFromLog(threadId, loadStoredSnapshots, options?.excludeRunIds)
+			: await loadStoredSnapshots();
 
 		// Surface the in-flight messages from any suspended checkpoint. The
 		// user's prompt is persisted to memory on receipt, but the intermediate
@@ -345,13 +348,13 @@ export class InstanceAiMemoryService {
 	/**
 	 * Durable-log fold-on-read: with the flag on, history agent trees derive
 	 * from the event log. Stored snapshot rows keep being written (they are the
-	 * flag-off and rollback path) but are not read here; they only serve as the
-	 * fallback when the thread has no log rows or the read fails/derives
-	 * nothing.
+	 * flag-off and rollback path) but are neither read nor loaded here; the
+	 * lazy loader runs only when the thread has no log rows or the read
+	 * fails/derives nothing.
 	 */
 	private async foldSnapshotsFromLog(
 		threadId: string,
-		storedSnapshots: AgentTreeSnapshot[],
+		loadStoredSnapshots: () => Promise<AgentTreeSnapshot[]>,
 		excludeRunIds?: string[],
 	): Promise<AgentTreeSnapshot[]> {
 		const start = Date.now();
@@ -363,15 +366,15 @@ export class InstanceAiMemoryService {
 				threadId,
 				error: error instanceof Error ? error.message : String(error),
 			});
-			return storedSnapshots;
+			return await loadStoredSnapshots();
 		}
 		// Pre-log thread (instance ran before the flag): stored snapshots still
 		// render. Production flips the flag together with the backfill migration
 		// (INS-851), so this branch is a dev-instance safety, not a design.
-		if (rows.length === 0) return storedSnapshots;
+		if (rows.length === 0) return await loadStoredSnapshots();
 
 		const entries = buildLogDerivedSnapshots(rows, new Set(excludeRunIds ?? []));
-		if (entries.length === 0) return storedSnapshots;
+		if (entries.length === 0) return await loadStoredSnapshots();
 		entries.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
 
 		this.durableLogMetrics.recordFoldRead(Date.now() - start, entries.length);

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -90,48 +90,28 @@ function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): 
 	return [...byId.values()].sort((a, b) => messageCreatedAtMs(a) - messageCreatedAtMs(b));
 }
 
-type LogRun = { events: InstanceAiEvent[]; messageGroupId?: string; lastAt: Date };
-
-/** Group a thread's log rows (already in seq order) by run: the run's events,
- *  its message group (from run-start), and its last-write time (mimics the
- *  snapshot row's write-at-run-end timestamp, which the parser aligns
- *  messages by). */
-function indexLogRuns(
-	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
-): Map<string, LogRun> {
-	const runs = new Map<string, LogRun>();
-	for (const row of rows) {
-		if (!row.runId) continue;
-		let run = runs.get(row.runId);
-		if (!run) {
-			run = { events: [], lastAt: row.createdAt };
-			runs.set(row.runId, run);
-		}
-		run.events.push(row.event);
-		run.lastAt = row.createdAt;
-		if (row.event.type === 'run-start') {
-			const groupId = row.event.payload.messageGroupId;
-			if (typeof groupId === 'string' && groupId) run.messageGroupId = groupId;
-		}
-	}
-	return runs;
-}
-
 /** Snapshot-shaped entries derived from the log, grouped the way the snapshot
  *  writer groups its rows: by run-start messageGroupId, else one entry per
- *  run. The parser pairs these to assistant messages positionally, so the
- *  entry's createdAt is the run's last fact time (≈ the write-at-run-end
- *  timestamp a stored snapshot would carry). */
+ *  run. Events keep their thread (seq) order within each group — runs of one
+ *  group can interleave (background tasks run concurrently with their parent)
+ *  and the reducer must see facts in the order they happened, exactly as the
+ *  run-sync bootstrap and the snapshot writer feed it. The parser pairs
+ *  entries to assistant messages positionally, so the entry's createdAt is
+ *  the group's last fact time (≈ the write-at-run-end timestamp a stored
+ *  snapshot would carry). */
 function buildLogDerivedSnapshots(
-	runs: Map<string, LogRun>,
+	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
 	skipRunIds: Set<string>,
 ): AgentTreeSnapshot[] {
-	type Group = {
-		runIds: string[];
-		events: InstanceAiEvent[];
-		messageGroupId?: string;
-		lastAt: Date;
-	};
+	// A run's run-start is its first fact, so the run-to-group mapping is
+	// complete before any grouping decision needs it.
+	const groupKeyByRun = new Map<string, string>();
+	for (const row of rows) {
+		if (row.event.type === 'run-start') {
+			const groupId = row.event.payload.messageGroupId;
+			if (typeof groupId === 'string' && groupId) groupKeyByRun.set(row.runId, groupId);
+		}
+	}
 	// An excluded run poisons its whole message group: deriving a partial tree
 	// from the group's completed runs would pair it against a turn whose
 	// assistant message does not exist yet — the misalignment excludeRunIds
@@ -139,21 +119,30 @@ function buildLogDerivedSnapshots(
 	// history.
 	const skipGroupKeys = new Set<string>();
 	for (const runId of skipRunIds) {
-		const groupId = runs.get(runId)?.messageGroupId;
+		const groupId = groupKeyByRun.get(runId);
 		if (groupId) skipGroupKeys.add(groupId);
 	}
+
+	type Group = {
+		runIds: string[];
+		events: InstanceAiEvent[];
+		messageGroupId?: string;
+		lastAt: Date;
+	};
 	const groups = new Map<string, Group>();
-	for (const [runId, run] of runs) {
-		const key = run.messageGroupId ?? runId;
-		if (skipRunIds.has(runId) || skipGroupKeys.has(key)) continue;
+	for (const row of rows) {
+		if (!row.runId) continue;
+		const messageGroupId = groupKeyByRun.get(row.runId);
+		const key = messageGroupId ?? row.runId;
+		if (skipRunIds.has(row.runId) || skipGroupKeys.has(key)) continue;
 		let group = groups.get(key);
 		if (!group) {
-			group = { runIds: [], events: [], messageGroupId: run.messageGroupId, lastAt: run.lastAt };
+			group = { runIds: [], events: [], messageGroupId, lastAt: row.createdAt };
 			groups.set(key, group);
 		}
-		group.runIds.push(runId);
-		group.events.push(...run.events);
-		if (run.lastAt > group.lastAt) group.lastAt = run.lastAt;
+		if (!group.runIds.includes(row.runId)) group.runIds.push(row.runId);
+		group.events.push(row.event);
+		if (row.createdAt > group.lastAt) group.lastAt = row.createdAt;
 	}
 
 	const entries: AgentTreeSnapshot[] = [];
@@ -381,7 +370,7 @@ export class InstanceAiMemoryService {
 		// (INS-851), so this branch is a dev-instance safety, not a design.
 		if (rows.length === 0) return storedSnapshots;
 
-		const entries = buildLogDerivedSnapshots(indexLogRuns(rows), new Set(excludeRunIds ?? []));
+		const entries = buildLogDerivedSnapshots(rows, new Set(excludeRunIds ?? []));
 		if (entries.length === 0) return storedSnapshots;
 		entries.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
 

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -98,11 +98,13 @@ function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): 
  *  run-sync bootstrap and the snapshot writer feed it. The parser pairs
  *  entries to assistant messages positionally, so the entry's createdAt is
  *  the group's last fact time (≈ the write-at-run-end timestamp a stored
- *  snapshot would carry). */
+ *  snapshot would carry). `skippedInFlight` reports whether run/group
+ *  exclusion dropped any rows, so the caller can tell an exclusion-emptied
+ *  fold apart from a thread with nothing renderable. */
 function buildLogDerivedSnapshots(
 	rows: Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>,
 	skipRunIds: Set<string>,
-): AgentTreeSnapshot[] {
+): { entries: AgentTreeSnapshot[]; skippedInFlight: boolean } {
 	// A run's run-start is its first fact, so the run-to-group mapping is
 	// complete before any grouping decision needs it.
 	const groupKeyByRun = new Map<string, string>();
@@ -130,11 +132,15 @@ function buildLogDerivedSnapshots(
 		lastAt: Date;
 	};
 	const groups = new Map<string, Group>();
+	let skippedInFlight = false;
 	for (const row of rows) {
 		if (!row.runId) continue;
 		const messageGroupId = groupKeyByRun.get(row.runId);
 		const key = messageGroupId ?? row.runId;
-		if (skipRunIds.has(row.runId) || skipGroupKeys.has(key)) continue;
+		if (skipRunIds.has(row.runId) || skipGroupKeys.has(key)) {
+			skippedInFlight = true;
+			continue;
+		}
 		let group = groups.get(key);
 		if (!group) {
 			group = { runIds: [], events: [], messageGroupId, lastAt: row.createdAt };
@@ -160,7 +166,7 @@ function buildLogDerivedSnapshots(
 			updatedAt: group.lastAt,
 		});
 	}
-	return entries;
+	return { entries, skippedInFlight };
 }
 
 @Service()
@@ -373,8 +379,19 @@ export class InstanceAiMemoryService {
 		// (INS-851), so this branch is a dev-instance safety, not a design.
 		if (rows.length === 0) return await loadStoredSnapshots();
 
-		const entries = buildLogDerivedSnapshots(rows, new Set(excludeRunIds ?? []));
-		if (entries.length === 0) return await loadStoredSnapshots();
+		const { entries, skippedInFlight } = buildLogDerivedSnapshots(
+			rows,
+			new Set(excludeRunIds ?? []),
+		);
+		if (entries.length === 0) {
+			// Emptied by exclusion: the thread's only renderable content is the
+			// in-flight group. Render nothing rather than fall back — the loader
+			// filters stored snapshots by exact runId only, so a completed
+			// sibling's snapshot would resurrect exactly the in-flight group
+			// state the exclusion keeps out of history.
+			if (skippedInFlight) return [];
+			return await loadStoredSnapshots();
+		}
 		entries.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
 
 		this.durableLogMetrics.recordFoldRead(Date.now() - start, entries.length);

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -132,10 +132,20 @@ function buildLogDerivedSnapshots(
 		messageGroupId?: string;
 		lastAt: Date;
 	};
+	// An excluded run poisons its whole message group: deriving a partial tree
+	// from the group's completed runs would pair it against a turn whose
+	// assistant message does not exist yet — the misalignment excludeRunIds
+	// exists to prevent. The in-flight turn renders via the SSE bootstrap, not
+	// history.
+	const skipGroupKeys = new Set<string>();
+	for (const runId of skipRunIds) {
+		const groupId = runs.get(runId)?.messageGroupId;
+		if (groupId) skipGroupKeys.add(groupId);
+	}
 	const groups = new Map<string, Group>();
 	for (const [runId, run] of runs) {
-		if (skipRunIds.has(runId)) continue;
 		const key = run.messageGroupId ?? runId;
+		if (skipRunIds.has(runId) || skipGroupKeys.has(key)) continue;
 		let group = groups.get(key);
 		if (!group) {
 			group = { runIds: [], events: [], messageGroupId: run.messageGroupId, lastAt: run.lastAt };

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -736,19 +736,31 @@ export class InstanceAiController {
 
 		// Exclude snapshots for active/suspended runs — they have no matching
 		// assistant message in native memory yet and would misalign the
-		// positional snapshot-to-message matching in parseStoredMessages.
+		// positional snapshot-to-message matching in parseStoredMessages. The
+		// live message-group ids ride along so the durable-log fold can exclude
+		// a whole in-flight group even when the active run's own run-start row
+		// has not been persisted yet (it is the group mapping's source there).
 		const threadStatus = this.instanceAiService.getThreadStatus(threadId);
 		const activeRunId = this.instanceAiService.getActiveRunId(threadId);
 		const excludeRunIds: string[] = [];
-		if (activeRunId) excludeRunIds.push(activeRunId);
+		const excludeMessageGroupIds: string[] = [];
+		if (activeRunId) {
+			excludeRunIds.push(activeRunId);
+			const activeGroupId = this.instanceAiService.getMessageGroupId(threadId);
+			if (activeGroupId) excludeMessageGroupIds.push(activeGroupId);
+		}
 		for (const t of threadStatus.backgroundTasks) {
-			if (t.status === 'running' && t.runId) excludeRunIds.push(t.runId);
+			if (t.status !== 'running') continue;
+			if (t.runId) excludeRunIds.push(t.runId);
+			if (t.messageGroupId) excludeMessageGroupIds.push(t.messageGroupId);
 		}
 
 		const result = await this.memoryService.getRichMessages(req.user.id, threadId, {
 			limit: query.limit,
 			page: query.page,
 			excludeRunIds: excludeRunIds.length > 0 ? excludeRunIds : undefined,
+			excludeMessageGroupIds:
+				excludeMessageGroupIds.length > 0 ? excludeMessageGroupIds : undefined,
 		});
 
 		// Include the next SSE event ID so the frontend can skip past events

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-event-log.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-event-log.repository.ts
@@ -77,4 +77,17 @@ export class InstanceAiEventLogRepository extends Repository<InstanceAiEventLogE
 			.getMany();
 		return rows.map((r) => jsonParse<InstanceAiEvent>(r.payload));
 	}
+
+	/** Every fact of a thread in seq order, with the run and write-time context
+	 *  the fold-on-read history derivation needs. */
+	async getForThread(
+		threadId: string,
+	): Promise<Array<{ runId: string; createdAt: Date; event: InstanceAiEvent }>> {
+		const rows = await this.find({ where: { threadId }, order: { seq: 'ASC' } });
+		return rows.map((r) => ({
+			runId: r.runId,
+			createdAt: r.createdAt,
+			event: jsonParse<InstanceAiEvent>(r.payload),
+		}));
+	}
 }


### PR DESCRIPTION
## Summary

Fold-on-read history behind `N8N_INSTANCE_AI_DURABLE_LOG` (default **off**; flag-off is byte-for-byte today's behavior). Follows [#33984](https://github.com/n8n-io/n8n/pull/33984) / [#33910](https://github.com/n8n-io/n8n/pull/33910): the log is now written and replayed; this PR makes history **read** from it.

### Design

With the flag on, `getRichMessages` derives every agent tree from the durable log (`buildLogDerivedSnapshots`: runs grouped by `run-start` `messageGroupId`, entry `createdAt` = the run's last fact time so the parser's positional message pairing keeps working). Stored snapshot rows keep being **written** — they are the flag-off and rollback path — but are no longer read on the flag-on path. This kills the degenerate-agentTree bug class (INS-595 family): history no longer depends on a tree frozen from an evictable buffer, and a run that crashed before its snapshot was written still renders.

There is deliberately **no snapshot/log merge layer**: per team decision, the flag only flips in production together with a backfill migration for pre-existing threads (INS-851), so the migration-era hybrid state never ships. Two one-line fallbacks keep the flag safe to toggle on a dev instance: a thread with no log rows renders from its stored snapshots, and a failed or empty-yield log read falls back the same way. Lifecycle-only runs (nothing beyond `run-start`/`run-finish`) surface no orphan card, matching today's behavior.

Also in: `InstanceAiEventLogRepository.getForThread` (seq-ordered thread read) and fold instrumentation — `instance-ai-history-folded` event + `instance_ai_history_fold_duration_seconds` histogram, so the ticket's latency budget (p95 within 25ms at p99 thread size) is observable in production. The evaluation measured p50 6.4ms at 500 facts; per the ticket, the derive-on-read cache is deferred unless the budget is missed.

### Ticket done-when mapping

- Degenerate-snapshot threads render 3/3 tool calls vs 0/3 today: covered by the test 'supersedes a degenerate stored snapshot with the tree folded from the log'.
- Fold latency within budget: histogram added; measured baseline from the evaluation report.

## How to test

Flag off (default): `pnpm vitest run src/modules/instance-ai` in `packages/cli` — unchanged behavior, the log is never read.

Flag on: `N8N_INSTANCE_AI_DURABLE_LOG=true pnpm start`, run a chat turn, then delete its row from `instance_ai_run_snapshots` (or kill -9 mid-run so no snapshot is ever written) and reload the thread: the turn still renders fully, folded from `instance_ai_events`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-841

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.