### PR TITLE
refactor(editor): Retire `rbac.store` shim, import from `@n8n/stores` directly (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
@@ -8,7 +8,7 @@ import { STORES } from '@n8n/stores';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import MainSidebarSourceControl from '@/app/components/MainSidebarSourceControl.vue';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { createComponentRenderer } from '@/__tests__/render';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.test.ts
@@ -9,7 +9,7 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import { getDropdownItems, mockedStore, type MockedStore } from '@/__tests__/utils';
 import { EnterpriseEditionFeature } from '@/app/constants';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import WorkflowSettingsVue from '@/app/components/WorkflowSettings/WorkflowSettings.vue';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -18,7 +18,7 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useNpsSurveyStore } from '@/app/stores/npsSurvey.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -7,7 +7,7 @@ import { RESOURCE_CENTER_EXPERIMENT } from '@/app/constants/experiments';
 import { setupServer } from '@/__tests__/server';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { usePostHog } from '@/app/stores/posthog.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import type { Scope } from '@n8n/permissions';
 import type { RouteRecordName } from 'vue-router';

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
@@ -1,6 +1,0 @@
-/**
- * @deprecated Import from `@n8n/stores/rbac.store` instead. This store moved to
- * `@n8n/stores` (CAT-3686 kernel slice); this re-export is a temporary shim kept
- * so existing importers keep working and will be removed once call sites migrate.
- */
-export * from '@n8n/stores/rbac.store';

--- a/packages/frontend/editor-ui/src/app/utils/rbac/checks/hasScope.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/checks/hasScope.test.ts
@@ -1,8 +1,8 @@
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { hasScope } from '@/app/utils/rbac/checks/hasScope';
 import type { ScopeOptions } from '@n8n/permissions';
 
-vi.mock('@/app/stores/rbac.store', () => ({
+vi.mock('@n8n/stores/rbac.store', () => ({
 	useRBACStore: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/app/utils/rbac/checks/hasScope.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/checks/hasScope.ts
@@ -1,4 +1,4 @@
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import type { RBACPermissionCheck, RBACPermissionOptions } from '@/app/types/rbac';
 
 export const hasScope: RBACPermissionCheck<RBACPermissionOptions> = (opts) => {

--- a/packages/frontend/editor-ui/src/app/utils/rbac/middleware/rbac.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/rbac/middleware/rbac.test.ts
@@ -1,4 +1,4 @@
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { rbacMiddleware } from '@/app/utils/rbac/middleware/rbac';
 import { VIEWS } from '@/app/constants';
 import {
@@ -9,7 +9,7 @@ import {
 import type { RouteLocationNormalized } from 'vue-router';
 import type { Scope } from '@n8n/permissions';
 
-vi.mock('@/app/stores/rbac.store', () => ({
+vi.mock('@n8n/stores/rbac.store', () => ({
 	useRBACStore: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.test.ts
@@ -10,7 +10,7 @@ import { useProjectsStore } from '../projects.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { ROLE } from '@n8n/api-types';
 import { SECRETS_PROVIDER_CONNECTION_MODAL_KEY } from '@/app/constants';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 // Mock vue-router
 const mockRouterPush = vi.fn();

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectExternalSecrets.vue
@@ -22,7 +22,7 @@ import {
 } from '@n8n/design-system';
 import type { TableHeader } from '@n8n/design-system/components/N8nDataTableServer';
 import { useSecretsProviderConnection } from '@/features/integrations/secretsProviders.ee/composables/useSecretsProviderConnection.ee';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 const i18n = useI18n();
 const toast = useToast();

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.test.ts
@@ -19,7 +19,7 @@ import { createUser } from '@/__tests__/data/users';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRolesStore } from '@/app/stores/roles.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import type { FrontendSettings } from '@n8n/api-types';
 
 const mockTrack = vi.fn();

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.test.ts
@@ -58,7 +58,7 @@ const mockRBACStore = {
 	hasScope: vi.fn(() => true), // Default: has permission
 };
 
-vi.mock('@/app/stores/rbac.store', () => ({
+vi.mock('@n8n/stores/rbac.store', () => ({
 	useRBACStore: vi.fn(() => mockRBACStore),
 }));
 

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
@@ -5,7 +5,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import * as externalSecretsApi from '@n8n/rest-api-client';
 import { connectProvider } from '@n8n/rest-api-client';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { ExternalSecretsProvider } from '@n8n/api-types';
 

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.ee.vue
@@ -13,7 +13,7 @@ import type { SecretProviderConnection, SecretProviderTypeResponse } from '@n8n/
 import { DateTime } from 'luxon';
 import { isDateObject } from '@/app/utils/typeGuards';
 import { useI18n } from '@n8n/i18n';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import ProjectIcon from '@/features/collaboration/projects/components/ProjectIcon.vue';
 import { splitName } from '@/features/collaboration/projects/projects.utils';

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/components/SecretsProviderConnectionCard.test.ts
@@ -5,7 +5,7 @@ import SecretsProviderConnectionCard from './SecretsProviderConnectionCard.ee.vu
 import type { SecretProviderConnection, SecretProviderTypeResponse } from '@n8n/api-types';
 import { DateTime } from 'luxon';
 import { createTestingPinia } from '@pinia/testing';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 export const MOCK_PROVIDER_TYPES: SecretProviderTypeResponse[] = [
 	{

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.test.ts
@@ -26,7 +26,7 @@ vi.mock('./useSecretsProviderConnection.ee', () => ({
 	useSecretsProviderConnection: () => mockConnection,
 }));
 
-vi.mock('@/app/stores/rbac.store', () => ({
+vi.mock('@n8n/stores/rbac.store', () => ({
 	useRBACStore: vi.fn(() => ({
 		hasScope: mockHasScope,
 	})),

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useConnectionModal.ee.ts
@@ -7,7 +7,7 @@ import {
 import type { IUpdateInformation } from '@/Interface';
 import type { INodeProperties } from 'n8n-workflow';
 import { useSecretsProviderConnection } from './useSecretsProviderConnection.ee';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useToast } from '@/app/composables/useToast';
 import { i18n } from '@n8n/i18n';
 import type { Scope } from '@n8n/permissions';

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.test.ts
@@ -2,7 +2,7 @@ import { createTestingPinia } from '@pinia/testing';
 import merge from 'lodash/merge';
 import { useSecretsProvidersList } from './useSecretsProvidersList.ee';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { EnterpriseEditionFeature } from '@/app/constants';
 import type { SecretProviderConnection, SecretProviderTypeResponse } from '@n8n/api-types';
 import * as secretsProviderApi from '@n8n/rest-api-client';

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/composables/useSecretsProvidersList.ee.ts
@@ -3,7 +3,7 @@ import type { SecretProviderConnection, SecretProviderTypeResponse } from '@n8n/
 import { EnterpriseEditionFeature } from '@/app/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import * as secretsProviderApi from '@n8n/rest-api-client';
 
 export function useSecretsProvidersList() {

--- a/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/secretsProviders.ee/views/SettingsSecretsProviders.test.ts
@@ -8,7 +8,7 @@ import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
 import SettingsSecretsProviders from './SettingsSecretsProviders.ee.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { setupServer } from '@/__tests__/server';
 import { computed, ref } from 'vue';
 import type { SecretProviderConnection } from '@n8n/api-types';

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.test.ts
@@ -1,6 +1,6 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { mockedStore, type MockedStore } from '@/__tests__/utils';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
 import RolesView from './RolesView.vue';

--- a/packages/frontend/editor-ui/src/features/roles/RolesView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/RolesView.vue
@@ -12,7 +12,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import InstanceRolesView from './instance/InstanceRolesView.vue';
 import ProjectRolesView from './project/ProjectRolesView.vue';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 type RolesTab = 'instance' | 'project';
 const DEFAULT_TAB: RolesTab = 'instance';

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
@@ -14,7 +14,7 @@ import { API_KEY_CREATE_OR_EDIT_MODAL_KEY } from '../apiKeys.constants';
 import { DateTime } from 'luxon';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import type { ApiKey, ApiKeyOwner, ApiKeyOwnerSummary } from '@n8n/api-types';

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
@@ -8,7 +8,7 @@ import { DEBOUNCE_TIME, getDebounceTime } from '@/app/constants/durations';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useCloudPlanStore } from '@/app/stores/cloudPlan.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { DOCS_DOMAIN } from '@/app/constants';
 import { API_KEY_CREATE_OR_EDIT_MODAL_KEY } from '../apiKeys.constants';
 import { useI18n } from '@n8n/i18n';

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/RoleMappingRuleEditor.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/RoleMappingRuleEditor.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted } from 'vue';
 import { N8nButton } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 import { useRolesStore } from '@/app/stores/roles.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useRoleMappingRules } from '../composables/useRoleMappingRules';

--- a/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/UserRoleProvisioningDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/settings/sso/provisioning/components/UserRoleProvisioningDropdown.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue';
 import { N8nCallout, N8nOption, N8nSelect } from '@n8n/design-system';
 import { useI18n, type BaseTextKey } from '@n8n/i18n';
 import { type SupportedProtocolType } from '../../sso.store';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 export type RoleAssignmentSetting = 'manual' | 'instance' | 'instance_and_project';
 export type RoleMappingMethodSetting = 'idp' | 'rules_in_n8n';

--- a/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/usage/views/SettingsUsageAndPlan.test.ts
@@ -10,7 +10,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import type { IUser } from '@n8n/rest-api-client/api/users';
 import { useToast } from '@/app/composables/useToast';
 import { waitFor } from '@testing-library/vue';
-import { useRBACStore } from '@/app/stores/rbac.store';
+import { useRBACStore } from '@n8n/stores/rbac.store';
 
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: vi.fn(),


### PR DESCRIPTION
## Summary

Retires the temporary `rbac.store` re-export shim introduced by the CAT-3686 kernel slice (#34141). All editor-ui consumers now import `useRBACStore` directly from `@n8n/stores/rbac.store`, and the shim at `packages/frontend/editor-ui/src/app/stores/rbac.store.ts` is deleted.

This is the **consumer-retirement prover** for the kernel-slice modularization: codemod importers → delete shim → let the production build prove the `@n8n/stores/rbac.store` dist subpath resolves. The pattern here is the template for retiring the later kernel-slice shims.

**Changes — import-path relocation only, no behavior change:**
- Rewrote 24 `import … from '@/app/stores/rbac.store'` specifiers to `'@n8n/stores/rbac.store'`.
- Updated 4 `vi.mock('@/app/stores/rbac.store', …)` paths to the new specifier so the affected suites still intercept the store (2 in files already covered by the import rewrite, 2 mock-only test files). Without this, those mocks would register against the deleted path and the real store would load.
- Deleted the shim `packages/frontend/editor-ui/src/app/stores/rbac.store.ts`.

Net: 27 files (26 modified, 1 deleted).

## How to test

Import-path-only change — no runtime behavior change, no env var / license / feature flag needed. Verified locally against `master` (`c5c5b3ea78`):

- `grep -rlE "from ['\"]@/app/stores/rbac\.store['\"]" packages/frontend/editor-ui/src` → **0 results** (old shim path fully retired).
- `pnpm --filter n8n-editor-ui typecheck` → green.
- `pnpm --filter n8n-editor-ui build` → green (`✓ built in ~7s`). This is the load-bearing check: it proves `@n8n/stores/rbac.store` resolves against `dist` via the `"./*"` wildcard export, not just the dev `src` alias.
- `pnpm --filter n8n-editor-ui test` → **973 files, 13461 passed + 2 todo, 0 failed** (includes the 4 remapped `vi.mock` suites).
- `eslint` on the changed source files → 0 errors.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3686

Follow-up to #34141 (rbac.store moved into `@n8n/stores` behind the shim); depends only on that PR, which is merged to master.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- N/A: internal import-path relocation, no docs surface -->
- [x] Tests included. <!-- No new tests — pure import-path relocation; existing suites are the coverage and are all green. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34316">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

