### PR TITLE
fix(Google Cloud Storage Node): Preserve headers for metadata request

### DIFF
--- a/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/ObjectDescription.ts
@@ -362,9 +362,13 @@ export const objectOperations: INodeProperties[] = [
 									// Without this, names containing '/', spaces, or '#' produce a 404.
 									requestOptions.url = `/b/${bucketName}/o/${encodeURIComponent(objectName)}`;
 									requestOptions.qs = projection ? { projection } : {};
-									requestOptions.headers = this.getNodeParameter(
+									const encryptionHeaders = this.getNodeParameter(
 										'encryptionHeaders',
 									) as IDataObject;
+									requestOptions.headers = {
+										...requestOptions.headers,
+										...encryptionHeaders,
+									};
 									delete requestOptions.body;
 
 									return requestOptions;

--- a/packages/nodes-base/nodes/Google/CloudStorage/test/ObjectDescription.resumableUpload.test.ts
+++ b/packages/nodes-base/nodes/Google/CloudStorage/test/ObjectDescription.resumableUpload.test.ts
@@ -326,6 +326,27 @@ describe('Google Cloud Storage - Create object resumable upload (preSend)', () =
 			expect(result.method).toBe('GET');
 			expect(result.url).toBe('/b/my-bucket/o/my-object');
 		});
+
+		it('preserves authorization on the final metadata request', async () => {
+			const fileSize = 100;
+			setupParamsServiceAccount();
+			assertBinaryData.mockReturnValue({ id: 'binary-id', mimeType: 'application/json' });
+			getBinaryMetadata.mockResolvedValue({ mimeType: 'application/json', fileSize });
+			getBinaryStream.mockResolvedValue(Readable.from([Buffer.alloc(fileSize, 'a')]));
+			httpRequest
+				.mockResolvedValueOnce({
+					headers: { location: 'https://storage.googleapis.com/upload/session-sa' },
+					body: {},
+				})
+				.mockResolvedValue({ statusCode: 200 });
+
+			const result = await bodySend.call(ctx, {
+				...baseOptions,
+				headers: { Authorization: 'Bearer sa-token' },
+			});
+
+			expect(result.headers).toEqual(expect.objectContaining({ Authorization: 'Bearer sa-token' }));
+		});
 	});
 
 	describe('final GET request', () => {


### PR DESCRIPTION
## Summary

Preserve headers already attached to the final metadata GET after a resumable Google Cloud Storage object upload, while merging customer-supplied encryption headers. Previously, this transition replaced the complete header object, so service-account requests lost `Authorization` after the upload itself succeeded.

## How to test

1. `cd packages/nodes-base`
2. `pnpm test nodes/Google/CloudStorage/test/ObjectDescription.resumableUpload.test.ts`
3. `pnpm lint`
4. `pnpm typecheck`

The regression test models the routing chain with a service-account `Authorization` header and asserts that the final metadata GET retains it.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #34269

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs are not required because this changes internal request-header handling only.
- [x] Tests included.
- [ ] PR labeled with the appropriate backport label if maintainers decide the fix is urgent.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

