### PR TITLE
fix(core): Replace https agent for 'Ignore SSL issues' OAuth2 requests with one that respects proxies

### DIFF
--- a/packages/@n8n/client-oauth2/package.json
+++ b/packages/@n8n/client-oauth2/package.json
@@ -23,6 +23,7 @@
     "dist/**/*"
   ],
   "dependencies": {
+    "@n8n/backend-network": "workspace:*",
     "@n8n/utils": "workspace:*",
     "axios": "catalog:"
   },
@@ -30,6 +31,7 @@
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
     "@vitest/coverage-v8": "catalog:",
+    "https-proxy-agent": "catalog:",
     "typescript": "catalog:typescript",
     "vite": "catalog:",
     "vitest": "catalog:",

--- a/packages/@n8n/client-oauth2/src/client-oauth2.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { createHttpsProxyAgent } from '@n8n/backend-network/proxy';
 import axios from 'axios';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { Agent } from 'https';
 import * as qs from 'querystring';
 
 import type { ClientOAuth2TokenData } from './client-oauth2-token';
@@ -57,8 +57,6 @@ export class ResponseError extends Error {
 	}
 }
 
-const sslIgnoringAgent = new Agent({ rejectUnauthorized: false });
-
 /**
  * Construct an object that can handle the multiple OAuth 2.0 flows.
  */
@@ -112,7 +110,12 @@ export class ClientOAuth2 {
 		};
 
 		if (options.ignoreSSLIssues) {
-			requestConfig.httpsAgent = sslIgnoringAgent;
+			// Build a proxy-aware agent that relaxes TLS verification, so ignoring SSL
+			// issues still routes through the env proxy (HTTPS_PROXY / NO_PROXY) instead
+			// of connecting directly and bypassing the proxy.
+			requestConfig.httpsAgent = createHttpsProxyAgent(url, undefined, {
+				rejectUnauthorized: false,
+			});
 		}
 
 		const response = await axios.request(requestConfig);

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import { Agent as HttpsAgent } from 'https';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import nock from 'nock';
 
 import { ClientOAuth2, ResponseError } from '@/client-oauth2';
@@ -229,6 +231,83 @@ describe('ClientOAuth2', () => {
 			expect(result).toBeInstanceOf(ResponseError);
 			expect(result.message).toEqual('HTTP status 302');
 			expect(result.body).toEqual('Redirected');
+		});
+
+		describe('ignoreSSLIssues', () => {
+			const PROXY_ENV_VARS = ['HTTPS_PROXY', 'https_proxy', 'NO_PROXY', 'no_proxy'] as const;
+			let savedProxyEnv: Record<string, string | undefined>;
+
+			beforeEach(() => {
+				savedProxyEnv = {};
+				for (const key of PROXY_ENV_VARS) {
+					savedProxyEnv[key] = process.env[key];
+					delete process.env[key];
+				}
+			});
+
+			afterEach(() => {
+				for (const key of PROXY_ENV_VARS) {
+					if (savedProxyEnv[key] === undefined) {
+						delete process.env[key];
+					} else {
+						process.env[key] = savedProxyEnv[key];
+					}
+				}
+				vi.restoreAllMocks();
+			});
+
+			const makeIgnoreSSLCall = async () =>
+				await client.accessTokenRequest({
+					url: config.accessTokenUri,
+					method: 'POST',
+					headers: {
+						Authorization: authHeader,
+						Accept: 'application/json',
+						'Content-Type': 'application/x-www-form-urlencoded',
+					},
+					body: {
+						refresh_token: 'test',
+						grant_type: 'refresh_token',
+					},
+					ignoreSSLIssues: true,
+				});
+
+			it('should use a plain https agent with relaxed TLS when no proxy is configured', async () => {
+				mockTokenResponse({
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						access_token: config.accessToken,
+						refresh_token: config.refreshToken,
+					}),
+				});
+
+				const axiosSpy = vi.spyOn(axios, 'request');
+
+				await makeIgnoreSSLCall();
+
+				const requestConfig = axiosSpy.mock.calls[0][0];
+				const httpsAgent = requestConfig.httpsAgent as HttpsAgent;
+				expect(httpsAgent).toBeInstanceOf(HttpsAgent);
+				expect(httpsAgent).not.toBeInstanceOf(HttpsProxyAgent);
+				expect(httpsAgent.options.rejectUnauthorized).toBe(false);
+			});
+
+			it('should route through an https proxy agent with relaxed TLS when HTTPS_PROXY is set', async () => {
+				process.env.HTTPS_PROXY = 'http://localhost:8888';
+
+				const axiosSpy = vi.spyOn(axios, 'request');
+
+				// The request itself is routed at the proxy (unreachable here) rather than
+				// nock's direct https mock, so it may reject — we only assert the agent it
+				// was built with.
+				await makeIgnoreSSLCall().catch(() => {});
+
+				const requestConfig = axiosSpy.mock.calls[0][0];
+				const httpsAgent = requestConfig.httpsAgent as HttpsProxyAgent<string>;
+				expect(httpsAgent).toBeInstanceOf(HttpsProxyAgent);
+				expect(httpsAgent.connectOpts.rejectUnauthorized).toBe(false);
+			});
 		});
 	});
 

--- a/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
+++ b/packages/@n8n/client-oauth2/test/client-oauth2.test.ts
@@ -275,7 +275,7 @@ describe('ClientOAuth2', () => {
 			it('should use a plain https agent with relaxed TLS when no proxy is configured', async () => {
 				mockTokenResponse({
 					status: 200,
-					headers: { 'Content-Type': 'application/json' },
+					headers: { contentType: 'application/json' },
 					body: JSON.stringify({
 						access_token: config.accessToken,
 						refresh_token: config.refreshToken,
@@ -294,19 +294,81 @@ describe('ClientOAuth2', () => {
 			});
 
 			it('should route through an https proxy agent with relaxed TLS when HTTPS_PROXY is set', async () => {
-				process.env.HTTPS_PROXY = 'http://localhost:8888';
+				process.env.HTTPS_PROXY = 'http://fake-proxy.example';
 
-				const axiosSpy = vi.spyOn(axios, 'request');
+				const axiosSpy = vi.spyOn(axios, 'request').mockResolvedValue({
+					status: 200,
+					headers: { contentType: 'application/json' },
+					data: JSON.stringify({
+						access_token: config.accessToken,
+						refresh_token: config.refreshToken,
+					}),
+				});
 
-				// The request itself is routed at the proxy (unreachable here) rather than
-				// nock's direct https mock, so it may reject — we only assert the agent it
-				// was built with.
-				await makeIgnoreSSLCall().catch(() => {});
+				await makeIgnoreSSLCall();
 
 				const requestConfig = axiosSpy.mock.calls[0][0];
 				const httpsAgent = requestConfig.httpsAgent as HttpsProxyAgent<string>;
 				expect(httpsAgent).toBeInstanceOf(HttpsProxyAgent);
 				expect(httpsAgent.connectOpts.rejectUnauthorized).toBe(false);
+				// The ignore-SSL branch must keep axios's own proxy handling disabled
+				// so routing stays with our agent, not double-proxied.
+				expect(requestConfig.proxy).toBe(false);
+			});
+
+			it('should honor NO_PROXY and use a plain relaxed-TLS agent even when HTTPS_PROXY is set', async () => {
+				process.env.HTTPS_PROXY = 'http://fake-proxy.example';
+				process.env.NO_PROXY = new URL(config.baseUrl).hostname;
+
+				mockTokenResponse({
+					status: 200,
+					headers: { contentType: 'application/json' },
+					body: JSON.stringify({
+						access_token: config.accessToken,
+						refresh_token: config.refreshToken,
+					}),
+				});
+
+				const axiosSpy = vi.spyOn(axios, 'request');
+
+				await makeIgnoreSSLCall();
+
+				const requestConfig = axiosSpy.mock.calls[0][0];
+				const httpsAgent = requestConfig.httpsAgent as HttpsAgent;
+				expect(httpsAgent).toBeInstanceOf(HttpsAgent);
+				expect(httpsAgent).not.toBeInstanceOf(HttpsProxyAgent);
+				expect(httpsAgent.options.rejectUnauthorized).toBe(false);
+			});
+
+			it('should not set an httpsAgent when ignoreSSLIssues is false, leaving the global proxy agent in place', async () => {
+				process.env.HTTPS_PROXY = 'http://fake-proxy.example';
+
+				mockTokenResponse({
+					status: 200,
+					headers: { contentType: 'application/json' },
+					body: JSON.stringify({
+						access_token: config.accessToken,
+						refresh_token: config.refreshToken,
+					}),
+				});
+
+				const axiosSpy = vi.spyOn(axios, 'request');
+
+				await client.accessTokenRequest({
+					url: config.accessTokenUri,
+					method: 'POST',
+					headers: {
+						authorization: authHeader,
+						accept: 'application/json',
+						contentType: 'application/x-www-form-urlencoded',
+					},
+					body: { refresh_token: 'test', grant_type: 'refresh_token' },
+					ignoreSSLIssues: false,
+				});
+
+				const requestConfig = axiosSpy.mock.calls[0][0];
+				expect(requestConfig.httpsAgent).toBeUndefined();
+				expect(requestConfig.proxy).toBe(false);
 			});
 		});
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1625,6 +1625,9 @@ importers:
 
   packages/@n8n/client-oauth2:
     dependencies:
+      '@n8n/backend-network':
+        specifier: workspace:*
+        version: link:../backend-network
       '@n8n/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1641,6 +1644,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+      https-proxy-agent:
+        specifier: 'catalog:'
+        version: 7.0.6
       nock:
         specifier: 'catalog:'
         version: 14.0.14


### PR DESCRIPTION
## Summary
When 'Ignore SSL' was enabled for Oauth2 API credentials a new 'https Agent' was created with `{ rejectUnauthorized: false }` to account for that. However, this new Agent was never provided any config related to any proxies that n8n was configured to use, meaning that when 'Ignore SSL issues' was enabled all requests skipped the proxy entirely.

This PR replaces that basic `node:https` `Agent` with a standardised call to `createHttpsProxyAgent` to create an agent which can both allow unauthorised requests _and_ route through any provided proxies.
<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test
### Steps
1. Configure n8n to run using a proxy
2. Create an 'OAuth2 API' credential that has 'Ignore SSL?' **enabled**
3. Create a new workflow with a single 'HTTP request' node which uses your credential
4. Execute the 'HTTP Request' node - before the fix, the proxy is ignored entirely so the token server is never hit. After the fix it works as expected, both the token server and proxy see the request.

Below is some AI generated code to get a token server and proxy working locally for debug purposes for detailed testing.

<details>
<summary><b>Detailed reproduction instructions</b></summary>

Two throwaway servers run alongside a local n8n:

- **`proxy.mjs`** — fake corporate proxy (CONNECT tunnel). Logs every request it handles — this log is the verdict.
- **`token-server.mjs`** — fake OAuth2 provider on self-signed HTTPS. The self-signed cert is *why* a user turns on Ignore SSL Issues in the first place.

The token host `oauth-target.invalid` is a reserved TLD (RFC 6761) that never resolves. **Do not add it to `/etc/hosts`** — that is the point: n8n cannot reach it directly, only via the proxy (which self-routes every CONNECT to the local token server). A proxy-bypassing request therefore dies with `ENOTFOUND`, which is exactly the reported symptom.



1. Save the two scripts below plus a self-signed cert (`cert.pem` / `key.pem`, SAN `oauth-target.invalid`) into a folder:
   ```bash
   openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 30 \
     -subj "/CN=oauth-target.invalid" -addext "subjectAltName=DNS:oauth-target.invalid"
   ```
6. Terminal A: `node token-server.mjs`
7. Terminal B: `node proxy.mjs`
8. Terminal C — start n8n pointed at the proxy, in the same shell (n8n reads these only at startup):
   ```bash
   export HTTP_PROXY=http://localhost:8888
   export HTTPS_PROXY=http://localhost:8888
   export NODE_EXTRA_CA_CERTS=./cert.pem   # so the control (OFF) case trusts the cert
   pnpm --filter n8n dev
   ```
9. In the n8n UI: **Credentials → OAuth2 API**, Grant Type = **Client Credentials**, Access Token URL = `https://oauth-target.invalid:8443/token`, Client ID/Secret = anything, and toggle **Ignore SSL Issues**. Save.
10. Add an **HTTP Request** node using that credential and execute it (this fires the token fetch). Point its data URL at a *different* host so it doesn't pollute the proxy log.
11. Watch `proxy.mjs` for a `CONNECT oauth-target.invalid:8443` line:

   | Ignore SSL Issues | `CONNECT` in proxy log? | Execution | Verdict |
   |---|---|---|---|
   | OFF | YES | succeeds | routed through proxy (control) |
   | ON (before fix) | NO | fails `ENOTFOUND oauth-target.invalid` | bypassed proxy — **bug** |
   | ON (after fix) | YES | succeeds | routed through proxy — **fixed** |

Ports override with `PROXY_PORT` / `TOKEN_PORT` if 8888 / 8443 clash.

### `proxy.mjs`

```js
// Standalone HTTP forward proxy. Stand-in for a corporate proxy.
// Logs every request it handles. Run: node proxy.mjs
import http from 'node:http';
import net from 'node:net';

const PORT = Number(process.env.PROXY_PORT ?? 8888);
// oauth-target.invalid is unresolvable by design. A real corporate proxy reaches
// the provider on the client's behalf; here the proxy self-routes ONLY that host
// to the local token server. Every other CONNECT is passed through to its real
// host so n8n's unrelated proxied traffic isn't misdirected.
const TOKEN_HOST = process.env.TOKEN_HOST ?? 'oauth-target.invalid';
const TOKEN_UPSTREAM_HOST = process.env.TOKEN_UPSTREAM_HOST ?? '127.0.0.1';
const TOKEN_UPSTREAM_PORT = Number(process.env.TOKEN_UPSTREAM_PORT ?? 8443);
const ts = () => new Date().toISOString().slice(11, 23);

const server = http.createServer((req, res) => {
	console.log(`${ts()}  HTTP    ${req.method} ${req.url}`);
	const target = new URL(req.url);
	const upstream = http.request(
		{
			host: target.hostname,
			port: target.port || 80,
			method: req.method,
			path: target.pathname + target.search,
			headers: req.headers,
		},
		(up) => {
			res.writeHead(up.statusCode ?? 502, up.headers);
			up.pipe(res);
		},
	);
	upstream.on('error', (err) => {
		console.log(`${ts()}  HTTP    error ${err.code || ''} ${err.message}`);
		res.writeHead(502).end();
	});
	req.pipe(upstream);
});

// HTTPS tunnelling. This is the path OAuth2 token requests use.
server.on('connect', (req, clientSocket, head) => {
	const [host, portStr] = req.url.split(':');
	const port = Number(portStr) || 443;
	const isToken = host === TOKEN_HOST;
	const [upHost, upPort] = isToken
		? [TOKEN_UPSTREAM_HOST, TOKEN_UPSTREAM_PORT]
		: [host, port];
	console.log(
		`${ts()}  CONNECT ${req.url}   <-- request reached the proxy${isToken ? '  [token]' : ''}`,
	);
	const upstream = net.connect(upPort, upHost, () => {
		clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
		upstream.write(head);
		upstream.pipe(clientSocket);
		clientSocket.pipe(upstream);
	});
	upstream.on('error', (err) => {
		console.log(`${ts()}  CONNECT error reaching ${req.url}: ${err.code || ''} ${err.message}`);
		clientSocket.end();
	});
	clientSocket.on('error', () => upstream.end());
});

server.listen(PORT, () => {
	console.log(`proxy listening on http://localhost:${PORT}`);
	console.log('waiting for traffic... (Ctrl-C to stop)\n');
});
```

### `token-server.mjs`

```js
// Standalone fake OAuth2 token endpoint (self-signed HTTPS).
// Listens on 127.0.0.1:8443. Run: node token-server.mjs
import fs from 'node:fs';
import https from 'node:https';
import path from 'node:path';
import { fileURLToPath } from 'node:url';

const __dirname = path.dirname(fileURLToPath(import.meta.url));
const PORT = Number(process.env.TOKEN_PORT ?? 8443);
const key = fs.readFileSync(path.join(__dirname, 'key.pem'));
const cert = fs.readFileSync(path.join(__dirname, 'cert.pem'));
const ts = () => new Date().toISOString().slice(11, 23);

const server = https.createServer({ key, cert }, (req, res) => {
	let body = '';
	req.on('data', (c) => (body += c));
	req.on('end', () => {
		console.log(`${ts()}  ${req.method} ${req.url}   <-- token endpoint was reached`);
		if (req.headers.authorization) console.log(`         auth header: ${req.headers.authorization}`);
		if (body) console.log(`         body: ${body}`);
		res.writeHead(200, { 'content-type': 'application/json' });
		res.end(
			JSON.stringify({
				access_token: 'repro-access-token',
				token_type: 'bearer',
				// Expire immediately so n8n refetches on EVERY execution, otherwise it
				// caches and no token request goes out after the first run.
				expires_in: 1,
			}),
		);
	});
});

// Log TLS failures (rejected self-signed cert when Ignore SSL is OFF) so they
// aren't silent. The proxy.mjs CONNECT log remains the authoritative verdict.
server.on('tlsClientError', (err) => {
	console.log(`${ts()}  TLS handshake failed: ${err.code || ''} ${err.message} (cert not trusted by client)`);
});
server.on('connection', (socket) => {
	console.log(`${ts()}  TCP connection opened from ${socket.remoteAddress}:${socket.remotePort}`);
});

server.listen(PORT, '127.0.0.1', () => {
	console.log(`token endpoint (self-signed HTTPS) listening on 127.0.0.1:${PORT}`);
	console.log(`OAuth2 Access Token URL:  https://oauth-target.invalid:${PORT}/token`);
	console.log('waiting for token requests... (Ctrl-C to stop)\n');
});
```

</details>
<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
Closes #28576

https://linear.app/n8n/issue/IAM-567/community-issue-oauth2-token-requests-bypass-proxy-when-ignore-ssl

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34234">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->