### PR TITLE
feat(Microsoft Excel SharePoint Node): Add Sheet Append with auto-map, define-fields, and RAW data modes (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
@@ -6,6 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
+import * as append from './actions/worksheet/append.operation';
 import * as clear from './actions/worksheet/clear.operation';
 import * as deleteWorksheet from './actions/worksheet/deleteWorksheet.operation';
 import * as readRows from './actions/worksheet/readRows.operation';
@@ -97,6 +98,12 @@ export class MicrosoftExcelSharePoint implements INodeType {
 				},
 				options: [
 					{
+						name: 'Append',
+						value: 'append',
+						description: 'Append rows to the end of a sheet',
+						action: 'Append rows to sheet',
+					},
+					{
 						name: 'Clear',
 						value: 'clear',
 						description: 'Clear sheet',
@@ -118,6 +125,7 @@ export class MicrosoftExcelSharePoint implements INodeType {
 				default: 'readRows',
 			},
 
+			...append.description,
 			...clear.description,
 			...deleteWorksheet.description,
 			...readRows.description,
@@ -132,6 +140,10 @@ export class MicrosoftExcelSharePoint implements INodeType {
 		const items = this.getInputData();
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
+
+		if (resource === 'worksheet' && operation === 'append') {
+			return [await append.execute.call(this, items)];
+		}
 
 		if (resource === 'worksheet' && operation === 'readRows') {
 			return [await readRows.execute.call(this, items)];

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
@@ -198,21 +198,35 @@ function getSettings(this: IExecuteFunctions): AppendSettings {
 	};
 }
 
-type ItemRow = { itemIndex: number; row: SheetRow } | { itemIndex: number; error: Error };
+type MappedDataMode = 'autoMap' | 'define';
+type RowResult = { itemIndex: number; row: SheetRow };
+type RowError = { itemIndex: number; error: Error };
+
+/** How to seed the header row from the first item, when the sheet has no data yet. */
+function columnSeeder(
+	dataMode: MappedDataMode,
+	items: INodeExecutionData[],
+	getFields: (itemIndex: number) => FieldEntry[],
+): (itemIndex: number) => string[] {
+	return dataMode === 'autoMap'
+		? (itemIndex) => columnsFromItem(items[itemIndex].json)
+		: (itemIndex) => columnsFromFields(getFields(itemIndex));
+}
 
 // autoMap/define build one row per item; a bad item (an expression failure, say)
-// is recorded and skipped under continueOnFail rather than blocking the batch —
-// the one departure from the OneDrive node, which has no such isolation. The
-// write itself still happens once for the whole batch, same as OneDrive.
+// is skipped under continue-on-fail rather than blocking the batch — the one
+// departure from the OneDrive node, which has no such isolation. The write
+// itself still happens once for the whole batch, same as OneDrive.
 function buildItemRows(
 	items: INodeExecutionData[],
 	continueOnFail: boolean,
-	dataMode: 'autoMap' | 'define',
+	dataMode: MappedDataMode,
 	getFields: (itemIndex: number) => FieldEntry[],
 	seedColumns: (itemIndex: number) => string[],
-): { columnsRow: string[]; rows: ItemRow[] } {
+): { columnsRow: string[]; okRows: RowResult[]; errorRows: RowError[] } {
 	let columnsRow: string[] | undefined;
-	const rows: ItemRow[] = [];
+	const okRows: RowResult[] = [];
+	const errorRows: RowError[] = [];
 
 	for (let i = 0; i < items.length; i++) {
 		try {
@@ -223,103 +237,104 @@ function buildItemRows(
 					? autoMapRow(items[i].json, columnsRow)
 					: defineRow(getFields(i), columnsRow);
 
-			rows.push({ itemIndex: i, row });
+			okRows.push({ itemIndex: i, row });
 		} catch (error) {
 			if (!continueOnFail) throw error;
-			rows.push({ itemIndex: i, error: error as Error });
+			errorRows.push({ itemIndex: i, error: error as Error });
 		}
 	}
 
-	return { columnsRow: columnsRow ?? [], rows };
+	return { columnsRow: columnsRow ?? [], okRows, errorRows };
 }
 
-export async function execute(
+/** Reassembles per-item output, keyed by original item index, back into that same order. */
+function combineInOrder(
+	itemCount: number,
+	byIndex: Map<number, INodeExecutionData[]>,
+): INodeExecutionData[] {
+	const returnData: INodeExecutionData[] = [];
+	for (let i = 0; i < itemCount; i++) {
+		const entries = byIndex.get(i);
+		if (entries) returnData.push.apply(returnData, entries);
+	}
+	return returnData;
+}
+
+// RAW mode never gets an auto-written header, and (like the OneDrive node)
+// isn't a per-item concept: one blob of rows for the whole batch, in one write.
+async function executeRaw(
 	this: IExecuteFunctions,
-	items: INodeExecutionData[],
+	sheetPath: string,
+	usedRangeAddress: string,
+	existingColumns: string[] | undefined,
+	settings: AppendSettings,
 ): Promise<INodeExecutionData[]> {
-	// https://learn.microsoft.com/en-us/graph/api/worksheet-range
-	const settings = getSettings.call(this);
-
-	const workbookRoot = await resolveWorkbookRoot.call(this, 0);
-	const sheetPath = `${workbookRoot}/workbook/worksheets/${encodeURIComponent(settings.worksheetId)}`;
-
-	const usedRange = await (microsoftApiRequest<ExcelResponse & { address: string }>).call(
+	const range = findAppendRange(usedRangeAddress, {
+		cols: settings.rawRows[0]?.length ?? 0,
+		rows: settings.rawRows.length,
+	});
+	const responseData = await (microsoftApiRequest<ExcelResponse>).call(
 		this,
-		'GET',
-		`${sheetPath}/usedRange`,
+		'PATCH',
+		`${sheetPath}/range(address='${range}')`,
+		{ values: settings.rawRows },
 	);
 
-	// An empty sheet has no header row to read; seed one from the first
-	// successfully-built item instead of throwing (the OneDrive node's
-	// behaviour for autoMap/define)
-	const isEmpty = isEmptyUsedRange(usedRange.address);
-	const existingColumns = isEmpty ? undefined : ((usedRange.values?.[0] as string[]) ?? []);
+	return prepareOutput.call(this, this.getNode(), responseData, {
+		columnsRow: existingColumns,
+		dataProperty: settings.dataProperty,
+		rawData: settings.rawData,
+	});
+}
 
-	if (settings.dataMode === 'raw') {
-		const range = findAppendRange(usedRange.address, {
-			cols: settings.rawRows[0]?.length ?? 0,
-			rows: settings.rawRows.length,
-		});
-		const responseData = await (microsoftApiRequest<ExcelResponse>).call(
-			this,
-			'PATCH',
-			`${sheetPath}/range(address='${range}')`,
-			{ values: settings.rawRows },
-		);
-
-		// RAW mode never gets an auto-written header, and (like the OneDrive
-		// node) isn't a per-item concept: one blob of rows for the whole batch
-		return prepareOutput.call(this, this.getNode(), responseData, {
-			columnsRow: existingColumns,
-			dataProperty: settings.dataProperty,
-			rawData: settings.rawData,
-		});
-	}
-
+// autoMap/define: one row per item, written together in a single PATCH.
+async function executeMapped(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+	sheetPath: string,
+	usedRangeAddress: string,
+	isEmpty: boolean,
+	existingColumns: string[] | undefined,
+	settings: AppendSettings,
+): Promise<INodeExecutionData[]> {
+	const dataMode = settings.dataMode as MappedDataMode;
 	const getFields = (itemIndex: number) =>
 		this.getNodeParameter('fieldsUi.values', itemIndex, []) as FieldEntry[];
 	const seedColumns =
 		existingColumns !== undefined
 			? () => existingColumns
-			: settings.dataMode === 'autoMap'
-				? (itemIndex: number) => columnsFromItem(items[itemIndex].json)
-				: (itemIndex: number) => columnsFromFields(getFields(itemIndex));
+			: columnSeeder(dataMode, items, getFields);
 
-	const { columnsRow, rows } = buildItemRows(
+	const { columnsRow, okRows, errorRows } = buildItemRows(
 		items,
 		this.continueOnFail(),
-		settings.dataMode,
+		dataMode,
 		getFields,
 		seedColumns,
 	);
 
 	const outputByIndex = new Map<number, INodeExecutionData[]>();
-
-	for (const r of rows) {
-		if ('error' in r) {
-			outputByIndex.set(
-				r.itemIndex,
-				this.helpers.constructExecutionMetaData(
-					this.helpers.returnJsonArray({ error: r.error.message }),
-					{ itemData: { item: r.itemIndex } },
-				),
-			);
-		}
+	for (const { itemIndex, error } of errorRows) {
+		outputByIndex.set(
+			itemIndex,
+			this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData: { item: itemIndex } },
+			),
+		);
 	}
 
-	const okRows = rows.filter((r): r is { itemIndex: number; row: SheetRow } => 'row' in r);
-
 	if (okRows.length > 0) {
+		// Only write the header once, the first time there's data to seed it from
 		const writesHeader = isEmpty;
 		const rowsToWrite = writesHeader
 			? [columnsRow, ...okRows.map((r) => r.row)]
 			: okRows.map((r) => r.row);
 
-		const range = findAppendRange(usedRange.address, {
+		const range = findAppendRange(usedRangeAddress, {
 			cols: rowsToWrite[0]?.length ?? 0,
 			rows: rowsToWrite.length,
 		});
-
 		const responseData = await (microsoftApiRequest<ExcelResponse>).call(
 			this,
 			'PATCH',
@@ -354,10 +369,39 @@ export async function execute(
 		}
 	}
 
-	const returnData: INodeExecutionData[] = [];
-	for (let i = 0; i < items.length; i++) {
-		const entries = outputByIndex.get(i);
-		if (entries) returnData.push.apply(returnData, entries);
-	}
-	return returnData;
+	return combineInOrder(items.length, outputByIndex);
+}
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	// https://learn.microsoft.com/en-us/graph/api/worksheet-range
+	const settings = getSettings.call(this);
+
+	const workbookRoot = await resolveWorkbookRoot.call(this, 0);
+	const sheetPath = `${workbookRoot}/workbook/worksheets/${encodeURIComponent(settings.worksheetId)}`;
+
+	const usedRange = await (microsoftApiRequest<ExcelResponse & { address: string }>).call(
+		this,
+		'GET',
+		`${sheetPath}/usedRange`,
+	);
+
+	// An empty sheet has no header row to read; the raw/mapped writers seed one
+	// from the input instead of throwing (the OneDrive node's behaviour)
+	const isEmpty = isEmptyUsedRange(usedRange.address);
+	const existingColumns = isEmpty ? undefined : ((usedRange.values?.[0] as string[]) ?? []);
+
+	return settings.dataMode === 'raw'
+		? await executeRaw.call(this, sheetPath, usedRange.address, existingColumns, settings)
+		: await executeMapped.call(
+				this,
+				items,
+				sheetPath,
+				usedRange.address,
+				isEmpty,
+				existingColumns,
+				settings,
+			);
 }

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
@@ -5,7 +5,12 @@ import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse, SheetRow } from '../../../Excel/v2/helpers/interfaces';
 // Reused from the OneDrive node so range math and output shaping cannot drift
-import { findAppendRange, prepareOutput } from '../../../Excel/v2/helpers/utils';
+import {
+	findAppendRange,
+	nextExcelColumn,
+	parseAddress,
+	prepareOutput,
+} from '../../../Excel/v2/helpers/utils';
 import {
 	workbookRLC,
 	siteRLC,
@@ -17,6 +22,7 @@ import {
 	columnsFromFields,
 	columnsFromItem,
 	defineRow,
+	isEmptySheet,
 	isEmptyUsedRange,
 	type DataMode,
 	type FieldEntry,
@@ -247,6 +253,20 @@ function buildItemRows(
 	return { columnsRow: columnsRow ?? [], okRows, errorRows };
 }
 
+/**
+ * `findAppendRange` treats any single-cell used-range address as an empty
+ * table and starts writing at that same cell — correct for a genuinely blank
+ * sheet, but it would overwrite a one-column sheet's real header if that
+ * header is the sheet's only populated cell. This computes the row below it
+ * instead, for that one case `findAppendRange` can't tell apart.
+ */
+function appendBelowSingleCell(address: string, cols: number, rows: number): string {
+	const { cellFrom } = parseAddress(address);
+	const startRow = Number(cellFrom.row) + 1;
+	const endColumn = nextExcelColumn(cellFrom.column, Math.max(cols - 1, 0));
+	return `${cellFrom.column}${startRow}:${endColumn}${startRow + Math.max(rows - 1, 0)}`;
+}
+
 /** Reassembles per-item output, keyed by original item index, back into that same order. */
 function combineInOrder(
 	itemCount: number,
@@ -331,10 +351,16 @@ async function executeMapped(
 			? [columnsRow, ...okRows.map((r) => r.row)]
 			: okRows.map((r) => r.row);
 
-		const range = findAppendRange(usedRangeAddress, {
-			cols: rowsToWrite[0]?.length ?? 0,
-			rows: rowsToWrite.length,
-		});
+		// A one-column sheet with only its header looks identical to a blank
+		// sheet to findAppendRange (both are single-cell addresses) — write
+		// below that cell explicitly instead of letting it assume row 1 is free
+		const range =
+			isEmptyUsedRange(usedRangeAddress) && !writesHeader
+				? appendBelowSingleCell(usedRangeAddress, rowsToWrite[0]?.length ?? 0, rowsToWrite.length)
+				: findAppendRange(usedRangeAddress, {
+						cols: rowsToWrite[0]?.length ?? 0,
+						rows: rowsToWrite.length,
+					});
 		const responseData = await (microsoftApiRequest<ExcelResponse>).call(
 			this,
 			'PATCH',
@@ -389,19 +415,28 @@ export async function execute(
 	);
 
 	// An empty sheet has no header row to read; the raw/mapped writers seed one
-	// from the input instead of throwing (the OneDrive node's behaviour)
-	const isEmpty = isEmptyUsedRange(usedRange.address);
-	const existingColumns = isEmpty ? undefined : ((usedRange.values?.[0] as string[]) ?? []);
+	// from the input instead of throwing (the OneDrive node's behaviour). RAW
+	// mode keeps the OneDrive node's address-only check for exact parity.
+	if (settings.dataMode === 'raw') {
+		const isEmpty = isEmptyUsedRange(usedRange.address);
+		const existingColumns = isEmpty ? undefined : ((usedRange.values?.[0] as string[]) ?? []);
+		return await executeRaw.call(this, sheetPath, usedRange.address, existingColumns, settings);
+	}
 
-	return settings.dataMode === 'raw'
-		? await executeRaw.call(this, sheetPath, usedRange.address, existingColumns, settings)
-		: await executeMapped.call(
-				this,
-				items,
-				sheetPath,
-				usedRange.address,
-				isEmpty,
-				existingColumns,
-				settings,
-			);
+	// autoMap/define also have to tell a genuinely empty sheet apart from a
+	// one-column sheet whose only cell already holds real data (its header) —
+	// the address alone can't do that, unlike the RAW-mode check above
+	const firstRow = usedRange.values?.[0] as SheetRow | undefined;
+	const isEmpty = isEmptySheet(usedRange.address, firstRow);
+	const existingColumns = isEmpty ? undefined : ((firstRow as string[]) ?? []);
+
+	return await executeMapped.call(
+		this,
+		items,
+		sheetPath,
+		usedRange.address,
+		isEmpty,
+		existingColumns,
+		settings,
+	);
 }

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
@@ -426,7 +426,7 @@ export async function execute(
 	// autoMap/define also have to tell a genuinely empty sheet apart from a
 	// one-column sheet whose only cell already holds real data (its header) —
 	// the address alone can't do that, unlike the RAW-mode check above
-	const firstRow = usedRange.values?.[0] as SheetRow | undefined;
+	const firstRow: SheetRow | undefined = usedRange.values?.[0];
 	const isEmpty = isEmptySheet(usedRange.address, firstRow);
 	const existingColumns = isEmpty ? undefined : ((firstRow as string[]) ?? []);
 

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
@@ -1,0 +1,292 @@
+import type { IExecuteFunctions, INode, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
+
+import type { ExcelResponse, SheetRow } from '../../../Excel/v2/helpers/interfaces';
+// Reused from the OneDrive node so range math and output shaping cannot drift
+import { findAppendRange, prepareOutput } from '../../../Excel/v2/helpers/utils';
+import {
+	workbookRLC,
+	siteRLC,
+	libraryRLC,
+	worksheetRLC,
+} from '../../descriptions/common.descriptions';
+import {
+	autoMapRow,
+	columnsFromFields,
+	columnsFromItem,
+	defineRow,
+	isEmptyUsedRange,
+	type DataMode,
+	type FieldEntry,
+} from '../../helpers/dataModes';
+import { resolveWorkbookRoot, validatePathSegment } from '../../helpers/utils';
+import { microsoftApiRequest } from '../../transport';
+
+const properties: INodeProperties[] = [
+	workbookRLC,
+	siteRLC,
+	libraryRLC,
+	worksheetRLC,
+	{
+		displayName: 'Data Mode',
+		name: 'dataMode',
+		type: 'options',
+		default: 'autoMap',
+		options: [
+			{
+				name: 'Auto-Map Input Data to Columns',
+				value: 'autoMap',
+				description: 'Use when node input properties match destination column names',
+			},
+			{
+				name: 'Map Each Column Below',
+				value: 'define',
+				description: 'Set the value for each destination column',
+			},
+			{
+				name: 'RAW',
+				value: 'raw',
+				description: 'Send raw data as JSON',
+			},
+		],
+	},
+	{
+		displayName: 'Data',
+		name: 'data',
+		type: 'json',
+		default: '',
+		required: true,
+		placeholder: 'e.g. [["Sara","1/2/2006","Berlin"],["George","5/3/2010","Paris"]]',
+		description: 'Raw values for the specified range as array of string arrays in JSON format',
+		displayOptions: {
+			show: {
+				dataMode: ['raw'],
+			},
+		},
+	},
+	{
+		displayName: 'Values to Send',
+		name: 'fieldsUi',
+		placeholder: 'Add Field',
+		type: 'fixedCollection',
+		typeOptions: {
+			multipleValues: true,
+		},
+		displayOptions: {
+			show: {
+				dataMode: ['define'],
+			},
+		},
+		default: {},
+		options: [
+			{
+				displayName: 'Field',
+				name: 'values',
+				values: [
+					{
+						displayName: 'Column',
+						name: 'column',
+						type: 'string',
+						default: '',
+						description: "Name of the destination column. Must match the sheet's header exactly.",
+					},
+					{
+						displayName: 'Value',
+						name: 'fieldValue',
+						type: 'string',
+						default: '',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		options: [
+			{
+				displayName: 'RAW Data',
+				name: 'rawData',
+				type: 'boolean',
+				// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-boolean
+				default: 0,
+				description:
+					'Whether the data should be returned RAW instead of parsed into keys according to their header',
+			},
+			{
+				displayName: 'Data Property',
+				name: 'dataProperty',
+				type: 'string',
+				default: 'data',
+				required: true,
+				displayOptions: {
+					show: {
+						rawData: [true],
+					},
+				},
+				description: 'The name of the property into which to write the RAW data',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['worksheet'],
+		operation: ['append'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+/** Throws unless `parsed` is an array of arrays of strings, matching the OneDrive node's RAW input validation. */
+function assertRawRows(node: INode, parsed: unknown): SheetRow[] {
+	const isArray = Array.isArray(parsed);
+	const isRowArray = isArray && parsed.every((row) => Array.isArray(row));
+	const isStringRowArray = isRowArray && parsed.flat().every((cell) => typeof cell === 'string');
+	if (!isStringRowArray) {
+		throw new NodeOperationError(node, 'Data must be an array of arrays of strings');
+	}
+	return parsed as SheetRow[];
+}
+
+type AppendSettings = {
+	/** Validated sheet resource-locator value; the segment of the request path after `/workbook/worksheets/`. */
+	worksheetId: string;
+	dataMode: DataMode;
+	/** Only populated (and only read) when `dataMode` is 'define'. */
+	definedFields: FieldEntry[];
+	/** Only populated (and only read) when `dataMode` is 'raw'; already validated as an array of arrays of strings. */
+	rawRows: SheetRow[];
+	/** When true, return Graph's response as-is under `dataProperty` instead of parsing rows into keyed objects. */
+	rawData: boolean;
+	/** Output property to write the raw response under. Only used when `rawData` is true. */
+	dataProperty: string;
+};
+
+// Validated and read up front so the request-building code below only ever deals
+// with `settings.xxx`, never raw `getNodeParameter` calls or `options.foo as bar`.
+function getSettings(this: IExecuteFunctions, itemIndex: number): AppendSettings {
+	const worksheetId = validatePathSegment(
+		this.getNode(),
+		'Sheet',
+		this.getNodeParameter('worksheet', itemIndex, '', { extractValue: true }) as string,
+	);
+
+	const dataMode = this.getNodeParameter('dataMode', itemIndex) as DataMode;
+
+	const definedFields =
+		dataMode === 'define'
+			? (this.getNodeParameter('fieldsUi.values', itemIndex, []) as FieldEntry[])
+			: [];
+
+	const rawRows =
+		dataMode === 'raw'
+			? assertRawRows(
+					this.getNode(),
+					processJsonInput(this.getNodeParameter('data', itemIndex), 'Data'),
+				)
+			: [];
+
+	const options = this.getNodeParameter('options', itemIndex, {}) as {
+		rawData?: boolean;
+		dataProperty?: string;
+	};
+
+	return {
+		worksheetId,
+		dataMode,
+		definedFields,
+		rawRows,
+		rawData: options.rawData || false,
+		dataProperty: options.dataProperty || 'data',
+	};
+}
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	// https://learn.microsoft.com/en-us/graph/api/worksheet-range
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			// Validate everything local before the workbook resolution, which may
+			// cost a request in URL mode
+			const settings = getSettings.call(this, i);
+
+			const workbookRoot = await resolveWorkbookRoot.call(this, i);
+			const sheetPath = `${workbookRoot}/workbook/worksheets/${encodeURIComponent(settings.worksheetId)}`;
+
+			const usedRange = await (microsoftApiRequest<ExcelResponse & { address: string }>).call(
+				this,
+				'GET',
+				`${sheetPath}/usedRange`,
+			);
+
+			// An empty sheet has no header row to read; seed one from this item's
+			// data instead of throwing (the OneDrive node's behaviour for autoMap/define)
+			const isEmpty = isEmptyUsedRange(usedRange.address);
+
+			const columnsRow = isEmpty
+				? settings.dataMode === 'autoMap'
+					? columnsFromItem(items[i].json)
+					: settings.dataMode === 'define'
+						? columnsFromFields(settings.definedFields)
+						: []
+				: ((usedRange.values?.[0] as string[]) ?? []);
+
+			let values: SheetRow[];
+			if (settings.dataMode === 'raw') {
+				values = settings.rawRows;
+			} else if (settings.dataMode === 'autoMap') {
+				values = [autoMapRow(items[i].json, columnsRow)];
+			} else {
+				values = [defineRow(settings.definedFields, columnsRow)];
+			}
+
+			// RAW mode never gets an auto-written header: the values it sends are
+			// whatever shape the builder supplied, headers included or not
+			const writesHeader = settings.dataMode !== 'raw' && isEmpty;
+			const rowsToWrite = writesHeader ? [columnsRow, ...values] : values;
+
+			const range = findAppendRange(usedRange.address, {
+				cols: rowsToWrite[0]?.length ?? 0,
+				rows: rowsToWrite.length,
+			});
+
+			const responseData = await (microsoftApiRequest<ExcelResponse>).call(
+				this,
+				'PATCH',
+				`${sheetPath}/range(address='${range}')`,
+				{ values: rowsToWrite },
+			);
+
+			// When we just wrote the header ourselves, Graph echoes it back as
+			// row 0 of the response — prepareOutput's default keyRow picks it up,
+			// so passing columnsRow here would double it up
+			const preparedData = prepareOutput.call(this, this.getNode(), responseData, {
+				columnsRow: writesHeader ? undefined : columnsRow,
+				dataProperty: settings.dataProperty,
+				rawData: settings.rawData,
+			});
+			returnData.push.apply(returnData, preparedData);
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionErrorData);
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/worksheet/append.operation.ts
@@ -159,8 +159,6 @@ type AppendSettings = {
 	/** Validated sheet resource-locator value; the segment of the request path after `/workbook/worksheets/`. */
 	worksheetId: string;
 	dataMode: DataMode;
-	/** Only populated (and only read) when `dataMode` is 'define'. */
-	definedFields: FieldEntry[];
 	/** Only populated (and only read) when `dataMode` is 'raw'; already validated as an array of arrays of strings. */
 	rawRows: SheetRow[];
 	/** When true, return Graph's response as-is under `dataProperty` instead of parsing rows into keyed objects. */
@@ -169,31 +167,24 @@ type AppendSettings = {
 	dataProperty: string;
 };
 
-// Validated and read up front so the request-building code below only ever deals
-// with `settings.xxx`, never raw `getNodeParameter` calls or `options.foo as bar`.
-function getSettings(this: IExecuteFunctions, itemIndex: number): AppendSettings {
+// Structural parameters (which sheet, which data mode, RAW input) aren't
+// per-item, the same as the OneDrive node: read once, up front, so the
+// request-building code below only ever deals with `settings.xxx`.
+function getSettings(this: IExecuteFunctions): AppendSettings {
 	const worksheetId = validatePathSegment(
 		this.getNode(),
 		'Sheet',
-		this.getNodeParameter('worksheet', itemIndex, '', { extractValue: true }) as string,
+		this.getNodeParameter('worksheet', 0, '', { extractValue: true }) as string,
 	);
 
-	const dataMode = this.getNodeParameter('dataMode', itemIndex) as DataMode;
-
-	const definedFields =
-		dataMode === 'define'
-			? (this.getNodeParameter('fieldsUi.values', itemIndex, []) as FieldEntry[])
-			: [];
+	const dataMode = this.getNodeParameter('dataMode', 0) as DataMode;
 
 	const rawRows =
 		dataMode === 'raw'
-			? assertRawRows(
-					this.getNode(),
-					processJsonInput(this.getNodeParameter('data', itemIndex), 'Data'),
-				)
+			? assertRawRows(this.getNode(), processJsonInput(this.getNodeParameter('data', 0), 'Data'))
 			: [];
 
-	const options = this.getNodeParameter('options', itemIndex, {}) as {
+	const options = this.getNodeParameter('options', 0, {}) as {
 		rawData?: boolean;
 		dataProperty?: string;
 	};
@@ -201,11 +192,45 @@ function getSettings(this: IExecuteFunctions, itemIndex: number): AppendSettings
 	return {
 		worksheetId,
 		dataMode,
-		definedFields,
 		rawRows,
 		rawData: options.rawData || false,
 		dataProperty: options.dataProperty || 'data',
 	};
+}
+
+type ItemRow = { itemIndex: number; row: SheetRow } | { itemIndex: number; error: Error };
+
+// autoMap/define build one row per item; a bad item (an expression failure, say)
+// is recorded and skipped under continueOnFail rather than blocking the batch —
+// the one departure from the OneDrive node, which has no such isolation. The
+// write itself still happens once for the whole batch, same as OneDrive.
+function buildItemRows(
+	items: INodeExecutionData[],
+	continueOnFail: boolean,
+	dataMode: 'autoMap' | 'define',
+	getFields: (itemIndex: number) => FieldEntry[],
+	seedColumns: (itemIndex: number) => string[],
+): { columnsRow: string[]; rows: ItemRow[] } {
+	let columnsRow: string[] | undefined;
+	const rows: ItemRow[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			if (!columnsRow) columnsRow = seedColumns(i);
+
+			const row =
+				dataMode === 'autoMap'
+					? autoMapRow(items[i].json, columnsRow)
+					: defineRow(getFields(i), columnsRow);
+
+			rows.push({ itemIndex: i, row });
+		} catch (error) {
+			if (!continueOnFail) throw error;
+			rows.push({ itemIndex: i, error: error as Error });
+		}
+	}
+
+	return { columnsRow: columnsRow ?? [], rows };
 }
 
 export async function execute(
@@ -213,80 +238,126 @@ export async function execute(
 	items: INodeExecutionData[],
 ): Promise<INodeExecutionData[]> {
 	// https://learn.microsoft.com/en-us/graph/api/worksheet-range
-	const returnData: INodeExecutionData[] = [];
+	const settings = getSettings.call(this);
 
-	for (let i = 0; i < items.length; i++) {
-		try {
-			// Validate everything local before the workbook resolution, which may
-			// cost a request in URL mode
-			const settings = getSettings.call(this, i);
+	const workbookRoot = await resolveWorkbookRoot.call(this, 0);
+	const sheetPath = `${workbookRoot}/workbook/worksheets/${encodeURIComponent(settings.worksheetId)}`;
 
-			const workbookRoot = await resolveWorkbookRoot.call(this, i);
-			const sheetPath = `${workbookRoot}/workbook/worksheets/${encodeURIComponent(settings.worksheetId)}`;
+	const usedRange = await (microsoftApiRequest<ExcelResponse & { address: string }>).call(
+		this,
+		'GET',
+		`${sheetPath}/usedRange`,
+	);
 
-			const usedRange = await (microsoftApiRequest<ExcelResponse & { address: string }>).call(
-				this,
-				'GET',
-				`${sheetPath}/usedRange`,
+	// An empty sheet has no header row to read; seed one from the first
+	// successfully-built item instead of throwing (the OneDrive node's
+	// behaviour for autoMap/define)
+	const isEmpty = isEmptyUsedRange(usedRange.address);
+	const existingColumns = isEmpty ? undefined : ((usedRange.values?.[0] as string[]) ?? []);
+
+	if (settings.dataMode === 'raw') {
+		const range = findAppendRange(usedRange.address, {
+			cols: settings.rawRows[0]?.length ?? 0,
+			rows: settings.rawRows.length,
+		});
+		const responseData = await (microsoftApiRequest<ExcelResponse>).call(
+			this,
+			'PATCH',
+			`${sheetPath}/range(address='${range}')`,
+			{ values: settings.rawRows },
+		);
+
+		// RAW mode never gets an auto-written header, and (like the OneDrive
+		// node) isn't a per-item concept: one blob of rows for the whole batch
+		return prepareOutput.call(this, this.getNode(), responseData, {
+			columnsRow: existingColumns,
+			dataProperty: settings.dataProperty,
+			rawData: settings.rawData,
+		});
+	}
+
+	const getFields = (itemIndex: number) =>
+		this.getNodeParameter('fieldsUi.values', itemIndex, []) as FieldEntry[];
+	const seedColumns =
+		existingColumns !== undefined
+			? () => existingColumns
+			: settings.dataMode === 'autoMap'
+				? (itemIndex: number) => columnsFromItem(items[itemIndex].json)
+				: (itemIndex: number) => columnsFromFields(getFields(itemIndex));
+
+	const { columnsRow, rows } = buildItemRows(
+		items,
+		this.continueOnFail(),
+		settings.dataMode,
+		getFields,
+		seedColumns,
+	);
+
+	const outputByIndex = new Map<number, INodeExecutionData[]>();
+
+	for (const r of rows) {
+		if ('error' in r) {
+			outputByIndex.set(
+				r.itemIndex,
+				this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ error: r.error.message }),
+					{ itemData: { item: r.itemIndex } },
+				),
 			);
-
-			// An empty sheet has no header row to read; seed one from this item's
-			// data instead of throwing (the OneDrive node's behaviour for autoMap/define)
-			const isEmpty = isEmptyUsedRange(usedRange.address);
-
-			const columnsRow = isEmpty
-				? settings.dataMode === 'autoMap'
-					? columnsFromItem(items[i].json)
-					: settings.dataMode === 'define'
-						? columnsFromFields(settings.definedFields)
-						: []
-				: ((usedRange.values?.[0] as string[]) ?? []);
-
-			let values: SheetRow[];
-			if (settings.dataMode === 'raw') {
-				values = settings.rawRows;
-			} else if (settings.dataMode === 'autoMap') {
-				values = [autoMapRow(items[i].json, columnsRow)];
-			} else {
-				values = [defineRow(settings.definedFields, columnsRow)];
-			}
-
-			// RAW mode never gets an auto-written header: the values it sends are
-			// whatever shape the builder supplied, headers included or not
-			const writesHeader = settings.dataMode !== 'raw' && isEmpty;
-			const rowsToWrite = writesHeader ? [columnsRow, ...values] : values;
-
-			const range = findAppendRange(usedRange.address, {
-				cols: rowsToWrite[0]?.length ?? 0,
-				rows: rowsToWrite.length,
-			});
-
-			const responseData = await (microsoftApiRequest<ExcelResponse>).call(
-				this,
-				'PATCH',
-				`${sheetPath}/range(address='${range}')`,
-				{ values: rowsToWrite },
-			);
-
-			// When we just wrote the header ourselves, Graph echoes it back as
-			// row 0 of the response — prepareOutput's default keyRow picks it up,
-			// so passing columnsRow here would double it up
-			const preparedData = prepareOutput.call(this, this.getNode(), responseData, {
-				columnsRow: writesHeader ? undefined : columnsRow,
-				dataProperty: settings.dataProperty,
-				rawData: settings.rawData,
-			});
-			returnData.push.apply(returnData, preparedData);
-		} catch (error) {
-			if (!this.continueOnFail()) throw error;
-
-			const executionErrorData = this.helpers.constructExecutionMetaData(
-				this.helpers.returnJsonArray({ error: error.message }),
-				{ itemData: { item: i } },
-			);
-			returnData.push.apply(returnData, executionErrorData);
 		}
 	}
 
+	const okRows = rows.filter((r): r is { itemIndex: number; row: SheetRow } => 'row' in r);
+
+	if (okRows.length > 0) {
+		const writesHeader = isEmpty;
+		const rowsToWrite = writesHeader
+			? [columnsRow, ...okRows.map((r) => r.row)]
+			: okRows.map((r) => r.row);
+
+		const range = findAppendRange(usedRange.address, {
+			cols: rowsToWrite[0]?.length ?? 0,
+			rows: rowsToWrite.length,
+		});
+
+		const responseData = await (microsoftApiRequest<ExcelResponse>).call(
+			this,
+			'PATCH',
+			`${sheetPath}/range(address='${range}')`,
+			{ values: rowsToWrite },
+		);
+
+		if (settings.rawData) {
+			// One RAW blob represents the whole write, not one entry per item —
+			// matches the OneDrive node's own RAW-output shape
+			outputByIndex.set(
+				okRows[0].itemIndex,
+				this.helpers.constructExecutionMetaData(
+					this.helpers.returnJsonArray({ [settings.dataProperty]: responseData }),
+					{ itemData: okRows.map((r) => ({ item: r.itemIndex })) },
+				),
+			);
+		} else {
+			// When we just wrote the header ourselves, Graph echoes it back as row 0
+			// of the response — prepareOutput's default keyRow picks it up, so
+			// passing columnsRow here would double it up
+			const preparedData = prepareOutput.call(this, this.getNode(), responseData, {
+				columnsRow: writesHeader ? undefined : columnsRow,
+				dataProperty: settings.dataProperty,
+				rawData: false,
+			});
+			preparedData.forEach((entry, index) => {
+				outputByIndex.set(okRows[index].itemIndex, [
+					{ ...entry, pairedItem: { item: okRows[index].itemIndex } },
+				]);
+			});
+		}
+	}
+
+	const returnData: INodeExecutionData[] = [];
+	for (let i = 0; i < items.length; i++) {
+		const entries = outputByIndex.get(i);
+		if (entries) returnData.push.apply(returnData, entries);
+	}
 	return returnData;
 }

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
@@ -10,6 +10,10 @@ export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; applicati
 		delegated: 'Sites.Read.All',
 		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
 	},
+	'worksheet:append': {
+		delegated: 'Sites.ReadWrite.All',
+		application: 'Sites.ReadWrite.All (or Sites.Selected granted for this site)',
+	},
 	'worksheet:clear': {
 		delegated: 'Sites.ReadWrite.All',
 		application: 'Sites.ReadWrite.All (or Sites.Selected granted for this site)',

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/dataModes.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/dataModes.ts
@@ -1,0 +1,37 @@
+import type { IDataObject } from 'n8n-workflow';
+
+import type { SheetRow } from '../../Excel/v2/helpers/interfaces';
+
+export type DataMode = 'autoMap' | 'define' | 'raw';
+
+export type FieldEntry = { column: string; fieldValue: string };
+
+/**
+ * Graph reports an empty sheet as a single-cell `usedRange` address (no ':',
+ * e.g. `Sheet1!A1`) — there's no header row to read yet.
+ */
+export function isEmptyUsedRange(address: string): boolean {
+	return !address.includes(':');
+}
+
+/** Column order derived from an item's own keys — seeds the header row when the sheet has no data yet. */
+export function columnsFromItem(item: IDataObject): string[] {
+	return Object.keys(item);
+}
+
+/** Column order as the builder defined it — seeds the header row when the sheet has no data yet. */
+export function columnsFromFields(fields: FieldEntry[]): string[] {
+	return fields.map((field) => field.column);
+}
+
+/** Projects an item's properties into `columns` order for the auto-map data mode. */
+export function autoMapRow(item: IDataObject, columns: string[]): SheetRow {
+	return columns.map((column) => (item[column] as SheetRow[number]) ?? null);
+}
+
+/** Projects a builder-defined field list into `columns` order for the define data mode. */
+export function defineRow(fields: FieldEntry[], columns: string[]): SheetRow {
+	const byColumn: Record<string, string> = {};
+	for (const field of fields) byColumn[field.column] = field.fieldValue;
+	return columns.map((column) => (byColumn[column] as SheetRow[number]) ?? null);
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/dataModes.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/dataModes.ts
@@ -8,10 +8,24 @@ export type FieldEntry = { column: string; fieldValue: string };
 
 /**
  * Graph reports an empty sheet as a single-cell `usedRange` address (no ':',
- * e.g. `Sheet1!A1`) — there's no header row to read yet.
+ * e.g. `Sheet1!A1`). Note this is also true for a one-column sheet that
+ * already has real data in that single cell (e.g. just a header, no rows
+ * yet) — use `isEmptySheet` when the header-seeding decision depends on it.
  */
 export function isEmptyUsedRange(address: string): boolean {
 	return !address.includes(':');
+}
+
+/**
+ * True only when the sheet genuinely has no data yet. A single-cell address
+ * alone can't tell a blank sheet apart from a one-column sheet whose only
+ * cell already holds a real header — the cell's own content has to be
+ * checked too, or that header would get treated as empty and overwritten.
+ */
+export function isEmptySheet(address: string, firstRow: SheetRow | undefined): boolean {
+	if (!isEmptyUsedRange(address)) return false;
+	const cell = firstRow?.[0];
+	return cell === null || cell === undefined || String(cell).trim() === '';
 }
 
 /** Column order derived from an item's own keys — seeds the header row when the sheet has no data yet. */

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.harness.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.harness.test.ts
@@ -1,0 +1,63 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+
+const workbookUrl = 'https://contoso.sharepoint.com/sites/site1/Shared Documents/book.xlsx';
+const shareId = `u!${Buffer.from(workbookUrl)
+	.toString('base64')
+	.replace(/=+$/, '')
+	.replace(/\+/g, '-')
+	.replace(/\//g, '_')}`;
+
+const credentials = {
+	microsoftOAuth2Api: {
+		oauthTokenData: {
+			access_token: 'test-access-token',
+		},
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+// A pasted workbook address resolves in one call, then the RAW row lands
+// below the sheet's existing data — the parity path with the OneDrive node's Append
+describe('Microsoft Excel (SharePoint) — Sheet: Append', () => {
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['append.workflow.json'],
+		nock: {
+			baseUrl: 'https://graph.microsoft.com',
+			mocks: [
+				{
+					method: 'get',
+					path: `/v1.0/shares/${shareId}/driveItem?%24select=id%2CparentReference`,
+					statusCode: 200,
+					responseBody: {
+						id: 'ITEM123',
+						parentReference: {
+							siteId: 'contoso.sharepoint.com,g1,g2',
+							driveId: 'b!drive1',
+						},
+					},
+				},
+				{
+					method: 'get',
+					path: '/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/worksheets/Sheet1/usedRange',
+					statusCode: 200,
+					responseBody: {
+						address: 'Sheet1!A1:B2',
+						values: [
+							['name', 'age'],
+							['alice', 30],
+						],
+					},
+				},
+				{
+					method: 'patch',
+					path: "/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/worksheets/Sheet1/range(address='A3:B3')",
+					statusCode: 200,
+					responseBody: {
+						values: [['bob', '25']],
+					},
+				},
+			],
+		},
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.sp.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.sp.test.ts
@@ -1,0 +1,40 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+// SP smoke test: site/library/workbook by ID, signed in as the Service Principal
+// (app-only) credential. preAuthentication is a no-op in the harness since the
+// fixture already carries an accessToken, so `authenticate` attaches Bearer directly.
+const credentials = {
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'test-access-token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+describe('Microsoft Excel (SharePoint), Service Principal worksheet => append smoke', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.get(
+			'/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/worksheets/Sheet1/usedRange',
+		)
+		.reply(200, {
+			address: 'Sheet1!A1:B2',
+			values: [
+				['name', 'age'],
+				['alice', 30],
+			],
+		})
+		.patch(
+			"/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/worksheets/Sheet1/range(address='A3:B3')",
+		)
+		.reply(200, { values: [['carl', '33']] });
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['append.sp.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.sp.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.sp.workflow.json
@@ -1,0 +1,76 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "8f4a1c22-6e1d-4a35-9c40-1af2f9f70322",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "worksheet",
+				"operation": "append",
+				"workbook": {
+					"__rl": true,
+					"mode": "id",
+					"value": "ITEM123"
+				},
+				"site": {
+					"__rl": true,
+					"mode": "id",
+					"value": "contoso.sharepoint.com,g1,g2"
+				},
+				"library": {
+					"__rl": true,
+					"mode": "id",
+					"value": "b!drive1"
+				},
+				"worksheet": {
+					"__rl": true,
+					"mode": "id",
+					"value": "Sheet1"
+				},
+				"dataMode": "raw",
+				"data": "[[\"carl\", \"33\"]]",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "4c9be7de-51f2-4633-8b0a-2f4f3f1f9d23",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "sp1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"name": "carl",
+					"age": "33"
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/append.workflow.json
@@ -1,0 +1,66 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "8f4a1c22-6e1d-4a35-9c40-1af2f9f70311",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftOAuth2Api",
+				"resource": "worksheet",
+				"operation": "append",
+				"workbook": {
+					"__rl": true,
+					"mode": "url",
+					"value": "https://contoso.sharepoint.com/sites/site1/Shared Documents/book.xlsx"
+				},
+				"worksheet": {
+					"__rl": true,
+					"mode": "id",
+					"value": "Sheet1"
+				},
+				"dataMode": "raw",
+				"data": "[[\"bob\", \"25\"]]",
+				"options": {}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "4c9be7de-51f2-4633-8b0a-2f4f3f1f9d12",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftOAuth2Api": {
+					"id": "c1",
+					"name": "Microsoft account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"name": "bob",
+					"age": "25"
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/dataModes.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/dataModes.test.ts
@@ -1,0 +1,75 @@
+import {
+	autoMapRow,
+	columnsFromFields,
+	columnsFromItem,
+	defineRow,
+	isEmptyUsedRange,
+} from '../../helpers/dataModes';
+
+describe('Microsoft Excel (SharePoint) — helpers/dataModes', () => {
+	describe('isEmptyUsedRange', () => {
+		it('treats a single-cell address as empty', () => {
+			expect(isEmptyUsedRange('Sheet1!A1')).toBe(true);
+		});
+
+		it('treats a multi-cell address as non-empty', () => {
+			expect(isEmptyUsedRange('Sheet1!A1:B2')).toBe(false);
+		});
+	});
+
+	describe('columnsFromItem', () => {
+		it('returns the keys of an item, in order', () => {
+			expect(columnsFromItem({ name: 'alice', age: 30 })).toEqual(['name', 'age']);
+		});
+
+		it('returns an empty array for an item with no keys', () => {
+			expect(columnsFromItem({})).toEqual([]);
+		});
+	});
+
+	describe('columnsFromFields', () => {
+		it('returns the column names in the order they were defined', () => {
+			expect(
+				columnsFromFields([
+					{ column: 'name', fieldValue: 'alice' },
+					{ column: 'age', fieldValue: '30' },
+				]),
+			).toEqual(['name', 'age']);
+		});
+
+		it('returns an empty array when no fields are defined', () => {
+			expect(columnsFromFields([])).toEqual([]);
+		});
+	});
+
+	describe('autoMapRow', () => {
+		it('projects the item into column order', () => {
+			expect(autoMapRow({ name: 'alice', age: 30 }, ['age', 'name'])).toEqual([30, 'alice']);
+		});
+
+		it('fills missing properties with null', () => {
+			expect(autoMapRow({ name: 'alice' }, ['name', 'age'])).toEqual(['alice', null]);
+		});
+	});
+
+	describe('defineRow', () => {
+		it('projects the defined fields into column order', () => {
+			expect(
+				defineRow(
+					[
+						{ column: 'age', fieldValue: '30' },
+						{ column: 'name', fieldValue: 'alice' },
+					],
+					['name', 'age'],
+				),
+			).toEqual(['alice', '30']);
+		});
+
+		it('fills undefined fields with null', () => {
+			expect(defineRow([{ column: 'name', fieldValue: 'alice' }], ['name', 'age'])).toEqual([
+				'alice',
+				null,
+			]);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/dataModes.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/dataModes.test.ts
@@ -3,6 +3,7 @@ import {
 	columnsFromFields,
 	columnsFromItem,
 	defineRow,
+	isEmptySheet,
 	isEmptyUsedRange,
 } from '../../helpers/dataModes';
 
@@ -14,6 +15,24 @@ describe('Microsoft Excel (SharePoint) — helpers/dataModes', () => {
 
 		it('treats a multi-cell address as non-empty', () => {
 			expect(isEmptyUsedRange('Sheet1!A1:B2')).toBe(false);
+		});
+	});
+
+	describe('isEmptySheet', () => {
+		it('treats a single-cell address with a blank cell as empty', () => {
+			expect(isEmptySheet('Sheet1!A1', [''])).toBe(true);
+		});
+
+		it('treats a single-cell address with no row data at all as empty', () => {
+			expect(isEmptySheet('Sheet1!A1', undefined)).toBe(true);
+		});
+
+		it('does not treat a one-column sheet with only its header as empty', () => {
+			expect(isEmptySheet('Sheet1!A1', ['Notes'])).toBe(false);
+		});
+
+		it('treats a multi-cell address as non-empty regardless of content', () => {
+			expect(isEmptySheet('Sheet1!A1:B2', [''])).toBe(false);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
@@ -1,0 +1,236 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { MicrosoftExcelSharePoint } from '../../MicrosoftExcelSharePoint.node';
+import * as transport from '../../transport';
+import type * as _importType0 from '../../transport';
+
+// Real transport module except the network helper
+vi.mock('../../transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const WORKBOOK_ROOT = `/v1.0/sites/${encodeURIComponent(SITE_ID)}/drives/b!drive1/items/ITEM123`;
+const SHEET_PATH = `${WORKBOOK_ROOT}/workbook/worksheets/Sheet1`;
+
+describe('Microsoft Excel (SharePoint) — Sheet: Append', () => {
+	let node: MicrosoftExcelSharePoint;
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	const byIdParams = {
+		resource: 'worksheet',
+		operation: 'append',
+		workbook: { mode: 'id', value: 'ITEM123' },
+		site: { mode: 'id', value: SITE_ID },
+		library: { mode: 'id', value: 'b!drive1' },
+		worksheet: 'Sheet1',
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftExcelSharePoint();
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getNode.mockReturnValue(mock<INode>());
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		ctx.helpers.constructExecutionMetaData.mockImplementation((inputData, options) =>
+			inputData.map((data) => ({ ...data, pairedItem: options?.itemData })),
+		);
+	});
+
+	it('auto-maps input data below existing rows', async () => {
+		ctx.getInputData.mockReturnValue([{ json: { name: 'bob', age: 25 } }]);
+		setParams({ ...byIdParams, dataMode: 'autoMap' });
+		apiRequest
+			.mockResolvedValueOnce({
+				address: 'Sheet1!A1:B2',
+				values: [
+					['name', 'age'],
+					['alice', 30],
+				],
+			})
+			.mockResolvedValueOnce({ values: [['bob', 25]] });
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A3:B3')`, {
+			values: [['bob', 25]],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([{ name: 'bob', age: 25 }]);
+	});
+
+	it('writes the defined fields below existing rows, in header order', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		setParams({
+			...byIdParams,
+			dataMode: 'define',
+			'fieldsUi.values': [
+				{ column: 'age', fieldValue: '40' },
+				{ column: 'name', fieldValue: 'carl' },
+			],
+		});
+		apiRequest
+			.mockResolvedValueOnce({
+				address: 'Sheet1!A1:B2',
+				values: [
+					['name', 'age'],
+					['alice', 30],
+				],
+			})
+			.mockResolvedValueOnce({ values: [['carl', '40']] });
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A3:B3')`, {
+			values: [['carl', '40']],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([{ name: 'carl', age: '40' }]);
+	});
+
+	it('sends RAW values as-is and returns the RAW response under the configured property', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		setParams({
+			...byIdParams,
+			dataMode: 'raw',
+			data: [
+				['x', 'y'],
+				['z', 'w'],
+			],
+			options: { rawData: true, dataProperty: 'raw' },
+		});
+		apiRequest
+			.mockResolvedValueOnce({
+				address: 'Sheet1!A1:B2',
+				values: [
+					['name', 'age'],
+					['alice', 30],
+				],
+			})
+			.mockResolvedValueOnce({
+				values: [
+					['x', 'y'],
+					['z', 'w'],
+				],
+			});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A3:B4')`, {
+			values: [
+				['x', 'y'],
+				['z', 'w'],
+			],
+		});
+		expect(result[0][0].json).toEqual({
+			raw: {
+				values: [
+					['x', 'y'],
+					['z', 'w'],
+				],
+			},
+		});
+	});
+
+	it('rejects RAW data that is not an array of arrays of strings', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		setParams({ ...byIdParams, dataMode: 'raw', data: [['x', 1]] });
+		apiRequest.mockResolvedValue({ address: 'Sheet1!A1:B2', values: [['name', 'age']] });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow(
+			'Data must be an array of arrays of strings',
+		);
+	});
+
+	it('writes the header row first when appending to an empty sheet (auto-map)', async () => {
+		ctx.getInputData.mockReturnValue([{ json: { name: 'dee', age: 19 } }]);
+		setParams({ ...byIdParams, dataMode: 'autoMap' });
+		apiRequest
+			.mockResolvedValueOnce({ address: 'Sheet1!A1', values: [['']] })
+			.mockResolvedValueOnce({
+				values: [
+					['name', 'age'],
+					['dee', 19],
+				],
+			});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A1:B2')`, {
+			values: [
+				['name', 'age'],
+				['dee', 19],
+			],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([{ name: 'dee', age: 19 }]);
+	});
+
+	it('writes the header row first when appending to an empty sheet (define)', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		setParams({
+			...byIdParams,
+			dataMode: 'define',
+			'fieldsUi.values': [
+				{ column: 'city', fieldValue: 'Berlin' },
+				{ column: 'name', fieldValue: 'Sara' },
+			],
+		});
+		apiRequest
+			.mockResolvedValueOnce({ address: 'Sheet1!A1', values: [['']] })
+			.mockResolvedValueOnce({
+				values: [
+					['city', 'name'],
+					['Berlin', 'Sara'],
+				],
+			});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A1:B2')`, {
+			values: [
+				['city', 'name'],
+				['Berlin', 'Sara'],
+			],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([{ city: 'Berlin', name: 'Sara' }]);
+	});
+
+	it('rejects an empty Sheet', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		setParams({ ...byIdParams, dataMode: 'autoMap', worksheet: '' });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow("The 'Sheet' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('keeps later items running when continue-on-fail is on', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }, { json: { name: 'x' } }]);
+		ctx.continueOnFail.mockReturnValue(true);
+		setParams({ ...byIdParams, dataMode: 'autoMap' });
+		apiRequest
+			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValueOnce({ address: 'Sheet1!A1:A2', values: [['name'], ['old']] })
+			.mockResolvedValueOnce({ values: [['x']] });
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(3);
+		expect(result[0].map((item) => item.json)).toEqual([{ error: 'boom' }, { name: 'x' }]);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
@@ -219,18 +219,62 @@ describe('Microsoft Excel (SharePoint) — Sheet: Append', () => {
 		expect(apiRequest).not.toHaveBeenCalled();
 	});
 
-	it('keeps later items running when continue-on-fail is on', async () => {
-		ctx.getInputData.mockReturnValue([{ json: {} }, { json: { name: 'x' } }]);
-		ctx.continueOnFail.mockReturnValue(true);
+	it('batches every item into a single write, like the OneDrive node', async () => {
+		ctx.getInputData.mockReturnValue([
+			{ json: { name: 'bob', age: 25 } },
+			{ json: { name: 'carl', age: 40 } },
+		]);
 		setParams({ ...byIdParams, dataMode: 'autoMap' });
 		apiRequest
-			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValueOnce({
+				address: 'Sheet1!A1:B2',
+				values: [
+					['name', 'age'],
+					['alice', 30],
+				],
+			})
+			.mockResolvedValueOnce({
+				values: [
+					['bob', 25],
+					['carl', 40],
+				],
+			});
+
+		const result = await node.execute.call(ctx);
+
+		// One GET, one PATCH, regardless of item count
+		expect(apiRequest).toHaveBeenCalledTimes(2);
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A3:B4')`, {
+			values: [
+				['bob', 25],
+				['carl', 40],
+			],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([
+			{ name: 'bob', age: 25 },
+			{ name: 'carl', age: 40 },
+		]);
+	});
+
+	it('keeps later items running when continue-on-fail is on', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }, { json: {} }]);
+		ctx.continueOnFail.mockReturnValue(true);
+		const params = { ...byIdParams, dataMode: 'define' };
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, itemIndex?: number, fallback?: unknown) => {
+				if (name === 'fieldsUi.values' && itemIndex === 0) throw new Error('boom');
+				if (name === 'fieldsUi.values') return [{ column: 'name', fieldValue: 'x' }] as never;
+				return (name in params ? params[name as keyof typeof params] : fallback) as never;
+			},
+		);
+		apiRequest
 			.mockResolvedValueOnce({ address: 'Sheet1!A1:A2', values: [['name'], ['old']] })
 			.mockResolvedValueOnce({ values: [['x']] });
 
 		const result = await node.execute.call(ctx);
 
-		expect(apiRequest).toHaveBeenCalledTimes(3);
+		// One shared GET + one shared PATCH, even with a bad item in the batch
+		expect(apiRequest).toHaveBeenCalledTimes(2);
 		expect(result[0].map((item) => item.json)).toEqual([{ error: 'boom' }, { name: 'x' }]);
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
@@ -211,6 +211,22 @@ describe('Microsoft Excel (SharePoint) — Sheet: Append', () => {
 		expect(result[0].map((item) => item.json)).toEqual([{ city: 'Berlin', name: 'Sara' }]);
 	});
 
+	it('appends below a one-column sheet that already has just its header, without overwriting it', async () => {
+		ctx.getInputData.mockReturnValue([{ json: { Notes: 'hello' } }]);
+		setParams({ ...byIdParams, dataMode: 'autoMap' });
+		apiRequest
+			.mockResolvedValueOnce({ address: 'Sheet1!A1', values: [['Notes']] })
+			.mockResolvedValueOnce({ values: [['hello']] });
+
+		const result = await node.execute.call(ctx);
+
+		// Must land on row 2, not overwrite the existing header at A1
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A2:A2')`, {
+			values: [['hello']],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([{ Notes: 'hello' }]);
+	});
+
 	it('writes one header for a multi-item batch appended to an empty sheet', async () => {
 		ctx.getInputData.mockReturnValue([
 			{ json: { name: 'bob', age: 25 } },

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/worksheet/append.test.ts
@@ -211,6 +211,38 @@ describe('Microsoft Excel (SharePoint) — Sheet: Append', () => {
 		expect(result[0].map((item) => item.json)).toEqual([{ city: 'Berlin', name: 'Sara' }]);
 	});
 
+	it('writes one header for a multi-item batch appended to an empty sheet', async () => {
+		ctx.getInputData.mockReturnValue([
+			{ json: { name: 'bob', age: 25 } },
+			{ json: { name: 'carl', age: 40 } },
+		]);
+		setParams({ ...byIdParams, dataMode: 'autoMap' });
+		apiRequest
+			.mockResolvedValueOnce({ address: 'Sheet1!A1', values: [['']] })
+			.mockResolvedValueOnce({
+				values: [
+					['name', 'age'],
+					['bob', 25],
+					['carl', 40],
+				],
+			});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(2);
+		expect(apiRequest).toHaveBeenNthCalledWith(2, 'PATCH', `${SHEET_PATH}/range(address='A1:B3')`, {
+			values: [
+				['name', 'age'],
+				['bob', 25],
+				['carl', 40],
+			],
+		});
+		expect(result[0].map((item) => item.json)).toEqual([
+			{ name: 'bob', age: 25 },
+			{ name: 'carl', age: 40 },
+		]);
+	});
+
 	it('rejects an empty Sheet', async () => {
 		ctx.getInputData.mockReturnValue([{ json: {} }]);
 		setParams({ ...byIdParams, dataMode: 'autoMap', worksheet: '' });


### PR DESCRIPTION
## Summary

Adds the Append operation to the Microsoft Excel (SharePoint) node (still hidden behind a flag while the node is being built out). Builders will be able to append rows to a sheet three ways: auto-mapping input properties to existing columns, manually defining each column's value, or sending raw row arrays, matching the equivalent operation on the OneDrive-based Excel node. Appending to a sheet with no data yet writes the header row first instead of failing.

Like the OneDrive node, this does one GET (read the used range) and one PATCH (write the rows) for the whole execution, not per item. Each item's row is still built independently first, so a bad item (an expression failure, say) is skipped under continue-on-fail instead of blocking the rest of the batch.

Column detection and the three data modes live in a new `helpers/dataModes.ts` module, split out so the upcoming Sheet Update ticket (ENT-205) can reuse the same logic.

Built on top of #34098 (ENT-198, Sheet Get Rows), which introduced the shared request/helper code this operation reuses. That PR has since merged, and this branch is rebased onto master.

## How to test

1. `pnpm --filter n8n-nodes-base test nodes/Microsoft/ExcelSharePoint` (104 tests: unit tests for the data-mode helpers, the Append operation itself including batching, empty-sheet, and continue-on-fail cases, a workflow harness test, and an app-only Service Principal smoke test).
2. Live-tested against a real SharePoint workbook in a local dev environment: appended rows with both Define Fields and RAW modes, under both the OAuth2 and Service Principal credentials, and confirmed the writes landed and read back correctly via Get Rows.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-201

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. (Not applicable: node is still hidden/unreleased.)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI