### PR TITLE
feat(Grist Node): Use a single Grist URL field in the credential

### DIFF
--- a/packages/nodes-base/credentials/GristApi.credentials.ts
+++ b/packages/nodes-base/credentials/GristApi.credentials.ts
@@ -25,7 +25,7 @@ export class GristApi implements ICredentialType {
 			default: 'https://api.getgrist.com',
 			required: true,
 			description:
-				'Defaults to hosted Grist. Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed.',
+				'Defaults to hosted Grist. Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed. Do not include /api.',
 		},
 	];
 }

--- a/packages/nodes-base/credentials/GristApi.credentials.ts
+++ b/packages/nodes-base/credentials/GristApi.credentials.ts
@@ -15,54 +15,17 @@ export class GristApi implements ICredentialType {
 			typeOptions: { password: true },
 			default: '',
 			required: true,
+			description:
+				'In Grist, open the account menu (top right) > Account settings > Developer to create or copy your API key',
 		},
 		{
-			displayName: 'Plan Type',
-			name: 'planType',
-			type: 'options',
-			default: 'free',
-			options: [
-				{
-					name: 'Free',
-					value: 'free',
-				},
-				{
-					name: 'Paid',
-					value: 'paid',
-				},
-				{
-					name: 'Self-Hosted',
-					value: 'selfHosted',
-				},
-			],
-		},
-		{
-			displayName: 'Custom Subdomain',
-			name: 'customSubdomain',
+			displayName: 'Grist URL',
+			name: 'url',
 			type: 'string',
-			default: '',
-			required: true,
-			description: 'Custom subdomain of your team',
-			displayOptions: {
-				show: {
-					planType: ['paid'],
-				},
-			},
-		},
-		{
-			displayName: 'Self-Hosted URL',
-			name: 'selfHostedUrl',
-			type: 'string',
-			default: '',
-			placeholder: 'http://localhost:8484',
+			default: 'https://api.getgrist.com',
 			required: true,
 			description:
-				'URL of your Grist instance. Include http/https without /api and no trailing slash.',
-			displayOptions: {
-				show: {
-					planType: ['selfHosted'],
-				},
-			},
+				'Defaults to hosted Grist. Use https://YOUR_TEAM.getgrist.com for a single team, or your own URL if self-managed.',
 		},
 	];
 }

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -15,12 +15,18 @@ import type {
 	GristSortProperties,
 } from './types';
 
+// A trailing slash or a trailing `/api` are both easy to paste in from a browser or the
+// API docs. Request paths append `/api` themselves, so the base URL needs neither.
+function normalizeBaseUrl(url: string): string {
+	return url.replace(/\/$/, '').replace(/\/api$/, '');
+}
+
 // Fallback for API-key credentials created before the single `url` field: self-hosted
 // instances stored a full URL, teams stored a subdomain. Defaults to the SaaS API host,
 // which serves every hosted account.
 function gristLegacyBaseUrl(credentials: GristCredentials): string {
 	if (credentials.selfHostedUrl) {
-		return credentials.selfHostedUrl.replace(/\/$/, '');
+		return normalizeBaseUrl(credentials.selfHostedUrl);
 	}
 	if (credentials.customSubdomain) {
 		return `https://${credentials.customSubdomain}.getgrist.com`;
@@ -32,7 +38,7 @@ function gristLegacyBaseUrl(credentials: GristCredentials): string {
 // back to their legacy fields.
 export function gristBaseUrl(credentials: GristCredentials): string {
 	if (credentials.url) {
-		return credentials.url.replace(/\/$/, '');
+		return normalizeBaseUrl(credentials.url);
 	}
 	return gristLegacyBaseUrl(credentials);
 }

--- a/packages/nodes-base/nodes/Grist/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Grist/GenericFunctions.ts
@@ -15,6 +15,28 @@ import type {
 	GristSortProperties,
 } from './types';
 
+// Fallback for API-key credentials created before the single `url` field: self-hosted
+// instances stored a full URL, teams stored a subdomain. Defaults to the SaaS API host,
+// which serves every hosted account.
+function gristLegacyBaseUrl(credentials: GristCredentials): string {
+	if (credentials.selfHostedUrl) {
+		return credentials.selfHostedUrl.replace(/\/$/, '');
+	}
+	if (credentials.customSubdomain) {
+		return `https://${credentials.customSubdomain}.getgrist.com`;
+	}
+	return 'https://api.getgrist.com';
+}
+
+// Resolve the Grist server base URL. Credentials store a single `url`; older ones fall
+// back to their legacy fields.
+export function gristBaseUrl(credentials: GristCredentials): string {
+	if (credentials.url) {
+		return credentials.url.replace(/\/$/, '');
+	}
+	return gristLegacyBaseUrl(credentials);
+}
+
 export async function gristApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -22,22 +44,14 @@ export async function gristApiRequest(
 	body: IDataObject | number[] = {},
 	qs: IDataObject = {},
 ) {
-	const { apiKey, planType, customSubdomain, selfHostedUrl } =
-		await this.getCredentials<GristCredentials>('gristApi');
-
-	const gristapiurl =
-		planType === 'free'
-			? `https://docs.getgrist.com/api${endpoint}`
-			: planType === 'paid'
-				? `https://${customSubdomain}.getgrist.com/api${endpoint}`
-				: `${selfHostedUrl}/api${endpoint}`;
+	const credentials = await this.getCredentials<GristCredentials>('gristApi');
 
 	const options: IRequestOptions = {
 		headers: {
-			Authorization: `Bearer ${apiKey}`,
+			Authorization: `Bearer ${credentials.apiKey}`,
 		},
 		method,
-		uri: gristapiurl,
+		uri: `${gristBaseUrl(credentials)}/api${endpoint}`,
 		qs,
 		body,
 		json: true,

--- a/packages/nodes-base/nodes/Grist/Grist.node.ts
+++ b/packages/nodes-base/nodes/Grist/Grist.node.ts
@@ -14,6 +14,7 @@ import {
 
 import {
 	gristApiRequest,
+	gristBaseUrl,
 	parseAutoMappedInputs,
 	parseDefinedFields,
 	parseFilterProperties,
@@ -73,30 +74,27 @@ export class Grist implements INodeType {
 				this: ICredentialTestFunctions,
 				credential: ICredentialsDecrypted,
 			): Promise<INodeCredentialTestResult> {
-				const { apiKey, planType, customSubdomain, selfHostedUrl } =
-					credential.data as GristCredentials;
-
-				const endpoint = '/orgs';
-
-				const gristapiurl =
-					planType === 'free'
-						? `https://docs.getgrist.com/api${endpoint}`
-						: planType === 'paid'
-							? `https://${customSubdomain}.getgrist.com/api${endpoint}`
-							: `${selfHostedUrl}/api${endpoint}`;
+				const credentials = credential.data as GristCredentials;
 
 				const options: IRequestOptions = {
 					headers: {
-						Authorization: `Bearer ${apiKey}`,
+						Authorization: `Bearer ${credentials.apiKey}`,
 					},
 					method: 'GET',
-					uri: gristapiurl,
-					qs: { limit: 1 },
+					uri: `${gristBaseUrl(credentials)}/api/orgs`,
 					json: true,
 				};
 
 				try {
-					await this.helpers.request(options);
+					// A valid token can still grant zero accessible orgs (e.g. nothing shared); treat
+					// that as a failing test rather than a misleading success.
+					const orgs = await this.helpers.request(options);
+					if (!Array.isArray(orgs) || orgs.length === 0) {
+						return {
+							status: 'Error',
+							message: 'Connected, but no Grist organizations are accessible to this account.',
+						};
+					}
 					return {
 						status: 'OK',
 						message: 'Authentication successful',

--- a/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/Grist.node.test.ts
@@ -1,0 +1,64 @@
+import type { ICredentialsDecrypted, ICredentialTestFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { Grist } from '../Grist.node';
+
+describe('Grist credentialTest', () => {
+	const run = async (
+		orgs: unknown,
+		data: ICredentialsDecrypted['data'] = { apiKey: 'k', url: 'https://api.getgrist.com' },
+	) => {
+		const request = vi.fn().mockResolvedValue(orgs);
+		const testFns = mock<ICredentialTestFunctions>();
+		testFns.helpers = { ...testFns.helpers, request };
+		// Plain object (not a deep mock) so an absent `url` reads as undefined rather than an auto-mock.
+		const credential = { data } as unknown as ICredentialsDecrypted;
+
+		const result = await new Grist().methods.credentialTest.gristApiTest.call(testFns, credential);
+		return { result, request };
+	};
+
+	it('passes when at least one org is accessible', async () => {
+		const { result, request } = await run([{ id: 1, name: 'Personal' }]);
+
+		expect(result.status).toBe('OK');
+		expect(request.mock.calls[0][0].uri).toBe('https://api.getgrist.com/api/orgs');
+		expect(request.mock.calls[0][0].headers.Authorization).toBe('Bearer k');
+	});
+
+	it('fails when no orgs are accessible', async () => {
+		const { result } = await run([]);
+
+		expect(result.status).toBe('Error');
+		expect(result.message).toContain('no Grist organizations are accessible');
+	});
+
+	it('fails when the response is not an array', async () => {
+		const { result } = await run({ unexpected: true });
+
+		expect(result.status).toBe('Error');
+	});
+
+	it('reports the request error message on failure', async () => {
+		const request = vi.fn().mockRejectedValue(new Error('Unauthorized'));
+		const testFns = mock<ICredentialTestFunctions>();
+		testFns.helpers = { ...testFns.helpers, request };
+		const credential = {
+			data: { apiKey: 'bad', url: 'https://api.getgrist.com' },
+		} as unknown as ICredentialsDecrypted;
+
+		const result = await new Grist().methods.credentialTest.gristApiTest.call(testFns, credential);
+
+		expect(result.status).toBe('Error');
+		expect(result.message).toBe('Unauthorized');
+	});
+
+	it('resolves the base URL from a legacy credential without a url', async () => {
+		const { request } = await run([{ id: 1 }], {
+			apiKey: 'k',
+			selfHostedUrl: 'http://localhost:8484',
+		});
+
+		expect(request.mock.calls[0][0].uri).toBe('http://localhost:8484/api/orgs');
+	});
+});

--- a/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
@@ -1,0 +1,32 @@
+import { gristBaseUrl } from '../GenericFunctions';
+
+describe('Grist gristBaseUrl', () => {
+	it('uses the unified url field, stripping a trailing slash', () => {
+		expect(gristBaseUrl({ url: 'https://api.getgrist.com' })).toBe('https://api.getgrist.com');
+		expect(gristBaseUrl({ url: 'https://team.getgrist.com/' })).toBe('https://team.getgrist.com');
+		expect(gristBaseUrl({ url: 'http://localhost:8484' })).toBe('http://localhost:8484');
+	});
+
+	describe('legacy credentials without a url', () => {
+		it('resolves a stored self-hosted URL, stripping a trailing slash', () => {
+			expect(gristBaseUrl({ selfHostedUrl: 'http://localhost:8484/' })).toBe(
+				'http://localhost:8484',
+			);
+		});
+
+		it('builds the team host from a stored subdomain', () => {
+			expect(gristBaseUrl({ customSubdomain: 'acme' })).toBe('https://acme.getgrist.com');
+		});
+
+		it('falls back to the SaaS API host (covers the old free plan)', () => {
+			expect(gristBaseUrl({ apiKey: 'k' })).toBe('https://api.getgrist.com');
+			expect(gristBaseUrl({})).toBe('https://api.getgrist.com');
+		});
+
+		it('prefers a self-hosted URL over a subdomain when both are present', () => {
+			expect(
+				gristBaseUrl({ selfHostedUrl: 'https://grist.example.com', customSubdomain: 'acme' }),
+			).toBe('https://grist.example.com');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
+++ b/packages/nodes-base/nodes/Grist/test/gristBaseUrl.test.ts
@@ -7,9 +7,27 @@ describe('Grist gristBaseUrl', () => {
 		expect(gristBaseUrl({ url: 'http://localhost:8484' })).toBe('http://localhost:8484');
 	});
 
+	it('strips a trailing /api, which request paths add themselves', () => {
+		expect(gristBaseUrl({ url: 'http://localhost:8484/api' })).toBe('http://localhost:8484');
+		expect(gristBaseUrl({ url: 'http://localhost:8484/api/' })).toBe('http://localhost:8484');
+	});
+
+	it('keeps a host whose name merely ends in api', () => {
+		expect(gristBaseUrl({ url: 'https://api.getgrist.com' })).toBe('https://api.getgrist.com');
+		expect(gristBaseUrl({ url: 'https://grist-api.example.com' })).toBe(
+			'https://grist-api.example.com',
+		);
+	});
+
 	describe('legacy credentials without a url', () => {
 		it('resolves a stored self-hosted URL, stripping a trailing slash', () => {
 			expect(gristBaseUrl({ selfHostedUrl: 'http://localhost:8484/' })).toBe(
+				'http://localhost:8484',
+			);
+		});
+
+		it('strips a trailing /api from a stored self-hosted URL', () => {
+			expect(gristBaseUrl({ selfHostedUrl: 'http://localhost:8484/api' })).toBe(
 				'http://localhost:8484',
 			);
 		});

--- a/packages/nodes-base/nodes/Grist/types.ts
+++ b/packages/nodes-base/nodes/Grist/types.ts
@@ -1,6 +1,8 @@
 export type GristCredentials = {
-	apiKey: string;
-	planType: 'free' | 'paid' | 'selfHosted';
+	apiKey?: string;
+	url?: string;
+	// Legacy API-key credential fields, superseded by `url` (no credential migration exists,
+	// so these are still read as a fallback for connections created before the unified field).
 	customSubdomain?: string;
 	selfHostedUrl?: string;
 };


### PR DESCRIPTION
## Summary

The Grist API credential used to ask for a **Plan Type** (Free / Paid / Self-Hosted) and then, depending on that choice, a **Custom Subdomain** or a **Self-Hosted URL**. That is three linked fields for what is really one piece of information: where your Grist lives.

This replaces them with a single **Grist URL** field. It defaults to `https://api.getgrist.com`, which works for any hosted account. Point it at `https://YOUR_TEAM.getgrist.com` to scope a connection to one team, or at your own instance's URL for self-managed Grist.

The API Key field also gains a short description pointing to where you copy the key in Grist.

**The connection test is stricter.** It read those same removed fields to build its request, so it now builds the request from the Grist URL as well, and it checks the account can reach at least one organization. A key that authenticates but grants access to nothing now surfaces as a failed test instead of a misleading success.

**Existing credentials keep working.** There is no credential migration, so when a credential predates the new field we fall back to whatever it stored before (self-hosted URL, or subdomain, or the hosted default). Nothing needs to be re-entered.

This is one step in splitting the larger Grist modernization PR n8n-io/n8n#33133 into small, single-purpose PRs.

### The single Grist URL field on the credential

<img src="https://github.com/user-attachments/assets/192d97b8-f8c2-445c-ae9a-4e6b584366cd " alt="01-apikey-credential-form" width="1440" data-linear-height="900" />

### Saving runs the connection test

<img src="https://github.com/user-attachments/assets/3739b3a9-3337-4ee0-aa61-8cba90f68869 " alt="02-apikey-connection-tested" width="1440" data-linear-height="900" />

### A credential that can't authenticate fails the test

<img src="https://github.com/user-attachments/assets/8cab62af-9912-4f07-bad0-59aed8360538 " alt="13-apikey-connection-failed" width="1440" data-linear-height="900" />

## How to test

1. Go to **Credentials** > **Create credential** > **Grist API**. The form now has just two fields: **API Key** and **Grist URL** (no Plan Type / subdomain).
2. Enter a valid API key (in Grist: account menu (top right) > Account settings > Developer) and a Grist URL (the `https://api.getgrist.com` default, or your own instance). **Save** runs the test and you get a green **Connection tested successfully**.
3. Change the API Key to something invalid and **Save** again: the test fails with a red banner. A valid key whose account can see no organizations fails the same way.
4. Backward compatibility: a credential created before this change (with the old Plan Type / subdomain / self-hosted URL) still resolves to the right host and keeps working, with nothing to re-enter.
5. Unit tests: `cd packages/nodes-base && pnpm test nodes/Grist`.

## Related Linear tickets, Github issues, and Community forum posts

Part of splitting up n8n-io/n8n#33133 (internal tracker [NODE-5348](https://linear.app/n8n/issue/NODE-5348/community-pr-featgrist-node-add-oauth2-trigger-column-mapping-resource)).

This simplifies the self-hosted host configuration originally added in [#2847](<https://github.com/n8n-io/n8n/issues/2847>) (requested in [#2788](<https://github.com/n8n-io/n8n/issues/2788>)). Self-hosted Grist stays fully supported: legacy credentials keep working through the field fallback.

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [X] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created. Companion docs PR: [https://github.com/n8n-io/n8n-docs/pull/5049](<https://github.com/n8n-io/n8n-docs/pull/5049>).
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (N/A).

---

![Open in Stage](https://camo.githubusercontent.com/e3b46e319aace348a9c2eabc45f307a073a3bf5a08d5220b2027eac6649007b5/68747470733a2f2f73746167657265766965772e6170702f6173736574732f67682d6f70656e2d696e2d73746167652d6c696768742e737667)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)