### PR TITLE
fix(editor): Restrict setup credential dropdown to pinned type

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
@@ -37,6 +37,8 @@ const slackOAuth2ApiType = {
 const slackNodeType = {
 	name: 'n8n-nodes-base.slack',
 	displayName: 'Slack',
+	description: '',
+	group: [],
 	version: 2,
 	defaults: { name: 'Slack' },
 	inputs: [NodeConnectionTypes.Main],

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
@@ -1,0 +1,190 @@
+import { computed, shallowRef } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import type { INodeUi } from '@/Interface';
+import { mockedStore } from '@/__tests__/utils';
+import { useCredentialsStore } from '../credentials.store';
+import { useNodeCredentialOptions } from './useNodeCredentialOptions';
+
+vi.mock('@/features/resolvers/composables/usePrivateCredentials', () => ({
+	usePrivateCredentials: vi.fn(() => ({ isEnabled: computed(() => false) })),
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', async () => {
+	const actual = await vi.importActual('@/app/stores/workflowDocument.store');
+	return {
+		...actual,
+		injectWorkflowDocumentStore: () => undefined,
+	};
+});
+
+const slackApiType = {
+	name: 'slackApi',
+	displayName: 'Slack API',
+	properties: [],
+} satisfies ICredentialType;
+
+const slackOAuth2ApiType = {
+	name: 'slackOAuth2Api',
+	displayName: 'Slack OAuth2 API',
+	extends: ['oAuth2Api'],
+	properties: [],
+} satisfies ICredentialType;
+
+const slackNodeType = {
+	name: 'n8n-nodes-base.slack',
+	displayName: 'Slack',
+	version: 2,
+	defaults: { name: 'Slack' },
+	inputs: [NodeConnectionTypes.Main],
+	outputs: [NodeConnectionTypes.Main],
+	credentials: [
+		{
+			name: 'slackApi',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['accessToken'],
+				},
+			},
+		},
+		{
+			name: 'slackOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['oAuth2'],
+				},
+			},
+		},
+	],
+	properties: [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			options: [
+				{ name: 'Access Token', value: 'accessToken' },
+				{ name: 'OAuth2', value: 'oAuth2' },
+			],
+			default: 'accessToken',
+		},
+	],
+} satisfies INodeTypeDescription;
+
+const slackNode: INodeUi = {
+	parameters: {
+		authentication: 'accessToken',
+	},
+	type: 'n8n-nodes-base.slack',
+	typeVersion: 2,
+	position: [0, 0],
+	id: 'slack-node-id',
+	name: 'Send Slack Message',
+	credentials: {},
+};
+
+function createCredential(overrides: { id: string; name: string; type: string }) {
+	return {
+		...overrides,
+		isManaged: false,
+		createdAt: '',
+		updatedAt: '',
+	};
+}
+
+function setupOptions(overrideCredType = '') {
+	const node = computed(() => slackNode);
+	const nodeType = computed(() => slackNodeType);
+	return useNodeCredentialOptions(node, nodeType, overrideCredType);
+}
+
+describe('useNodeCredentialOptions', () => {
+	let credentialsStore: ReturnType<typeof mockedStore<typeof useCredentialsStore>>;
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia({ stubActions: false }));
+		credentialsStore = mockedStore(useCredentialsStore);
+		credentialsStore.state.credentialTypes = {
+			slackApi: slackApiType,
+			slackOAuth2Api: slackOAuth2ApiType,
+		};
+		credentialsStore.state.credentials = {
+			'token-cred': createCredential({
+				id: 'token-cred',
+				name: 'Team Slack Token',
+				type: 'slackApi',
+			}),
+			'oauth-cred': createCredential({
+				id: 'oauth-cred',
+				name: 'Slack account',
+				type: 'slackOAuth2Api',
+			}),
+		};
+	});
+
+	it('shows only override credential type options for setup cards', () => {
+		const { credentialTypesNodeDescriptionDisplayed } = setupOptions('slackApi');
+
+		expect(credentialTypesNodeDescriptionDisplayed.value).toHaveLength(1);
+		expect(credentialTypesNodeDescriptionDisplayed.value[0].options).toEqual([
+			expect.objectContaining({ id: 'token-cred', type: 'slackApi' }),
+		]);
+	});
+
+	it('shows only OAuth credentials when override is slackOAuth2Api', () => {
+		const { credentialTypesNodeDescriptionDisplayed } = setupOptions('slackOAuth2Api');
+
+		expect(credentialTypesNodeDescriptionDisplayed.value).toHaveLength(1);
+		expect(credentialTypesNodeDescriptionDisplayed.value[0].options).toEqual([
+			expect.objectContaining({ id: 'oauth-cred', type: 'slackOAuth2Api' }),
+		]);
+	});
+
+	it('keeps mixed credential options in the NDV when no override is set', () => {
+		const { credentialTypesNodeDescriptionDisplayed } = setupOptions('');
+
+		expect(credentialTypesNodeDescriptionDisplayed.value).toHaveLength(1);
+		expect(
+			credentialTypesNodeDescriptionDisplayed.value[0].options.map((option) => option.id),
+		).toEqual(['token-cred', 'oauth-cred']);
+	});
+
+	it('disables mixed credential behavior when override is set', () => {
+		const slackApiDescription = slackNodeType.credentials[0];
+		const { showMixedCredentials } = setupOptions('slackApi');
+
+		expect(showMixedCredentials(slackApiDescription)).toBe(false);
+	});
+
+	it('enables mixed credential behavior without override on auth-switchable nodes', () => {
+		const slackApiDescription = slackNodeType.credentials[0];
+		const { showMixedCredentials } = setupOptions('');
+
+		expect(showMixedCredentials(slackApiDescription)).toBe(true);
+	});
+
+	it('reacts when override changes from empty to a pinned type', () => {
+		const overrideCredType = shallowRef('');
+		const node = computed(() => slackNode);
+		const nodeType = computed(() => slackNodeType);
+		const { credentialTypesNodeDescriptionDisplayed } = useNodeCredentialOptions(
+			node,
+			nodeType,
+			overrideCredType,
+		);
+
+		expect(
+			credentialTypesNodeDescriptionDisplayed.value[0].options.map((option) => option.id),
+		).toEqual(['token-cred', 'oauth-cred']);
+
+		overrideCredType.value = 'slackApi';
+
+		expect(
+			credentialTypesNodeDescriptionDisplayed.value[0].options.map((option) => option.id),
+		).toEqual(['token-cred']);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
@@ -36,6 +36,10 @@ export function useNodeCredentialOptions(
 	const nodeHelpers = useNodeHelpers();
 	const credentialsStore = useCredentialsStore();
 	const mainNodeAuthField = computed(() => getMainAuthField(nodeType.value));
+	const hasOverride = computed(() => {
+		const override = unref(overrideCredType);
+		return typeof override === 'string' && override !== '';
+	});
 
 	const credentialTypesNodeDescriptions = computed(() =>
 		credentialsStore.getCredentialTypesNodeDescriptions(unref(overrideCredType), nodeType.value),
@@ -90,7 +94,7 @@ export function useNodeCredentialOptions(
 	}
 
 	function showMixedCredentials(credentialType: INodeCredentialDescription): boolean {
-		if (!node.value) {
+		if (!node.value || hasOverride.value) {
 			return false;
 		}
 
@@ -100,6 +104,10 @@ export function useNodeCredentialOptions(
 	}
 
 	function getAllRelatedCredentialTypes(credentialType: INodeCredentialDescription): string[] {
+		if (hasOverride.value) {
+			return [credentialType.name];
+		}
+
 		const credentialIsRequired = showMixedCredentials(credentialType);
 		if (credentialIsRequired) {
 			if (mainNodeAuthField.value) {


### PR DESCRIPTION
## Summary

When Instance AI or the workflow setup panel pins a credential type (via `override-cred-type`), the credential dropdown was still using mixed-credentials behavior for auth-switchable nodes like Slack. That caused credentials from sibling auth types (e.g. `slackOAuth2Api` when the step asked for `slackApi`) to appear in the list, making it look like the wrong credential type was configured and preventing users from selecting a valid credential for the pinned type.

This change treats a non-empty `overrideCredType` as strict: the dropdown only lists credentials of the pinned type, and mixed-credentials behavior is disabled for create/select flows in setup cards.

Status quo: https://www.loom.com/share/56d9cbf184f84585962b357b296c1e91
Fix: https://www.loom.com/share/29ab51828db84408a2780dd4924e8f15

## How to test

1. Ensure you have both a **Slack API** (token) and **Slack OAuth2 API** credential in your instance.
2. Use Instance AI to build a workflow with a Slack node configured for Access Token auth (`slackApi`).
3. When the inline setup card opens, confirm the credential dropdown only shows **Slack API** credentials — OAuth credentials should no longer appear.
4. Create or select a token credential and apply the setup step successfully.
5. Open the same Slack node in the canvas NDV and confirm mixed credentials still work (both token and OAuth credentials visible when no override is set).

Unit tests:
```bash
cd packages/frontend/editor-ui && pnpm test src/features/credentials/composables/useNodeCredentialOptions.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-772/unable-to-select-credential-from-dropdown-in-setup-step

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34252">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

