### PR TITLE
fix(editor): Restore regex blank-line handling in sticky markdown

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.test.ts
@@ -130,11 +130,9 @@ describe('components', () => {
 			);
 		});
 
-		// ADO-5423: a single blank line in sticky markdown must keep collapsing
-		// to one block. When `\n\n` produces two separate <p> tags, the user-agent
-		// default margins stack on top of the theme spacing and notes gain the
-		// extra top padding / margin (and shifted UL) reported in the bug.
-		it('renders a single blank line as one block in sticky markdown (ADO-5423)', () => {
+		// ADO-5423: a single blank line stays a real paragraph break — the sticky
+		// top and paragraph spacing is handled in CSS, not by collapsing paragraphs.
+		it('renders a single blank line as separate paragraphs in sticky markdown (ADO-5423)', () => {
 			const wrapper = render(N8nMarkdown, {
 				global: {
 					directives: {
@@ -148,14 +146,12 @@ describe('components', () => {
 				},
 			});
 
-			const paragraphs = wrapper.container.querySelectorAll('p');
-			expect(paragraphs).toHaveLength(1);
+			expect(wrapper.container.querySelectorAll('p')).toHaveLength(2);
 		});
 
-		// Pinning #27231: a blank line BETWEEN a list and following text must stay
-		// a real paragraph break, otherwise the &nbsp; substitution turns the
-		// trailing text into a list-item continuation under the last bullet.
-		it('keeps text after a list as a separate block (sticky markdown)', () => {
+		// withMultiBreaks keeps additional blank lines as visible spacing, which
+		// markdown would otherwise collapse, by inserting non-breaking-space spacers.
+		it('preserves extra blank lines as spacing with withMultiBreaks', () => {
 			const wrapper = render(N8nMarkdown, {
 				global: {
 					directives: {
@@ -163,62 +159,14 @@ describe('components', () => {
 					},
 				},
 				props: {
-					content: '- item1\n- item2\n\nfollowing text',
+					content: 'Line 1\n\n\n\nLine 2',
 					withMultiBreaks: true,
 					theme: 'sticky',
 				},
 			});
 
-			expect(wrapper.container.querySelectorAll('ul li')).toHaveLength(2);
-			const list = wrapper.container.querySelector('ul');
-			expect(list?.textContent).not.toContain('following text');
-		});
-
-		// A blank line inside a fenced code block must stay literal: the &nbsp;
-		// soft-break substitution must not leak into rendered code.
-		it('leaves blank lines inside code blocks untouched (sticky markdown)', () => {
-			const wrapper = render(N8nMarkdown, {
-				global: {
-					directives: {
-						n8nHtml,
-					},
-				},
-				props: {
-					content: '```\nconst a = 1;\n\nconst b = 2;\n```',
-					withMultiBreaks: true,
-					theme: 'sticky',
-				},
-			});
-
-			const code = wrapper.container.querySelector('pre code');
-			expect(code?.textContent).toContain('const a = 1;');
-			expect(code?.textContent).toContain('const b = 2;');
-			expect(code?.textContent).not.toContain('&nbsp;');
-			expect(code?.textContent).not.toContain(' ');
-		});
-
-		// A longer outer fence (4 backticks) can contain a shorter inner fence (3
-		// backticks) as literal content. The shorter run must NOT close the block, so
-		// blank lines after it stay literal and never become a &nbsp; soft-break.
-		it('treats a shorter inner fence as code, not a closing fence (sticky markdown)', () => {
-			const wrapper = render(N8nMarkdown, {
-				global: {
-					directives: {
-						n8nHtml,
-					},
-				},
-				props: {
-					content: '````\nouter code\n```\nstill code\n\nalso still code\n````',
-					withMultiBreaks: true,
-					theme: 'sticky',
-				},
-			});
-
-			const code = wrapper.container.querySelector('pre code');
-			expect(code?.textContent).toContain('still code');
-			expect(code?.textContent).toContain('also still code');
-			expect(code?.textContent).not.toContain('&nbsp;');
-			expect(code?.textContent).not.toContain(' ');
+			expect(wrapper.container.querySelectorAll('p')).toHaveLength(2);
+			expect(wrapper.html()).toContain('&nbsp;');
 		});
 
 		it('should not render YouTube embed player with extra parameters', () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdown/Markdown.vue
@@ -99,52 +99,10 @@ const htmlContent = computed(() => {
 	const fileIdRegex = new RegExp('fileId:([0-9]+)');
 	let contentToRender = props.content;
 	if (props.withMultiBreaks) {
-		// Turn blank lines between plain text into &nbsp; soft breaks so they render
-		// as one paragraph (avoids UA <p> margins stacking on top of theme spacing).
-		// Keep them as real paragraph breaks when adjacent to block-level markdown
-		// (list, heading, blockquote, code fence, hr) so structures parse correctly,
-		// and leave blank lines inside fenced code blocks untouched so they stay literal.
-		// Parse a code-fence line into its fence char and run length (>= 3). A fence
-		// can be made of 3+ backticks or tildes; the closing fence must use the same
-		// char and be at least as long, and carry no info string after it.
-		const parseFence = (line: string) => {
-			const match = /^\s*(`{3,}|~{3,})(.*)$/.exec(line);
-			return match ? { char: match[1][0], length: match[1].length, rest: match[2] } : null;
-		};
-		const isBlockStart = (line: string) =>
-			/^\s*([-*+]|\d+\.)\s/.test(line) ||
-			/^#{1,6}\s/.test(line) ||
-			/^>/.test(line) ||
-			parseFence(line) !== null ||
-			/^---+\s*$/.test(line);
-		const lines = contentToRender.split('\n');
-		let openFence: { char: string; length: number } | null = null;
-		contentToRender = lines
-			.map((line, i) => {
-				const fence = parseFence(line);
-				if (openFence) {
-					// A closing fence matches the opening char, is at least as long, and
-					// has no trailing content; shorter/different fences stay code content.
-					if (
-						fence &&
-						fence.char === openFence.char &&
-						fence.length >= openFence.length &&
-						fence.rest.trim() === ''
-					) {
-						openFence = null;
-					}
-					return line;
-				}
-				if (fence) {
-					openFence = { char: fence.char, length: fence.length };
-					return line;
-				}
-				if (line !== '') return line;
-				const prev = lines[i - 1] ?? '';
-				const next = lines[i + 1] ?? '';
-				return isBlockStart(prev) || isBlockStart(next) ? '' : '&nbsp;';
-			})
-			.join('\n');
+		contentToRender = contentToRender.replace(/\n{3,}/g, (match) => {
+			// Keep \n\n for the paragraph break, add &nbsp;\n for each extra blank line
+			return '\n\n' + '&nbsp;\n'.repeat(match.length - 2);
+		});
 	}
 	const html = md.render(contentToRender);
 


### PR DESCRIPTION
## Summary

Reverts the `Markdown.vue` change from #32704, returning `withMultiBreaks` to the prior regex. Sticky header spacing is now handled in CSS (#34116), so the fence-tracking parser is no longer needed.


## How to test

1. Sticky note with `withMultiBreaks`.
2. Single blank line → two paragraphs; multiple blank lines → extra spacing preserved.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5423

Reverts #32704. Companion: #34116.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI