### PR TITLE
feat(Microsoft Excel SharePoint Node): Add Workbook Add Sheet and Delete (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/MicrosoftExcelSharePoint.node.ts
@@ -7,6 +7,7 @@ import type {
 import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 import * as getAllTables from './actions/table/getAll.operation';
+import * as workbook from './actions/workbook/Workbook.resource';
 import * as append from './actions/worksheet/append.operation';
 import * as clear from './actions/worksheet/clear.operation';
 import * as deleteWorksheet from './actions/worksheet/deleteWorksheet.operation';
@@ -89,6 +90,10 @@ export class MicrosoftExcelSharePoint implements INodeType {
 						name: 'Table',
 						value: 'table',
 					},
+					{
+						name: 'Workbook',
+						value: 'workbook',
+					},
 				],
 				default: 'worksheet',
 			},
@@ -163,6 +168,7 @@ export class MicrosoftExcelSharePoint implements INodeType {
 			...readRows.description,
 			...getAllWorksheets.description,
 			...getAllTables.description,
+			...workbook.description,
 		],
 	};
 
@@ -193,6 +199,14 @@ export class MicrosoftExcelSharePoint implements INodeType {
 
 		if (resource === 'worksheet' && operation === 'deleteWorksheet') {
 			return [await deleteWorksheet.execute.call(this, items)];
+		}
+
+		if (resource === 'workbook' && operation === 'addWorksheet') {
+			return [await workbook.addWorksheet.execute.call(this, items)];
+		}
+
+		if (resource === 'workbook' && operation === 'deleteWorkbook') {
+			return [await workbook.deleteWorkbook.execute.call(this, items)];
 		}
 
 		throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/Workbook.resource.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/Workbook.resource.ts
@@ -1,0 +1,37 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as addWorksheet from './addWorksheet.operation';
+import * as deleteWorkbook from './deleteWorkbook.operation';
+
+export { addWorksheet, deleteWorkbook };
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['workbook'],
+			},
+		},
+		options: [
+			{
+				name: 'Add Sheet',
+				value: 'addWorksheet',
+				description: 'Add a new sheet to the workbook',
+				action: 'Add a sheet to a workbook',
+			},
+			{
+				name: 'Delete',
+				value: 'deleteWorkbook',
+				description: 'Delete a workbook',
+				action: 'Delete a workbook',
+			},
+		],
+		default: 'addWorksheet',
+	},
+	...addWorksheet.description,
+	...deleteWorkbook.description,
+];

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
@@ -5,6 +5,13 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
+import { withWorkbookSession } from '../../helpers/sessions';
+import { resolveWorkbookRoot } from '../../helpers/utils';
+import { microsoftApiRequest } from '../../transport';
+
 // https://learn.microsoft.com/en-us/graph/api/resources/workbookworksheet
 type AddWorksheetResponse = {
 	id: string;
@@ -12,13 +19,6 @@ type AddWorksheetResponse = {
 	position: number;
 	visibility: string;
 };
-
-import { updateDisplayOptions } from '@utils/utilities';
-
-import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
-import { withWorkbookSession } from '../../helpers/sessions';
-import { resolveWorkbookRoot } from '../../helpers/utils';
-import { microsoftApiRequest } from '../../transport';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -72,6 +72,10 @@ export async function execute(
 ): Promise<INodeExecutionData[]> {
 	// https://learn.microsoft.com/en-us/graph/api/worksheetcollection-add
 	const returnData: INodeExecutionData[] = [];
+	// Hoisted once for the whole run and passed into resolveWorkbookRoot below,
+	// so a multi-item run resolves each distinct address/site only once.
+	const workbookRootCache = new Map<string, string>();
+	const siteIdCache = new Map<string, string>();
 
 	for (let i = 0; i < items.length; i++) {
 		try {
@@ -81,7 +85,7 @@ export async function execute(
 				body.name = settings.name;
 			}
 
-			const workbookRoot = await resolveWorkbookRoot.call(this, i);
+			const workbookRoot = await resolveWorkbookRoot.call(this, i, workbookRootCache, siteIdCache);
 			// Typed here instead of cast at the call site below. Parens are required:
 			// a generic instantiation can't be followed directly by a property access.
 			const responseData = await (withWorkbookSession<AddWorksheetResponse>).call(

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
@@ -1,0 +1,111 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
+import { withWorkbookSession } from '../../helpers/sessions';
+import { resolveWorkbookRoot } from '../../helpers/utils';
+import { microsoftApiRequest } from '../../transport';
+
+const properties: INodeProperties[] = [
+	workbookRLC,
+	siteRLC,
+	libraryRLC,
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add option',
+		default: {},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+				description:
+					'The name of the sheet to be added. The name should be unique. If not specified, Excel will determine the name of the new sheet.',
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['workbook'],
+		operation: ['addWorksheet'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+type AddWorksheetSettings = {
+	/** Optional name for the new sheet; empty means Excel assigns the default name. */
+	name: string;
+};
+
+// Validated and read up front so the request-building code below only ever deals
+// with `settings.xxx`, never raw `getNodeParameter` calls or `options.foo as bar`.
+function getSettings(this: IExecuteFunctions, itemIndex: number): AddWorksheetSettings {
+	const options = this.getNodeParameter('options', itemIndex, {}) as { name?: string };
+	return {
+		name: options.name || '',
+	};
+}
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	// https://learn.microsoft.com/en-us/graph/api/worksheetcollection-add
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			const settings = getSettings.call(this, i);
+			const body: IDataObject = {};
+			if (settings.name) {
+				body.name = settings.name;
+			}
+
+			const workbookRoot = await resolveWorkbookRoot.call(this, i);
+			// Typed here instead of cast at the call site below. Parens are required:
+			// a generic instantiation can't be followed directly by a property access.
+			const responseData = await (withWorkbookSession<IDataObject>).call(
+				this,
+				workbookRoot,
+				async (headers) =>
+					await (microsoftApiRequest<IDataObject>).call(
+						this,
+						'POST',
+						`${workbookRoot}/workbook/worksheets/add`,
+						body,
+						{},
+						undefined,
+						headers,
+					),
+			);
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(responseData),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionData);
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionErrorData);
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/addWorksheet.operation.ts
@@ -5,6 +5,14 @@ import type {
 	INodeProperties,
 } from 'n8n-workflow';
 
+// https://learn.microsoft.com/en-us/graph/api/resources/workbookworksheet
+type AddWorksheetResponse = {
+	id: string;
+	name: string;
+	position: number;
+	visibility: string;
+};
+
 import { updateDisplayOptions } from '@utils/utilities';
 
 import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
@@ -76,11 +84,11 @@ export async function execute(
 			const workbookRoot = await resolveWorkbookRoot.call(this, i);
 			// Typed here instead of cast at the call site below. Parens are required:
 			// a generic instantiation can't be followed directly by a property access.
-			const responseData = await (withWorkbookSession<IDataObject>).call(
+			const responseData = await (withWorkbookSession<AddWorksheetResponse>).call(
 				this,
 				workbookRoot,
 				async (headers) =>
-					await (microsoftApiRequest<IDataObject>).call(
+					await (microsoftApiRequest<AddWorksheetResponse>).call(
 						this,
 						'POST',
 						`${workbookRoot}/workbook/worksheets/add`,

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/deleteWorkbook.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/deleteWorkbook.operation.ts
@@ -1,0 +1,51 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+
+import { updateDisplayOptions } from '@utils/utilities';
+
+import { libraryRLC, siteRLC, workbookRLC } from '../../descriptions/common.descriptions';
+import { resolveWorkbookRoot } from '../../helpers/utils';
+import { microsoftApiRequest } from '../../transport';
+
+const properties: INodeProperties[] = [workbookRLC, siteRLC, libraryRLC];
+
+const displayOptions = {
+	show: {
+		resource: ['workbook'],
+		operation: ['deleteWorkbook'],
+	},
+};
+
+export const description = updateDisplayOptions(displayOptions, properties);
+
+export async function execute(
+	this: IExecuteFunctions,
+	items: INodeExecutionData[],
+): Promise<INodeExecutionData[]> {
+	// https://learn.microsoft.com/en-us/graph/api/driveitem-delete
+	const returnData: INodeExecutionData[] = [];
+
+	for (let i = 0; i < items.length; i++) {
+		try {
+			// The file itself, not a `/workbook` subpath — deleting the item removes
+			// the workbook whole, so no session is opened for this operation.
+			const workbookRoot = await resolveWorkbookRoot.call(this, i);
+			await microsoftApiRequest.call(this, 'DELETE', workbookRoot);
+
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ success: true }),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionData);
+		} catch (error) {
+			if (!this.continueOnFail()) throw error;
+
+			const executionErrorData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray({ error: error.message }),
+				{ itemData: { item: i } },
+			);
+			returnData.push.apply(returnData, executionErrorData);
+		}
+	}
+
+	return returnData;
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/deleteWorkbook.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/actions/workbook/deleteWorkbook.operation.ts
@@ -23,12 +23,16 @@ export async function execute(
 ): Promise<INodeExecutionData[]> {
 	// https://learn.microsoft.com/en-us/graph/api/driveitem-delete
 	const returnData: INodeExecutionData[] = [];
+	// Hoisted once for the whole run and passed into resolveWorkbookRoot below,
+	// so a multi-item run resolves each distinct address/site only once.
+	const workbookRootCache = new Map<string, string>();
+	const siteIdCache = new Map<string, string>();
 
 	for (let i = 0; i < items.length; i++) {
 		try {
 			// The file itself, not a `/workbook` subpath — deleting the item removes
 			// the workbook whole, so no session is opened for this operation.
-			const workbookRoot = await resolveWorkbookRoot.call(this, i);
+			const workbookRoot = await resolveWorkbookRoot.call(this, i, workbookRootCache, siteIdCache);
 			await microsoftApiRequest.call(this, 'DELETE', workbookRoot);
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/constants.ts
@@ -30,6 +30,14 @@ export const REQUIRED_PERMISSIONS: Record<string, { delegated: string; applicati
 		delegated: 'Sites.Read.All',
 		application: 'Sites.Read.All (or Sites.Selected granted for this site)',
 	},
+	'workbook:addWorksheet': {
+		delegated: 'Sites.ReadWrite.All',
+		application: 'Sites.ReadWrite.All (or Sites.Selected granted for this site)',
+	},
+	'workbook:deleteWorkbook': {
+		delegated: 'Sites.ReadWrite.All',
+		application: 'Sites.ReadWrite.All (or Sites.Selected granted for this site)',
+	},
 };
 
 // A 404 can come from any of the location segments, so the message must not

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/sessions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/sessions.ts
@@ -1,0 +1,37 @@
+import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+
+import { microsoftApiRequest } from '../transport';
+
+/**
+ * Runs `send` inside a workbook session: opens a session that persists
+ * changes, hands `send` the `workbook-session-id` header to attach to its
+ * request, then closes the session — even if `send` throws, so a failed
+ * write doesn't leave a session open on Graph's side.
+ */
+export async function withWorkbookSession<T>(
+	this: IExecuteFunctions,
+	workbookRoot: string,
+	send: (headers: IDataObject) => Promise<T>,
+): Promise<T> {
+	const { id } = await (microsoftApiRequest<{ id: string }>).call(
+		this,
+		'POST',
+		`${workbookRoot}/workbook/createSession`,
+		{ persistChanges: true },
+	);
+	const headers: IDataObject = { 'workbook-session-id': id };
+
+	try {
+		return await send(headers);
+	} finally {
+		await microsoftApiRequest.call(
+			this,
+			'POST',
+			`${workbookRoot}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			headers,
+		);
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/sessions.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/helpers/sessions.ts
@@ -3,6 +3,30 @@ import type { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 import { microsoftApiRequest } from '../transport';
 
 /**
+ * Best-effort: an unclosed session simply expires on Graph's side, so a
+ * failure here must never mask `send`'s real result or error.
+ */
+async function closeSessionQuietly(
+	this: IExecuteFunctions,
+	workbookRoot: string,
+	headers: IDataObject,
+): Promise<void> {
+	try {
+		await microsoftApiRequest.call(
+			this,
+			'POST',
+			`${workbookRoot}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			headers,
+		);
+	} catch {
+		// Swallowed on purpose, see above.
+	}
+}
+
+/**
  * Runs `send` inside a workbook session: opens a session that persists
  * changes, hands `send` the `workbook-session-id` header to attach to its
  * request, then closes the session — even if `send` throws, so a failed
@@ -21,17 +45,14 @@ export async function withWorkbookSession<T>(
 	);
 	const headers: IDataObject = { 'workbook-session-id': id };
 
+	let result: T;
 	try {
-		return await send(headers);
-	} finally {
-		await microsoftApiRequest.call(
-			this,
-			'POST',
-			`${workbookRoot}/workbook/closeSession`,
-			{},
-			{},
-			undefined,
-			headers,
-		);
+		result = await send(headers);
+	} catch (sendError) {
+		await closeSessionQuietly.call(this, workbookRoot, headers);
+		throw sendError;
 	}
+
+	await closeSessionQuietly.call(this, workbookRoot, headers);
+	return result;
 }

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.harness.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.harness.test.ts
@@ -1,0 +1,52 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+
+const workbookRoot = '/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123';
+
+const credentials = {
+	microsoftOAuth2Api: {
+		oauthTokenData: {
+			access_token: 'test-access-token',
+		},
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+// Add Sheet must open, use, and close a workbook session in order — the same
+// sequence the OneDrive node performs for the equivalent operation.
+describe('Microsoft Excel (SharePoint) Node', () => {
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['addWorksheet.workflow.json'],
+		nock: {
+			baseUrl: 'https://graph.microsoft.com',
+			mocks: [
+				{
+					method: 'post',
+					path: `${workbookRoot}/workbook/createSession`,
+					requestBody: { persistChanges: true },
+					statusCode: 200,
+					responseBody: { id: 'session-abc' },
+				},
+				{
+					method: 'post',
+					path: `${workbookRoot}/workbook/worksheets/add`,
+					requestBody: { name: 'Q4 Report' },
+					requestHeaders: { 'workbook-session-id': 'session-abc' },
+					statusCode: 200,
+					responseBody: {
+						id: '{266ADAB7-25B6-4F28-A2D1-FD5BFBD7A4F0}',
+						name: 'Q4 Report',
+						position: 1,
+					},
+				},
+				{
+					method: 'post',
+					path: `${workbookRoot}/workbook/closeSession`,
+					requestHeaders: { 'workbook-session-id': 'session-abc' },
+					statusCode: 200,
+					responseBody: {},
+				},
+			],
+		},
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.sp.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.sp.test.ts
@@ -1,0 +1,46 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+// SP smoke test: site/library/workbook by ID, signed in as the Service Principal
+// (app-only) credential. preAuthentication is a no-op in the harness since the
+// fixture already carries an accessToken, so `authenticate` attaches Bearer directly.
+const credentials = {
+	microsoftEntraServicePrincipalApi: {
+		accessToken: 'test-access-token',
+		authentication: 'clientSecret',
+		tenantId: '11111111-1111-1111-1111-111111111111',
+		clientId: '22222222-2222-2222-2222-222222222222',
+		clientSecret: 'test-client-secret',
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+describe('Microsoft Excel (SharePoint), Service Principal workbook => addWorksheet smoke', () => {
+	nock('https://graph.microsoft.com')
+		.matchHeader('Authorization', 'Bearer test-access-token')
+		.post(
+			'/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/createSession',
+			{ persistChanges: true },
+		)
+		.reply(200, { id: 'session-abc' })
+		.post(
+			'/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/worksheets/add',
+			{ name: 'Q4 Report' },
+		)
+		.matchHeader('workbook-session-id', 'session-abc')
+		.reply(200, {
+			id: '{266ADAB7-25B6-4F28-A2D1-FD5BFBD7A4F0}',
+			name: 'Q4 Report',
+			position: 1,
+		})
+		.post(
+			'/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123/workbook/closeSession',
+		)
+		.matchHeader('workbook-session-id', 'session-abc')
+		.reply(200, {});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['addWorksheet.sp.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.sp.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.sp.workflow.json
@@ -1,0 +1,72 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "8f4a1c22-6e1d-4a35-9c40-1af2f9f70402",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftEntraServicePrincipalApi",
+				"resource": "workbook",
+				"operation": "addWorksheet",
+				"workbook": {
+					"__rl": true,
+					"mode": "id",
+					"value": "ITEM123"
+				},
+				"site": {
+					"__rl": true,
+					"mode": "id",
+					"value": "contoso.sharepoint.com,g1,g2"
+				},
+				"library": {
+					"__rl": true,
+					"mode": "id",
+					"value": "b!drive1"
+				},
+				"options": {
+					"name": "Q4 Report"
+				}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "4c9be7de-51f2-4633-8b0a-2f4f3f1f9d06",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftEntraServicePrincipalApi": {
+					"id": "sp1",
+					"name": "Microsoft Entra Service Principal account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"id": "{266ADAB7-25B6-4F28-A2D1-FD5BFBD7A4F0}",
+					"name": "Q4 Report",
+					"position": 1
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/addWorksheet.workflow.json
@@ -1,0 +1,72 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "8f4a1c22-6e1d-4a35-9c40-1af2f9f70401",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftOAuth2Api",
+				"resource": "workbook",
+				"operation": "addWorksheet",
+				"workbook": {
+					"__rl": true,
+					"mode": "id",
+					"value": "ITEM123"
+				},
+				"site": {
+					"__rl": true,
+					"mode": "id",
+					"value": "contoso.sharepoint.com,g1,g2"
+				},
+				"library": {
+					"__rl": true,
+					"mode": "id",
+					"value": "b!drive1"
+				},
+				"options": {
+					"name": "Q4 Report"
+				}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "4c9be7de-51f2-4633-8b0a-2f4f3f1f9d04",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftOAuth2Api": {
+					"id": "c1",
+					"name": "Microsoft account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"id": "{266ADAB7-25B6-4F28-A2D1-FD5BFBD7A4F0}",
+					"name": "Q4 Report",
+					"position": 1
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/deleteWorkbook.harness.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/deleteWorkbook.harness.test.ts
@@ -1,0 +1,31 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+
+const workbookRoot = '/v1.0/sites/contoso.sharepoint.com%2Cg1%2Cg2/drives/b!drive1/items/ITEM123';
+
+const credentials = {
+	microsoftOAuth2Api: {
+		oauthTokenData: {
+			access_token: 'test-access-token',
+		},
+		graphApiBaseUrl: 'https://graph.microsoft.com',
+	},
+};
+
+// Delete removes the file itself — no workbook session tail, unlike Add Sheet.
+describe('Microsoft Excel (SharePoint) Node', () => {
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['deleteWorkbook.workflow.json'],
+		nock: {
+			baseUrl: 'https://graph.microsoft.com',
+			mocks: [
+				{
+					method: 'delete',
+					path: workbookRoot,
+					statusCode: 204,
+					responseBody: '',
+				},
+			],
+		},
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/deleteWorkbook.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/deleteWorkbook.workflow.json
@@ -1,0 +1,67 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "8f4a1c22-6e1d-4a35-9c40-1af2f9f70501",
+			"name": "When clicking ‘Test workflow’"
+		},
+		{
+			"parameters": {
+				"authentication": "microsoftOAuth2Api",
+				"resource": "workbook",
+				"operation": "deleteWorkbook",
+				"workbook": {
+					"__rl": true,
+					"mode": "id",
+					"value": "ITEM123"
+				},
+				"site": {
+					"__rl": true,
+					"mode": "id",
+					"value": "contoso.sharepoint.com,g1,g2"
+				},
+				"library": {
+					"__rl": true,
+					"mode": "id",
+					"value": "b!drive1"
+				}
+			},
+			"type": "n8n-nodes-base.microsoftExcelSharePoint",
+			"typeVersion": 1,
+			"position": [200, 0],
+			"id": "4c9be7de-51f2-4633-8b0a-2f4f3f1f9d05",
+			"name": "Microsoft Excel (SharePoint)",
+			"credentials": {
+				"microsoftOAuth2Api": {
+					"id": "c1",
+					"name": "Microsoft account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking ‘Test workflow’": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel (SharePoint)",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Microsoft Excel (SharePoint)": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	}
+}

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/sessions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/sessions.test.ts
@@ -1,0 +1,87 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { withWorkbookSession } from '../../helpers/sessions';
+import * as transport from '../../transport';
+import type * as _importType0 from '../../transport';
+
+// Real transport module except the network helper
+vi.mock('../../transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+describe('Microsoft Excel (SharePoint) — helpers/sessions', () => {
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+	const workbookRoot = '/v1.0/sites/s/drives/d/items/i';
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<IExecuteFunctions>();
+	});
+
+	it('opens a session, runs send with the session header, then closes the session', async () => {
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource === `${workbookRoot}/workbook/createSession`) return { id: 'session-abc' };
+			if (resource === `${workbookRoot}/workbook/closeSession`) return {};
+			throw new Error(`unexpected request: ${resource}`);
+		});
+		const send = vi.fn().mockResolvedValue('done');
+
+		const result = await withWorkbookSession.call(ctx, workbookRoot, send);
+
+		expect(result).toBe('done');
+		expect(send).toHaveBeenCalledWith({ 'workbook-session-id': 'session-abc' });
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			1,
+			'POST',
+			`${workbookRoot}/workbook/createSession`,
+			{ persistChanges: true },
+		);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			`${workbookRoot}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+	});
+
+	it('closes the session even when send throws', async () => {
+		apiRequest.mockResolvedValue({ id: 'session-abc' });
+		const send = vi.fn().mockRejectedValue(new Error('boom'));
+
+		await expect(withWorkbookSession.call(ctx, workbookRoot, send)).rejects.toThrow('boom');
+
+		expect(apiRequest).toHaveBeenCalledTimes(2);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			`${workbookRoot}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+	});
+
+	it('does not attempt to close a session that never opened', async () => {
+		apiRequest.mockRejectedValueOnce(new Error('createSession failed'));
+		const send = vi.fn();
+
+		await expect(withWorkbookSession.call(ctx, workbookRoot, send)).rejects.toThrow(
+			'createSession failed',
+		);
+
+		expect(send).not.toHaveBeenCalled();
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/sessions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/helpers/sessions.test.ts
@@ -84,4 +84,32 @@ describe('Microsoft Excel (SharePoint) — helpers/sessions', () => {
 		expect(send).not.toHaveBeenCalled();
 		expect(apiRequest).toHaveBeenCalledTimes(1);
 	});
+
+	it("returns send's result even when closeSession itself fails", async () => {
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource === `${workbookRoot}/workbook/createSession`) return { id: 'session-abc' };
+			if (resource === `${workbookRoot}/workbook/closeSession`) {
+				throw new Error('closeSession unreachable');
+			}
+			throw new Error(`unexpected request: ${resource}`);
+		});
+		const send = vi.fn().mockResolvedValue('done');
+
+		const result = await withWorkbookSession.call(ctx, workbookRoot, send);
+
+		expect(result).toBe('done');
+	});
+
+	it("propagates send's error, not closeSession's, when both fail", async () => {
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource === `${workbookRoot}/workbook/createSession`) return { id: 'session-abc' };
+			if (resource === `${workbookRoot}/workbook/closeSession`) {
+				throw new Error('closeSession unreachable');
+			}
+			throw new Error(`unexpected request: ${resource}`);
+		});
+		const send = vi.fn().mockRejectedValue(new Error('boom'));
+
+		await expect(withWorkbookSession.call(ctx, workbookRoot, send)).rejects.toThrow('boom');
+	});
 });

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/workbook/addWorksheet.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/workbook/addWorksheet.test.ts
@@ -1,0 +1,165 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { MicrosoftExcelSharePoint } from '../../MicrosoftExcelSharePoint.node';
+import * as transport from '../../transport';
+import type * as _importType0 from '../../transport';
+
+// Real transport module except the network helper
+vi.mock('../../transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const WORKBOOK_ROOT = `/v1.0/sites/${encodeURIComponent(SITE_ID)}/drives/b!drive1/items/ITEM123`;
+
+describe('Microsoft Excel (SharePoint) — Workbook: Add Sheet', () => {
+	let node: MicrosoftExcelSharePoint;
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	const byIdParams = {
+		resource: 'workbook',
+		operation: 'addWorksheet',
+		workbook: { mode: 'id', value: 'ITEM123' },
+		site: { mode: 'id', value: SITE_ID },
+		library: { mode: 'id', value: 'b!drive1' },
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftExcelSharePoint();
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		ctx.helpers.constructExecutionMetaData.mockImplementation((inputData, options) =>
+			inputData.map((data) => ({ ...data, pairedItem: options?.itemData })),
+		);
+	});
+
+	it('opens a session, adds the sheet with the session header, then closes the session', async () => {
+		setParams(byIdParams);
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource === `${WORKBOOK_ROOT}/workbook/createSession`) return { id: 'session-abc' };
+			if (resource === `${WORKBOOK_ROOT}/workbook/worksheets/add`)
+				return { id: 'sheet-1', name: 'Sheet2' };
+			if (resource === `${WORKBOOK_ROOT}/workbook/closeSession`) return {};
+			throw new Error(`unexpected request: ${resource}`);
+		});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(3);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			1,
+			'POST',
+			`${WORKBOOK_ROOT}/workbook/createSession`,
+			{ persistChanges: true },
+		);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			`${WORKBOOK_ROOT}/workbook/worksheets/add`,
+			{},
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			3,
+			'POST',
+			`${WORKBOOK_ROOT}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+		expect(result[0][0].json).toEqual({ id: 'sheet-1', name: 'Sheet2' });
+	});
+
+	it('sends the chosen name in the request body', async () => {
+		setParams({ ...byIdParams, options: { name: 'Q4' } });
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource.endsWith('/createSession')) return { id: 'session-abc' };
+			return { id: 'sheet-1', name: 'Q4' };
+		});
+
+		await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			2,
+			'POST',
+			`${WORKBOOK_ROOT}/workbook/worksheets/add`,
+			{ name: 'Q4' },
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+	});
+
+	it('still closes the session when adding the sheet fails', async () => {
+		setParams(byIdParams);
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource.endsWith('/createSession')) return { id: 'session-abc' };
+			if (resource.endsWith('/worksheets/add')) throw new Error('boom');
+			return {};
+		});
+
+		await expect(node.execute.call(ctx)).rejects.toThrow('boom');
+
+		expect(apiRequest).toHaveBeenCalledTimes(3);
+		expect(apiRequest).toHaveBeenNthCalledWith(
+			3,
+			'POST',
+			`${WORKBOOK_ROOT}/workbook/closeSession`,
+			{},
+			{},
+			undefined,
+			{ 'workbook-session-id': 'session-abc' },
+		);
+	});
+
+	it('rejects an empty Site when the workbook is chosen by ID', async () => {
+		setParams({ ...byIdParams, site: { mode: 'id', value: '' } });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow("The 'Site' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('keeps later items running when continue-on-fail is on', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }, { json: {} }]);
+		ctx.continueOnFail.mockReturnValue(true);
+		setParams(byIdParams);
+		let createSessionCalls = 0;
+		apiRequest.mockImplementation(async (_method: string, resource: string) => {
+			if (resource.endsWith('/createSession')) {
+				createSessionCalls++;
+				if (createSessionCalls === 1) throw new Error('boom');
+				return { id: 'session-abc' };
+			}
+			if (resource.endsWith('/worksheets/add')) return { id: 'sheet-1' };
+			return {};
+		});
+
+		const result = await node.execute.call(ctx);
+
+		expect(result[0].map((item) => item.json)).toEqual([{ error: 'boom' }, { id: 'sheet-1' }]);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/workbook/deleteWorkbook.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/ExcelSharePoint/test/workbook/deleteWorkbook.test.ts
@@ -1,0 +1,85 @@
+import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { MicrosoftExcelSharePoint } from '../../MicrosoftExcelSharePoint.node';
+import * as transport from '../../transport';
+import type * as _importType0 from '../../transport';
+
+// Real transport module except the network helper
+vi.mock('../../transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const WORKBOOK_ROOT = `/v1.0/sites/${encodeURIComponent(SITE_ID)}/drives/b!drive1/items/ITEM123`;
+
+describe('Microsoft Excel (SharePoint) — Workbook: Delete', () => {
+	let node: MicrosoftExcelSharePoint;
+	let ctx: DeepMockProxy<IExecuteFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	const byIdParams = {
+		resource: 'workbook',
+		operation: 'deleteWorkbook',
+		workbook: { mode: 'id', value: 'ITEM123' },
+		site: { mode: 'id', value: SITE_ID },
+		library: { mode: 'id', value: 'b!drive1' },
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		node = new MicrosoftExcelSharePoint();
+		ctx = mockDeep<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 1 }));
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.helpers.returnJsonArray.mockImplementation((data) =>
+			(Array.isArray(data) ? data : [data]).map((json) => ({ json })),
+		);
+		ctx.helpers.constructExecutionMetaData.mockImplementation((inputData, options) =>
+			inputData.map((data) => ({ ...data, pairedItem: options?.itemData })),
+		);
+	});
+
+	it('deletes the workbook file directly, without opening a session', async () => {
+		setParams(byIdParams);
+		apiRequest.mockResolvedValue({});
+
+		const result = await node.execute.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledTimes(1);
+		expect(apiRequest).toHaveBeenCalledWith('DELETE', WORKBOOK_ROOT);
+		expect(result[0][0].json).toEqual({ success: true });
+	});
+
+	it('rejects an empty Site when the workbook is chosen by ID', async () => {
+		setParams({ ...byIdParams, site: { mode: 'id', value: '' } });
+
+		await expect(node.execute.call(ctx)).rejects.toThrow("The 'Site' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('keeps later items running when continue-on-fail is on', async () => {
+		ctx.getInputData.mockReturnValue([{ json: {} }, { json: {} }]);
+		ctx.continueOnFail.mockReturnValue(true);
+		setParams(byIdParams);
+		apiRequest.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({});
+
+		const result = await node.execute.call(ctx);
+
+		expect(result[0].map((item) => item.json)).toEqual([{ error: 'boom' }, { success: true }]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds two operations to the Workbook resource on the (still hidden, pre-launch) Microsoft Excel (SharePoint) node: Add Sheet and Delete. Add Sheet opens a workbook session, adds the sheet, then closes the session. Delete removes the file directly, no session needed. The session open, use, close sequence lives in shared helper code so the upcoming Table Append operation can reuse it.

## How to test

Import a workflow with the Microsoft Excel (SharePoint) node, set Resource to Workbook, and run Add Sheet or Delete against a real SharePoint-hosted workbook (the credential needs Sites.ReadWrite.All). The node stays hidden until its launch ticket removes the flag, so today this is exercised through the included unit, harness, and app-only tests. Also manually verified against a real tenant: Add Sheet (named and unnamed) both created sheets successfully via the live Graph API.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-203

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34244">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
