### PR TITLE
fix(scan-community-package): Lint package source from provenance-attested git commit

### DIFF
--- a/packages/@n8n/scan-community-package/scanner/provenance.mjs
+++ b/packages/@n8n/scan-community-package/scanner/provenance.mjs
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 const NPM_PROVENANCE_PREDICATE_TYPE = 'https://slsa.dev/provenance/v1';
 const N8N_COMMUNITY_NODE_PUBLISH_DOCS_URL =
 	'https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/';
@@ -28,4 +30,58 @@ export const checkPackageProvenance = (packageMetadata, version) => {
 	}
 
 	return { passed: true };
+};
+
+/**
+ * Extracts the git source repository and attested commit from an npm
+ * provenance attestation bundle.
+ *
+ * npm provenance (SLSA v1) bundles carry, in `predicate.buildDefinition
+ * .resolvedDependencies`, a `git+https://...@<ref>` entry whose `digest
+ * .gitCommit` pins the exact commit the published artifact was built from.
+ * That commit is what the scanner must lint to run source-level rules
+ * (filename conventions, node-description content) that no-op on compiled
+ * `.d.ts`/`.js` output. Pure so tests can feed a fixture bundle directly.
+ *
+ * @returns {{ repoUrl: string, commitSha: string } | null}
+ */
+export const extractSourceLocationFromBundle = (bundle) => {
+	const slsa = (bundle?.attestations ?? []).find(
+		(a) => a.predicateType === NPM_PROVENANCE_PREDICATE_TYPE,
+	);
+	const payloadB64 = slsa?.bundle?.dsseEnvelope?.payload;
+	if (!payloadB64) return null;
+
+	let statement;
+	try {
+		statement = JSON.parse(Buffer.from(payloadB64, 'base64').toString());
+	} catch {
+		return null;
+	}
+
+	const deps = statement?.predicate?.buildDefinition?.resolvedDependencies ?? [];
+	for (const dep of deps) {
+		const uri = dep?.uri ?? '';
+		// `git+https://github.com/owner/repo@refs/heads/main` → repo URL + commit
+		const match = uri.match(/^git\+(https?:\/\/.+?)(?:@.+)?$/);
+		const commitSha = dep?.digest?.gitCommit;
+		if (match && /^[0-9a-f]{7,40}$/.test(commitSha)) {
+			return { repoUrl: match[1], commitSha };
+		}
+	}
+	return null;
+};
+
+/**
+ * Fetches the provenance attestation bundle for a published version and
+ * resolves the source repository + attested commit to lint. Requires the
+ * version to already have passed `checkPackageProvenance` (i.e. carry SLSA
+ * provenance).
+ */
+export const getSourceLocation = async (packageMetadata, version) => {
+	const attestationsUrl = packageMetadata?.versions?.[version]?.dist?.attestations?.url;
+	if (!attestationsUrl) return null;
+
+	const { data } = await axios.get(attestationsUrl);
+	return extractSourceLocationFromBundle(data);
 };

--- a/packages/@n8n/scan-community-package/scanner/scanner.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.mjs
@@ -11,7 +11,7 @@ import glob from 'fast-glob';
 import { fileURLToPath } from 'url';
 import { defineConfig } from 'eslint/config';
 
-import { checkPackageProvenance } from './provenance.mjs';
+import { checkPackageProvenance, getSourceLocation } from './provenance.mjs';
 
 const { stdout } = process;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -77,44 +77,33 @@ export const resolvePackage = (packageSpec) => {
 	return { packageName: parts[0], version: parts[1] || null };
 };
 
-const downloadAndExtractPackage = async (packageName, version) => {
-	try {
-		// Download the tarball using safe arguments
-		const npmResult = spawnSync('npm', ['-q', 'pack', `${packageName}@${version}`], {
-			cwd: TEMP_DIR,
-			stdio: 'pipe',
-			shell: process.platform === 'win32',
-		});
-		if (npmResult.status !== 0) {
-			throw new Error(`npm pack failed: ${npmResult.stderr?.toString()}`);
-		}
-		const tarballName = fs.readdirSync(TEMP_DIR).find((file) => file.endsWith('.tgz'));
-		if (!tarballName) {
-			throw new Error('Tarball not found');
-		}
-
-		// Unpack the tarball
-		const packageDir = safeJoinPath(TEMP_DIR, `${packageName}-${version}`);
-		fs.mkdirSync(packageDir, { recursive: true });
-		const tarResult = spawnSync(
-			'tar',
-			['-xzf', tarballName, '-C', packageDir, '--strip-components=1'],
-			{
-				cwd: TEMP_DIR,
-				stdio: 'pipe',
-				shell: process.platform === 'win32',
-			},
-		);
-		if (tarResult.status !== 0) {
-			throw new Error(`tar extraction failed: ${tarResult.stderr?.toString()}`);
-		}
-		fs.unlinkSync(safeJoinPath(TEMP_DIR, tarballName));
-
-		return packageDir;
-	} catch (error) {
-		console.error(`\nFailed to download package: ${error.message}`);
-		throw error;
+const cloneSourcePackage = (repoUrl, commitSha) => {
+	if (!/^https?:\/\//.test(repoUrl)) {
+		throw new Error(`Refusing to clone non-http(s) source URL: ${repoUrl}`);
 	}
+	if (!/^[0-9a-f]{7,40}$/.test(commitSha)) {
+		throw new Error(`Invalid commit SHA from provenance: ${commitSha}`);
+	}
+
+	const repoDir = safeJoinPath(TEMP_DIR, commitSha);
+	fs.rmSync(repoDir, { recursive: true, force: true });
+	const cloneResult = spawnSync('git', ['clone', '--quiet', repoUrl, repoDir], {
+		stdio: 'pipe',
+		shell: process.platform === 'win32',
+	});
+	if (cloneResult.status !== 0) {
+		throw new Error(`git clone failed: ${cloneResult.stderr?.toString()}`);
+	}
+	// Checkout the exact attested commit so the scan covers what was built,
+	// not whatever the default branch points at by scan time.
+	const checkoutResult = spawnSync('git', ['-C', repoDir, 'checkout', '--quiet', commitSha], {
+		stdio: 'pipe',
+		shell: process.platform === 'win32',
+	});
+	if (checkoutResult.status !== 0) {
+		throw new Error(`git checkout ${commitSha} failed: ${checkoutResult.stderr?.toString()}`);
+	}
+	return repoDir;
 };
 
 /**
@@ -137,18 +126,13 @@ export const buildScanConfig = async () => {
 		// Register the full `eslint-plugin-n8n-nodes-base` plugin and apply its
 		// three rulesets so the scan gate enforces the same rules as
 		// `n8n-node lint` (see node-cli/src/configs/eslint.ts). The off-overrides
-		// below are kept identical. Scoping differs on purpose: `n8n-node lint`
-		// runs at dev-time on `nodes/**` / `credentials/**` `.ts` sources, but
-		// published tarballs ship compiled output under `dist/` (e.g.
-		// `dist/nodes/Foo/Foo.node.js` + `.d.ts`). We match `nodes`/`credentials`
-		// dirs at any depth and target `.ts`/`.d.ts` only — the AST-walking rules
-		// resolve against the type-preserving `.d.ts`. Compiled `.js` is
-		// deliberately excluded: the description AST is buried in a constructor
-		// there so the rules no-op, and file-shape rules like
-		// node-filename-against-convention would false-positive on the `.js`
-		// extension (that check is meaningful only against `.ts` sources at
-		// dev-time). Without the `dist/`-aware glob these rules never run at the
-		// gate at all.
+		// below are kept identical. The gate lints the **source** of the package
+		// (cloned from the provenance-attested git commit), not the compiled
+		// `dist/` output the tarball ships — the official template sets
+		// `files: ["dist"]`, so source is not in the tarball, and the AST-walking
+		// rules no-op on compiled `.d.ts`/`.js` (the description AST is a type
+		// annotation there, not a literal). `analyzePackage` ignores `dist/` and
+		// `.git/`, matching `n8n-node lint`'s `globalIgnores(['dist'])`.
 		{ plugins: { 'n8n-nodes-base': n8nNodesPlugin } },
 		{
 			files: ['package.json'],
@@ -185,13 +169,27 @@ export const buildScanConfig = async () => {
 			languageOptions: { parser },
 		},
 		// The external `nodes`/`credentials` rulesets walk a TSESTree AST, so
-		// TS sources (when present in the tarball) need the TS parser too.
+		// the cloned `.ts` sources need the TS parser.
 		{
 			files: ['**/*.ts'],
 			languageOptions: { parser },
 		},
 	);
 };
+
+/**
+ * Selects the files the gate lints inside a (cloned) source tree: authored
+ * `.ts` + `.json`, excluding build output (`dist/`), VCS metadata (`.git/`),
+ * deps (`node_modules/`), and lockfiles. Exported so the source-vs-compiled
+ * selection can be unit-tested without running ESLint (the external
+ * `n8n-nodes-base` parser instance no-ops under vitest — see `buildScanConfig`).
+ */
+export const collectLintFiles = (packageDir) =>
+	glob.sync(['**/*.ts', '**/*.json'], {
+		cwd: packageDir,
+		absolute: true,
+		ignore: ['node_modules/**', 'dist/**', '.git/**', '**/package-lock.json'],
+	});
 
 export const analyzePackage = async (packageDir) => {
 	const eslint = new ESLint({
@@ -202,15 +200,13 @@ export const analyzePackage = async (packageDir) => {
 	});
 
 	try {
-		// Lint both JS and JSON files. JSON inclusion is required because rules
-		// such as `no-overrides-field`, `valid-peer-dependencies`, and
-		// `package-name-convention` only run against `package.json`. Without
-		// it the scanner silently skips every package.json-based rule.
-		const filesToLint = glob.sync(['**/*.js', '**/*.ts', '**/*.json'], {
-			cwd: packageDir,
-			absolute: true,
-			ignore: ['node_modules/**', '**/package-lock.json'],
-		});
+		// `n8n-node lint` lints `**/*.ts` + `package.json`. The gate lints the
+		// cloned SOURCE, so ignore committed build output + VCS metadata (mirrors
+		// `n8n-node lint`'s `globalIgnores(['dist'])`). `.js` is deliberately
+		// excluded: published packages ship only `dist/` (the official template
+		// sets `files: ["dist"]`), and linting authored `.js` (e.g. gulpfile.js)
+		// trips rules like `no-restricted-imports` that are meaningless there.
+		const filesToLint = collectLintFiles(packageDir);
 
 		if (filesToLint.length === 0) {
 			return { passed: true, message: 'No files found to analyze' };
@@ -287,13 +283,35 @@ export const analyzePackageByName = async (packageName, version) => {
 
 		stdout.write(`✅ Provenance check passed for ${label} \n`);
 
-		stdout.write(`Downloading ${label}...`);
-		const packageDir = await downloadAndExtractPackage(packageName, exactVersion);
+		stdout.write(`Locating source for ${label}...`);
+		const sourceLocation = await getSourceLocation(packageMetadata, exactVersion);
 		if (stdout.TTY) {
 			stdout.clearLine(0);
 			stdout.cursorTo(0);
 		}
-		stdout.write(`✅ Downloaded ${label} \n`);
+		if (!sourceLocation) {
+			stdout.write(
+				`❌ Could not determine source repository from provenance attestation for ${label} \n`,
+			);
+			return {
+				packageName,
+				version: exactVersion,
+				passed: false,
+				message:
+					'Could not determine source repository and commit from the npm provenance attestation',
+			};
+		}
+		stdout.write(
+			`✅ Source located: ${sourceLocation.repoUrl}@${sourceLocation.commitSha.slice(0, 7)} \n`,
+		);
+
+		stdout.write(`Cloning source for ${label}...`);
+		const packageDir = cloneSourcePackage(sourceLocation.repoUrl, sourceLocation.commitSha);
+		if (stdout.TTY) {
+			stdout.clearLine(0);
+			stdout.cursorTo(0);
+		}
+		stdout.write(`✅ Cloned ${label} \n`);
 
 		stdout.write(`Analyzing ${label}...`);
 		const analysisResult = await analyzePackage(packageDir);

--- a/packages/@n8n/scan-community-package/scanner/scanner.test.mjs
+++ b/packages/@n8n/scan-community-package/scanner/scanner.test.mjs
@@ -3,7 +3,7 @@ import path from 'path';
 import os from 'os';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { analyzePackage, buildScanConfig } from './scanner.mjs';
+import { analyzePackage, buildScanConfig, collectLintFiles } from './scanner.mjs';
 
 /**
  * Build a temporary package directory on disk so we can hand it to
@@ -92,7 +92,7 @@ describe('analyzePackage', () => {
 				peerDependencies: { 'n8n-workflow': '*' },
 				overrides: { 'change-case': '4.1.2' },
 			},
-			'index.js': "module.exports = {};\n",
+			'index.js': 'module.exports = {};\n',
 		});
 
 		const result = await analyzePackage(fixtureDir);
@@ -113,7 +113,7 @@ describe('analyzePackage', () => {
 				peerDependencies: { 'n8n-workflow': '*' },
 				n8n: { n8nNodesApiVersion: 1, nodes: ['dist/nodes/Foo/Foo.node.js'] },
 			},
-			'index.js': "module.exports = {};\n",
+			'index.js': 'module.exports = {};\n',
 		});
 
 		const result = await analyzePackage(fixtureDir);
@@ -130,7 +130,7 @@ describe('analyzePackage', () => {
 				peerDependencies: { 'n8n-workflow': '*' },
 				scripts: { postinstall: 'node ./malicious.js' },
 			},
-			'index.js': "module.exports = {};\n",
+			'index.js': 'module.exports = {};\n',
 		});
 
 		const result = await analyzePackage(fixtureDir);
@@ -139,10 +139,52 @@ describe('analyzePackage', () => {
 		expect(result.details).toContain('no-forbidden-lifecycle-scripts');
 	});
 
-	// A well-formed node package's compiled sources must not trip the external
-	// node rules — those rules can't see enough in `.d.ts`/`.js` output to fire,
-	// so scanning must not produce false positives on legitimate packages.
-	it('does not false-positive on a well-formed node package layout (CE-1606)', async () => {
+	// CE-1713: the gate lints the package SOURCE (cloned from the provenance-
+	// attested git commit), not compiled `dist/` output. `collectLintFiles`
+	// selects authored `.ts` + `.json` and excludes `dist/`, `.git/`, `node_modules/`
+	// and lockfiles — mirroring `n8n-node lint`'s `globalIgnores(['dist'])`. `.js`
+	// is excluded too (compiled output + build scripts like gulpfile.js trip rules
+	// that are meaningless there). Asserted at the glob level because the external
+	// `n8n-nodes-base` AST-walking rules no-op under vitest (see `buildScanConfig`);
+	// full TS rule execution is verified by the end-to-end `node` scan on a real
+	// package (CE-1713 reproduction).
+	describe('collectLintFiles', () => {
+		it('selects authored .ts and .json, excludes dist/, .git/, .js and lockfiles', () => {
+			fixtureDir = makeFixturePackage({
+				'package.json': {
+					name: 'n8n-nodes-fixture',
+					version: '1.0.0',
+					description: 'A fixture community node package',
+					license: 'MIT',
+					author: { name: 'Test Author', email: 'test@example.com' },
+					keywords: ['n8n-community-node-package'],
+					peerDependencies: { 'n8n-workflow': '*' },
+					n8n: { n8nNodesApiVersion: 1, nodes: ['dist/nodes/Foo/Foo.node.js'] },
+				},
+				'nodes/Foo/Foo.node.ts': 'export class Foo {}\n',
+				'credentials/FooApi.credentials.ts': 'export class FooApi {}\n',
+				'gulpfile.js': "require('gulp');\n",
+				'package-lock.json': '{}',
+				'dist/nodes/Foo/Foo.node.js': '"use strict";\n',
+				'dist/nodes/Foo/Foo.node.d.ts': 'export declare class Foo {}\n',
+				'.git/config': '[core]\n',
+			});
+
+			const selected = collectLintFiles(fixtureDir)
+				.map((p) => path.relative(fixtureDir, p))
+				.sort();
+
+			expect(selected).toEqual(
+				['credentials/FooApi.credentials.ts', 'nodes/Foo/Foo.node.ts', 'package.json'].sort(),
+			);
+		});
+	});
+
+	// `dist/` build output in the cloned source repo must be ignored end-to-end:
+	// a file in `dist/` that would produce a parse error if linted must not be
+	// reached. This is robust under vitest (JSON parsing works regardless of the
+	// external plugin's parser instance).
+	it('ignores committed dist/ build output in the source tree', async () => {
 		fixtureDir = makeFixturePackage({
 			'package.json': {
 				name: 'n8n-nodes-fixture',
@@ -154,20 +196,8 @@ describe('analyzePackage', () => {
 				peerDependencies: { 'n8n-workflow': '*' },
 				n8n: { n8nNodesApiVersion: 1, nodes: ['dist/nodes/Foo/Foo.node.js'] },
 			},
-			'dist/nodes/Foo/Foo.node.d.ts': `export declare class Foo {
-    description: {
-        displayName: string;
-        name: string;
-        properties: {
-            displayName: string;
-            name: string;
-            type: string;
-            default: string;
-        }[];
-    };
-}
-`,
-			'dist/nodes/Foo/Foo.node.js': "\"use strict\";\nObject.defineProperty(exports, \"__esModule\", { value: true });\nexports.Foo = void 0;\nclass Foo {}\nexports.Foo = Foo;\n",
+			// Malformed JSON that would parse-error if `dist/` were not ignored.
+			'dist/broken.json': '{ this is not valid json }',
 		});
 
 		const result = await analyzePackage(fixtureDir);

--- a/packages/@n8n/scan-community-package/test/provenance.test.mjs
+++ b/packages/@n8n/scan-community-package/test/provenance.test.mjs
@@ -1,85 +1,189 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { checkPackageProvenance } from '../scanner/provenance.mjs';
+import {
+	checkPackageProvenance,
+	extractSourceLocationFromBundle,
+	getSourceLocation,
+} from '../scanner/provenance.mjs';
 
-test('checkPackageProvenance passes when npm provenance metadata is present', () => {
-	assert.deepEqual(
-		checkPackageProvenance(
+/**
+ * Build an npm attestations bundle shape (sigstore DSSE envelope) carrying a
+ * SLSA v1 provenance statement that pins a git source repo + commit, matching
+ * what `registry.npmjs.org/-/npm/v1/attestations/...` actually returns.
+ */
+function makeBundle({ repoUrl, commitSha, ref = 'refs/heads/main' }) {
+	const statement = {
+		_type: 'https://in-toto.io/Statement/v1',
+		predicateType: 'https://slsa.dev/provenance/v1',
+		subject: [],
+		predicate: {
+			buildDefinition: {
+				buildType: 'https://slsa.dev/buildtypes/github-actions/v1',
+				externalParameters: {
+					workflow: { ref, repository: repoUrl, path: '.github/workflows/publish.yml' },
+				},
+				resolvedDependencies: [
+					{
+						uri: `git+${repoUrl}@${ref}`,
+						digest: { gitCommit: commitSha },
+					},
+				],
+			},
+		},
+	};
+	return {
+		attestations: [
 			{
-				versions: {
-					'1.0.0': {
-						dist: {
-							attestations: {
-								provenance: {
-									predicateType: 'https://slsa.dev/provenance/v1',
-								},
+				predicateType: 'https://slsa.dev/provenance/v1',
+				bundle: {
+					dsseEnvelope: {
+						payload: Buffer.from(JSON.stringify(statement)).toString('base64'),
+					},
+				},
+			},
+		],
+	};
+}
+
+describe('checkPackageProvenance', () => {
+	it('passes when npm provenance metadata is present', () => {
+		expect(
+			checkPackageProvenance(
+				{
+					versions: {
+						'1.0.0': {
+							dist: {
+								attestations: { provenance: { predicateType: 'https://slsa.dev/provenance/v1' } },
 							},
 						},
 					},
 				},
-			},
-			'1.0.0',
-		),
-		{ passed: true },
-	);
-});
+				'1.0.0',
+			),
+		).toEqual({ passed: true });
+	});
 
-test('checkPackageProvenance fails when npm provenance metadata is missing', () => {
-	assert.deepEqual(
-		checkPackageProvenance(
-			{
-				versions: {
-					'1.0.0': { dist: {} },
-				},
-			},
-			'1.0.0',
-		),
-		{
+	it('fails when npm provenance metadata is missing', () => {
+		expect(checkPackageProvenance({ versions: { '1.0.0': { dist: {} } } }, '1.0.0')).toEqual({
 			passed: false,
 			message:
 				'Package was not published with npm provenance. Learn how to publish community nodes with provenance: https://docs.n8n.io/integrations/creating-nodes/deploy/submit-community-nodes/',
-		},
-	);
-});
+		});
+	});
 
-test('checkPackageProvenance fails when lint checks pass but npm provenance is missing', () => {
-	const lintResult = { passed: true };
-	const provenanceResult = checkPackageProvenance(
-		{
-			versions: {
-				'1.0.0': { dist: {} },
-			},
-		},
-		'1.0.0',
-	);
+	it('fails when lint checks pass but npm provenance is missing', () => {
+		const lintResult = { passed: true };
+		const provenanceResult = checkPackageProvenance(
+			{ versions: { '1.0.0': { dist: {} } } },
+			'1.0.0',
+		);
 
-	assert.equal(lintResult.passed, true);
-	assert.equal(provenanceResult.passed, false);
-	assert.match(provenanceResult.message, /Package was not published with npm provenance/);
-});
+		expect(lintResult.passed).toBe(true);
+		expect(provenanceResult.passed).toBe(false);
+		expect(provenanceResult.message).toMatch(/Package was not published with npm provenance/);
+	});
 
-test('checkPackageProvenance fails for unsupported provenance predicate types', () => {
-	assert.deepEqual(
-		checkPackageProvenance(
-			{
-				versions: {
-					'1.0.0': {
-						dist: {
-							attestations: {
-								provenance: {
-									predicateType: 'https://example.com/provenance/v1',
+	it('fails for unsupported provenance predicate types', () => {
+		expect(
+			checkPackageProvenance(
+				{
+					versions: {
+						'1.0.0': {
+							dist: {
+								attestations: {
+									provenance: { predicateType: 'https://example.com/provenance/v1' },
 								},
 							},
 						},
 					},
 				},
-			},
-			'1.0.0',
-		),
-		{
+				'1.0.0',
+			),
+		).toEqual({
 			passed: false,
 			message: 'Unsupported npm provenance predicate type: https://example.com/provenance/v1',
-		},
-	);
+		});
+	});
+});
+
+describe('extractSourceLocationFromBundle', () => {
+	it('extracts the git repo URL and attested commit from a SLSA provenance bundle', () => {
+		const bundle = makeBundle({
+			repoUrl: 'https://github.com/luzconsulting/n8n-nodes-salessuite',
+			commitSha: '42cdce5c0b8e14a84ddc20de86612270670348a4',
+		});
+
+		expect(extractSourceLocationFromBundle(bundle)).toEqual({
+			repoUrl: 'https://github.com/luzconsulting/n8n-nodes-salessuite',
+			commitSha: '42cdce5c0b8e14a84ddc20de86612270670348a4',
+		});
+	});
+
+	it('returns null when the bundle has no SLSA provenance attestation', () => {
+		const bundle = {
+			attestations: [
+				{ predicateType: 'https://github.com/npm/attestation/tree/main/specs/publish/v0.1' },
+			],
+		};
+		expect(extractSourceLocationFromBundle(bundle)).toBeNull();
+	});
+
+	it('returns null when resolvedDependencies lacks a git entry', () => {
+		const bundle = makeBundle({ repoUrl: 'https://github.com/o/r', commitSha: 'abc1234' });
+		// strip the git dependency, keep the workflow repo but no resolved git source
+		bundle.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(
+			JSON.stringify({
+				predicateType: 'https://slsa.dev/provenance/v1',
+				predicate: { buildDefinition: { resolvedDependencies: [] } },
+			}),
+		).toString('base64');
+		expect(extractSourceLocationFromBundle(bundle)).toBeNull();
+	});
+
+	it('returns null for a malformed payload', () => {
+		const bundle = {
+			attestations: [
+				{
+					predicateType: 'https://slsa.dev/provenance/v1',
+					bundle: { dsseEnvelope: { payload: 'not-json' } },
+				},
+			],
+		};
+		expect(extractSourceLocationFromBundle(bundle)).toBeNull();
+	});
+});
+
+describe('getSourceLocation', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('fetches the attestation bundle and resolves the source location', async () => {
+		const bundle = makeBundle({
+			repoUrl: 'https://github.com/o/r',
+			commitSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		});
+		const axios = await import('axios');
+		vi.spyOn(axios.default, 'get').mockResolvedValue({ data: bundle });
+
+		const result = await getSourceLocation(
+			{
+				versions: {
+					'1.0.0': {
+						dist: { attestations: { url: 'https://registry.npmjs.org/-/npm/v1/attestations/x' } },
+					},
+				},
+			},
+			'1.0.0',
+		);
+
+		expect(result).toEqual({
+			repoUrl: 'https://github.com/o/r',
+			commitSha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+		});
+	});
+
+	it('returns null when the version has no attestations url', async () => {
+		expect(await getSourceLocation({ versions: { '1.0.0': { dist: {} } } }, '1.0.0')).toBeNull();
+	});
 });


### PR DESCRIPTION
## Summary

`@n8n/scan-community-package` was linting the **compiled** output shipped in published tarballs. That made the gate a near-dead check:

- Published community packages ship only `dist/` (the official `n8n-node` template sets `"files": ["dist"]`) — source is not in the tarball.
- The AST-walking node/credential rules **no-op** on compiled `.d.ts`/`.js` (the description AST is a type annotation there, not a literal `description = { ... }`), so the content rules silently never fired.
- The filename-convention rules **always false-positive** on compiled output — they hard-code a `.ts` suffix, so `SalesSuiteApi.credentials.d.ts` can never satisfy an expected `SalesSuiteApi.credentials.ts` (the bug reported in CE-1713).

### The fix

The scanner already **requires npm provenance** (SLSA v1). That attestation carries the source repo + the **attested commit SHA** in `predicate.buildDefinition.resolvedDependencies`. The scanner now:

1. extracts the repo URL + commit SHA from the provenance attestation (`extractSourceLocationFromBundle`),
2. clones the repo at that exact commit,
3. lints the **authored source** — mirroring `n8n-node lint` (`globalIgnores(['dist'])`, lint `**/*.ts` + `package.json`, drop `.js`).

The filename-convention and node-description content rules then run as designed.

## How to test

End-to-end on the ticket's own package:

```bash
npx @n8n/scan-community-package @luzconsulting/n8n-nodes-salessuite@1.0.4
```

- **Before:** `❌ ... Rename file to SalesSuiteApi.credentials.ts [non-autofixable] n8n-nodes-base/cred-filename-against-convention` (false positive; the content rules silently missed everything).
- **After:** provenance → source located (`42cdce5`) → cloned → linted. The false positive is gone; 6 **genuine** violations now surface (raw-error rethrows via `require-node-api-error`, wrong dynamic-options display names/descriptions).

```bash
cd packages/@n8n/scan-community-package && pnpm test   # 19/19
```

New unit tests:
- `extractSourceLocationFromBundle` parses the SLSA bundle → `{ repoUrl, commitSha }`; returns `null` for missing/malformed provenance.
- `collectLintFiles` selects authored `.ts`+`.json` and excludes `dist/`, `.git/`, `node_modules/`, lockfiles, and `.js` (proving the source-vs-compiled selection at the glob level).
- `analyzePackage` ignores committed `dist/` build output (robust under vitest via a malformed-JSON-in-`dist` fixture).

Note: the external `n8n-nodes-base` AST-walking rules no-op in-process under vitest (parser-instance mismatch — already documented in the existing `buildScanConfig` tests), so TS rule execution is verified by the `node`-driven e2e reproduction above rather than a vitest execution assertion. This PR also fixes `test/provenance.test.mjs`, which used `node:test` under vitest (`No test suite found`).

## ⚠️ Behavior change — needs coordination

Switching from compiled output to source means **packages that currently pass the gate may now fail for genuine source-level violations** the compiled gate silently missed (e.g. the ticket's package surfaces 6 real issues. This is the gate working, but it changes what community packages are accepted and should be coordinated with the community-node review process. If a hard flip is too disruptive, a phase-in (warn-only, or a curated allowlist) could gate this — flagging here for review.

Requires usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--no-lazy-fetch]
           [--no-optional-locks] [--no-advice] [--bare] [--git-dir=<path>]
           [--work-tree=<path>] [--namespace=<name>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone      Clone a repository into a new directory
   init       Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add        Add file contents to the index
   mv         Move or rename a file, a directory, or a symlink
   restore    Restore working tree files
   rm         Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect     Use binary search to find the commit that introduced a bug
   diff       Show changes between commits, commit and working tree, etc
   grep       Print lines matching a pattern
   log        Show commit logs
   show       Show various types of objects
   status     Show the working tree status

grow, mark and tweak your common history
   backfill   Download missing objects in a partial clone
   branch     List, create, or delete branches
   commit     Record changes to the repository
   history    EXPERIMENTAL: Rewrite history
   merge      Join two or more development histories together
   rebase     Reapply commits on top of another base tip
   reset      Set `HEAD` or the index to a known state
   switch     Switch branches
   tag        Create, list, delete or verify tags

collaborate (see also: git help workflows)
   fetch      Download objects and refs from another repository
   pull       Fetch from and integrate with another repository or a local branch
   push       Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
See 'git help git' for an overview of the system. on the host (the scanner already shells out to npm <command>

Usage:

npm install        install all the dependencies in your project
npm install <foo>  add the <foo> dependency to your project
npm test           run this project's tests
npm run <foo>      run the script named <foo>
npm <command> -h   quick help on <command>
npm -l             display usage info for all commands
npm help <term>    search for help on <term>
npm help npm       more involved overview

All commands:

    access, adduser, audit, bugs, cache, ci, completion,
    config, dedupe, deprecate, diff, dist-tag, docs, doctor,
    edit, exec, explain, explore, find-dupes, fund, get, help,
    help-search, init, install, install-ci-test, install-test,
    link, ll, login, logout, ls, org, outdated, owner, pack,
    ping, pkg, prefix, profile, prune, publish, query, rebuild,
    repo, restart, root, run, sbom, search, set, shrinkwrap,
    star, stars, start, stop, team, test, token, undeprecate,
    uninstall, unpublish, unstar, update, version, view, whoami

Specify configs in the ini-formatted file:
    /Users/garrit/.npmrc
or on the command line via: npm <command> --key=value

More configuration info: npm help config
Configuration fields: npm help 7 config

npm@11.6.2 /Users/garrit/.local/share/mise/installs/node/24.13.0/lib/node_modules/npm/, so consistent). Source location is trusted via npm's sigstore-backed provenance; non- repo URLs and malformed SHAs are rejected before cloning.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1713

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with , , or  (if the PR is an urgent fix that needs to be backported)
EOF
)