### PR TITLE
fix(Gmail Node): Handle multi-address Reply-To in the reply operation

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.encode.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.encode.test.ts
@@ -1,0 +1,121 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import addressparser from 'nodemailer/lib/addressparser';
+import { mock } from 'vitest-mock-extended';
+
+import { googleApiRequest } from '../../GenericFunctions';
+import type * as genericFunctionsModule from '../../GenericFunctions';
+import type { GmailMessage, GmailMessageMetadata, GmailUserProfile } from '../../types';
+import { replyToEmail } from '../../utils/replyToEmail';
+
+// Only googleApiRequest is mocked here; encodeEmail runs for real so the derived
+// recipient string is exercised through nodemailer's MailComposer — the layer
+// where the multi-address Reply-To bug actually manifested.
+vi.mock('../../GenericFunctions', async () => ({
+	...(await vi.importActual<typeof genericFunctionsModule>('../../GenericFunctions')),
+	googleApiRequest: vi.fn(),
+}));
+
+const mockedGoogleApiRequest = vi.mocked(googleApiRequest);
+
+const mockUserProfile: GmailUserProfile = {
+	emailAddress: 'user@gmail.com',
+	messagesTotal: 100,
+	threadsTotal: 50,
+	historyId: 'history123',
+};
+
+const mockSentMessage: GmailMessage = {
+	id: 'sent123',
+	threadId: 'thread123',
+	labelIds: ['SENT'],
+	snippet: '',
+	historyId: 'history124',
+	sizeEstimate: 1000,
+	raw: '',
+	payload: {
+		partId: '',
+		mimeType: 'text/plain',
+		filename: '',
+		headers: [],
+		body: { attachmentId: '', size: 0, data: '' },
+		parts: [],
+	},
+};
+
+const buildMetadata = (replyTo: string): GmailMessageMetadata => ({
+	id: 'message123',
+	threadId: 'thread123',
+	labelIds: ['INBOX'],
+	payload: {
+		partId: '',
+		mimeType: 'text/plain',
+		filename: '',
+		headers: [
+			{ name: 'Subject', value: 'Original Subject' },
+			{ name: 'Message-ID', value: '<original@example.com>' },
+			{ name: 'From', value: 'John Doe <john@example.com>' },
+			{ name: 'To', value: 'recipient@example.com' },
+			{ name: 'Reply-To', value: replyTo },
+		],
+		body: { attachmentId: '', size: 0, data: '' },
+		parts: [],
+	},
+});
+
+// Decode the base64url `raw` payload and unfold folded header lines.
+const decodeToHeader = (raw: string): string => {
+	const mime = Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+		.toString('utf8')
+		.replace(/\r?\n[ \t]+/g, ' ');
+	return mime.match(/^To: (.+)$/m)?.[1] ?? '';
+};
+
+describe('replyToEmail — real encodeEmail round-trip', () => {
+	let mockExecuteFunctions: IExecuteFunctions;
+
+	beforeEach(() => {
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		vi.clearAllMocks();
+	});
+
+	test.each([
+		{
+			name: 'plain comma-separated addresses',
+			replyTo: 'jacob@example.com, charles@example.com',
+			expectedRecipients: ['jacob@example.com', 'charles@example.com'],
+		},
+		{
+			name: 'display name containing a comma',
+			replyTo: '"Doe, Jacob" <jacob@example.com>, charles@example.com',
+			expectedRecipients: ['jacob@example.com', 'charles@example.com'],
+		},
+	])(
+		'produces a valid multi-recipient To header: $name',
+		async ({ replyTo, expectedRecipients }) => {
+			mockedGoogleApiRequest
+				.mockResolvedValueOnce(buildMetadata(replyTo))
+				.mockResolvedValueOnce(mockUserProfile)
+				.mockResolvedValueOnce(mockSentMessage);
+
+			await replyToEmail.call(
+				mockExecuteFunctions,
+				'message123',
+				{ replyToSenderOnly: true },
+				0,
+				2.2,
+			);
+
+			const sendCall = mockedGoogleApiRequest.mock.calls.find(
+				(call) => call[1] === '/gmail/v1/users/me/messages/send',
+			);
+			const body = sendCall?.[2] as { raw: string };
+			const toHeader = decodeToHeader(body.raw);
+
+			// The two addresses must survive as distinct recipients, not a single
+			// malformed `"a, b"@domain` address (the reported bug).
+			expect(addressparser(toHeader, { flatten: true }).map((a) => a.address)).toEqual(
+				expectedRecipients,
+			);
+		},
+	);
+});

--- a/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
@@ -629,4 +629,161 @@ describe('replyToEmail', () => {
 			}),
 		);
 	});
+
+	const buildHeaders = ({
+		from = 'John Doe <john@example.com>',
+		to = 'recipient@example.com',
+		replyTo,
+	}: {
+		from?: string;
+		to?: string;
+		replyTo?: string;
+	}) => {
+		const headers = [
+			{ name: 'Subject', value: 'Original Subject' },
+			{ name: 'Message-ID', value: '<original@example.com>' },
+			{ name: 'From', value: from },
+			{ name: 'To', value: to },
+		];
+		if (replyTo !== undefined) headers.push({ name: 'Reply-To', value: replyTo });
+		return headers;
+	};
+
+	const runReply = async (
+		headers: Array<{ name: string; value: string }>,
+		options: IDataObject,
+	) => {
+		mockedGoogleApiRequest
+			.mockResolvedValueOnce({
+				...mockMessageMetadata,
+				payload: { ...mockMessageMetadata.payload, headers },
+			})
+			.mockResolvedValueOnce(mockUserProfile)
+			.mockResolvedValueOnce(mockSentMessage);
+		await replyToEmail.call(mockExecuteFunctions, 'message123', options, 0, 2.2);
+	};
+
+	// Address-list parsing for the derived recipient (`to`) string. The reply-to
+	// header is parsed per-address, so no case produces a malformed `<a, b>`
+	// recipient. `replyToSenderOnly` off appends the original To recipient, which
+	// is processed before Reply-To.
+	test.each([
+		{
+			name: 'single Reply-To, sender-only on',
+			headers: buildHeaders({ replyTo: 'jacob@example.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<jacob@example.com>',
+		},
+		{
+			name: 'single Reply-To, sender-only off',
+			headers: buildHeaders({ replyTo: 'jacob@example.com' }),
+			options: {},
+			expectedTo: '<recipient@example.com>, <jacob@example.com>',
+		},
+		{
+			name: 'two Reply-To addresses, sender-only on',
+			headers: buildHeaders({ replyTo: 'jacob@example.com, charles@example.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<jacob@example.com>, <charles@example.com>',
+		},
+		{
+			name: 'two Reply-To addresses, sender-only off',
+			headers: buildHeaders({ replyTo: 'jacob@example.com, charles@example.com' }),
+			options: {},
+			expectedTo: '<recipient@example.com>, <jacob@example.com>, <charles@example.com>',
+		},
+		{
+			name: 'comma-separated multi-address From (no Reply-To)',
+			headers: buildHeaders({ from: 'jacob@example.com, charles@example.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<jacob@example.com>, <charles@example.com>',
+		},
+		{
+			name: 'display name containing a comma',
+			headers: buildHeaders({ replyTo: '"Doe, Jacob" <jacob@example.com>, charles@example.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '"Doe, Jacob" <jacob@example.com>, <charles@example.com>',
+		},
+		{
+			name: 'trailing comma',
+			headers: buildHeaders({ replyTo: 'jacob@example.com,' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<jacob@example.com>',
+		},
+		{
+			name: 'mixed bracketed and plain addresses',
+			headers: buildHeaders({ replyTo: 'Jacob <jacob@example.com>, plain@example.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: 'Jacob <jacob@example.com>, <plain@example.com>',
+		},
+		{
+			name: 'empty Reply-To',
+			headers: buildHeaders({ replyTo: '' }),
+			options: {},
+			expectedTo: '<recipient@example.com>',
+		},
+		{
+			name: 'whitespace-only Reply-To',
+			headers: buildHeaders({ replyTo: '   ' }),
+			options: {},
+			expectedTo: '<recipient@example.com>',
+		},
+		{
+			name: 'name-only Reply-To (no address)',
+			headers: buildHeaders({ replyTo: '"No Address Here"' }),
+			options: {},
+			expectedTo: '<recipient@example.com>',
+		},
+		{
+			// Thread replies share this util and expose `replyToRecipientsOnly`.
+			name: 'replyToRecipientsOnly splits the To header (thread path)',
+			headers: buildHeaders({
+				to: '"Doe, Jane" <jane@example.com>, bob@example.com',
+				replyTo: undefined,
+			}),
+			options: { replyToRecipientsOnly: true },
+			expectedTo: '"Doe, Jane" <jane@example.com>, <bob@example.com>',
+		},
+		{
+			name: 'group-syntax address header',
+			headers: buildHeaders({ replyTo: 'Team:a@example.com,b@example.com;' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<a@example.com>, <b@example.com>',
+		},
+		{
+			// mockUserProfile.emailAddress is user@gmail.com. Self-reply keeps the
+			// sender rather than filtering it out (no empty recipient).
+			name: 'own address in Reply-To is kept on self-reply',
+			headers: buildHeaders({ replyTo: 'user@gmail.com' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '<user@gmail.com>',
+		},
+		{
+			name: 'own address in To is filtered case-insensitively',
+			headers: buildHeaders({
+				from: 'sender@example.com',
+				to: 'User@Gmail.com, other@example.com',
+			}),
+			options: { replyToRecipientsOnly: true },
+			expectedTo: '<other@example.com>',
+		},
+		{
+			name: 'display name with embedded quotes is escaped',
+			headers: buildHeaders({ replyTo: '"Jacob \\"J\\" Doe" <jacob@example.com>' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '"Jacob \\"J\\" Doe" <jacob@example.com>',
+		},
+		{
+			// Degenerate: sender-only skips the To header, so a Reply-To that parses
+			// to no address leaves an empty recipient list.
+			name: 'empty Reply-To with sender-only yields no recipient',
+			headers: buildHeaders({ replyTo: '' }),
+			options: { replyToSenderOnly: true },
+			expectedTo: '',
+		},
+	])('should build a clean recipient list: $name', async ({ headers, options, expectedTo }) => {
+		await runReply(headers, options);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(expect.objectContaining({ to: expectedTo }));
+	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
@@ -1,5 +1,6 @@
 import uniq from 'lodash/uniq';
 import { NodeOperationError, type IDataObject, type IExecuteFunctions } from 'n8n-workflow';
+import addressparser from 'nodemailer/lib/addressparser';
 
 import type { IEmail } from '@utils/sendAndWait/interfaces';
 
@@ -89,12 +90,16 @@ export async function replyToEmail(
 			? false
 			: (options.replyToRecipientsOnly as boolean);
 
-	const prepareEmailString = (email: string) => {
-		if (email.includes(emailAddress)) return;
-		if (email.includes('<') && email.includes('>')) {
-			to.push(email);
-		} else {
-			to.push(`<${email}>`);
+	// If the name contains an RFC 5322 special, wrap it in quotes and escape any
+	// embedded `"` or `\`; otherwise it can be used as-is.
+	const formatDisplayName = (name: string) =>
+		/["(),:;<>@[\]\\]/.test(name) ? `"${name.replace(/["\\]/g, '\\$&')}"` : name;
+
+	const addRecipients = (headerValue: string, excludeSelf: boolean) => {
+		for (const { address, name } of addressparser(headerValue, { flatten: true })) {
+			if (!address) continue;
+			if (excludeSelf && address.toLowerCase() === emailAddress.toLowerCase()) continue;
+			to.push(name ? `${formatDisplayName(name)} <${address}>` : `<${address}>`);
 		}
 	};
 
@@ -106,17 +111,11 @@ export async function replyToEmail(
 	for (const header of payload.headers) {
 		const headerName = (header.name || '').toLowerCase();
 		if (headerName === replyToHeaderName && !replyToRecipientsOnly) {
-			const replyToEmail = header.value;
-			if (replyToEmail.includes('<') && replyToEmail.includes('>')) {
-				to.push(replyToEmail);
-			} else {
-				to.push(`<${replyToEmail}>`);
-			}
+			addRecipients(header.value, false);
 		}
 
 		if (headerName === 'to' && !replyToSenderOnly) {
-			const toEmails = header.value;
-			toEmails.split(',').forEach(prepareEmailString);
+			addRecipients(header.value, true);
 		}
 	}
 


### PR DESCRIPTION
## Summary

The Gmail node's **Reply** operation wrapped the entire `Reply-To`/`From` header value in a single pair of angle brackets. When the original message's `Reply-To` (or `From`) header contained multiple comma-separated addresses, this produced one malformed recipient — e.g. `<jacob@example.com, charles@example.com>` — which nodemailer re-quoted into `'jacob@example.com, charles'@example.com` and mail servers rejected (`Invalid To header` / `501 Syntax error in recipient address`).

The recipient list is now parsed as a proper RFC 5322 address list using nodemailer's `addressparser` (already a transitive dependency, loaded on this path). Each address is emitted individually, display names are preserved and quoted when they contain special characters, and the sender's own address is excluded only from the To-recipient path (never from the reply target, so a self-reply still has a recipient). This replaces the previous naive comma-split, which also broke on display names containing commas (e.g. `"Doe, Jacob" <jacob@example.com>`).

This util is shared by both the **message** and **thread** reply operations, so both are fixed.

## How to test

Use below workflow and then send an email to your gmail account with `NODE-5480` in the subject (for it to be caught be the workflow). 
Then try different variants of reply-to, to, cc combinations. 
Also helpful: throwaway email inboxes like yopmail.com or byom.de

[NODE-5480 Email ReplyTo Multiple.json](https://github.com/user-attachments/files/30081146/NODE-5480.Email.ReplyTo.Multiple.json)


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5480

fixes #34221

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34312">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

