### PR TITLE
fix(core): Retry transient AI assistant service errors during Instance AI environment setup

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
@@ -200,6 +200,10 @@ describe('AgentKnowledgeSandboxService', () => {
 		getMock.mockRejectedValue(new DaytonaNotFoundError('not found'));
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it('creates a scoped sandbox', async () => {
 		const aiService = makeAiService();
 		const service = makeService({}, mock<Logger>(), aiService);
@@ -347,6 +351,30 @@ describe('AgentKnowledgeSandboxService', () => {
 			{ id: projectId },
 			expect.anything(),
 		);
+	});
+
+	it('retries transient proxy setup failures', async () => {
+		vi.useFakeTimers();
+		const client = mock<AiAssistantClient>();
+		client.getSandboxProxyConfig
+			.mockRejectedValueOnce(Object.assign(new Error('Bad Gateway'), { statusCode: 502 }))
+			.mockResolvedValue({ image: 'proxy-image' });
+		client.getBuilderApiProxyToken.mockResolvedValue({
+			accessToken: 'proxy-token',
+			tokenType: 'Bearer',
+		});
+		client.getSandboxProxyBaseUrl.mockReturnValue('https://sandbox-proxy.example');
+		const aiService = makeAiService({
+			isProxyEnabled: vi.fn().mockReturnValue(true),
+			getClient: vi.fn().mockResolvedValue(client),
+		});
+		const service = makeService({}, mock<Logger>(), aiService);
+
+		const promise = service.warmSandbox(projectId, agentId);
+		await vi.advanceTimersByTimeAsync(1000);
+		await promise;
+
+		expect(client.getSandboxProxyConfig).toHaveBeenCalledTimes(2);
 	});
 
 	describe('globKnowledgeFiles', () => {

--- a/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
@@ -13,6 +13,7 @@ import { createHash } from 'node:crypto';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { AiService } from '@/services/ai.service';
+import { callAiServiceWithRetry } from '@/utils/ai-service-retry';
 import { TtlMap } from '@/utils/ttl-map';
 
 import {
@@ -792,11 +793,17 @@ export class AgentKnowledgeSandboxService {
 		}
 
 		const client = await this.aiService.getClient();
-		const proxyConfig = await client.getSandboxProxyConfig();
+		const proxyConfig = await callAiServiceWithRetry(
+			'Agent knowledge sandbox proxy config fetch',
+			async () => await client.getSandboxProxyConfig(),
+			this.logger,
+		);
 		// The proxy does not enforce per-user identity; the project id is the stable scope for agents.
-		const token = await client.getBuilderApiProxyToken(
-			{ id: projectId },
-			{ userMessageId: nanoid() },
+		const token = await callAiServiceWithRetry(
+			'Agent knowledge sandbox proxy token mint',
+			async () =>
+				await client.getBuilderApiProxyToken({ id: projectId }, { userMessageId: nanoid() }),
+			this.logger,
 		);
 
 		return {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-model.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-model.service.test.ts
@@ -43,6 +43,10 @@ describe('InstanceAiModelService', () => {
 		service = new InstanceAiModelService(settingsService, aiService, outboundHttp);
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	describe('isProxyEnabled', () => {
 		it('should mirror the AI service proxy state', () => {
 			aiService.isProxyEnabled.mockReturnValue(true);
@@ -74,6 +78,26 @@ describe('InstanceAiModelService', () => {
 				creditsClaimed: 12,
 			});
 			expect(client.getInstanceAiCredits).toHaveBeenCalledWith({ id: 'user-1' });
+		});
+
+		it('should retry transient failures when fetching credits', async () => {
+			vi.useFakeTimers();
+			aiService.isProxyEnabled.mockReturnValue(true);
+			const transient = Object.assign(new Error('Bad Gateway'), { statusCode: 502 });
+			const client = createClient();
+			client.getInstanceAiCredits
+				.mockRejectedValueOnce(transient)
+				.mockResolvedValue({ creditsQuota: 5700, creditsClaimed: 12 });
+			aiService.getClient.mockResolvedValue(client as never);
+
+			const promise = service.getCredits(fakeUser);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toEqual({
+				creditsQuota: 5700,
+				creditsClaimed: 12,
+			});
+			expect(client.getInstanceAiCredits).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -38,7 +38,7 @@ type Overrides = {
 
 function createSandboxService(overrides: Overrides = {}) {
 	const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-	const errorReporter = { error: vi.fn() } as unknown as ErrorReporter;
+	const errorReporter = { error: vi.fn(), warn: vi.fn() } as unknown as ErrorReporter;
 	const runState: InstanceAiSandboxRunState = {
 		getActiveRunId: vi.fn(() => undefined),
 		hasSuspendedRun: vi.fn(() => false),
@@ -68,7 +68,7 @@ function createSandboxService(overrides: Overrides = {}) {
 		aiService,
 	};
 	const service = new InstanceAiSandboxService(options);
-	return { service, logger, runState, backgroundTasks, settingsService, aiService };
+	return { service, logger, errorReporter, runState, backgroundTasks, settingsService, aiService };
 }
 
 describe('InstanceAiSandboxService', () => {
@@ -229,7 +229,7 @@ describe('InstanceAiSandboxService', () => {
 			vi.useFakeTimers();
 			const transient = Object.assign(new Error('Bad Gateway'), { statusCode: 502 });
 			const getSandboxProxyConfig = vi.fn().mockRejectedValue(transient);
-			const { service } = createProxyService({ getSandboxProxyConfig });
+			const { service, errorReporter } = createProxyService({ getSandboxProxyConfig });
 
 			const promise = service.resolveSandboxConfig(fakeUser);
 			const assertion = expect(promise).rejects.toThrow(
@@ -239,6 +239,13 @@ describe('InstanceAiSandboxService', () => {
 
 			await assertion;
 			expect(getSandboxProxyConfig).toHaveBeenCalledTimes(3);
+			expect(errorReporter.warn).toHaveBeenCalledTimes(1);
+			expect(errorReporter.warn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					message: 'Sandbox proxy config fetch failed after 3 attempts',
+					cause: transient,
+				}),
+			);
 		});
 
 		it('does not retry definite client errors', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts
@@ -170,6 +170,109 @@ describe('InstanceAiSandboxService', () => {
 		});
 	});
 
+	describe('AI service transient failures', () => {
+		function createProxyService(client: {
+			getSandboxProxyConfig: Mock;
+			getInstanceAiApiProxyToken?: Mock;
+		}) {
+			return createSandboxService({
+				config: { sandboxEnabled: true, sandboxProvider: 'daytona' },
+				aiService: {
+					isProxyEnabled: vi.fn(() => true),
+					getClient: vi.fn(async () => ({
+						getSandboxProxyBaseUrl: vi.fn(() => 'https://proxy.base'),
+						getInstanceAiApiProxyToken:
+							client.getInstanceAiApiProxyToken ?? vi.fn(async () => ({ accessToken: 'token-1' })),
+						getSandboxProxyConfig: client.getSandboxProxyConfig,
+					})),
+				},
+			});
+		}
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('retries the proxy config fetch on transient 5xx errors', async () => {
+			vi.useFakeTimers();
+			const transient = Object.assign(new Error('Service Unavailable'), { statusCode: 503 });
+			const getSandboxProxyConfig = vi
+				.fn()
+				.mockRejectedValueOnce(transient)
+				.mockRejectedValueOnce(transient)
+				.mockResolvedValue({ image: 'proxy-image' });
+			const { service } = createProxyService({ getSandboxProxyConfig });
+
+			const promise = service.resolveSandboxConfig(fakeUser);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toMatchObject({ image: 'proxy-image' });
+			expect(getSandboxProxyConfig).toHaveBeenCalledTimes(3);
+		});
+
+		it('treats errors without a status code as transient', async () => {
+			vi.useFakeTimers();
+			const getSandboxProxyConfig = vi
+				.fn()
+				.mockRejectedValueOnce(new SyntaxError("Unexpected token '<'"))
+				.mockResolvedValue({ image: 'proxy-image' });
+			const { service } = createProxyService({ getSandboxProxyConfig });
+
+			const promise = service.resolveSandboxConfig(fakeUser);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toMatchObject({ image: 'proxy-image' });
+			expect(getSandboxProxyConfig).toHaveBeenCalledTimes(2);
+		});
+
+		it('surfaces an OperationalError after exhausting retries', async () => {
+			vi.useFakeTimers();
+			const transient = Object.assign(new Error('Bad Gateway'), { statusCode: 502 });
+			const getSandboxProxyConfig = vi.fn().mockRejectedValue(transient);
+			const { service } = createProxyService({ getSandboxProxyConfig });
+
+			const promise = service.resolveSandboxConfig(fakeUser);
+			const assertion = expect(promise).rejects.toThrow(
+				'The AI assistant service is temporarily unavailable',
+			);
+			await vi.runAllTimersAsync();
+
+			await assertion;
+			expect(getSandboxProxyConfig).toHaveBeenCalledTimes(3);
+		});
+
+		it('does not retry definite client errors', async () => {
+			const unauthorized = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+			const getSandboxProxyConfig = vi.fn().mockRejectedValue(unauthorized);
+			const { service } = createProxyService({ getSandboxProxyConfig });
+
+			await expect(service.resolveSandboxConfig(fakeUser)).rejects.toBe(unauthorized);
+			expect(getSandboxProxyConfig).toHaveBeenCalledTimes(1);
+		});
+
+		it('retries transient failures when minting proxy auth tokens', async () => {
+			vi.useFakeTimers();
+			const transient = Object.assign(new Error('Service Unavailable'), { statusCode: 503 });
+			const getInstanceAiApiProxyToken = vi
+				.fn()
+				.mockRejectedValueOnce(transient)
+				.mockResolvedValue({ accessToken: 'token-2' });
+			const { service } = createProxyService({
+				getSandboxProxyConfig: vi.fn(async () => ({ image: 'proxy-image' })),
+				getInstanceAiApiProxyToken,
+			});
+
+			const config = await service.resolveSandboxConfig(fakeUser);
+			if (!config.enabled || config.provider !== 'daytona') throw new Error('unexpected config');
+
+			const tokenPromise = config.getAuthToken?.();
+			await vi.runAllTimersAsync();
+
+			await expect(tokenPromise).resolves.toBe('token-2');
+			expect(getInstanceAiApiProxyToken).toHaveBeenCalledTimes(2);
+		});
+	});
+
 	describe('getSandboxConfigFromEnv', () => {
 		const daytonaEnvConfig: Partial<InstanceAiConfig> = {
 			sandboxEnabled: true,

--- a/packages/cli/src/modules/instance-ai/instance-ai-model.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-model.service.ts
@@ -9,6 +9,7 @@ import { N8N_VERSION } from '@/constants';
 import { AiService } from '@/services/ai.service';
 import { ProxyTokenManager } from '@/services/proxy-token-manager';
 import { createAiProxyFetch } from '@/utils/ai-proxy-fetch';
+import { callAiServiceWithRetry } from '@/utils/ai-service-retry';
 
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 
@@ -148,6 +149,9 @@ export class InstanceAiModelService {
 			return { creditsQuota: UNLIMITED_CREDITS, creditsClaimed: 0 };
 		}
 		const client = await this.aiService.getClient();
-		return await client.getInstanceAiCredits({ id: user.id });
+		return await callAiServiceWithRetry(
+			'Instance AI credits fetch',
+			async () => await client.getInstanceAiCredits({ id: user.id }),
+		);
 	}
 }

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -234,6 +234,7 @@ export class InstanceAiSandboxService {
 					'Sandbox proxy config fetch',
 					async () => await client.getSandboxProxyConfig(),
 					this.logger,
+					this.options.errorReporter,
 				);
 				return {
 					...base,
@@ -249,6 +250,7 @@ export class InstanceAiSandboxService {
 									{ userMessageId: nanoid() },
 								),
 							this.logger,
+							this.options.errorReporter,
 						);
 
 						return token.accessToken;

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -10,10 +10,11 @@ import {
 	type SandboxConfig,
 } from '@n8n/instance-ai';
 import type { ErrorReporter } from 'n8n-core';
-import { OperationalError, UnexpectedError } from 'n8n-workflow';
+import { UnexpectedError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 
 import { N8N_VERSION } from '@/constants';
+import { callAiServiceWithRetry } from '@/utils/ai-service-retry';
 
 import { normalizeSandboxProvider, requireN8nSandboxServiceUrl } from '../sandbox-provider';
 
@@ -21,24 +22,6 @@ const SANDBOX_NAME_MAX_LEN = 63;
 const SANDBOX_LABEL_MAX_LEN = 63;
 const NAME_PREFIX_SLUG_MAX_LEN = 24;
 const DEFAULT_SANDBOX_TTL_MS = 15 * 60 * 1000;
-
-const AI_SERVICE_MAX_ATTEMPTS = 3;
-const AI_SERVICE_RETRY_BACKOFF_BASE_MS = 1_000;
-const AI_SERVICE_RETRY_BACKOFF_CAP_MS = 5_000;
-
-async function sleep(ms: number): Promise<void> {
-	await new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// The AI assistant service SDK carries the upstream HTTP status as a numeric statusCode;
-// gateway HTML bodies and network failures are re-wrapped without one, so treat a missing
-// status as transient rather than parsing error messages.
-function isTransientAiServiceError(error: unknown): boolean {
-	if (typeof error !== 'object' || error === null) return false;
-	const status = 'statusCode' in error ? error.statusCode : undefined;
-	if (typeof status !== 'number') return true;
-	return status >= 500 || status === 408 || status === 429;
-}
 
 /** Cached runtime sandbox + workspace pair for a single thread. */
 export type RuntimeSandboxEntry = {
@@ -179,37 +162,6 @@ export class InstanceAiSandboxService {
 		return this.options.logger;
 	}
 
-	/**
-	 * Call the AI assistant service, retrying transient failures (5xx/408/429, gateway
-	 * HTML bodies, network errors) with capped exponential backoff. Exhausted retries
-	 * surface as a user-facing OperationalError; definite client errors rethrow as-is.
-	 */
-	private async callAiService<T>(label: string, call: () => Promise<T>): Promise<T> {
-		for (let attempt = 1; ; attempt++) {
-			try {
-				return await call();
-			} catch (error) {
-				if (!isTransientAiServiceError(error)) throw error;
-				if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {
-					throw new OperationalError(
-						'The AI assistant service is temporarily unavailable. Please try again in a few minutes.',
-						{ cause: error },
-					);
-				}
-				this.logger.warn(`${label} hit a transient AI assistant service error; retrying`, {
-					attempt,
-					error: error instanceof Error ? error.message : String(error),
-				});
-				await sleep(
-					Math.min(
-						AI_SERVICE_RETRY_BACKOFF_BASE_MS * 2 ** (attempt - 1),
-						AI_SERVICE_RETRY_BACKOFF_CAP_MS,
-					),
-				);
-			}
-		}
-	}
-
 	private get instanceAiConfig(): InstanceAiConfig {
 		return this.options.config;
 	}
@@ -278,9 +230,10 @@ export class InstanceAiSandboxService {
 			// If AI assistant service is available, route Daytona calls through its sandbox proxy
 			if (this.options.aiService.isProxyEnabled()) {
 				const client = await this.options.aiService.getClient();
-				const proxyConfig = await this.callAiService(
+				const proxyConfig = await callAiServiceWithRetry(
 					'Sandbox proxy config fetch',
 					async () => await client.getSandboxProxyConfig(),
+					this.logger,
 				);
 				return {
 					...base,
@@ -288,13 +241,14 @@ export class InstanceAiSandboxService {
 					image: proxyConfig.image,
 					logger: this.logger,
 					getAuthToken: async () => {
-						const token = await this.callAiService(
+						const token = await callAiServiceWithRetry(
 							'Sandbox proxy token mint',
 							async () =>
 								await client.getInstanceAiApiProxyToken(
 									{ id: user.id },
 									{ userMessageId: nanoid() },
 								),
+							this.logger,
 						);
 
 						return token.accessToken;

--- a/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
+++ b/packages/cli/src/modules/instance-ai/sandbox/instance-ai-sandbox.service.ts
@@ -10,7 +10,7 @@ import {
 	type SandboxConfig,
 } from '@n8n/instance-ai';
 import type { ErrorReporter } from 'n8n-core';
-import { UnexpectedError } from 'n8n-workflow';
+import { OperationalError, UnexpectedError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 
 import { N8N_VERSION } from '@/constants';
@@ -21,6 +21,24 @@ const SANDBOX_NAME_MAX_LEN = 63;
 const SANDBOX_LABEL_MAX_LEN = 63;
 const NAME_PREFIX_SLUG_MAX_LEN = 24;
 const DEFAULT_SANDBOX_TTL_MS = 15 * 60 * 1000;
+
+const AI_SERVICE_MAX_ATTEMPTS = 3;
+const AI_SERVICE_RETRY_BACKOFF_BASE_MS = 1_000;
+const AI_SERVICE_RETRY_BACKOFF_CAP_MS = 5_000;
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The AI assistant service SDK carries the upstream HTTP status as a numeric statusCode;
+// gateway HTML bodies and network failures are re-wrapped without one, so treat a missing
+// status as transient rather than parsing error messages.
+function isTransientAiServiceError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false;
+	const status = 'statusCode' in error ? error.statusCode : undefined;
+	if (typeof status !== 'number') return true;
+	return status >= 500 || status === 408 || status === 429;
+}
 
 /** Cached runtime sandbox + workspace pair for a single thread. */
 export type RuntimeSandboxEntry = {
@@ -161,6 +179,37 @@ export class InstanceAiSandboxService {
 		return this.options.logger;
 	}
 
+	/**
+	 * Call the AI assistant service, retrying transient failures (5xx/408/429, gateway
+	 * HTML bodies, network errors) with capped exponential backoff. Exhausted retries
+	 * surface as a user-facing OperationalError; definite client errors rethrow as-is.
+	 */
+	private async callAiService<T>(label: string, call: () => Promise<T>): Promise<T> {
+		for (let attempt = 1; ; attempt++) {
+			try {
+				return await call();
+			} catch (error) {
+				if (!isTransientAiServiceError(error)) throw error;
+				if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {
+					throw new OperationalError(
+						'The AI assistant service is temporarily unavailable. Please try again in a few minutes.',
+						{ cause: error },
+					);
+				}
+				this.logger.warn(`${label} hit a transient AI assistant service error; retrying`, {
+					attempt,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				await sleep(
+					Math.min(
+						AI_SERVICE_RETRY_BACKOFF_BASE_MS * 2 ** (attempt - 1),
+						AI_SERVICE_RETRY_BACKOFF_CAP_MS,
+					),
+				);
+			}
+		}
+	}
+
 	private get instanceAiConfig(): InstanceAiConfig {
 		return this.options.config;
 	}
@@ -229,16 +278,23 @@ export class InstanceAiSandboxService {
 			// If AI assistant service is available, route Daytona calls through its sandbox proxy
 			if (this.options.aiService.isProxyEnabled()) {
 				const client = await this.options.aiService.getClient();
-				const proxyConfig = await client.getSandboxProxyConfig();
+				const proxyConfig = await this.callAiService(
+					'Sandbox proxy config fetch',
+					async () => await client.getSandboxProxyConfig(),
+				);
 				return {
 					...base,
 					daytonaApiUrl: client.getSandboxProxyBaseUrl(),
 					image: proxyConfig.image,
 					logger: this.logger,
 					getAuthToken: async () => {
-						const token = await client.getInstanceAiApiProxyToken(
-							{ id: user.id },
-							{ userMessageId: nanoid() },
+						const token = await this.callAiService(
+							'Sandbox proxy token mint',
+							async () =>
+								await client.getInstanceAiApiProxyToken(
+									{ id: user.id },
+									{ userMessageId: nanoid() },
+								),
 						);
 
 						return token.accessToken;

--- a/packages/cli/src/services/__tests__/ai.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai.service.test.ts
@@ -3,9 +3,10 @@ import type {
 	AiApplySuggestionRequestDto,
 	AiChatRequestDto,
 } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
 import type { GlobalConfig } from '@n8n/config';
 import { AiAssistantClient, type AiAssistantSDK } from '@n8n_io/ai-assistant-sdk';
-import type { InstanceSettings } from 'n8n-core';
+import type { ErrorReporter, InstanceSettings } from 'n8n-core';
 import type { IUser } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -32,13 +33,15 @@ describe('AiService', () => {
 		aiAssistant: { baseUrl },
 	});
 	const instanceSettings = mock<InstanceSettings>({ instanceId });
+	const logger = mock<Logger>();
+	const errorReporter = mock<ErrorReporter>();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		(AiAssistantClient as Mock).mockImplementation(function () {
 			return client;
 		});
-		aiService = new AiService(license, globalConfig, instanceSettings);
+		aiService = new AiService(license, globalConfig, instanceSettings, logger, errorReporter);
 	});
 
 	afterEach(() => {
@@ -202,7 +205,13 @@ describe('AiService', () => {
 				logging: { level: 'info' },
 				aiAssistant: { baseUrl: '' },
 			});
-			const serviceNoUrl = new AiService(license, configWithoutUrl, instanceSettings);
+			const serviceNoUrl = new AiService(
+				license,
+				configWithoutUrl,
+				instanceSettings,
+				logger,
+				errorReporter,
+			);
 
 			expect(serviceNoUrl.isProxyEnabled()).toBe(false);
 		});
@@ -234,6 +243,41 @@ describe('AiService', () => {
 			await aiService.getClient();
 
 			expect(AiAssistantClient).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('createFreeAiCredits', () => {
+		const credits = mock<AiAssistantSDK.AiCreditResponsePayload>();
+
+		beforeEach(() => {
+			license.isAiAssistantEnabled.mockReturnValue(true);
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should retry transient upstream errors before succeeding', async () => {
+			vi.useFakeTimers();
+			const transient = Object.assign(new Error('Bad Gateway'), { statusCode: 502 });
+			client.generateAiCreditsCredentials
+				.mockRejectedValueOnce(transient)
+				.mockResolvedValue(credits);
+
+			const promise = aiService.createFreeAiCredits(user);
+			await vi.runAllTimersAsync();
+
+			await expect(promise).resolves.toEqual(credits);
+			expect(client.generateAiCreditsCredentials).toHaveBeenCalledTimes(2);
+			expect(client.generateAiCreditsCredentials).toHaveBeenCalledWith(user);
+		});
+
+		it('should not retry definite client errors', async () => {
+			const alreadyClaimed = Object.assign(new Error('Already claimed'), { statusCode: 400 });
+			client.generateAiCreditsCredentials.mockRejectedValue(alreadyClaimed);
+
+			await expect(aiService.createFreeAiCredits(user)).rejects.toBe(alreadyClaimed);
+			expect(client.generateAiCreditsCredentials).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/packages/cli/src/services/ai.service.ts
+++ b/packages/cli/src/services/ai.service.ts
@@ -3,14 +3,16 @@ import type {
 	AiAskRequestDto,
 	AiChatRequestDto,
 } from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { AiAssistantClient } from '@n8n_io/ai-assistant-sdk';
-import { InstanceSettings } from 'n8n-core';
+import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import { assert, type IUser } from 'n8n-workflow';
 
 import { N8N_VERSION } from '../constants';
 import { License } from '../license';
+import { callAiServiceWithRetry } from '../utils/ai-service-retry';
 
 @Service()
 export class AiService {
@@ -22,6 +24,8 @@ export class AiService {
 		private readonly licenseService: License,
 		private readonly globalConfig: GlobalConfig,
 		private readonly instanceSettings: InstanceSettings,
+		private readonly logger: Logger,
+		private readonly errorReporter: ErrorReporter,
 	) {}
 
 	async init() {
@@ -86,6 +90,12 @@ export class AiService {
 
 	async createFreeAiCredits(user: IUser) {
 		const client = await this.getClient();
-		return await client.generateAiCreditsCredentials(user);
+		// Retrying the claim is no worse than the user clicking again; already-claimed is a definite 4xx.
+		return await callAiServiceWithRetry(
+			'AI credits credential generation',
+			async () => await client.generateAiCreditsCredentials(user),
+			this.logger,
+			this.errorReporter,
+		);
 	}
 }

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -1,0 +1,51 @@
+import { OperationalError } from 'n8n-workflow';
+
+const AI_SERVICE_MAX_ATTEMPTS = 3;
+const AI_SERVICE_RETRY_BACKOFF_BASE_MS = 1_000;
+const AI_SERVICE_RETRY_BACKOFF_CAP_MS = 5_000;
+const AI_SERVICE_UNAVAILABLE_MESSAGE =
+	'The AI assistant service is temporarily unavailable. Please try again in a few minutes.';
+
+type RetryLogger = {
+	warn: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+async function sleep(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The AI assistant service SDK carries upstream HTTP status as numeric statusCode;
+// gateway HTML bodies and network failures are re-wrapped without one.
+function isTransientAiServiceError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false;
+	const status = 'statusCode' in error ? error.statusCode : undefined;
+	if (typeof status !== 'number') return true;
+	return status >= 500 || status === 408 || status === 429;
+}
+
+export async function callAiServiceWithRetry<T>(
+	label: string,
+	call: () => Promise<T>,
+	logger?: RetryLogger,
+): Promise<T> {
+	for (let attempt = 1; ; attempt++) {
+		try {
+			return await call();
+		} catch (error) {
+			if (!isTransientAiServiceError(error)) throw error;
+			if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {
+				throw new OperationalError(AI_SERVICE_UNAVAILABLE_MESSAGE, { cause: error });
+			}
+			logger?.warn(`${label} hit a transient AI assistant service error; retrying`, {
+				attempt,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			await sleep(
+				Math.min(
+					AI_SERVICE_RETRY_BACKOFF_BASE_MS * 2 ** (attempt - 1),
+					AI_SERVICE_RETRY_BACKOFF_CAP_MS,
+				),
+			);
+		}
+	}
+}

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -10,6 +10,10 @@ type RetryLogger = {
 	warn: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
+type RetryErrorReporter = {
+	warn: (error: Error | string) => void;
+};
+
 async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -27,6 +31,7 @@ export async function callAiServiceWithRetry<T>(
 	label: string,
 	call: () => Promise<T>,
 	logger?: RetryLogger,
+	errorReporter?: RetryErrorReporter,
 ): Promise<T> {
 	for (let attempt = 1; ; attempt++) {
 		try {
@@ -34,6 +39,12 @@ export async function callAiServiceWithRetry<T>(
 		} catch (error) {
 			if (!isTransientAiServiceError(error)) throw error;
 			if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {
+				// Warning-level Sentry trail for user-visible exhaustion, without error-level paging.
+				errorReporter?.warn(
+					new Error(`${label} failed after ${AI_SERVICE_MAX_ATTEMPTS} attempts`, {
+						cause: error,
+					}),
+				);
 				throw new OperationalError(AI_SERVICE_UNAVAILABLE_MESSAGE, { cause: error });
 			}
 			logger?.warn(`${label} hit a transient AI assistant service error; retrying`, {


### PR DESCRIPTION
## Summary

Creating an Instance AI execution environment failed permanently on a single transient upstream error from the AI assistant service: fetching the sandbox proxy config or minting a proxy auth token threw a raw `AIServiceAPIResponseError` straight to the user and aborted the run.

Both calls now retry transient failures with capped exponential backoff (3 attempts, 1s base, 5s cap):

- HTTP 5xx, 408, and 429 responses (classified via the SDK error's `statusCode`)
- errors without a status code — the SDK re-wraps gateway HTML bodies (`Unexpected token '<', "<!DOCTYPE"...`) and network failures without one, so a missing status is treated as transient rather than parsing error messages

Once retries are exhausted, the failure surfaces as an `OperationalError` with a user-facing message ("The AI assistant service is temporarily unavailable. Please try again in a few minutes.") carrying the original error as `cause`. Since `OperationalError` defaults to warning level, exhausted transients also stop reporting as error-level events. Definite client errors (e.g. 401) still fail fast unchanged.

The same retry treatment is applied to free AI credits credential generation (`AiService.createFreeAiCredits`): repeating the claim on a transient 5xx is no worse than the user clicking the button again, and an already-claimed response is a definite 4xx that fails fast unchanged.

Sibling of #34319, which applies the same treatment to the Daytona sandbox write path.

## How to test

- `pushd packages/cli && pnpm vitest run src/modules/instance-ai/__tests__/instance-ai-sandbox.service.test.ts`
- New cases cover: retry-then-succeed on 5xx, missing-status classified as transient, `OperationalError` after exhaustion, no retry on 401, and token-mint retries via `getAuthToken`.
- Manual: requires a cloud-like setup with the AI assistant service proxy enabled; a transient 503 on `/v1/sandbox-proxy/config` during build start previously killed the run, now it recovers.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-894
- https://linear.app/n8n/issue/INS-895
- https://linear.app/n8n/issue/INS-892
- https://linear.app/n8n/issue/INS-893

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


