### PR TITLE
refactor(core): Split agent execution orchestrator into chat/task and workflow services (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -37,7 +37,7 @@ import {
 	SubworkflowPolicyChecker,
 } from '@/executions/pre-execution-checks';
 import { ExternalHooks } from '@/external-hooks';
-import { AgentExecutionOrchestratorService } from '@/modules/agents/agent-execution-orchestrator.service';
+import { AgentWorkflowExecutionService } from '@/modules/agents/agent-workflow-execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { UrlService } from '@/services/url.service';
@@ -1232,7 +1232,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 	describe('executeAgent', () => {
 		const ownershipService = mockInstance(OwnershipService);
-		const agentExecutionOrchestratorService = mockInstance(AgentExecutionOrchestratorService);
+		const agentWorkflowExecutionService = mockInstance(AgentWorkflowExecutionService);
 
 		const AGENT_ID = 'agent-id';
 		const MESSAGE = 'hello';
@@ -1241,8 +1241,8 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 		beforeEach(() => {
 			vi.clearAllMocks();
-			agentExecutionOrchestratorService.executeForWorkflow.mockResolvedValue(
-				mock<Awaited<ReturnType<typeof agentExecutionOrchestratorService.executeForWorkflow>>>(),
+			agentWorkflowExecutionService.executeForWorkflow.mockResolvedValue(
+				mock<Awaited<ReturnType<typeof agentWorkflowExecutionService.executeForWorkflow>>>(),
 			);
 		});
 
@@ -1258,8 +1258,8 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 			await executeAgent({ inlineAgent }, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'trigger');
 
-			expect(agentExecutionOrchestratorService.executeForWorkflow).not.toHaveBeenCalled();
-			expect(agentExecutionOrchestratorService.executeInlineForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).not.toHaveBeenCalled();
+			expect(agentWorkflowExecutionService.executeInlineForWorkflow).toHaveBeenCalledWith(
 				inlineAgent,
 				MESSAGE,
 				EXEC_ID,
@@ -1284,7 +1284,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 			await executeAgent({ inlineAgent }, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual');
 
-			expect(agentExecutionOrchestratorService.executeInlineForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeInlineForWorkflow).toHaveBeenCalledWith(
 				inlineAgent,
 				MESSAGE,
 				EXEC_ID,
@@ -1314,7 +1314,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 
 			expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
@@ -1349,7 +1349,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				outputSchema,
 			);
 
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
@@ -1387,7 +1387,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				workflowContext,
 			);
 
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
@@ -1420,7 +1420,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 
 			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('workflow-1');
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
@@ -1446,7 +1446,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				'Cannot execute agent without a projectId or workflowId in additional data',
 			);
 			expect(ownershipService.getWorkflowProjectCached).not.toHaveBeenCalled();
-			expect(agentExecutionOrchestratorService.executeForWorkflow).not.toHaveBeenCalled();
+			expect(agentWorkflowExecutionService.executeForWorkflow).not.toHaveBeenCalled();
 		});
 
 		it('throws when workflowId is missing even if projectId is present', async () => {
@@ -1459,7 +1459,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			await expect(
 				executeAgent({ agentId: AGENT_ID }, MESSAGE, EXEC_ID, THREAD_ID, additionalData, 'manual'),
 			).rejects.toThrow('Cannot execute agent without a workflowId in additional data');
-			expect(agentExecutionOrchestratorService.executeForWorkflow).not.toHaveBeenCalled();
+			expect(agentWorkflowExecutionService.executeForWorkflow).not.toHaveBeenCalled();
 		});
 
 		it('executes for trigger runs without any user', async () => {
@@ -1482,7 +1482,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 			);
 
 			expect(ownershipService.getPersonalProjectOwnerCached).not.toHaveBeenCalled();
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,
@@ -1513,8 +1513,8 @@ describe('WorkflowExecuteAdditionalData', () => {
 					mode,
 				);
 
-				// AgentExecutionOrchestratorService.executeForWorkflow should use draft mode.
-				expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+				// AgentWorkflowExecutionService.executeForWorkflow should use draft mode.
+				expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 					AGENT_ID,
 					MESSAGE,
 					EXEC_ID,
@@ -1547,8 +1547,8 @@ describe('WorkflowExecuteAdditionalData', () => {
 
 			await executeAgent({ agentId: AGENT_ID }, MESSAGE, EXEC_ID, THREAD_ID, additionalData, mode);
 
-			// AgentExecutionOrchestratorService.executeForWorkflow should use draft mode.
-			expect(agentExecutionOrchestratorService.executeForWorkflow).toHaveBeenCalledWith(
+			// AgentWorkflowExecutionService.executeForWorkflow should use draft mode.
+			expect(agentWorkflowExecutionService.executeForWorkflow).toHaveBeenCalledWith(
 				AGENT_ID,
 				MESSAGE,
 				EXEC_ID,

--- a/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts
@@ -2,23 +2,17 @@ import type { Agent as RuntimeAgent, StreamChunk } from '@n8n/agents';
 import { N8N_CHAT_INTEGRATION_TYPE, type AgentJsonConfig } from '@n8n/api-types';
 import { mockLogger } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
-import type { JSONSchema7 } from 'json-schema';
-import { OperationalError, UserError } from 'n8n-workflow';
-import type { ExecuteAgentWorkflowContext, IRunExecutionData } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { CredentialsService } from '@/credentials/credentials.service';
 import type { Telemetry } from '@/telemetry';
 
 import { AgentExecutionOrchestratorService } from '../agent-execution-orchestrator.service';
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentRuntimeCacheService } from '../agent-runtime-cache.service';
-import type { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
-import type { Agent } from '../entities/agent.entity';
 import type { IntegrationMessageContextService } from '../integrations/integration-message-context.service';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
-import type { AgentRepository } from '../repositories/agent.repository';
 import type { ToolRegistry } from '../tool-registry';
 
 const agentId = 'agent-1';
@@ -31,20 +25,6 @@ const schema: AgentJsonConfig = {
 	model: 'anthropic/claude-sonnet-4-5',
 	instructions: 'Help users',
 };
-
-function makeAgent(overrides: Partial<Agent> = {}): Agent {
-	return {
-		id: agentId,
-		name: 'Support Agent',
-		projectId,
-		schema,
-		activeVersionId: 'published-version',
-		activeVersion: { schema, tools: {}, skills: {}, publishedById: userId },
-		tools: {},
-		skills: {},
-		...overrides,
-	} as unknown as Agent;
-}
 
 function makeReadableStream(chunks: StreamChunk[]): ReadableStream<StreamChunk> {
 	return new ReadableStream<StreamChunk>({
@@ -103,37 +83,29 @@ function makeRuntime(chunks: StreamChunk[] = [{ type: 'finish', finishReason: 's
 }
 
 function makeService() {
-	const agentRepository = mock<AgentRepository>();
 	const checkpointStorage = mock<N8NCheckpointStorage>();
 	const executionService = mock<AgentExecutionService>();
 	const telemetry = mock<Telemetry>();
 	const runtimeCacheService = mock<AgentRuntimeCacheService>();
-	const credentialsService = mock<CredentialsService>();
-	const reconstructionService = mock<AgentRuntimeReconstructionService>();
 	const integrationMessageContextService = mock<IntegrationMessageContextService>();
 
 	executionService.recordMessage.mockResolvedValue('execution-1');
 
 	const service = new AgentExecutionOrchestratorService(
 		mockLogger(),
-		agentRepository,
 		checkpointStorage,
 		executionService,
 		telemetry,
 		runtimeCacheService,
-		credentialsService,
-		reconstructionService,
 		integrationMessageContextService,
 	);
 
 	return {
 		service,
-		agentRepository,
 		checkpointStorage,
 		executionService,
 		telemetry,
 		runtimeCacheService,
-		reconstructionService,
 		integrationMessageContextService,
 	};
 }
@@ -486,529 +458,6 @@ describe('AgentExecutionOrchestratorService', () => {
 
 		expect(executionService.recordMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ threadId: 'thread-1', userMessage: null, hitlStatus: 'suspended' }),
-		);
-	});
-
-	it('executes workflow runs with thread-scoped persistence and tool-call output', async () => {
-		const { service, agentRepository, reconstructionService, executionService, telemetry } =
-			makeService();
-		const runtime = makeRuntime([
-			{ type: 'tool-call', toolCallId: 'tc-1', toolName: 'lookup', input: { id: 1 } },
-			{ type: 'tool-result', toolCallId: 'tc-1', toolName: 'lookup', output: { ok: true } },
-			{ type: 'finish', finishReason: 'stop', structuredOutput: { answer: 'done' } },
-		]);
-
-		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
-		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
-
-		const result = await service.executeForWorkflow(
-			agentId,
-			'hello',
-			'execution-1',
-			'thread-1',
-			projectId,
-			userId,
-		);
-
-		expect(runtime.agent.stream).toHaveBeenCalledWith(
-			'hello',
-			expect.objectContaining({
-				// resourceId is the memory store's read scope: it must be stable
-				// across executions (NOT the execution id) or a reused session id
-				// would never see its prior messages.
-				persistence: { resourceId: 'thread-1', threadId: 'thread-1' },
-			}),
-		);
-		expect(result).toEqual(
-			expect.objectContaining({
-				response: '',
-				structuredOutput: { answer: 'done' },
-				toolCalls: [{ toolName: 'lookup', input: { id: 1 }, result: { ok: true } }],
-			}),
-		);
-
-		const streamOptions = runtime.agent.stream.mock.calls[0][1] as {
-			executionCounter: { incrementMessageCount: () => void };
-		};
-		streamOptions.executionCounter.incrementMessageCount();
-		expect(telemetry.trackAgentExecution).toHaveBeenCalledWith({
-			agent_id: agentId,
-			user_id: userId,
-			message_count: 1,
-		});
-		expect(executionService.recordMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				telemetry: expect.objectContaining({
-					runType: 'production',
-					configuration: expect.objectContaining({
-						model: 'anthropic/claude-sonnet-4-5',
-					}),
-				}),
-			}),
-		);
-	});
-
-	it('applies per-call structured output schema and improves empty-output errors', async () => {
-		const { service, agentRepository, reconstructionService } = makeService();
-		const outputSchema: JSONSchema7 = {
-			type: 'object',
-			properties: { answer: { type: 'string' } },
-		};
-		const runtime = makeRuntime([{ type: 'error', error: new Error('No output generated.') }]);
-
-		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
-		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
-
-		await expect(
-			service.executeForWorkflow(
-				agentId,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-				userId,
-				false,
-				outputSchema,
-			),
-		).rejects.toThrow(OperationalError);
-		expect(runtime.agent.structuredOutput).toHaveBeenCalledWith(outputSchema);
-	});
-
-	describe('workflow data tools', () => {
-		const baseContext = {
-			workflowId: 'wf-1',
-			workflowName: 'My workflow',
-			callingNodeName: 'Message an Agent',
-			inputData: [{ json: { a: 1 } }],
-			inputDataScope: 'item' as const,
-			nodes: [{ name: 'Webhook', type: 'n8n-nodes-base.webhook' }],
-			runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
-		};
-
-		const setupRuntimeWithToolSpy = (declaredTools: Array<{ name: string }> = []) => {
-			const { service, agentRepository, reconstructionService } = makeService();
-			const runtime = makeRuntime();
-			const toolFn = vi.fn();
-			Object.assign(runtime.agent, { tool: toolFn, declaredTools });
-			agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
-			reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
-			return { service, toolFn };
-		};
-
-		const toolNamesFrom = (toolFn: Mock): string[] => {
-			const [tools] = toolFn.mock.calls[0] as [Array<{ name: string }>];
-			return tools.map((t) => t.name);
-		};
-
-		it('always injects fetch_input_data when workflowContext is provided', async () => {
-			const { service, toolFn } = setupRuntimeWithToolSpy();
-			const workflowContext: ExecuteAgentWorkflowContext = {
-				...baseContext,
-				exposeWorkflowData: false,
-			};
-
-			await service.executeForWorkflow(
-				agentId,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-				undefined,
-				undefined,
-				undefined,
-				workflowContext,
-			);
-
-			expect(toolFn).toHaveBeenCalledTimes(1);
-			expect(toolNamesFrom(toolFn)).toEqual(['fetch_input_data']);
-		});
-
-		it('also injects fetch_workflow_context when exposeWorkflowData is true', async () => {
-			const { service, toolFn } = setupRuntimeWithToolSpy();
-			const workflowContext: ExecuteAgentWorkflowContext = {
-				...baseContext,
-				exposeWorkflowData: true,
-			};
-
-			await service.executeForWorkflow(
-				agentId,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-				undefined,
-				undefined,
-				undefined,
-				workflowContext,
-			);
-
-			expect(toolNamesFrom(toolFn)).toEqual(['fetch_input_data', 'fetch_workflow_context']);
-		});
-
-		it('injects no tools without workflowContext', async () => {
-			const { service, toolFn } = setupRuntimeWithToolSpy();
-
-			await service.executeForWorkflow(agentId, 'hello', 'execution-1', 'thread-1', projectId);
-
-			expect(toolFn).not.toHaveBeenCalled();
-		});
-
-		it('surfaces an error when the agent already declares a reserved tool name', async () => {
-			const { service, toolFn } = setupRuntimeWithToolSpy([{ name: 'fetch_input_data' }]);
-			const workflowContext: ExecuteAgentWorkflowContext = {
-				...baseContext,
-				exposeWorkflowData: false,
-			};
-
-			await expect(
-				service.executeForWorkflow(
-					agentId,
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-					undefined,
-					undefined,
-					undefined,
-					workflowContext,
-				),
-			).rejects.toThrow('"fetch_input_data"');
-
-			expect(toolFn).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('executeInlineForWorkflow', () => {
-		const inlinePayload = {
-			config: {
-				name: 'Inline Agent',
-				model: 'anthropic/claude-sonnet-4-5',
-				credential: 'cred-1',
-				instructions: 'Help users',
-			},
-		};
-
-		it('compiles from the embedded config, records no session, and tracks inline telemetry', async () => {
-			const { service, agentRepository, reconstructionService, executionService, telemetry } =
-				makeService();
-			const runtime = makeRuntime([
-				{ type: 'text-start', id: 'text-1' },
-				{ type: 'text-delta', id: 'text-1', delta: 'answer' },
-				{ type: 'text-end', id: 'text-1' },
-				{ type: 'finish', finishReason: 'stop' },
-			]);
-			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
-
-			const workflowContext: ExecuteAgentWorkflowContext = {
-				workflowId: 'wf-1',
-				callingNodeName: 'Message an Agent',
-				// Memory is injected only for caller-supplied session ids.
-				hasCallerSessionId: true,
-				nodes: [],
-				runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
-			};
-			Object.assign(runtime.agent, { tool: vi.fn(), declaredTools: [] });
-
-			const result = await service.executeInlineForWorkflow(
-				inlinePayload,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-				userId,
-				'production',
-				undefined,
-				workflowContext,
-			);
-
-			// No entity lookup — the embedded config is the source of truth.
-			expect(agentRepository.findByIdAndProjectId).not.toHaveBeenCalled();
-			expect(reconstructionService.reconstructFromResolvedSource).toHaveBeenCalledWith(
-				expect.objectContaining({
-					config: expect.objectContaining({
-						name: 'Inline Agent',
-						// Injected server-side: conversation-thread memory keeps a
-						// session-id-keyed thread across executions; long-term memory
-						// stays off (it would accumulate under the synthetic id).
-						memory: {
-							enabled: true,
-							storage: 'n8n',
-							observationalMemory: { enabled: false },
-							episodicMemory: { enabled: false },
-						},
-					}),
-					memoryOwnerAgentId: 'inline:wf-1:Message an Agent',
-					projectId,
-					runtimeProfile: 'inline',
-					skills: {},
-					toolDescriptors: {},
-					toolCodeByName: {},
-				}),
-			);
-
-			expect(result.response).toBe('answer');
-			// Inline runs have no persisted session.
-			expect(result.session).toBeNull();
-			expect(executionService.recordMessage).not.toHaveBeenCalled();
-
-			// Thread-scoped persistence: stable across executions, so a reused
-			// session id continues the same conversation.
-			expect(runtime.agent.stream).toHaveBeenCalledWith(
-				'hello',
-				expect.objectContaining({
-					persistence: { resourceId: 'thread-1', threadId: 'thread-1' },
-				}),
-			);
-
-			expect(telemetry.trackAgentTurnFinished).toHaveBeenCalledWith(
-				expect.objectContaining({
-					agent_id: 'inline:wf-1:Message an Agent',
-					agent_type: 'inline',
-					run_type: 'production',
-					turn_status: 'succeeded',
-					configuration: expect.objectContaining({ model: 'anthropic/claude-sonnet-4-5' }),
-				}),
-			);
-		});
-
-		it('injects no memory when the caller supplied no session id (nothing to continue)', async () => {
-			const { service, reconstructionService } = makeService();
-			const runtime = makeRuntime([{ type: 'finish', finishReason: 'stop' }]);
-			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
-			Object.assign(runtime.agent, { tool: vi.fn(), declaredTools: [] });
-
-			const workflowContext: ExecuteAgentWorkflowContext = {
-				workflowId: 'wf-1',
-				callingNodeName: 'Message an Agent',
-				hasCallerSessionId: false,
-				nodes: [],
-				runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
-			};
-
-			await service.executeInlineForWorkflow(
-				inlinePayload,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-				userId,
-				'production',
-				undefined,
-				workflowContext,
-			);
-
-			const [source] = reconstructionService.reconstructFromResolvedSource.mock.calls[0];
-			// A per-call thread can never be continued — persisting it would only
-			// accumulate rows no session UI or cleanup path can reach.
-			expect(source.config).not.toHaveProperty('memory');
-		});
-
-		it.each([
-			['skills', { skills: [{ type: 'skill', id: 'triage' }] }],
-			// Memory is injected server-side; the node cannot configure it.
-			['memory', { memory: { enabled: true, storage: 'n8n' } }],
-			// Approval suspends the run, which workflow executions can't resume.
-			[
-				'tool approval',
-				{
-					tools: [{ type: 'workflow', workflow: 'Lookup Orders', requireApproval: true }],
-				},
-			],
-			[
-				'MCP approval',
-				{
-					mcpServers: [
-						{
-							name: 'github',
-							url: 'https://mcp.example.com',
-							transport: 'streamableHttp',
-							authentication: 'none',
-							approval: { mode: 'global' },
-						},
-					],
-				},
-			],
-		])('rejects configs with saved-agent-only capabilities (%s)', async (_key, extra) => {
-			const { service, reconstructionService } = makeService();
-
-			await expect(
-				service.executeInlineForWorkflow(
-					{
-						config: {
-							...inlinePayload.config,
-							...extra,
-						} as unknown as typeof inlinePayload.config,
-					},
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-				),
-			).rejects.toThrow(UserError);
-			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
-		});
-
-		it('rejects custom (code) tools, whose bodies live only on saved agents', async () => {
-			const { service, reconstructionService } = makeService();
-
-			await expect(
-				service.executeInlineForWorkflow(
-					{
-						config: {
-							...inlinePayload.config,
-							tools: [{ type: 'custom', id: 'my_tool' }],
-						} as unknown as typeof inlinePayload.config,
-					},
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-				),
-			).rejects.toThrow(UserError);
-			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
-		});
-
-		it('rejects an unrunnable draft config (no credential)', async () => {
-			const { service, reconstructionService } = makeService();
-
-			await expect(
-				service.executeInlineForWorkflow(
-					{ config: { ...inlinePayload.config, credential: '' } },
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-				),
-			).rejects.toThrow(UserError);
-			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
-		});
-
-		it('tracks a failed inline turn before rethrowing a stream reader error', async () => {
-			const { service, reconstructionService, telemetry } = makeService();
-			const runtime = makeRuntime();
-			runtime.agent.stream.mockResolvedValue({
-				stream: makeFailingStream(new Error('reader failed while consuming stream')),
-			});
-			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
-
-			await expect(
-				service.executeInlineForWorkflow(
-					inlinePayload,
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-				),
-			).rejects.toThrow('reader failed while consuming stream');
-
-			// Telemetry fires even for failed runs — the rethrow happens after.
-			expect(telemetry.trackAgentTurnFinished).toHaveBeenCalledWith(
-				expect.objectContaining({ agent_type: 'inline', turn_status: 'failed' }),
-			);
-		});
-
-		it('surfaces inline compile failures as an OperationalError', async () => {
-			const { service, reconstructionService } = makeService();
-			reconstructionService.reconstructFromResolvedSource.mockRejectedValue(new Error('boom'));
-
-			const execution = service.executeInlineForWorkflow(
-				inlinePayload,
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-			);
-
-			await expect(execution).rejects.toThrow(OperationalError);
-			await expect(execution).rejects.toThrow('Failed to compile agent: boom');
-		});
-
-		it('rejects a malformed $fromAI expression in a node tool before compiling', async () => {
-			const { service, reconstructionService } = makeService();
-
-			const execution = service.executeInlineForWorkflow(
-				{
-					config: {
-						...inlinePayload.config,
-						tools: [
-							{
-								type: 'node',
-								name: 'HTTP Request',
-								node: {
-									nodeType: 'n8n-nodes-base.httpRequestTool',
-									nodeTypeVersion: 4.4,
-									nodeParameters: { url: '={{ $fromAI( }}' },
-								},
-							},
-						],
-					} as unknown as typeof inlinePayload.config,
-				},
-				'hello',
-				'execution-1',
-				'thread-1',
-				projectId,
-			);
-
-			await expect(execution).rejects.toThrow(UserError);
-			await expect(execution).rejects.toThrow('Invalid $fromAI expression');
-			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
-		});
-
-		it('rejects approval-gated tools, which could never resume in workflow context', async () => {
-			const { service, reconstructionService } = makeService();
-
-			await expect(
-				service.executeInlineForWorkflow(
-					{
-						config: {
-							...inlinePayload.config,
-							tools: [{ type: 'workflow', workflow: 'Lookup', requireApproval: true }],
-						} as unknown as typeof inlinePayload.config,
-					},
-					'hello',
-					'execution-1',
-					'thread-1',
-					projectId,
-				),
-			).rejects.toThrow('Invalid inline agent configuration');
-			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
-		});
-	});
-
-	it('maps structured-output stream reader errors before recording and rethrowing', async () => {
-		const { service, agentRepository, reconstructionService, executionService } = makeService();
-		const outputSchema: JSONSchema7 = {
-			type: 'object',
-			properties: { answer: { type: 'string' } },
-		};
-		const runtime = makeRuntime();
-		runtime.agent.stream.mockResolvedValue({
-			stream: makeFailingStream(new Error('No output generated. Check the stream for errors.')),
-		});
-
-		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
-		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
-
-		const execution = service.executeForWorkflow(
-			agentId,
-			'hello',
-			'execution-1',
-			'thread-1',
-			projectId,
-			userId,
-			false,
-			outputSchema,
-		);
-
-		await expect(execution).rejects.toThrow(OperationalError);
-		await expect(execution).rejects.toThrow("Couldn't get structured output matching the schema");
-		await expect(execution).rejects.not.toThrow('Check the stream');
-		expect(executionService.recordMessage).toHaveBeenCalledWith(
-			expect.objectContaining({
-				record: expect.objectContaining({
-					error: expect.stringContaining("Couldn't get structured output matching the schema"),
-				}),
-			}),
 		);
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-runtime-reconstruction-integration-tools.test.ts
@@ -253,13 +253,10 @@ describe('AgentRuntimeReconstructionService integration tools', () => {
 		);
 		agentExecutionOrchestratorService = new AgentExecutionOrchestratorService(
 			logger,
-			agentRepository,
 			n8nCheckpointStorage,
 			agentExecutionService,
 			telemetry,
 			runtimeCacheService,
-			credentialsService,
-			agentRuntimeReconstructionService,
 			mock<IntegrationMessageContextService>(),
 		);
 		agentIntegrationPersistenceService = new AgentIntegrationPersistenceService(

--- a/packages/cli/src/modules/agents/__tests__/agent-workflow-execution.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-workflow-execution.service.test.ts
@@ -1,0 +1,654 @@
+import type { Agent as RuntimeAgent, StreamChunk } from '@n8n/agents';
+import type { AgentJsonConfig } from '@n8n/api-types';
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { JSONSchema7 } from 'json-schema';
+import { OperationalError, UserError } from 'n8n-workflow';
+import type { ExecuteAgentWorkflowContext, IRunExecutionData } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+import type { Telemetry } from '@/telemetry';
+
+import { AgentWorkflowExecutionService } from '../agent-workflow-execution.service';
+import type { AgentExecutionService } from '../agent-execution.service';
+import type { AgentRuntimeReconstructionService } from '../agent-runtime-reconstruction.service';
+import type { Agent } from '../entities/agent.entity';
+import type { AgentRepository } from '../repositories/agent.repository';
+import type { ToolRegistry } from '../tool-registry';
+
+const agentId = 'agent-1';
+const projectId = 'project-1';
+const userId = 'user-1';
+
+const schema: AgentJsonConfig = {
+	name: 'Support Agent',
+	model: 'anthropic/claude-sonnet-4-5',
+	instructions: 'Help users',
+};
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+	return {
+		id: agentId,
+		name: 'Support Agent',
+		projectId,
+		schema,
+		activeVersionId: 'published-version',
+		activeVersion: { schema, tools: {}, skills: {}, publishedById: userId },
+		tools: {},
+		skills: {},
+		...overrides,
+	} as unknown as Agent;
+}
+
+function makeReadableStream(chunks: StreamChunk[]): ReadableStream<StreamChunk> {
+	return new ReadableStream<StreamChunk>({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
+function makeFailingStream(error: Error): ReadableStream<StreamChunk> {
+	const chunks: StreamChunk[] = [
+		{ type: 'text-start', id: 'text-1' },
+		{ type: 'text-delta', id: 'text-1', delta: 'partial answer' },
+	];
+	let index = 0;
+
+	return new ReadableStream<StreamChunk>({
+		pull(controller) {
+			const chunk = chunks[index++];
+			if (chunk) {
+				controller.enqueue(chunk);
+				return;
+			}
+
+			controller.error(error);
+		},
+	});
+}
+
+function makeRuntime(chunks: StreamChunk[] = [{ type: 'finish', finishReason: 'stop' }]) {
+	return {
+		agent: {
+			name: 'Runtime Agent',
+			stream: vi.fn().mockResolvedValue({ stream: makeReadableStream(chunks) }),
+			resume: vi.fn().mockResolvedValue({ stream: makeReadableStream(chunks) }),
+			structuredOutput: vi.fn(),
+			close: vi.fn(),
+		} as unknown as RuntimeAgent & {
+			stream: Mock;
+			resume: Mock;
+			structuredOutput: Mock;
+		},
+		toolRegistry: mock<ToolRegistry>(),
+		projectId,
+		agentId,
+		telemetryConfiguration: {
+			model: schema.model,
+			channels: [],
+			tool_types: [],
+			tool_count: 0,
+			num_skills: 0,
+			memory_type: 'none' as const,
+		},
+	};
+}
+
+function makeService() {
+	const agentRepository = mock<AgentRepository>();
+	const executionService = mock<AgentExecutionService>();
+	const telemetry = mock<Telemetry>();
+	const credentialsService = mock<CredentialsService>();
+	const reconstructionService = mock<AgentRuntimeReconstructionService>();
+
+	executionService.recordMessage.mockResolvedValue('execution-1');
+
+	const service = new AgentWorkflowExecutionService(
+		mockLogger(),
+		agentRepository,
+		executionService,
+		telemetry,
+		credentialsService,
+		reconstructionService,
+	);
+
+	return {
+		service,
+		agentRepository,
+		executionService,
+		telemetry,
+		reconstructionService,
+	};
+}
+
+describe('AgentWorkflowExecutionService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('executes workflow runs with thread-scoped persistence and tool-call output', async () => {
+		const { service, agentRepository, reconstructionService, executionService, telemetry } =
+			makeService();
+		const runtime = makeRuntime([
+			{ type: 'tool-call', toolCallId: 'tc-1', toolName: 'lookup', input: { id: 1 } },
+			{ type: 'tool-result', toolCallId: 'tc-1', toolName: 'lookup', output: { ok: true } },
+			{ type: 'finish', finishReason: 'stop', structuredOutput: { answer: 'done' } },
+		]);
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
+		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
+
+		const result = await service.executeForWorkflow(
+			agentId,
+			'hello',
+			'execution-1',
+			'thread-1',
+			projectId,
+			userId,
+		);
+
+		expect(runtime.agent.stream).toHaveBeenCalledWith(
+			'hello',
+			expect.objectContaining({
+				// resourceId is the memory store's read scope: it must be stable
+				// across executions (NOT the execution id) or a reused session id
+				// would never see its prior messages.
+				persistence: { resourceId: 'thread-1', threadId: 'thread-1' },
+			}),
+		);
+		expect(result).toEqual(
+			expect.objectContaining({
+				response: '',
+				structuredOutput: { answer: 'done' },
+				toolCalls: [{ toolName: 'lookup', input: { id: 1 }, result: { ok: true } }],
+			}),
+		);
+
+		const streamOptions = runtime.agent.stream.mock.calls[0][1] as {
+			executionCounter: { incrementMessageCount: () => void };
+		};
+		streamOptions.executionCounter.incrementMessageCount();
+		expect(telemetry.trackAgentExecution).toHaveBeenCalledWith({
+			agent_id: agentId,
+			user_id: userId,
+			message_count: 1,
+		});
+		expect(executionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				telemetry: expect.objectContaining({
+					runType: 'production',
+					configuration: expect.objectContaining({
+						model: 'anthropic/claude-sonnet-4-5',
+					}),
+				}),
+			}),
+		);
+	});
+
+	it('applies per-call structured output schema and improves empty-output errors', async () => {
+		const { service, agentRepository, reconstructionService } = makeService();
+		const outputSchema: JSONSchema7 = {
+			type: 'object',
+			properties: { answer: { type: 'string' } },
+		};
+		const runtime = makeRuntime([{ type: 'error', error: new Error('No output generated.') }]);
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
+		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
+
+		await expect(
+			service.executeForWorkflow(
+				agentId,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+				userId,
+				false,
+				outputSchema,
+			),
+		).rejects.toThrow(OperationalError);
+		expect(runtime.agent.structuredOutput).toHaveBeenCalledWith(outputSchema);
+	});
+
+	describe('workflow data tools', () => {
+		const baseContext = {
+			workflowId: 'wf-1',
+			workflowName: 'My workflow',
+			callingNodeName: 'Message an Agent',
+			inputData: [{ json: { a: 1 } }],
+			inputDataScope: 'item' as const,
+			nodes: [{ name: 'Webhook', type: 'n8n-nodes-base.webhook' }],
+			runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
+		};
+
+		const setupRuntimeWithToolSpy = (declaredTools: Array<{ name: string }> = []) => {
+			const { service, agentRepository, reconstructionService } = makeService();
+			const runtime = makeRuntime();
+			const toolFn = vi.fn();
+			Object.assign(runtime.agent, { tool: toolFn, declaredTools });
+			agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
+			reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
+			return { service, toolFn };
+		};
+
+		const toolNamesFrom = (toolFn: Mock): string[] => {
+			const [tools] = toolFn.mock.calls[0] as [Array<{ name: string }>];
+			return tools.map((t) => t.name);
+		};
+
+		it('always injects fetch_input_data when workflowContext is provided', async () => {
+			const { service, toolFn } = setupRuntimeWithToolSpy();
+			const workflowContext: ExecuteAgentWorkflowContext = {
+				...baseContext,
+				exposeWorkflowData: false,
+			};
+
+			await service.executeForWorkflow(
+				agentId,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+				undefined,
+				undefined,
+				undefined,
+				workflowContext,
+			);
+
+			expect(toolFn).toHaveBeenCalledTimes(1);
+			expect(toolNamesFrom(toolFn)).toEqual(['fetch_input_data']);
+		});
+
+		it('also injects fetch_workflow_context when exposeWorkflowData is true', async () => {
+			const { service, toolFn } = setupRuntimeWithToolSpy();
+			const workflowContext: ExecuteAgentWorkflowContext = {
+				...baseContext,
+				exposeWorkflowData: true,
+			};
+
+			await service.executeForWorkflow(
+				agentId,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+				undefined,
+				undefined,
+				undefined,
+				workflowContext,
+			);
+
+			expect(toolNamesFrom(toolFn)).toEqual(['fetch_input_data', 'fetch_workflow_context']);
+		});
+
+		it('injects no tools without workflowContext', async () => {
+			const { service, toolFn } = setupRuntimeWithToolSpy();
+
+			await service.executeForWorkflow(agentId, 'hello', 'execution-1', 'thread-1', projectId);
+
+			expect(toolFn).not.toHaveBeenCalled();
+		});
+
+		it('surfaces an error when the agent already declares a reserved tool name', async () => {
+			const { service, toolFn } = setupRuntimeWithToolSpy([{ name: 'fetch_input_data' }]);
+			const workflowContext: ExecuteAgentWorkflowContext = {
+				...baseContext,
+				exposeWorkflowData: false,
+			};
+
+			await expect(
+				service.executeForWorkflow(
+					agentId,
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+					undefined,
+					undefined,
+					undefined,
+					workflowContext,
+				),
+			).rejects.toThrow('"fetch_input_data"');
+
+			expect(toolFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('executeInlineForWorkflow', () => {
+		const inlinePayload = {
+			config: {
+				name: 'Inline Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				credential: 'cred-1',
+				instructions: 'Help users',
+			},
+		};
+
+		it('compiles from the embedded config, records no session, and tracks inline telemetry', async () => {
+			const { service, agentRepository, reconstructionService, executionService, telemetry } =
+				makeService();
+			const runtime = makeRuntime([
+				{ type: 'text-start', id: 'text-1' },
+				{ type: 'text-delta', id: 'text-1', delta: 'answer' },
+				{ type: 'text-end', id: 'text-1' },
+				{ type: 'finish', finishReason: 'stop' },
+			]);
+			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
+
+			const workflowContext: ExecuteAgentWorkflowContext = {
+				workflowId: 'wf-1',
+				callingNodeName: 'Message an Agent',
+				// Memory is injected only for caller-supplied session ids.
+				hasCallerSessionId: true,
+				nodes: [],
+				runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
+			};
+			Object.assign(runtime.agent, { tool: vi.fn(), declaredTools: [] });
+
+			const result = await service.executeInlineForWorkflow(
+				inlinePayload,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+				userId,
+				'production',
+				undefined,
+				workflowContext,
+			);
+
+			// No entity lookup — the embedded config is the source of truth.
+			expect(agentRepository.findByIdAndProjectId).not.toHaveBeenCalled();
+			expect(reconstructionService.reconstructFromResolvedSource).toHaveBeenCalledWith(
+				expect.objectContaining({
+					config: expect.objectContaining({
+						name: 'Inline Agent',
+						// Injected server-side: conversation-thread memory keeps a
+						// session-id-keyed thread across executions; long-term memory
+						// stays off (it would accumulate under the synthetic id).
+						memory: {
+							enabled: true,
+							storage: 'n8n',
+							observationalMemory: { enabled: false },
+							episodicMemory: { enabled: false },
+						},
+					}),
+					memoryOwnerAgentId: 'inline:wf-1:Message an Agent',
+					projectId,
+					runtimeProfile: 'inline',
+					skills: {},
+					toolDescriptors: {},
+					toolCodeByName: {},
+				}),
+			);
+
+			expect(result.response).toBe('answer');
+			// Inline runs have no persisted session.
+			expect(result.session).toBeNull();
+			expect(executionService.recordMessage).not.toHaveBeenCalled();
+
+			// Thread-scoped persistence: stable across executions, so a reused
+			// session id continues the same conversation.
+			expect(runtime.agent.stream).toHaveBeenCalledWith(
+				'hello',
+				expect.objectContaining({
+					persistence: { resourceId: 'thread-1', threadId: 'thread-1' },
+				}),
+			);
+
+			expect(telemetry.trackAgentTurnFinished).toHaveBeenCalledWith(
+				expect.objectContaining({
+					agent_id: 'inline:wf-1:Message an Agent',
+					agent_type: 'inline',
+					run_type: 'production',
+					turn_status: 'succeeded',
+					configuration: expect.objectContaining({ model: 'anthropic/claude-sonnet-4-5' }),
+				}),
+			);
+		});
+
+		it('injects no memory when the caller supplied no session id (nothing to continue)', async () => {
+			const { service, reconstructionService } = makeService();
+			const runtime = makeRuntime([{ type: 'finish', finishReason: 'stop' }]);
+			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
+			Object.assign(runtime.agent, { tool: vi.fn(), declaredTools: [] });
+
+			const workflowContext: ExecuteAgentWorkflowContext = {
+				workflowId: 'wf-1',
+				callingNodeName: 'Message an Agent',
+				hasCallerSessionId: false,
+				nodes: [],
+				runExecutionData: { resultData: { runData: {} } } as unknown as IRunExecutionData,
+			};
+
+			await service.executeInlineForWorkflow(
+				inlinePayload,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+				userId,
+				'production',
+				undefined,
+				workflowContext,
+			);
+
+			const [source] = reconstructionService.reconstructFromResolvedSource.mock.calls[0];
+			// A per-call thread can never be continued — persisting it would only
+			// accumulate rows no session UI or cleanup path can reach.
+			expect(source.config).not.toHaveProperty('memory');
+		});
+
+		it.each([
+			['skills', { skills: [{ type: 'skill', id: 'triage' }] }],
+			// Memory is injected server-side; the node cannot configure it.
+			['memory', { memory: { enabled: true, storage: 'n8n' } }],
+			// Approval suspends the run, which workflow executions can't resume.
+			[
+				'tool approval',
+				{
+					tools: [{ type: 'workflow', workflow: 'Lookup Orders', requireApproval: true }],
+				},
+			],
+			[
+				'MCP approval',
+				{
+					mcpServers: [
+						{
+							name: 'github',
+							url: 'https://mcp.example.com',
+							transport: 'streamableHttp',
+							authentication: 'none',
+							approval: { mode: 'global' },
+						},
+					],
+				},
+			],
+		])('rejects configs with saved-agent-only capabilities (%s)', async (_key, extra) => {
+			const { service, reconstructionService } = makeService();
+
+			await expect(
+				service.executeInlineForWorkflow(
+					{
+						config: {
+							...inlinePayload.config,
+							...extra,
+						} as unknown as typeof inlinePayload.config,
+					},
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+				),
+			).rejects.toThrow(UserError);
+			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
+		});
+
+		it('rejects custom (code) tools, whose bodies live only on saved agents', async () => {
+			const { service, reconstructionService } = makeService();
+
+			await expect(
+				service.executeInlineForWorkflow(
+					{
+						config: {
+							...inlinePayload.config,
+							tools: [{ type: 'custom', id: 'my_tool' }],
+						} as unknown as typeof inlinePayload.config,
+					},
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+				),
+			).rejects.toThrow(UserError);
+			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
+		});
+
+		it('rejects an unrunnable draft config (no credential)', async () => {
+			const { service, reconstructionService } = makeService();
+
+			await expect(
+				service.executeInlineForWorkflow(
+					{ config: { ...inlinePayload.config, credential: '' } },
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+				),
+			).rejects.toThrow(UserError);
+			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
+		});
+
+		it('tracks a failed inline turn before rethrowing a stream reader error', async () => {
+			const { service, reconstructionService, telemetry } = makeService();
+			const runtime = makeRuntime();
+			runtime.agent.stream.mockResolvedValue({
+				stream: makeFailingStream(new Error('reader failed while consuming stream')),
+			});
+			reconstructionService.reconstructFromResolvedSource.mockResolvedValue(runtime);
+
+			await expect(
+				service.executeInlineForWorkflow(
+					inlinePayload,
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+				),
+			).rejects.toThrow('reader failed while consuming stream');
+
+			// Telemetry fires even for failed runs — the rethrow happens after.
+			expect(telemetry.trackAgentTurnFinished).toHaveBeenCalledWith(
+				expect.objectContaining({ agent_type: 'inline', turn_status: 'failed' }),
+			);
+		});
+
+		it('surfaces inline compile failures as an OperationalError', async () => {
+			const { service, reconstructionService } = makeService();
+			reconstructionService.reconstructFromResolvedSource.mockRejectedValue(new Error('boom'));
+
+			const execution = service.executeInlineForWorkflow(
+				inlinePayload,
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+			);
+
+			await expect(execution).rejects.toThrow(OperationalError);
+			await expect(execution).rejects.toThrow('Failed to compile agent: boom');
+		});
+
+		it('rejects a malformed $fromAI expression in a node tool before compiling', async () => {
+			const { service, reconstructionService } = makeService();
+
+			const execution = service.executeInlineForWorkflow(
+				{
+					config: {
+						...inlinePayload.config,
+						tools: [
+							{
+								type: 'node',
+								name: 'HTTP Request',
+								node: {
+									nodeType: 'n8n-nodes-base.httpRequestTool',
+									nodeTypeVersion: 4.4,
+									nodeParameters: { url: '={{ $fromAI( }}' },
+								},
+							},
+						],
+					} as unknown as typeof inlinePayload.config,
+				},
+				'hello',
+				'execution-1',
+				'thread-1',
+				projectId,
+			);
+
+			await expect(execution).rejects.toThrow(UserError);
+			await expect(execution).rejects.toThrow('Invalid $fromAI expression');
+			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
+		});
+
+		it('rejects approval-gated tools, which could never resume in workflow context', async () => {
+			const { service, reconstructionService } = makeService();
+
+			await expect(
+				service.executeInlineForWorkflow(
+					{
+						config: {
+							...inlinePayload.config,
+							tools: [{ type: 'workflow', workflow: 'Lookup', requireApproval: true }],
+						} as unknown as typeof inlinePayload.config,
+					},
+					'hello',
+					'execution-1',
+					'thread-1',
+					projectId,
+				),
+			).rejects.toThrow('Invalid inline agent configuration');
+			expect(reconstructionService.reconstructFromResolvedSource).not.toHaveBeenCalled();
+		});
+	});
+
+	it('maps structured-output stream reader errors before recording and rethrowing', async () => {
+		const { service, agentRepository, reconstructionService, executionService } = makeService();
+		const outputSchema: JSONSchema7 = {
+			type: 'object',
+			properties: { answer: { type: 'string' } },
+		};
+		const runtime = makeRuntime();
+		runtime.agent.stream.mockResolvedValue({
+			stream: makeFailingStream(new Error('No output generated. Check the stream for errors.')),
+		});
+
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent());
+		reconstructionService.reconstructFromAgentEntity.mockResolvedValue(runtime);
+
+		const execution = service.executeForWorkflow(
+			agentId,
+			'hello',
+			'execution-1',
+			'thread-1',
+			projectId,
+			userId,
+			false,
+			outputSchema,
+		);
+
+		await expect(execution).rejects.toThrow(OperationalError);
+		await expect(execution).rejects.toThrow("Couldn't get structured output matching the schema");
+		await expect(execution).rejects.not.toThrow('Check the stream');
+		expect(executionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				record: expect.objectContaining({
+					error: expect.stringContaining("Couldn't get structured output matching the schema"),
+				}),
+			}),
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution-orchestrator.service.ts
@@ -1,56 +1,23 @@
-import type {
-	Agent as RuntimeAgent,
-	AgentExecutionCounter,
-	BuiltAgent,
-	BuiltTool,
-	CredentialProvider,
-	StreamChunk,
-} from '@n8n/agents';
-import type { AgentJsonConfig, AgentPersistedMessageDto } from '@n8n/api-types';
-import {
-	AGENT_WORKFLOW_TRIGGER_TYPE,
-	formatZodErrors,
-	N8N_CHAT_INTEGRATION_TYPE,
-	RunnableInlineAgentConfigSchema,
-	sanitizeAgentJsonConfig,
-} from '@n8n/api-types';
+import type { Agent as RuntimeAgent, StreamChunk } from '@n8n/agents';
+import type { AgentPersistedMessageDto } from '@n8n/api-types';
+import { N8N_CHAT_INTEGRATION_TYPE } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
-import type { JSONSchema7 } from 'json-schema';
-import {
-	OperationalError,
-	type ExecuteAgentData,
-	type ExecuteAgentWorkflowContext,
-	type InlineAgentPayload,
-	UserError,
-} from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
-import { CredentialsService } from '@/credentials/credentials.service';
 import type { AgentRunTelemetryType, IAgentConfigurationTelemetryProperties } from '@/interfaces';
 import { Telemetry } from '@/telemetry';
 
-import {
-	buildAgentConfigurationTelemetry,
-	buildAgentConfigurationTelemetryFromConfig,
-} from './agent-telemetry';
 import { AgentExecutionService } from './agent-execution.service';
 import { AgentRuntimeCacheService } from './agent-runtime-cache.service';
-import { AgentRuntimeReconstructionService } from './agent-runtime-reconstruction.service';
-import type { Agent } from './entities/agent.entity';
-import { ExecutionRecorder, type MessageRecord } from './execution-recorder';
+import { ExecutionRecorder } from './execution-recorder';
 import { IntegrationMessageContextService } from './integrations/integration-message-context.service';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
-import { AgentRepository } from './repositories/agent.repository';
 import type { ToolRegistry } from './tool-registry';
-import { createInputDataTool } from './tools/input-data-tool';
-import { createWorkflowContextTool } from './tools/workflow-context-tool';
-import { createAgentCredentialProvider } from './utils/agent-credential-provider';
+import { createAgentExecutionCounter } from './utils/agent-execution-counter';
 import { streamAgentChunks } from './utils/agent-stream';
-import { validateNodeToolConfigs, validateNodeToolExpressions } from './utils/node-tool-validation';
 import { executionsToMessagesDto } from './utils/execution-to-message-mapper';
-import { getPublishedAgentSnapshot } from './utils/agent-published-snapshot';
-import { describeStructuredOutputError } from './utils/structured-output-error';
 
 export interface AgentMemoryScope {
 	threadId: string;
@@ -175,59 +142,23 @@ function getMaxIterationsChunks(): StreamChunk[] {
 	];
 }
 
+/**
+ * Executes agents for the interactive surfaces — in-app test chat, published
+ * chat integrations (Slack, Telegram, …), and scheduled/manual tasks — as
+ * streaming runs against cached runtimes, with HITL suspend/resume via
+ * checkpoints. Workflow-invoked runs (AI Agent node, "Message an Agent")
+ * live in `AgentWorkflowExecutionService`.
+ */
 @Service()
 export class AgentExecutionOrchestratorService {
 	constructor(
 		private readonly logger: Logger,
-		private readonly agentRepository: AgentRepository,
 		private readonly n8nCheckpointStorage: N8NCheckpointStorage,
 		private readonly agentExecutionService: AgentExecutionService,
 		private readonly telemetry: Telemetry,
 		private readonly runtimeCacheService: AgentRuntimeCacheService,
-		private readonly credentialsService: CredentialsService,
-		private readonly agentRuntimeReconstructionService: AgentRuntimeReconstructionService,
 		private readonly integrationMessageContextService: IntegrationMessageContextService,
 	) {}
-
-	private normalizeWorkflowStreamError(error: unknown, outputSchema?: JSONSchema7): Error {
-		const normalizedError = error instanceof Error ? error : new Error(String(error));
-		if (!outputSchema || normalizedError instanceof OperationalError) return normalizedError;
-
-		const structuredOutputError = describeStructuredOutputError(normalizedError.message);
-		if (!structuredOutputError) return normalizedError;
-
-		return new OperationalError(structuredOutputError, { cause: normalizedError });
-	}
-
-	createAgentExecutionCounter({
-		agentId,
-		userId,
-	}: {
-		agentId: string;
-		userId?: string;
-	}): AgentExecutionCounter {
-		const attribution = userId ? { user_id: userId } : {};
-		return {
-			incrementMessageCount: () =>
-				this.telemetry.trackAgentExecution({
-					agent_id: agentId,
-					...attribution,
-					message_count: 1,
-				}),
-			incrementTokenCount: (tokenCount) =>
-				this.telemetry.trackAgentExecution({
-					agent_id: agentId,
-					...attribution,
-					token_count: tokenCount,
-				}),
-			incrementToolCallCount: () =>
-				this.telemetry.trackAgentExecution({
-					agent_id: agentId,
-					...attribution,
-					tool_call_count: 1,
-				}),
-		};
-	}
 
 	/**
 	 * Return user-visible conversation history for a persisted chat thread.
@@ -303,7 +234,10 @@ export class AgentExecutionOrchestratorService {
 			const resultStream = await agentInstance.resume('stream', resumeData, {
 				runId,
 				toolCallId,
-				executionCounter: this.createAgentExecutionCounter({ agentId, userId: user?.id }),
+				executionCounter: createAgentExecutionCounter(this.telemetry, {
+					agentId,
+					userId: user?.id,
+				}),
 			});
 
 			for await (const value of streamAgentChunks(resultStream.stream)) {
@@ -509,7 +443,7 @@ export class AgentExecutionOrchestratorService {
 		try {
 			const resultStream = await agentInstance.stream(message, {
 				persistence: { threadId, resourceId },
-				executionCounter: this.createAgentExecutionCounter({ agentId, userId }),
+				executionCounter: createAgentExecutionCounter(this.telemetry, { agentId, userId }),
 			});
 
 			for await (const value of streamAgentChunks(resultStream.stream)) {
@@ -560,474 +494,4 @@ export class AgentExecutionOrchestratorService {
 				});
 		}
 	}
-
-	/**
-	 * Apply per-call add-ons to a reconstructed runtime: a structured-output
-	 * schema and extra tools (e.g. the workflow-data tools for MessageAnAgent
-	 * invocations). An extra-tool name already declared on the agent would
-	 * otherwise be silently dropped (losing workflow data access) or trigger a
-	 * "Static tool name collision" error from the SDK at stream time — surface
-	 * it instead so the agent author can rename their tool.
-	 */
-	private applyPerCallAgentExtras(
-		reconstructed: RuntimeAgent,
-		outputSchema?: JSONSchema7,
-		extraTools?: BuiltTool[],
-	): { ok: boolean; agent?: BuiltAgent; error?: string } {
-		if (outputSchema) {
-			reconstructed.structuredOutput(outputSchema);
-		}
-		if (extraTools?.length) {
-			const declared = new Set(reconstructed.declaredTools.map((t) => t.name));
-			const collisions = extraTools.filter((t) => declared.has(t.name)).map((t) => t.name);
-			if (collisions.length) {
-				const names = collisions.map((n) => `"${n}"`).join(', ');
-				const plural = collisions.length > 1;
-				return {
-					ok: false,
-					error:
-						`Agent declares ${plural ? 'tools' : 'a tool'} named ${names}, ` +
-						`which ${plural ? 'are' : 'is'} reserved by n8n for workflow data access. ` +
-						`Rename the agent ${plural ? 'tools' : 'tool'} to avoid the collision.`,
-				};
-			}
-			reconstructed.tool(extraTools);
-		}
-		return { ok: true, agent: reconstructed as BuiltAgent };
-	}
-
-	/**
-	 * Compile an agent in isolation without writing to the shared runtime cache.
-	 * Used by executeForWorkflow so that concurrent Slack / chat executions
-	 * are not affected.
-	 */
-	async compileIsolated(
-		agentEntity: Agent,
-		credentialProvider: CredentialProvider,
-		outputSchema?: JSONSchema7,
-		extraTools?: BuiltTool[],
-	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
-		if (!agentEntity.schema) {
-			return { ok: false, error: 'Agent has no JSON config. Create a config first.' };
-		}
-
-		try {
-			// No `user`: this path runs an agent invoked from inside a workflow
-			// execution (AI Agent node, or a "Message an Agent" tool call from
-			// another workflow) — there is no interactive n8n user, only a bare
-			// telemetry id (see `executeForWorkflow`'s `telemetryUserId`), and for
-			// webhook/trigger-fired executions even that can be absent. This
-			// runtime also isn't cached (see the docstring above), so there's no
-			// cache-key concern here either — just no per-user tool filtering.
-			const { agent: reconstructed } =
-				await this.agentRuntimeReconstructionService.reconstructFromAgentEntity(
-					agentEntity,
-					credentialProvider,
-				);
-			return this.applyPerCallAgentExtras(reconstructed, outputSchema, extraTools);
-		} catch (e) {
-			return {
-				ok: false,
-				error: e instanceof Error ? e.message : 'Unknown compilation error',
-			};
-		}
-	}
-
-	/**
-	 * Compile an inline (node-embedded) agent definition in isolation. Mirrors
-	 * `compileIsolated`, but reconstructs from a raw config instead of an
-	 * entity: inline agents have no skill/custom-tool bodies and run under the
-	 * 'inline' runtime profile (no checkpoints, knowledge, integrations, or
-	 * sub-agent delegation).
-	 */
-	private async compileIsolatedFromSource(
-		config: AgentJsonConfig,
-		syntheticAgentId: string,
-		projectId: string,
-		credentialProvider: CredentialProvider,
-		outputSchema?: JSONSchema7,
-		extraTools?: BuiltTool[],
-	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
-		try {
-			const { agent: reconstructed } =
-				await this.agentRuntimeReconstructionService.reconstructFromResolvedSource({
-					config,
-					memoryOwnerAgentId: syntheticAgentId,
-					projectId,
-					credentialProvider,
-					toolDescriptors: {},
-					toolCodeByName: {},
-					skills: {},
-					runtimeProfile: 'inline',
-				});
-			return this.applyPerCallAgentExtras(reconstructed, outputSchema, extraTools);
-		} catch (e) {
-			return {
-				ok: false,
-				error: e instanceof Error ? e.message : 'Unknown compilation error',
-			};
-		}
-	}
-
-	/** Per-call workflow-data tools exposed to a workflow-invoked agent. */
-	private buildWorkflowExtraTools(
-		workflowContext?: ExecuteAgentWorkflowContext,
-	): BuiltTool[] | undefined {
-		if (!workflowContext) return undefined;
-
-		const extraTools: BuiltTool[] = [createInputDataTool(workflowContext)];
-		if (workflowContext.exposeWorkflowData) {
-			extraTools.push(createWorkflowContextTool(workflowContext));
-		}
-		return extraTools;
-	}
-
-	/** Stream one workflow-invoked agent run and collect its outcome. */
-	private async streamWorkflowAgent(params: {
-		agentInstance: BuiltAgent;
-		message: string;
-		threadId: string;
-		telemetryAgentId: string;
-		telemetryUserId?: string;
-		outputSchema?: JSONSchema7;
-	}): Promise<WorkflowAgentRunOutcome> {
-		const { agentInstance, message, threadId, telemetryAgentId, telemetryUserId, outputSchema } =
-			params;
-
-		const recorder = new ExecutionRecorder();
-
-		let structuredOutput: unknown = null;
-		const toolCalls: ExecuteAgentData['toolCalls'] = [];
-		const toolInputs = new Map<string, { toolName: string; input: unknown }>();
-		let streamError: Error | undefined;
-
-		try {
-			const resultStream = await agentInstance.stream(message, {
-				// The memory store scopes message reads by `resourceId` (the
-				// "per-user scope"; chat integrations pass the chat user id there).
-				// Workflow runs have no user, so key the scope by the thread
-				// itself: it is stable across executions, which is what lets a
-				// caller-supplied session id actually continue the conversation.
-				// The previous key — the execution id — changed every run and hid
-				// all prior messages of the thread from the model.
-				persistence: { resourceId: threadId, threadId },
-				executionCounter: this.createAgentExecutionCounter({
-					agentId: telemetryAgentId,
-					userId: telemetryUserId,
-				}),
-			});
-
-			for await (const value of streamAgentChunks(resultStream.stream)) {
-				recorder.record(value);
-
-				if (value.type === 'tool-call') {
-					toolInputs.set(value.toolCallId, { toolName: value.toolName, input: value.input });
-				} else if (value.type === 'tool-result') {
-					const pending = toolInputs.get(value.toolCallId);
-					toolCalls.push({
-						toolName: value.toolName,
-						input: pending?.input ?? null,
-						result: value.output,
-					});
-					toolInputs.delete(value.toolCallId);
-				} else if (value.type === 'finish' && value.structuredOutput !== undefined) {
-					structuredOutput = value.structuredOutput;
-				}
-			}
-		} catch (error) {
-			const normalizedError = this.normalizeWorkflowStreamError(error, outputSchema);
-			recorder.record({ type: 'error', error: normalizedError });
-			recorder.record({ type: 'finish', finishReason: 'error' });
-			streamError = normalizedError;
-		}
-
-		return {
-			recorder,
-			messageRecord: recorder.getMessageRecord(),
-			structuredOutput,
-			toolCalls,
-			streamError,
-		};
-	}
-
-	/**
-	 * Turn a collected workflow-invoked run into the caller-facing result,
-	 * translating failure states into thrown errors.
-	 */
-	private buildWorkflowResult(params: {
-		run: WorkflowAgentRunOutcome;
-		session: ExecuteAgentData['session'];
-		outputSchema?: JSONSchema7;
-	}): ExecuteAgentData {
-		const { run, session, outputSchema } = params;
-		const { recorder, messageRecord, structuredOutput, toolCalls, streamError } = run;
-
-		if (streamError !== undefined) {
-			throw streamError;
-		}
-
-		if (recorder.suspended) {
-			throw new OperationalError(
-				'Agent execution suspended waiting for tool approval. ' +
-					'Suspend/resume is not supported in workflow execution context.',
-			);
-		}
-
-		if (messageRecord.error) {
-			if (outputSchema) {
-				const structuredOutputError = describeStructuredOutputError(messageRecord.error);
-				if (structuredOutputError) {
-					throw new OperationalError(structuredOutputError);
-				}
-			}
-			throw new OperationalError(`Agent execution failed: ${messageRecord.error}`);
-		}
-
-		if (messageRecord.finishReason === 'error') {
-			throw new OperationalError(
-				outputSchema
-					? 'Agent execution finished with an error while producing structured output. ' +
-							"The agent's model or provider may not support JSON Schema structured output."
-					: 'Agent execution finished with an error.',
-			);
-		}
-
-		return {
-			response: messageRecord.assistantResponse,
-			structuredOutput: structuredOutput ?? null,
-			usage: messageRecord.usage
-				? {
-						promptTokens: messageRecord.usage.promptTokens,
-						completionTokens: messageRecord.usage.completionTokens,
-						totalTokens: messageRecord.usage.totalTokens,
-					}
-				: null,
-			toolCalls,
-			finishReason: messageRecord.finishReason,
-			session,
-		};
-	}
-
-	async executeForWorkflow(
-		agentId: string,
-		message: string,
-		// Kept for positional compatibility; memory persistence is keyed by
-		// threadId (stable across executions), not by the execution.
-		_executionId: string,
-		threadId: string,
-		projectId: string,
-		telemetryUserId?: string,
-		useDraftVersion?: boolean,
-		outputSchema?: JSONSchema7,
-		workflowContext?: ExecuteAgentWorkflowContext,
-	): Promise<ExecuteAgentData> {
-		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
-		if (!agentEntity) {
-			throw new OperationalError('Agent not found or not accessible.');
-		}
-
-		const credentialProvider = createAgentCredentialProvider(this.credentialsService, projectId);
-
-		let agentData: Agent = agentEntity;
-
-		if (!useDraftVersion) {
-			agentData = getPublishedAgentSnapshot(agentEntity);
-		}
-		const telemetryConfiguration = buildAgentConfigurationTelemetry(agentData);
-
-		const extraTools = this.buildWorkflowExtraTools(workflowContext);
-		const compiled = await this.compileIsolated(
-			agentData,
-			credentialProvider,
-			outputSchema,
-			extraTools?.length ? extraTools : undefined,
-		);
-		if (!compiled.ok || !compiled.agent) {
-			throw new OperationalError(`Failed to compile agent: ${compiled.error ?? 'unknown error'}`);
-		}
-
-		const agentInstance = compiled.agent;
-		const run = await this.streamWorkflowAgent({
-			agentInstance,
-			message,
-			threadId,
-			telemetryAgentId: agentId,
-			telemetryUserId,
-			outputSchema,
-		});
-
-		void this.agentExecutionService
-			.recordMessage({
-				threadId,
-				agentId,
-				agentName: agentInstance.name,
-				projectId,
-				userMessage: message,
-				record: run.messageRecord,
-				source: AGENT_WORKFLOW_TRIGGER_TYPE,
-				telemetry: {
-					runType: useDraftVersion ? 'test' : 'production',
-					configuration: telemetryConfiguration,
-				},
-			})
-			.catch((error) => {
-				this.logger.warn('Failed to record agent execution from workflow', {
-					agentId,
-					threadId,
-					error: error instanceof Error ? error.message : String(error),
-				});
-			});
-
-		return this.buildWorkflowResult({
-			run,
-			// sessionId here is still the scoped thread key — executeAgent remaps it
-			// to the caller-facing id; this method never sees the unscoped one.
-			session: { agentId, projectId, sessionId: threadId, threadId },
-			outputSchema,
-		});
-	}
-
-	/**
-	 * Execute an inline agent embedded in a workflow node's parameters. There is
-	 * no entity, so published/draft gating does not apply — the embedded config
-	 * is always what runs. When the caller supplies a session id, conversation-
-	 * thread memory persists (the thread tables carry no agent FK) so that id
-	 * continues the conversation across executions; but no session is *recorded*
-	 * for the sessions UI (`agent_execution_threads.agentId` is an FK to
-	 * `agents`), so the result carries `session: null`.
-	 */
-	async executeInlineForWorkflow(
-		inlineAgent: InlineAgentPayload,
-		message: string,
-		// Kept for positional compatibility; memory persistence is keyed by
-		// threadId (stable across executions), not by the execution.
-		_executionId: string,
-		threadId: string,
-		projectId: string,
-		telemetryUserId?: string,
-		runType: AgentRunTelemetryType = 'production',
-		outputSchema?: JSONSchema7,
-		workflowContext?: ExecuteAgentWorkflowContext,
-	): Promise<ExecuteAgentData> {
-		const config = await this.validateInlineAgentConfig(inlineAgent);
-
-		// Session memory: when the caller supplied a session id, inline agents run
-		// with plain conversation-thread memory so that id continues the same
-		// conversation across executions. Injected server-side, never part of the node's
-		// config: long-term memory (observational/episodic) stays off because it
-		// accumulates under the agent id, and inline agents only have a synthetic,
-		// node-rename-sensitive one. Without a session id the thread is per-call
-		// and can never be continued, so nothing is persisted — inline runs record
-		// no session, which would otherwise grow unreachable thread/message rows.
-		const persistMemory = workflowContext?.hasCallerSessionId === true;
-		const runtimeConfig: AgentJsonConfig = persistMemory
-			? {
-					...config,
-					memory: {
-						enabled: true,
-						storage: 'n8n',
-						observationalMemory: { enabled: false },
-						episodicMemory: { enabled: false },
-					},
-				}
-			: config;
-
-		const credentialProvider = createAgentCredentialProvider(this.credentialsService, projectId);
-
-		// For telemetry/logging and memory-owner keying — never persisted, and
-		// stable enough to aggregate runs of the same node across executions.
-		const syntheticAgentId = `inline:${workflowContext?.workflowId ?? 'unknown'}:${
-			workflowContext?.callingNodeName ?? 'unknown'
-		}`;
-
-		const extraTools = this.buildWorkflowExtraTools(workflowContext);
-		const compiled = await this.compileIsolatedFromSource(
-			runtimeConfig,
-			syntheticAgentId,
-			projectId,
-			credentialProvider,
-			outputSchema,
-			extraTools?.length ? extraTools : undefined,
-		);
-		if (!compiled.ok || !compiled.agent) {
-			throw new OperationalError(`Failed to compile agent: ${compiled.error ?? 'unknown error'}`);
-		}
-
-		const run = await this.streamWorkflowAgent({
-			agentInstance: compiled.agent,
-			message,
-			threadId,
-			telemetryAgentId: syntheticAgentId,
-			telemetryUserId,
-			outputSchema,
-		});
-
-		// No `recordMessage` here: inline runs have no agent entity to attach a
-		// session to. Emit the turn-finished telemetry directly instead.
-		try {
-			this.telemetry.trackAgentTurnFinished({
-				agent_id: syntheticAgentId,
-				thread_id: threadId,
-				run_type: runType,
-				agent_type: 'inline',
-				turn_status:
-					run.messageRecord.error !== null || run.messageRecord.finishReason === 'error'
-						? 'failed'
-						: 'succeeded',
-				configuration: buildAgentConfigurationTelemetryFromConfig(runtimeConfig),
-				latency_ms: run.messageRecord.duration,
-				cost: run.messageRecord.totalCost ?? 0,
-				tool_call_count: run.messageRecord.timeline.filter((t) => t.type === 'tool-call').length,
-			});
-		} catch (error) {
-			this.logger.warn('Failed to track inline agent execution telemetry', {
-				threadId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-
-		return this.buildWorkflowResult({ run, session: null, outputSchema });
-	}
-
-	/**
-	 * Validate the node-supplied inline definition into a runnable config.
-	 * The strict schema rejects capabilities inline agents don't support
-	 * (skills, memory, sub-agents, custom tools, the options block), so
-	 * saved-agent-only features can't sneak in through raw JSON. See
-	 * `InlineAgentJsonConfigSchema` for the authoritative allowlist.
-	 */
-	private async validateInlineAgentConfig(payload: InlineAgentPayload): Promise<AgentJsonConfig> {
-		const parsed = RunnableInlineAgentConfigSchema.safeParse({
-			config: sanitizeAgentJsonConfig(payload.config),
-		});
-		if (!parsed.success) {
-			const details = formatZodErrors(parsed.error)
-				.map((issue) => `${issue.path}: ${issue.message}`)
-				.join('; ');
-			throw new UserError(`Invalid inline agent configuration: ${details}`);
-		}
-		const config = parsed.data.config;
-
-		try {
-			validateNodeToolExpressions(config.tools);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			throw new UserError(`Invalid $fromAI expression in node tool config: ${message}`);
-		}
-
-		const nodeError = await validateNodeToolConfigs(config.tools);
-		if (nodeError) {
-			throw new UserError(`Invalid inline agent configuration: ${nodeError}`);
-		}
-
-		return config;
-	}
-}
-
-interface WorkflowAgentRunOutcome {
-	recorder: ExecutionRecorder;
-	messageRecord: MessageRecord;
-	structuredOutput: unknown;
-	toolCalls: ExecuteAgentData['toolCalls'];
-	streamError?: Error;
 }

--- a/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-workflow-execution.service.ts
@@ -1,0 +1,538 @@
+import type { Agent as RuntimeAgent, BuiltAgent, BuiltTool, CredentialProvider } from '@n8n/agents';
+import type { AgentJsonConfig } from '@n8n/api-types';
+import {
+	AGENT_WORKFLOW_TRIGGER_TYPE,
+	formatZodErrors,
+	RunnableInlineAgentConfigSchema,
+	sanitizeAgentJsonConfig,
+} from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import type { JSONSchema7 } from 'json-schema';
+import {
+	OperationalError,
+	type ExecuteAgentData,
+	type ExecuteAgentWorkflowContext,
+	type InlineAgentPayload,
+	UserError,
+} from 'n8n-workflow';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+import type { AgentRunTelemetryType } from '@/interfaces';
+import { Telemetry } from '@/telemetry';
+
+import {
+	buildAgentConfigurationTelemetry,
+	buildAgentConfigurationTelemetryFromConfig,
+} from './agent-telemetry';
+import { AgentExecutionService } from './agent-execution.service';
+import { AgentRuntimeReconstructionService } from './agent-runtime-reconstruction.service';
+import type { Agent } from './entities/agent.entity';
+import { ExecutionRecorder, type MessageRecord } from './execution-recorder';
+import { AgentRepository } from './repositories/agent.repository';
+import { createInputDataTool } from './tools/input-data-tool';
+import { createWorkflowContextTool } from './tools/workflow-context-tool';
+import { createAgentCredentialProvider } from './utils/agent-credential-provider';
+import { createAgentExecutionCounter } from './utils/agent-execution-counter';
+import { streamAgentChunks } from './utils/agent-stream';
+import { validateNodeToolConfigs, validateNodeToolExpressions } from './utils/node-tool-validation';
+import { getPublishedAgentSnapshot } from './utils/agent-published-snapshot';
+import { describeStructuredOutputError } from './utils/structured-output-error';
+
+/**
+ * Executes agents invoked from inside a workflow execution (the AI Agent node
+ * or a "Message an Agent" tool call): non-streaming runs against isolated
+ * compiles that never touch the shared runtime cache. The interactive chat /
+ * scheduled-task paths live in `AgentExecutionOrchestratorService`.
+ */
+@Service()
+export class AgentWorkflowExecutionService {
+	constructor(
+		private readonly logger: Logger,
+		private readonly agentRepository: AgentRepository,
+		private readonly agentExecutionService: AgentExecutionService,
+		private readonly telemetry: Telemetry,
+		private readonly credentialsService: CredentialsService,
+		private readonly agentRuntimeReconstructionService: AgentRuntimeReconstructionService,
+	) {}
+
+	private normalizeWorkflowStreamError(error: unknown, outputSchema?: JSONSchema7): Error {
+		const normalizedError = error instanceof Error ? error : new Error(String(error));
+		if (!outputSchema || normalizedError instanceof OperationalError) return normalizedError;
+
+		const structuredOutputError = describeStructuredOutputError(normalizedError.message);
+		if (!structuredOutputError) return normalizedError;
+
+		return new OperationalError(structuredOutputError, { cause: normalizedError });
+	}
+
+	/**
+	 * Apply per-call add-ons to a reconstructed runtime: a structured-output
+	 * schema and extra tools (e.g. the workflow-data tools for MessageAnAgent
+	 * invocations). An extra-tool name already declared on the agent would
+	 * otherwise be silently dropped (losing workflow data access) or trigger a
+	 * "Static tool name collision" error from the SDK at stream time — surface
+	 * it instead so the agent author can rename their tool.
+	 */
+	private applyPerCallAgentExtras(
+		reconstructed: RuntimeAgent,
+		outputSchema?: JSONSchema7,
+		extraTools?: BuiltTool[],
+	): { ok: boolean; agent?: BuiltAgent; error?: string } {
+		if (outputSchema) {
+			reconstructed.structuredOutput(outputSchema);
+		}
+		if (extraTools?.length) {
+			const declared = new Set(reconstructed.declaredTools.map((t) => t.name));
+			const collisions = extraTools.filter((t) => declared.has(t.name)).map((t) => t.name);
+			if (collisions.length) {
+				const names = collisions.map((n) => `"${n}"`).join(', ');
+				const plural = collisions.length > 1;
+				return {
+					ok: false,
+					error:
+						`Agent declares ${plural ? 'tools' : 'a tool'} named ${names}, ` +
+						`which ${plural ? 'are' : 'is'} reserved by n8n for workflow data access. ` +
+						`Rename the agent ${plural ? 'tools' : 'tool'} to avoid the collision.`,
+				};
+			}
+			reconstructed.tool(extraTools);
+		}
+		return { ok: true, agent: reconstructed as BuiltAgent };
+	}
+
+	/**
+	 * Compile an agent in isolation without writing to the shared runtime cache.
+	 * Used by executeForWorkflow so that concurrent Slack / chat executions
+	 * are not affected.
+	 */
+	async compileIsolated(
+		agentEntity: Agent,
+		credentialProvider: CredentialProvider,
+		outputSchema?: JSONSchema7,
+		extraTools?: BuiltTool[],
+	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
+		if (!agentEntity.schema) {
+			return { ok: false, error: 'Agent has no JSON config. Create a config first.' };
+		}
+
+		try {
+			// No `user`: this path runs an agent invoked from inside a workflow
+			// execution (AI Agent node, or a "Message an Agent" tool call from
+			// another workflow) — there is no interactive n8n user, only a bare
+			// telemetry id (see `executeForWorkflow`'s `telemetryUserId`), and for
+			// webhook/trigger-fired executions even that can be absent. This
+			// runtime also isn't cached (see the docstring above), so there's no
+			// cache-key concern here either — just no per-user tool filtering.
+			const { agent: reconstructed } =
+				await this.agentRuntimeReconstructionService.reconstructFromAgentEntity(
+					agentEntity,
+					credentialProvider,
+				);
+			return this.applyPerCallAgentExtras(reconstructed, outputSchema, extraTools);
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Unknown compilation error',
+			};
+		}
+	}
+
+	/**
+	 * Compile an inline (node-embedded) agent definition in isolation. Mirrors
+	 * `compileIsolated`, but reconstructs from a raw config instead of an
+	 * entity: inline agents have no skill/custom-tool bodies and run under the
+	 * 'inline' runtime profile (no checkpoints, knowledge, integrations, or
+	 * sub-agent delegation).
+	 */
+	private async compileIsolatedFromSource(
+		config: AgentJsonConfig,
+		syntheticAgentId: string,
+		projectId: string,
+		credentialProvider: CredentialProvider,
+		outputSchema?: JSONSchema7,
+		extraTools?: BuiltTool[],
+	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
+		try {
+			const { agent: reconstructed } =
+				await this.agentRuntimeReconstructionService.reconstructFromResolvedSource({
+					config,
+					memoryOwnerAgentId: syntheticAgentId,
+					projectId,
+					credentialProvider,
+					toolDescriptors: {},
+					toolCodeByName: {},
+					skills: {},
+					runtimeProfile: 'inline',
+				});
+			return this.applyPerCallAgentExtras(reconstructed, outputSchema, extraTools);
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Unknown compilation error',
+			};
+		}
+	}
+
+	/** Per-call workflow-data tools exposed to a workflow-invoked agent. */
+	private buildWorkflowExtraTools(
+		workflowContext?: ExecuteAgentWorkflowContext,
+	): BuiltTool[] | undefined {
+		if (!workflowContext) return undefined;
+
+		const extraTools: BuiltTool[] = [createInputDataTool(workflowContext)];
+		if (workflowContext.exposeWorkflowData) {
+			extraTools.push(createWorkflowContextTool(workflowContext));
+		}
+		return extraTools;
+	}
+
+	/** Stream one workflow-invoked agent run and collect its outcome. */
+	private async streamWorkflowAgent(params: {
+		agentInstance: BuiltAgent;
+		message: string;
+		threadId: string;
+		telemetryAgentId: string;
+		telemetryUserId?: string;
+		outputSchema?: JSONSchema7;
+	}): Promise<WorkflowAgentRunOutcome> {
+		const { agentInstance, message, threadId, telemetryAgentId, telemetryUserId, outputSchema } =
+			params;
+
+		const recorder = new ExecutionRecorder();
+
+		let structuredOutput: unknown = null;
+		const toolCalls: ExecuteAgentData['toolCalls'] = [];
+		const toolInputs = new Map<string, { toolName: string; input: unknown }>();
+		let streamError: Error | undefined;
+
+		try {
+			const resultStream = await agentInstance.stream(message, {
+				// The memory store scopes message reads by `resourceId` (the
+				// "per-user scope"; chat integrations pass the chat user id there).
+				// Workflow runs have no user, so key the scope by the thread
+				// itself: it is stable across executions, which is what lets a
+				// caller-supplied session id actually continue the conversation.
+				// The previous key — the execution id — changed every run and hid
+				// all prior messages of the thread from the model.
+				persistence: { resourceId: threadId, threadId },
+				executionCounter: createAgentExecutionCounter(this.telemetry, {
+					agentId: telemetryAgentId,
+					userId: telemetryUserId,
+				}),
+			});
+
+			for await (const value of streamAgentChunks(resultStream.stream)) {
+				recorder.record(value);
+
+				if (value.type === 'tool-call') {
+					toolInputs.set(value.toolCallId, { toolName: value.toolName, input: value.input });
+				} else if (value.type === 'tool-result') {
+					const pending = toolInputs.get(value.toolCallId);
+					toolCalls.push({
+						toolName: value.toolName,
+						input: pending?.input ?? null,
+						result: value.output,
+					});
+					toolInputs.delete(value.toolCallId);
+				} else if (value.type === 'finish' && value.structuredOutput !== undefined) {
+					structuredOutput = value.structuredOutput;
+				}
+			}
+		} catch (error) {
+			const normalizedError = this.normalizeWorkflowStreamError(error, outputSchema);
+			recorder.record({ type: 'error', error: normalizedError });
+			recorder.record({ type: 'finish', finishReason: 'error' });
+			streamError = normalizedError;
+		}
+
+		return {
+			recorder,
+			messageRecord: recorder.getMessageRecord(),
+			structuredOutput,
+			toolCalls,
+			streamError,
+		};
+	}
+
+	/**
+	 * Turn a collected workflow-invoked run into the caller-facing result,
+	 * translating failure states into thrown errors.
+	 */
+	private buildWorkflowResult(params: {
+		run: WorkflowAgentRunOutcome;
+		session: ExecuteAgentData['session'];
+		outputSchema?: JSONSchema7;
+	}): ExecuteAgentData {
+		const { run, session, outputSchema } = params;
+		const { recorder, messageRecord, structuredOutput, toolCalls, streamError } = run;
+
+		if (streamError !== undefined) {
+			throw streamError;
+		}
+
+		if (recorder.suspended) {
+			throw new OperationalError(
+				'Agent execution suspended waiting for tool approval. ' +
+					'Suspend/resume is not supported in workflow execution context.',
+			);
+		}
+
+		if (messageRecord.error) {
+			if (outputSchema) {
+				const structuredOutputError = describeStructuredOutputError(messageRecord.error);
+				if (structuredOutputError) {
+					throw new OperationalError(structuredOutputError);
+				}
+			}
+			throw new OperationalError(`Agent execution failed: ${messageRecord.error}`);
+		}
+
+		if (messageRecord.finishReason === 'error') {
+			throw new OperationalError(
+				outputSchema
+					? 'Agent execution finished with an error while producing structured output. ' +
+							"The agent's model or provider may not support JSON Schema structured output."
+					: 'Agent execution finished with an error.',
+			);
+		}
+
+		return {
+			response: messageRecord.assistantResponse,
+			structuredOutput: structuredOutput ?? null,
+			usage: messageRecord.usage
+				? {
+						promptTokens: messageRecord.usage.promptTokens,
+						completionTokens: messageRecord.usage.completionTokens,
+						totalTokens: messageRecord.usage.totalTokens,
+					}
+				: null,
+			toolCalls,
+			finishReason: messageRecord.finishReason,
+			session,
+		};
+	}
+
+	async executeForWorkflow(
+		agentId: string,
+		message: string,
+		// Kept for positional compatibility; memory persistence is keyed by
+		// threadId (stable across executions), not by the execution.
+		_executionId: string,
+		threadId: string,
+		projectId: string,
+		telemetryUserId?: string,
+		useDraftVersion?: boolean,
+		outputSchema?: JSONSchema7,
+		workflowContext?: ExecuteAgentWorkflowContext,
+	): Promise<ExecuteAgentData> {
+		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agentEntity) {
+			throw new OperationalError('Agent not found or not accessible.');
+		}
+
+		const credentialProvider = createAgentCredentialProvider(this.credentialsService, projectId);
+
+		let agentData: Agent = agentEntity;
+
+		if (!useDraftVersion) {
+			agentData = getPublishedAgentSnapshot(agentEntity);
+		}
+		const telemetryConfiguration = buildAgentConfigurationTelemetry(agentData);
+
+		const extraTools = this.buildWorkflowExtraTools(workflowContext);
+		const compiled = await this.compileIsolated(
+			agentData,
+			credentialProvider,
+			outputSchema,
+			extraTools?.length ? extraTools : undefined,
+		);
+		if (!compiled.ok || !compiled.agent) {
+			throw new OperationalError(`Failed to compile agent: ${compiled.error ?? 'unknown error'}`);
+		}
+
+		const agentInstance = compiled.agent;
+		const run = await this.streamWorkflowAgent({
+			agentInstance,
+			message,
+			threadId,
+			telemetryAgentId: agentId,
+			telemetryUserId,
+			outputSchema,
+		});
+
+		void this.agentExecutionService
+			.recordMessage({
+				threadId,
+				agentId,
+				agentName: agentInstance.name,
+				projectId,
+				userMessage: message,
+				record: run.messageRecord,
+				source: AGENT_WORKFLOW_TRIGGER_TYPE,
+				telemetry: {
+					runType: useDraftVersion ? 'test' : 'production',
+					configuration: telemetryConfiguration,
+				},
+			})
+			.catch((error) => {
+				this.logger.warn('Failed to record agent execution from workflow', {
+					agentId,
+					threadId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+
+		return this.buildWorkflowResult({
+			run,
+			// sessionId here is still the scoped thread key — executeAgent remaps it
+			// to the caller-facing id; this method never sees the unscoped one.
+			session: { agentId, projectId, sessionId: threadId, threadId },
+			outputSchema,
+		});
+	}
+
+	/**
+	 * Execute an inline agent embedded in a workflow node's parameters. There is
+	 * no entity, so published/draft gating does not apply — the embedded config
+	 * is always what runs. When the caller supplies a session id, conversation-
+	 * thread memory persists (the thread tables carry no agent FK) so that id
+	 * continues the conversation across executions; but no session is *recorded*
+	 * for the sessions UI (`agent_execution_threads.agentId` is an FK to
+	 * `agents`), so the result carries `session: null`.
+	 */
+	async executeInlineForWorkflow(
+		inlineAgent: InlineAgentPayload,
+		message: string,
+		// Kept for positional compatibility; memory persistence is keyed by
+		// threadId (stable across executions), not by the execution.
+		_executionId: string,
+		threadId: string,
+		projectId: string,
+		telemetryUserId?: string,
+		runType: AgentRunTelemetryType = 'production',
+		outputSchema?: JSONSchema7,
+		workflowContext?: ExecuteAgentWorkflowContext,
+	): Promise<ExecuteAgentData> {
+		const config = await this.validateInlineAgentConfig(inlineAgent);
+
+		// Session memory: when the caller supplied a session id, inline agents run
+		// with plain conversation-thread memory so that id continues the same
+		// conversation across executions. Injected server-side, never part of the node's
+		// config: long-term memory (observational/episodic) stays off because it
+		// accumulates under the agent id, and inline agents only have a synthetic,
+		// node-rename-sensitive one. Without a session id the thread is per-call
+		// and can never be continued, so nothing is persisted — inline runs record
+		// no session, which would otherwise grow unreachable thread/message rows.
+		const persistMemory = workflowContext?.hasCallerSessionId === true;
+		const runtimeConfig: AgentJsonConfig = persistMemory
+			? {
+					...config,
+					memory: {
+						enabled: true,
+						storage: 'n8n',
+						observationalMemory: { enabled: false },
+						episodicMemory: { enabled: false },
+					},
+				}
+			: config;
+
+		const credentialProvider = createAgentCredentialProvider(this.credentialsService, projectId);
+
+		// For telemetry/logging and memory-owner keying — never persisted, and
+		// stable enough to aggregate runs of the same node across executions.
+		const syntheticAgentId = `inline:${workflowContext?.workflowId ?? 'unknown'}:${
+			workflowContext?.callingNodeName ?? 'unknown'
+		}`;
+
+		const extraTools = this.buildWorkflowExtraTools(workflowContext);
+		const compiled = await this.compileIsolatedFromSource(
+			runtimeConfig,
+			syntheticAgentId,
+			projectId,
+			credentialProvider,
+			outputSchema,
+			extraTools?.length ? extraTools : undefined,
+		);
+		if (!compiled.ok || !compiled.agent) {
+			throw new OperationalError(`Failed to compile agent: ${compiled.error ?? 'unknown error'}`);
+		}
+
+		const run = await this.streamWorkflowAgent({
+			agentInstance: compiled.agent,
+			message,
+			threadId,
+			telemetryAgentId: syntheticAgentId,
+			telemetryUserId,
+			outputSchema,
+		});
+
+		// No `recordMessage` here: inline runs have no agent entity to attach a
+		// session to. Emit the turn-finished telemetry directly instead.
+		try {
+			this.telemetry.trackAgentTurnFinished({
+				agent_id: syntheticAgentId,
+				thread_id: threadId,
+				run_type: runType,
+				agent_type: 'inline',
+				turn_status:
+					run.messageRecord.error !== null || run.messageRecord.finishReason === 'error'
+						? 'failed'
+						: 'succeeded',
+				configuration: buildAgentConfigurationTelemetryFromConfig(runtimeConfig),
+				latency_ms: run.messageRecord.duration,
+				cost: run.messageRecord.totalCost ?? 0,
+				tool_call_count: run.messageRecord.timeline.filter((t) => t.type === 'tool-call').length,
+			});
+		} catch (error) {
+			this.logger.warn('Failed to track inline agent execution telemetry', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+
+		return this.buildWorkflowResult({ run, session: null, outputSchema });
+	}
+
+	/**
+	 * Validate the node-supplied inline definition into a runnable config.
+	 * The strict schema rejects capabilities inline agents don't support
+	 * (skills, memory, sub-agents, custom tools, the options block), so
+	 * saved-agent-only features can't sneak in through raw JSON. See
+	 * `InlineAgentJsonConfigSchema` for the authoritative allowlist.
+	 */
+	private async validateInlineAgentConfig(payload: InlineAgentPayload): Promise<AgentJsonConfig> {
+		const parsed = RunnableInlineAgentConfigSchema.safeParse({
+			config: sanitizeAgentJsonConfig(payload.config),
+		});
+		if (!parsed.success) {
+			const details = formatZodErrors(parsed.error)
+				.map((issue) => `${issue.path}: ${issue.message}`)
+				.join('; ');
+			throw new UserError(`Invalid inline agent configuration: ${details}`);
+		}
+		const config = parsed.data.config;
+
+		try {
+			validateNodeToolExpressions(config.tools);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new UserError(`Invalid $fromAI expression in node tool config: ${message}`);
+		}
+
+		const nodeError = await validateNodeToolConfigs(config.tools);
+		if (nodeError) {
+			throw new UserError(`Invalid inline agent configuration: ${nodeError}`);
+		}
+
+		return config;
+	}
+}
+
+interface WorkflowAgentRunOutcome {
+	recorder: ExecutionRecorder;
+	messageRecord: MessageRecord;
+	structuredOutput: unknown;
+	toolCalls: ExecuteAgentData['toolCalls'];
+	streamError?: Error;
+}

--- a/packages/cli/src/modules/agents/utils/agent-execution-counter.ts
+++ b/packages/cli/src/modules/agents/utils/agent-execution-counter.ts
@@ -1,0 +1,30 @@
+import type { AgentExecutionCounter } from '@n8n/agents';
+
+import type { Telemetry } from '@/telemetry';
+
+export function createAgentExecutionCounter(
+	telemetry: Telemetry,
+	{ agentId, userId }: { agentId: string; userId?: string },
+): AgentExecutionCounter {
+	const attribution = userId ? { user_id: userId } : {};
+	return {
+		incrementMessageCount: () =>
+			telemetry.trackAgentExecution({
+				agent_id: agentId,
+				...attribution,
+				message_count: 1,
+			}),
+		incrementTokenCount: (tokenCount) =>
+			telemetry.trackAgentExecution({
+				agent_id: agentId,
+				...attribution,
+				token_count: tokenCount,
+			}),
+		incrementToolCallCount: () =>
+			telemetry.trackAgentExecution({
+				agent_id: agentId,
+				...attribution,
+				tool_call_count: 1,
+			}),
+	};
+}

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -375,10 +375,10 @@ export async function executeAgent(
 		);
 	}
 
-	const { AgentExecutionOrchestratorService } = await import(
-		'@/modules/agents/agent-execution-orchestrator.service'
+	const { AgentWorkflowExecutionService } = await import(
+		'@/modules/agents/agent-workflow-execution.service'
 	);
-	const agentExecutionOrchestratorService = Container.get(AgentExecutionOrchestratorService);
+	const agentWorkflowExecutionService = Container.get(AgentWorkflowExecutionService);
 
 	if (!additionalData.workflowId) {
 		throw new UnexpectedError('Cannot execute agent without a workflowId in additional data');
@@ -388,7 +388,7 @@ export async function executeAgent(
 	const scopedThreadId = `wf:${additionalData.workflowId}:${threadId}`;
 
 	if (source.inlineAgent) {
-		return await agentExecutionOrchestratorService.executeInlineForWorkflow(
+		return await agentWorkflowExecutionService.executeInlineForWorkflow(
 			source.inlineAgent,
 			message,
 			executionId,
@@ -403,7 +403,7 @@ export async function executeAgent(
 
 	const useDraftVersion = isManualOrChatExecution(executionMode);
 
-	const result = await agentExecutionOrchestratorService.executeForWorkflow(
+	const result = await agentWorkflowExecutionService.executeForWorkflow(
 		source.agentId,
 		message,
 		executionId,


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/n8n-io/n8n/pull/34128: Split `AgentExecutionOrchestratorService` into two separate services

- **`AgentExecutionOrchestratorService`** keeps the chat/task half. These are streaming runs against cached runtimes with HITL suspend/resume.
- **New `AgentWorkflowExecutionService`** takes the workflow half: `executeForWorkflow`, `executeInlineForWorkflow`, `compileIsolated`, and their private helpers. These are non-streaming runs against isolated (uncached) compiles for workflow-invoked agents.
- The telemetry execution counter used by both halves moved to a shared helper, `utils/agent-execution-counter.ts`.
- The test file was split along the same seam (9 chat/task tests + 19 workflow tests, all moved verbatim with trimmed `makeService()` factories).

## How to test

No behavior changes — existing unit tests cover both halves:

```bash
cd packages/cli
pnpm vitest run src/modules/agents/__tests__/agent-execution-orchestrator.service.test.ts \
  src/modules/agents/__tests__/agent-workflow-execution.service.test.ts \
  src/__tests__/workflow-execute-additional-data.test.ts
```

For an end-to-end check: chat with an agent in the app (chat half) and run a workflow with a "Message an Agent" node (workflow half).

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to #34128
- https://linear.app/n8n/issue/AGENT-345

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34263">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

