### PR TITLE
fix(core): Normalize AWS header values before signing

### DIFF
--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -693,9 +693,10 @@ export function buildSmithyHttpRequest(
 
 	// Drop host; smithy derives it from hostname.
 	const headers: Record<string, string> = { host: signOpts.host ?? hostname };
-	for (const [k, v] of Object.entries((signOpts.headers ?? {}) as Record<string, string>)) {
+	for (const [k, v] of Object.entries((signOpts.headers ?? {}) as Record<string, unknown>)) {
 		const lower = k.toLowerCase();
-		if (lower !== 'host') headers[lower] = v;
+		// Header values can originate from IDataObject as numbers, for example S3 multipart lengths.
+		if (lower !== 'host' && v != null) headers[lower] = String(v);
 	}
 
 	// aws4 defaults the Content-Type to 'application/x-www-form-urlencoded; charset=utf-8'

--- a/packages/nodes-base/credentials/test/Aws.signing.test.ts
+++ b/packages/nodes-base/credentials/test/Aws.signing.test.ts
@@ -211,6 +211,26 @@ describe('AWS signing (integration, real signer)', () => {
 		expect(result.body).toBe(buf);
 	});
 
+	it('normalizes numeric headers before signing an S3 multipart upload part', async () => {
+		const buf = Buffer.from('binary content');
+		const result = await aws.authenticate(credentials, {
+			...baseRequest,
+			method: 'PUT',
+			body: buf,
+			headers: { 'Content-Length': buf.length },
+			qs: {
+				service: 's3',
+				path: '/my-bucket/binary.json?partNumber=1&uploadId=test-upload',
+			},
+		});
+
+		const headers = result.headers as Record<string, string>;
+		const authorization = headers.authorization ?? headers.Authorization;
+
+		expect(headers['content-length']).toBe(String(buf.length));
+		expect(signedHeadersFrom(authorization)).toContain('content-length');
+	});
+
 	describe('SES email endpoints', () => {
 		// SES endpoints are `email.<region>.amazonaws.com` but sign under `ses`
 		// (botocore: endpointPrefix 'email', signingName 'ses'). aws4 remapped this


### PR DESCRIPTION
## Summary

- Normalize non-null AWS request header values to strings before passing them to the Smithy signer.
- Preserve the coercion behavior of the legacy `aws4` path for numeric headers such as multipart S3 `Content-Length`.
- Add a regression test using the real signer with an S3 multipart PUT and an explicit numeric header.

Before this change, a valid numeric header could reach `@smithy/signature-v4`, which canonicalizes
headers with `.trim()` and throws before the request is sent.

## How to test

```bash
pnpm agent:setup build

pushd packages/nodes-base
pnpm test credentials/test/Aws.signing.test.ts
pnpm typecheck
NODE_OPTIONS=--max-old-space-size=8192 pnpm exec eslint \
  credentials/common/aws/utils.ts \
  credentials/test/Aws.signing.test.ts \
  --quiet
popd
```

The targeted signing suite passes 24 tests, including the new numeric `Content-Length` case.

## Related Linear tickets, Github issues, and Community forum posts

- Regression introduced by #33304.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] No documentation update is required; this restores the existing AWS signing contract.
- [x] Tests included.
- [ ] Backport labeling left to the maintainers.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

