### PR TITLE
fix(editor): Refresh editor checksum on workflow deactivation while editing

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.test.ts
@@ -1,0 +1,126 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { mock } from 'vitest-mock-extended';
+import type { Router } from 'vue-router';
+import type { WorkflowAutoDeactivated } from '@n8n/api-types/push/workflow';
+import { workflowAutoDeactivated } from './workflowAutoDeactivated';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import type { PushHandlerOptions } from './types';
+
+const {
+	mockUiStore,
+	mockInitializeWorkspace,
+	mockFetchWorkflow,
+	mockSetWorkflowInactive,
+	mockPushBannerToStack,
+} = vi.hoisted(() => ({
+	mockUiStore: { stateIsDirty: true },
+	mockInitializeWorkspace: vi.fn(),
+	mockFetchWorkflow: vi.fn().mockResolvedValue({ checksum: 'abc' }),
+	mockSetWorkflowInactive: vi.fn(),
+	mockPushBannerToStack: vi.fn(),
+}));
+
+vi.mock('@/app/stores/ui.store', () => ({
+	useUIStore: () => mockUiStore,
+}));
+
+vi.mock('@/app/composables/useCanvasOperations', () => ({
+	useCanvasOperations: () => ({ initializeWorkspace: mockInitializeWorkspace }),
+}));
+
+vi.mock('@/app/stores/workflowsList.store', () => ({
+	useWorkflowsListStore: () => ({ fetchWorkflow: mockFetchWorkflow }),
+}));
+
+vi.mock('@/app/stores/workflows.store', () => ({
+	useWorkflowsStore: () => ({ setWorkflowInactive: mockSetWorkflowInactive }),
+}));
+
+vi.mock('@/features/shared/banners/banners.store', () => ({
+	useBannersStore: () => ({ pushBannerToStack: mockPushBannerToStack }),
+}));
+
+describe('workflowAutoDeactivated', () => {
+	const documentId = createWorkflowDocumentId('wf-123');
+	let options: PushHandlerOptions;
+	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
+
+	function makeEvent(workflowId = 'wf-123'): WorkflowAutoDeactivated {
+		return { type: 'workflowAutoDeactivated', data: { workflowId } };
+	}
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+		mockUiStore.stateIsDirty = true;
+		mockFetchWorkflow.mockResolvedValue({ checksum: 'abc' });
+		options = { router: mock<Router>(), documentId };
+		workflowDocumentStore = useWorkflowDocumentStore(documentId);
+	});
+
+	it('marks the workflow inactive in the workflows store', async () => {
+		await workflowAutoDeactivated(makeEvent(), options);
+
+		expect(mockSetWorkflowInactive).toHaveBeenCalledWith('wf-123');
+	});
+
+	it('pushes the auto-deactivated banner when viewing the workflow', async () => {
+		await workflowAutoDeactivated(makeEvent(), options);
+
+		expect(mockPushBannerToStack).toHaveBeenCalledWith('WORKFLOW_AUTO_DEACTIVATED');
+	});
+
+	it('does not fetch or push the banner for a different workflow', async () => {
+		await workflowAutoDeactivated(makeEvent('wf-other'), options);
+
+		expect(mockSetWorkflowInactive).toHaveBeenCalledWith('wf-other');
+		expect(mockFetchWorkflow).not.toHaveBeenCalled();
+		expect(mockPushBannerToStack).not.toHaveBeenCalled();
+	});
+
+	it('re-hydrates the workspace when there are no unsaved changes', async () => {
+		mockUiStore.stateIsDirty = false;
+		const updatedWorkflow = { id: 'wf-123', activeVersionId: null, checksum: 'fresh' };
+		mockFetchWorkflow.mockResolvedValue(updatedWorkflow);
+
+		await workflowAutoDeactivated(makeEvent(), options);
+
+		expect(mockInitializeWorkspace).toHaveBeenCalledWith(updatedWorkflow);
+	});
+
+	// Regression: INS-859 (deactivation sibling of the activation fix in #34095). An
+	// auto-deactivation (e.g. a trigger failing to re-register) also clears activeVersionId
+	// server-side, which is part of the conflict checksum (WORKFLOW_CHECKSUM_FIELDS in
+	// packages/workflow/src/workflow-checksum.ts). If it lands while the editor has unsaved
+	// edits, the stored `expectedChecksum` must be refreshed — otherwise the next autosave
+	// sends the pre-deactivation checksum and the backend rejects it with a false 409
+	// ("Workflow was changed by someone else"). The dirty branch used to null the active state
+	// without refreshing the checksum; this pins that gap.
+	it('refreshes the editor checksum on auto-deactivation even when there are unsaved changes', async () => {
+		// Editor holds the pre-deactivation checksum.
+		workflowDocumentStore.setChecksum('checksum-before-deactivate');
+
+		// User dragged a node → workspace is dirty, autosave pending.
+		mockUiStore.stateIsDirty = true;
+
+		// Auto-deactivation lands: server checksum now reflects the cleared activeVersionId.
+		mockFetchWorkflow.mockResolvedValue({
+			id: 'wf-123',
+			activeVersionId: null,
+			checksum: 'checksum-after-deactivate',
+		});
+
+		await workflowAutoDeactivated(makeEvent(), options);
+
+		// The stored expectedChecksum must be the post-deactivation value; otherwise the next
+		// autosave 409s with "Workflow was changed by someone else".
+		expect(workflowDocumentStore.checksum).toBe('checksum-after-deactivate');
+		// The in-progress edits must survive: reconcile the checksum, never re-hydrate.
+		expect(mockInitializeWorkspace).not.toHaveBeenCalled();
+		// The banner still fires after reconciling the checksum.
+		expect(mockPushBannerToStack).toHaveBeenCalledWith('WORKFLOW_AUTO_DEACTIVATED');
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -21,16 +21,20 @@ export async function workflowAutoDeactivated(
 	workflowsStore.setWorkflowInactive(data.workflowId);
 
 	if (workflowDocumentStore.workflowId === data.workflowId) {
-		// Only update workflow if there are no unsaved changes
-		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
-			if (!updatedWorkflow.checksum) {
-				throw new Error('Failed to fetch workflow');
-			}
+		const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to fetch workflow');
+		}
+
+		if (uiStore.stateIsDirty) {
+			// Unsaved changes in the editor: reflect the deactivation locally and refresh the
+			// expectedChecksum so the next save doesn't 409, but don't re-hydrate — that would
+			// discard the in-progress edits.
+			workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
+		} else {
 			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
-		} else {
-			workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
 		}
 
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.test.ts
@@ -86,4 +86,35 @@ describe('workflowDeactivated', () => {
 
 		expect(workflowDocumentStore.publicationStatus).toBe('partial');
 	});
+
+	// Regression: INS-859 (deactivation sibling of the activation fix in #34095).
+	// `activeVersionId` is part of the conflict checksum (WORKFLOW_CHECKSUM_FIELDS in
+	// packages/workflow/src/workflow-checksum.ts), so deactivating a published workflow changes
+	// its server-side checksum. When the deactivation lands while the editor has unsaved edits,
+	// the stored `expectedChecksum` must be refreshed — otherwise the next autosave sends the
+	// pre-deactivation checksum and the backend's `_detectConflicts` rejects it with a false 409
+	// ("Workflow was changed by someone else"). The dirty branch used to null the active state
+	// without refreshing the checksum; this pins that gap.
+	it('refreshes the editor checksum on deactivation even when there are unsaved changes', async () => {
+		// Editor holds the pre-deactivation checksum.
+		workflowDocumentStore.setChecksum('checksum-before-deactivate');
+
+		// User dragged a node → workspace is dirty, autosave pending.
+		mockUiStore.stateIsDirty = true;
+
+		// Deactivation lands: server checksum now reflects the cleared activeVersionId.
+		mockFetchWorkflow.mockResolvedValue({
+			id: 'wf-123',
+			activeVersionId: null,
+			checksum: 'checksum-after-deactivate',
+		});
+
+		await workflowDeactivated(makeEvent(), options);
+
+		// The stored expectedChecksum must be the post-deactivation value; otherwise the next
+		// autosave 409s with "Workflow was changed by someone else".
+		expect(workflowDocumentStore.checksum).toBe('checksum-after-deactivate');
+		// The in-progress edits must survive: reconcile the checksum, never re-hydrate.
+		expect(mockInitializeWorkspace).not.toHaveBeenCalled();
+	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -22,16 +22,20 @@ export async function workflowDeactivated(
 			workflowDocumentStore.setPublicationStatus({ status: 'idle' });
 		}
 
-		// Only update workflow if there are no unsaved changes
-		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
-			if (!updatedWorkflow.checksum) {
-				throw new Error('Failed to fetch workflow');
-			}
+		const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
+		if (!updatedWorkflow.checksum) {
+			throw new Error('Failed to fetch workflow');
+		}
+
+		if (uiStore.stateIsDirty) {
+			// Unsaved changes in the editor: reflect the deactivation locally and refresh the
+			// expectedChecksum so the next save doesn't 409, but don't re-hydrate — that would
+			// discard the in-progress edits.
+			workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
+			workflowDocumentStore.setChecksum(updatedWorkflow.checksum);
+		} else {
 			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
-		} else {
-			workflowDocumentStore.setActiveState({ activeVersionId: null, activeVersion: null });
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Sibling of #34095 (activation-path checksum reconciliation), on the **deactivation** path.

`activeVersionId` is part of the workflow conflict checksum (`WORKFLOW_CHECKSUM_FIELDS`), so (auto-)deactivating a published workflow changes its server-side checksum. Both deactivation push handlers — `workflowDeactivated` and `workflowAutoDeactivated` — refreshed the stored `expectedChecksum` only on the clean (non-dirty) path via a full re-hydrate. In the dirty branch they nulled the local active state but never refreshed the checksum.

Result: deactivating a published workflow while the user has **unsaved edits** left a stale `expectedChecksum`, so the next autosave 409'd with a false "Workflow was changed by someone else" — the same failure mode as INS-859, on the deactivation path.

This mirrors the merged activation fix: in the dirty branch of both handlers, reconcile the checksum with `setChecksum(updatedWorkflow.checksum)` **without** re-hydrating the workspace (re-hydrating would discard the in-progress edits — the whole point). Clean-state behaviour is unchanged.

## How to test

1. Open a published workflow in the editor.
2. Make an unsaved change (e.g. drag a node) so the workspace is dirty.
3. Have the workflow deactivate while you keep the editor open:
   - `workflowDeactivated` — unpublish the workflow (e.g. from another session).
   - `workflowAutoDeactivated` — a trigger fails to re-register, so the backend auto-deactivates it.
4. Continue editing so the next autosave fires.
5. **Before:** autosave 409s with "Workflow was changed by someone else". **After:** autosave succeeds and the in-progress edits are preserved (the editor is not re-hydrated).

Covered by unit regression tests for each handler. Each asserts the stored checksum is refreshed when the workspace is dirty (red before this change, green after) and that `initializeWorkspace` is **not** called so the edits survive — proven independently of the checksum assertion.

```
pnpm test workflowDeactivated workflowAutoDeactivated   # 10 passed (2 files)
pnpm typecheck                                          # clean
pnpm lint                                               # 0 errors
```

## Related Linear tickets, Github issues, and Community forum posts

Originating class: https://linear.app/n8n/issue/INS-859
Activation-path fix (sibling): #34095

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

