### PR TITLE
fix(Gmail Node): support multiple Reply-To addresses

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
@@ -308,6 +308,40 @@ describe('replyToEmail', () => {
 		);
 	});
 
+	test('should handle multiple Reply-To email addresses', async () => {
+		const messageWithMultipleReplyTo = {
+			...mockMessageMetadata,
+			payload: {
+				...mockMessageMetadata.payload,
+				headers: [
+					{ name: 'Subject', value: 'Original Subject' },
+					{ name: 'Message-ID', value: '<original@example.com>' },
+					{ name: 'From', value: 'John Doe <john@example.com>' },
+					{ name: 'To', value: 'recipient@example.com' },
+					{
+						name: 'Reply-To',
+						value: 'reply1@example.com, reply2@example.com',
+					},
+				],
+			},
+		};
+
+		mockedGoogleApiRequest
+			.mockResolvedValueOnce(messageWithMultipleReplyTo)
+			.mockResolvedValueOnce(mockUserProfile)
+			.mockResolvedValueOnce(mockSentMessage);
+
+		const options: IDataObject = {};
+
+		await replyToEmail.call(mockExecuteFunctions, 'message123', options, 0, 2.2);
+
+		const email = mockedEncodeEmail.mock.calls[0][0];
+
+		expect(email.to).toContain('<reply1@example.com>');
+		expect(email.to).toContain('<reply2@example.com>');
+		expect(email.to).toContain('<recipient@example.com>');
+	});
+
 	test('should use custom sender name when provided', async () => {
 		mockedGoogleApiRequest
 			.mockResolvedValueOnce(mockMessageMetadata)

--- a/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
@@ -106,12 +106,10 @@ export async function replyToEmail(
 	for (const header of payload.headers) {
 		const headerName = (header.name || '').toLowerCase();
 		if (headerName === replyToHeaderName && !replyToRecipientsOnly) {
-			const replyToEmail = header.value;
-			if (replyToEmail.includes('<') && replyToEmail.includes('>')) {
-				to.push(replyToEmail);
-			} else {
-				to.push(`<${replyToEmail}>`);
-			}
+			header.value
+				.split(',')
+				.map((email) => email.trim())
+				.forEach(prepareEmailString);
 		}
 
 		if (headerName === 'to' && !replyToSenderOnly) {


### PR DESCRIPTION
## Summary

This PR fixes Gmail reply handling when the `Reply-To` header contains multiple email addresses.

Previously, when the Reply-To header contained multiple email addresses, the entire header value was treated as a single email address instead of parsing each address individually. This resulted in malformed email addresses and caused the Gmail Reply operation to fail.

Previously, replying to an email with multiple addresses in the Reply-To header resulted in an error because the reply utility treated the entire header value as a single email address instead of parsing each address individually.

Example error:
<img width="1542" height="555" alt="image" src="https://github.com/user-attachments/assets/17c9fb5a-eeae-4272-baad-a858167a35de" />



### Changes

- Parse multiple email addresses from the `Reply-To` header individually.
- Preserve the existing email formatting and recipient filtering logic.
- Maintain backward compatibility with the existing `Reply-To` behavior.
- Add a unit test covering multiple `Reply-To` addresses.
- Verify that all existing `replyToEmail` unit tests continue to pass.

### Testing

- ✅ Added a unit test for multiple `Reply-To` addresses.
- ✅ All `replyToEmail` unit tests pass successfully (18/18).

## How to test

1. Configure a Gmail **Reply** node.
2. Use the message ID of an email whose `Reply-To` header contains multiple email addresses.
3. Execute the node.
4. Verify that the reply is addressed to all email addresses specified in the `Reply-To` header.

## Related Linear tickets, GitHub issues, and Community forum posts

Linear: https://linear.app/n8n/issue/GHC-8955

fixes #34221


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

