### PR TITLE
fix(ai-builder): Honor eq @version conditions in generated node type definitions

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
+++ b/packages/@n8n/instance-ai/evaluations/credentials/seeder.ts
@@ -56,6 +56,14 @@ const CREDENTIAL_TEMPLATES: Record<string, CredentialTemplate> = {
 		defaultName: '[eval] WhatsApp OAuth account',
 		buildData: () => ({ clientId: 'eval-client-id', clientSecret: 'eval-client-secret' }),
 	},
+	googlePalmApi: {
+		defaultName: '[eval] Google Gemini',
+		envVar: 'EVAL_GEMINI_API_KEY',
+		buildData: (key) => ({
+			host: 'https://generativelanguage.googleapis.com',
+			apiKey: key,
+		}),
+	},
 	httpHeaderAuth: {
 		defaultName: '[eval] HTTP Header',
 		buildData: () => ({ name: 'Authorization', value: 'Bearer eval-placeholder' }),

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -2193,6 +2193,111 @@ describe('generate-types', () => {
 			expect(generateTypes.propertyAppliesToVersion(prop, 2.1)).toBe(false);
 			expect(generateTypes.propertyAppliesToVersion(prop, 3)).toBe(false);
 		});
+
+		it('should handle eq (equal) version condition', () => {
+			const prop: NodeProperty = {
+				name: 'modelName',
+				displayName: 'Model',
+				type: 'options',
+				default: 'models/gemini-2.5-flash',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { eq: 1 } }],
+					},
+				},
+			};
+			expect(generateTypes.propertyAppliesToVersion(prop, 1)).toBe(true);
+			expect(generateTypes.propertyAppliesToVersion(prop, 1.1)).toBe(false);
+			expect(generateTypes.propertyAppliesToVersion(prop, 2)).toBe(false);
+		});
+
+		it('should handle not (not equal) version condition', () => {
+			const prop: NodeProperty = {
+				name: 'text',
+				displayName: 'Text',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { not: 2 } }],
+					},
+				},
+			};
+			expect(generateTypes.propertyAppliesToVersion(prop, 1)).toBe(true);
+			expect(generateTypes.propertyAppliesToVersion(prop, 2)).toBe(false);
+			expect(generateTypes.propertyAppliesToVersion(prop, 2.1)).toBe(true);
+		});
+
+		it('should handle between version condition', () => {
+			const prop: NodeProperty = {
+				name: 'text',
+				displayName: 'Text',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					show: {
+						'@version': [{ _cnd: { between: { from: 2, to: 3 } } }],
+					},
+				},
+			};
+			expect(generateTypes.propertyAppliesToVersion(prop, 2)).toBe(true);
+			expect(generateTypes.propertyAppliesToVersion(prop, 2.5)).toBe(true);
+			expect(generateTypes.propertyAppliesToVersion(prop, 3)).toBe(true);
+			expect(generateTypes.propertyAppliesToVersion(prop, 1.9)).toBe(false);
+			expect(generateTypes.propertyAppliesToVersion(prop, 3.1)).toBe(false);
+		});
+	});
+
+	describe('filterPropertiesForVersion with per-version default overrides', () => {
+		// The light-versioning pattern: the same property is declared twice with
+		// version-gated defaults (e.g. LmChatGoogleGemini's modelName). An `eq`
+		// gate that isn't enforced leaks the old property into newer versions'
+		// typedefs, where the emitter keeps the first (old) duplicate.
+		const oldDefault: NodeProperty = {
+			name: 'modelName',
+			displayName: 'Model',
+			type: 'options',
+			default: 'models/old-model',
+			displayOptions: {
+				show: {
+					'@version': [{ _cnd: { eq: 1 } }],
+				},
+			},
+		};
+		const newDefault: NodeProperty = {
+			...oldDefault,
+			default: 'models/new-model',
+			displayOptions: {
+				show: {
+					'@version': [{ _cnd: { gte: 1.1 } }],
+				},
+			},
+		};
+
+		it('should keep only the matching duplicate for each version', () => {
+			const v1 = generateTypes.filterPropertiesForVersion([oldDefault, newDefault], 1);
+			expect(v1.map((p) => p.default)).toEqual(['models/old-model']);
+
+			const v11 = generateTypes.filterPropertiesForVersion([oldDefault, newDefault], 1.1);
+			expect(v11.map((p) => p.default)).toEqual(['models/new-model']);
+		});
+
+		it('should emit the version-correct @default in the generated type file', () => {
+			const node: NodeTypeDescription = {
+				name: '@n8n/n8n-nodes-langchain.lmChatExample',
+				displayName: 'Example Chat Model',
+				description: 'Example',
+				group: ['transform'],
+				version: [1, 1.1],
+				inputs: [],
+				outputs: ['ai_languageModel'],
+				properties: [oldDefault, newDefault],
+			};
+
+			const content = generateTypes.generateSingleVersionTypeFile(node, 1.1);
+			expect(content).toContain('@default models/new-model');
+			expect(content).not.toContain('@default models/old-model');
+		});
 	});
 
 	describe('groupVersionsByProperties', () => {

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
@@ -1919,10 +1919,13 @@ export function getPropertiesForCombination(
  */
 interface VersionCondition {
 	_cnd: {
+		eq?: number;
+		not?: number;
 		gt?: number;
 		gte?: number;
 		lt?: number;
 		lte?: number;
+		between?: { from: number; to: number };
 	};
 }
 
@@ -1937,11 +1940,14 @@ function versionMatchesCondition(version: number, condition: number | VersionCon
 
 	// It's a conditional expression like { _cnd: { gte: 3.1 } }
 	if (condition._cnd) {
-		const { gt, gte, lt, lte } = condition._cnd;
+		const { eq, not, gt, gte, lt, lte, between } = condition._cnd;
+		if (eq !== undefined && version !== eq) return false;
+		if (not !== undefined && version === not) return false;
 		if (gt !== undefined && !(version > gt)) return false;
 		if (gte !== undefined && !(version >= gte)) return false;
 		if (lt !== undefined && !(version < lt)) return false;
 		if (lte !== undefined && !(version <= lte)) return false;
+		if (between !== undefined && !(version >= between.from && version <= between.to)) return false;
 		return true;
 	}
 


### PR DESCRIPTION
## Summary

The workflow-sdk type-definition generator's `versionMatchesCondition` only implemented `gt`/`gte`/`lt`/`lte` — a `{ _cnd: { eq: 1 } }` `@version` gate destructured to all-undefined and returned `true` for every version. Old-version-gated properties therefore leaked into newer versions' generated typedefs, and since the emitter keeps the first duplicate of a same-named property, the **old** default won.

Concrete impact: `LmChatGoogleGemini` v1.1 changed its default to `models/gemini-3-flash-preview` in April (#28853), but the generated `V11Params` typedef kept advertising the v1 default `models/gemini-2.5-flash` (retired, 404s for new users) — directly contradicting the node's own `builderHint`. The AI builder reads that `@default` and follows it (reproduced in eval runs at HEAD).

This PR implements `eq`, `not`, and `between` per the canonical `displayOptions` condition contract. No node version bump or default change is needed — the existing v1.1 default is correct once the generator honors the gate.

Second (separable) commit: adds a `googlePalmApi` credential template to the eval credential seeder, needed by the `gemini-model-hint-compliance` lang-tracer suite case sourced from this bug.

## How to test

Unit tests cover each operator plus the regression pattern (duplicate same-named property with version-gated defaults). Empirical check:

```bash
cd packages/@n8n/workflow-sdk
npx tsx -e "
import { generateSingleVersionTypeFile } from './src/generate-types/generate-types.ts';
import { LmChatGoogleGemini } from '../nodes-langchain/nodes/llms/LmChatGoogleGemini/LmChatGoogleGemini.node.ts';
const desc = new LmChatGoogleGemini().description;
for (const v of [1, 1.1]) console.log(v, (generateSingleVersionTypeFile(desc, v).match(/@default models[^\n]*/g) || []).join(' | '));"
```

Before: both versions emit `@default models/gemini-2.5-flash`. After: v1 → `models/gemini-2.5-flash`, v1.1 → `models/gemini-3-flash-preview`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-911

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

