### PR TITLE
chore: Consolidate ts tooling catalog

### DIFF
--- a/packages/@n8n/db/package.json
+++ b/packages/@n8n/db/package.json
@@ -61,7 +61,6 @@
     "express": "catalog:",
     "testcontainers": "catalog:",
     "typescript": "catalog:",
-    "typescript6": "npm:@typescript/typescript6@6.0.2",
     "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:"

--- a/packages/@n8n/db/vite.config.ts
+++ b/packages/@n8n/db/vite.config.ts
@@ -1,9 +1,11 @@
 import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decorators';
 import fs from 'node:fs';
 import path from 'node:path';
-// Uses the legacy JS compiler via the `typescript6` alias: tsgo (typescript 7)
-// ships no programmatic API for this LanguageService-based entity transform.
-import ts from 'typescript6';
+// This LanguageService-based entity transform needs the real JS compiler API.
+// The package builds on TypeScript 6, so `typescript` resolves to it directly;
+// when it migrates to tsgo (TS7, no JS API) it should adopt the `typescript-tooling`
+// catalog so `typescript` keeps resolving to the TS6 API.
+import ts from 'typescript';
 import { mergeConfig, type Plugin } from 'vite';
 import { configDefaults } from 'vitest/config';
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -117,8 +117,8 @@
     "ts-essentials": "^7.0.3",
     "tsconfig-paths": "^4.2.0",
     "@vitest/coverage-v8": "catalog:",
-    "typescript": "catalog:typescript",
-    "typescript6": "npm:@typescript/typescript6@6.0.2",
+    "@typescript/native": "catalog:typescript-tooling",
+    "typescript": "catalog:typescript-tooling",
     "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:"

--- a/packages/cli/vitest.tsc-entity-transform.ts
+++ b/packages/cli/vitest.tsc-entity-transform.ts
@@ -1,8 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 // tsgo (typescript 7) ships no programmatic API, so this LanguageService-based
-// transform imports the legacy JS compiler via the `typescript6` alias.
-import ts from 'typescript6';
+// transform needs the real JS compiler. Under the `typescript-tooling` catalog
+// `typescript` resolves to the TS6 API (while `tsc` stays tsgo via @typescript/native).
+import ts from 'typescript';
 import type { Plugin } from 'vite';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2040,9 +2040,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
-      typescript6:
-        specifier: npm:@typescript/typescript6@6.0.2
-        version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
         version: 8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)
@@ -4002,7 +3999,7 @@ importers:
         version: 5.1.2
       '@qdrant/js-client-rest':
         specifier: 'catalog:'
-        version: 1.16.2(typescript@7.0.2)
+        version: 1.16.2(@typescript/typescript6@6.0.2)
       '@rudderstack/rudder-sdk-node':
         specifier: 'catalog:'
         version: 3.0.5
@@ -4400,6 +4397,9 @@ importers:
       '@types/yargs-parser':
         specifier: 21.0.0
         version: 21.0.0
+      '@typescript/native':
+        specifier: catalog:typescript-tooling
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -4447,15 +4447,12 @@ importers:
         version: 7.1.1
       ts-essentials:
         specifier: ^7.0.3
-        version: 7.0.3(typescript@7.0.2)
+        version: 7.0.3(@typescript/typescript6@6.0.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
       typescript:
-        specifier: catalog:typescript
-        version: 7.0.2
-      typescript6:
-        specifier: npm:@typescript/typescript6@6.0.2
+        specifier: catalog:typescript-tooling
         version: '@typescript/typescript6@6.0.2'
       vite:
         specifier: 'catalog:'
@@ -4465,7 +4462,7 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.28.1)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
       vitest-mock-extended:
         specifier: 'catalog:'
-        version: 3.1.0(typescript@7.0.2)(vitest@4.1.9)
+        version: 3.1.0(@typescript/typescript6@6.0.2)(vitest@4.1.9)
 
   packages/core:
     dependencies:
@@ -40180,9 +40177,9 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  ts-essentials@7.0.3(typescript@7.0.2):
+  ts-essentials@7.0.3(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 7.0.2
+      typescript: '@typescript/typescript6@6.0.2'
 
   ts-graphviz@2.1.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27494,12 +27494,6 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
       undici: 6.27.0
 
-  '@qdrant/js-client-rest@1.16.2(typescript@6.0.2)':
-    dependencies:
-      '@qdrant/openapi-typescript-fetch': 1.2.6
-      typescript: 6.0.2
-      undici: 6.27.0
-
   '@qdrant/js-client-rest@1.16.2(typescript@7.0.2)':
     dependencies:
       '@qdrant/openapi-typescript-fetch': 1.2.6

--- a/scripts/typescript-migration/README.md
+++ b/scripts/typescript-migration/README.md
@@ -48,6 +48,11 @@ resolves to the real TS 6 JS API that the tooling needs.
 - value-imports the `typescript` module for its API (`import ts from
   'typescript'`, `ts.createProgram`, …) — **not** type-only imports.
 
+First-party code in these packages must `import ts from 'typescript'` — the
+catalog points that specifier at the TS6 API. Do **not** add a separately-named
+alias dependency (e.g. `"typescript6": "npm:@typescript/typescript6@…"`); keep
+the single `typescript-tooling` convention so the 7.1 cleanup is one catalog flip.
+
 Currently on `typescript-tooling`: `@n8n/eslint-config`,
 `@n8n/eslint-plugin-community-nodes`, `@n8n/node-cli`, `@n8n/nodes-langchain`.
 

--- a/scripts/typescript-migration/SUMMARY.md
+++ b/scripts/typescript-migration/SUMMARY.md
@@ -1,6 +1,6 @@
 # TypeScript 6 → 7 migration benchmarks
 
-Generated 2026-07-16T08:22:55.276Z from `scripts/typescript-migration/results/`.
+Generated 2026-07-16T08:25:04.413Z from `scripts/typescript-migration/results/`.
 
 | Package | typecheck Δ | build Δ |
 | --- | --- | --- |

--- a/scripts/typescript-migration/SUMMARY.md
+++ b/scripts/typescript-migration/SUMMARY.md
@@ -1,6 +1,6 @@
 # TypeScript 6 → 7 migration benchmarks
 
-Generated 2026-07-16T06:54:52.709Z from `scripts/typescript-migration/results/`.
+Generated 2026-07-16T08:22:55.276Z from `scripts/typescript-migration/results/`.
 
 | Package | typecheck Δ | build Δ |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

In the [Typescript migration PR](https://github.com/n8n-io/n8n/pull/34228) we introduced a `typescript-tooling` catalog entry for packages that require the old TS6 compiler API entry as well as the new TS7 `tsc` executable. 

This new PR introduces this pattern to `cli` and `db` as those had their own custom pattern to consolidate the whole monorepo to use identical patterns.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

