### PR TITLE
fix(core): Create proxied Instance AI sandboxes from snapshots only

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
@@ -207,7 +207,7 @@ describe('createSandbox', () => {
 		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith(undefined, logger, '1.2.3');
 	});
 
-	it('prepares snapshot and image in Daytona proxy snapshot fallback mode', async () => {
+	it('creates from the snapshot only in Daytona proxy snapshot fallback mode', async () => {
 		const getAuthToken = vi.fn().mockResolvedValue('jwt-token');
 		const config: SandboxConfig = {
 			enabled: true,
@@ -227,7 +227,8 @@ describe('createSandbox', () => {
 		).resolves.toBe(sandbox);
 
 		expect(mockSnapshotName).toHaveBeenCalledWith();
-		expect(mockEnsureImage).toHaveBeenCalledWith();
+		// Image builds cannot run through the sandbox proxy, so no image is prepared or passed.
+		expect(mockEnsureImage).not.toHaveBeenCalled();
 		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
 		expect(mockCreateSharedSandbox).toHaveBeenCalledWith(
 			{
@@ -236,7 +237,6 @@ describe('createSandbox', () => {
 				id: sharedConfig.id,
 				daytonaApiUrl: 'https://proxy.example.com',
 				getAuthToken,
-				image: { dockerfile: 'FROM node:20' },
 				labels: {
 					'n8n-instance-ai-sandbox-id': sharedConfig.id,
 				},
@@ -244,6 +244,24 @@ describe('createSandbox', () => {
 			},
 			{ logger, errorReporter },
 		);
+	});
+
+	it('fails fast in proxy mode when no snapshot can be resolved', async () => {
+		mockSnapshotName.mockReturnValue(undefined);
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://proxy.example.com',
+			getAuthToken: vi.fn().mockResolvedValue('jwt-token'),
+			image: 'node:20',
+		};
+
+		await expect(
+			createSandbox(config, { logger, errorReporter, useSnapshotFallback: true }),
+		).rejects.toThrow('No Instance AI sandbox snapshot is available');
+
+		expect(mockEnsureImage).not.toHaveBeenCalled();
+		expect(mockCreateSharedSandbox).not.toHaveBeenCalled();
 	});
 
 	it('uses an explicit snapshot override instead of the version-derived name', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
@@ -106,13 +106,34 @@ export async function createSandbox(
 		snapshot: snapshot ?? '(none — building from image)',
 		source: config.snapshot ? 'override' : isProxyMode ? 'n8n-version' : 'image-only',
 	});
+
+	// The sandbox proxy can't serve image-build context uploads, so proxy mode is snapshot-only.
+	if (isProxyMode) {
+		if (!snapshot) {
+			throw new Error(
+				`No Instance AI sandbox snapshot is available for this n8n version (${config.n8nVersion ?? 'unknown'}) and sandbox images cannot be built through the sandbox proxy`,
+			);
+		}
+		const sharedConfig = toSharedDaytonaSandboxConfig(config);
+		delete sharedConfig.image;
+		return await createSharedSandbox(
+			{
+				...sharedConfig,
+				snapshot,
+			},
+			{
+				logger: options.logger,
+				errorReporter: options.errorReporter,
+			},
+		);
+	}
+
 	const image = await snapshotManager.ensureImage();
 
 	return await createSharedSandbox(
 		{
 			...toSharedDaytonaSandboxConfig(config),
 			image,
-			...(snapshot ? { snapshot } : {}),
 		},
 		{
 			logger: options.logger,


### PR DESCRIPTION
## Summary

When an Instance AI sandbox was created through the AI assistant service's sandbox proxy (how cloud instances reach Daytona; direct mode is self-hosted admins using their own Daytona keys) and the versioned snapshot (e.g. `n8n/instance-ai:2.31.0`) was missing upstream, sandbox creation silently fell back to a declarative image build. That build stages local workspace files as an image context, and the sandbox proxy does not serve the context-upload endpoints, so the fallback always died with a misleading `DaytonaAuthorizationError: Endpoint not allowed` after a slow, doomed attempt. Sentry confirms the fallback never once succeeded: 141 events across 133 users since June 17 ([INSTANCE-BACKEND-264R](https://sentry.io/organizations/n8nio/issues/7558112152/)), so removing it loses nothing.

Proxy mode is now snapshot-only:

- No image descriptor is prepared or passed through the proxy, so a missing snapshot surfaces the real snapshot-create error instead of the auth error from the impossible build. The base-image string is also stripped from the shared config so no image candidate survives.
- When no snapshot name can be resolved at all (no version-derived name, no `N8N_INSTANCE_AI_SANDBOX_SNAPSHOT` override), creation fails fast with a self-explanatory error.
- Proxy mode no longer runs `ensureImage()`, skipping workspace-file staging work that was never used.

Direct mode (admin-supplied Daytona keys) is unchanged and still builds images.

Why here and not in the shared `@n8n/agents` adapter (which already has `createStrategyMode`): the agents module legitimately creates proxied sandboxes from plain registry-image names, which need no context upload — only instance-ai's context-staged declarative image is impossible through the proxy, so the guard belongs on the instance-ai path.

Third PR in the sandbox-reliability series, after #34319 (sandbox write retries) and #34324 (AI service call retries).

**Note: this makes the failure correct and diagnosable but does not restore building when a snapshot is genuinely unpublished** — that needs snapshot publication guaranteed at release time and/or a proxy allowlist change, tracked separately.

## How to test

- `pushd packages/@n8n/instance-ai && pnpm vitest run src/workspace/__tests__/create-workspace.test.ts`
- Updated case asserts proxy mode passes only `snapshot` (no `image`) to the shared factory and never prepares an image; new case asserts a clear fail-fast error when no snapshot is resolvable.
- Manual: requires the sandbox proxy (`getAuthToken` mode). With a snapshot name that doesn't exist upstream, creation previously failed with `DaytonaAuthorizationError: Endpoint not allowed`; it now reports the missing snapshot directly.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/INS-901

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)