### PR TITLE
fix(core): Prevent getIncomingData from throwing on a missing connection type

### DIFF
--- a/packages/core/src/execution-engine/partial-execution-utils/__tests__/get-incoming-data.test.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/__tests__/get-incoming-data.test.ts
@@ -1,0 +1,17 @@
+import { NodeConnectionTypes, type IRunData } from 'n8n-workflow';
+
+import { toITaskData } from './helpers';
+import { getIncomingData } from '../get-incoming-data';
+
+describe('getIncomingData', () => {
+	test('returns null, instead of throwing, when the run data lacks the requested connection type', () => {
+		const runData: IRunData = {
+			'Basic Node': [toITaskData([{ data: { value: 1 } }])],
+		};
+
+		expect(() =>
+			getIncomingData(runData, 'Basic Node', 0, NodeConnectionTypes.AiTool, 0),
+		).not.toThrow();
+		expect(getIncomingData(runData, 'Basic Node', 0, NodeConnectionTypes.AiTool, 0)).toBeNull();
+	});
+});

--- a/packages/core/src/execution-engine/partial-execution-utils/get-incoming-data.ts
+++ b/packages/core/src/execution-engine/partial-execution-utils/get-incoming-data.ts
@@ -7,7 +7,7 @@ export function getIncomingData(
 	connectionType: NodeConnectionType,
 	outputIndex: number,
 ): INodeExecutionData[] | null {
-	return runData[nodeName]?.at(runIndex)?.data?.[connectionType].at(outputIndex) ?? null;
+	return runData[nodeName]?.at(runIndex)?.data?.[connectionType]?.at(outputIndex) ?? null;
 }
 
 function getRunIndexLength(runData: IRunData, nodeName: string) {


### PR DESCRIPTION
## Summary

`getIncomingData` (`packages/core/src/execution-engine/partial-execution-utils/get-incoming-data.ts`) is typed to return `INodeExecutionData[] | null`, but throws a `TypeError` instead of returning `null` when a node's recorded run data exists but has no entry for the requested `connectionType`:

```ts
return runData[nodeName]?.at(runIndex)?.data?.[connectionType].at(outputIndex) ?? null;
```

The `?.` before `[connectionType]` only guards `data` being nullish — it does not guard the *result* of `data[connectionType]` (`ITaskDataConnections` is a sparse map keyed only by the connection types a node actually produced). When that lookup is `undefined`, the following `.at(outputIndex)` throws instead of short-circuiting to `null`.

This is reachable from `findStartNodes` (`find-start-nodes.ts`), which calls `getIncomingDataFromAnyRun` → `getIncomingData` for every declared outgoing connection type of a node while walking the graph to determine where a partial execution should (re-)start. A node whose stored task data doesn't happen to include a given connection type — e.g. a non-`main` connection type, or an output branch that produced no data on the last run — crashes graph traversal instead of being treated as "no data for this connection," which is the behavior the function's own return type and the `?? null` already promise.

Fix: add the missing `?.` before `.at(outputIndex)`.

## How to test

Added a regression test in `packages/core/src/execution-engine/partial-execution-utils/__tests__/get-incoming-data.test.ts` that reproduces the crash against unfixed code and asserts `getIncomingData` returns `null` instead of throwing when the run data lacks the requested connection type.

```bash
cd packages/core
pnpm test src/execution-engine/partial-execution-utils
```

All 118 tests in the directory pass (117 pre-existing + 1 new). Also ran the package's full test suite and `pnpm typecheck` with no new failures introduced by this change.

## Related Linear tickets, Github issues, and Community forum posts

None — found via code review, not filed as an issue first.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

**AI-assisted contribution disclosure:** This bug was found and the fix implemented with Claude Code assistance — agentic code search across `packages/workflow` and `packages/core` for pure-logic bugs in graph-traversal/execution-engine utilities. A human reviewed the diagnosis, ran the reproduction and full test suite locally, and verified the fix before submitting. This was not an unsupervised autonomous agent submission.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

