### PR TITLE
fix(core): Run a follow-up publication outbox drain for requests coalesced mid-pass (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -192,6 +192,40 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			expect(firstProcessed).toBe(1);
 			expect(secondProcessed).toBe(1);
 		});
+
+		test('runs a follow-up pass when a drain is requested while one is in flight', async () => {
+			const lateRecord = makeRecord({ id: 2 });
+			let releaseClaim!: () => void;
+			const claimGate = new Promise<void>((resolve) => {
+				releaseClaim = resolve;
+			});
+			// First pass: the only worker is already past claiming — it hangs on a
+			// claim that resolves to null, mirroring a record inserted just after
+			// the workers exhausted the queue. Plain mockImplementation (not *Once)
+			// so no unconsumed once-stubs leak into later tests.
+			const laterClaims = [lateRecord];
+			let isFirstClaim = true;
+			outboxRepository.claimNextPendingRecord.mockImplementation(async () => {
+				if (isFirstClaim) {
+					isFirstClaim = false;
+					await claimGate;
+					return null;
+				}
+				return laterClaims.shift() ?? null;
+			});
+			consumer.startPolling();
+
+			const first = consumer.drainPending();
+			// A wake-up landing mid-pass must not be swallowed by coalescing: its
+			// record would otherwise sit pending until the poll fallback.
+			const wake = consumer.wakeUp();
+
+			releaseClaim();
+			await Promise.all([first, wake]);
+
+			expect(applier.apply).toHaveBeenCalledTimes(1);
+			expect(applier.apply).toHaveBeenCalledWith(lateRecord);
+		});
 	});
 
 	describe('parallel drains', () => {

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -36,6 +36,8 @@ export class WorkflowPublicationOutboxConsumer {
 
 	private activeDrain: Promise<number> | null = null;
 
+	private drainRequested = false;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly workflowsConfig: WorkflowsConfig,
@@ -128,24 +130,36 @@ export class WorkflowPublicationOutboxConsumer {
 	}
 
 	/**
-	 * Claim and process every currently pending record in a single pass, returning
-	 * the number processed. Used both by the scheduled poll cycle and at leader
-	 * startup for an immediate drain. The loop stops if the instance steps down or
-	 * shuts down mid-drain; claiming is atomic, so an extra concurrent drain never
-	 * double-processes a record. Concurrent callers coalesce onto the same in-flight
-	 * pass rather than running an overlapping drain, which also lets shutdown wait
-	 * for the active pass to settle.
+	 * Claim and process every currently pending record, returning the number
+	 * processed. Used both by the scheduled poll cycle and at leader startup for
+	 * an immediate drain. The loop stops if the instance steps down or shuts down
+	 * mid-drain; claiming is atomic, so an extra concurrent drain never
+	 * double-processes a record. Concurrent callers coalesce onto the same
+	 * in-flight pass rather than running an overlapping drain, which also lets
+	 * shutdown wait for the active pass to settle. Because an in-flight pass may
+	 * already be past claiming, a coalesced call additionally requests a
+	 * follow-up pass, so records enqueued around the tail of a pass are still
+	 * drained promptly instead of waiting for the poll fallback.
 	 */
 	async drainPending(): Promise<number> {
-		if (this.activeDrain) return await this.activeDrain;
-
-		const drain = this.runDrain();
-		this.activeDrain = drain;
-		try {
-			return await drain;
-		} finally {
-			this.activeDrain = null;
+		if (this.activeDrain) {
+			this.drainRequested = true;
+			return await this.activeDrain;
 		}
+
+		let processed = 0;
+		do {
+			this.drainRequested = false;
+			const drain = this.runDrain();
+			this.activeDrain = drain;
+			try {
+				processed += await drain;
+			} finally {
+				this.activeDrain = null;
+			}
+		} while (this.drainRequested && this.shouldKeepPolling());
+
+		return processed;
 	}
 
 	private async runDrain(): Promise<number> {


### PR DESCRIPTION
## Summary

`drainPending()` coalesces concurrent callers onto the in-flight pass, which swallows a wake-up that arrives at the **tail** of a drain:

1. The drain's worker makes its final `claimNextPendingRecord` call — an atomic statement whose visibility horizon is fixed when it starts.
2. A publish commits its outbox record after that horizon and fires the `workflow-publish-wake-up` event (the notifier deliberately fires after commit).
3. The wake-up's `drainPending()` runs while `activeDrain` is still set — it coalesces onto the finishing pass and returns.
4. The drain resolves; the record sits pending until the poll fallback (default 15s).

The window spans the final claim's DB round-trip (query, wire, parse) plus worker settling — the event loop is idle during that I/O and can process the wake-up. When it fires, the symptom is identical to the pubsub-wiring bug fixed in #34207: publication silently waiting out the poll interval.

The fix completes the coalescing pattern with a re-check: coalesced callers set a `drainRequested` flag, and the drain owner loops (`do { runDrain() } while (drainRequested && shouldKeepPolling())`), so records enqueued around the tail of a pass are drained promptly.

Split out of #34207 per [Slack discussion](https://n8nio.slack.com/archives/C0AK9U8CDHT/p1784115704112549?thread_ts=1784102661.962949&cid=C0AK9U8CDHT) to keep that PR minimal.

## How to test

The regression unit test reproduces the window deterministically: a gated `claimNextPendingRecord` mock holds the drain's final (empty) claim open, a wake-up arrives mid-pass, and the test asserts the record enqueued during the window is processed by the follow-up pass instead of being dropped.

```
cd packages/cli && pnpm test src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3767

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34242">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

