### PR TITLE
feat(API): Add POST /projects/folders to create a folder in personal project

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/folders/folders.handler.ts
@@ -12,6 +12,7 @@ import { FolderNotFoundError } from '@/errors/folder-not-found.error';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { FolderService } from '@/services/folder.service';
+import { ProjectService } from '@/services/project.service.ee';
 
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
@@ -33,6 +34,7 @@ const handleError = (error: unknown) => {
 
 type FolderHandlers = {
 	createFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
+	createPersonalFolder: PublicAPIEndpoint<AuthenticatedRequest>;
 	getFolders: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string }>>;
 	deleteFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string; folderId: string }>>;
 	getFolder: PublicAPIEndpoint<AuthenticatedRequest<{ projectId: string; folderId: string }>>;
@@ -54,6 +56,33 @@ const folderHandlers: FolderHandlers = {
 
 			try {
 				const folder = await Container.get(FolderService).createFolder(payload.data, projectId);
+				return res.status(201).json(folder);
+			} catch (error) {
+				return handleError(error);
+			}
+		},
+	],
+	createPersonalFolder: [
+		isLicensed('feat:folders'),
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'folder:create' }),
+		async (req, res) => {
+			const personalProject = await Container.get(ProjectService).getPersonalProject(req.user);
+			if (!personalProject) {
+				throw new NotFoundError('Could not find a personal project for this user');
+			}
+
+			await assertProjectScope(req.user, personalProject.id, ['folder:create']);
+
+			const payload = CreateFolderDto.safeParse(req.body);
+			if (payload.error) {
+				throw new BadRequestError(payload.error.errors[0].message);
+			}
+
+			try {
+				const folder = await Container.get(FolderService).createFolder(
+					payload.data,
+					personalProject.id,
+				);
 				return res.status(201).json(folder);
 			} catch (error) {
 				return handleError(error);

--- a/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.personal.yml
+++ b/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.personal.yml
@@ -1,0 +1,30 @@
+post:
+  x-eov-operation-id: createPersonalFolder
+  x-required-scope: folder:create
+  x-eov-operation-handler: v1/handlers/folders/folders.handler
+  tags:
+    - Folders
+  summary: Create a folder in your personal project
+  description: Create a folder in the calling user's personal project.
+  requestBody:
+    description: Payload for folder to create.
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/folder.create.yml'
+    required: true
+  responses:
+    '201':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/folder.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'
+    '404':
+      $ref: '../../../../shared/spec/responses/notFound.yml'

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -169,6 +169,8 @@ paths:
     $ref: './handlers/folders/spec/paths/folders.yml'
   /projects/{projectId}/folders/{folderId}:
     $ref: './handlers/folders/spec/paths/folders.folderId.yml'
+  /projects/folders:
+    $ref: './handlers/folders/spec/paths/folders.personal.yml'
   /n8n-packages/export:
     $ref: './handlers/n8n-packages/spec/paths/n8n-packages.export.yml'
   /n8n-packages/import:

--- a/packages/cli/test/integration/public-api/folders.test.ts
+++ b/packages/cli/test/integration/public-api/folders.test.ts
@@ -5,6 +5,7 @@ import { Container } from '@n8n/di';
 import type { ApiKeyScope } from '@n8n/permissions';
 
 import { FolderService } from '@/services/folder.service';
+import { ProjectService } from '@/services/project.service.ee';
 
 import { createFolder } from '../shared/db/folders';
 import { createOwnerWithApiKey, createMemberWithApiKey } from '../shared/db/users';
@@ -184,6 +185,36 @@ describe('POST /projects/:projectId/folders', () => {
 			.send({ name: 'Folder' });
 
 		expect(response.statusCode).toBe(500);
+	});
+});
+
+describe('POST /projects/folders', () => {
+	test("should create a folder in the calling user's personal project", async () => {
+		testServer.license.enable('feat:folders');
+
+		const response = await authOwnerAgent
+			.post('/projects/folders')
+			.send({ name: 'Top Level Folder' });
+
+		expect(response.statusCode).toBe(201);
+		expect(response.body).toHaveProperty('name', 'Top Level Folder');
+
+		const listResponse = await authOwnerAgent
+			.get(`/projects/${ownerPersonalProject.id}/folders`)
+			.query({ filter: JSON.stringify({ name: 'Top Level Folder' }) });
+
+		expect(listResponse.body.count).toBe(1);
+		expect(listResponse.body.data[0].id).toBe(response.body.id);
+	});
+
+	test('should return 404 when the calling user has no personal project', async () => {
+		testServer.license.enable('feat:folders');
+		vi.spyOn(Container.get(ProjectService), 'getPersonalProject').mockResolvedValueOnce(null);
+
+		const response = await authOwnerAgent.post('/projects/folders').send({ name: 'Folder' });
+
+		expect(response.statusCode).toBe(404);
+		expect(response.body.message).toBe('Could not find a personal project for this user');
 	});
 });
 


### PR DESCRIPTION
## Summary

- **Add** a new endpoint `POST /projects/folders` that creates a folder directly in the calling user's own personal project — `projectId` is not required.
- This is an **alternative approach** to the `personal` project ID alias landed in #34091, opened as a draft so we can compare the two side by side before we settle on one.

**Trade-off vs #34091:**
- This avoids a "magic string" in the URL entirely — no reserved `projectId` value to document or discover.
- It does mean folder creation now has two entry points to maintain (`POST /projects/{projectId}/folders` and `POST /projects/folders`), each with their own OpenAPI path definition, versus one endpoint handling both cases via a small branch.

## How to test

- `POST /api/v1/projects/folders` with `{ "name": "..." }`, using any valid API key — the folder is created in the caller's own personal project.

## Related Linear tickets, Github issues, and Community forum posts

Linear ticket: https://linear.app/n8n/issue/API-16/api-get-projects-provides-unhelpful-error

Related PR (alternative approach): #34091

## Test plan

- [x] Added a new `describe('POST /projects/folders', ...)` block to `packages/cli/test/integration/public-api/folders.test.ts` covering: folder creation in the personal project, and a 404 when the caller has no personal project.
- [x] `pnpm test:integration` (`folders.test.ts`) — 55/55 passing.
- [x] `pnpm typecheck` — clean.
- [x] `eslint` (targeted changed files) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34260">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

