### PR TITLE
chore: Move janitor execution from tsx to build+run

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "reset": "node scripts/ensure-zx.mjs && zx scripts/reset.mjs",
     "format": "turbo run format && node scripts/format.mjs",
     "grind": "node scripts/grind.mjs",
+    "janitor": "cd packages/testing/janitor && pnpm janitor",
+    "janitor:fix": "cd packages/testing/janitor && pnpm janitor:fix",
     "nathan": "node scripts/nathan.mjs",
     "agent:setup": "node scripts/agent-setup.mjs",
     "format:check": "turbo run format:check",

--- a/packages/testing/janitor/package.json
+++ b/packages/testing/janitor/package.json
@@ -51,7 +51,6 @@
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "fast-check": "catalog:",
-    "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/testing/janitor/package.json
+++ b/packages/testing/janitor/package.json
@@ -25,7 +25,9 @@
     "format:check": "biome ci .",
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "janitor": "pnpm build && ./bin/janitor.mjs",
+    "janitor:fix": "pnpm janitor -- --fix --write"
   },
   "keywords": [
     "playwright",

--- a/packages/testing/playwright/package.json
+++ b/packages/testing/playwright/package.json
@@ -45,8 +45,8 @@
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
-    "janitor": "tsx ../janitor/src/cli.ts",
-    "janitor:fix": "tsx ../janitor/src/cli.ts --fix --write"
+    "janitor": "cd ../janitor && pnpm janitor",
+    "janitor:fix": "cd ../janitor && pnpm janitor:fix"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.91.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6395,9 +6395,6 @@ importers:
       fast-check:
         specifier: 'catalog:'
         version: 3.23.2
-      tsx:
-        specifier: 'catalog:'
-        version: 4.19.3
       typescript:
         specifier: 'catalog:'
         version: 6.0.2


### PR DESCRIPTION
## Summary

Instead of relying on a extremely slow `tsx` execution of janitor, just build and run the binary.

This resolves issues where Janitor kept OOMing because with `tsx`.

Also adds a top-level `janitor` and `janitor:fix` commands

## How to test

```bash
pnpm janitor
pnpm janitor:fix

cd packages/testing/playwright
pnpm janitor
pnpm janitor:fix


cd packages/testing/janitor
pnpm janitor
pnpm janitor:fix
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

