### PR TITLE
fix(core): Sign SES requests with the ses service name

### DIFF
--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -87,6 +87,11 @@ function getAwsSigningService(service: string): string {
 		// Legacy region-first SQS endpoints (`<region>.queue.amazonaws.com`).
 		case 'queue':
 			return 'sqs';
+		// SES (v1 and v2) endpoints are `email.<region>.amazonaws.com` but sign
+		// under `ses`. aws4 remapped this inside its RequestSigner; smithy signs
+		// the name it is given, so the mapping must live here.
+		case 'email':
+			return 'ses';
 		default:
 			return baseService;
 	}

--- a/packages/nodes-base/credentials/test/Aws.signing.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.signing.test.ts
@@ -211,6 +211,89 @@ describe('AWS signing (integration, real signer)', () => {
 		expect(result.body).toBe(buf);
 	});
 
+	describe('SES email endpoints', () => {
+		// SES endpoints are `email.<region>.amazonaws.com` but sign under `ses`
+		// (botocore: endpointPrefix 'email', signingName 'ses'). aws4 remapped this
+		// internally; smithy signs the name it is given. SES v2 rejects an
+		// email-scoped credential outright, v1 happens to tolerate it.
+
+		it('signs an SES v2 REST call (HTTP Request node shape) with the ses service name', async () => {
+			const result = await aws.authenticate(credentials, {
+				...baseRequest,
+				method: 'POST',
+				url: 'https://email.eu-central-1.amazonaws.com/v2/email/outbound-emails',
+				body: { FromEmailAddress: 'sender@example.com' },
+			});
+
+			const headers = result.headers as Record<string, string>;
+			expect(headers.authorization).toContain('/eu-central-1/ses/aws4_request');
+		});
+
+		it('signs an SES v1 query call (SES node shape, service param) with the ses service name', async () => {
+			// The AwsSes node passes service 'email', taking the default-endpoint branch.
+			const result = await aws.authenticate(credentials, {
+				...baseRequest,
+				method: 'POST',
+				qs: { service: 'email', path: '/?Action=GetSendQuota&Version=2010-12-01' },
+			});
+
+			const headers = result.headers as Record<string, string>;
+			expect(headers.authorization).toContain('/eu-central-1/ses/aws4_request');
+		});
+
+		describe('parity with the legacy aws4 signer', () => {
+			beforeEach(() => {
+				// Freeze time so both signers embed the same X-Amz-Date
+				vi.useFakeTimers();
+				vi.setSystemTime(new Date('2026-07-15T12:00:00.000Z'));
+			});
+
+			afterEach(() => {
+				vi.useRealTimers();
+				delete process.env.N8N_AWS_LEGACY_SIGNER;
+			});
+
+			function signatureFrom(headers: Record<string, string>): string {
+				const authorization = headers.authorization ?? headers.Authorization;
+				return /Signature=([0-9a-f]{64})/.exec(authorization)?.[1] ?? '<unsigned>';
+			}
+
+			it('produces the aws4 signature byte-for-byte for an SES v2 send', async () => {
+				const request: IHttpRequestOptions = {
+					...baseRequest,
+					method: 'POST',
+					url: 'https://email.eu-central-1.amazonaws.com/v2/email/outbound-emails',
+					body: { FromEmailAddress: 'sender@example.com' },
+				};
+
+				const smithy = await aws.authenticate(credentials, { ...request });
+				process.env.N8N_AWS_LEGACY_SIGNER = 'true';
+				const legacy = await aws.authenticate(credentials, { ...request });
+
+				const smithySignature = signatureFrom(smithy.headers as Record<string, string>);
+				expect(smithySignature).toMatch(/^[0-9a-f]{64}$/);
+				expect(smithySignature).toBe(signatureFrom(legacy.headers as Record<string, string>));
+			});
+
+			it("canonicalizes '+' and '@' in SES paths identically to aws4", async () => {
+				// Suppression-list addresses put raw emails in the path
+				const request: IHttpRequestOptions = {
+					...baseRequest,
+					url: 'https://email.eu-central-1.amazonaws.com/v2/email/suppression/addresses/bounce+test@example.com',
+				};
+
+				const smithy = await aws.authenticate(credentials, { ...request });
+				process.env.N8N_AWS_LEGACY_SIGNER = 'true';
+				const legacy = await aws.authenticate(credentials, { ...request });
+
+				const smithySignature = signatureFrom(smithy.headers as Record<string, string>);
+				expect(smithySignature).toMatch(/^[0-9a-f]{64}$/);
+				expect(smithySignature).toBe(signatureFrom(legacy.headers as Record<string, string>));
+				expect(smithy.url).toBe(legacy.url);
+			});
+		});
+	});
+
 	describe('legacy fallback', () => {
 		afterEach(() => {
 			delete process.env.N8N_AWS_LEGACY_SIGNER;


### PR DESCRIPTION
## Summary

Since 2.30.0 every AWS-signed call to Amazon SES is signed with the wrong SigV4 service name, and SES v2 rejects those requests with a 403 `SignatureDoesNotMatch`.

**What broke.** SES is the one common AWS service whose hostname does not match its signing name: its endpoints live at `email.<region>.amazonaws.com`, but signatures must be scoped to the service name `ses` (botocore models: `endpointPrefix: "email"`, `signingName: "ses"` — for both SES v1 and v2). The old `aws4` library silently corrected this inside its `RequestSigner` — even when we passed `service: 'email'` explicitly. When #33304 switched signing to `@smithy/signature-v4`, the smithy signer signs exactly the service it is given, and we now always give it the hostname-derived name. So the credential scope on every SES request flipped from `.../ses/aws4_request` to `.../email/aws4_request`.

**Why reports say "SES v2".** SES v2 hard-rejects an `email`-scoped credential. The v1 query API happens to tolerate it, so the dedicated SES node kept working while SES v2 REST calls through the HTTP Request node (predefined AWS credentials) started failing.

**Why we're confident this is the whole story.** We compared both signers byte-for-byte on identical requests (frozen clock, real `Aws.credentials.authenticate()` flow): the canonical requests are identical in every case — including `+`/`@` in paths, base64 page tokens in queries, and content-type defaults. The *only* divergence is the scope's service name, and pinning the service to `ses` makes both signers produce byte-identical `Authorization` headers.

**The fix** is one entry in `getAwsSigningService()`, the same pattern as the existing bedrock, legacy-SQS, and S3 mappings. The existing `-fips` normalization covers `email-fips` hosts too. Four regression tests cover the HTTP Request node shape (SES v2 REST), the SES node shape (v1 query API), and byte-parity with the legacy aws4 signer — all four fail without the mapping.

**Workaround for affected users** until this ships: `N8N_AWS_LEGACY_SIGNER=true` restores the old signer.

## How to test

- `cd packages/nodes-base && pnpm vitest run credentials/test/Aws.signing.test.ts` — the `SES email endpoints` describe block fails on master and passes here.
- Manual (needs an SES-enabled AWS account): HTTP Request node with AWS credentials, `POST https://email.<region>.amazonaws.com/v2/email/outbound-emails` with a JSON body — 403 `SignatureDoesNotMatch` on master, works with this fix.

## Related Linear tickets, Github issues, and Community forum posts

Regression introduced by #33304 (aws4 → smithy signer switch). No Linear ticket yet — happy to link one if the team wants it tracked.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (No docs impact — behavior returns to pre-2.30.0.)
- [x] Tests included.
- [x] PR Labeled with backport labels if urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

