### PR TITLE
fix(core): Hide sub-workflow tool from agent tool selection (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/agent-builder-tool-node-types.ts
+++ b/packages/@n8n/api-types/src/agent-builder-tool-node-types.ts
@@ -1,8 +1,14 @@
-import { AI_VENDOR_NODE_TYPES, CHAT_TOOL_NODE_TYPE } from 'n8n-workflow';
+import {
+	AI_VENDOR_NODE_TYPES,
+	CHAT_TOOL_NODE_TYPE,
+	WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE,
+} from 'n8n-workflow';
 
 export const AGENT_BUILDER_HIDDEN_AVAILABLE_TOOL_NODE_TYPES: readonly string[] = [
 	...AI_VENDOR_NODE_TYPES.map((nodeType) => `${nodeType}Tool`),
 	CHAT_TOOL_NODE_TYPE,
+	// Agents call workflows via native workflow tools, not the sub-workflow node
+	WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE,
 ];
 
 export const AGENT_BUILDER_AVAILABLE_AI_UTILITY_TOOL_NODE_TYPES = [

--- a/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
@@ -157,6 +157,10 @@ describe('AgentsToolsService', () => {
 			}
 		});
 
+		it('rejects the sub-workflow tool node', () => {
+			expect(isAgentToolNodeType('@n8n/n8n-nodes-langchain.toolWorkflow')).toBe(false);
+		});
+
 		it('allows shared AI utility tool node IDs', () => {
 			for (const nodeType of AGENT_BUILDER_AVAILABLE_AI_UTILITY_TOOL_NODE_TYPES) {
 				expect(isAgentToolNodeType(nodeType)).toBe(true);


### PR DESCRIPTION
## Summary

Adds the sub-workflow call tool (`@n8n/n8n-nodes-langchain.toolWorkflow`) to the `AGENT_BUILDER_HIDDEN_AVAILABLE_TOOL_NODE_TYPES` denylist, so agents only call workflows via native workflow tools. This single constant disables it in both places it could be added: the shared agent tools modal (used by first-class and inline agents) and the agent builder's `search_nodes`/`get_node_types` tools. Existing agents with the tool already configured keep working, and the node itself remains available for regular canvas workflows.

## How to test

1. Open a first-class agent → Add tool → verify "Call n8n Workflow Tool" no longer appears in Available tools, while the "Workflows" section still lists workflows.
2. Repeat inside a Message an Agent (v2) node with an inline agent.
3. Ask the agent builder to add a sub-workflow tool — it should use a native workflow tool instead.
4. Unit tests: `pnpm test src/modules/agents/__tests__/agents-tools.service.test.ts` in `packages/cli`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-399

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

