### PR TITLE
fix(editor): Dissolve single-node canvas group when converting its nodes to a sub-workflow

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
@@ -373,7 +373,7 @@ describe('useWorkflowExtraction', () => {
 		it('keeps the group when only some members are extracted', async () => {
 			const nodeA = makeNode('A', [0, 0]);
 			const nodeB = makeNode('B', [200, 0]);
-			const nodeC = makeNode('C', [400, 0]); // sobrevive: no se extrae
+			const nodeC = makeNode('C', [400, 0]);
 			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id, nodeC.id] };
 
 			setWorkflowNodes([nodeA, nodeB, nodeC]);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
@@ -32,6 +32,7 @@ const {
 		getGroupForNode: vi.fn(),
 		getGroupById: vi.fn(),
 		addNodesToGroup: vi.fn(),
+		deleteGroup: vi.fn(),
 	},
 	mockNodeTypesStore: {
 		getNodeType: vi.fn().mockReturnValue({
@@ -115,7 +116,7 @@ vi.mock('vue-router', () => ({
 }));
 
 import { useWorkflowExtraction } from '@/app/composables/useWorkflowExtraction';
-import { UpdateNodeGroupCommand } from '@/app/models/history';
+import { RemoveNodeGroupCommand, UpdateNodeGroupCommand } from '@/app/models/history';
 
 function makeNode(name: string, position: [number, number] = [0, 0]): INodeUi {
 	return {
@@ -173,6 +174,7 @@ describe('useWorkflowExtraction', () => {
 		mockWorkflowDocumentStore.getGroupForNode.mockReset();
 		mockWorkflowDocumentStore.getGroupById.mockReset();
 		mockWorkflowDocumentStore.addNodesToGroup.mockReset();
+		mockWorkflowDocumentStore.deleteGroup.mockReset();
 		mockNodeTypesStore.getNodeType.mockClear();
 		mockHistoryStore.startRecordingUndo.mockClear();
 		mockHistoryStore.stopRecordingUndo.mockClear();
@@ -286,9 +288,18 @@ describe('useWorkflowExtraction', () => {
 		it('records the Execute Workflow node joining the group as undoable history', async () => {
 			const nodeA = makeNode('A', [0, 0]);
 			const nodeB = makeNode('B', [200, 0]);
-			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id] };
+			const nodeC = makeNode('C', [400, 0]); // survives, so the group is kept
+			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id, nodeC.id] };
 
-			setWorkflowNodes([nodeA, nodeB]);
+			setWorkflowNodes([nodeA, nodeB, nodeC]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+				B: {
+					[NodeConnectionTypes.Main]: [[{ node: 'C', type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+			};
 			mockWorkflowDocumentStore.getGroupForNode.mockImplementation((nodeId: string) =>
 				group.nodeIds.includes(nodeId) ? group : undefined,
 			);
@@ -300,7 +311,7 @@ describe('useWorkflowExtraction', () => {
 
 			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
 
-			await extractNodesIntoSubworkflow({ start: 'A', end: undefined }, [nodeA, nodeB], 'Sub');
+			await extractNodesIntoSubworkflow({ start: 'A', end: 'B' }, [nodeA, nodeB], 'Sub');
 
 			expect(mockWorkflowDocumentStore.addNodesToGroup).toHaveBeenCalledWith(group.id, [
 				'execute-node-id',
@@ -312,8 +323,86 @@ describe('useWorkflowExtraction', () => {
 				| UpdateNodeGroupCommand
 				| undefined;
 			expect(groupCommand).toBeInstanceOf(UpdateNodeGroupCommand);
-			expect(groupCommand?.before.nodeIds).toEqual([nodeA.id, nodeB.id]);
-			expect(groupCommand?.after.nodeIds).toEqual([nodeA.id, nodeB.id, 'execute-node-id']);
+			expect(groupCommand?.before.nodeIds).toEqual([nodeA.id, nodeB.id, nodeC.id]);
+			expect(groupCommand?.after.nodeIds).toEqual([
+				nodeA.id,
+				nodeB.id,
+				nodeC.id,
+				'execute-node-id',
+			]);
+		});
+
+		it('dissolves the group when every group member is extracted', async () => {
+			const nodeA = makeNode('A', [0, 0]);
+			const nodeB = makeNode('B', [200, 0]);
+			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id] };
+
+			setWorkflowNodes([nodeA, nodeB]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+			};
+			mockWorkflowDocumentStore.getGroupForNode.mockImplementation((nodeId: string) =>
+				group.nodeIds.includes(nodeId) ? group : undefined,
+			);
+			mockWorkflowDocumentStore.getGroupById.mockReturnValue({
+				...group,
+				nodeIds: [...group.nodeIds],
+			});
+
+			mockSuccessfulWorkflowCreation();
+
+			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
+
+			await extractNodesIntoSubworkflow({ start: 'A', end: 'B' }, [nodeA, nodeB], 'Sub');
+
+			expect(mockWorkflowDocumentStore.deleteGroup).toHaveBeenCalledWith(group.id);
+
+			expect(mockWorkflowDocumentStore.addNodesToGroup).not.toHaveBeenCalled();
+
+			const removeCommand = mockHistoryStore.pushCommandToUndo.mock.calls
+				.map(([command]) => command)
+				.find((command) => command instanceof RemoveNodeGroupCommand) as
+				| RemoveNodeGroupCommand
+				| undefined;
+			expect(removeCommand).toBeInstanceOf(RemoveNodeGroupCommand);
+			expect(removeCommand?.group.nodeIds).toEqual([nodeA.id, nodeB.id]);
+		});
+
+		it('keeps the group when only some members are extracted', async () => {
+			const nodeA = makeNode('A', [0, 0]);
+			const nodeB = makeNode('B', [200, 0]);
+			const nodeC = makeNode('C', [400, 0]); // sobrevive: no se extrae
+			const group = { id: 'g1', name: 'Group 1', nodeIds: [nodeA.id, nodeB.id, nodeC.id] };
+
+			setWorkflowNodes([nodeA, nodeB, nodeC]);
+			mockWorkflowDocumentStore.connectionsBySourceNode = {
+				A: {
+					[NodeConnectionTypes.Main]: [[{ node: 'B', type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+				B: {
+					[NodeConnectionTypes.Main]: [[{ node: 'C', type: NodeConnectionTypes.Main, index: 0 }]],
+				},
+			};
+			mockWorkflowDocumentStore.getGroupForNode.mockImplementation((nodeId: string) =>
+				group.nodeIds.includes(nodeId) ? group : undefined,
+			);
+			mockWorkflowDocumentStore.getGroupById
+				.mockReturnValueOnce({ ...group, nodeIds: [...group.nodeIds] })
+				.mockReturnValueOnce({ ...group, nodeIds: [...group.nodeIds, 'execute-node-id'] });
+
+			mockSuccessfulWorkflowCreation();
+
+			const { extractNodesIntoSubworkflow } = useWorkflowExtraction();
+
+			await extractNodesIntoSubworkflow({ start: 'A', end: 'B' }, [nodeA, nodeB], 'Sub');
+
+			expect(mockWorkflowDocumentStore.addNodesToGroup).toHaveBeenCalledWith(group.id, [
+				'execute-node-id',
+			]);
+
+			expect(mockWorkflowDocumentStore.deleteGroup).not.toHaveBeenCalled();
 		});
 
 		it('copies shared sub-nodes into the sub-workflow but keeps them in the parent', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.test.ts
@@ -11,6 +11,7 @@ const {
 	mockNodeTypesStore,
 	mockCanvasOperations,
 	mockTelemetry,
+	mockGroupTelemetry,
 	mockHistoryStore,
 	mockUIStore,
 } = vi.hoisted(() => ({
@@ -55,6 +56,9 @@ const {
 	},
 	mockTelemetry: {
 		track: vi.fn(),
+	},
+	mockGroupTelemetry: {
+		trackUngrouped: vi.fn(),
 	},
 	mockHistoryStore: {
 		startRecordingUndo: vi.fn(),
@@ -101,6 +105,10 @@ vi.mock('@/app/composables/useToast', () => ({
 
 vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn().mockReturnValue(mockTelemetry),
+}));
+
+vi.mock('@/features/workflows/canvas/composables/useCanvasNodeGroupTelemetry', () => ({
+	useCanvasNodeGroupTelemetry: vi.fn().mockReturnValue(mockGroupTelemetry),
 }));
 
 vi.mock('@n8n/i18n', () => ({
@@ -160,6 +168,7 @@ describe('useWorkflowExtraction', () => {
 		mockCanvasOperations.deleteNodes.mockClear();
 		mockCanvasOperations.replaceNodeParameters.mockClear();
 		mockTelemetry.track.mockClear();
+		mockGroupTelemetry.trackUngrouped.mockClear();
 		mockUIStore.resetLastInteractedWith.mockClear();
 		mockUIStore.markStateDirty.mockClear();
 		mockUIStore.openModalWithData.mockClear();
@@ -368,6 +377,11 @@ describe('useWorkflowExtraction', () => {
 				| undefined;
 			expect(removeCommand).toBeInstanceOf(RemoveNodeGroupCommand);
 			expect(removeCommand?.group.nodeIds).toEqual([nodeA.id, nodeB.id]);
+
+			expect(mockGroupTelemetry.trackUngrouped).toHaveBeenCalledWith(
+				expect.objectContaining({ id: group.id }),
+				'sub-workflow-extraction',
+			);
 		});
 
 		it('keeps the group when only some members are extracted', async () => {
@@ -403,6 +417,7 @@ describe('useWorkflowExtraction', () => {
 			]);
 
 			expect(mockWorkflowDocumentStore.deleteGroup).not.toHaveBeenCalled();
+			expect(mockGroupTelemetry.trackUngrouped).not.toHaveBeenCalled();
 		});
 
 		it('copies shared sub-nodes into the sub-workflow but keeps them in the parent', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -17,7 +17,8 @@ import { useToast } from './useToast';
 import { useRouter } from 'vue-router';
 import { VIEWS, WORKFLOW_EXTRACTION_NAME_MODAL_KEY } from '@/app/constants';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { RemoveNodeGroupCommand, UpdateNodeGroupCommand } from '@/app/models/history';
+import { UpdateNodeGroupCommand } from '@/app/models/history';
+import { deleteGroupWithHistory } from '@/features/workflows/canvas/nodeGroups.utils';
 import { useCanvasOperations } from './useCanvasOperations';
 import { useSelectionValidation } from './useSelectionValidation';
 
@@ -451,12 +452,7 @@ export function useWorkflowExtraction() {
 		// Whole group extracted: the only node left would be the Execute node. In this case, a single-node
 		// group is invalid, so dissolve the group and leave the Execute node ungrouped.
 		if (remainingGroupMembers.length === 0) {
-			const snapshot = {
-				...groupBeforeReplacements,
-				nodeIds: [...groupBeforeReplacements.nodeIds],
-			};
-			workflowDocumentStore.value.deleteGroup(groupId);
-			historyStore.pushCommandToUndo(new RemoveNodeGroupCommand(snapshot, Date.now()));
+			deleteGroupWithHistory(groupBeforeReplacements, workflowDocumentStore.value, historyStore);
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -460,8 +460,6 @@ export function useWorkflowExtraction() {
 			return;
 		}
 
-		// Some group members survived aside the Subworkflow, and the Subworkflow would not be the single
-		// remaining node, so keep the group and add the Execute node.
 		workflowDocumentStore.value.addNodesToGroup(groupId, [replacementNodeId]);
 		const groupAfterReplacements = workflowDocumentStore.value.getGroupById(groupId);
 		if (groupAfterReplacements) {

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -17,7 +17,7 @@ import { useToast } from './useToast';
 import { useRouter } from 'vue-router';
 import { VIEWS, WORKFLOW_EXTRACTION_NAME_MODAL_KEY } from '@/app/constants';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { UpdateNodeGroupCommand } from '@/app/models/history';
+import { RemoveNodeGroupCommand, UpdateNodeGroupCommand } from '@/app/models/history';
 import { useCanvasOperations } from './useCanvasOperations';
 import { useSelectionValidation } from './useSelectionValidation';
 
@@ -390,7 +390,7 @@ export function useWorkflowExtraction() {
 			})
 		)[0];
 
-		addReplacementNodeToSelectionGroup(
+		addReplacementNodeToCanvasGroup(
 			nodesToRemoveFromParent.map((node) => node.id),
 			executeWorkflowNode.id,
 		);
@@ -431,9 +431,9 @@ export function useWorkflowExtraction() {
 		historyStore.stopRecordingUndo();
 	}
 
-	function addReplacementNodeToSelectionGroup(selectionIds: string[], replacementNodeId: string) {
+	function addReplacementNodeToCanvasGroup(removableNodeIds: string[], replacementNodeId: string) {
 		const affectedGroupIds = uniq(
-			selectionIds
+			removableNodeIds
 				.map((nodeId) => workflowDocumentStore.value.getGroupForNode(nodeId)?.id)
 				.filter((id): id is string => id !== undefined),
 		);
@@ -441,14 +441,34 @@ export function useWorkflowExtraction() {
 		if (affectedGroupIds.length !== 1) return;
 
 		const groupId = affectedGroupIds[0];
-		const groupBefore = workflowDocumentStore.value.getGroupById(groupId);
+		const groupBeforeReplacements = workflowDocumentStore.value.getGroupById(groupId);
+		if (!groupBeforeReplacements) return;
+
+		const remainingGroupMembers = groupBeforeReplacements.nodeIds.filter(
+			(id) => !removableNodeIds.includes(id),
+		);
+
+		// Whole group extracted: the only node left would be the Execute node. In this case, a single-node
+		// group is invalid, so dissolve the group and leave the Execute node ungrouped.
+		if (remainingGroupMembers.length === 0) {
+			const snapshot = {
+				...groupBeforeReplacements,
+				nodeIds: [...groupBeforeReplacements.nodeIds],
+			};
+			workflowDocumentStore.value.deleteGroup(groupId);
+			historyStore.pushCommandToUndo(new RemoveNodeGroupCommand(snapshot, Date.now()));
+			return;
+		}
+
+		// Some group members survived aside the Subworkflow, and the Subworkflow would not be the single
+		// remaining node, so keep the group and add the Execute node.
 		workflowDocumentStore.value.addNodesToGroup(groupId, [replacementNodeId]);
-		const groupAfter = workflowDocumentStore.value.getGroupById(groupId);
-		if (groupBefore && groupAfter) {
+		const groupAfterReplacements = workflowDocumentStore.value.getGroupById(groupId);
+		if (groupAfterReplacements) {
 			historyStore.pushCommandToUndo(
 				new UpdateNodeGroupCommand(
-					{ ...groupBefore, nodeIds: [...groupBefore.nodeIds] },
-					{ ...groupAfter, nodeIds: [...groupAfter.nodeIds] },
+					{ ...groupBeforeReplacements, nodeIds: [...groupBeforeReplacements.nodeIds] },
+					{ ...groupAfterReplacements, nodeIds: [...groupAfterReplacements.nodeIds] },
 					Date.now(),
 				),
 			);

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -5,6 +5,7 @@ import {
 	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
 	NodeConnectionTypes,
 	NodeHelpers,
+	EXECUTE_WORKFLOW_NODE_TYPE,
 } from 'n8n-workflow';
 import type {
 	ExtractableSubgraphData,
@@ -121,7 +122,7 @@ export function useWorkflowExtraction() {
 				},
 				options: {},
 			},
-			type: 'n8n-nodes-base.executeWorkflow',
+			type: EXECUTE_WORKFLOW_NODE_TYPE,
 			typeVersion: 1.2,
 			position,
 			name,

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowExtraction.ts
@@ -19,6 +19,7 @@ import { VIEWS, WORKFLOW_EXTRACTION_NAME_MODAL_KEY } from '@/app/constants';
 import { useHistoryStore } from '@/app/stores/history.store';
 import { UpdateNodeGroupCommand } from '@/app/models/history';
 import { deleteGroupWithHistory } from '@/features/workflows/canvas/nodeGroups.utils';
+import { useCanvasNodeGroupTelemetry } from '@/features/workflows/canvas/composables/useCanvasNodeGroupTelemetry';
 import { useCanvasOperations } from './useCanvasOperations';
 import { useSelectionValidation } from './useSelectionValidation';
 
@@ -51,6 +52,7 @@ export function useWorkflowExtraction() {
 	const canvasOperations = useCanvasOperations();
 	const i18n = useI18n();
 	const telemetry = useTelemetry();
+	const groupTelemetry = useCanvasNodeGroupTelemetry();
 	const { expandSelectionWithSubNodes, isSelectionExtractable } = useSelectionValidation();
 
 	function showError(message: string) {
@@ -453,6 +455,7 @@ export function useWorkflowExtraction() {
 		// group is invalid, so dissolve the group and leave the Execute node ungrouped.
 		if (remainingGroupMembers.length === 0) {
 			deleteGroupWithHistory(groupBeforeReplacements, workflowDocumentStore.value, historyStore);
+			groupTelemetry.trackUngrouped(groupBeforeReplacements, 'sub-workflow-extraction');
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodeGroups.ts
@@ -160,7 +160,7 @@ export function useWorkflowDocumentNodeGroups() {
 	function replaceNodeInGroup(id: string, previousNodeId: string, newNodeId: string) {
 		if (previousNodeId === newNodeId) return;
 		const group = groups.value.get(id);
-		if (!group || !group.nodeIds.includes(previousNodeId)) return;
+		if (!group?.nodeIds.includes(previousNodeId)) return;
 
 		applyUpsertGroup(
 			{

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
@@ -7,19 +7,15 @@ import { computed, toValue } from 'vue';
 import { useSelectionValidation } from '@/app/composables/useSelectionValidation';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useHistoryStore } from '@/app/stores/history.store';
-import {
-	AddNodeGroupCommand,
-	RemoveNodeGroupCommand,
-	UpdateNodeGroupCommand,
-} from '@/app/models/history';
+import { AddNodeGroupCommand, UpdateNodeGroupCommand } from '@/app/models/history';
 import {
 	isCanvasGroupNode,
 	parseCanvasGroupNodeId,
 } from '@/features/workflows/canvas/canvas.types';
-
-function snapshotGroup(group: IWorkflowGroup): IWorkflowGroup {
-	return { ...group, nodeIds: [...group.nodeIds] };
-}
+import {
+	deleteGroupWithHistory,
+	snapshotGroup,
+} from '@/features/workflows/canvas/nodeGroups.utils';
 
 export function useCanvasNodeGroupActions(
 	selectedNodes: MaybeRefOrGetter<GraphNode[]>,
@@ -104,9 +100,7 @@ export function useCanvasNodeGroupActions(
 		if (isReadOnly.value) return;
 		const group = workflowDocumentStore.value.getGroupById(id);
 		if (!group) return;
-		const snapshot = snapshotGroup(group);
-		workflowDocumentStore.value.deleteGroup(id);
-		historyStore.pushCommandToUndo(new RemoveNodeGroupCommand(snapshot, Date.now()));
+		deleteGroupWithHistory(group, workflowDocumentStore.value, historyStore);
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
@@ -16,7 +16,7 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { RemoveNodeGroupCommand } from '@/app/models/history';
+import { deleteGroupWithHistory } from '@/features/workflows/canvas/nodeGroups.utils';
 import { useCanvasNodeGroupTelemetry } from './useCanvasNodeGroupTelemetry';
 
 type ConnectionChangeAction = 'add' | 'remove';
@@ -190,9 +190,7 @@ export function useCanvasNodeGroupOperationGuards() {
 				onClick: (event: MouseEvent) => {
 					event.preventDefault();
 					event.stopPropagation();
-					const snapshot = { ...group, nodeIds: [...group.nodeIds] };
-					workflowDocumentStore.value.deleteGroup(group.id);
-					historyStore.pushCommandToUndo(new RemoveNodeGroupCommand(snapshot, Date.now()));
+					deleteGroupWithHistory(group, workflowDocumentStore.value, historyStore);
 					groupTelemetry.trackUngrouped(group, 'update-blocked-toast');
 					notification?.close();
 				},

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupTelemetry.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupTelemetry.ts
@@ -8,7 +8,8 @@ export type CanvasNodeGroupEventSource =
 	| 'group-toolbar'
 	| 'keyboard-shortcut'
 	| 'context-menu'
-	| 'update-blocked-toast';
+	| 'update-blocked-toast'
+	| 'sub-workflow-extraction';
 
 /**
  * Telemetry for canvas node groups: capturing how users

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/nodeGroups.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/nodeGroups.utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { IWorkflowGroup } from 'n8n-workflow';
+
+import { snapshotGroup, deleteGroupWithHistory } from './nodeGroups.utils';
+import { RemoveNodeGroupCommand } from '@/app/models/history';
+import type { useHistoryStore } from '@/app/stores/history.store';
+import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
+function createGroup(overrides: Partial<IWorkflowGroup> = {}): IWorkflowGroup {
+	return { id: 'group-1', name: 'Group 1', nodeIds: ['a', 'b'], ...overrides };
+}
+
+describe('snapshotGroup', () => {
+	it('returns a new object with the same values', () => {
+		const group = createGroup();
+		const snapshot = snapshotGroup(group);
+
+		expect(snapshot).toEqual(group);
+		expect(snapshot).not.toBe(group);
+	});
+
+	it('copies nodeIds so later mutations of the source do not leak into the snapshot', () => {
+		const group = createGroup({ nodeIds: ['a', 'b'] });
+		const snapshot = snapshotGroup(group);
+
+		expect(snapshot.nodeIds).not.toBe(group.nodeIds);
+
+		group.nodeIds.push('c');
+		expect(snapshot.nodeIds).toEqual(['a', 'b']);
+	});
+});
+
+describe('deleteGroupWithHistory', () => {
+	function setup() {
+		const workflowDocumentStore = {
+			deleteGroup: vi.fn(),
+		} as unknown as WorkflowDocumentStore;
+		const historyStore = {
+			pushCommandToUndo: vi.fn(),
+		} as unknown as ReturnType<typeof useHistoryStore>;
+		return { workflowDocumentStore, historyStore };
+	}
+
+	it('deletes the group by id', () => {
+		const { workflowDocumentStore, historyStore } = setup();
+		const group = createGroup();
+
+		deleteGroupWithHistory(group, workflowDocumentStore, historyStore);
+
+		expect(workflowDocumentStore.deleteGroup).toHaveBeenCalledWith('group-1');
+	});
+
+	it('pushes a RemoveNodeGroupCommand carrying the group id and nodeIds', () => {
+		const { workflowDocumentStore, historyStore } = setup();
+		const group = createGroup({ id: 'group-1', nodeIds: ['a', 'b'] });
+
+		deleteGroupWithHistory(group, workflowDocumentStore, historyStore);
+
+		expect(historyStore.pushCommandToUndo).toHaveBeenCalledTimes(1);
+		const command = vi.mocked(historyStore.pushCommandToUndo).mock.calls[0][0];
+		expect(command).toBeInstanceOf(RemoveNodeGroupCommand);
+		expect((command as RemoveNodeGroupCommand).group.id).toBe('group-1');
+		expect((command as RemoveNodeGroupCommand).group.nodeIds).toEqual(['a', 'b']);
+	});
+
+	it('snapshots the group so mutating the source after the call does not change the undo command', () => {
+		const { workflowDocumentStore, historyStore } = setup();
+		const group = createGroup({ nodeIds: ['a', 'b'] });
+
+		deleteGroupWithHistory(group, workflowDocumentStore, historyStore);
+		group.nodeIds.push('c');
+
+		const command = vi.mocked(historyStore.pushCommandToUndo).mock
+			.calls[0][0] as RemoveNodeGroupCommand;
+		expect(command.group.nodeIds).toEqual(['a', 'b']);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/nodeGroups.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/nodeGroups.utils.ts
@@ -1,0 +1,24 @@
+import type { IWorkflowGroup } from 'n8n-workflow';
+
+import { RemoveNodeGroupCommand } from '@/app/models/history';
+import type { useHistoryStore } from '@/app/stores/history.store';
+import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
+export function snapshotGroup(group: IWorkflowGroup): IWorkflowGroup {
+	return { ...group, nodeIds: [...group.nodeIds] };
+}
+
+/**
+ * Deletes a group and pushes an undo command that restores it.
+ * Snapshots the group at call time, so callers pass the group whose current
+ * state should be restored (e.g. a state captured before node replacements).
+ */
+export function deleteGroupWithHistory(
+	group: IWorkflowGroup,
+	workflowDocumentStore: WorkflowDocumentStore,
+	historyStore: ReturnType<typeof useHistoryStore>,
+) {
+	const snapshot = snapshotGroup(group);
+	workflowDocumentStore.deleteGroup(group.id);
+	historyStore.pushCommandToUndo(new RemoveNodeGroupCommand(snapshot, Date.now()));
+}


### PR DESCRIPTION
## Summary
When converting all canvas group nodes to a sub-workflow, the extracted nodes are replaced by a single "Execute Sub-workflow" node, which is added to their canvas group so the group survives the conversion.

If the whole group was extracted, the group ended up containing just that one Execute node — an invalid single-node group left on the canvas.

Now, when no original group member survives the extraction, the group is dissolved and the Execute node is left ungrouped. Partial extractions (where some members remain) still keep the group and add the Execute node to it, as before. The dissolution is recorded as an undoable history command.

## How to test
1. Open a workflow and add a couple of connected nodes (e.g. Aggregate → Edit Fields).
2. Select them and group them (Cmd/Ctrl+G) into a canvas group.
3. With the group selected, click "Convert N nodes to sub-workflow" and confirm.
4. Expected: the group disappears and a single "Execute Sub-workflow" node
   remains, ungrouped. Before the fix, an empty-looking single-node group stayed.
5. Undo (Cmd/Ctrl+Z): the original nodes and the group are restored.
6. Partial case: create a group of 3 nodes, convert only 2 of them. The group
   should remain, now containing the surviving node + the Execute node.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5580

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->