### PR TITLE
fix(core): Fix change in width of all dropdowns in UI

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nAiModelSelectorDropdown/AiModelSelectorDropdown.vue
@@ -105,6 +105,7 @@ defineExpose({
 		placement="bottom-start"
 		teleported
 		searchable
+		width="var(--reka-dropdown-menu-trigger-width)"
 		@select="handleSelect"
 	>
 		<template #trigger>

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
@@ -512,6 +512,33 @@ describe('N8nDropdownMenu', () => {
 		});
 	});
 
+	describe('width prop', () => {
+		it('should default the content width to 24rem', async () => {
+			render(DropdownMenu, {
+				props: {
+					items: createItems(3),
+					modelValue: true,
+				},
+			});
+
+			const { dropdown } = await getDropdownContent();
+			expect(dropdown).toHaveStyle({ '--n8n--dropdown-menu-width': '24rem' });
+		});
+
+		it('should apply a custom width value', async () => {
+			render(DropdownMenu, {
+				props: {
+					items: createItems(3),
+					modelValue: true,
+					width: '10rem',
+				},
+			});
+
+			const { dropdown } = await getDropdownContent();
+			expect(dropdown).toHaveStyle({ '--n8n--dropdown-menu-width': '10rem' });
+		});
+	});
+
 	describe('teleported prop', () => {
 		it('should teleport to body by default', async () => {
 			const { container } = render(DropdownMenu, {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.types.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.types.ts
@@ -89,6 +89,8 @@ export interface DropdownMenuProps<T = string, D = never> {
 	teleported?: boolean;
 	/** Maximum height of the dropdown menu */
 	maxHeight?: string | number;
+	/** Maximum width of the dropdown menu. */
+	width?: string;
 	/** Whether to show loading state */
 	loading?: boolean;
 	/** Number of skeleton items to show when loading */

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
@@ -35,6 +35,7 @@ const props = withDefaults(defineProps<DropdownMenuProps<T, D>>(), {
 	searchPlaceholder: 'Search...',
 	searchDebounce: 0,
 	emptyText: 'No items',
+	width: '24rem',
 });
 
 const emit = defineEmits<{
@@ -72,12 +73,17 @@ const placementParts = computed(() => {
 });
 
 const contentContainerStyle = computed(() => {
-	if (props.maxHeight) {
-		const maxHeightValue =
-			typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight;
-		return { maxHeight: maxHeightValue, overflowY: 'auto' };
-	}
-	return {};
+	const maxHeightStyle = props.maxHeight
+		? {
+				maxHeight: typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight,
+				overflowY: 'auto',
+			}
+		: {};
+
+	return {
+		'--n8n--dropdown-menu-width': props.width,
+		...maxHeightStyle,
+	};
 });
 
 const handleOpenChange = (open: boolean) => {
@@ -364,7 +370,6 @@ defineExpose({ open, close });
 	--n8n--dropdown--offset--origin-y: center;
 	--animation--popover-in--translate-x: var(--n8n--dropdown--offset--slide-x);
 	--animation--popover-in--translate-y: var(--n8n--dropdown--offset--slide-y);
-	--n8n--dropdown-menu-width: var(--reka-dropdown-menu-trigger-width);
 	display: flex;
 	flex-direction: column;
 	width: fit-content;


### PR DESCRIPTION
## Summary

See thread https://n8nio.slack.com/archives/C03594NKD7W/p1784109217972939

### Before

<img width="188" height="184" alt="Screenshot 2026-07-15 at 14 54 00" src="https://github.com/user-attachments/assets/d790e87f-c867-4c71-b73a-192bc0b3e367" />

<img width="182" height="208" alt="Screenshot 2026-07-15 at 14 54 31" src="https://github.com/user-attachments/assets/8845eb99-c9a6-4963-8963-8c2d9f6e2f4b" />


### After

<img width="250" height="206" alt="Screenshot 2026-07-15 at 14 53 37" src="https://github.com/user-attachments/assets/7d451794-4fa9-4cb7-9ee5-3ded4c773252" />
<img width="210" height="210" alt="Screenshot 2026-07-15 at 14 54 50" src="https://github.com/user-attachments/assets/b4b4a408-197b-4261-a032-f5c0d8abf67f" />


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-349/create-agent-dropdown-menu-items-are-cut-off


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34249">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

