### PR TITLE
ci: Fix standalone release build filter quoting

### DIFF
--- a/.github/workflows/release-standalone-package.yml
+++ b/.github/workflows/release-standalone-package.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup and Build
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: 'pnpm turbo build --filter "...${{ github.event.inputs.package }}"'
+          build-command: 'pnpm turbo build --filter=...${{ github.event.inputs.package }}'
 
       - name: Pre publishing changes
         run: |


### PR DESCRIPTION
## Summary

Fix the `Release: Standalone Package` workflow, which fails at the "Setup and Build" step with:

```
x No package found with name '"...@n8n/scan-community-package"' in workspace
```

Note the stray double-quotes inside the package name. The workflow passes a quoted `--filter` value:

```yaml
build-command: 'pnpm turbo build --filter "...${{ github.event.inputs.package }}"'
```

The `setup-nodejs` action expands this command unquoted via an env var (`$BUILD_COMMAND --summarize`). Bash word-splits the expansion but does not perform quote removal on its result, so the literal `"` characters survive and get baked into the `--filter` argument turbo receives. Turbo then looks for a package whose name includes the quotes and finds nothing.

Switch to the `--filter=<value>` form and drop the redundant quotes. The package name comes from a fixed `choice` list (scoped npm names, no spaces or metacharacters), so the quotes were never load-bearing — `--filter=` avoids the space that unquoted splitting would otherwise break on.

## How to test

Run the `Release: Standalone Package` workflow on `master` with any of the 7 package choices (e.g. `@n8n/scan-community-package`). Before this change the "Setup and Build" step exits 1 at the turbo filter lookup; after it the build proceeds.

## Related Linear tickets, Github issues, and Community forum posts

- Failing run: https://github.com/n8n-io/n8n/actions/runs/29424058110/job/87381749567

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34297">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

