### PR TITLE
fix(editor): Widen options menu from small triggers and tooltip truncated items

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
@@ -512,6 +512,34 @@ describe('N8nDropdownMenu', () => {
 		});
 	});
 
+	describe('maxWidth prop', () => {
+		it('should apply maxWidth as number (pixels)', async () => {
+			render(DropdownMenu, {
+				props: {
+					items: createItems(3),
+					modelValue: true,
+					maxWidth: 320,
+				},
+			});
+
+			const { dropdown } = await getDropdownContent();
+			expect(dropdown).toHaveStyle({ maxWidth: '320px' });
+		});
+
+		it('should apply maxWidth as string', async () => {
+			render(DropdownMenu, {
+				props: {
+					items: createItems(3),
+					modelValue: true,
+					maxWidth: 'var(--spacing--5xl)',
+				},
+			});
+
+			const { dropdown } = await getDropdownContent();
+			expect(dropdown).toHaveStyle({ maxWidth: 'var(--spacing--5xl)' });
+		});
+	});
+
 	describe('teleported prop', () => {
 		it('should teleport to body by default', async () => {
 			const { container } = render(DropdownMenu, {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.types.ts
@@ -89,6 +89,8 @@ export interface DropdownMenuProps<T = string, D = never> {
 	teleported?: boolean;
 	/** Maximum height of the dropdown menu */
 	maxHeight?: string | number;
+	/** Maximum width of the dropdown menu. Overrides the default trigger-width cap — useful for small/icon triggers whose menu would otherwise be too narrow. */
+	maxWidth?: string | number;
 	/** Whether to show loading state */
 	loading?: boolean;
 	/** Number of skeleton items to show when loading */

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
@@ -72,12 +72,16 @@ const placementParts = computed(() => {
 });
 
 const contentContainerStyle = computed(() => {
+	const style: Record<string, string> = {};
 	if (props.maxHeight) {
-		const maxHeightValue =
+		style.maxHeight =
 			typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight;
-		return { maxHeight: maxHeightValue, overflowY: 'auto' };
+		style.overflowY = 'auto';
 	}
-	return {};
+	if (props.maxWidth) {
+		style.maxWidth = typeof props.maxWidth === 'number' ? `${props.maxWidth}px` : props.maxWidth;
+	}
+	return style;
 });
 
 const handleOpenChange = (open: boolean) => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.test.ts
@@ -121,28 +121,44 @@ describe('N8nDropdownMenuItem', () => {
 			});
 		});
 
-		it('should show title attribute when label is 20+ characters', async () => {
+		it('should show title attribute when the label is truncated', async () => {
+			// jsdom has no layout, so stub the label element's measurements to simulate overflow.
+			const scrollSpy = vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(200);
+			const clientSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(100);
+
 			renderMenuItem({
 				id: 'test',
-				label: 'A very long label that exceeds twenty characters',
+				label: 'A very long label that the menu is too narrow to show',
 			});
 
 			await waitFor(() => {
 				const label = document.querySelector('[role="menuitem"] .n8n-text');
-				expect(label).toHaveAttribute('title', 'A very long label that exceeds twenty characters');
+				expect(label).toHaveAttribute(
+					'title',
+					'A very long label that the menu is too narrow to show',
+				);
 			});
+
+			scrollSpy.mockRestore();
+			clientSpy.mockRestore();
 		});
 
-		it('should not show title attribute when label is under 20 characters', async () => {
+		it('should not show title attribute when the label fits', async () => {
+			const scrollSpy = vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(100);
+			const clientSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(100);
+
 			renderMenuItem({
 				id: 'test',
-				label: 'Short label',
+				label: 'A very long label that the menu is too narrow to show',
 			});
 
 			await waitFor(() => {
-				const label = document.querySelector('[role="menuitem"] .n8n-text');
-				expect(label).not.toHaveAttribute('title');
+				expect(document.querySelector('[role="menuitem"] .n8n-text')).toBeInTheDocument();
 			});
+			expect(document.querySelector('[role="menuitem"] .n8n-text')).not.toHaveAttribute('title');
+
+			scrollSpy.mockRestore();
+			clientSpy.mockRestore();
 		});
 
 		it('should render item with custom class', async () => {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -7,7 +7,16 @@ import {
 	DropdownMenuSubContent,
 	DropdownMenuPortal,
 } from 'reka-ui';
-import { computed, inject, nextTick, onBeforeUnmount, ref, useCssModule, watch } from 'vue';
+import {
+	computed,
+	inject,
+	nextTick,
+	onBeforeUnmount,
+	onMounted,
+	ref,
+	useCssModule,
+	watch,
+} from 'vue';
 
 import Icon from '@n8n/design-system/components/N8nIcon/Icon.vue';
 import N8nLoading from '@n8n/design-system/components/N8nLoading';
@@ -83,7 +92,21 @@ const trailingProps = computed(() => ({
 	class: $style['item-trailing'],
 }));
 
-const titleAttr = computed(() => (props.label.length >= 20 ? props.label : undefined));
+// Only surface a native tooltip when the label is actually truncated by the
+// ellipsis, so users can read option names the menu is too narrow to show.
+const labelRef = ref<{ $el?: HTMLElement } | null>(null);
+const isLabelTruncated = ref(false);
+
+const measureLabelTruncation = async () => {
+	await waitForLayout();
+	const el = labelRef.value?.$el;
+	isLabelTruncated.value = el ? el.scrollWidth > el.clientWidth : false;
+};
+
+onMounted(measureLabelTruncation);
+watch(() => props.label, measureLabelTruncation);
+
+const titleAttr = computed(() => (isLabelTruncated.value ? props.label : undefined));
 
 const handleSelect = (value: T) => {
 	emit('select', value);
@@ -203,6 +226,7 @@ onBeforeUnmount(() => {
 				</slot>
 				<slot name="item-label" :item="props" :ui="labelProps">
 					<N8nText
+						ref="labelRef"
 						:class="$style['item-label']"
 						:title="titleAttr"
 						size="medium"
@@ -348,6 +372,7 @@ onBeforeUnmount(() => {
 			</slot>
 			<slot name="item-label" :item="props" :ui="labelProps">
 				<N8nText
+					ref="labelRef"
 					:class="$style['item-label']"
 					:title="titleAttr"
 					size="medium"

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/__snapshots__/DropdownMenuItem.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/__snapshots__/DropdownMenuItem.test.ts.snap
@@ -84,37 +84,6 @@ exports[`N8nDropdownMenuItem > rendering > should render disabled item 1`] = `
 
 exports[`N8nDropdownMenuItem > rendering > should render highlighted item 1`] = `
 <div
-  class="item highlighted"
-  data-reka-collection-item=""
-  role="menuitem"
-  tabindex="-1"
->
-  
-  
-  
-  
-  <!--v-if-->
-  
-  
-  <span
-    class="n8n-text text-dark size-medium regular item-label item-label"
-  >
-    
-    Highlighted Item
-    
-  </span>
-  
-  
-  
-  <!--v-if-->
-  
-  
-  
-</div>
-`;
-
-exports[`N8nDropdownMenuItem > rendering > should render highlighted item 2`] = `
-<div
   aria-selected="true"
   class="item"
   data-reka-collection-item=""

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
@@ -275,6 +275,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 		<template v-if="!isReadOnly" #actions>
 			<N8nDropdownMenu
 				:items="dropdownOptions"
+				max-width="var(--spacing--5xl)"
 				:disabled="isAddDisabled"
 				data-test-id="collection-parameter-add-header"
 				@select="optionSelected"
@@ -350,6 +351,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 						<template #content>{{ addTooltipText }}</template>
 						<N8nDropdownMenu
 							:items="dropdownOptions"
+							max-width="var(--spacing--5xl)"
 							:disabled="isAddDisabled"
 							data-test-id="collection-parameter-add-header"
 							@select="optionSelected"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
@@ -312,6 +312,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 				<N8nDropdownMenu
 					ref="addDropdownRef"
 					:items="dropdownOptions"
+					max-width="var(--spacing--5xl)"
 					:class="$style.addDropdown"
 					data-test-id="collection-parameter-add-dropdown"
 					@select="optionSelected"
@@ -381,6 +382,7 @@ function valueChanged(parameterData: IUpdateInformation) {
 				<N8nDropdownMenu
 					ref="addDropdownRef"
 					:items="dropdownOptions"
+					max-width="var(--spacing--5xl)"
 					:class="$style.addDropdown"
 					data-test-id="collection-parameter-add-dropdown"
 					@select="optionSelected"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -593,6 +593,7 @@ const onAddButtonClick = () => {
 						<N8nDropdownMenu
 							v-if="hasMultipleOptions"
 							:items="dropdownOptions"
+							max-width="var(--spacing--5xl)"
 							:disabled="isAddDisabled"
 							data-test-id="fixed-collection-add-header"
 							@select="optionSelected"
@@ -713,6 +714,7 @@ const onAddButtonClick = () => {
 					<N8nDropdownMenu
 						v-if="hasMultipleOptions"
 						:items="dropdownOptions"
+						max-width="var(--spacing--5xl)"
 						:disabled="isAddDisabled"
 						data-test-id="fixed-collection-add-header"
 						@select="optionSelected"

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -683,6 +683,7 @@ const onAddButtonClick = () => {
 				<N8nDropdownMenu
 					v-else-if="hasMultipleOptions"
 					:items="dropdownOptions"
+					max-width="var(--spacing--5xl)"
 					:class="$style.dropdown"
 					:data-test-id="`fixed-collection-add-top-level-dropdown`"
 					:disabled="isAddDisabled"
@@ -785,6 +786,7 @@ const onAddButtonClick = () => {
 						<N8nDropdownMenu
 							v-else-if="hasMultipleOptions"
 							:items="dropdownOptions"
+							max-width="var(--spacing--5xl)"
 							:class="$style.dropdown"
 							:data-test-id="`fixed-collection-add-nested-dropdown`"
 							@select="optionSelected"


### PR DESCRIPTION
## Summary

The menu opened in options menu should have sufficient width
before:
<img width="566" height="624" alt="Screenshot 2026-07-15 at 17 31 53" src="https://github.com/user-attachments/assets/a13a93a2-15bb-4292-b244-d834e9adb8ad" />
after:
<img width="490" height="606" alt="Screenshot 2026-07-15 at 17 31 59" src="https://github.com/user-attachments/assets/663f3f9d-bec5-480b-b3f5-fd9d685d7418" />


## How to test

1. Enable the collection-overhaul experiment (browser console):

`window.featureFlags.override('048_collection_overhaul', 'variant') `

   then reload.
2. Open the **Airtable** node or **Google Sheets** node and open a `collection`/`fixedCollection` options menu from the small header `+` button.
3. The menu should be wide enough to show option labels like **Permission Level** instead of clipping them at the icon width.
4. For any option still too long for the menu, hover it — a tooltip with the full label should appear. Short labels that fit should show no tooltip.

## Related Linear tickets, Github issues, and Community forum posts

Surfaced while working on https://linear.app/n8n/issue/ADO-5586 (tracked separately from #34212).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34230">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

