### PR TITLE
fix: Stop janitor dead-code rule OOMing on large Playwright suites (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/rules/dead-code.rule.test.ts
+++ b/packages/testing/janitor/src/rules/dead-code.rule.test.ts
@@ -1,6 +1,10 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe } from 'vitest';
 
 import { DeadCodeRule } from './dead-code.rule.js';
+import { setConfig, resetConfig, defineConfig } from '../config.js';
 import { test, expect } from '../test/fixtures.js';
 import { isMethodFix } from '../types.js';
 
@@ -338,6 +342,271 @@ const page = new TestPage();
 		if (fixData && isMethodFix(fixData)) {
 			expect(fixData.className).toBe('TestPage');
 			expect(fixData.memberName).toBe('unusedMethod');
+		}
+	});
+
+	test('allows a method used only via a same-file this.method() call', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/pages/TestPage.ts',
+			`
+export class TestPage {
+	async publicMethod() {
+		await this.calledInternally();
+	}
+	async calledInternally() {}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { TestPage } from '../pages/TestPage';
+const page = new TestPage();
+page.publicMethod();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		// calledInternally() is only ever called via this.calledInternally() in its
+		// own file — that same-file usage must still count, so nothing is flagged.
+		expect(violations).toHaveLength(0);
+	});
+
+	test('does not flag a dead method when another class has a same-named used method', ({
+		project,
+		createFile,
+	}) => {
+		const fileA = createFile(
+			'/services/HelperA.ts',
+			`
+export class HelperA {
+	async save() {}
+}
+`,
+		);
+		const fileB = createFile(
+			'/services/HelperB.ts',
+			`
+export class HelperB {
+	async save() {}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { HelperA } from '../services/HelperA';
+import { HelperB } from '../services/HelperB';
+const a = new HelperA();
+a.save();
+const b = new HelperB();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [fileA, fileB]);
+
+		// HelperB.save() is genuinely unused, but the name-based text scan cannot
+		// tell it apart from HelperA.save() (which is used) — so, by design, it errs
+		// towards not flagging rather than risk a false positive.
+		expect(violations).toHaveLength(0);
+	});
+
+	test('allows a class referenced only within its own declaring file', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/pages/Base.ts',
+			`
+export class Base {}
+
+export class Derived extends Base {}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { Derived } from '../pages/Base';
+const d = new Derived();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		// Base is used only by 'extends Base' in the same file. A same-file
+		// reference must count, so Base is not dead; Derived is used externally.
+		expect(violations.map((v) => v.message)).not.toContainEqual(
+			expect.stringContaining('Dead class: Base'),
+		);
+		expect(violations).toHaveLength(0);
+	});
+
+	test('allows a property used only via a same-file this.prop access', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/pages/TestPage.ts',
+			`
+export class TestPage {
+	private readonly base = 'x';
+	get selector() {
+		return this.base + '-suffix';
+	}
+	async use() {
+		return this.selector;
+	}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { TestPage } from '../pages/TestPage';
+const page = new TestPage();
+page.use();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		// selector is read only via this.selector in the same file — must still count.
+		expect(violations.map((v) => v.message)).not.toContainEqual(
+			expect.stringContaining('selector'),
+		);
+	});
+
+	test('does not flag native #private members even when unreferenced', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/pages/TestPage.ts',
+			`
+export class TestPage {
+	#secret = 1;
+	#helper() {
+		return this.#secret;
+	}
+	async use() {
+		this.#helper();
+	}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { TestPage } from '../pages/TestPage';
+const page = new TestPage();
+page.use();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		// #private members can't be seen by an external `.name` scan; they must be
+		// excluded outright rather than falsely flagged.
+		expect(violations).toHaveLength(0);
+	});
+
+	test('flags an unused protected method (only private/# are exempt for methods)', ({
+		project,
+		createFile,
+	}) => {
+		const file = createFile(
+			'/pages/TestPage.ts',
+			`
+export class TestPage {
+	async used() {}
+	protected async orphanProtected() {}
+}
+`,
+		);
+
+		createFile(
+			'/tests/test.spec.ts',
+			`
+import { TestPage } from '../pages/TestPage';
+const page = new TestPage();
+page.used();
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations.map((v) => v.message)).toContainEqual(
+			expect.stringContaining('orphanProtected'),
+		);
+	});
+
+	test('analyze() reads the suite from disk, covers all categories, and honours ignore globs', () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'janitor-dead-code-'));
+		try {
+			fs.mkdirSync(path.join(tmpDir, 'pages', 'components'), { recursive: true });
+			fs.mkdirSync(path.join(tmpDir, 'composables', 'flows'), { recursive: true });
+			fs.mkdirSync(path.join(tmpDir, 'tests'), { recursive: true });
+			fs.mkdirSync(path.join(tmpDir, 'node_modules', 'vendor'), { recursive: true });
+			fs.mkdirSync(path.join(tmpDir, 'dist'), { recursive: true });
+
+			fs.writeFileSync(
+				path.join(tmpDir, 'pages', 'components', 'TestPage.ts'),
+				`export class TestPage {
+	alive() {}
+	orphan() {}
+}
+`,
+			);
+			// A flow (composables) declaration proves that target category is analysed too.
+			fs.writeFileSync(
+				path.join(tmpDir, 'composables', 'flows', 'TestFlow.ts'),
+				`export class TestFlow {
+	deadFlowStep() {}
+}
+`,
+			);
+			fs.writeFileSync(
+				path.join(tmpDir, 'tests', 'test.spec.ts'),
+				`import { TestPage } from '../pages/components/TestPage';
+import { TestFlow } from '../composables/TestFlow';
+const page = new TestPage();
+page.alive();
+const flow = new TestFlow();
+`,
+			);
+			// Every `.orphan()` here lives in a file the ignore globs must skip; if any
+			// slipped into the corpus, orphan() would look used and NOT be flagged.
+			fs.writeFileSync(path.join(tmpDir, 'types.d.ts'), 'declare const x: X;\nx.orphan();\n');
+			fs.writeFileSync(
+				path.join(tmpDir, 'node_modules', 'vendor', 'index.ts'),
+				'export const y = {};\ny.orphan();\n',
+			);
+			fs.writeFileSync(
+				path.join(tmpDir, 'dist', 'built.js.ts'),
+				'declare const w: W;\nw.orphan();\n',
+			);
+
+			setConfig(defineConfig({ rootDir: tmpDir }));
+			const violations = new DeadCodeRule().analyze({ rootDir: tmpDir });
+			const messages = violations.map((v) => v.message);
+
+			// orphan() only appears in ignored files -> flagged; alive() is used.
+			expect(messages).toContainEqual(expect.stringContaining('TestPage.orphan()'));
+			expect(messages).not.toContainEqual(expect.stringContaining('TestPage.alive()'));
+			// The composables category is reached: TestFlow (used) has a dead step.
+			expect(messages).toContainEqual(expect.stringContaining('TestFlow.deadFlowStep()'));
+		} finally {
+			resetConfig();
+			fs.rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/testing/janitor/src/rules/dead-code.rule.ts
+++ b/packages/testing/janitor/src/rules/dead-code.rule.ts
@@ -1,27 +1,73 @@
 import { AstRule } from '@n8n/rules-engine/ast';
 import type { AstProjectConfig } from '@n8n/rules-engine/ast';
-import { SyntaxKind, type Project, type SourceFile } from 'ts-morph';
+import { globSync } from 'glob';
+import * as fs from 'node:fs';
+import {
+	SyntaxKind,
+	type ClassDeclaration,
+	type MethodDeclaration,
+	type Project,
+	type PropertyDeclaration,
+	type SourceFile,
+} from 'ts-morph';
 
 import { getConfig } from '../config.js';
 import type { Violation } from '../types.js';
 import { matchesPatterns } from '../utils/paths.js';
 
+/** Public member and class names declared across the target files. */
+type DeclaredNames = { members: Set<string>; classes: Set<string> };
+
+/**
+ * Names found referenced across the suite text:
+ * - `members`: member names that appear as a `.name` access anywhere.
+ * - `classes`: class names that appear more than once (the declaration itself is
+ *   one occurrence, so a second occurrence means the class is referenced).
+ */
+interface UsageIndex {
+	members: Set<string>;
+	classes: Set<string>;
+}
+
 /**
  * Dead Code Rule
  *
- * Finds unused methods, properties, and classes via reference tracing.
+ * Finds unused methods, properties, and classes.
  *
  * Detects:
- * - Unused public methods (no external references)
- * - Unused public properties (no external references)
- * - Dead classes (entire class not referenced externally)
- * - Empty classes (no public members)
+ * - Unused public methods (never called anywhere)
+ * - Unused public properties (never accessed anywhere)
+ * - Dead classes (class name never referenced beyond its own declaration)
+ *
+ * Usage is traced from the raw text of the suite, not the ts-morph language
+ * service. `findReferences` forces ts-morph to build a fully type-checked
+ * program over the whole import closure (n8n-workflow + node_modules), and
+ * loading every spec as an AST just to read it costs multiple GB — together
+ * that needed ~10GB of heap and minutes for this suite. Instead only the
+ * declaration files (pages/flows/helpers/services) are parsed into an AST; the
+ * whole suite (including those declaration files themselves) is then scanned as
+ * plain text so a member used only from another page still counts.
+ *
+ * A member is "used" if `.name` appears anywhere; a class if its name appears
+ * beyond its own declaration. This is a name-based heuristic, and deliberately
+ * errs towards NOT flagging (a false positive here would auto-delete live code
+ * under `--fix`). Known blind spots, all of which only cause under-reporting:
+ * - it matches by name, not resolved symbol, so it cannot tell same-named
+ *   members/classes on different files apart: once any `goto()` is called, no
+ *   other `goto()` in the suite can be flagged. Shared conventional verb names
+ *   (goto/open/close/search) are effectively never flagged.
+ * - it does not strip comments or strings, so a name mentioned in a JSDoc
+ *   `@example`, doc comment, or `getByTestId('...')` string counts as a use.
+ * Members reached only by computed/bracket access (`obj['m']`) or destructuring
+ * are the one theoretical false-positive seam; none exist in the suite today.
  */
 export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 	readonly id = 'dead-code';
 	readonly name = 'Dead Code';
 	readonly description = 'Find unused methods, properties, and classes';
 	readonly severity = 'warning' as const;
+
+	private usage: UsageIndex = { members: new Set(), classes: new Set() };
 
 	getTargetGlobs(): string[] {
 		const config = getConfig();
@@ -34,35 +80,120 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 	}
 
 	protected projectConfig(): AstProjectConfig {
-		// Reference resolution needs the whole suite loaded (a method used only by a
-		// test must be seen as referenced) — so load broadly and filter to targets below.
+		// Only the declaration files need an AST (to enumerate classes and their
+		// members). Usage across the whole suite is traced from raw text below, so
+		// we neither load every spec as an AST nor resolve dependencies.
 		return {
 			packages: ['.'],
-			spec: { globs: ['**/*.ts', '!**/*.d.ts', '!node_modules/**'], resolveDependencies: true },
+			spec: { globs: [...this.getTargetGlobs(), '!**/*.d.ts'], resolveDependencies: false },
 		};
 	}
 
 	analyze(context: { rootDir: string }): Violation[] {
-		return this.projects(context).flatMap(({ project }) => this.analyzeProject(project));
+		return this.projects(context).flatMap(({ project }) =>
+			this.findDeadCode(this.declarationFiles(project), this.readSuiteCorpus(context.rootDir)),
+		);
 	}
 
+	/**
+	 * Test seam: declarations come from `files`, usage from the (in-memory)
+	 * project's own source files.
+	 */
 	analyzeProject(
 		project: Project,
-		files: SourceFile[] = project
-			.getSourceFiles()
-			.filter((f) => matchesPatterns(f.getFilePath(), this.getTargetGlobs())),
+		files: SourceFile[] = this.declarationFiles(project),
 	): Violation[] {
+		const corpus = project.getSourceFiles().map((f) => f.getFullText());
+		return this.findDeadCode(files, corpus);
+	}
+
+	/** Source files that declare the artifacts this rule checks (pages/flows/helpers/services). */
+	private declarationFiles(project: Project): SourceFile[] {
+		return project
+			.getSourceFiles()
+			.filter((f) => matchesPatterns(f.getFilePath(), this.getTargetGlobs()));
+	}
+
+	private findDeadCode(files: SourceFile[], corpus: Iterable<string>): Violation[] {
+		this.usage = this.buildUsageIndex(corpus, this.collectDeclaredNames(files));
+
 		const violations: Violation[] = [];
-
 		for (const file of files) {
-			const fileViolations = this.analyzeFile(project, file);
-			violations.push(...fileViolations);
+			violations.push(...this.analyzeFile(file));
 		}
-
 		return violations;
 	}
 
-	private analyzeFile(project: Project, file: SourceFile): Violation[] {
+	/**
+	 * Yield every non-declaration `.ts` file in the suite as plain text, one at a
+	 * time. Streaming (read -> scan -> discard) keeps peak memory at a single
+	 * file rather than holding the whole suite's text at once.
+	 */
+	private *readSuiteCorpus(rootDir: string): Iterable<string> {
+		const paths = globSync('**/*.ts', {
+			cwd: rootDir,
+			absolute: true,
+			ignore: ['**/node_modules/**', '**/dist/**', '**/*.d.ts'],
+		});
+		for (const p of paths) {
+			yield fs.readFileSync(p, 'utf8');
+		}
+	}
+
+	/**
+	 * Names declared across the target files. Methods are candidates unless
+	 * `private`/`#private`; properties also exclude `protected`.
+	 */
+	private collectDeclaredNames(files: SourceFile[]): DeclaredNames {
+		const members = new Set<string>();
+		const classes = new Set<string>();
+
+		for (const file of files) {
+			for (const classDecl of file.getClasses()) {
+				const className = classDecl.getName();
+				if (className) classes.add(className);
+
+				for (const method of classDecl.getMethods()) {
+					if (this.shouldCheckMethod(method)) members.add(method.getName());
+				}
+				for (const prop of classDecl.getProperties()) {
+					if (this.shouldCheckProperty(prop)) members.add(prop.getName());
+				}
+			}
+		}
+
+		return { members, classes };
+	}
+
+	/**
+	 * Single pass over the corpus with one regex: an identifier, optionally
+	 * preceded by a dot. A dotted identifier is a `.name` access -> marks the
+	 * member used; every identifier occurrence counts toward its class, which is
+	 * "used" once seen beyond its single declaration occurrence. Storage is
+	 * bounded to declared names, so the index stays small.
+	 */
+	private buildUsageIndex(corpus: Iterable<string>, declared: DeclaredNames): UsageIndex {
+		const members = new Set<string>();
+		const classCounts = new Map<string, number>();
+		const token = /(\.)?([A-Za-z_$][\w$]*)/g;
+
+		for (const text of corpus) {
+			token.lastIndex = 0;
+			for (let m = token.exec(text); m !== null; m = token.exec(text)) {
+				const [, dot, name] = m;
+				if (dot && declared.members.has(name)) members.add(name);
+				if (declared.classes.has(name)) classCounts.set(name, (classCounts.get(name) ?? 0) + 1);
+			}
+		}
+
+		const classes = new Set<string>();
+		for (const [name, count] of classCounts) {
+			if (count > 1) classes.add(name);
+		}
+		return { members, classes };
+	}
+
+	private analyzeFile(file: SourceFile): Violation[] {
 		const violations: Violation[] = [];
 
 		for (const classDecl of file.getClasses()) {
@@ -70,14 +201,14 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 			if (!className) continue;
 
 			// Check if entire class is unused
-			if (!this.hasExternalReferences(file, classDecl)) {
+			if (!this.usage.classes.has(className)) {
 				violations.push(this.createDeadClassViolation(file, classDecl, className));
 				continue; // Don't report individual members if whole class is dead
 			}
 
 			// Check individual members
-			violations.push(...this.checkUnusedMethods(project, file, classDecl, className));
-			violations.push(...this.checkUnusedProperties(project, file, classDecl, className));
+			violations.push(...this.checkUnusedMethods(file, classDecl, className));
+			violations.push(...this.checkUnusedProperties(file, classDecl, className));
 		}
 
 		return violations;
@@ -85,7 +216,7 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 
 	private createDeadClassViolation(
 		file: SourceFile,
-		classDecl: ReturnType<SourceFile['getClasses']>[0],
+		classDecl: ClassDeclaration,
 		className: string,
 	): Violation {
 		return this.fileViolation(
@@ -100,21 +231,17 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 	}
 
 	private checkUnusedMethods(
-		project: Project,
 		file: SourceFile,
-		classDecl: ReturnType<SourceFile['getClasses']>[0],
+		classDecl: ClassDeclaration,
 		className: string,
 	): Violation[] {
 		const violations: Violation[] = [];
 
 		for (const method of classDecl.getMethods()) {
-			if (method.hasModifier(SyntaxKind.PrivateKeyword)) continue;
+			if (!this.shouldCheckMethod(method)) continue;
 
 			const methodName = method.getName();
-			if (
-				!this.hasExternalReferences(file, method) &&
-				!this.hasTextUsage(project, file, methodName)
-			) {
+			if (!this.usage.members.has(methodName)) {
 				violations.push(
 					this.fileViolation(
 						file,
@@ -133,18 +260,17 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 	}
 
 	private checkUnusedProperties(
-		project: Project,
 		file: SourceFile,
-		classDecl: ReturnType<SourceFile['getClasses']>[0],
+		classDecl: ClassDeclaration,
 		className: string,
 	): Violation[] {
 		const violations: Violation[] = [];
 
 		for (const prop of classDecl.getProperties()) {
-			if (this.isPrivateOrProtected(prop)) continue;
+			if (!this.shouldCheckProperty(prop)) continue;
 
 			const propName = prop.getName();
-			if (!this.hasExternalReferences(file, prop) && !this.hasTextUsage(project, file, propName)) {
+			if (!this.usage.members.has(propName)) {
 				violations.push(
 					this.fileViolation(
 						file,
@@ -162,44 +288,17 @@ export class DeadCodeRule extends AstRule<{ rootDir: string }> {
 		return violations;
 	}
 
-	private isPrivateOrProtected(
-		prop: ReturnType<ReturnType<SourceFile['getClasses']>[0]['getProperties']>[0],
-	): boolean {
+	/** Methods are candidates unless `private` or a native `#private` (whose `.#name` the text scan can't see). */
+	private shouldCheckMethod(method: MethodDeclaration): boolean {
+		return !method.hasModifier(SyntaxKind.PrivateKeyword) && !method.getName().startsWith('#');
+	}
+
+	/** Properties are candidates unless `private`/`protected` or a native `#private`. */
+	private shouldCheckProperty(prop: PropertyDeclaration): boolean {
 		return (
-			prop.hasModifier(SyntaxKind.PrivateKeyword) || prop.hasModifier(SyntaxKind.ProtectedKeyword)
-		);
-	}
-
-	/**
-	 * Text-based fallback for when ts-morph can't trace references through
-	 * complex generics (e.g. Playwright fixture type chains).
-	 * Searches all project files for `.memberName` followed by a non-word char.
-	 */
-	private hasTextUsage(project: Project, sourceFile: SourceFile, memberName: string): boolean {
-		const escaped = memberName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		const pattern = new RegExp(`\\.${escaped}\\b`);
-		for (const file of project.getSourceFiles()) {
-			if (file === sourceFile) continue;
-			if (pattern.test(file.getFullText())) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private hasExternalReferences(
-		sourceFile: SourceFile,
-		node: { findReferencesAsNodes: () => unknown[]; getStartLineNumber: () => number },
-	): boolean {
-		const refs = node.findReferencesAsNodes() as Array<{
-			getSourceFile: () => SourceFile;
-			getStartLineNumber: () => number;
-		}>;
-
-		return refs.some(
-			(ref) =>
-				ref.getSourceFile() !== sourceFile ||
-				ref.getStartLineNumber() !== node.getStartLineNumber(),
+			!prop.hasModifier(SyntaxKind.PrivateKeyword) &&
+			!prop.hasModifier(SyntaxKind.ProtectedKeyword) &&
+			!prop.getName().startsWith('#')
 		);
 	}
 }


### PR DESCRIPTION
## Summary

The Playwright janitor's `dead-code` rule OOM-killed the janitor on large suites. Its `projectConfig` loaded **every** `**/*.ts` spec as a ts-morph AST with `resolveDependencies: true`, then ran the language-service `findReferencesAsNodes()` per class and per member — forcing a fully type-checked program over the whole `n8n-workflow` + `node_modules` import closure. On the current suite that needed **~10 GB of heap and 3–4 minutes**, and crashed at the default Node heap. Every other rule runs at ~300 MB, <1s.

This rewrites the rule to trace usage from the raw **text** of the suite instead of the language service:

- Only the declaration files (pages/flows/helpers/services) are parsed into an AST, purely to enumerate classes and their members.
- The whole suite is then streamed as plain text (read → scan → discard) and a single bounded regex pass records which names are referenced.
- A member is "used" if `.name` appears anywhere (including a same-file `this.name` call); a class is "used" if its name appears beyond its own declaration.

It's a name-based heuristic that deliberately errs towards **not** flagging (a false positive would auto-delete live code under `--fix`); the known blind spots (shared verb names, comment/string mentions) are documented in the rule. This matches what the rule's previous text fallback already relied on.

**Result:** full run drops from OOM / 8.5 GB RSS to **~0.25 GB**, minutes → seconds, and the rule reports the same violations on the real suite.

This is an alternative to #34201, which tried to address the same OOM by switching janitor execution from `tsx` to build+run. Measurement showed the packaging change did not fix the memory (both `tsx` and plain `node` peaked >4 GB); the cost was entirely in this rule. This PR fixes the root cause, so the execution path can stay as-is.

## How to test

```bash
cd packages/testing/janitor
pnpm test                     # 30 files / 380 tests, incl. dead-code coverage
cd ../playwright
pnpm janitor --rule=dead-code # completes in seconds at ~0.25 GB, no OOM
```

New tests cover: same-file `this.method()`/`this.prop` usage counting as used; name-collision conservatism; `#private`/protected member handling; and the production `analyze()` on-disk path including the `node_modules` / `dist` / `.d.ts` ignore globs.

## Related Linear tickets, Github issues, and Community forum posts

Alternative approach to #34201 (same janitor OOM, different fix).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34264">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

