### PR TITLE
feat(core)!: Return chat WebSocket messages as JSON frames

### DIFF
--- a/packages/cli/src/chat/__tests__/chat-service.test.ts
+++ b/packages/cli/src/chat/__tests__/chat-service.test.ts
@@ -45,7 +45,9 @@ describe('ChatService', () => {
 
 		await chatService.startSession(req);
 
-		expect(mockWs.send).toHaveBeenCalledWith('Connection rejected');
+		expect(mockWs.send).toHaveBeenCalledWith(
+			JSON.stringify({ type: 'error', message: 'Connection rejected' }),
+		);
 		expect(mockWs.close).toHaveBeenCalledWith(1008);
 	});
 
@@ -222,7 +224,9 @@ describe('ChatService', () => {
 
 			await chatService.startSession(req);
 
-			expect(mockWs.send).toHaveBeenCalledWith('Connection rejected');
+			expect(mockWs.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'error', message: 'Connection rejected' }),
+			);
 			expect(mockWs.close).toHaveBeenCalledWith(1008);
 		});
 
@@ -289,7 +293,7 @@ describe('ChatService', () => {
 
 				await (chatService as any).checkHeartbeats();
 
-				expect(mockWs.send).toHaveBeenCalledWith('n8n|heartbeat');
+				expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat' }));
 				expect(clearInterval).toHaveBeenCalledWith(123);
 				expect((chatService as any).sessions.get(sessionKey)).toBeUndefined();
 			});
@@ -307,7 +311,7 @@ describe('ChatService', () => {
 
 				await (chatService as any).checkHeartbeats();
 
-				expect(mockWs.send).toHaveBeenCalledWith('n8n|heartbeat');
+				expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat' }));
 				expect((chatService as any).sessions.get(sessionKey)).toBeDefined();
 			});
 		});
@@ -331,7 +335,7 @@ describe('ChatService', () => {
 			};
 			(chatService as any).sessions.set(sessionKey, session);
 
-			const data = 'n8n|heartbeat-ack';
+			const data = JSON.stringify({ type: 'heartbeat-ack' });
 			const incomingMessageHandler = (chatService as any).incomingMessageHandler(sessionKey);
 			await incomingMessageHandler(data);
 
@@ -361,6 +365,22 @@ describe('ChatService', () => {
 			expect(session.nodeWaitingForChatResponse).toBeUndefined();
 		});
 
+		it('should ignore non-JSON frames without resuming or reporting an error', async () => {
+			const sessionKey = 'abc|123|public';
+			const session = {
+				executionId: '123',
+			};
+			(chatService as any).sessions.set(sessionKey, session);
+
+			const data = 'not json';
+			const incomingMessageHandler = (chatService as any).incomingMessageHandler(sessionKey);
+			await incomingMessageHandler(data);
+
+			expect(mockExecutionManager.runWorkflow).not.toHaveBeenCalled();
+			expect(mockErrorReporter.error).not.toHaveBeenCalled();
+			expect(mockLogger.error).not.toHaveBeenCalled();
+		});
+
 		it('should handle errors during message processing', async () => {
 			const sessionKey = 'abc|123|public';
 			const session = {
@@ -368,7 +388,8 @@ describe('ChatService', () => {
 			};
 			(chatService as any).sessions.set(sessionKey, session);
 
-			const data = 'invalid json';
+			// Valid JSON but not a valid chat message — parsing fails and is reported
+			const data = JSON.stringify({ foo: 'bar' });
 			const incomingMessageHandler = (chatService as any).incomingMessageHandler(sessionKey);
 			await incomingMessageHandler(data);
 
@@ -460,7 +481,7 @@ describe('ChatService', () => {
 			);
 			await pollAndProcessChatResponses();
 
-			expect(session.connection.send).toHaveBeenCalledWith('n8n|continue');
+			expect(session.connection.send).toHaveBeenCalledWith(JSON.stringify({ type: 'continue' }));
 			expect(session.nodeWaitingForChatResponse).toBeUndefined();
 		});
 
@@ -482,7 +503,7 @@ describe('ChatService', () => {
 			);
 			await pollAndProcessChatResponses();
 
-			expect(session.connection.send).toHaveBeenCalledWith('n8n|continue');
+			expect(session.connection.send).toHaveBeenCalledWith(JSON.stringify({ type: 'continue' }));
 			expect(session.nodeWaitingForChatResponse).toBeUndefined();
 		});
 
@@ -515,11 +536,48 @@ describe('ChatService', () => {
 			);
 			await pollAndProcessChatResponses();
 
-			expect(session.connection.send).toHaveBeenCalledWith('test message');
+			expect(session.connection.send).toHaveBeenCalledWith(
+				'{"type":"message","text":"test message"}',
+			);
 			expect(session.nodeWaitingForChatResponse).toEqual('node1');
 		});
 
-		it('should stringify message if it is an object', async () => {
+		it('should wrap a string message as a message frame even when its text is JSON', async () => {
+			const sessionKey = 'abc|123|public';
+			const session = {
+				isProcessing: false,
+				executionId: '123',
+				connection: { send: vi.fn() },
+				sessionId: 'abc',
+				nodeWaitingForChatResponse: undefined,
+			};
+			(chatService as any).sessions.set(sessionKey, session);
+			const messageText = '{"type":"with-buttons","text":"hi","blockUserInput":false,"buttons":[]}';
+			mockExecutionManager.findExecution.mockResolvedValue({
+				status: 'waiting',
+				data: {
+					resultData: {
+						lastNodeExecuted: 'node1',
+						runData: { node1: [{ data: { main: [[{ sendMessage: messageText }]] } }] },
+					},
+				},
+				workflowData: { nodes: [{ name: 'node1' }] },
+			} as any);
+			(chatService as any).shouldResumeImmediately = vi.fn().mockReturnValue(false);
+			(chatService as any).resumeExecution = vi.fn();
+
+			const pollAndProcessChatResponses = (chatService as any).pollAndProcessChatResponses(
+				sessionKey,
+			);
+			await pollAndProcessChatResponses();
+
+			// A string message is always carried as the text of a message frame
+			expect(session.connection.send).toHaveBeenCalledWith(
+				JSON.stringify({ type: 'message', text: messageText }),
+			);
+		});
+
+		it('should send an object message as-is when it is already a structured frame', async () => {
 			const sessionKey = 'abc|123|public';
 			const session = {
 				isProcessing: false,

--- a/packages/cli/src/chat/chat-service.ts
+++ b/packages/cli/src/chat/chat-service.ts
@@ -5,7 +5,15 @@ import { Service } from '@n8n/di';
 import { timingSafeEqual } from 'crypto';
 import { ErrorReporter } from 'n8n-core';
 import { ensureError } from '@n8n/utils/errors/ensure-error';
-import { jsonParse, UnexpectedError, CHAT_NODE_TYPE, CHAT_TOOL_NODE_TYPE } from 'n8n-workflow';
+import {
+	jsonParse,
+	UnexpectedError,
+	CHAT_NODE_TYPE,
+	CHAT_TOOL_NODE_TYPE,
+	ChatNodeMessageType,
+	type ChatNodeMessageRegular,
+	type ChatNodeMessageWithButtons,
+} from 'n8n-workflow';
 import { type RawData, WebSocket } from 'ws';
 import { z } from 'zod';
 
@@ -29,17 +37,39 @@ const HEARTBEAT_INTERVAL = 30 * 1000;
 const HEARTBEAT_TIMEOUT = 60 * 1000;
 
 /**
- * let frontend know that no user input is expected
+ * Every frame sent over the socket is JSON with a `type` discriminator, so the
+ * frontend never has to guess whether a payload is a plain string or a
+ * structured message (e.g. one that renders buttons).
  */
-const N8N_CONTINUE = 'n8n|continue';
-/**
- * send message for heartbeat check
- */
-const N8N_HEARTBEAT = 'n8n|heartbeat';
-/**
- * frontend did acknowledge the heartbeat
- */
-const N8N_HEARTBEAT_ACK = 'n8n|heartbeat-ack';
+const ServerFrameType = {
+	HEARTBEAT: 'heartbeat',
+	/** no user input is expected */
+	CONTINUE: 'continue',
+	ERROR: 'error',
+} as const;
+
+/** frontend acknowledges the heartbeat */
+const CLIENT_HEARTBEAT_ACK = 'heartbeat-ack';
+
+type ServerFrame =
+	| { type: typeof ServerFrameType.HEARTBEAT }
+	| { type: typeof ServerFrameType.CONTINUE }
+	| { type: typeof ServerFrameType.ERROR; message: string }
+	| ChatNodeMessageRegular
+	| ChatNodeMessageWithButtons;
+
+function sendFrame(ws: Pick<WebSocket, 'send'>, frame: ServerFrame) {
+	ws.send(JSON.stringify(frame));
+}
+
+function isHeartbeatAck(parsed: unknown): boolean {
+	return (
+		typeof parsed === 'object' &&
+		parsed !== null &&
+		'type' in parsed &&
+		parsed.type === CLIENT_HEARTBEAT_ACK
+	);
+}
 
 function closeConnection(ws: WebSocket) {
 	if (ws.readyState !== WebSocket.OPEN) return;
@@ -89,7 +119,7 @@ export class ChatService {
 		const execution = await this.executionManager.findExecution(executionId);
 
 		if (!execution) {
-			ws.send('Connection rejected');
+			sendFrame(ws, { type: ServerFrameType.ERROR, message: 'Connection rejected' });
 			ws.close(1008);
 			return;
 		}
@@ -100,7 +130,7 @@ export class ChatService {
 			const storedBuf = Buffer.from(execution.data.resumeToken);
 			if (!token || tokenBuf.length !== storedBuf.length || !timingSafeEqual(tokenBuf, storedBuf)) {
 				// Same generic message as missing execution — do not leak which check failed
-				ws.send('Connection rejected');
+				sendFrame(ws, { type: ServerFrameType.ERROR, message: 'Connection rejected' });
 				ws.close(1008);
 				return;
 			}
@@ -140,7 +170,7 @@ export class ChatService {
 
 		this.sessions.set(key, session);
 
-		ws.send(N8N_HEARTBEAT);
+		sendFrame(ws, { type: ServerFrameType.HEARTBEAT });
 	}
 
 	private async processWaitingExecution(
@@ -148,19 +178,19 @@ export class ChatService {
 		session: Session,
 		sessionKey: string,
 	) {
-		let message = getMessage(execution);
-		if (typeof message === 'object') {
-			message = JSON.stringify(message);
-		}
+		const message = getMessage(execution);
 
 		if (message === undefined) return;
 
-		session.connection.send(message);
+		const frame =
+			typeof message === 'string' ? { type: ChatNodeMessageType.MESSAGE, text: message } : message;
+
+		sendFrame(session.connection, frame);
 
 		const lastNode = getLastNodeExecuted(execution);
 
 		if (lastNode && shouldResumeImmediately(lastNode)) {
-			session.connection.send(N8N_CONTINUE);
+			sendFrame(session.connection, { type: ServerFrameType.CONTINUE });
 			const data: ChatMessage = {
 				action: 'sendMessage',
 				chatInput: getLastNodeMessage(execution, lastNode),
@@ -182,7 +212,7 @@ export class ChatService {
 		const lastNode = getLastNodeExecuted(execution);
 
 		if (execution.status === 'waiting' && lastNode?.name !== session.nodeWaitingForChatResponse) {
-			session.connection.send(N8N_CONTINUE);
+			sendFrame(session.connection, { type: ServerFrameType.CONTINUE });
 			session.nodeWaitingForChatResponse = undefined;
 		}
 	}
@@ -241,16 +271,22 @@ export class ChatService {
 
 				if (!session) return;
 
-				const message = this.stringifyRawData(data);
+				let parsed: unknown;
+				try {
+					parsed = jsonParse(this.stringifyRawData(data));
+				} catch {
+					// Ignore frames that aren't valid JSON
+					return;
+				}
 
-				if (message === N8N_HEARTBEAT_ACK) {
+				if (isHeartbeatAck(parsed)) {
 					session.lastHeartbeat = Date.now();
 					return;
 				}
 
 				const executionId = session.executionId;
 				if (await this.shouldResumeOnMessage(executionId)) {
-					await this.resumeExecution(executionId, this.parseChatMessage(message), sessionKey);
+					await this.resumeExecution(executionId, this.parseChatMessage(parsed), sessionKey);
 					session.nodeWaitingForChatResponse = undefined;
 				}
 			} catch (e) {
@@ -285,7 +321,7 @@ export class ChatService {
 				// chat response it means that the execution was resumed by a
 				// form, so we send a continue message to the frontend to let it
 				// know that no user message is expected
-				session.connection.send(N8N_CONTINUE);
+				sendFrame(session.connection, { type: ServerFrameType.CONTINUE });
 				session.nodeWaitingForChatResponse = undefined;
 			}
 
@@ -310,9 +346,9 @@ export class ChatService {
 		if (sessionKey) this.sessions.delete(sessionKey);
 	}
 
-	private parseChatMessage(message: string): ChatMessage {
+	private parseChatMessage(parsed: unknown): ChatMessage {
 		try {
-			const parsedMessage = chatMessageSchema.parse(jsonParse(message));
+			const parsedMessage = chatMessageSchema.parse(parsed);
 
 			if (parsedMessage.files) {
 				parsedMessage.files = parsedMessage.files.map((file) => ({
@@ -344,7 +380,7 @@ export class ChatService {
 					this.cleanupSession(session, key);
 				} else {
 					try {
-						session.connection.send(N8N_HEARTBEAT);
+						sendFrame(session.connection, { type: ServerFrameType.HEARTBEAT });
 					} catch (e) {
 						this.cleanupSession(session, key);
 						const error = ensureError(e);

--- a/packages/testing/playwright/tests/infrastructure/webhook-proc/chat-send-and-wait.spec.ts
+++ b/packages/testing/playwright/tests/infrastructure/webhook-proc/chat-send-and-wait.spec.ts
@@ -3,8 +3,6 @@ import { nanoid } from 'nanoid';
 
 import { test, expect } from '../../../fixtures/base';
 
-const HEARTBEAT = 'n8n|heartbeat';
-const HEARTBEAT_ACK = 'n8n|heartbeat-ack';
 const QUESTION = 'What is your name?';
 
 test.use({ capability: { webhooks: 1, workers: 1 } });
@@ -43,8 +41,14 @@ function openChatSocket(wsUrl: string) {
 
 	socket.addEventListener('message', (event) => {
 		const message = String(event.data);
-		if (message === HEARTBEAT) {
-			socket.send(HEARTBEAT_ACK);
+		let parsed: { type?: string } | undefined;
+		try {
+			parsed = JSON.parse(message) as { type?: string };
+		} catch {
+			parsed = undefined;
+		}
+		if (parsed?.type === 'heartbeat') {
+			socket.send(JSON.stringify({ type: 'heartbeat-ack' }));
 			return;
 		}
 		received.push(message);

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1551,8 +1551,14 @@ export interface IPairedItemData {
 }
 
 export const ChatNodeMessageType = {
+	MESSAGE: 'message',
 	WITH_BUTTONS: 'with-buttons',
 } as const;
+
+export type ChatNodeMessageRegular = {
+	type: typeof ChatNodeMessageType.MESSAGE;
+	text: string;
+};
 
 export type ChatNodeMessageButtonType = 'primary' | 'secondary';
 


### PR DESCRIPTION
## Summary

Makes the chat WebSocket service (`chat-service`) send **every** frame as JSON with a `type` discriminator (`heartbeat`, `continue`, `error`, `message`, `with-buttons`) instead of a mix of raw strings and JSON. The frontend can then tell frames apart by `type` rather than inferring structure from the payload, so a plain text message and a structured (button) message are no longer ambiguous.

Because the WebSocket wire format changes, this is a **v3 breaking change** and targets `3.x`.

- Regular string messages are wrapped as `{ "type": "message", "text": … }`; structured messages already carry their own `type`.
- Control frames (`heartbeat`/`continue`) and the rejection message become JSON; inbound heartbeat-ack is JSON. Non-JSON inbound frames are ignored.

### Companion PR (must land first)

The `@n8n/chat` widget is made backward-compatible (understands both the legacy string sentinels and the new JSON frames) in a **separate, non-breaking PR on `master`: #34348**. That widget change rides the daily `master`→`3.x` sync. **Land #34348 first** so `3.x` always has a widget that understands JSON before this server change merges (the editor chat bundles the widget from source). Rebase this branch onto `3.x` after the sync if needed.

## How to test

1. With #34348 present (on this branch's `3.x` base), run a Chat Trigger workflow in the editor and use the chat panel.
2. In DevTools → Network → WS → the `/chat` socket → Messages, confirm all server frames are JSON:
   - a **Free Text** reply renders as text,
   - an **Approval** reply renders buttons,
   - a Free Text reply whose text is itself JSON renders as plain text,
   - `heartbeat`/`continue` frames produce no bubbles; the client replies `{"type":"heartbeat-ack"}`.
3. Automated: `cd packages/cli && pnpm test src/chat/__tests__/chat-service.test.ts`.

> **Hosted chat / CDN:** the hosted `/webhook/:id/chat` page loads `@n8n/chat` from the jsdelivr CDN, so it reflects the new behavior once a `@n8n/chat` build including #34348 is published. The widget update is backward compatible, so publishing it is safe for both v2 and v3 hosted pages. Custom frontends that speak the chat WebSocket directly must handle the JSON frames.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4436

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI