### PR TITLE
refactor(core)!: Migrate node defaults.color to iconColor

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V1/AgentV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V1/AgentV1.node.ts
@@ -277,9 +277,9 @@ export class AgentV1 implements INodeType {
 		this.description = {
 			version: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9],
 			...baseDescription,
+			iconColor: 'black',
 			defaults: {
 				name: 'AI Agent',
-				color: '#404040',
 			},
 			inputs: `={{
 				((agent, hasOutputParser) => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentToolV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentToolV2.node.ts
@@ -20,9 +20,9 @@ export class AgentToolV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2.2],
+			iconColor: 'black',
 			defaults: {
 				name: 'AI Agent Tool',
-				color: '#404040',
 			},
 			inputs: `={{
 				((hasOutputParser, needsFallback) => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V2/AgentV2.node.ts
@@ -25,9 +25,9 @@ export class AgentV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2, 2.1, 2.2],
+			iconColor: 'black',
 			defaults: {
 				name: 'AI Agent',
-				color: '#404040',
 			},
 			inputs: `={{
 				((hasOutputParser, needsFallback) => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentToolV3.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentToolV3.node.ts
@@ -23,9 +23,9 @@ export class AgentToolV3 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [3],
+			iconColor: 'black',
 			defaults: {
 				name: 'AI Agent Tool',
-				color: '#404040',
 			},
 			inputs: `={{
 				((hasOutputParser, needsFallback) => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentV3.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/V3/AgentV3.node.ts
@@ -29,9 +29,9 @@ export class AgentV3 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [3, 3.1],
+			iconColor: 'black',
 			defaults: {
 				name: 'AI Agent',
-				color: '#404040',
 			},
 			inputs: `={{
 				((hasOutputParser, needsFallback) => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/OpenAiAssistant/OpenAiAssistant.node.ts
@@ -27,9 +27,9 @@ export class OpenAiAssistant implements INodeType {
 		version: [1, 1.1],
 		description: 'Utilizes Assistant API from Open AI.',
 		subtitle: 'Open AI Assistant',
+		iconColor: 'black',
 		defaults: {
 			name: 'OpenAI Assistant',
-			color: '#404040',
 		},
 		codex: {
 			alias: ['LangChain'],

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V1/ChainSummarizationV1.node.ts
@@ -23,9 +23,9 @@ export class ChainSummarizationV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'gray',
 			defaults: {
 				name: 'Summarization Chain',
-				color: '#909298',
 			},
 
 			inputs: [

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainSummarization/V2/ChainSummarizationV2.node.ts
@@ -57,9 +57,9 @@ export class ChainSummarizationV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2, 2.1],
+			iconColor: 'gray',
 			defaults: {
 				name: 'Summarization Chain',
-				color: '#909298',
 			},
 
 			inputs: `={{ ((parameter) => { ${getInputs.toString()}; return getInputs(parameter) })($parameter) }}`,

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryXata/MemoryXata.node.ts
@@ -30,8 +30,6 @@ export class MemoryXata implements INodeType {
 		description: 'Use Xata Memory',
 		defaults: {
 			name: 'Xata',
-			// eslint-disable-next-line n8n-nodes-base/node-class-description-non-core-color-present
-			color: '#1321A7',
 		},
 		codex: {
 			categories: ['AI'],

--- a/packages/@n8n/nodes-langchain/nodes/trigger/ManualChatTrigger/ManualChatTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/trigger/ManualChatTrigger/ManualChatTrigger.node.ts
@@ -17,9 +17,9 @@ export class ManualChatTrigger implements INodeType {
 		eventTriggerDescription: '',
 		maxNodes: 1,
 		hidden: true,
+		iconColor: 'gray',
 		defaults: {
 			name: 'When chat message received',
-			color: '#909298',
 		},
 		codex: {
 			categories: ['Core Nodes'],

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePineconeInsert/VectorStorePineconeInsert.node.ts
@@ -27,8 +27,6 @@ export class VectorStorePineconeInsert implements INodeType {
 		description: 'Insert data into Pinecone Vector Store index',
 		defaults: {
 			name: 'Pinecone: Insert',
-			// eslint-disable-next-line n8n-nodes-base/node-class-description-non-core-color-present
-			color: '#1321A7',
 		},
 		codex: {
 			categories: ['AI'],

--- a/packages/core/test/helpers/constants.ts
+++ b/packages/core/test/helpers/constants.ts
@@ -49,7 +49,6 @@ export const predefinedNodesTypes: INodeTypeData = {
 				description: 'Test tool executor',
 				defaults: {
 					name: 'Test Tool Executor',
-					color: '#0000FF',
 				},
 				inputs: [NodeConnectionTypes.AiTool, NodeConnectionTypes.Main],
 				outputs: [NodeConnectionTypes.Main],
@@ -69,7 +68,6 @@ export const predefinedNodesTypes: INodeTypeData = {
 				inputs: [],
 				defaults: {
 					name: 'Test Tool',
-					color: '#0000FF',
 				},
 				outputs: [NodeConnectionTypes.AiTool],
 				properties: [],
@@ -87,7 +85,6 @@ export const predefinedNodesTypes: INodeTypeData = {
 				description: 'Tests if versioning works',
 				defaults: {
 					name: 'Version Test',
-					color: '#0000FF',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				outputs: [NodeConnectionTypes.Main],
@@ -146,7 +143,6 @@ export const predefinedNodesTypes: INodeTypeData = {
 				description: 'Sets a value',
 				defaults: {
 					name: 'Set',
-					color: '#0000FF',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				outputs: [NodeConnectionTypes.Main],
@@ -178,7 +174,6 @@ export const predefinedNodesTypes: INodeTypeData = {
 				description: 'Sets multiple values',
 				defaults: {
 					name: 'Set Multi',
-					color: '#0000FF',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				outputs: [NodeConnectionTypes.Main],

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
@@ -319,7 +319,7 @@ const makeNodeType = (outputs: NodeConnectionType[], name: string) =>
 		inputs: [],
 		outputs,
 		properties: [],
-		defaults: { color: '', name: '' },
+		defaults: { name: '' },
 		group: [],
 		description: '',
 	}) as INodeTypeDescription;

--- a/packages/frontend/editor-ui/src/app/utils/nodeIcon.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeIcon.test.ts
@@ -256,6 +256,15 @@ describe('util: Node Icon', () => {
 			});
 		});
 
+		it('should not fall back to the legacy defaults.color when iconColor is absent', () => {
+			const result = getNodeIconSource(
+				{ icon: 'icon:user', defaults: { color: '#ff0000' } } as unknown as IconNodeType,
+				null,
+				null,
+			);
+			expect(result).toEqual({ type: 'icon', name: 'user' });
+		});
+
 		it('should include badge if available', () => {
 			const result = getNodeIconSource(
 				mock<IconNodeType>({ badgeIconUrl: 'images/badge.svg', name: undefined }),

--- a/packages/frontend/editor-ui/src/app/utils/nodeIcon.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeIcon.ts
@@ -106,8 +106,7 @@ const getNodeIconColor = (nodeType: IconNodeType): string | undefined => {
 	if ('iconColor' in nodeType && nodeType.iconColor) {
 		return `var(--node--icon--color--${nodeType.iconColor})`;
 	}
-	const defaultColor = nodeType?.defaults?.color;
-	return typeof defaultColor === 'string' ? defaultColor : undefined;
+	return undefined;
 };
 
 const prefixBaseUrl = (url: string): string => {

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.test.ts
@@ -30,7 +30,7 @@ const nodeType: INodeTypeDescription = {
 		},
 	],
 	properties: [],
-	defaults: { color: '', name: '' },
+	defaults: { name: '' },
 	group: [],
 	description: '',
 };
@@ -153,7 +153,7 @@ describe('NDVSubConnections', () => {
 			],
 			outputs: [NodeConnectionTypes.AiLanguageModel],
 			properties: [],
-			defaults: { color: '', name: '' },
+			defaults: { name: '' },
 			group: [],
 			description: '',
 		};

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.constants.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.test.constants.ts
@@ -90,7 +90,7 @@ export const EXECUTE_WORKFLOW_NODE_TYPE_TEST: INodeTypeDescription = {
 	version: [1, 1.1, 1.2],
 	subtitle: '={{"Workflow: " + $parameter["workflowId"]}}',
 	description: 'Execute another workflow',
-	defaults: { name: 'Execute Workflow', color: '#ff6d5a' },
+	defaults: { name: 'Execute Workflow' },
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],
 	properties: [

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/__tests__/utils.ts
@@ -30,9 +30,7 @@ export const mockSimplifiedNodeType = (
 		},
 		alias: ['alias1', 'alias2'],
 	},
-	defaults: {
-		color: '#ffffff',
-	},
+	defaults: {},
 	outputs: [],
 	...overrides,
 });
@@ -58,7 +56,7 @@ const mockSubcategoryItemProps = (
 	icon: 'smile',
 	title: 'Sample title',
 	subcategory: 'sampleSubcategory',
-	defaults: { color: '#ffffff' },
+	defaults: {},
 	forceIncludeNodes: ['node1', 'node2'],
 	...overrides,
 });

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -162,9 +162,9 @@ function getEvaluationNode(
 			...evaluationNode,
 			properties: {
 				...evaluationNode.properties,
+				iconColor: 'neutral',
 				defaults: {
 					name: 'Evaluation',
-					color: '#c3c9d5',
 				},
 			},
 		},
@@ -402,9 +402,9 @@ export function TriggerView() {
 					displayName: 'When running evaluation',
 					description: 'Run a dataset through your workflow to test performance',
 					icon: 'fa:check-double',
+					iconColor: 'neutral',
 					defaults: {
 						name: 'Evaluation',
-						color: '#c3c9d5',
 					},
 				},
 			}

--- a/packages/nodes-base/nodes/Cron/Cron.node.ts
+++ b/packages/nodes-base/nodes/Cron/Cron.node.ts
@@ -19,9 +19,9 @@ export class Cron implements INodeType {
 		eventTriggerDescription: '',
 		activationMessage:
 			'Your cron trigger will now trigger executions on the schedule you have defined.',
+		iconColor: 'emerald',
 		defaults: {
 			name: 'Cron',
-			color: '#29a568',
 		},
 
 		inputs: [],

--- a/packages/nodes-base/nodes/Crypto/v1/CryptoV1.node.ts
+++ b/packages/nodes-base/nodes/Crypto/v1/CryptoV1.node.ts
@@ -37,7 +37,6 @@ const versionDescription: INodeTypeDescription = {
 	description: 'Provide cryptographic utilities',
 	defaults: {
 		name: 'Crypto',
-		color: '#408000',
 	},
 	usableAsTool: true,
 	inputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Crypto/v2/CryptoV2.node.ts
+++ b/packages/nodes-base/nodes/Crypto/v2/CryptoV2.node.ts
@@ -78,7 +78,6 @@ const versionDescription: INodeTypeDescription = {
 	description: 'Provide cryptographic utilities',
 	defaults: {
 		name: 'Crypto',
-		color: '#408000',
 	},
 	usableAsTool: true,
 	inputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
+++ b/packages/nodes-base/nodes/DateTime/V1/DateTimeV1.node.ts
@@ -52,9 +52,9 @@ const versionDescription: INodeTypeDescription = {
 	version: 1,
 	description: 'Allows you to manipulate date and time values',
 	subtitle: '={{$parameter["action"]}}',
+	iconColor: 'green',
 	defaults: {
 		name: 'Date & Time',
-		color: '#408000',
 	},
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/DateTime/V2/DateTimeV2.node.ts
+++ b/packages/nodes-base/nodes/DateTime/V2/DateTimeV2.node.ts
@@ -25,9 +25,9 @@ export class DateTimeV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 2,
+			iconColor: 'green',
 			defaults: {
 				name: 'Date & Time',
-				color: '#408000',
 			},
 			usableAsTool: true,
 			inputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v1/EmailReadImapV1.node.ts
@@ -65,9 +65,9 @@ const versionDescription: INodeTypeDescription = {
 	version: 1,
 	description: 'Triggers the workflow when a new email is received',
 	eventTriggerDescription: 'Waiting for you to receive an email',
+	iconColor: 'green',
 	defaults: {
 		name: 'Email Trigger (IMAP)',
-		color: '#44AA22',
 	},
 	triggerPanel: {
 		header: '',

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -40,7 +40,6 @@ const versionDescription: INodeTypeDescription = {
 	eventTriggerDescription: 'Waiting for you to receive an email',
 	defaults: {
 		name: 'Email Trigger (IMAP)',
-		color: '#44AA22',
 	},
 	triggerPanel: {
 		header: '',

--- a/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/Evaluation/Evaluation.node.ee.ts
@@ -35,9 +35,9 @@ export class Evaluation implements INodeType {
 		description: 'Runs an evaluation',
 		eventTriggerDescription: '',
 		subtitle: '={{$parameter["operation"]}}',
+		iconColor: 'neutral',
 		defaults: {
 			name: 'Evaluation',
-			color: '#c3c9d5',
 		},
 		// Pass function explicitly since expression context doesn't allow imports in getInputConnectionTypes
 		inputs: `={{(${getInputConnectionTypes})($parameter, ${metricRequiresModelConnection})}}`,

--- a/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
+++ b/packages/nodes-base/nodes/Evaluation/EvaluationTrigger/EvaluationTrigger.node.ee.ts
@@ -39,9 +39,9 @@ export class EvaluationTrigger implements INodeType {
 		version: [4.6, 4.7],
 		description: 'Run a test dataset through your workflow to check performance',
 		eventTriggerDescription: '',
+		iconColor: 'neutral',
 		defaults: {
 			name: 'When fetching a dataset row',
-			color: '#c3c9d5',
 		},
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
+++ b/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
@@ -18,9 +18,9 @@ export class FilterV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'sky-blue',
 			defaults: {
 				name: 'Filter',
-				color: '#229eff',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
+++ b/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
@@ -21,9 +21,9 @@ export class FilterV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2, 2.1, 2.2, 2.3],
+			iconColor: 'sky-blue',
 			defaults: {
 				name: 'Filter',
-				color: '#229eff',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Function/Function.node.ts
+++ b/packages/nodes-base/nodes/Function/Function.node.ts
@@ -22,9 +22,9 @@ export class Function implements INodeType {
 		version: 1,
 		description:
 			'Run custom function code which gets executed once and allows you to add, remove, change and replace items',
+		iconColor: 'amber',
 		defaults: {
 			name: 'Function',
-			color: '#FF9922',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
+++ b/packages/nodes-base/nodes/FunctionItem/FunctionItem.node.ts
@@ -21,9 +21,9 @@ export class FunctionItem implements INodeType {
 		group: ['transform'],
 		version: 1,
 		description: 'Run custom function code which gets executed once per item',
+		iconColor: 'amber',
 		defaults: {
 			name: 'Function Item',
-			color: '#ddbb33',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/HtmlExtract/HtmlExtract.node.ts
+++ b/packages/nodes-base/nodes/HtmlExtract/HtmlExtract.node.ts
@@ -57,9 +57,9 @@ export class HtmlExtract implements INodeType {
 		hidden: true,
 		subtitle: '={{$parameter["sourceData"] + ": " + $parameter["dataPropertyName"]}}',
 		description: 'Extracts data from HTML',
+		iconColor: 'dark-blue',
 		defaults: {
 			name: 'HTML Extract',
-			color: '#333377',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V1/HttpRequestV1.node.ts
@@ -43,9 +43,9 @@ export class HttpRequestV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'blue',
 			defaults: {
 				name: 'HTTP Request',
-				color: '#2200DD',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V2/HttpRequestV2.node.ts
@@ -44,9 +44,9 @@ export class HttpRequestV2 implements INodeType {
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
+			iconColor: 'blue',
 			defaults: {
 				name: 'HTTP Request',
-				color: '#2200DD',
 			},
 			version: 2,
 			inputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -73,9 +73,9 @@ export class HttpRequestV3 implements INodeType {
 			...baseDescription,
 			subtitle: '={{$parameter["method"] + ": " + $parameter["url"]}}',
 			version: [3, 4, 4.1, 4.2, 4.3, 4.4],
+			iconColor: 'blue',
 			defaults: {
 				name: 'HTTP Request',
-				color: '#0004F5',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
+++ b/packages/nodes-base/nodes/ICalendar/ICalendar.node.ts
@@ -19,9 +19,9 @@ export class ICalendar implements INodeType {
 		version: 1,
 		subtitle: '={{$parameter["operation"]}}',
 		description: 'Create iCalendar file',
+		iconColor: 'green',
 		defaults: {
 			name: 'iCalendar',
-			color: '#408000',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/If/V1/IfV1.node.ts
+++ b/packages/nodes-base/nodes/If/V1/IfV1.node.ts
@@ -17,9 +17,9 @@ export class IfV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'green',
 			defaults: {
 				name: 'If',
-				color: '#408000',
 			},
 			inputs: [NodeConnectionTypes.Main],
 

--- a/packages/nodes-base/nodes/If/V2/IfV2.node.ts
+++ b/packages/nodes-base/nodes/If/V2/IfV2.node.ts
@@ -21,9 +21,9 @@ export class IfV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2, 2.1, 2.2, 2.3],
+			iconColor: 'green',
 			defaults: {
 				name: 'If',
-				color: '#408000',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main, NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Interval/Interval.node.ts
+++ b/packages/nodes-base/nodes/Interval/Interval.node.ts
@@ -18,9 +18,9 @@ export class Interval implements INodeType {
 		eventTriggerDescription: '',
 		activationMessage:
 			'Your interval trigger will now trigger executions on the schedule you have defined.',
+		iconColor: 'lime',
 		defaults: {
 			name: 'Interval',
-			color: '#00FF00',
 		},
 
 		inputs: [],

--- a/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
+++ b/packages/nodes-base/nodes/Merge/v1/MergeV1.node.ts
@@ -21,9 +21,9 @@ export class MergeV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'teal',
 			defaults: {
 				name: 'Merge',
-				color: '#00bbcc',
 			},
 
 			inputs: [NodeConnectionTypes.Main, NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/MoveBinaryData/MoveBinaryData.node.ts
+++ b/packages/nodes-base/nodes/MoveBinaryData/MoveBinaryData.node.ts
@@ -54,9 +54,9 @@ export class MoveBinaryData implements INodeType {
 		version: [1, 1.1],
 		subtitle: '={{$parameter["mode"]==="binaryToJson" ? "Binary to JSON" : "JSON to Binary"}}',
 		description: 'Move data between binary and JSON properties',
+		iconColor: 'purple',
 		defaults: {
 			name: 'Convert to/from binary data',
-			color: '#7722CC',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFile/ReadBinaryFile.node.ts
@@ -15,9 +15,9 @@ export class ReadBinaryFile implements INodeType {
 		version: 1,
 		hidden: true,
 		description: 'Reads a binary file from disk',
+		iconColor: 'forest-green',
 		defaults: {
 			name: 'Read Binary File',
-			color: '#449922',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
+++ b/packages/nodes-base/nodes/ReadBinaryFiles/ReadBinaryFiles.node.ts
@@ -18,9 +18,9 @@ export class ReadBinaryFiles implements INodeType {
 		group: ['input'],
 		version: 1,
 		description: 'Reads binary files from disk',
+		iconColor: 'forest-green',
 		defaults: {
 			name: 'Read Binary Files',
-			color: '#44AA44',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/ReadPdf/ReadPDF.node.ts
+++ b/packages/nodes-base/nodes/ReadPdf/ReadPDF.node.ts
@@ -19,9 +19,9 @@ export class ReadPDF implements INodeType {
 		group: ['input'],
 		version: 1,
 		description: 'Reads a PDF and extracts its content',
+		iconColor: 'dark-blue',
 		defaults: {
 			name: 'Read PDF',
-			color: '#003355',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Set/v1/SetV1.node.ts
+++ b/packages/nodes-base/nodes/Set/v1/SetV1.node.ts
@@ -16,9 +16,9 @@ const versionDescription: INodeTypeDescription = {
 	group: ['input'],
 	version: [1, 2],
 	description: 'Sets values on items and optionally remove other values',
+	iconColor: 'blue',
 	defaults: {
 		name: 'Set',
-		color: '#0000FF',
 	},
 	inputs: [NodeConnectionTypes.Main],
 	outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Simulate/Simulate.node.ts
+++ b/packages/nodes-base/nodes/Simulate/Simulate.node.ts
@@ -25,9 +25,9 @@ export class Simulate implements INodeType {
 		description: 'Simulate a node',
 		subtitle: '={{$parameter.subtitle || undefined}}',
 		icon: 'fa:arrow-right',
+		iconColor: 'neutral',
 		defaults: {
 			name: 'Simulate',
-			color: '#b0b0b0',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/Simulate/SimulateTrigger.node.ts
+++ b/packages/nodes-base/nodes/Simulate/SimulateTrigger.node.ts
@@ -26,9 +26,9 @@ export class SimulateTrigger implements INodeType {
 		group: ['trigger'],
 		version: 1,
 		description: 'Simulate a trigger node',
+		iconColor: 'neutral',
 		defaults: {
 			name: 'Simulate Trigger',
-			color: '#b0b0b0',
 		},
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v1/SplitInBatchesV1.node.ts
@@ -15,9 +15,9 @@ export class SplitInBatchesV1 implements INodeType {
 		group: ['organization'],
 		version: 1,
 		description: 'Split data into batches and iterate over each batch',
+		iconColor: 'dark-green',
 		defaults: {
 			name: 'Split In Batches',
-			color: '#007755',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
+++ b/packages/nodes-base/nodes/SplitInBatches/v2/SplitInBatchesV2.node.ts
@@ -15,9 +15,9 @@ export class SplitInBatchesV2 implements INodeType {
 		group: ['organization'],
 		version: 2,
 		description: 'Split data into batches and iterate over each batch',
+		iconColor: 'dark-green',
 		defaults: {
 			name: 'Split In Batches',
-			color: '#007755',
 		},
 		inputs: [NodeConnectionTypes.Main],
 

--- a/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v1/SpreadsheetFileV1.node.ts
@@ -38,9 +38,9 @@ export class SpreadsheetFileV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 1,
+			iconColor: 'blue',
 			defaults: {
 				name: 'Spreadsheet File',
-				color: '#2244FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/SpreadsheetFileV2.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/SpreadsheetFileV2.node.ts
@@ -18,9 +18,9 @@ export class SpreadsheetFileV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 2,
+			iconColor: 'blue',
 			defaults: {
 				name: 'Spreadsheet File',
-				color: '#2244FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
+++ b/packages/nodes-base/nodes/StickyNote/StickyNote.node.ts
@@ -13,9 +13,9 @@ export class StickyNote implements INodeType {
 		group: ['input'],
 		version: 1,
 		description: 'Make your workflow easier to understand',
+		iconColor: 'amber',
 		defaults: {
 			name: 'Sticky Note',
-			color: '#FFD233',
 		},
 
 		inputs: [],

--- a/packages/nodes-base/nodes/Switch/V1/SwitchV1.node.ts
+++ b/packages/nodes-base/nodes/Switch/V1/SwitchV1.node.ts
@@ -16,9 +16,9 @@ export class SwitchV1 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [1],
+			iconColor: 'green',
 			defaults: {
 				name: 'Switch',
-				color: '#506000',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [

--- a/packages/nodes-base/nodes/Switch/V2/SwitchV2.node.ts
+++ b/packages/nodes-base/nodes/Switch/V2/SwitchV2.node.ts
@@ -18,9 +18,9 @@ export class SwitchV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: [2],
+			iconColor: 'green',
 			defaults: {
 				name: 'Switch',
-				color: '#506000',
 			},
 			inputs: [NodeConnectionTypes.Main],
 

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -53,9 +53,9 @@ export class SwitchV3 implements INodeType {
 			...baseDescription,
 			subtitle: `=mode: {{(${capitalize})($parameter["mode"])}}`,
 			version: [3, 3.1, 3.2, 3.3, 3.4],
+			iconColor: 'green',
 			defaults: {
 				name: 'Switch',
-				color: '#506000',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: `={{(${configuredOutputs})($parameter)}}`,

--- a/packages/nodes-base/nodes/WorkflowTrigger/WorkflowTrigger.node.ts
+++ b/packages/nodes-base/nodes/WorkflowTrigger/WorkflowTrigger.node.ts
@@ -24,7 +24,6 @@ export class WorkflowTrigger implements INodeType {
 		activationMessage: 'Your workflow will now trigger executions on the event you have defined.',
 		defaults: {
 			name: 'Workflow Trigger',
-			color: '#ff6d5a',
 		},
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
+++ b/packages/nodes-base/nodes/WriteBinaryFile/WriteBinaryFile.node.ts
@@ -17,9 +17,9 @@ export class WriteBinaryFile implements INodeType {
 		group: ['output'],
 		version: 1,
 		description: 'Writes a binary file to disk',
+		iconColor: 'red',
 		defaults: {
 			name: 'Write Binary File',
-			color: '#CC2233',
 		},
 		inputs: [NodeConnectionTypes.Main],
 		outputs: [NodeConnectionTypes.Main],

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2739,10 +2739,6 @@ export interface INodeOutputConfiguration {
 export type ExpressionString = `={{${string}}}`;
 
 export type NodeDefaults = Partial<{
-	/**
-	 * @deprecated Use {@link INodeTypeBaseDescription.iconColor|iconColor} instead. `iconColor` supports dark mode and uses preset colors from n8n's design system.
-	 */
-	color: string;
 	name: string;
 }>;
 

--- a/packages/workflow/test/node-helpers.test.ts
+++ b/packages/workflow/test/node-helpers.test.ts
@@ -6387,7 +6387,6 @@ describe('NodeHelpers', () => {
 				version: 0,
 				defaults: {
 					name: '',
-					color: '',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				properties: [],
@@ -6407,7 +6406,6 @@ describe('NodeHelpers', () => {
 				version: 0,
 				defaults: {
 					name: '',
-					color: '',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				properties: [],
@@ -6427,7 +6425,6 @@ describe('NodeHelpers', () => {
 				version: 0,
 				defaults: {
 					name: '',
-					color: '',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				properties: [],
@@ -6447,7 +6444,6 @@ describe('NodeHelpers', () => {
 				version: 0,
 				defaults: {
 					name: '',
-					color: '',
 				},
 				inputs: [NodeConnectionTypes.Main],
 				properties: [],

--- a/packages/workflow/test/node-types.ts
+++ b/packages/workflow/test/node-types.ts
@@ -20,7 +20,7 @@ const stickyNode: LoadedClass<INodeType> = {
 			group: ['input'],
 			version: 1,
 			description: 'Make your workflow easier to understand',
-			defaults: { name: 'Sticky Note', color: '#FFD233' },
+			defaults: { name: 'Sticky Note' },
 			inputs: [],
 			outputs: [],
 			properties: [
@@ -551,7 +551,6 @@ const setNode: LoadedClass<INodeType> = {
 			description: 'Sets a value',
 			defaults: {
 				name: 'Set',
-				color: '#0000FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
@@ -584,7 +583,6 @@ const codeNode: LoadedClass<INodeType> = {
 			description: 'Code node',
 			defaults: {
 				name: 'Code',
-				color: '#0000FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
@@ -611,7 +609,6 @@ const htmlNode: LoadedClass<INodeType> = {
 			description: 'HTML node',
 			defaults: {
 				name: 'HTML',
-				color: '#0000FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
@@ -638,7 +635,6 @@ const formNode: LoadedClass<INodeType> = {
 			description: 'Form node',
 			defaults: {
 				name: 'Form',
-				color: '#0000FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
@@ -910,7 +906,6 @@ const manualTriggerNode: LoadedClass<INodeType> = {
 			maxNodes: 1,
 			defaults: {
 				name: 'When clicking ‘Execute workflow’',
-				color: '#909298',
 			},
 			inputs: [],
 			outputs: [NodeConnectionTypes.Main],
@@ -938,7 +933,7 @@ const executeWorkflowNode: LoadedClass<INodeType> = {
 			version: [1, 1.1, 1.2],
 			subtitle: '={{"Workflow: " + $parameter["workflowId"]}}',
 			description: 'Execute another workflow',
-			defaults: { name: 'Execute Workflow', color: '#ff6d5a' },
+			defaults: { name: 'Execute Workflow' },
 			inputs: [],
 			outputs: [],
 			properties: [
@@ -1164,7 +1159,6 @@ const aiAgentNode: LoadedClass<INodeType> = {
 			description: 'Generates an action plan and executes it. Can use external tools.',
 			defaults: {
 				name: 'AI Agent',
-				color: '#404040',
 			},
 			inputs: [
 				NodeConnectionTypes.Main,
@@ -1345,7 +1339,6 @@ export class NodeTypes implements INodeTypes {
 					description: 'Sets multiple values',
 					defaults: {
 						name: 'Set Multi',
-						color: '#0000FF',
 					},
 					inputs: [NodeConnectionTypes.Main],
 					outputs: [NodeConnectionTypes.Main],


### PR DESCRIPTION
## Summary

Migrates all built-in nodes from the legacy `defaults.color` (a raw hex canvas color, e.g. `color: '#29a568'`) to `iconColor`, and removes support for the legacy field in v3.

`iconColor` uses a fixed set of named design-system colors (e.g. `iconColor: 'amber'`) that are **theme-aware** (proper dark-mode rendering), unlike the old raw hex. `defaults.color` was already `@deprecated`.

**This is a breaking change** and targets `3.x`.

What changed:
- **49 built-in nodes** migrated to `iconColor` (nearest design-system color to their old hex; anchored to existing `iconColor` picks for shared hexes).
- **`defaults.color` fully removed**: the `NodeDefaults.color` type field (`packages/workflow`) **and** the runtime read-path/fallback in `getNodeIconColor` (`packages/frontend/editor-ui`).
- **2 SVG-icon nodes** (MemoryXata, Pinecone Insert) drop the legacy field without adding `iconColor` — their `file:*.svg` icons are never tinted, so the field was dead.
- `node-dev` scaffolding templates + README and test fixtures updated off `defaults.color`.

<img width="813" height="563" alt="Bildschirmfoto 2026-07-14 um 18 58 38" src="https://github.com/user-attachments/assets/7404ae36-54fa-42a4-b43f-6e9e09f4d8e1" />


Impact on community nodes: a node still using `defaults.color` with no `iconColor` keeps working but renders its icon in the default (neutral) color until it migrates to `iconColor` (or, as is already common, an SVG icon). Authors building against the new types get a compile-time nudge (the type field is gone).

## How to test

Importable workflow containing one of every affected node type (each labelled with its `#hex → iconColor` mapping): 
[defaults.color → iconColor migration preview.json](https://github.com/user-attachments/files/30017388/defaults.color.iconColor.migration.preview.json)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5413

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

