### PR TITLE
fix(editor): Show only the latest node as executing during manual executions

### DIFF
--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -60,12 +60,17 @@ export type NodeExecuteBefore = {
 		executionId: string;
 		nodeName: string;
 		/**
-		 * Monotonic counter shared across all `nodeExecuteBefore` and
-		 * `nodeExecuteAfter` events of a single execution, assigned in engine order
-		 * by the instance running the workflow. Lets the UI order node events that
-		 * arrive late or out of order (e.g. after a suspended background tab
-		 * resumes) and render only the latest node as executing. Unique per event;
-		 * starts at 0.
+		 * Monotonic counter over this execution *segment*'s `nodeExecuteBefore` and
+		 * `nodeExecuteAfter` events, assigned in engine order by the instance
+		 * running the workflow. Lets the UI order node events that arrive late or
+		 * out of order (e.g. after a suspended background tab resumes) and render
+		 * only the latest node as executing.
+		 *
+		 * Scoped to a segment, not the whole execution: the counter restarts at 0
+		 * for each run, including when a waiting execution (Wait/Form node) resumes
+		 * — resuming rebuilds the push hooks with a fresh counter. Only compare
+		 * sequence numbers within a segment; ordering does not carry across a resume
+		 * boundary. Unique per event within a segment; starts at 0.
 		 */
 		sequenceNumber: number;
 		data: ITaskStartedData;
@@ -81,7 +86,7 @@ export type NodeExecuteAfter = {
 	data: {
 		executionId: string;
 		nodeName: string;
-		/** Per-execution monotonic counter — see {@link NodeExecuteBefore}. */
+		/** Per-segment monotonic counter — see {@link NodeExecuteBefore}. */
 		sequenceNumber: number;
 		/**
 		 * The data field for task data in `NodeExecuteAfter` is always trimmed (undefined).

--- a/packages/@n8n/api-types/src/push/execution.ts
+++ b/packages/@n8n/api-types/src/push/execution.ts
@@ -59,6 +59,15 @@ export type NodeExecuteBefore = {
 	data: {
 		executionId: string;
 		nodeName: string;
+		/**
+		 * Monotonic counter shared across all `nodeExecuteBefore` and
+		 * `nodeExecuteAfter` events of a single execution, assigned in engine order
+		 * by the instance running the workflow. Lets the UI order node events that
+		 * arrive late or out of order (e.g. after a suspended background tab
+		 * resumes) and render only the latest node as executing. Unique per event;
+		 * starts at 0.
+		 */
+		sequenceNumber: number;
 		data: ITaskStartedData;
 	};
 };
@@ -72,6 +81,8 @@ export type NodeExecuteAfter = {
 	data: {
 		executionId: string;
 		nodeName: string;
+		/** Per-execution monotonic counter — see {@link NodeExecuteBefore}. */
+		sequenceNumber: number;
 		/**
 		 * The data field for task data in `NodeExecuteAfter` is always trimmed (undefined).
 		 */

--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -1,3 +1,4 @@
+import type { PushMessage } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { Project, User } from '@n8n/db';
@@ -545,9 +546,38 @@ describe('Execution Lifecycle Hooks', () => {
 				await lifecycleHooks.runHook('nodeExecuteBefore', [nodeName, taskStartedData]);
 
 				expect(push.send).toHaveBeenCalledWith(
-					{ type: 'nodeExecuteBefore', data: { executionId, nodeName, data: taskStartedData } },
+					{
+						type: 'nodeExecuteBefore',
+						data: { executionId, nodeName, sequenceNumber: 0, data: taskStartedData },
+					},
 					pushRef,
 				);
+			});
+		});
+
+		describe('node event sequencing', () => {
+			it('assigns a strictly increasing sequence number across the whole execution', async () => {
+				const secondNode = 'Second Node';
+
+				// Two nodes run start-to-finish on a single execution's hooks.
+				await lifecycleHooks.runHook('nodeExecuteBefore', [nodeName, taskStartedData]);
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+				await lifecycleHooks.runHook('nodeExecuteBefore', [secondNode, taskStartedData]);
+				await lifecycleHooks.runHook('nodeExecuteAfter', [secondNode, taskData, runExecutionData]);
+
+				const isNodeEvent = (
+					message: PushMessage,
+				): message is Extract<PushMessage, { type: 'nodeExecuteBefore' | 'nodeExecuteAfter' }> =>
+					message.type === 'nodeExecuteBefore' || message.type === 'nodeExecuteAfter';
+
+				const sequenceNumbers = push.send.mock.calls
+					.map(([message]) => message)
+					.filter(isNodeEvent)
+					.map((message) => message.data.sequenceNumber);
+
+				// One counter for the whole execution, spanning both node boundaries
+				// and both event kinds: before(A) < after(A) < before(B) < after(B).
+				expect(sequenceNumbers).toEqual([0, 1, 2, 3]);
 			});
 		});
 
@@ -591,6 +621,7 @@ describe('Execution Lifecycle Hooks', () => {
 						data: {
 							executionId,
 							nodeName,
+							sequenceNumber: 0,
 							itemCountByConnectionType: {
 								main: [1],
 							},

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -280,6 +280,13 @@ function hookFunctionsPush(
 		return resolvedUser;
 	}
 
+	// Monotonic counter shared by this execution's node-event pushes so the UI can
+	// order events that arrive late or out of order (e.g. after a suspended
+	// background tab resumes) and render only the latest node as executing
+	// (CAT-2895). Assigned in engine order here on the instance running the
+	// workflow; it rides the worker→main pubsub relay unchanged.
+	let nodeEventSequence = 0;
+
 	hooks.addHandler('nodeExecuteBefore', function (nodeName, data) {
 		const { executionId } = this;
 		// Push data to session which started workflow before each
@@ -291,7 +298,10 @@ function hookFunctionsPush(
 		});
 
 		pushInstance.send(
-			{ type: 'nodeExecuteBefore', data: { executionId, nodeName, data } },
+			{
+				type: 'nodeExecuteBefore',
+				data: { executionId, nodeName, sequenceNumber: nodeEventSequence++, data },
+			},
 			pushRef,
 		);
 	});
@@ -310,7 +320,13 @@ function hookFunctionsPush(
 		pushInstance.send(
 			{
 				type: 'nodeExecuteAfter',
-				data: { executionId, nodeName, itemCountByConnectionType, data: taskData },
+				data: {
+					executionId,
+					nodeName,
+					sequenceNumber: nodeEventSequence++,
+					itemCountByConnectionType,
+					data: taskData,
+				},
 			},
 			pushRef,
 		);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -280,11 +280,13 @@ function hookFunctionsPush(
 		return resolvedUser;
 	}
 
-	// Monotonic counter shared by this execution's node-event pushes so the UI can
-	// order events that arrive late or out of order (e.g. after a suspended
+	// Monotonic counter over this execution segment's node-event pushes so the UI
+	// can order events that arrive late or out of order (e.g. after a suspended
 	// background tab resumes) and render only the latest node as executing
 	// (CAT-2895). Assigned in engine order here on the instance running the
-	// workflow; it rides the worker→main pubsub relay unchanged.
+	// workflow; it rides the worker→main pubsub relay unchanged. Scoped to a
+	// segment: this closure is per run, so a waiting-execution (Wait/Form node)
+	// resume rebuilds the hooks and restarts the counter at 0.
 	let nodeEventSequence = 0;
 
 	hooks.addHandler('nodeExecuteBefore', function (nodeName, data) {

--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.test.ts
@@ -6,51 +6,107 @@ describe('useExecutingNode composable', () => {
 		expect(executingNode.value).toEqual([]);
 	});
 
-	it('should add a node to the executing queue', () => {
-		const { executingNode, addExecutingNode } = useExecutingNode();
-		addExecutingNode('node1');
+	it('should show a node once it starts executing', () => {
+		const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode();
+		addExecutingNode('node1', 0);
 		expect(executingNode.value).toEqual(['node1']);
-	});
-
-	it('should remove an executing node from the queue (removes one occurrence at a time)', () => {
-		const { executingNode, addExecutingNode, removeExecutingNode } = useExecutingNode();
-
-		// Add nodes, including duplicates.
-		addExecutingNode('node1');
-		addExecutingNode('node2');
-		addExecutingNode('node1');
-
-		// After removal, only the first occurrence of "node1" should be removed.
-		removeExecutingNode('node1');
-		expect(executingNode.value).toEqual(['node2', 'node1']);
-	});
-
-	it('should not remove a node that does not exist', () => {
-		const { executingNode, removeExecutingNode } = useExecutingNode();
-
-		// Manually set the state for testing.
-		executingNode.value = ['node1'];
-		removeExecutingNode('node2'); // Trying to remove a non-existent node.
-		expect(executingNode.value).toEqual(['node1']);
-	});
-
-	it('should return true if a node is executing', () => {
-		const { addExecutingNode, isNodeExecuting } = useExecutingNode();
-		addExecutingNode('node1');
 		expect(isNodeExecuting('node1')).toBe(true);
 	});
 
-	it('should return false if a node is not executing', () => {
+	it('should return false for a node that is not executing', () => {
 		const { isNodeExecuting } = useExecutingNode();
 		expect(isNodeExecuting('node1')).toBe(false);
 	});
 
-	it('should clear the node execution queue', () => {
-		const { executingNode, addExecutingNode, clearNodeExecutionQueue } = useExecutingNode();
-		addExecutingNode('node1');
-		addExecutingNode('node2');
-		expect(executingNode.value).toEqual(['node1', 'node2']);
-		clearNodeExecutionQueue();
-		expect(executingNode.value).toEqual([]);
+	describe('only the latest node executes', () => {
+		it('supersedes the current node when a higher sequence number arrives', () => {
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode();
+
+			addExecutingNode('nodeA', 0);
+			addExecutingNode('nodeB', 2);
+
+			expect(executingNode.value).toEqual(['nodeB']);
+			expect(isNodeExecuting('nodeA')).toBe(false);
+			expect(isNodeExecuting('nodeB')).toBe(true);
+		});
+
+		it('ignores a stale / out-of-order event with a lower sequence number', () => {
+			const { executingNode, addExecutingNode, isNodeExecuting } = useExecutingNode();
+
+			// nodeB (seq 2) is executing; a late nodeA event (seq 1) resurfaces after
+			// a suspended tab resumes — it must not overwrite the current node.
+			addExecutingNode('nodeB', 2);
+			addExecutingNode('nodeA', 1);
+
+			expect(executingNode.value).toEqual(['nodeB']);
+			expect(isNodeExecuting('nodeA')).toBe(false);
+			expect(isNodeExecuting('nodeB')).toBe(true);
+		});
+	});
+
+	describe('clearing', () => {
+		it("clears when the shown node's own nodeExecuteAfter arrives", () => {
+			const { executingNode, addExecutingNode, removeExecutingNode, isNodeExecuting } =
+				useExecutingNode();
+
+			addExecutingNode('nodeA', 0);
+			removeExecutingNode('nodeA');
+
+			expect(executingNode.value).toEqual([]);
+			expect(isNodeExecuting('nodeA')).toBe(false);
+		});
+
+		it('ignores a nodeExecuteAfter for a node that is not the one shown', () => {
+			const { executingNode, addExecutingNode, removeExecutingNode, isNodeExecuting } =
+				useExecutingNode();
+
+			// nodeB superseded nodeA; a late after(nodeA) must not clear nodeB's spinner.
+			addExecutingNode('nodeB', 2);
+			removeExecutingNode('nodeA');
+
+			expect(executingNode.value).toEqual(['nodeB']);
+			expect(isNodeExecuting('nodeB')).toBe(true);
+		});
+
+		it('clears the queue and resets the sequence baseline', () => {
+			const { executingNode, addExecutingNode, clearNodeExecutionQueue, lastAddedExecutingNode } =
+				useExecutingNode();
+
+			addExecutingNode('nodeA', 5);
+			clearNodeExecutionQueue();
+
+			expect(executingNode.value).toEqual([]);
+			expect(lastAddedExecutingNode.value).toBeNull();
+
+			// After a clear the baseline is reset, so the next run's first event (seq 0)
+			// is accepted even though 0 is not greater than the previous sequence.
+			addExecutingNode('nodeB', 0);
+			expect(executingNode.value).toEqual(['nodeB']);
+		});
+	});
+
+	describe('per-run counter reset', () => {
+		it('shows the next node when the counter restarts at 0 (e.g. wait-node resume)', () => {
+			const { executingNode, addExecutingNode, removeExecutingNode, isNodeExecuting } =
+				useExecutingNode();
+
+			// A run reaches a wait node, which finishes and clears the spinner.
+			addExecutingNode('Wait', 0);
+			removeExecutingNode('Wait');
+			expect(executingNode.value).toEqual([]);
+
+			// On resume the per-execution counter restarts at 0. Because nothing is
+			// shown, the resumed node is accepted despite the low sequence number.
+			addExecutingNode('AfterWait', 0);
+			expect(isNodeExecuting('AfterWait')).toBe(true);
+			expect(executingNode.value).toEqual(['AfterWait']);
+		});
+	});
+
+	it('tracks the last node that started executing', () => {
+		const { lastAddedExecutingNode, addExecutingNode } = useExecutingNode();
+		addExecutingNode('nodeA', 0);
+		addExecutingNode('nodeB', 1);
+		expect(lastAddedExecutingNode.value).toBe('nodeB');
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExecutingNode.ts
@@ -1,38 +1,51 @@
 import { ref } from 'vue';
 
 /**
- * Composable to keep track of the currently executing node.
- * The queue is used to keep track of the order in which nodes are executed and to ensure that
- * the UI reflects the correct execution status.
+ * Tracks the single node rendered as executing (the per-node loading spinner).
  *
- * Once a node is added to the queue, it will be removed after a short delay
- * to allow the running spinner to show for a small amount of time.
+ * Only the latest node executes at a time (CAT-2895): each `nodeExecuteBefore`
+ * carries a `sequenceNumber` — a per-execution monotonic counter assigned in
+ * engine order — and we show the node of the highest one seen, clearing it on
+ * its own `nodeExecuteAfter`. Events that arrive late or out of order (e.g.
+ * after a suspended background tab resumes) carry a lower number and are
+ * ignored, so a stale node can never overwrite the current one or leave several
+ * spinners running at once.
  *
- * The number of additions and removals from the queue should always be equal.
- * A node can exist multiple times in the queue, in order to prevent the loading spinner from
- * disappearing when a node is executed multiple times in quick succession.
+ * `executingNode` stays an array for its consumers' sake, but now holds at most
+ * one entry. The counter restarts at 0 per run — and mid-run on a wait-node
+ * resume — so a fresh event is also accepted whenever nothing is currently
+ * shown, not only when it beats the last sequence number.
  */
 export function useExecutingNode() {
 	const executingNode = ref<string[]>([]);
 	const lastAddedExecutingNode = ref<string | null>(null);
+	// Sequence number of the node currently shown; -1 when nothing is shown.
+	let latestSequenceNumber = -1;
 
-	function addExecutingNode(nodeName: string) {
-		executingNode.value.push(nodeName);
+	function addExecutingNode(nodeName: string, sequenceNumber: number) {
+		// Ignore an event older than the one currently shown (a late/out-of-order
+		// delivery). When nothing is shown, accept it regardless — a new run, a
+		// wait-node resume, or the first node all restart the counter at 0.
+		if (executingNode.value.length > 0 && sequenceNumber <= latestSequenceNumber) {
+			return;
+		}
+		executingNode.value = [nodeName];
 		lastAddedExecutingNode.value = nodeName;
+		latestSequenceNumber = sequenceNumber;
 	}
 
 	function removeExecutingNode(nodeName: string) {
-		const executionIndex = executingNode.value.indexOf(nodeName);
-		if (executionIndex === -1) {
-			return;
+		// Identity-guarded: only clear when the node finishing is the one shown, so
+		// a late/reordered `nodeExecuteAfter` for a superseded node is a no-op.
+		if (executingNode.value[0] === nodeName) {
+			executingNode.value = [];
 		}
-
-		executingNode.value.splice(executionIndex, 1);
 	}
 
 	function clearNodeExecutionQueue() {
 		executingNode.value = [];
 		lastAddedExecutingNode.value = null;
+		latestSequenceNumber = -1;
 	}
 
 	function isNodeExecuting(nodeName: string): boolean {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -23,7 +23,10 @@ vi.mock('@/features/execution/executions/executions.utils', async (importOrigina
 	return { ...actual, openFormPopupWindow: vi.fn() };
 });
 
+vi.mock('./trackNodeExecution', () => ({ trackNodeExecution: vi.fn() }));
+
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
+import { trackNodeExecution } from './trackNodeExecution';
 
 describe('nodeExecuteAfter', () => {
 	const documentId = createWorkflowDocumentId('test-wf');
@@ -33,6 +36,7 @@ describe('nodeExecuteAfter', () => {
 
 	beforeEach(() => {
 		vi.mocked(openFormPopupWindow).mockClear();
+		vi.mocked(trackNodeExecution).mockClear();
 		setActivePinia(createPinia());
 
 		options = { router: mock<Router>(), documentId };
@@ -90,6 +94,32 @@ describe('nodeExecuteAfter', () => {
 				Array.from({ length: 1 }).fill({ json: { [TRIMMED_TASK_DATA_CONNECTIONS_KEY]: true } }),
 			],
 		});
+	});
+
+	it('tracks a non-waiting node execution exactly once', async () => {
+		const event: NodeExecuteAfter = {
+			type: 'nodeExecuteAfter',
+			data: {
+				executionId: 'exec-1',
+				nodeName: 'Test Node',
+				sequenceNumber: 1,
+				itemCountByConnectionType: { main: [1] },
+				data: {
+					executionTime: 100,
+					startTime: 1234567890,
+					executionIndex: 0,
+					source: [],
+				},
+			},
+		};
+
+		await nodeExecuteAfter(event, options);
+
+		expect(trackNodeExecution).toHaveBeenCalledTimes(1);
+		expect(trackNodeExecution).toHaveBeenCalledWith(
+			event.data,
+			workflowExecutionStateStore.workflowId,
+		);
 	});
 
 	it('should skip when the execution id does not match the active execution', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -61,6 +61,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: { main: [2, 1] },
 				data: {
 					executionTime: 100,
@@ -102,6 +103,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'other-exec',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: { main: [1] },
 				data: {
 					executionTime: 100,
@@ -127,6 +129,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: {
 					main: [3],
 					ai_memory: [1, 2],
@@ -164,6 +167,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: {},
 				data: {
 					executionTime: 100,
@@ -188,6 +192,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: { main: [1] },
 				data: {
 					executionTime: 100,
@@ -221,6 +226,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Test Node',
+				sequenceNumber: 1,
 				itemCountByConnectionType: {
 					main: [1],
 					// @ts-expect-error Testing invalid connection type
@@ -254,6 +260,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Wait',
+				sequenceNumber: 1,
 				itemCountByConnectionType: {},
 				data: {
 					executionTime: 0,
@@ -277,6 +284,7 @@ describe('nodeExecuteAfter', () => {
 			data: {
 				executionId: 'exec-1',
 				nodeName: 'Wait',
+				sequenceNumber: 1,
 				itemCountByConnectionType: {},
 				data: {
 					executionTime: 0,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -65,13 +65,6 @@ export async function nodeExecuteAfter(
 		pushDataWithPlaceholderOutputData,
 	);
 
-	if (pushDataWithPlaceholderOutputData.data.executionStatus !== 'waiting') {
-		// `trackNodeExecution` only reads nodeName/error and is typed for the
-		// `nodeExecuteAfter` payload (which now carries `sequenceNumber`), so pass
-		// the original event rather than the trimmed `nodeExecuteAfterData` copy.
-		void trackNodeExecution(pushData, workflowExecutionStateStore.workflowId);
-	}
-
 	workflowExecutionStateStore.executingNode.removeExecutingNode(pushData.nodeName);
 
 	// Side effects

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -66,10 +66,10 @@ export async function nodeExecuteAfter(
 	);
 
 	if (pushDataWithPlaceholderOutputData.data.executionStatus !== 'waiting') {
-		void trackNodeExecution(
-			pushDataWithPlaceholderOutputData,
-			workflowExecutionStateStore.workflowId,
-		);
+		// `trackNodeExecution` only reads nodeName/error and is typed for the
+		// `nodeExecuteAfter` payload (which now carries `sequenceNumber`), so pass
+		// the original event rather than the trimmed `nodeExecuteAfterData` copy.
+		void trackNodeExecution(pushData, workflowExecutionStateStore.workflowId);
 	}
 
 	workflowExecutionStateStore.executingNode.removeExecutingNode(pushData.nodeName);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.test.ts
@@ -14,12 +14,13 @@ describe('nodeExecuteBefore', () => {
 	let options: PushHandlerOptions;
 	let workflowExecutionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 
-	function makeEvent(executionId = 'exec-1'): NodeExecuteBefore {
+	function makeEvent(executionId = 'exec-1', sequenceNumber = 0): NodeExecuteBefore {
 		return {
 			type: 'nodeExecuteBefore',
 			data: {
 				executionId,
 				nodeName: 'Test Node',
+				sequenceNumber,
 				data: { startTime: 0, executionIndex: 0, source: [] },
 			},
 		};
@@ -39,11 +40,12 @@ describe('nodeExecuteBefore', () => {
 		workflowExecutionStateStore.setActiveExecutionId('exec-1');
 	});
 
-	it('adds the executing node when the execution id matches the active execution', async () => {
-		await nodeExecuteBefore(makeEvent('exec-1'), options);
+	it('adds the executing node with its sequence number when the execution id matches', async () => {
+		await nodeExecuteBefore(makeEvent('exec-1', 4), options);
 
 		expect(workflowExecutionStateStore.executingNode.addExecutingNode).toHaveBeenCalledWith(
 			'Test Node',
+			4,
 		);
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
@@ -20,7 +20,7 @@ export async function nodeExecuteBefore(
 		return;
 	}
 
-	workflowExecutionStateStore.executingNode.addExecutingNode(data.nodeName);
+	workflowExecutionStateStore.executingNode.addExecutingNode(data.nodeName, data.sequenceNumber);
 
 	useExecutionDataStore(createExecutionDataId(data.executionId)).addNodeExecutionStartedData(data);
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
@@ -748,6 +748,7 @@ describe('workflowExecutionState.store', () => {
 				executionDataStore.addNodeExecutionStartedData({
 					executionId: 'exec-1',
 					nodeName: 'Code',
+					sequenceNumber: 0,
 					data: { startTime: 1 } as never,
 				});
 				executionStateStore.setActiveExecutionId('exec-1');
@@ -767,6 +768,7 @@ describe('workflowExecutionState.store', () => {
 				executionDataStore.addNodeExecutionStartedData({
 					executionId: IN_PROGRESS_EXECUTION_ID,
 					nodeName: 'Pending',
+					sequenceNumber: 0,
 					data: { startTime: 1 } as never,
 				});
 				executionStateStore.setActiveExecutionId(null);
@@ -896,6 +898,7 @@ describe('workflowExecutionState.store', () => {
 			executionStateStore.addActiveNodeExecutionStartedData({
 				executionId: 'exec-1',
 				nodeName: 'Code',
+				sequenceNumber: 0,
 				data: { startTime: 1 } as never,
 			});
 
@@ -911,6 +914,7 @@ describe('workflowExecutionState.store', () => {
 			executionDataStore.addNodeExecutionStartedData({
 				executionId: 'exec-1',
 				nodeName: 'Code',
+				sequenceNumber: 0,
 				data: { startTime: 1 } as never,
 			});
 			executionStateStore.setActiveExecutionId('exec-1');
@@ -933,6 +937,7 @@ describe('workflowExecutionState.store', () => {
 				executionStateStore.addActiveNodeExecutionStartedData({
 					executionId: 'x',
 					nodeName: 'N',
+					sequenceNumber: 0,
 					data: { startTime: 1 } as never,
 				}),
 			).not.toThrow();
@@ -1363,7 +1368,7 @@ describe('workflowExecutionState.store', () => {
 			executionStateStore.setSelectedTriggerNodeName('Trigger');
 			executionStateStore.setCurrentWorkflowExecutions([makeExecutionSummary({ id: '1' })]);
 			executionStateStore.setLastSuccessfulExecutionId('last-1');
-			executionStateStore.executingNode.addExecutingNode('Node');
+			executionStateStore.executingNode.addExecutingNode('Node', 0);
 
 			executionStateStore.resetExecutionState();
 
@@ -1430,7 +1435,7 @@ describe('workflowExecutionState.store', () => {
 				createWorkflowDocumentId('wf-1'),
 			);
 
-			workflowExecutionStateStore.executingNode.addExecutingNode('Node A');
+			workflowExecutionStateStore.executingNode.addExecutingNode('Node A', 0);
 
 			expect(workflowExecutionStateStore.executingNode.isNodeExecuting('Node A')).toBe(true);
 			expect(workflowExecutionStateStore.executingNode.lastAddedExecutingNode).toBe('Node A');
@@ -1440,11 +1445,47 @@ describe('workflowExecutionState.store', () => {
 			const a = useWorkflowExecutionStateStore(createWorkflowDocumentId('wf-a'));
 			const b = useWorkflowExecutionStateStore(createWorkflowDocumentId('wf-b'));
 
-			a.executingNode.addExecutingNode('Node A');
+			a.executingNode.addExecutingNode('Node A', 0);
 
 			expect(a.executingNode.isNodeExecuting('Node A')).toBe(true);
 			expect(b.executingNode.isNodeExecuting('Node A')).toBe(false);
 			expect(b.executingNode.executingNode).toEqual([]);
+		});
+
+		// CAT-2895: only the latest node (highest sequence number) renders as
+		// executing, so a stale node left over from a suspended tab can never add
+		// a second spinner. Driven through the store so the per-node canvas
+		// projection (executionRunningByNodeId) is asserted end to end.
+		it('shows only the latest node as executing, superseding the earlier one', () => {
+			const id = createWorkflowDocumentId('wf-latest');
+			const documentStore = useWorkflowDocumentStore(id);
+			const executionStateStore = useWorkflowExecutionStateStore(id);
+
+			documentStore.addNode({
+				id: 'a-id',
+				name: 'Node A',
+				type: 'n8n-nodes-base.set',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			});
+			documentStore.addNode({
+				id: 'b-id',
+				name: 'Node B',
+				type: 'n8n-nodes-base.set',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			});
+
+			executionStateStore.executingNode.addExecutingNode('Node A', 0);
+			executionStateStore.executingNode.addExecutingNode('Node B', 1);
+
+			expect(executionStateStore.executingNode.isNodeExecuting('Node A')).toBe(false);
+			expect(executionStateStore.executingNode.isNodeExecuting('Node B')).toBe(true);
+			// The canvas projection sees exactly one running node.
+			expect(executionStateStore.executionRunningByNodeId.get('a-id')?.value).toBe(false);
+			expect(executionStateStore.executionRunningByNodeId.get('b-id')?.value).toBe(true);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.test.ts
@@ -369,6 +369,7 @@ describe('LogsPanel', () => {
 			createExecutionDataId(IN_PROGRESS_EXECUTION_ID),
 		).addNodeExecutionStartedData({
 			nodeName: 'AI Agent',
+			sequenceNumber: 0,
 			executionId: '567',
 			data: { executionIndex: 0, startTime: Date.parse('2025-04-20T12:34:51.000Z'), source: [] },
 		});


### PR DESCRIPTION
## Summary

Manual executions could show **several nodes spinning as "executing" at once** (CAT-2895). The backend relays `nodeExecuteBefore` / `nodeExecuteAfter` fire-and-forget, so a browser tab suspended to save memory can miss or reorder those events, leaving stale nodes marked as running.

The fix has two parts:

- **Backend (`core`):** every `nodeExecuteBefore` / `nodeExecuteAfter` now carries a per-execution monotonic `sequenceNumber`, assigned in engine order and shared across both event kinds (`before(A)=0, after(A)=1, before(B)=2, …`). It rides the worker→main relay unchanged, giving the client a correct total order even in scaling / multi-main mode.
- **Frontend (`editor`):** `useExecutingNode` now renders **only the node with the highest `sequenceNumber` seen**, cleared on its own `after`. Lower / out-of-order events (from a suspended-tab resume) are ignored, so a stale node can never overwrite the current one or add a second spinner. When nothing is shown a fresh event is accepted regardless of its number, so a new run — or a wait-node resume, where the per-execution counter restarts at 0 — still shows its node.

### ⚠️ Behaviour trade-off for product review

This is the strict "only the latest node" behaviour (the literal read of the requirement), which has one deliberate consequence:

- **An AI Agent and its active sub-node no longer both spin.** While a sub-node (tool / model / memory) runs it has the higher `sequenceNumber`, so only the sub-node renders as executing and the parent Agent's spinner is hidden until it resumes. Previously both spun.

This was chosen knowingly and provisionally to ship the simplest fix for the reported symptom. Flagging it here so product can decide whether genuine parent + sub-node concurrency should be preserved (a fast-follow if so).

## How to test

**Automated**

```
pnpm --filter n8n-editor-ui test \
  src/app/composables/useExecutingNode.test.ts \
  src/app/stores/workflowExecutionState.store.test.ts
```

Covers: a higher-`sequenceNumber` event supersedes the current node; a stale / out-of-order (lower-number) event is ignored; the identity-guarded clear; the wait-resume counter restart; and an end-to-end "only one node runs" assertion on the per-node canvas projection.

**Manual (the original repro, intermittent)**

1. Open a long-running workflow in two browser tabs and start both in parallel.
2. Navigate away for 10+ seconds so the tabs suspend, then return to them.
3. Before: multiple nodes show the running spinner. After: only one (the latest) does.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2895

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- No user-facing docs affected. -->
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34182">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

