### PR TITLE
fix(ai-builder): Resurface channel edit modal on AIA agent builder's artifact mode

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -62,9 +62,10 @@ vi.mock('../composables/useAgentApi', () => ({
 	getAgentTasks: (...args: unknown[]) => getAgentTasksSpy(...args),
 }));
 
+const integrationsCatalogRef = ref<Array<{ type: string; label: string; icon?: string }>>([]);
 vi.mock('../composables/useAgentIntegrationsCatalog', () => ({
 	useAgentIntegrationsCatalog: () => ({
-		catalog: { value: [] },
+		catalog: integrationsCatalogRef,
 	}),
 }));
 
@@ -117,9 +118,8 @@ function mountSection(
 				N8nTooltip: { template: '<span><slot /></span>' },
 				AgentChannelModal: {
 					name: 'AgentChannelModal',
-					props: ['simpleSetup'],
-					template:
-						'<div data-testid="agent-channel-modal-stub" :data-simple-setup="simpleSetup" />',
+					props: ['view', 'open'],
+					template: '<div v-if="open" data-testid="agent-channel-modal-stub" :data-view="view" />',
 				},
 			},
 		},
@@ -178,6 +178,7 @@ describe('AgentCapabilitiesSection', () => {
 		getAgentTasksSpy.mockResolvedValue([]);
 		projectAgentsListRef.value = [];
 		ensureProjectAgentsLoadedSpy.mockResolvedValue([]);
+		integrationsCatalogRef.value = [];
 	});
 
 	it('formats node and custom tool chip labels for display', () => {
@@ -635,8 +636,8 @@ describe('AgentCapabilitiesSection', () => {
 		expect(wrapper.find('[data-testid="agent-capabilities-add-skill"]').exists()).toBe(false);
 	});
 
-	describe('simpleChannelSetup', () => {
-		it('does not force simple setup on the channel modal by default', async () => {
+	describe('channel modal', () => {
+		it('opens the channel list view when clicking the add-channel button', async () => {
 			const wrapper = mountSection([]);
 
 			await wrapper.find('[data-testid="agent-capabilities-add-channel"]').trigger('click');
@@ -644,18 +645,21 @@ describe('AgentCapabilitiesSection', () => {
 
 			const modal = wrapper.find('[data-testid="agent-channel-modal-stub"]');
 			expect(modal.exists()).toBe(true);
-			expect(modal.attributes('data-simple-setup')).toBe('false');
+			expect(modal.attributes('data-view')).toBe('list');
 		});
 
-		it('forwards simpleChannelSetup to the channel modal as simple-setup', async () => {
-			const wrapper = mountSection([], {}, null, [], [], { simpleChannelSetup: true });
+		it('opens the per-channel edit view when clicking a configured channel chip', async () => {
+			integrationsCatalogRef.value = [{ type: 'linear', label: 'Linear', icon: 'zap' }];
+			const wrapper = mountSection([], {}, null, [], [], {
+				connectedTriggers: ['linear'],
+			});
 
-			await wrapper.find('[data-testid="agent-capabilities-add-channel"]').trigger('click');
+			await wrapper.find('[data-testid="agent-capabilities-channel-row"]').trigger('click');
 			await flushPromises();
 
 			const modal = wrapper.find('[data-testid="agent-channel-modal-stub"]');
 			expect(modal.exists()).toBe(true);
-			expect(modal.attributes('data-simple-setup')).toBe('true');
+			expect(modal.attributes('data-view')).toBe('linear_edit');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChannelModal.test.ts
@@ -79,19 +79,16 @@ function mountModal(props: Record<string, unknown>) {
 				N8nText: { template: '<span><slot /></span>' },
 				AgentChannelListItem: { template: '<li data-testid="channel-list-item" />' },
 				AgentChannelSlackSetup: {
-					props: ['forceNewCredential', 'setupMode', 'mode'],
-					template:
-						'<div data-testid="slack-setup" :data-mode="mode" :data-force-new-credential="forceNewCredential" :data-setup-mode="setupMode" />',
+					props: ['mode'],
+					template: '<div data-testid="slack-setup" :data-mode="mode" />',
 				},
 				AgentChannelLinearSetup: {
-					props: ['forceNewCredential', 'mode'],
-					template:
-						'<div data-testid="linear-setup" :data-mode="mode" :data-force-new-credential="forceNewCredential" />',
+					props: ['mode'],
+					template: '<div data-testid="linear-setup" :data-mode="mode" />',
 				},
 				AgentChannelTelegramSetup: {
-					props: ['forceNewCredential', 'mode'],
-					template:
-						'<div data-testid="telegram-setup" :data-mode="mode" :data-force-new-credential="forceNewCredential" />',
+					props: ['mode'],
+					template: '<div data-testid="telegram-setup" :data-mode="mode" />',
 				},
 			},
 		},
@@ -99,36 +96,20 @@ function mountModal(props: Record<string, unknown>) {
 }
 
 describe('AgentChannelModal', () => {
-	it('does not force a new credential or simple setup by default', () => {
+	it('renders the channel list for the list view', () => {
+		const wrapper = mountModal({ view: 'list' });
+
+		expect(wrapper.findAll('[data-testid="channel-list-item"]')).toHaveLength(catalog.value.length);
+	});
+
+	it('renders the per-channel setup view for a setup view', () => {
 		const wrapper = mountModal({ view: 'linear_setup' });
-
-		const linearSetup = wrapper.find('[data-testid="linear-setup"]');
-		expect(linearSetup.attributes('data-force-new-credential')).toBe('false');
-	});
-
-	it('forces a new credential and simple setup mode on the Slack setup child when simpleSetup is set', () => {
-		const wrapper = mountModal({ view: 'slack_setup', simpleSetup: true });
-
-		const slackSetup = wrapper.find('[data-testid="slack-setup"]');
-		expect(slackSetup.attributes('data-force-new-credential')).toBe('true');
-		expect(slackSetup.attributes('data-setup-mode')).toBe('simple');
-	});
-
-	it('forces a new credential on non-Slack setup children when simpleSetup is set', () => {
-		const wrapper = mountModal({ view: 'linear_setup', simpleSetup: true });
-
-		const linearSetup = wrapper.find('[data-testid="linear-setup"]');
-		expect(linearSetup.attributes('data-force-new-credential')).toBe('true');
-	});
-
-	it('redirects a channel edit view to the simple setup view instead of the advanced edit UI', () => {
-		const wrapper = mountModal({ view: 'linear_edit', simpleSetup: true });
 
 		const linearSetup = wrapper.find('[data-testid="linear-setup"]');
 		expect(linearSetup.attributes('data-mode')).toBe('setup');
 	});
 
-	it('keeps the advanced edit view when simpleSetup is not set', () => {
+	it('renders the per-channel edit view for an edit view', () => {
 		const wrapper = mountModal({ view: 'linear_edit' });
 
 		const linearSetup = wrapper.find('[data-testid="linear-setup"]');

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -109,7 +109,6 @@ const i18n = useI18n();
 						:is-published="Boolean(agent?.activeVersionId)"
 						:task-refs="localConfig?.tasks ?? []"
 						:reload-key="tasksReloadKey"
-						:simple-channel-setup="artifactMode"
 						@open-tool="emit('open-tool', $event)"
 						@open-skill="emit('open-skill', $event)"
 						@add-tool="emit('add-tool')"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -47,19 +47,11 @@ const props = withDefaults(
 		 * also suppresses the inline `AgentChannelModal`.
 		 */
 		sections?: AgentCapabilitySection[];
-		/**
-		 * Restricts the channel modal to the simple, guided per-channel setup used by
-		 * the AI-assistant channel-setup HITL card (forces a new credential, skips
-		 * the advanced list/edit UI). Set by the artifact-mode agent preview embedded
-		 * in the AI assistant; the standalone Agent Builder leaves this off.
-		 */
-		simpleChannelSetup?: boolean;
 	}>(),
 	{
 		disabled: false,
 		taskRefs: () => [],
 		sections: () => ['channels', 'tools', 'skills', 'subAgents', 'tasks'],
-		simpleChannelSetup: false,
 	},
 );
 
@@ -710,7 +702,6 @@ function handleChannelDisconnected(channelType: string) {
 			:project-id="projectId"
 			:connected-channels="connectedTriggers"
 			:is-published="isPublished"
-			:simple-setup="simpleChannelSetup"
 			@channel-connected="handleChannelConnected"
 			@channel-disconnected="handleChannelDisconnected"
 			@agent-changed="emit('agent-changed')"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChannelModal.vue
@@ -36,24 +36,9 @@ interface Props {
 	view: ChannelView;
 	connectedChannels: string[];
 	isPublished: boolean;
-	/**
-	 * Force creating a new credential in the setup flow (hides the existing-credential
-	 * picker). Used by the AIA channel-setup HITL so a new agent gets its own credential.
-	 */
-	forceNewCredential?: boolean;
-	/**
-	 * Restrict the modal to the simple, guided per-channel setup — used when the
-	 * modal is opened from the AI-assistant-embedded agent preview (artifact mode).
-	 * Forces a new credential and skips the advanced list/edit UI: any request to
-	 * edit a connected channel is redirected to the simple setup view instead.
-	 */
-	simpleSetup?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), {
-	forceNewCredential: false,
-	simpleSetup: false,
-});
+const props = defineProps<Props>();
 
 const emit = defineEmits<{
 	'update:open': [value: boolean];
@@ -77,21 +62,12 @@ const {
 	disconnect,
 } = useAgentIntegrationStatus(props.projectId, props.agentId);
 
-// In simple-setup mode there is no advanced edit UI, so any request to edit a
-// connected channel is redirected to its (simple) setup view instead.
-function normalizeView(view: ChannelView): ChannelView {
-	if (props.simpleSetup && view.endsWith('_edit')) {
-		return view.replace('_edit', '_setup') as ChannelView;
-	}
-	return view;
-}
-
-const currentView = ref<ChannelView>(normalizeView(props.view));
+const currentView = ref<ChannelView>(props.view);
 
 watch(
 	() => props.view,
 	(newView) => {
-		currentView.value = normalizeView(newView);
+		currentView.value = newView;
 	},
 );
 
@@ -137,10 +113,6 @@ const showFooterActions = computed(
 	() =>
 		isEditMode.value && selectedChannelType.value !== null && selectedChannelType.value !== 'slack',
 );
-
-// Simple-setup mode always creates a fresh credential — mirrors the AIA
-// channel-setup HITL card so the artifact preview gets the same guided flow.
-const effectiveForceNewCredential = computed(() => props.forceNewCredential || props.simpleSetup);
 
 const currentChannelCredentialId = computed(() =>
 	getChannelCredentialId(selectedChannelType.value),
@@ -198,7 +170,7 @@ function goToSetup(channelType: string) {
 }
 
 function goToEdit(channelType: string) {
-	currentView.value = normalizeView(`${channelType}_edit` as ChannelView);
+	currentView.value = `${channelType}_edit` as ChannelView;
 }
 
 function goBackToList() {
@@ -257,7 +229,7 @@ watch(
 	(isOpen) => {
 		if (isOpen) {
 			void loadChannelState();
-			currentView.value = normalizeView(props.view);
+			currentView.value = props.view;
 		}
 	},
 	{ immediate: true },
@@ -339,8 +311,6 @@ watch(
 						:loading="isLoading('slack')"
 						:error-message="hasError('slack') ? errorMessages.slack : ''"
 						:error-is-conflict="errorIsConflict.slack"
-						:force-new-credential="effectiveForceNewCredential"
-						:setup-mode="simpleSetup ? 'simple' : 'advanced'"
 						@create="createCredential"
 						@edit="editCredential"
 						@connect="saveChannelConfig"
@@ -366,7 +336,6 @@ watch(
 						:agent-name="agentId"
 						:project-id="projectId"
 						:agent-id="agentId"
-						:force-new-credential="effectiveForceNewCredential"
 						@create="createCredential"
 						@edit="editCredential"
 						@connect="saveChannelConfig"
@@ -392,7 +361,6 @@ watch(
 						:agent-name="agentId"
 						:project-id="projectId"
 						:agent-id="agentId"
-						:force-new-credential="effectiveForceNewCredential"
 						@create="createCredential"
 						@edit="editCredential"
 						@connect="saveChannelConfig"


### PR DESCRIPTION
## Summary

AIA agent artifact mode's add flow now shows the "advanced" setup (existing-credential picker and the Slack manifest panel) instead of forcing a fresh credential. This also allows removing / disconnecting the channel.

## How to test
- Start a new conversation with Instance AI to create an agent.
- Set up a Slack channel for said agent, either via HITL or manually.
- Click on Slack chip.
- Verify the following modal shows up:

<img width="920" height="729" alt="image" src="https://github.com/user-attachments/assets/b3b7bf67-c8c7-426f-a150-abedb0351d87" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-373/bug-slack-channel-integration-cannot-be-removed

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

