### PR TITLE
fix(core): Conform eval mock output to declared structured-output schema (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/eval/__tests__/llm-completion-mock.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/llm-completion-mock.test.ts
@@ -102,6 +102,20 @@ function chatRequest(body: unknown): IHttpRequestOptions {
 	} as unknown as IHttpRequestOptions;
 }
 
+function responsesRequest(body: unknown): IHttpRequestOptions {
+	return {
+		url: 'http://127.0.0.1/eval/My%20Agent/v1/responses',
+		method: 'POST',
+		body,
+	} as unknown as IHttpRequestOptions;
+}
+
+const strictSchema = {
+	type: 'object',
+	properties: { category: { type: 'string' } },
+	additionalProperties: false,
+};
+
 beforeEach(() => {
 	submitQueue.length = 0;
 	submitCapture.handler = undefined;
@@ -257,5 +271,55 @@ describe('createLlmCompletionMockHandler', () => {
 		expect(promptCapture.prompt).toContain('fetch_data');
 		expect(promptCapture.prompt).toContain('analyze this');
 		expect(promptCapture.prompt).toContain('Tool results ARE present');
+	});
+
+	it('conforms final content to a declared structured-output schema (drops undeclared fields)', async () => {
+		submitQueue.push({ kind: 'final', content: '{"category":"bug","subject":"extra"}' });
+		const handler = createLlmCompletionMockHandler();
+
+		const res = await handler(
+			responsesRequest({
+				input: [{ role: 'user', content: 'classify this' }],
+				text: { format: { type: 'json_schema', name: 'c', schema: strictSchema } },
+			}),
+			node,
+		);
+
+		expect(res?.body).toEqual({ content: '{"category":"bug"}' });
+	});
+
+	it('injects the declared structured-output schema into the mock prompt', async () => {
+		submitQueue.push({ kind: 'final', content: '{}' });
+		const handler = createLlmCompletionMockHandler();
+
+		await handler(
+			responsesRequest({
+				input: [{ role: 'user', content: 'classify this' }],
+				text: {
+					format: {
+						type: 'json_schema',
+						name: 'c',
+						schema: {
+							type: 'object',
+							properties: { client_project: { type: 'boolean' }, ignore: { type: 'boolean' } },
+							additionalProperties: false,
+						},
+					},
+				},
+			}),
+			node,
+		);
+
+		expect(promptCapture.prompt).toContain('client_project');
+		expect(promptCapture.prompt?.toLowerCase()).toContain('schema');
+	});
+
+	it('leaves final content unchanged when the request declares no schema', async () => {
+		submitQueue.push({ kind: 'final', content: '{"category":"bug","subject":"kept"}' });
+		const handler = createLlmCompletionMockHandler();
+
+		const res = await handler(responsesRequest({ input: [{ role: 'user', content: 'hi' }] }), node);
+
+		expect(res?.body).toEqual({ content: '{"category":"bug","subject":"kept"}' });
 	});
 });

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/structured-output-conformance.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/structured-output-conformance.test.ts
@@ -1,0 +1,138 @@
+import {
+	discoverStructuredOutputSchema,
+	conformContentToSchema,
+	applyStructuredOutputConformance,
+} from '../structured-output-conformance';
+
+const strict = (properties: Record<string, unknown>) => ({
+	type: 'object',
+	properties,
+	additionalProperties: false,
+});
+
+/** Parse JSON, tolerating a ```json fenced code block. */
+function parseMaybeFenced(text: string): unknown {
+	const fence = /```(?:json)?\s*([\s\S]*?)```/i.exec(text);
+	return JSON.parse(fence ? fence[1].trim() : text);
+}
+
+describe('conformContentToSchema', () => {
+	it('drops a field the strict schema does not declare', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const out = conformContentToSchema('{"category":"bug","subject":"extra"}', schema);
+		expect(parseMaybeFenced(out)).toEqual({ category: 'bug' });
+	});
+
+	it('unwraps a stray single-key wrapper the schema does not declare', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const out = conformContentToSchema('{"output":{"category":"bug"}}', schema);
+		expect(parseMaybeFenced(out)).toEqual({ category: 'bug' });
+	});
+
+	it('preserves a wrapper key the schema DOES declare (standalone parser) and prunes inside it', () => {
+		const schema = strict({
+			__structured__output: strict({ answer: { type: 'string' } }),
+		});
+		const out = conformContentToSchema(
+			'{"__structured__output":{"answer":"yes","stray":1}}',
+			schema,
+		);
+		expect(parseMaybeFenced(out)).toEqual({ __structured__output: { answer: 'yes' } });
+	});
+
+	it('prunes recursively inside nested strict objects', () => {
+		const schema = strict({
+			person: strict({ name: { type: 'string' } }),
+		});
+		const out = conformContentToSchema('{"person":{"name":"Ada","age":30},"junk":true}', schema);
+		expect(parseMaybeFenced(out)).toEqual({ person: { name: 'Ada' } });
+	});
+
+	it('prunes items of an array property against the array item schema', () => {
+		const schema = strict({
+			rows: { type: 'array', items: strict({ id: { type: 'number' } }) },
+		});
+		const out = conformContentToSchema('{"rows":[{"id":1,"x":"a"},{"id":2,"x":"b"}]}', schema);
+		expect(parseMaybeFenced(out)).toEqual({ rows: [{ id: 1 }, { id: 2 }] });
+	});
+
+	it('leaves extra keys intact when the schema is not strict', () => {
+		const schema = { type: 'object', properties: { category: { type: 'string' } } };
+		const out = conformContentToSchema('{"category":"bug","subject":"kept"}', schema);
+		expect(parseMaybeFenced(out)).toEqual({ category: 'bug', subject: 'kept' });
+	});
+
+	it('re-wraps in a ```json code block when the input content was fenced', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const out = conformContentToSchema('```json\n{"category":"bug","subject":"x"}\n```', schema);
+		expect(out.trimStart().startsWith('```json')).toBe(true);
+		expect(parseMaybeFenced(out)).toEqual({ category: 'bug' });
+	});
+
+	it('returns content unchanged when no schema is provided', () => {
+		expect(conformContentToSchema('{"category":"bug","subject":"x"}', undefined)).toBe(
+			'{"category":"bug","subject":"x"}',
+		);
+	});
+
+	it('returns content unchanged when it is not JSON', () => {
+		const schema = strict({ category: { type: 'string' } });
+		expect(conformContentToSchema('just a plain answer', schema)).toBe('just a plain answer');
+	});
+});
+
+describe('discoverStructuredOutputSchema', () => {
+	it('reads the native Responses API schema at text.format.schema', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const body = { text: { format: { type: 'json_schema', name: 'x', schema } } };
+		expect(discoverStructuredOutputSchema(body)).toEqual(schema);
+	});
+
+	it('reads the native chat-completions schema at response_format.json_schema.schema', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const body = { response_format: { type: 'json_schema', json_schema: { name: 'x', schema } } };
+		expect(discoverStructuredOutputSchema(body)).toEqual(schema);
+	});
+
+	it('parses a fenced JSON-Schema block out of format_instructions in input[]', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const instructions = [
+			'You must format your output as a JSON value that adheres to the given "JSON Schema".',
+			'Here is the JSON Schema instance your output must adhere to. Include the enclosing markdown codeblock:',
+			'```json',
+			JSON.stringify(schema),
+			'```',
+		].join('\n');
+		const body = { input: [{ role: 'user', content: instructions }] };
+		expect(discoverStructuredOutputSchema(body)).toEqual(schema);
+	});
+
+	it('returns undefined when no schema is present anywhere', () => {
+		expect(
+			discoverStructuredOutputSchema({ input: [{ role: 'user', content: 'hi' }] }),
+		).toBeUndefined();
+	});
+
+	it('ignores a fenced json block that is not a JSON Schema', () => {
+		const body = {
+			input: [{ role: 'user', content: '```json\n{"just":"data","no":"schema"}\n```' }],
+		};
+		expect(discoverStructuredOutputSchema(body)).toBeUndefined();
+	});
+});
+
+describe('applyStructuredOutputConformance', () => {
+	it('discovers the schema from the body and conforms the content', () => {
+		const schema = strict({ category: { type: 'string' } });
+		const body = { text: { format: { type: 'json_schema', schema } } };
+		const out = applyStructuredOutputConformance('{"category":"bug","subject":"x"}', body);
+		expect(parseMaybeFenced(out)).toEqual({ category: 'bug' });
+	});
+
+	it('leaves content unchanged when the body declares no schema', () => {
+		const out = applyStructuredOutputConformance('{"a":1,"b":2}', {
+			input: [{ role: 'user', content: 'no schema here' }],
+		});
+		expect(out).toBe('{"a":1,"b":2}');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/llm-completion-mock.ts
+++ b/packages/cli/src/modules/instance-ai/eval/llm-completion-mock.ts
@@ -11,6 +11,11 @@ import { createEvalAgent, extractText, Tool } from '@n8n/instance-ai';
 import type { EvalLlmMockHandler, EvalMockHttpResponse } from 'n8n-core';
 import { z } from 'zod';
 
+import {
+	conformContentToSchema,
+	discoverStructuredOutputSchema,
+} from './structured-output-conformance';
+
 const COMPLETION_MOCK_PROMPT = `You simulate ONE response from the LLM that powers an AI agent inside an n8n workflow under evaluation. The agent runs a tool-calling loop and calls you once per turn. Decide the agent's NEXT step and submit it via submit_agent_step.
 
 This is a MOCK whose only purpose is to exercise the workflow's wiring and data flow — NOT to produce a realistic deliverable. Keep everything MINIMAL and schema-valid. Never write long documents, full HTML pages, or essays; a short stub string that satisfies the schema is ideal.
@@ -25,7 +30,7 @@ Rules:
 - kind="tool_call": set toolName to one of the available tools and toolArguments to an object matching THAT tool's input schema EXACTLY (same keys, nesting, and types). Use the SMALLEST valid value for every field — a one-line string, a single-element array — never a long document.
 - kind="final": set content to a short final answer string. Two structured-output cases override this:
   - If a structured-output / "format final response" style tool is available, NEVER finalize with plain content — call that tool with schema-valid arguments instead.
-  - Only when NO such tool exists but the conversation carries structured-output format instructions (a JSON schema the reply must match, often demanding a \`\`\`json code block and/or an "output" wrapper key): content MUST be exactly that JSON — every required field present, exact key names and wrapper, correct types (a numeric field gets a number like 42, never a descriptive string like "about 42" or "below the 42 threshold"). Keep-it-minimal applies to field VALUES only — never drop fields, the wrapper, or the code block.
+  - Only when NO such tool exists but the conversation carries structured-output format instructions (a JSON schema the reply must match): content MUST be exactly JSON that satisfies THAT schema — every declared field present, exact key names, correct types (a numeric field gets a number like 42, never a descriptive string like "about 42" or "below the 42 threshold"). Do NOT add fields the schema does not declare, and do NOT wrap the object in an extra key unless the schema itself declares that wrapper (some parsers require a specific top-level key such as "__structured__output" — include it only when the schema shows it). Reproduce a \`\`\`json code block only if the instructions show one. Keep-it-minimal applies to field VALUES only — never drop declared fields.
 - content is ONLY the assistant's answer (plain text, or the structured JSON). NEVER wrap it in a provider API envelope — no chat.completion/response object, no "choices"/"output"/"id"/"object" keys. The harness adds the wire envelope.
 - Call exactly ONE tool per step. Never fabricate a whole multi-step result in a single turn.
 - If the scenario, node hint, or data context states a specific value, reproduce it; otherwise keep values minimal.`;
@@ -155,6 +160,7 @@ function buildUserPrompt(
 	summary: ConversationSummary,
 	options: LlmCompletionMockOptions | undefined,
 	nodeHint: string | undefined,
+	outputSchema: Record<string, unknown> | undefined,
 ): string {
 	const toolList =
 		tools
@@ -176,6 +182,18 @@ function buildUserPrompt(
 			? 'Tool results ARE present — you likely have enough to finalize.'
 			: 'No tool results yet — advance the loop by calling a non-final tool unless none exist.',
 	];
+	// When the request declares a structured-output schema, hand it to the mock
+	// verbatim so it emits the exact keys/types (not a paraphrased "category"
+	// string). This is what steers e.g. a Text Classifier's boolean-per-category
+	// output; the conformance pass then guarantees no extra keys survive.
+	if (outputSchema) {
+		sections.push(
+			'',
+			'## Required structured output',
+			'Your final `content` MUST be JSON matching this schema EXACTLY — include every declared property with the correct type, add no extra keys, and do not wrap it in another object unless the schema itself declares that wrapper:',
+			JSON.stringify(outputSchema),
+		);
+	}
 	if (options?.globalContext) sections.push('', '## Data context', options.globalContext);
 	if (nodeHint) sections.push('', '## Node hint', nodeHint);
 	if (options?.scenarioHints) sections.push('', '## Scenario', options.scenarioHints);
@@ -237,7 +255,14 @@ export function createLlmCompletionMockHandler(
 		const body = requestOptions.body;
 		const tools = extractTools(body);
 		const summary = summarizeConversation(body);
-		const userPrompt = buildUserPrompt(tools, summary, options, options?.nodeHints?.[node.name]);
+		const outputSchema = discoverStructuredOutputSchema(body);
+		const userPrompt = buildUserPrompt(
+			tools,
+			summary,
+			options,
+			options?.nodeHints?.[node.name],
+			outputSchema,
+		);
 
 		const capture: CompletionStep = {};
 		const agent = createEvalAgent('eval-llm-completion-mock', {
@@ -279,7 +304,15 @@ export function createLlmCompletionMockHandler(
 				tool_calls: [{ name: capture.toolName, arguments: capture.toolArguments ?? {} }],
 			};
 		} else if (capture.kind === 'final') {
-			responseBody = { content: unwrapProviderEnvelope(capture.content ?? '') };
+			// Unwrap a stray provider envelope, then conform to any structured-output
+			// schema the request declared (drops invented fields / stray wrappers that
+			// would fail the node's `additionalProperties: false` parser).
+			responseBody = {
+				content: conformContentToSchema(
+					unwrapProviderEnvelope(capture.content ?? ''),
+					outputSchema,
+				),
+			};
 		} else {
 			// Agent never submitted — fall back to its raw text so the turn isn't empty.
 			const fallback = extractText(result).trim();
@@ -287,7 +320,9 @@ export function createLlmCompletionMockHandler(
 				`[EvalMock] llm-completion-mock produced no submit_agent_step for "${node.name}"; using raw text fallback`,
 			);
 			responseBody = {
-				content: unwrapProviderEnvelope(fallback) || '[eval completion-mock: empty response]',
+				content:
+					conformContentToSchema(unwrapProviderEnvelope(fallback), outputSchema) ||
+					'[eval completion-mock: empty response]',
 			};
 		}
 

--- a/packages/cli/src/modules/instance-ai/eval/structured-output-conformance.ts
+++ b/packages/cli/src/modules/instance-ai/eval/structured-output-conformance.ts
@@ -1,0 +1,174 @@
+/**
+ * Coerce an eval mock's structured-output content to the schema the workflow
+ * node declared.
+ *
+ * Information Extractor / Text Classifier nodes declare a strict JSON Schema
+ * (`additionalProperties: false`, fixed properties) and deliver it to the model
+ * as prompt text (LangChain `StructuredOutputParser` format instructions), so
+ * the mock LLM can invent extra fields or a stray wrapper key that the node then
+ * rejects with "Model output doesn't fit required format". A real OpenAI
+ * structured-output response conforms to the schema; this makes the mock do the
+ * same by pruning the generated content to the declared shape.
+ *
+ * Every step degrades to a no-op on anything unexpected (no schema found,
+ * non-JSON content, unparseable instructions), so the common no-schema path is
+ * never disturbed.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A parsed JSON value is treated as a schema only if it carries schema markers. */
+function looksLikeJsonSchema(value: unknown): value is Record<string, unknown> {
+	return (
+		isRecord(value) &&
+		('properties' in value || 'additionalProperties' in value || value.type === 'object')
+	);
+}
+
+/** Flatten a message `content` field (string or content-part array) to text. */
+function contentToText(content: unknown): string {
+	if (typeof content === 'string') return content;
+	if (Array.isArray(content)) {
+		return content
+			.map((part) =>
+				typeof part === 'string'
+					? part
+					: isRecord(part) && typeof part.text === 'string'
+						? part.text
+						: '',
+			)
+			.join('\n');
+	}
+	return '';
+}
+
+const FENCED_JSON = /```(?:json)?\s*([\s\S]*?)```/gi;
+
+/**
+ * Find the structured-output JSON Schema a `/v1/responses` or chat-completions
+ * request declares, from any of: native Responses `text.format.schema`, native
+ * chat `response_format.json_schema.schema`, or a fenced ```json``` schema block
+ * embedded in the conversation as StructuredOutputParser format instructions.
+ * Returns undefined when none is present.
+ */
+export function discoverStructuredOutputSchema(body: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(body)) return undefined;
+
+	// (1) native Responses API — text.format.schema
+	const text = body.text;
+	if (isRecord(text) && isRecord(text.format) && looksLikeJsonSchema(text.format.schema)) {
+		return text.format.schema;
+	}
+
+	// (2) native chat-completions — response_format.json_schema.schema
+	const responseFormat = body.response_format;
+	if (
+		isRecord(responseFormat) &&
+		isRecord(responseFormat.json_schema) &&
+		looksLikeJsonSchema(responseFormat.json_schema.schema)
+	) {
+		return responseFormat.json_schema.schema;
+	}
+
+	// (3) format-instructions prose — the last fenced ```json``` block that is a schema
+	const items = Array.isArray(body.input)
+		? body.input
+		: Array.isArray(body.messages)
+			? body.messages
+			: [];
+	let found: Record<string, unknown> | undefined;
+	for (const item of items) {
+		if (!isRecord(item)) continue;
+		const itemText = contentToText(item.content);
+		if (!itemText.includes('```')) continue;
+		FENCED_JSON.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = FENCED_JSON.exec(itemText)) !== null) {
+			try {
+				const parsed: unknown = JSON.parse(match[1].trim());
+				if (looksLikeJsonSchema(parsed)) found = parsed; // keep the last schema-shaped block
+			} catch {
+				// not JSON — ignore this fence
+			}
+		}
+	}
+	return found;
+}
+
+function schemaProperties(schema: unknown): Record<string, unknown> | undefined {
+	return isRecord(schema) && isRecord(schema.properties) ? schema.properties : undefined;
+}
+
+function isStrictObject(schema: unknown): boolean {
+	return isRecord(schema) && schema.additionalProperties === false;
+}
+
+/**
+ * Drop keys a strict object schema doesn't declare; recurse into declared
+ * properties and array items. Leaves values untouched when the schema isn't
+ * strict or doesn't describe the value's shape.
+ */
+function pruneToSchema(value: unknown, schema: unknown): unknown {
+	if (isRecord(value)) {
+		const props = schemaProperties(schema);
+		if (!props) return value;
+		const strict = isStrictObject(schema);
+		const out: Record<string, unknown> = {};
+		for (const [key, val] of Object.entries(value)) {
+			const declared = key in props;
+			if (strict && !declared) continue; // drop what the schema forbids
+			out[key] = declared ? pruneToSchema(val, props[key]) : val;
+		}
+		return out;
+	}
+	if (Array.isArray(value) && isRecord(schema) && schema.type === 'array') {
+		return value.map((element) => pruneToSchema(element, schema.items));
+	}
+	return value;
+}
+
+/**
+ * Conform a generated content string to a declared schema: unwrap a stray
+ * single-key wrapper the schema doesn't declare, then prune keys the strict
+ * schema forbids. No schema, non-JSON content, or any failure => return the
+ * content unchanged. Re-wraps in a ```json``` block only if the input was fenced.
+ */
+export function conformContentToSchema(
+	content: string,
+	schema: Record<string, unknown> | undefined,
+): string {
+	if (!schema) return content;
+
+	const fenced = /^```(?:json)?\s*([\s\S]*?)```$/i.exec(content.trim());
+	const jsonText = fenced ? fenced[1].trim() : content.trim();
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(jsonText);
+	} catch {
+		return content;
+	}
+
+	// Unwrap a stray single-key wrapper (e.g. `{ output: {...} }`) that the schema
+	// does not declare. A wrapper the schema DOES declare (e.g. `__structured__output`)
+	// is a property, so it fails this test and is preserved.
+	if (isRecord(parsed) && isStrictObject(schema)) {
+		const keys = Object.keys(parsed);
+		const props = schemaProperties(schema) ?? {};
+		const soleKey = keys[0];
+		if (keys.length === 1 && !(soleKey in props) && isRecord(parsed[soleKey])) {
+			parsed = parsed[soleKey];
+		}
+	}
+
+	const conformed = pruneToSchema(parsed, schema);
+	const serialized = JSON.stringify(conformed);
+	return fenced ? `\`\`\`json\n${serialized}\n\`\`\`` : serialized;
+}
+
+/** Discover the declared schema from the request body and conform `content` to it. */
+export function applyStructuredOutputConformance(content: string, body: unknown): string {
+	return conformContentToSchema(content, discoverStructuredOutputSchema(body));
+}


### PR DESCRIPTION
## Summary

Follow-up to #34140 (OpenAI Responses-envelope normalizer). That fixed the *flat-envelope* form of the eval mock's structured-output problem; this fixes the **residual strict-schema form**.

Information Extractor / Text Classifier nodes declare a strict JSON Schema (`additionalProperties: false`) and hand it to the model as `StructuredOutputParser` **format-instructions prose**, not a machine-readable field. The eval completion mock never read that schema, so it invented extra fields or a stray `output` wrapper (and its prompt wrongly claimed structured output "often" needs an `output` wrapper key). The node then rejected the mock output with **"Model output doesn't fit required format"**, reddening execution even though the built workflow was correct.

## What changed

- **New `structured-output-conformance.ts`** — discovers the declared schema from any of: native Responses `text.format.schema`, native chat `response_format.json_schema.schema`, or the fenced ```json``` block in format-instructions. Then coerces generated content to it: unwrap a stray single-key wrapper the schema doesn't declare, recursively prune keys a strict schema forbids (incl. array items), and **preserve** a wrapper the schema *does* declare (e.g. the standalone parser's `__structured__output`). Every failure path is a safe no-op, so the common no-schema path is untouched.
- **`llm-completion-mock.ts`** — inject the discovered schema into the mock prompt so it emits the right shape, then conform the final content. Reworded the misleading structured-output prompt bullet.

## Testing

- 16 helper unit tests + 12 handler tests (new/updated); full `eval/__tests__` suite green (526). Typecheck ✓, lint clean.
- E2E against a local instance: the Information Extractor path now produces schema-valid output and executes green; the Text Classifier mock went from emitting `{}` to schema-shaped output.

## Known follow-up

One Text Classifier eval case still shows an execution red whose cause is ambiguous — a direct probe of the real `@langchain/classic` parser accepts the conformed output, so the residual looks like log truncation / a verifier 60s timeout / build non-determinism rather than this code. Tracking separately.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34323">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

