### PR TITLE
feat(core): Add telemetry events for advanced HITL usage (no-changelog)

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -3683,4 +3683,24 @@ describe('TelemetryEventRelay', () => {
 			expect(typeof result.patch).toBe('number');
 		});
 	});
+
+	describe('HITL events', () => {
+		it('should track on `hitl-response-actioned` event', () => {
+			const event: RelayEventMap['hitl-response-actioned'] = {
+				nodeType: 'n8n-nodes-base.slack',
+				approved: true,
+				authorized: false,
+				executionId: 'exec1',
+				workflowId: 'wf1',
+			};
+
+			eventService.emit('hitl-response-actioned', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('Advanced HITL response actioned', {
+				node_type: 'n8n-nodes-base.slack',
+				is_approved: true,
+				is_authorized: false,
+			});
+		});
+	});
 });

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -2,6 +2,7 @@ import type { AuthenticationMethod, ProjectRelation, RedactionFloor } from '@n8n
 import type { AuthProviderType, User, IWorkflowDb } from '@n8n/db';
 import type {
 	CancellationReason,
+	HitlResponseTelemetryPayload,
 	IPersonalizationSurveyAnswersV4,
 	IRun,
 	IWorkflowBase,
@@ -241,6 +242,8 @@ export type RelayEventMap = {
 		nodeName: string;
 		nodeType?: string;
 	};
+
+	'hitl-response-actioned': HitlResponseTelemetryPayload;
 
 	// #endregion
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -212,8 +212,25 @@ export class TelemetryEventRelay extends EventRelay {
 				this.instanceAiMcpRegistryConnectionCreated(event),
 			'instance-ai-mcp-registry-connection-deleted': (event) =>
 				this.instanceAiMcpRegistryConnectionDeleted(event),
+			'hitl-response-actioned': (event) => this.hitlResponseActioned(event),
 		});
 	}
+
+	// #region HITL
+
+	private hitlResponseActioned({
+		nodeType,
+		approved,
+		authorized,
+	}: RelayEventMap['hitl-response-actioned']) {
+		this.telemetry.track('Advanced HITL response actioned', {
+			node_type: nodeType,
+			is_approved: approved,
+			is_authorized: authorized,
+		});
+	}
+
+	// #endregion
 
 	// #region Instance AI MCP
 

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -806,6 +806,9 @@ export async function getBase({
 		logAiEvent: (eventName: AiEvent, payload: AiEventPayload) => {
 			eventService.emit(eventName, payload);
 		},
+		logHitlResponse: (payload) => {
+			eventService.emit('hitl-response-actioned', payload);
+		},
 		getRunnerStatus: (taskType: string) =>
 			Container.get(TaskRequester as ServiceIdentifier<TaskRequester>).getRunnerStatus(taskType),
 	};

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -157,6 +157,15 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return this.webhookData.webhookDescription.name;
 	}
 
+	logHitlResponse(payload: { approved: boolean; authorized: boolean }) {
+		this.additionalData.logHitlResponse?.({
+			...payload,
+			nodeType: this.node.type,
+			executionId: this.additionalData.executionId,
+			workflowId: this.workflow.id,
+		});
+	}
+
 	async validateCookieAuth(cookieValue: string): Promise<IUser> {
 		if (!this.additionalData.validateCookieAuth) {
 			throw new UnexpectedError('Cookie auth validation is not available');

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
@@ -228,4 +228,54 @@ describe('telemetry', () => {
 			vi.unstubAllGlobals();
 		});
 	});
+
+	describe('trackNodeParametersValuesChange - advanced HITL', () => {
+		it('tracks the enable event when Slack captureResponder is turned on', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.slack', {
+				name: 'parameters.captureResponder',
+				value: true,
+			});
+
+			expect(trackSpy).toHaveBeenCalledWith('User enabled advanced HITL', {
+				node_type: 'n8n-nodes-base.slack',
+			});
+		});
+
+		it('tracks the enable event when Telegram chatApproval is turned on', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.telegram', {
+				name: 'parameters.chatApproval',
+				value: true,
+			});
+
+			expect(trackSpy).toHaveBeenCalledWith('User enabled advanced HITL', {
+				node_type: 'n8n-nodes-base.telegram',
+			});
+		});
+
+		it('does not track the enable event when the toggle is turned off', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.slack', {
+				name: 'parameters.captureResponder',
+				value: false,
+			});
+
+			expect(trackSpy).not.toHaveBeenCalledWith('User enabled advanced HITL', expect.anything());
+		});
+
+		it('does not track the enable event for an unrelated parameter change', () => {
+			const trackSpy = vi.spyOn(telemetry, 'track');
+
+			telemetry.trackNodeParametersValuesChange('n8n-nodes-base.slack', {
+				name: 'parameters.otherOptions.someField',
+				value: true,
+			});
+
+			expect(trackSpy).not.toHaveBeenCalledWith('User enabled advanced HITL', expect.anything());
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -210,6 +210,15 @@ export class Telemetry {
 					toValue: change.value,
 				});
 			}
+
+			// Advanced HITL (one-tap approval) opt-in toggles, tracked per node.
+			const advancedHitlPathMap: { [key: string]: string } = {
+				[SLACK_NODE_TYPE]: 'parameters.captureResponder',
+				[TELEGRAM_NODE_TYPE]: 'parameters.chatApproval',
+			};
+			if (change.name === advancedHitlPathMap[nodeType] && change.value === true) {
+				this.track('User enabled advanced HITL', { node_type: nodeType });
+			}
 		}
 	}
 

--- a/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
@@ -178,10 +178,9 @@ export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
 	const approvers = this.getNodeParameter('approvers', []) as string[];
 	if (approvers.length > 0 && !approvers.includes(payload.user?.id ?? '')) {
 		this.logHitlResponse({ approved, authorized: false });
-		await notifyNotAuthorized(this, payload);
-		// Acknowledge the interaction so Slack doesn't time out and retry the same click
-		// (which would re-run this handler and repeat the notice). The execution stays waiting.
+		// Acknowledge the interaction before the best-effort notification so Slack does not time out and retry the click.
 		this.getResponseObject().status(200).send('');
+		await notifyNotAuthorized(this, payload);
 		return { noWebhookResponse: true };
 	}
 

--- a/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
+++ b/packages/nodes-base/nodes/Slack/V2/SlackHitlWebhook.ts
@@ -167,19 +167,25 @@ export async function slackSendAndWaitWebhook(this: IWebhookFunctions) {
 			? jsonParse<SlackInteractionPayload>(body.payload, { fallbackValue: {} })
 			: (body as SlackInteractionPayload);
 
-	// No approvers configured means anyone can respond (the original default). If a list is set,
-	// a click from anyone not on it is ignored: tell them privately and keep waiting.
-	const approvers = this.getNodeParameter('approvers', []) as string[];
-	if (approvers.length > 0 && !approvers.includes(payload.user?.id ?? '')) {
-		await notifyNotAuthorized(this, payload);
-		return { noWebhookResponse: true };
-	}
-
 	// Fail closed: approve only when both signals agree — the HMAC-minted callback reference
 	// (verified at the CLI layer) and Slack's native action_id. Anything else counts as declined.
 	const action = payload.actions?.[0];
 	const parsed = parseHitlCallbackReference(action?.value ?? '');
 	const approved = parsed?.decision === 'a' && action?.action_id === HITL_APPROVE_ACTION_ID;
+
+	// No approvers configured means anyone can respond (the original default). If a list is set,
+	// a click from anyone not on it is ignored: tell them privately and keep waiting.
+	const approvers = this.getNodeParameter('approvers', []) as string[];
+	if (approvers.length > 0 && !approvers.includes(payload.user?.id ?? '')) {
+		this.logHitlResponse({ approved, authorized: false });
+		await notifyNotAuthorized(this, payload);
+		// Acknowledge the interaction so Slack doesn't time out and retry the same click
+		// (which would re-run this handler and repeat the notice). The execution stays waiting.
+		this.getResponseObject().status(200).send('');
+		return { noWebhookResponse: true };
+	}
+
+	this.logHitlResponse({ approved, authorized: true });
 	const responder = await extractSlackResponder(this, payload);
 
 	// Slack tells us when the button was clicked via action_ts (epoch seconds). If it's

--- a/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Slack/test/v2/node/SlackHitlWebhook.test.ts
@@ -257,7 +257,7 @@ describe('slackSendAndWaitWebhook', () => {
 	});
 
 	it('ignores a click from someone not on the approver list and notifies them privately', async () => {
-		const { ctx, httpRequest } = createContext({
+		const { ctx, httpRequest, status, send } = createContext({
 			interaction: true,
 			signatureSecret: 'secret',
 			approvers: ['U_ALLOWED'],
@@ -284,6 +284,9 @@ describe('slackSendAndWaitWebhook', () => {
 			'/chat.postEphemeral',
 			expect.objectContaining({ channel: 'C1', user: 'U_OTHER' }),
 		);
+		// Must acknowledge with a 200 so Slack doesn't time out and retry the same click.
+		expect(status).toHaveBeenCalledWith(200);
+		expect(send).toHaveBeenCalledWith('');
 	});
 
 	it('resumes when the responder is on the approver list', async () => {
@@ -569,6 +572,84 @@ describe('slackSendAndWaitWebhook', () => {
 		const result = await slackSendAndWaitWebhook.call(ctx);
 
 		expect(result).toEqual({ noWebhookResponse: true });
+	});
+
+	it('emits an actioned telemetry event with authorized: true when an approver approves', async () => {
+		const { ctx, httpRequest } = createContext({
+			interaction: true,
+			signatureSecret: 'secret',
+			approvers: ['U1'],
+			payload: {
+				user: { id: 'U1' },
+				actions: [
+					{ action_id: HITL_APPROVE_ACTION_ID, value: APPROVE_VALUE, action_ts: '1700000000.000' },
+				],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(ctx.logHitlResponse).toHaveBeenCalledWith({ approved: true, authorized: true });
+	});
+
+	it('emits an actioned telemetry event with approved: false for a decline', async () => {
+		const { ctx, httpRequest } = createContext({
+			interaction: true,
+			signatureSecret: 'secret',
+			payload: {
+				user: { id: 'U1' },
+				actions: [
+					{ action_id: HITL_DECLINE_ACTION_ID, value: DECLINE_VALUE, action_ts: '1700000000.000' },
+				],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+				response_url: 'https://hooks.slack.com/actions/xxx',
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ user: { profile: {} } });
+		httpRequest.mockResolvedValue({});
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(ctx.logHitlResponse).toHaveBeenCalledWith({ approved: false, authorized: true });
+	});
+
+	it('emits an actioned telemetry event with authorized: false when a non-approver clicks', async () => {
+		const { ctx } = createContext({
+			interaction: true,
+			signatureSecret: 'secret',
+			approvers: ['U_ALLOWED'],
+			payload: {
+				user: { id: 'U_OTHER' },
+				actions: [
+					{ action_id: HITL_APPROVE_ACTION_ID, value: APPROVE_VALUE, action_ts: '1700000000.000' },
+				],
+				channel: { id: 'C1' },
+				message: { ts: '111.222' },
+			},
+		});
+		verifySignature.mockResolvedValue(true);
+		slackApiRequest.mockResolvedValue({ ok: true });
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(ctx.logHitlResponse).toHaveBeenCalledWith({ approved: true, authorized: false });
+	});
+
+	it('emits no telemetry event for a non-interaction (standard link button) request', async () => {
+		const { ctx } = createContext({ method: 'GET', interaction: false });
+		sendAndWaitWebhook.mockResolvedValue({ noWebhookResponse: true });
+
+		await slackSendAndWaitWebhook.call(ctx);
+
+		expect(ctx.logHitlResponse).not.toHaveBeenCalled();
 	});
 
 	it('falls back to the receive time for respondedAt when action_ts is invalid', async () => {

--- a/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
+++ b/packages/nodes-base/nodes/Telegram/hitl/webhook.ts
@@ -128,6 +128,7 @@ export async function telegramSendAndWaitWebhook(
 		.filter(Boolean);
 
 	if (!isAuthorizedResponder(from, approverIds)) {
+		this.logHitlResponse({ approved: parsed.decision === 'a', authorized: false });
 		try {
 			await apiRequest.call(this, 'POST', 'answerCallbackQuery', {
 				callback_query_id: callbackQueryId,
@@ -156,6 +157,7 @@ export async function telegramSendAndWaitWebhook(
 	const chatId = callbackQuery.message?.chat?.id;
 	const messageId = callbackQuery.message?.message_id;
 	const approved = parsed.decision === 'a';
+	this.logHitlResponse({ approved, authorized: true });
 	const postDecisionBehavior = options.postDecisionBehavior ?? 'showOutcome';
 
 	if (chatId !== undefined && messageId !== undefined) {

--- a/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/node/telegramHitlWebhook.test.ts
@@ -265,6 +265,83 @@ describe('telegramSendAndWaitWebhook', () => {
 		);
 	});
 
+	it('emits an actioned telemetry event with authorized: true on an authorized approval', async () => {
+		webhookFns.getBodyData.mockReturnValue(makeCallbackQueryBody());
+		webhookFns.getNodeParameter.mockImplementation((name: unknown) => {
+			if (name === 'chatApproval') return true;
+			if (name === 'chatApprovalOptions') return { postDecisionBehavior: 'showOutcome' };
+			return undefined;
+		});
+		webhookFns.getHeaderData.mockReturnValue({
+			'x-telegram-bot-api-secret-token': VALID_SECRET_TOKEN,
+		});
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(webhookFns.logHitlResponse).toHaveBeenCalledWith({ approved: true, authorized: true });
+	});
+
+	it('emits an actioned telemetry event with approved: false for a decline', async () => {
+		webhookFns.getBodyData.mockReturnValue(
+			makeCallbackQueryBody({ data: buildHitlCallbackReference('42', 'd', TEST_HMAC_SECRET) }),
+		);
+		webhookFns.getNodeParameter.mockImplementation((name: unknown) => {
+			if (name === 'chatApproval') return true;
+			if (name === 'chatApprovalOptions') return { postDecisionBehavior: 'keepMessage' };
+			return undefined;
+		});
+		webhookFns.getHeaderData.mockReturnValue({
+			'x-telegram-bot-api-secret-token': VALID_SECRET_TOKEN,
+		});
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(webhookFns.logHitlResponse).toHaveBeenCalledWith({ approved: false, authorized: true });
+	});
+
+	it('emits an actioned telemetry event with authorized: false when the approver list rejects the sender', async () => {
+		webhookFns.getBodyData.mockReturnValue(makeCallbackQueryBody({ from: { id: 111 } }));
+		webhookFns.getNodeParameter.mockImplementation((name: unknown) => {
+			if (name === 'chatApproval') return true;
+			if (name === 'chatApprovalOptions') return { approverIds: '777, 888' };
+			return undefined;
+		});
+		webhookFns.getHeaderData.mockReturnValue({
+			'x-telegram-bot-api-secret-token': VALID_SECRET_TOKEN,
+		});
+		const status = vi.fn().mockReturnThis();
+		const send = vi.fn();
+		webhookFns.getResponseObject.mockReturnValue({ status, send } as never);
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(webhookFns.logHitlResponse).toHaveBeenCalledWith({ approved: true, authorized: false });
+	});
+
+	it('emits no telemetry event when delegating to the shared handler (standard link button)', async () => {
+		(sendAndWaitWebhook as Mock).mockResolvedValue({ noWebhookResponse: true });
+		webhookFns.getBodyData.mockReturnValue({});
+		webhookFns.getNodeParameter.mockReturnValue(false);
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(webhookFns.logHitlResponse).not.toHaveBeenCalled();
+	});
+
+	it('emits no telemetry event for an unrecognizable callback reference (400)', async () => {
+		webhookFns.getBodyData.mockReturnValue({ callback_query: { id: 'cbq-1', data: 'garbage' } });
+		webhookFns.getNodeParameter.mockImplementation((name: unknown) =>
+			name === 'chatApproval' ? true : undefined,
+		);
+		const status = vi.fn().mockReturnThis();
+		const send = vi.fn();
+		webhookFns.getResponseObject.mockReturnValue({ status, send } as never);
+
+		await telegramSendAndWaitWebhook.call(webhookFns);
+
+		expect(webhookFns.logHitlResponse).not.toHaveBeenCalled();
+	});
+
 	it('does not edit the message when postDecisionBehavior is keepMessage', async () => {
 		webhookFns.getBodyData.mockReturnValue(makeCallbackQueryBody());
 		webhookFns.getNodeParameter.mockImplementation((name: unknown) => {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1469,6 +1469,8 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getResponseObject(): express.Response;
 	getWebhookName(): string;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
+	/** Emits telemetry for an advanced HITL response actioned via this webhook. */
+	logHitlResponse(payload: { approved: boolean; authorized: boolean }): void;
 	nodeHelpers: NodeHelperFunctions;
 	helpers: RequestHelperFunctions & BaseHelperFunctions & BinaryHelperFunctions;
 }
@@ -3467,6 +3469,17 @@ type AiEventPayload = {
 	nodeType?: string;
 };
 
+/** Telemetry emitted when an advanced HITL (human-in-the-loop) response is actioned. */
+export type HitlResponseTelemetryPayload = {
+	nodeType: string;
+	/** The decision the responder made. */
+	approved: boolean;
+	/** Whether the responder was on the node's approver allow-list (empty list = anyone). */
+	authorized: boolean;
+	executionId?: string;
+	workflowId?: string;
+};
+
 export type AgentRequestQuery = { [nodeName: string]: Record<string, unknown> | string };
 // Used to transport an agent request for partial execution
 export interface AiAgentRequest {
@@ -3528,6 +3541,7 @@ export interface IWorkflowExecuteAdditionalData {
 	projectId?: string;
 	variables: IDataObject;
 	logAiEvent: (eventName: AiEvent, payload: AiEventPayload) => void;
+	logHitlResponse?: (payload: HitlResponseTelemetryPayload) => void;
 	parentCallbackManager?: CallbackManager;
 	/**
 	 * The execution mode of the root (top-level) workflow. Used to propagate manual


### PR DESCRIPTION
## Summary

Adds telemetry so we can see whether **advanced HITL** (one-tap approval) is being turned on and used, per node, for **Slack** and **Telegram**. Two events, following existing naming conventions:

- **`User enabled advanced HITL`** (frontend) — fires when a user turns the advanced toggle on for a node (`captureResponder` for Slack, `chatApproval` for Telegram), reusing the existing `trackNodeParametersValuesChange` hook. Property: `node_type`.
- **`Advanced HITL response actioned`** (backend) — fires when an advanced response arrives via the interactive callback. Properties: `node_type`, `is_approved`, `is_authorized`.

The backend event is fired from inside the Slack/Telegram node webhook handlers (the only place that knows both the outcome and the authorization result). Since `nodes-base` can't reach the CLI telemetry service directly, it goes through a new `logHitlResponse` callback on the webhook context that mirrors the existing `logAiEvent` bridge (`workflow` type → `core` context impl → `cli` `eventService.emit` → `TelemetryEventRelay` → `telemetry.track`).

Standard link-button HITL fires **no new events**. Gmail (ENT-162) is deferred; the shared plumbing is built so it's a small follow-up.

This PR also includes a small **fix**: the Slack unauthorized branch now acknowledges the interaction with a `200`, so Slack doesn't time out and retry the same click (which previously re-ran the handler, repeating the "not authorized" notice — and double-counting the telemetry event).

Stacked on top of #34123 (ENT-160); base is `ent-160-slack-hitl-shared`.

## How to test

Telemetry only leaves the process when diagnostics is enabled, so point it at a local capture endpoint:

```bash
export N8N_DIAGNOSTICS_ENABLED=true
export N8N_DIAGNOSTICS_CONFIG_FRONTEND="dummy;http://localhost:9000"
export N8N_DIAGNOSTICS_CONFIG_BACKEND="dummy;http://localhost:9000"
```
Run a small server on `:9000` that logs POSTed RudderStack batches (with CORS + OPTIONS handling so the browser preflight passes).

**Enable event (no Slack/Telegram needed):** open a Slack (or Telegram) *Send and Wait for Approval* node, turn on **Capture who responded** / **Approve within chat** → expect `User enabled advanced HITL` with the node type. Toggle off → no event. A standard link-button config fires nothing.

**Actioned event (needs a real integration + public URL):** build *Manual Trigger → Telegram/Slack Send and Wait for Approval* with the advanced toggle on and an approver list, execute, then tap Approve/Decline:
- Approver approves → `Advanced HITL response actioned` `{ is_approved: true, is_authorized: true }`
- Non-approver clicks → `{ is_approved: <attempt>, is_authorized: false }` (single event — no retry)
- Decline → `is_approved: false`

Automated coverage: Slack/Telegram webhook handler tests, the CLI relay test, and the frontend telemetry plugin test all pass.
<img width="874" height="404" alt="Screenshot 2026-07-15 at 11 44 21" src="https://github.com/user-attachments/assets/adac681b-e2a1-4407-8eb1-2061f3a05347" />

<img width="715" height="325" alt="Screenshot 2026-07-15 at 12 10 12" src="https://github.com/user-attachments/assets/a330315a-d984-48b2-955c-c8417b002d8e" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-166

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34225">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->