### PR TITLE
feat(API): Add public API endpoint to toggle SAML login

### DIFF
--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -3,6 +3,7 @@ import type {
 	AddDataTableRowsDto,
 	PublicApiCreateDataTableDto,
 	PublicTestRunStatus,
+	SamlToggleDto,
 	UpdateDataTableDto,
 	UpdateDataTableColumnDto,
 	UpdateDataTableRowDto,
@@ -397,4 +398,8 @@ export declare namespace SecurityPolicyRequest {
 
 export declare namespace SsoSamlRequest {
 	type Get = AuthenticatedRequest;
+}
+
+export declare namespace SettingsSsoSamlRequest {
+	type Toggle = AuthenticatedRequest<{}, {}, SamlToggleDto>;
 }

--- a/packages/cli/src/public-api/v1/handlers/settings-sso-saml/settings-sso-saml.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/settings-sso-saml/settings-sso-saml.handler.ts
@@ -1,0 +1,45 @@
+import { SamlToggleDto } from '@n8n/api-types';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { SamlService } from '@/modules/sso-saml/saml.service.ee';
+
+import type { SettingsSsoSamlRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import {
+	apiKeyHasScopeWithGlobalScopeFallback,
+	isLicensed,
+} from '../../shared/middlewares/global.middleware';
+
+type SettingsSsoSamlHandlers = {
+	toggleSamlLogin: PublicAPIEndpoint<SettingsSsoSamlRequest.Toggle>;
+};
+
+const settingsSsoSamlHandlers: SettingsSsoSamlHandlers = {
+	toggleSamlLogin: [
+		isLicensed('feat:saml'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'saml:manage' }),
+		async (req, res) => {
+			const payload = SamlToggleDto.safeParse(req.body);
+			if (!payload.success) {
+				throw new BadRequestError(payload.error.errors[0]?.message ?? 'Invalid request body');
+			}
+
+			if (Container.get(InstanceSettingsLoaderConfig).ssoManagedByEnv) {
+				throw new ConflictError(
+					'SSO configuration is managed via environment variables and cannot be modified through the API',
+				);
+			}
+
+			await Container.get(SamlService).setSamlPreferences({
+				loginEnabled: payload.data.loginEnabled,
+			});
+
+			return res.json({ loginEnabled: payload.data.loginEnabled });
+		},
+	],
+};
+
+export = settingsSsoSamlHandlers;

--- a/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/paths/settings.sso.saml.toggle.yml
+++ b/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/paths/settings.sso.saml.toggle.yml
@@ -1,0 +1,34 @@
+post:
+  x-eov-operation-id: toggleSamlLogin
+  x-required-scope: saml:manage
+  x-eov-operation-handler: v1/handlers/settings-sso-saml/settings-sso-saml.handler
+  tags:
+    - SettingsSsoSaml
+  summary: Enable or disable SAML login
+  description: >
+    Enable or disable SAML login for the instance. The change takes effect exactly as it would
+    from the UI, using the same validation. Requires the `saml:manage` scope and the SAML feature
+    to be licensed. When SSO configuration is managed via environment variables, the write is
+    rejected with 409 and no changes are made.
+  requestBody:
+    description: The desired SAML login state.
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/saml-toggle.request.yml'
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/saml-toggle.response.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+    '409':
+      $ref: '../../../../shared/spec/responses/conflict.yml'

--- a/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/schemas/saml-toggle.request.yml
+++ b/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/schemas/saml-toggle.request.yml
@@ -1,0 +1,9 @@
+type: object
+additionalProperties: false
+required:
+  - loginEnabled
+properties:
+  loginEnabled:
+    type: boolean
+    description: Whether SAML login should be enabled for the instance.
+    example: true

--- a/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/schemas/saml-toggle.response.yml
+++ b/packages/cli/src/public-api/v1/handlers/settings-sso-saml/spec/schemas/saml-toggle.response.yml
@@ -1,0 +1,9 @@
+type: object
+additionalProperties: false
+required:
+  - loginEnabled
+properties:
+  loginEnabled:
+    type: boolean
+    description: The SAML login state after the toggle operation.
+    example: true

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -67,6 +67,8 @@ paths:
     $ref: './handlers/security-policy/spec/paths/security-policy.yml'
   /settings/sso/saml:
     $ref: './handlers/sso-saml/spec/paths/settings.sso.saml.yml'
+  /settings/sso/saml/toggle:
+    $ref: './handlers/settings-sso-saml/spec/paths/settings.sso.saml.toggle.yml'
   /credentials:
     $ref: './handlers/credentials/spec/paths/credentials.yml'
   /credentials/{id}:

--- a/packages/cli/test/integration/public-api/settings-sso-saml.test.ts
+++ b/packages/cli/test/integration/public-api/settings-sso-saml.test.ts
@@ -2,18 +2,18 @@ import { testDb } from '@n8n/backend-test-utils';
 import { InstanceSettingsLoaderConfig } from '@n8n/config';
 import type { User } from '@n8n/db';
 import { Container } from '@n8n/di';
-
-import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
-import { SamlService } from '@/modules/sso-saml/saml.service.ee';
-import { setSamlLoginEnabled } from '@/modules/sso-saml/saml-helpers';
-import {
-	getCurrentAuthenticationMethod,
-	setCurrentAuthenticationMethod,
-} from '@/sso.ee/sso-helpers';
 import { createOwnerWithApiKey } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
 import { sampleConfig } from '../saml/sample-metadata';
+
+import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { setSamlLoginEnabled } from '@/modules/sso-saml/saml-helpers';
+import { SamlService } from '@/modules/sso-saml/saml.service.ee';
+import {
+	getCurrentAuthenticationMethod,
+	setCurrentAuthenticationMethod,
+} from '@/sso.ee/sso-helpers';
 
 describe('SAML toggle in Public API', () => {
 	let owner: User;
@@ -47,8 +47,6 @@ describe('SAML toggle in Public API', () => {
 
 	describe('POST /settings/sso/saml/toggle', () => {
 		it('enables SAML login', async () => {
-			testServer.license.enable('feat:saml');
-
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.post('/settings/sso/saml/toggle')
@@ -60,7 +58,6 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('disables SAML login', async () => {
-			testServer.license.enable('feat:saml');
 			await setSamlLoginEnabled(true);
 			await setCurrentAuthenticationMethod('saml');
 
@@ -75,8 +72,6 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('rejects a malformed request body with 400', async () => {
-			testServer.license.enable('feat:saml');
-
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.post('/settings/sso/saml/toggle')
@@ -86,8 +81,6 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('rejects with 401 without a valid API key', async () => {
-			testServer.license.enable('feat:saml');
-
 			const response = await testServer
 				.publicApiAgentWithoutApiKey()
 				.post('/settings/sso/saml/toggle')
@@ -97,6 +90,8 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('rejects with 403 when not licensed', async () => {
+			testServer.license.disable('feat:saml');
+
 			const response = await testServer
 				.publicApiAgentFor(owner)
 				.post('/settings/sso/saml/toggle')
@@ -107,7 +102,6 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('rejects with 403 when the API key lacks the saml:manage scope', async () => {
-			testServer.license.enable('feat:saml');
 			const scopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
 
 			const response = await testServer
@@ -119,7 +113,6 @@ describe('SAML toggle in Public API', () => {
 		});
 
 		it('rejects a write with 409 when SSO is managed via environment variables', async () => {
-			testServer.license.enable('feat:saml');
 			setManagedByEnv(true);
 
 			const response = await testServer

--- a/packages/cli/test/integration/public-api/settings-sso-saml.test.ts
+++ b/packages/cli/test/integration/public-api/settings-sso-saml.test.ts
@@ -1,0 +1,134 @@
+import { testDb } from '@n8n/backend-test-utils';
+import { InstanceSettingsLoaderConfig } from '@n8n/config';
+import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import { FeatureNotLicensedError } from '@/errors/feature-not-licensed.error';
+import { SamlService } from '@/modules/sso-saml/saml.service.ee';
+import { setSamlLoginEnabled } from '@/modules/sso-saml/saml-helpers';
+import {
+	getCurrentAuthenticationMethod,
+	setCurrentAuthenticationMethod,
+} from '@/sso.ee/sso-helpers';
+import { createOwnerWithApiKey } from '@test-integration/db/users';
+import { setupTestServer } from '@test-integration/utils';
+
+import { sampleConfig } from '../saml/sample-metadata';
+
+describe('SAML toggle in Public API', () => {
+	let owner: User;
+	const testServer = setupTestServer({
+		endpointGroups: ['publicApi', 'saml'],
+		enabledFeatures: ['feat:saml'],
+	});
+	const licenseErrorMessage = new FeatureNotLicensedError('feat:saml').message;
+
+	const setManagedByEnv = (value: boolean) => {
+		Container.get(InstanceSettingsLoaderConfig).ssoManagedByEnv = value;
+	};
+
+	beforeAll(async () => {
+		await testDb.init();
+	});
+
+	beforeEach(async () => {
+		await testDb.truncate(['User']);
+		setManagedByEnv(false);
+		await setSamlLoginEnabled(false);
+		await setCurrentAuthenticationMethod('email');
+
+		owner = await createOwnerWithApiKey();
+		await Container.get(SamlService).setSamlPreferences(sampleConfig);
+	});
+
+	afterEach(() => {
+		setManagedByEnv(false);
+	});
+
+	describe('POST /settings/sso/saml/toggle', () => {
+		it('enables SAML login', async () => {
+			testServer.license.enable('feat:saml');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: true });
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ loginEnabled: true });
+			expect(getCurrentAuthenticationMethod()).toBe('saml');
+		});
+
+		it('disables SAML login', async () => {
+			testServer.license.enable('feat:saml');
+			await setSamlLoginEnabled(true);
+			await setCurrentAuthenticationMethod('saml');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: false });
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ loginEnabled: false });
+			expect(getCurrentAuthenticationMethod()).toBe('email');
+		});
+
+		it('rejects a malformed request body with 400', async () => {
+			testServer.license.enable('feat:saml');
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: 'not-a-boolean' });
+
+			expect(response.status).toBe(400);
+		});
+
+		it('rejects with 401 without a valid API key', async () => {
+			testServer.license.enable('feat:saml');
+
+			const response = await testServer
+				.publicApiAgentWithoutApiKey()
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: true });
+
+			expect(response.status).toBe(401);
+		});
+
+		it('rejects with 403 when not licensed', async () => {
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: true });
+
+			expect(response.status).toBe(403);
+			expect(response.body).toHaveProperty('message', licenseErrorMessage);
+		});
+
+		it('rejects with 403 when the API key lacks the saml:manage scope', async () => {
+			testServer.license.enable('feat:saml');
+			const scopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:read'] });
+
+			const response = await testServer
+				.publicApiAgentFor(scopedOwner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: true });
+
+			expect(response.status).toBe(403);
+		});
+
+		it('rejects a write with 409 when SSO is managed via environment variables', async () => {
+			testServer.license.enable('feat:saml');
+			setManagedByEnv(true);
+
+			const response = await testServer
+				.publicApiAgentFor(owner)
+				.post('/settings/sso/saml/toggle')
+				.send({ loginEnabled: true });
+
+			expect(response.status).toBe(409);
+			expect(getCurrentAuthenticationMethod()).toBe('email');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
+++ b/packages/nodes-base/nodes/N8n/n8n-api-coverage.json
@@ -184,6 +184,9 @@
 		"GET /settings/sso/saml": {
 			"status": "gap"
 		},
+		"POST /settings/sso/saml/toggle": {
+			"status": "gap"
+		},
 		"POST /variables": {
 			"status": "gap"
 		},


### PR DESCRIPTION
## Summary

Adds a new public API endpoint `POST /settings/sso/saml/toggle` to enable or disable SAML login for the instance.

<img width="666" height="413" alt="image" src="https://github.com/user-attachments/assets/243caedd-06e1-451e-8289-b21a5a1294eb" />


- The write goes through the existing `SamlService.setSamlPreferences`, so no SAML logic or validation is reimplemented in the API layer — the change takes effect exactly as it would from the UI.
- Requires the `saml:manage` scope (`apiKeyHasScopeWithGlobalScopeFallback`) and the `feat:saml` license (`isLicensed`).
- When SSO is managed via environment variables (`ssoManagedByEnv`), the write is rejected with `409` and no changes are made.
- Malformed request bodies are validated with `SamlToggleDto` and return `400`.
- OpenAPI spec (path + request/response schemas) added so the public API reference generates automatically.

Part of [API-12](https://linear.app/n8n/issue/API-12) — adding public API endpoints for SAML SSO configuration.

## How to test

This endpoint is gated by the SAML feature, which requires an enterprise license with `feat:saml` and an API key with the `saml:manage` scope.

Integration tests cover the full matrix in `packages/cli/test/integration/public-api/settings-sso-saml.test.ts`:

```bash
cd packages/cli
pnpm test settings-sso-saml.test.ts
```

Manual test against a licensed instance:

```bash
# Enable SAML login
curl -X POST https://<instance>/api/v1/settings/sso/saml/toggle \
  -H "X-N8N-API-KEY: <key>" \
  -H "Content-Type: application/json" \
  -d '{"loginEnabled": true}'

# Disable SAML login
curl -X POST https://<instance>/api/v1/settings/sso/saml/toggle \
  -H "X-N8N-API-KEY: <key>" \
  -H "Content-Type: application/json" \
  -d '{"loginEnabled": false}'
```

Expected: `200` with `{"loginEnabled": <bool>}`; `400` for a malformed body; `401` without a valid key; `403` without `saml:manage` or without `feat:saml` licensed; `409` when SSO is managed via environment variables.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/API-57

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

