### PR TITLE
fix: Serialize date output in FTP, Set, IMAP and Unleashed nodes

### DIFF
--- a/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/EmailReadImap.node.ts
@@ -13,13 +13,14 @@ export class EmailReadImap extends VersionedNodeType {
 			iconColor: 'green',
 			group: ['trigger'],
 			description: 'Triggers the workflow when a new email is received',
-			defaultVersion: 2.1,
+			defaultVersion: 2.2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new EmailReadImapV1(baseDescription),
 			2: new EmailReadImapV2(baseDescription),
 			2.1: new EmailReadImapV2(baseDescription),
+			2.2: new EmailReadImapV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/test/v2/utils.test.ts
@@ -97,6 +97,46 @@ describe('Test IMap V2 utils', () => {
 			});
 		});
 
+		const rawEmailWithDate = 'Date: Wed, 01 Jan 2020 12:00:00 +0000\r\nSubject: Hello\r\n\r\nBody';
+
+		const resolveEmailWithDate = async (typeVersion: number) => {
+			const messageWithDate = {
+				attributes: { uuid: 1, uid: 950, struct: {} },
+				parts: [{ which: '', body: rawEmailWithDate }],
+			};
+			const localConnection = mock<ImapSimple>({
+				search: vi.fn().mockResolvedValue([messageWithDate]),
+			});
+
+			triggerFunctions.getNode.mockReturnValue(mock<INode>({ typeVersion }));
+			triggerFunctions.getNodeParameter.calledWith('format').mockReturnValue('resolved');
+			triggerFunctions.getNodeParameter
+				.calledWith('dataPropertyAttachmentsPrefixName')
+				.mockReturnValue('resolved');
+			triggerFunctions.getWorkflowStaticData.mockReturnValue({});
+
+			const onEmailBatch = vi.fn();
+			await getNewEmails.call(triggerFunctions, {
+				imapConnection: localConnection,
+				searchCriteria: [],
+				postProcessAction: '',
+				getText,
+				getAttachment,
+				onEmailBatch,
+			});
+			return onEmailBatch.mock.calls[0][0][0] as { json: { date: unknown } };
+		};
+
+		it('should return the mail date as an ISO string in resolved format on version 2.2', async () => {
+			const item = await resolveEmailWithDate(2.2);
+			expect(item.json.date).toBe('2020-01-01T12:00:00.000Z');
+		});
+
+		it('should keep the mail date as a Date object in resolved format before version 2.2', async () => {
+			const item = await resolveEmailWithDate(2.1);
+			expect(item.json.date).toBeInstanceOf(Date);
+		});
+
 		it('should skip emails with missing HEADER part in simple format', async () => {
 			const messageWithoutHeader = {
 				attributes: { uuid: 1, uid: 900, struct: {} },

--- a/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/EmailReadImapV2.node.ts
@@ -35,7 +35,7 @@ const versionDescription: INodeTypeDescription = {
 	icon: 'fa:inbox',
 	iconColor: 'green',
 	group: ['trigger'],
-	version: [2, 2.1],
+	version: [2, 2.1, 2.2],
 	description: 'Triggers the workflow when a new email is received',
 	eventTriggerDescription: 'Waiting for you to receive an email',
 	defaults: {

--- a/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
+++ b/packages/nodes-base/nodes/EmailReadImap/v2/utils.ts
@@ -12,6 +12,7 @@ import {
 	type INodeExecutionData,
 	type IDataObject,
 	type ITriggerFunctions,
+	deepCopy,
 	NodeOperationError,
 	type IBinaryKeyData,
 } from 'n8n-workflow';
@@ -46,8 +47,11 @@ async function parseRawEmail(
 		additionalData.attachments = undefined;
 	}
 
+	const json: IDataObject = { ...responseData, ...additionalData };
+
 	return {
-		json: { ...responseData, ...additionalData },
+		// v2.2+ deep-serializes the mail so the Date and any other non-JSON values stay JSON-safe
+		json: this.getNode().typeVersion >= 2.2 ? deepCopy(json) : json,
 		binary: Object.keys(binaryData).length ? binaryData : undefined,
 	} as INodeExecutionData;
 }

--- a/packages/nodes-base/nodes/Ftp/Ftp.node.ts
+++ b/packages/nodes-base/nodes/Ftp/Ftp.node.ts
@@ -1,7 +1,7 @@
 import { formatPemBlock } from '@n8n/utils/format-pem-block';
 import { generatePairedItemData } from '@utils/utilities';
 import { createWriteStream } from 'fs';
-import { BINARY_ENCODING, NodeApiError, NodeConnectionTypes } from 'n8n-workflow';
+import { BINARY_ENCODING, deepCopy, NodeApiError, NodeConnectionTypes } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialsDecrypted,
@@ -128,7 +128,7 @@ export class Ftp implements INodeType {
 		icon: 'node:ftp',
 		iconColor: 'dark-blue',
 		group: ['input'],
-		version: 1,
+		version: [1, 1.1],
 		subtitle: '={{$parameter["protocol"] + ": " + $parameter["operation"]}}',
 		description: 'Transfer files via FTP or SFTP',
 		defaults: {
@@ -589,6 +589,7 @@ export class Ftp implements INodeType {
 		const items = this.getInputData();
 		let returnItems: INodeExecutionData[] = [];
 		const operation = this.getNodeParameter('operation', 0);
+		const serializeDates = this.getNode().typeVersion >= 1.1;
 
 		let credentials: ICredentialDataDecryptedObject | undefined = undefined;
 		const protocol = this.getNodeParameter('protocol', 0) as string;
@@ -682,8 +683,11 @@ export class Ftp implements INodeType {
 								responseData.forEach((item) => normalizeSFtpItem(item, path));
 							}
 
+							const json = responseData as unknown as IDataObject[];
 							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
+								this.helpers.returnJsonArray(
+									serializeDates ? json.map((item) => deepCopy(item)) : json,
+								),
 								{ itemData: { item: i } },
 							);
 							returnItems = returnItems.concat(executionData);
@@ -808,8 +812,11 @@ export class Ftp implements INodeType {
 								);
 							}
 
+							const json = responseData as unknown as IDataObject[];
 							const executionData = this.helpers.constructExecutionMetaData(
-								this.helpers.returnJsonArray(responseData as unknown as IDataObject[]),
+								this.helpers.returnJsonArray(
+									serializeDates ? json.map((item) => deepCopy(item)) : json,
+								),
 								{ itemData: { item: i } },
 							);
 							returnItems = returnItems.concat(executionData);

--- a/packages/nodes-base/nodes/Ftp/__test__/Ftp.node.test.ts
+++ b/packages/nodes-base/nodes/Ftp/__test__/Ftp.node.test.ts
@@ -17,6 +17,7 @@ describe('Ftp', () => {
 		vi.resetAllMocks();
 
 		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNode.mockReturnValue({ typeVersion: 1 } as never);
 		executeFunctions.helpers.constructExecutionMetaData.mockImplementation(
 			(data) => data as NodeExecutionWithMetadata[],
 		);
@@ -102,6 +103,67 @@ describe('Ftp', () => {
 				readyTimeout: 12345,
 			}),
 		);
+	});
+
+	const setupSftpList = (typeVersion: number) => {
+		const list = vi.fn().mockResolvedValue([
+			{
+				name: 'file.txt',
+				type: '-',
+				size: 10,
+				accessTime: Date.UTC(2020, 0, 1, 12, 0, 0),
+				modifyTime: Date.UTC(2020, 0, 2, 12, 0, 0),
+			},
+		]);
+		vi.spyOn(sftpModule, 'default').mockImplementation(function () {
+			return { connect: vi.fn(), list, end: vi.fn() } as unknown as sftp;
+		});
+		executeFunctions.getNode.mockReturnValue({ typeVersion } as never);
+		executeFunctions.getCredentials.mockResolvedValue({
+			host: 'test.com',
+			port: 22,
+			username: 'test',
+			password: 'test',
+		});
+		executeFunctions.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		executeFunctions.getNodeParameter.mockImplementation((parameterName, _idx, defaultValue) => {
+			switch (parameterName) {
+				case 'operation':
+					return 'list';
+				case 'protocol':
+					return 'sftp';
+				case 'path':
+					return '/test';
+				case 'recursive':
+					return false;
+				case 'options':
+					return {};
+				default:
+					return defaultValue;
+			}
+		});
+	};
+
+	it('should return sftp list timestamps as ISO strings on version 1.1', async () => {
+		setupSftpList(1.1);
+
+		const result = await new Ftp().execute.call(executeFunctions);
+
+		const item = result[0][0].json;
+		expect(item.accessTime).toBe('2020-01-01T12:00:00.000Z');
+		expect(item.modifyTime).toBe('2020-01-02T12:00:00.000Z');
+	});
+
+	it('should return sftp list timestamps as Date objects on version 1', async () => {
+		setupSftpList(1);
+
+		const result = await new Ftp().execute.call(executeFunctions);
+
+		const item = result[0][0].json;
+		expect(item.accessTime).toBeInstanceOf(Date);
+		expect(item.modifyTime).toBeInstanceOf(Date);
 	});
 
 	it('should add timeout option with sftp with private key', async () => {

--- a/packages/nodes-base/nodes/Set/Set.node.ts
+++ b/packages/nodes-base/nodes/Set/Set.node.ts
@@ -13,7 +13,7 @@ export class Set extends VersionedNodeType {
 			iconColor: 'blue',
 			group: ['input'],
 			description: 'Add or edit fields on an input item and optionally remove other fields',
-			defaultVersion: 3.4,
+			defaultVersion: 3.5,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -24,6 +24,7 @@ export class Set extends VersionedNodeType {
 			3.2: new SetV2(baseDescription),
 			3.3: new SetV2(baseDescription),
 			3.4: new SetV2(baseDescription),
+			3.5: new SetV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Set/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Set/test/v2/utils.test.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import get from 'lodash/get';
 import { constructExecutionMetaData } from 'n8n-core';
 import type { IDataObject, IExecuteFunctions, IGetNodeParameterOptions, INode } from 'n8n-workflow';
@@ -344,6 +345,29 @@ describe('test Set2, validateEntry', () => {
 		expect(result).toEqual({
 			name: 'foo',
 			value: 'undefined',
+		});
+	});
+
+	describe('date & object serialization on version 3.5', () => {
+		it('should return a dateTime field as an ISO string', () => {
+			const result = validateEntry('foo', 'dateTime', '2020-01-01T12:00:00Z', node, 0, false, 3.5);
+
+			expect(typeof result.value).toBe('string');
+			expect(result.value).toBe(new Date('2020-01-01T12:00:00Z').toISOString());
+		});
+
+		it('should deep-serialize dates nested inside object fields', () => {
+			const value = JSON.stringify({ nested: { when: '2020-01-01T12:00:00.000Z' } });
+			const result = validateEntry('foo', 'object', value, node, 0, false, 3.5);
+
+			expect(result.value).toEqual({ nested: { when: '2020-01-01T12:00:00.000Z' } });
+		});
+
+		it('should keep a dateTime field as a DateTime object before version 3.5', () => {
+			const result = validateEntry('foo', 'dateTime', '2020-01-01T12:00:00Z', node, 0, false, 3.4);
+
+			expect(typeof result.value).not.toBe('string');
+			expect(DateTime.isDateTime(result.value)).toBe(true);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
+++ b/packages/nodes-base/nodes/Set/v2/SetV2.node.ts
@@ -20,7 +20,7 @@ const versionDescription: INodeTypeDescription = {
 	name: 'set',
 	iconColor: 'blue',
 	group: ['input'],
-	version: [3, 3.1, 3.2, 3.3, 3.4],
+	version: [3, 3.1, 3.2, 3.3, 3.4, 3.5],
 	description: 'Modify, add, or remove item fields',
 	subtitle: '={{$parameter["mode"]}}',
 	defaults: {

--- a/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Set/v2/helpers/utils.ts
@@ -205,9 +205,17 @@ export const validateEntry = (
 		}
 	}
 
+	const newValue = validationResult.newValue;
+
+	// v3.5+ serializes values to JSON-safe form so output never carries live
+	// Luxon DateTime objects (dateTime fields) or nested dates inside objects/arrays
+	if (nodeVersion && nodeVersion >= 3.5 && newValue !== undefined && newValue !== null) {
+		return { name, value: deepCopy(newValue) };
+	}
+
 	return {
 		name,
-		value: validationResult.newValue ?? null,
+		value: newValue ?? null,
 	};
 };
 

--- a/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.test.ts
@@ -1,0 +1,36 @@
+import { convertNETDates } from './GenericFunctions';
+
+describe('UnleashedSoftware Node: Generic Functions', () => {
+	describe('convertNETDates', () => {
+		it('should convert .NET dates to Date objects by default', () => {
+			const item: { [key: string]: unknown } = { created: '/Date(1586833770780)/' };
+
+			convertNETDates(item);
+
+			expect(item.created).toBeInstanceOf(Date);
+			expect((item.created as Date).getTime()).toBe(1586833770780);
+		});
+
+		it('should convert .NET dates to ISO strings when serializeDates is true', () => {
+			const item: { [key: string]: unknown } = {
+				created: '/Date(1586833770780)/',
+				nested: { updated: '/Date(1586833770780)/' },
+			};
+
+			convertNETDates(item, true);
+
+			expect(item.created).toBe(new Date(1586833770780).toISOString());
+			expect((item.nested as { updated: unknown }).updated).toBe(
+				new Date(1586833770780).toISOString(),
+			);
+		});
+
+		it('should leave non-date strings untouched', () => {
+			const item: { [key: string]: unknown } = { name: 'Product 1' };
+
+			convertNETDates(item, true);
+
+			expect(item.name).toBe('Product 1');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/UnleashedSoftware/GenericFunctions.ts
@@ -85,18 +85,20 @@ export async function unleashedApiRequestAllItems(
 //which is useless on JS side and could not treated as a date for other nodes
 //so we need to convert all of the fields that has it.
 
-export function convertNETDates(item: { [key: string]: any }) {
+export function convertNETDates(item: { [key: string]: any }, serializeDates = false) {
 	Object.keys(item).forEach((path) => {
 		const type = typeof item[path] as string;
 		if (type === 'string') {
 			const value = item[path] as string;
 			const a = /\/Date\((\d*)\)\//.exec(value);
 			if (a) {
-				item[path] = new Date(+a[1]);
+				const date = new Date(+a[1]);
+				// v1.1+ returns ISO strings so node output stays JSON-safe
+				item[path] = serializeDates ? date.toISOString() : date;
 			}
 		}
 		if (type === 'object' && item[path]) {
-			convertNETDates(item[path] as IDataObject);
+			convertNETDates(item[path] as IDataObject, serializeDates);
 		}
 	});
 }

--- a/packages/nodes-base/nodes/UnleashedSoftware/UnleashedSoftware.node.ts
+++ b/packages/nodes-base/nodes/UnleashedSoftware/UnleashedSoftware.node.ts
@@ -24,7 +24,7 @@ export class UnleashedSoftware implements INodeType {
 		subtitle: '={{$parameter["operation"] + ":" + $parameter["resource"]}}',
 		// eslint-disable-next-line n8n-nodes-base/node-class-description-icon-not-svg
 		icon: 'file:unleashedSoftware.png',
-		version: 1,
+		version: [1, 1.1],
 		description: 'Consume Unleashed Software API',
 		defaults: {
 			name: 'Unleashed Software',
@@ -70,6 +70,7 @@ export class UnleashedSoftware implements INodeType {
 		const length = items.length;
 		const qs: IDataObject = {};
 		let responseData: IDataObject | IDataObject[] = [];
+		const serializeDates = this.getNode().typeVersion >= 1.1;
 
 		for (let i = 0; i < length; i++) {
 			const resource = this.getNodeParameter('resource', 0);
@@ -121,7 +122,7 @@ export class UnleashedSoftware implements INodeType {
 						)) as IDataObject;
 						responseData = responseData.Items as IDataObject[];
 					}
-					convertNETDates(responseData);
+					convertNETDates(responseData, serializeDates);
 					responseData = this.helpers.constructExecutionMetaData(
 						this.helpers.returnJsonArray(responseData),
 						{ itemData: { item: i } },
@@ -173,7 +174,7 @@ export class UnleashedSoftware implements INodeType {
 						responseData = responseData.Items as IDataObject[];
 					}
 
-					convertNETDates(responseData);
+					convertNETDates(responseData, serializeDates);
 					responseData = this.helpers.constructExecutionMetaData(
 						this.helpers.returnJsonArray(responseData),
 						{ itemData: { item: i } },
@@ -183,7 +184,7 @@ export class UnleashedSoftware implements INodeType {
 				if (operation === 'get') {
 					const productId = this.getNodeParameter('productId', i) as string;
 					responseData = await unleashedApiRequest.call(this, 'GET', `/StockOnHand/${productId}`);
-					convertNETDates(responseData);
+					convertNETDates(responseData, serializeDates);
 				}
 			}
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-core.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/ndv-core.spec.ts
@@ -153,7 +153,7 @@ test.describe(
 			await n8n.canvas.openNode('Edit Fields (old)');
 			await n8n.ndv.openSettings();
 			await expect(n8n.ndv.getNodeVersion()).toContainText('Set node version 2');
-			await expect(n8n.ndv.getNodeVersion()).toContainText('Latest version: 3.4');
+			await expect(n8n.ndv.getNodeVersion()).toContainText('Latest version: 3.5');
 			await n8n.ndv.close();
 
 			await n8n.canvas.openNode('Edit Fields (latest)');


### PR DESCRIPTION
## Summary

Four non-database nodes leaked live JS `Date` (or Luxon `DateTime`) objects straight into node output — inconsistent, since the same value comes back as a string after any serialization boundary. New node versions return them as JSON-safe strings:

- **FTP v1.1** — SFTP/FTP listing `modifyTime` / `accessTime`
- **Unleashed Software v1.1** — `/Date(...)/` fields
- **Email Trigger (IMAP) v2.2** — the resolved-format mail `date`
- **Edit Fields (Set) v3.5** — `dateTime` fields and nested dates inside object/array values

All behind new node versions: FTP, IMAP and Set deep-serialize their output; Unleashed converts its .NET dates to ISO strings in place.

## How to test

See Linear

## Related tickets

https://linear.app/n8n/issue/NODE-5426
Parent: https://linear.app/n8n/issue/NODE-3077

## Checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title follows conventions
- [x] Tests included


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

