### PR TITLE
fix(editor): Decouple MCP redirect URI controls from env-lock flag

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
@@ -39,6 +39,17 @@ vi.mock('@/features/ai/mcpAccess/composables/useMcp', () => ({
 	}),
 }));
 
+const { showErrorMock, showMessageMock } = vi.hoisted(() => ({
+	showErrorMock: vi.fn(),
+	showMessageMock: vi.fn(),
+}));
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({
+		showError: showErrorMock,
+		showMessage: showMessageMock,
+	}),
+}));
+
 let pinia: ReturnType<typeof createTestingPinia>;
 let mcpStore: MockedStore<typeof useMCPStore>;
 let usersStore: MockedStore<typeof useUsersStore>;
@@ -108,6 +119,8 @@ describe('SettingsMCPView', () => {
 
 		mcpStore.getAllOAuthClients.mockResolvedValue([]);
 		mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
+		mcpStore.fetchAllowedRedirectUris.mockResolvedValue([]);
+		mcpStore.setAllowedRedirectUris.mockResolvedValue(undefined);
 	});
 
 	afterEach(() => {
@@ -761,6 +774,181 @@ describe('SettingsMCPView', () => {
 			await nextTick();
 
 			expect(mcpStore.getInstanceClientStats).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Redirect URI controls decoupled from env-lock', () => {
+		beforeEach(() => {
+			usersStore.isAdmin = true;
+			usersStore.isInstanceOwner = false;
+			mcpStore.fetchAllowedRedirectUris.mockResolvedValue(['https://example.com/oauth']);
+		});
+
+		it('should disable toggle but keep redirect-URI controls enabled when admin, env-managed, and MCP is enabled', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: true,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = true;
+
+			const { getByTestId, container } = createComponent({ pinia });
+			await nextTick();
+
+			expect(getByTestId('disable-mcp-button')).toBeDisabled();
+
+			await clickTab(container, 'tab-settings');
+
+			const oauthSettingsTab = getByTestId('mcp-oauth-settings-tab');
+			expect(oauthSettingsTab).toBeVisible();
+
+			const redirectUriInput = getByTestId('mcp-redirect-uris-input');
+			const saveButton = getByTestId('mcp-redirect-uris-save-button');
+
+			expect(redirectUriInput).not.toBeDisabled();
+			expect(saveButton).not.toBeDisabled();
+		});
+
+		it('should enable toggle and enable redirect-URI controls when admin, not env-managed, and MCP is enabled', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = false;
+
+			const { getByTestId, container } = createComponent({ pinia });
+			await nextTick();
+
+			expect(getByTestId('disable-mcp-button')).not.toBeDisabled();
+
+			await clickTab(container, 'tab-settings');
+
+			const redirectUriInput = getByTestId('mcp-redirect-uris-input');
+			const saveButton = getByTestId('mcp-redirect-uris-save-button');
+
+			expect(redirectUriInput).not.toBeDisabled();
+			expect(saveButton).not.toBeDisabled();
+		});
+
+		it('should disable both toggle and redirect-URI controls for a non-admin user', async () => {
+			usersStore.isAdmin = false;
+			usersStore.isInstanceOwner = false;
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = false;
+
+			const { getByTestId, queryByTestId } = createComponent({ pinia });
+			await nextTick();
+
+			expect(getByTestId('disable-mcp-button')).toBeDisabled();
+			expect(queryByTestId('mcp-oauth-settings-tab')).not.toBeInTheDocument();
+		});
+
+		it('should reactively disable toggle but keep redirect-URI controls enabled when env-lock is toggled to true', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = false;
+
+			const { getByTestId, container } = createComponent({ pinia });
+			await nextTick();
+
+			await clickTab(container, 'tab-settings');
+
+			expect(getByTestId('disable-mcp-button')).not.toBeDisabled();
+			expect(getByTestId('mcp-redirect-uris-input')).not.toBeDisabled();
+
+			// Reassign the whole object instead of mutating nested properties
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: true,
+				},
+			};
+			mcpStore.mcpManagedByEnv = true;
+			await nextTick();
+
+			expect(getByTestId('disable-mcp-button')).toBeDisabled();
+			expect(getByTestId('mcp-redirect-uris-input')).not.toBeDisabled();
+		});
+		it('should display an error toast if the API call to save redirect URIs fails', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = false;
+			mcpStore.setAllowedRedirectUris.mockRejectedValue(new Error('API Error'));
+
+			const { getByTestId, container } = createComponent({ pinia });
+			await nextTick();
+
+			await clickTab(container, 'tab-settings');
+
+			const saveButton = getByTestId('mcp-redirect-uris-save-button');
+			await userEvent.click(saveButton);
+
+			await nextTick();
+			expect(showErrorMock).toHaveBeenCalled();
+		});
+
+		it('should display a validation error message if the user enters an invalid URL', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = true;
+			mcpStore.mcpManagedByEnv = false;
+
+			const { getByTestId, container } = createComponent({ pinia });
+			await nextTick();
+
+			await clickTab(container, 'tab-settings');
+
+			const redirectUriInput = getByTestId('mcp-redirect-uris-input');
+			const saveButton = getByTestId('mcp-redirect-uris-save-button');
+
+			await userEvent.clear(redirectUriInput);
+			await userEvent.type(redirectUriInput, 'invalid-url');
+			await userEvent.click(saveButton);
+
+			await nextTick();
+			const errorDiv = container.querySelector('[class*="error-message"]');
+			expect(errorDiv).toBeVisible();
+		});
+
+		it('should not show the OAuth section when MCP is disabled', async () => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: false,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.mcpAccessEnabled = false;
+			mcpStore.mcpManagedByEnv = false;
+
+			const { queryByTestId } = createComponent({ pinia });
+			await nextTick();
+
+			expect(queryByTestId('mcp-oauth-settings-tab')).not.toBeInTheDocument();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
@@ -94,6 +94,8 @@ const redirectUrisLoading = ref(false);
 
 const canToggleMCP = computed(() => canManageMcpInstance.value && !mcpStore.mcpManagedByEnv);
 
+const canEditRedirectUris = computed(() => canManageMcpInstance.value);
+
 const canSeeInstanceStats = canManageMcpInstance;
 
 const showInstanceCapacityNotice = computed(
@@ -521,7 +523,7 @@ onMounted(async () => {
 							type="textarea"
 							:rows="6"
 							:placeholder="i18n.baseText('settings.mcp.allowedRedirectUris.placeholder')"
-							:disabled="!canToggleMCP"
+							:disabled="!canEditRedirectUris"
 							data-test-id="mcp-redirect-uris-input"
 						/>
 					</N8nInputLabel>
@@ -532,7 +534,7 @@ onMounted(async () => {
 						<N8nButton
 							:label="i18n.baseText('settings.mcp.allowedRedirectUris.save')"
 							:loading="redirectUrisLoading"
-							:disabled="!canToggleMCP"
+							:disabled="!canEditRedirectUris"
 							size="small"
 							data-test-id="mcp-redirect-uris-save-button"
 							@click="saveRedirectUris"


### PR DESCRIPTION
## Summary
  
When the MCP access toggle is managed by an environment variable (`N8N_MCP_ACCESS_ENABLED`), the **Allowed Redirect URIs** field and its Save button were also greyed out, even though no environment variable governs the redirect‑URI list, and the backend’s `PATCH /oauth/allowed-redirect-uris` endpoint has zero env‑lock checks. That means admins who follow the documented pattern (lock the toggle via env) suddenly lost the ability to manage OAuth redirect URIs from the UI.

The reason it happened is a single computed property `canToggleMCP` was doing double duty. It was meant for the “Enable MCP access” toggle but was also reused to disable the redirect‑URI input and save button. Since `canToggleMCP` includes `!mcpManagedByEnv`, the env‑lock bled into a control that doesn’t have an env var.

**What this PR does**  
- Introduces a new computed `canEditRedirectUris` that checks **only** the admin role (no env‑lock factor).  
- Swaps the `:disabled` bindings of the redirect‑URI `<N8nInput>` and Save `<N8nButton>` from `!canToggleMCP` to `!canEditRedirectUris`.  
- Nothing else. Layout, tabs, empty states, data loading, all untouched.

> [!NOTE]
> You might wonder: “Shouldn’t the OAuth section be visible even when MCP access is **off**?” The backend *does* accept redirect‑URI updates regardless of whether MCP is enabled, so technically that’s possible. However, that would be a product‑behavior change — the UI has always only shown those controls when MCP is active. Changing that requires a design discussion (empty‑state flow, tab navigation, etc.) and would introduce its own regression risks. We’ve consciously kept this PR minimal and focused on the reported bug (where `N8N_MCP_ACCESS_ENABLED=true` but the fields are disabled). If there’s appetite for exposing the OAuth settings even when MCP is turned off, I’m happy to open a separate follow‑up issue/PR — but that’s a feature, not a bugfix.

**Testing**  
- All existing MCP settings tests pass.  
- Added a new `describe` block covering exactly the env‑lock decoupling, reactivity toggling, error handling, and the regression guard (fields hidden when MCP is disabled).

## How to test

1. Start a self‑hosted n8n instance with:  
   ```
   N8N_MCP_ACCESS_ENABLED=true
   N8N_MCP_MANAGED_BY_ENV=true
   ```
2. Log in as an instance admin.  
3. Go to **Settings → Instance‑level MCP → OAuth settings** tab.  
4. Verify the **Enable MCP access** toggle is disabled (locked by env).  
5. Verify the **Allowed Redirect URIs** textarea and **Save** button are **editable**.  
6. Try saving a valid URL and an invalid one; check error handling.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #34144
- Linear Ticket ID: [GHC-8936](https://linear.app/n8n/issue/GHC-8936)
## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34184">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

