### PR TITLE
feat(API): Add credentialResolverId, timeSavedMode & binaryMode properties to workflow settings schema

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -46,6 +46,18 @@ properties:
     type: string
     description: Comma-separated list of workflow IDs allowed to call this workflow (only used with workflowsFromAList policy)
     example: '14, 18, 23'
+  timeSavedMode:
+    type: string
+    enum: ['fixed', 'dynamic']
+    description: |
+      Controls how the time saved per execution is calculated.
+      Available options:
+      - `fixed`: Uses a predetermined time value specified in the `timeSavedPerExecution` field.
+        * Requires the `timeSavedPerExecution` field to be set
+        * Use when the time saved is consistent across all executions
+      - `dynamic`: Automatically calculates time saved based on actual execution metrics
+        * The `timeSavedPerExecution` field is ignored when this mode is active
+        * Use when time saved varies between executions
   timeSavedPerExecution:
     type: number
     description: Estimated time saved per execution in minutes

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -25,6 +25,14 @@ properties:
   executionOrder:
     type: string
     example: v1
+  binaryMode:
+    type: string
+    enum: ['separate', 'combined']
+    description: |
+      Controls how binary data is resolved from a node's input. This is a derived,
+      internal setting rather than something intended to be set programmatically.
+      It is included in workflow responses for reference, but any value sent when
+      creating or updating a workflow is ignored.
   callerPolicy:
     type: string
     enum: ['any', 'none', 'workflowsFromAList', 'workflowsFromSameOwner']

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -119,3 +119,11 @@ properties:
           type: string
         value:
           type: string
+  credentialResolverId:
+    type: string
+    description: |
+      ID of the credential resolver used to resolve credentials for this workflow,
+      overriding the instance's default (system) resolver. Requires the dynamic
+      credentials feature to be enabled on the instance.
+      Set to an empty string to explicitly use the system resolver, or omit the
+      field to leave the current value unchanged.

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -122,8 +122,8 @@ properties:
   credentialResolverId:
     type: string
     description: |
-      ID of the credential resolver used to resolve credentials for this workflow,
-      overriding the instance's default (system) resolver. Requires the dynamic
-      credentials feature to be enabled on the instance.
-      Set to an empty string to explicitly use the system resolver, or omit the
-      field to leave the current value unchanged.
+      ID of the credential resolver used to resolve credentials for this workflow.
+      This is a derived, internal setting managed via the workflow's credential
+      resolver configuration rather than something intended to be set programmatically.
+      It is included in workflow responses for reference, but any value sent when
+      creating or updating a workflow is ignored.

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -310,6 +310,13 @@ const workflowHandlers: WorkflowHandlers = {
 			// null moves the workflow to the project root, (undefined) leaves the current folder untouched
 			const resolvedParentFolderId = parentFolderId === null ? PROJECT_ROOT : parentFolderId;
 
+			// binaryMode is a derived, internal setting rather than something users
+			// are expected to control programmatically; strip it so the settings
+			// merge in WorkflowService.update preserves whatever is already stored.
+			if (updateData.settings?.binaryMode !== undefined) {
+				delete updateData.settings.binaryMode;
+			}
+
 			try {
 				// Credential tamper protection is enforced centrally in WorkflowService.update
 				const updatedWorkflow = await Container.get(WorkflowService).update(

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.handler.ts
@@ -310,11 +310,15 @@ const workflowHandlers: WorkflowHandlers = {
 			// null moves the workflow to the project root, (undefined) leaves the current folder untouched
 			const resolvedParentFolderId = parentFolderId === null ? PROJECT_ROOT : parentFolderId;
 
-			// binaryMode is a derived, internal setting rather than something users
-			// are expected to control programmatically; strip it so the settings
-			// merge in WorkflowService.update preserves whatever is already stored.
+			// binaryMode and credentialResolverId are derived, internal settings
+			// rather than something users are expected to control programmatically;
+			// strip them so the settings merge in WorkflowService.update preserves
+			// whatever is already stored.
 			if (updateData.settings?.binaryMode !== undefined) {
 				delete updateData.settings.binaryMode;
+			}
+			if (updateData.settings?.credentialResolverId !== undefined) {
+				delete updateData.settings.credentialResolverId;
 			}
 
 			try {

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
@@ -65,6 +65,14 @@ export async function createWorkflow(
 	body: WorkflowEntity & { projectId?: string; parentFolderId?: string | null },
 ): Promise<WorkflowEntity> {
 	const { projectId, parentFolderId, ...rest } = body;
+
+	// binaryMode is a derived, internal setting rather than something users are
+	// expected to control programmatically; ignore any value sent so new
+	// workflows always get the default.
+	if (rest.settings?.binaryMode !== undefined) {
+		delete rest.settings.binaryMode;
+	}
+
 	const workflow = createWorkflowEntityFromPayload(rest);
 
 	// A policy supplied via the API is explicit intent, so a below-floor value is

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
@@ -66,11 +66,14 @@ export async function createWorkflow(
 ): Promise<WorkflowEntity> {
 	const { projectId, parentFolderId, ...rest } = body;
 
-	// binaryMode is a derived, internal setting rather than something users are
-	// expected to control programmatically; ignore any value sent so new
-	// workflows always get the default.
+	// binaryMode and credentialResolverId are derived, internal settings rather
+	// than something users are expected to control programmatically; ignore any
+	// value sent so new workflows always get the default.
 	if (rest.settings?.binaryMode !== undefined) {
 		delete rest.settings.binaryMode;
+	}
+	if (rest.settings?.credentialResolverId !== undefined) {
+		delete rest.settings.credentialResolverId;
 	}
 
 	const workflow = createWorkflowEntityFromPayload(rest);

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1706,6 +1706,7 @@ describe('POST /workflows', () => {
 				saveDataSuccessExecution: 'all',
 				executionTimeout: 3600,
 				timezone: 'America/New_York',
+				timeSavedMode: 'dynamic',
 			},
 		};
 
@@ -2316,6 +2317,7 @@ describe('PUT /workflows/:id', () => {
 				saveDataSuccessExecution: 'all',
 				executionTimeout: 3600,
 				timezone: 'America/New_York',
+				timeSavedMode: 'dynamic',
 				callerPolicy: 'workflowsFromSameOwner',
 				availableInMCP: false,
 			},

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1621,6 +1621,25 @@ describe('POST /workflows', () => {
 		expect(sharedWorkflow?.role).toEqual('workflow:owner');
 	});
 
+	test('should ignore binaryMode when creating a workflow', async () => {
+		const payload = {
+			...mockPostWorkflowPayload(),
+			settings: {
+				executionOrder: 'v1',
+				binaryMode: 'combined',
+			},
+		};
+
+		const response = await authOwnerAgent.post('/workflows').send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.settings.binaryMode).toBeUndefined();
+
+		const workflow = await workflowRepository.findOneBy({ id: response.body.id });
+
+		expect(workflow?.settings?.binaryMode).toBeUndefined();
+	});
+
 	test('should create workflow with node groups', async () => {
 		const payload = {
 			name: 'grouped',
@@ -2283,6 +2302,32 @@ describe('PUT /workflows/:id', () => {
 		});
 
 		expect(sharedWorkflow?.workflow.activeVersionId).toBeNull();
+	});
+
+	test('should ignore binaryMode when updating a workflow', async () => {
+		const workflow = await createWorkflowWithHistory(
+			{ settings: { executionOrder: 'v1', binaryMode: 'combined' } },
+			member,
+		);
+
+		const payload = {
+			name: workflow.name,
+			nodes: workflow.nodes,
+			connections: workflow.connections,
+			settings: {
+				executionOrder: 'v1',
+				binaryMode: 'separate',
+			},
+		};
+
+		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body.settings.binaryMode).toBe('combined');
+
+		const workflowAfter = await workflowRepository.findOneBy({ id: workflow.id });
+
+		expect(workflowAfter?.settings?.binaryMode).toBe('combined');
 	});
 
 	test('should update non-owned workflow if owner', async () => {

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1570,6 +1570,7 @@ describe('POST /workflows', () => {
 				executionOrder: 'v1',
 				callerPolicy: 'workflowsFromSameOwner',
 				availableInMCP: false,
+				credentialResolverId: 'some-resolver-id',
 				customTelemetryTags: [
 					{ key: 'env', value: 'production' },
 					{ key: 'category', value: 'data-cleaning' },
@@ -2179,6 +2180,7 @@ describe('PUT /workflows/:id', () => {
 				timezone: 'America/New_York',
 				callerPolicy: 'workflowsFromSameOwner',
 				availableInMCP: false,
+				credentialResolverId: 'some-resolver-id',
 				customTelemetryTags: [
 					{ key: 'env', value: 'production' },
 					{ key: 'category', value: 'data-cleaning' },

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1570,7 +1570,6 @@ describe('POST /workflows', () => {
 				executionOrder: 'v1',
 				callerPolicy: 'workflowsFromSameOwner',
 				availableInMCP: false,
-				credentialResolverId: 'some-resolver-id',
 				customTelemetryTags: [
 					{ key: 'env', value: 'production' },
 					{ key: 'category', value: 'data-cleaning' },
@@ -1622,23 +1621,26 @@ describe('POST /workflows', () => {
 		expect(sharedWorkflow?.role).toEqual('workflow:owner');
 	});
 
-	test('should ignore binaryMode when creating a workflow', async () => {
+	test.each([
+		{ key: 'binaryMode', value: 'combined' },
+		{ key: 'credentialResolverId', value: 'some-resolver-id' },
+	] as const)('should ignore $key when creating a workflow', async ({ key, value }) => {
 		const payload = {
 			...mockPostWorkflowPayload(),
 			settings: {
 				executionOrder: 'v1',
-				binaryMode: 'combined',
+				[key]: value,
 			},
 		};
 
 		const response = await authOwnerAgent.post('/workflows').send(payload);
 
 		expect(response.statusCode).toBe(200);
-		expect(response.body.settings.binaryMode).toBeUndefined();
+		expect(response.body.settings[key]).toBeUndefined();
 
 		const workflow = await workflowRepository.findOneBy({ id: response.body.id });
 
-		expect(workflow?.settings?.binaryMode).toBeUndefined();
+		expect(workflow?.settings?.[key]).toBeUndefined();
 	});
 
 	test('should create workflow with node groups', async () => {
@@ -2180,7 +2182,6 @@ describe('PUT /workflows/:id', () => {
 				timezone: 'America/New_York',
 				callerPolicy: 'workflowsFromSameOwner',
 				availableInMCP: false,
-				credentialResolverId: 'some-resolver-id',
 				customTelemetryTags: [
 					{ key: 'env', value: 'production' },
 					{ key: 'category', value: 'data-cleaning' },
@@ -2306,31 +2307,41 @@ describe('PUT /workflows/:id', () => {
 		expect(sharedWorkflow?.workflow.activeVersionId).toBeNull();
 	});
 
-	test('should ignore binaryMode when updating a workflow', async () => {
-		const workflow = await createWorkflowWithHistory(
-			{ settings: { executionOrder: 'v1', binaryMode: 'combined' } },
-			member,
-		);
+	test.each([
+		{ key: 'binaryMode', original: 'combined', attempted: 'separate' },
+		{
+			key: 'credentialResolverId',
+			original: 'original-resolver-id',
+			attempted: 'attempted-new-resolver-id',
+		},
+	] as const)(
+		'should ignore $key when updating a workflow',
+		async ({ key, original, attempted }) => {
+			const workflow = await createWorkflowWithHistory(
+				{ settings: { executionOrder: 'v1', [key]: original } },
+				member,
+			);
 
-		const payload = {
-			name: workflow.name,
-			nodes: workflow.nodes,
-			connections: workflow.connections,
-			settings: {
-				executionOrder: 'v1',
-				binaryMode: 'separate',
-			},
-		};
+			const payload = {
+				name: workflow.name,
+				nodes: workflow.nodes,
+				connections: workflow.connections,
+				settings: {
+					executionOrder: 'v1',
+					[key]: attempted,
+				},
+			};
 
-		const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
+			const response = await authMemberAgent.put(`/workflows/${workflow.id}`).send(payload);
 
-		expect(response.statusCode).toBe(200);
-		expect(response.body.settings.binaryMode).toBe('combined');
+			expect(response.statusCode).toBe(200);
+			expect(response.body.settings[key]).toBe(original);
 
-		const workflowAfter = await workflowRepository.findOneBy({ id: workflow.id });
+			const workflowAfter = await workflowRepository.findOneBy({ id: workflow.id });
 
-		expect(workflowAfter?.settings?.binaryMode).toBe('combined');
-	});
+			expect(workflowAfter?.settings?.[key]).toBe(original);
+		},
+	);
 
 	test('should update non-owned workflow if owner', async () => {
 		const workflow = await createWorkflowWithHistory({}, member);


### PR DESCRIPTION
## Summary

* Adds the `credentialResolverId`, `timeSavedMode` and `binaryMode` properties to the workflow settings OpenAPI schema
  * `binaryMode` and `credentialResolverId` are special cases here. They are present in the response from `GET /api/v1/workflows` and `GET /api/v1/workflows/{workflowId}`. We want to be able to use this response in the update endpoint without users having to strip any fields. Hence, we've included them as a no-op as there are no cases to set these programmatically right now.
* Update integration test suite to cover new properties and no-op cases for `binaryMode` and `credentialResolverId  in both create & update

This picks up the schema change from #23814, credited to @sohamingle, and addresses the review feedback requesting test coverage.

## How to test

1. Access the public API documentation at `/api/v1/docs`
2. Verify the `credentialResolverId`, `timeSavedMode` and `binaryMode` properties appear in the workflow settings schema
3. Create/update a workflow via API with `timeSavedMode` set to `'fixed'` or `'dynamic'
4. Attempt to set `binaryMode` or `credentialResolverId` on workflow create & update, notice no-op

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-701

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

