### PR TITLE
feat(core): Crash-resume interrupted Instance AI runs from step checkpoints (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
+++ b/packages/@n8n/api-types/src/schemas/__tests__/agent-run-reducer.test.ts
@@ -233,6 +233,38 @@ describe('agent-run-reducer', () => {
 			expect(state.agentsById['root'].status).toBe('completed');
 		});
 
+		it('run-resumed re-activates the tree so the resumed stream lands on a live root', () => {
+			const state = stateWithRun('run-1', 'root');
+			// A crashed run's replay carries tool-interrupted terminal facts; the
+			// resume boundary must leave the run streamable again.
+			reduceEvent(state, {
+				type: 'tool-call',
+				runId: 'run-1',
+				agentId: 'root',
+				payload: { toolCallId: 'tc-1', toolName: 'update-workflow', args: {} },
+			});
+			reduceEvent(state, {
+				type: 'tool-interrupted',
+				runId: 'run-1',
+				agentId: 'root',
+				payload: { toolCallId: 'tc-1', error: 'interrupted by restart' },
+			});
+			reduceEvent(state, {
+				type: 'run-resumed',
+				runId: 'run-1',
+				agentId: 'orchestrator-run-1',
+				payload: { reason: 'crash_interrupted' },
+			});
+
+			expect(state.status).toBe('active');
+			expect(state.agentsById['root'].status).toBe('active');
+			// The resume publishes under a per-run agentId; it aliases to the root.
+			expect(state.agentsById['orchestrator-run-1']).toBe(state.agentsById['root']);
+			// The resumed stream's terminal fact still folds normally.
+			reduceEvent(state, makeRunFinish('run-1', 'root', 'completed'));
+			expect(state.status).toBe('completed');
+		});
+
 		it('run-finish(cancelled) sets status to cancelled', () => {
 			const state = stateWithRun('run-1', 'root');
 			reduceEvent(state, makeRunFinish('run-1', 'root', 'cancelled'));

--- a/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
+++ b/packages/@n8n/api-types/src/schemas/agent-run-reducer.ts
@@ -230,6 +230,22 @@ export function reduceEvent(state: AgentRunState, event: InstanceAiEvent): Agent
 			break;
 		}
 
+		case 'run-resumed': {
+			// Crash-resume boundary (durable-log resilience): the run continues
+			// under its original runId after a process restart. Re-activate the
+			// root so the resumed stream's events land on a live tree; whether to
+			// surface the boundary itself is the UI's call (INS-837).
+			state.status = 'active';
+			const root = state.agentsById[state.rootAgentId];
+			if (root) {
+				root.status = 'active';
+				if (event.agentId !== state.rootAgentId && isSafeObjectKey(event.agentId)) {
+					state.agentsById[event.agentId] = root;
+				}
+			}
+			break;
+		}
+
 		case 'text-delta': {
 			const agent = ensureAgent(state, event.agentId);
 			if (agent) {

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -98,6 +98,7 @@ export type ToolCallId = string & { readonly __brand: 'ToolCallId' };
 export const instanceAiEventTypeSchema = z.enum([
 	'run-start',
 	'run-finish',
+	'run-resumed',
 	'agent-spawned',
 	'agent-completed',
 	'text-delta',
@@ -215,6 +216,13 @@ export const runFinishPayloadSchema = z.object({
 	 * entries and label them as archived.
 	 */
 	archivedWorkflowIds: z.array(z.string()).optional(),
+});
+
+// Durable-log RFC (resilience phase): appended when the interrupted-run sweep
+// re-drives a crashed run from its step checkpoint. Marks the resume boundary
+// in the durable timeline under the original runId; surfacing is the UI's call.
+export const runResumedPayloadSchema = z.object({
+	reason: z.literal('crash_interrupted'),
 });
 
 export const agentSpawnedTargetResourceSchema = z.object({
@@ -751,6 +759,7 @@ const eventBase = {
 export const instanceAiEventSchema = z.discriminatedUnion('type', [
 	z.object({ type: z.literal('run-start'), ...eventBase, payload: runStartPayloadSchema }),
 	z.object({ type: z.literal('run-finish'), ...eventBase, payload: runFinishPayloadSchema }),
+	z.object({ type: z.literal('run-resumed'), ...eventBase, payload: runResumedPayloadSchema }),
 	z.object({ type: z.literal('agent-spawned'), ...eventBase, payload: agentSpawnedPayloadSchema }),
 	z.object({
 		type: z.literal('agent-completed'),

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -499,6 +499,9 @@ export type { RunTokenUsage, BuilderUsageItem } from './stream/usage-accumulator
 export const resumeAgentRun: typeof StreamRunnerMod.resumeAgentRun = lazyFunction(
 	() => loadStreamRunner().resumeAgentRun,
 );
+export const crashResumeAgentRun: typeof StreamRunnerMod.crashResumeAgentRun = lazyFunction(
+	() => loadStreamRunner().crashResumeAgentRun,
+);
 export const streamAgentRun: typeof StreamRunnerMod.streamAgentRun = lazyFunction(
 	() => loadStreamRunner().streamAgentRun,
 );

--- a/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
+++ b/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
@@ -15,7 +15,7 @@ import {
 } from './resumable-stream-executor';
 import type { RunTokenUsage } from '../stream/usage-accumulator';
 import type { WorkSummary } from '../stream/work-summary-accumulator';
-import { resumeAgentStream } from '../utils/stream-helpers';
+import { crashResumeAgentStream, resumeAgentStream } from '../utils/stream-helpers';
 import type { SuspensionInfo } from '../utils/stream-helpers';
 
 export interface StreamableAgent {
@@ -66,6 +66,22 @@ export async function resumeAgentRun(
 	options: StreamRunOptions & { agentRunId: string },
 ): Promise<StreamRunResult> {
 	const resumed = await resumeAgentStream(agent, resumeData, resumeOptions);
+	const stream = normalizeStreamSource(resumed);
+	const agentRunId = (typeof stream.runId === 'string' && stream.runId) || options.agentRunId;
+	return await consumeStream(agent, stream, { ...options, agentRunId });
+}
+
+/**
+ * Durable-log RFC (resilience phase): re-drive a crash-interrupted run from a
+ * `running`-status step checkpoint. Consumes the resumed stream through the
+ * same machinery as a fresh or HITL-resumed run.
+ */
+export async function crashResumeAgentRun(
+	agent: unknown,
+	crashResumeOptions: Record<string, unknown>,
+	options: StreamRunOptions & { agentRunId: string },
+): Promise<StreamRunResult> {
+	const resumed = await crashResumeAgentStream(agent, crashResumeOptions);
 	const stream = normalizeStreamSource(resumed);
 	const agentRunId = (typeof stream.runId === 'string' && stream.runId) || options.agentRunId;
 	return await consumeStream(agent, stream, { ...options, agentRunId });

--- a/packages/@n8n/instance-ai/src/utils/stream-helpers.ts
+++ b/packages/@n8n/instance-ai/src/utils/stream-helpers.ts
@@ -40,6 +40,7 @@ export interface Resumable {
 		data: Record<string, unknown>,
 		options: Record<string, unknown>,
 	) => Promise<unknown>;
+	crashResume?: (options: Record<string, unknown>) => Promise<unknown>;
 }
 
 /** Cast an agent to Resumable for suspend/resume operations. */
@@ -63,4 +64,25 @@ export async function resumeAgentStream(
 	}
 
 	throw new Error('Agent does not support stream resume');
+}
+
+/**
+ * Durable-log RFC (resilience phase): re-drive a run from a `running`-status
+ * step checkpoint after a process crash (see Agent.crashResume).
+ */
+export async function crashResumeAgentStream(
+	agent: unknown,
+	options: Record<string, unknown>,
+): Promise<unknown> {
+	if (!isRecord(agent)) {
+		throw new Error('Agent does not support crash resume');
+	}
+
+	const resumable = asResumable(agent);
+
+	if (typeof resumable.crashResume === 'function') {
+		return await resumable.crashResume(options);
+	}
+
+	throw new Error('Agent does not support crash resume');
 }

--- a/packages/cli/src/events/maps/instance-ai.event-map.ts
+++ b/packages/cli/src/events/maps/instance-ai.event-map.ts
@@ -34,6 +34,8 @@ export type InstanceAiEventMap = {
 	'instance-ai-run-swept': {
 		outcome: 'interrupted' | 'crash-resumed';
 		toolInterruptedFacts: number;
+		/** Steering corrections re-queued into the crash-resumed model context. */
+		correctionsRequeued: number;
 	};
 	'instance-ai-run-finished': {
 		/** 'suspended' is a non-terminal HITL segment: usage/tool counts only; the terminal event counts the run. */

--- a/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/instance-ai-metrics.service.ts
@@ -138,6 +138,12 @@ export class PrometheusInstanceAiMetricsService implements PrometheusMetricsColl
 		runsSweptTotal.inc({ outcome: 'interrupted' }, 0);
 		runsSweptTotal.inc({ outcome: 'crash-resumed' }, 0);
 
+		const sweepCorrectionsRequeuedTotal = new promClient.Counter({
+			name: `${this.config.prefix}instance_ai_sweep_corrections_requeued_total`,
+			help: 'Steering corrections re-queued into crash-resumed Instance AI model contexts.',
+		});
+		sweepCorrectionsRequeuedTotal.inc(0);
+
 		this.eventService.on('instance-ai-durable-log-drained', ({ rows, bytes }) => {
 			durableLogRowsTotal.inc(rows);
 			durableLogBytesTotal.inc(bytes);
@@ -161,8 +167,9 @@ export class PrometheusInstanceAiMetricsService implements PrometheusMetricsColl
 		this.eventService.on('instance-ai-parser-fallback', ({ count }) => {
 			parserFallbacksTotal.inc(count);
 		});
-		this.eventService.on('instance-ai-run-swept', ({ outcome }) => {
+		this.eventService.on('instance-ai-run-swept', ({ outcome, correctionsRequeued }) => {
 			runsSweptTotal.inc({ outcome }, 1);
+			if (correctionsRequeued > 0) sweepCorrectionsRequeuedTotal.inc(correctionsRequeued);
 		});
 
 		this.eventService.on(

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -156,6 +156,7 @@ vi.mock('@n8n/instance-ai', async () => {
 			}
 		},
 		resumeAgentRun: vi.fn(),
+		crashResumeAgentRun: vi.fn(),
 		createInstanceAiTraceContext: vi.fn(async () => ({ rootRun: { otelTraceId: undefined } })),
 		TerminalOutcomeStorage: class {
 			constructor(_memory: unknown) {}
@@ -173,6 +174,7 @@ import {
 	createAllTools,
 	createLazyRuntimeWorkspace,
 	createLazyWorkspaceRuntimeSkillSource,
+	crashResumeAgentRun,
 	createOrchestratorRunControl,
 	createSandbox,
 	createWorkspace,
@@ -626,6 +628,24 @@ type TerminalGuardOrderServiceInternals = {
 			abortController: AbortController;
 			snapshotStorage: unknown;
 			tracing?: InstanceAiTraceContext;
+		},
+	) => Promise<void>;
+	trackConfirmationRequest: Mock;
+	checkpointStore: { load: Mock };
+	revalidateActiveUser: Mock;
+	crashResumeInterruptedRun: InstanceAiService['crashResumeInterruptedRun'];
+	processCrashResumedStream: (
+		agent: unknown,
+		opts: {
+			runId: string;
+			agentRunId: string;
+			threadId: string;
+			user: User;
+			signal: AbortSignal;
+			abortController: AbortController;
+			snapshotStorage: unknown;
+			messageGroupId?: string;
+			contextNotes?: string[];
 		},
 	) => Promise<void>;
 };
@@ -3807,5 +3827,121 @@ describe('InstanceAiService — clearThreadState agent-builder cleanup', () => {
 			'Failed to clean up agent-builder sessions for thread',
 			expect.objectContaining({ threadId: 'thread-a' }),
 		);
+	});
+});
+
+describe('InstanceAiService — crash-resumed stream (durable-log RFC)', () => {
+	const CRASH_OPTS = {
+		runId: 'run-1',
+		agentRunId: 'agent-run-1',
+		threadId: 'thread-a',
+		signal: new AbortController().signal,
+		snapshotStorage: {},
+		messageGroupId: 'group-1',
+	};
+
+	function createCrashResumeService() {
+		const service = createTerminalGuardOrderService();
+		service.trackConfirmationRequest = vi.fn();
+		return service;
+	}
+
+	beforeEach(() => {
+		vi.mocked(crashResumeAgentRun).mockReset();
+	});
+
+	it('re-suspending at HITL registers the suspension like the resumed path and does not finalize', async () => {
+		const service = createCrashResumeService();
+		const abortController = new AbortController();
+		const confirmationEvent = {
+			type: 'confirmation-request',
+			runId: 'run-1',
+			agentId: 'orchestrator-run-1',
+			payload: { requestId: 'req-1', toolCallId: 'tc-1', message: 'Approve?' },
+		};
+		vi.mocked(crashResumeAgentRun).mockResolvedValueOnce({
+			status: 'suspended',
+			agentRunId: 'agent-run-1',
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+			suspension: {
+				toolCallId: 'tc-1',
+				requestId: 'req-1',
+				toolName: 'ask-user',
+				suspendPayload: { requestId: 'req-1' },
+			},
+			confirmationEvent,
+		} as never);
+
+		await service.processCrashResumedStream({}, { ...CRASH_OPTS, user: fakeUser, abortController });
+
+		// In-memory suspension registered under the original run + checkpoint key,
+		// with the log-derived message group (the tracing registry died with the
+		// crashed process).
+		expect(service.runState.suspendRun).toHaveBeenCalledWith(
+			'thread-a',
+			expect.objectContaining({
+				runId: 'run-1',
+				agentRunId: 'agent-run-1',
+				requestId: 'req-1',
+				toolCallId: 'tc-1',
+				toolName: 'ask-user',
+				messageGroupId: 'group-1',
+			}),
+		);
+		// Persisted index row so the suspension survives ANOTHER restart.
+		expect(service.suspendedThreads.persistPendingConfirmation).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestId: 'req-1',
+				threadId: 'thread-a',
+				runId: 'run-1',
+				kind: 'suspended',
+				toolCallId: 'tc-1',
+				checkpointKey: 'agent-run-1',
+			}),
+		);
+		// The confirmation card reaches the client; the run is NOT finalized.
+		expect(service.eventBus.events.map((event) => event.type)).toEqual(['confirmation-request']);
+		expect(service.saveAgentTreeSnapshot).toHaveBeenCalledWith('thread-a', 'run-1', {});
+		expect(service.eventBus.events.some((event) => event.type === 'run-finish')).toBe(false);
+	});
+
+	it('a completed crash-resumed run finalizes with a run-finish and clears the active run', async () => {
+		const service = createCrashResumeService();
+		const abortController = new AbortController();
+		vi.mocked(crashResumeAgentRun).mockResolvedValueOnce({
+			status: 'completed',
+			agentRunId: 'agent-run-1',
+			text: Promise.resolve('done'),
+			workSummary: { toolCalls: [], totalToolCalls: 0, totalToolErrors: 0 },
+		} as never);
+
+		await service.processCrashResumedStream({}, { ...CRASH_OPTS, user: fakeUser, abortController });
+
+		expect(service.runState.clearActiveRun).toHaveBeenCalledWith('thread-a');
+		const finish = service.eventBus.events.find((event) => event.type === 'run-finish');
+		expect(finish?.payload).toMatchObject({ status: 'completed' });
+		// Terminal usage claim is deduped per run segment.
+		expect(service.creditService.claimRunUsage).toHaveBeenCalledWith(
+			fakeUser,
+			'thread-a',
+			'agent-run-1',
+			[],
+			'completed',
+		);
+	});
+
+	it('crashResumeInterruptedRun refuses a checkpoint that is not a running step checkpoint', async () => {
+		const service = createCrashResumeService();
+		service.revalidateActiveUser = vi.fn(async () => fakeUser);
+		service.checkpointStore = { load: vi.fn(async () => ({ status: 'suspended' })) };
+
+		const resumed = await service.crashResumeInterruptedRun({
+			threadId: 'thread-a',
+			runId: 'run-1',
+			userId: fakeUser.id,
+			checkpointKey: 'agent-run-1',
+		});
+
+		expect(resumed).toBe(false);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/durable-event-log.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/durable-event-log.test.ts
@@ -229,6 +229,12 @@ describe('DurableEventLog', () => {
 			textDelta('AAA'),
 			toolCall('tc-1'),
 			{ type: 'status', runId: RUN, agentId: AGENT, payload: { message: 'working' } },
+			{
+				type: 'run-resumed',
+				runId: RUN,
+				agentId: AGENT,
+				payload: { reason: 'crash_interrupted' },
+			},
 			runFinish(),
 		]);
 
@@ -238,15 +244,18 @@ describe('DurableEventLog', () => {
 			'text-delta',
 			'tool-call',
 			'status',
+			'run-resumed',
 			'run-finish',
 		]);
-		// Deltas and status carry no id; structural facts carry the DB seq.
+		// Deltas and status carry no id; structural facts (including the
+		// crash-resume boundary) carry the DB seq.
 		expect(live[0].id).toBeUndefined();
 		expect(live[2].id).toBeUndefined();
 		expect(live[1].id).toBeDefined();
 		expect(live[3].id).toBeDefined();
+		expect(live[4].id).toBeDefined();
 		// Persisted seqs are contiguous from 1.
-		expect(repo.rows.map((r) => r.seq)).toEqual([1, 2, 3]);
+		expect(repo.rows.map((r) => r.seq)).toEqual([1, 2, 3, 4]);
 	});
 
 	it('continues the seq across a restart (fresh instance seeds from the DB)', async () => {

--- a/packages/cli/src/modules/instance-ai/event-bus/__tests__/interrupted-run-sweeper.test.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/__tests__/interrupted-run-sweeper.test.ts
@@ -70,6 +70,7 @@ interface Setup {
 	lastFactAt?: Date | null;
 	durableLog?: boolean;
 	host?: Partial<InterruptedRunResumeHost>;
+	claimSucceeds?: boolean;
 }
 
 function buildSweeper(setup: Setup) {
@@ -98,6 +99,7 @@ function buildSweeper(setup: Setup) {
 
 	const checkpointRepo = mock<InstanceAiCheckpointRepository>();
 	checkpointRepo.findActiveByThreadId.mockResolvedValue(setup.checkpoints ?? []);
+	checkpointRepo.claimForCrashResume.mockResolvedValue(setup.claimSucceeds ?? true);
 
 	const published: InstanceAiEvent[] = [];
 	const eventBus = {
@@ -108,8 +110,11 @@ function buildSweeper(setup: Setup) {
 	};
 
 	const metrics = new DurableLogMetrics(mock<EventService>());
+	const crashResumeInterruptedRun =
+		setup.host?.crashResumeInterruptedRun ?? vi.fn(async () => true);
 	const host: InterruptedRunResumeHost = {
 		isRunLive: setup.host?.isRunLive ?? (() => false),
+		crashResumeInterruptedRun,
 	};
 
 	const sweeper = new InterruptedRunSweeper(
@@ -122,7 +127,7 @@ function buildSweeper(setup: Setup) {
 		{ isMultiMain: setup.isMultiMain ?? false } as InstanceSettings,
 	);
 	sweeper.setResumeHost(host);
-	return { sweeper, published, metrics, eventLogRepo };
+	return { sweeper, published, metrics, eventLogRepo, checkpointRepo, crashResumeInterruptedRun };
 }
 
 describe('InterruptedRunSweeper', () => {
@@ -238,16 +243,128 @@ describe('InterruptedRunSweeper', () => {
 		expect(published.at(-1)?.type).toBe('run-finish');
 	});
 
-	it('marks a run with a running step checkpoint interrupted (crash-resume is a later phase)', async () => {
+	it('crash-resumes a run with a running step checkpoint instead of marking it interrupted', async () => {
+		const { sweeper, published, metrics, crashResumeInterruptedRun } = buildSweeper({
+			events: [runStart(), toolCall('tc-inflight', { name: 'wf' })],
+			checkpoints: [runningCheckpoint()],
+		});
+
+		await sweeper.sweep();
+
+		// The in-flight call still becomes a durable fact; the terminal event is
+		// the resumed run's to publish, not the sweeper's.
+		expect(published.map((e) => e.type)).toEqual(['tool-interrupted']);
+		expect(crashResumeInterruptedRun).toHaveBeenCalledWith({
+			threadId: THREAD,
+			runId: RUN,
+			userId: 'user-1',
+			checkpointKey: 'agent:run-sdk-1',
+			messageGroupId: 'mg-1',
+			contextNotes: [expect.stringContaining('"update-workflow" tool call')],
+		});
+		expect(metrics.sweep.runsCrashResumed).toBe(1);
+		expect(metrics.sweep.runsMarkedInterrupted).toBe(0);
+	});
+
+	it('leaves the run alone when the checkpoint claim is lost to a concurrent sweeper', async () => {
+		const { sweeper, published, metrics, crashResumeInterruptedRun } = buildSweeper({
+			events: [runStart()],
+			checkpoints: [runningCheckpoint()],
+			claimSucceeds: false,
+		});
+
+		await sweeper.sweep();
+
+		expect(crashResumeInterruptedRun).not.toHaveBeenCalled();
+		expect(published.some((e) => e.type === 'run-finish')).toBe(false);
+		expect(metrics.sweep.runsMarkedInterrupted).toBe(0);
+		expect(metrics.sweep.runsCrashResumed).toBe(0);
+	});
+
+	it('falls back to marking the run interrupted when the resume host declines', async () => {
 		const { sweeper, published, metrics } = buildSweeper({
 			events: [runStart()],
 			checkpoints: [runningCheckpoint()],
+			host: { crashResumeInterruptedRun: vi.fn(async () => false) },
 		});
 
 		await sweeper.sweep();
 
 		expect(published.at(-1)?.type).toBe('run-finish');
 		expect(metrics.sweep.runsMarkedInterrupted).toBe(1);
+		expect(metrics.sweep.runsCrashResumed).toBe(0);
+	});
+
+	it('marks the run interrupted when the log has no run-start userId to resume as', async () => {
+		const anonymousRunStart: InstanceAiEvent = {
+			type: 'run-start',
+			runId: RUN,
+			agentId: AGENT,
+			payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+		};
+		const { sweeper, published, crashResumeInterruptedRun, checkpointRepo } = buildSweeper({
+			events: [anonymousRunStart],
+			checkpoints: [runningCheckpoint()],
+		});
+
+		await sweeper.sweep();
+
+		expect(checkpointRepo.claimForCrashResume).not.toHaveBeenCalled();
+		expect(crashResumeInterruptedRun).not.toHaveBeenCalled();
+		expect(published.at(-1)?.type).toBe('run-finish');
+	});
+
+	it('re-queues steering corrections missing from the checkpoint as context notes', async () => {
+		const correctionCall: InstanceAiEvent = {
+			type: 'tool-call',
+			runId: RUN,
+			agentId: AGENT,
+			payload: {
+				toolCallId: 'tc-correct-undrained',
+				toolName: 'task-control',
+				args: { action: 'correct-task', correction: 'Use the staging URL instead' },
+			},
+		};
+		const drainedCorrection: InstanceAiEvent = {
+			type: 'tool-call',
+			runId: RUN,
+			agentId: AGENT,
+			payload: {
+				toolCallId: 'tc-correct-drained',
+				toolName: 'task-control',
+				args: { action: 'correct-task', correction: 'Already applied' },
+			},
+		};
+		const { sweeper, metrics, crashResumeInterruptedRun } = buildSweeper({
+			events: [
+				runStart(),
+				correctionCall,
+				toolResult('tc-correct-undrained'),
+				drainedCorrection,
+				toolResult('tc-correct-drained'),
+			],
+			checkpoints: [
+				runningCheckpoint({
+					state: {
+						persistence: { threadId: THREAD, resourceId: 'user-1', hostRunId: RUN },
+						status: 'running',
+						// The drained correction's toolCallId appears in the serialized
+						// message list; the undrained one does not.
+						messageList: { messages: [{ toolCallId: 'tc-correct-drained' }] },
+						pendingToolCalls: {},
+					} as never,
+				}),
+			],
+		});
+
+		await sweeper.sweep();
+
+		expect(crashResumeInterruptedRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				contextNotes: [expect.stringContaining('Use the staging URL instead')],
+			}),
+		);
+		expect(metrics.sweep.correctionsRequeued).toBe(1);
 	});
 
 	it('multi-main: recent durable activity is a liveness heartbeat and skips the run', async () => {

--- a/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/durable-log-metrics.ts
@@ -57,6 +57,8 @@ export class DurableLogMetrics {
 		runsMarkedInterrupted: 0,
 		runsCrashResumed: 0,
 		toolInterruptedFacts: 0,
+		/** Steering corrections re-queued into crash-resumed model contexts. */
+		correctionsRequeued: 0,
 	};
 
 	constructor(private readonly eventService: EventService) {}
@@ -120,9 +122,18 @@ export class DurableLogMetrics {
 		this.sweep.toolInterruptedFacts++;
 	}
 
-	recordSweepOutcome(outcome: 'interrupted' | 'crash-resumed', toolInterruptedFacts: number): void {
+	recordSweepOutcome(
+		outcome: 'interrupted' | 'crash-resumed',
+		toolInterruptedFacts: number,
+		correctionsRequeued = 0,
+	): void {
 		if (outcome === 'interrupted') this.sweep.runsMarkedInterrupted++;
 		else this.sweep.runsCrashResumed++;
-		this.eventService.emit('instance-ai-run-swept', { outcome, toolInterruptedFacts });
+		this.sweep.correctionsRequeued += correctionsRequeued;
+		this.eventService.emit('instance-ai-run-swept', {
+			outcome,
+			toolInterruptedFacts,
+			correctionsRequeued,
+		});
 	}
 }

--- a/packages/cli/src/modules/instance-ai/event-bus/interrupted-run-sweeper.ts
+++ b/packages/cli/src/modules/instance-ai/event-bus/interrupted-run-sweeper.ts
@@ -21,13 +21,29 @@ interface InFlightToolCall {
 	args: Record<string, unknown>;
 }
 
+/** A steering correction recorded in the log (task-control correct-task call). */
+interface LoggedCorrection {
+	toolCallId: string;
+	correction: string;
+}
+
 /**
- * The narrow slice of InstanceAiService the sweeper consults. Injected at init
- * (module wiring) instead of DI to avoid a service-level dependency cycle.
+ * The narrow slice of InstanceAiService the sweeper consults and drives.
+ * Injected at init (module wiring) instead of DI to avoid a service-level
+ * dependency cycle.
  */
 export interface InterruptedRunResumeHost {
 	/** Whether this specific run is live (active or suspended) in this process. */
 	isRunLive(threadId: string, runId: string): boolean;
+	/** Re-drive a crash-interrupted run from its step checkpoint. */
+	crashResumeInterruptedRun(request: {
+		threadId: string;
+		runId: string;
+		userId: string;
+		checkpointKey: string;
+		messageGroupId?: string;
+		contextNotes?: string[];
+	}): Promise<boolean>;
 }
 
 /**
@@ -39,10 +55,12 @@ export interface InterruptedRunResumeHost {
  *
  * 1. In-flight tool calls (tool-call with no terminal fact) become durable
  *    `tool-interrupted` facts — effect unverified, never re-executed blindly.
- * 2. One `run-finish { status: 'interrupted' }` is appended — the fold renders
- *    every in-flight item as terminated; no walk-and-mutate. (A later phase of
- *    the RFC re-drives runs with a `running` step checkpoint from that
- *    checkpoint instead; until then every swept run is marked interrupted.)
+ * 2. If a `running`-status step checkpoint exists for the run, the run is
+ *    re-driven from it via the crash-resume path (the resumed run publishes
+ *    its own terminal event); steering corrections present in the log but
+ *    absent from the checkpoint are re-queued into the resumed context.
+ * 3. Otherwise one `run-finish { status: 'interrupted' }` is appended — the
+ *    fold renders every in-flight item as terminated; no walk-and-mutate.
  *
  * Runs whose own checkpoint (matched by `hostRunId`) is HITL-`suspended` are
  * skipped: the pending confirmation orphan path (SuspendedRunRestorer) owns
@@ -53,10 +71,13 @@ export interface InterruptedRunResumeHost {
  * so a run whose newest fact or checkpoint write is younger than the grace
  * window is treated as live on a sibling main and skipped. Single-main skips
  * the grace window (no siblings; an unfinished run with no local live run is
- * dead), which keeps immediate post-crash sweeps instant. Two mains booting
- * together may still both mark one dead run — accepted: the duplicate
- * terminal facts are benign (the fold is last-writer-wins per run), and a
- * per-run claim would need the lease table this design deliberately avoids.
+ * dead), which keeps immediate post-crash sweeps instant. Before a
+ * crash-resume the checkpoint is claimed with an atomic compare-and-swap, so
+ * two sweeping mains can never double-drive one run. Two mains booting
+ * together may still both MARK one checkpoint-less dead run — accepted: the
+ * duplicate terminal facts are benign (the fold is last-writer-wins per run),
+ * and a per-run claim would need the lease table this design deliberately
+ * avoids.
  */
 @Service()
 export class InterruptedRunSweeper {
@@ -154,6 +175,49 @@ export class InterruptedRunSweeper {
 			this.metrics.recordSweepToolInterruptedFact();
 		}
 
+		// Exact hostRunId match only (runCheckpoints is pre-filtered): a run
+		// with a `running` step checkpoint is re-driven instead of terminated.
+		const runningCheckpoint = runCheckpoints.find((row) => row.state?.status === 'running');
+		if (runningCheckpoint?.state && this.resumeHost) {
+			const userId = findRunUserId(events);
+			if (userId) {
+				// Atomic claim: exactly one sweeping main may re-drive this run.
+				const claimed = await this.checkpointRepo.claimForCrashResume(
+					runningCheckpoint.key,
+					runningCheckpoint.updatedAt,
+				);
+				if (!claimed) {
+					this.logger.info('Crash-resume claim lost to a concurrent sweeper, skipping run', {
+						threadId,
+						runId,
+					});
+					return;
+				}
+				const { notes, correctionsRequeued } = this.buildContextNotes(
+					inFlight,
+					events,
+					runningCheckpoint.state,
+				);
+				const resumed = await this.resumeHost.crashResumeInterruptedRun({
+					threadId,
+					runId,
+					userId,
+					checkpointKey: runningCheckpoint.key,
+					messageGroupId: findRunMessageGroupId(events),
+					contextNotes: notes,
+				});
+				if (resumed) {
+					this.metrics.recordSweepOutcome('crash-resumed', inFlight.length, correctionsRequeued);
+					this.logger.info('Crash-resumed interrupted Instance AI run from step checkpoint', {
+						threadId,
+						runId,
+						checkpointKey: runningCheckpoint.key,
+					});
+					return;
+				}
+			}
+		}
+
 		this.eventBus.publish(threadId, {
 			type: 'run-finish',
 			runId,
@@ -167,6 +231,62 @@ export class InterruptedRunSweeper {
 			inFlightToolCalls: inFlight.length,
 		});
 	}
+
+	/**
+	 * Notes appended to the crash-resumed model context: interrupted tool calls
+	 * (verify-before-retry, never blind re-execution) and steering corrections
+	 * recorded in the log but absent from the checkpoint's message list
+	 * (queued-but-undrained at crash time).
+	 */
+	private buildContextNotes(
+		inFlight: InFlightToolCall[],
+		events: InstanceAiEvent[],
+		checkpointState: { messageList?: unknown },
+	): { notes: string[]; correctionsRequeued: number } {
+		const notes: string[] = [];
+		for (const call of inFlight) {
+			notes.push(
+				`Your previous "${call.toolName}" tool call (arguments: ${JSON.stringify(call.args)}) was interrupted by a restart before its result was recorded. Its effect is unverified — check whether it took effect before retrying it, and re-request confirmation for anything destructive.`,
+			);
+		}
+
+		// Serialized message lists embed tool call ids verbatim, so a substring
+		// check is a reliable containment test without decoding the SDK format.
+		const checkpointJson = JSON.stringify(checkpointState.messageList ?? '');
+		let correctionsRequeued = 0;
+		for (const correction of collectLoggedCorrections(events)) {
+			if (checkpointJson.includes(correction.toolCallId)) continue;
+			correctionsRequeued++;
+			notes.push(
+				`Before the restart the user sent this steering correction, which was recorded but may not have been applied yet: "${correction.correction}". Make sure it is applied.`,
+			);
+		}
+		return { notes, correctionsRequeued };
+	}
+}
+
+/** Steering corrections recorded as task-control `correct-task` calls. */
+export function collectLoggedCorrections(events: InstanceAiEvent[]): LoggedCorrection[] {
+	const corrections: LoggedCorrection[] = [];
+	for (const event of events) {
+		if (event.type !== 'tool-call') continue;
+		const { action, correction } = event.payload.args;
+		if (action === 'correct-task' && typeof correction === 'string') {
+			corrections.push({ toolCallId: event.payload.toolCallId, correction });
+		}
+	}
+	return corrections;
+}
+
+function findRunUserId(events: InstanceAiEvent[]): string | undefined {
+	return events.find((e) => e.type === 'run-start')?.userId;
+}
+
+function findRunMessageGroupId(events: InstanceAiEvent[]): string | undefined {
+	for (const event of events) {
+		if (event.type === 'run-start') return event.payload.messageGroupId;
+	}
+	return undefined;
 }
 
 /** tool-call facts with no matching terminal fact (result/error/interrupted). */

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -51,6 +51,7 @@ import {
 	PlannedTaskCoordinator,
 	PlannedTaskStorage,
 	PLANNED_TASK_PERMISSION_OVERRIDES,
+	crashResumeAgentRun,
 	releaseTraceClient,
 	resumeAgentRun,
 	RunStateRegistry,
@@ -1555,6 +1556,13 @@ export class InstanceAiService {
 		...args: Parameters<InstanceAiService['processResumedStream']>
 	): void {
 		this.trackInFlightExecution(this.processResumedStream(...args));
+	}
+
+	/** Same shutdown-drain contract as `startExecuteRun`, for the crash-resume path. */
+	private startProcessCrashResumedStream(
+		...args: Parameters<InstanceAiService['processCrashResumedStream']>
+	): void {
+		this.trackInFlightExecution(this.processCrashResumedStream(...args));
 	}
 
 	/**
@@ -4423,6 +4431,407 @@ export class InstanceAiService {
 	 * with `inFlightExecutions` and shutdown can drain it before the DB
 	 * closes.
 	 */
+	/**
+	 * Durable-log RFC (resilience phase): re-drive a crash-interrupted run from
+	 * a `running`-status step checkpoint found by the interrupted-run sweep.
+	 * Rebuilds the execution environment + agent (same machinery as the
+	 * suspended-orphan restorer), registers the run as active under its
+	 * original runId, and consumes the resumed stream to a terminal state.
+	 * Returns false when the run cannot be resumed — the sweeper then
+	 * finalizes it as `run-finish { interrupted }` instead.
+	 */
+	async crashResumeInterruptedRun(request: {
+		threadId: string;
+		runId: string;
+		userId: string;
+		checkpointKey: string;
+		messageGroupId?: string;
+		contextNotes?: string[];
+	}): Promise<boolean> {
+		const user = await this.revalidateActiveUser(request.userId);
+		if (!user) return false;
+
+		try {
+			const state = await this.checkpointStore.load(request.checkpointKey);
+			if (!state || state.status !== 'running') return false;
+		} catch {
+			return false;
+		}
+
+		const abortController = new AbortController();
+		let environment;
+		try {
+			environment = await this.createExecutionEnvironment(
+				user,
+				request.threadId,
+				request.runId,
+				abortController.signal,
+				request.messageGroupId,
+				this.threadPushRef.get(request.threadId),
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Cannot crash-resume run: failed to build execution environment', {
+				threadId: request.threadId,
+				runId: request.runId,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+
+		const runControl = createOrchestratorRunControl(environment.orchestrationContext);
+		let agent;
+		try {
+			agent = await this.createAgentFromEnvironment(
+				environment,
+				request.threadId,
+				request.runId,
+				user,
+				undefined,
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Cannot crash-resume run: failed to build agent', {
+				threadId: request.threadId,
+				runId: request.runId,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+
+		// Register as an active run under the ORIGINAL runId so cancel /
+		// liveness / shutdown paths see it. startRun would mint a new runId, so
+		// seed via suspendRun + activateSuspendedRun (the orphan restorer's
+		// re-seeding trick) with a synthetic requestId.
+		this.runState.suspendRun(request.threadId, {
+			runId: request.runId,
+			agentRunId: request.checkpointKey,
+			agent,
+			threadId: request.threadId,
+			user,
+			toolCallId: '',
+			requestId: `crash-resume:${request.runId}`,
+			abortController,
+			messageGroupId: request.messageGroupId,
+			createdAt: Date.now(),
+			tracing: undefined,
+			modelId: environment.modelId,
+			runHandoff: runControl.state,
+		});
+		this.runState.activateSuspendedRun(request.threadId);
+
+		// Durable resume boundary under the original runId — attributable in
+		// the live timeline and in folded history (INS-837: a structural fact,
+		// surfacing is the UI's call).
+		this.eventBus.publish(request.threadId, {
+			type: 'run-resumed',
+			runId: request.runId,
+			agentId: orchestratorAgentId(request.runId),
+			payload: { reason: 'crash_interrupted' },
+		});
+
+		this.startProcessCrashResumedStream(agent, {
+			runId: request.runId,
+			agentRunId: request.checkpointKey,
+			threadId: request.threadId,
+			user,
+			signal: abortController.signal,
+			abortController,
+			snapshotStorage: this.dbSnapshotStorage,
+			modelId: environment.modelId,
+			contextNotes: request.contextNotes,
+			messageGroupId: request.messageGroupId,
+			runHandoff: runControl.state,
+		});
+		return true;
+	}
+
+	/**
+	 * Run body for a crash-resumed orchestrator run (durable-log resilience
+	 * phase). Tracked via `trackInFlightExecution` (same shutdown-drain
+	 * contract as the other run bodies). Tracing is deliberately absent: the
+	 * trace registry that owned this run died with the crashed process, so
+	 * `messageGroupId` comes from the durable log instead of the tracing
+	 * registry. A run that re-suspends at HITL is registered exactly like the
+	 * resumed path (in-memory suspension + persisted pending confirmation), so
+	 * the confirm endpoint and a later restart both keep working.
+	 */
+	private async processCrashResumedStream(
+		agent: unknown,
+		opts: {
+			runId: string;
+			agentRunId: string;
+			threadId: string;
+			user: User;
+			signal: AbortSignal;
+			abortController: AbortController;
+			snapshotStorage: DbSnapshotStorage;
+			modelId?: ModelConfig;
+			contextNotes?: string[];
+			messageGroupId?: string;
+			runHandoff?: OrchestratorRunHandoffState;
+		},
+	): Promise<void> {
+		try {
+			this.instanceAiErrorReporter.beginRun(opts.runId);
+			const runControl = createOrchestratorRunControlForState(opts.runHandoff);
+			const stopSignal = (): OrchestratorRunStopSignal | undefined => runControl.getStopSignal();
+			const result = await crashResumeAgentRun(
+				agent,
+				{
+					runId: opts.agentRunId,
+					recoverUsageOnAbort: true,
+					stepCheckpoints: true,
+					persistence: {
+						resourceId: opts.user.id,
+						threadId: opts.threadId,
+						hostRunId: opts.runId,
+					},
+					providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+					...(opts.contextNotes?.length ? { contextNotes: opts.contextNotes } : {}),
+				},
+				{
+					threadId: opts.threadId,
+					runId: opts.runId,
+					agentId: orchestratorAgentId(opts.runId),
+					signal: opts.signal,
+					eventBus: this.eventBus,
+					logger: this.logger,
+					agentRunId: opts.agentRunId,
+					onActivity: () => this.runState.touchActiveRun(opts.threadId),
+					stopSignal,
+					outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
+				},
+			);
+
+			if (result.status === 'suspended') {
+				// As in the resumed path, record suspended-segment usage here.
+				this.emitRunMetrics(opts.threadId, 'suspended', {
+					modelId: opts.modelId,
+					workSummary: result.workSummary,
+					usage: result.usage,
+				});
+				if (result.suspension) {
+					this.runState.suspendRun(opts.threadId, {
+						runId: opts.runId,
+						agentRunId: result.agentRunId,
+						agent,
+						threadId: opts.threadId,
+						user: opts.user,
+						toolCallId: result.suspension.toolCallId,
+						...(result.suspension.toolName ? { toolName: result.suspension.toolName } : {}),
+						...(result.suspension.suspendPayload
+							? { suspendPayload: result.suspension.suspendPayload }
+							: {}),
+						requestId: result.suspension.requestId,
+						abortController: opts.abortController,
+						messageGroupId: opts.messageGroupId,
+						createdAt: Date.now(),
+						tracing: undefined,
+						...(opts.modelId !== undefined ? { modelId: opts.modelId } : {}),
+						runHandoff: runControl.state,
+					});
+					// Persisted index row so this suspension survives ANOTHER restart
+					// (the orphan-confirmation path picks it up, same as any HITL wait).
+					void this.suspendedThreads.persistPendingConfirmation({
+						requestId: result.suspension.requestId,
+						threadId: opts.threadId,
+						userId: opts.user.id,
+						runId: opts.runId,
+						messageGroupId: opts.messageGroupId,
+						kind: 'suspended',
+						toolCallId: result.suspension.toolCallId,
+						checkpointKey: result.agentRunId,
+					});
+					void this.creditService.claimRunUsage(
+						opts.user,
+						opts.threadId,
+						`${result.agentRunId || opts.runId}:${result.suspension.requestId}`,
+						result.usage?.usage ?? [],
+						'suspended',
+					);
+				}
+
+				const waitingDecision = await this.terminalOutcome.evaluateWaitingResponse(
+					opts.threadId,
+					opts.runId,
+					result.confirmationEvent,
+					{ messageGroupId: opts.messageGroupId },
+				);
+				if (waitingDecision?.reason === 'confirmation-invalid') {
+					await this.terminalOutcome.finishInvalidConfirmationRun({
+						threadId: opts.threadId,
+						runId: opts.runId,
+						abortController: opts.abortController,
+						snapshotStorage: opts.snapshotStorage,
+						tracing: undefined,
+					});
+					return;
+				}
+
+				if (result.confirmationEvent) {
+					this.trackConfirmationRequest(opts.threadId, result.confirmationEvent);
+					this.eventBus.publish(opts.threadId, result.confirmationEvent);
+				}
+				// Persist the refreshed tree so the HITL wait survives a page reload.
+				await this.saveAgentTreeSnapshot(opts.threadId, opts.runId, opts.snapshotStorage);
+				return;
+			}
+
+			if (result.status === 'cancelled' && this.shouldPreserveHitlOnShutdown(opts.runId)) {
+				return;
+			}
+
+			if (result.status === 'errored') {
+				this.instanceAiErrorReporter.report(
+					result.error ?? new Error('Instance AI crash-resumed stream errored'),
+					{
+						component: 'instance-ai-stream',
+						threadId: opts.threadId,
+						runId: opts.runId,
+						agentId: orchestratorAgentId(opts.runId),
+						userId: opts.user.id,
+						messageGroupId: opts.messageGroupId,
+					},
+				);
+			}
+			const userFacingErrorMessage =
+				result.status === 'errored' ? getUserFacingErrorMessage(result.error) : undefined;
+			const userFacingErrorCode =
+				result.status === 'errored' ? getUserFacingErrorCode(result.error) : undefined;
+			if (runControl.shouldEmitTerminalOutcome(result.stopReason)) {
+				await this.terminalOutcome.evaluateTerminalResponse(
+					opts.threadId,
+					opts.runId,
+					result.status,
+					{
+						messageGroupId: opts.messageGroupId,
+						workSummary: result.workSummary,
+						errorMessage: userFacingErrorMessage,
+						errorCode: userFacingErrorCode,
+					},
+				);
+			}
+			const archivedWorkflowIds = await this.temporaryWorkflowService.reapForRun(
+				opts.threadId,
+				opts.user,
+				undefined,
+				this.backgroundTasks.getRunningTasks(opts.threadId).length,
+			);
+			await this.finalizeRun(opts.threadId, opts.runId, result.status, opts.snapshotStorage, {
+				userId: opts.user.id,
+				...(opts.modelId !== undefined ? { modelId: opts.modelId } : {}),
+				archivedWorkflowIds,
+				workSummary: result.workSummary,
+				usage: result.usage,
+				errorReason: userFacingErrorMessage,
+				...(result.status === 'errored'
+					? {
+							errorInfo: {
+								errorMessage: result.error
+									? getErrorMessage(result.error)
+									: 'Instance AI crash-resumed stream errored',
+								errorSource: 'stream' as const,
+							},
+						}
+					: {}),
+			});
+
+			// Bill token usage for every terminal outcome, deduped per run segment.
+			await this.creditService.claimRunUsage(
+				opts.user,
+				opts.threadId,
+				result.agentRunId || opts.runId,
+				result.usage?.usage ?? [],
+				result.status,
+			);
+		} catch (error) {
+			if (opts.signal.aborted) {
+				if (this.shouldPreserveHitlOnShutdown(opts.runId)) {
+					return;
+				}
+				const runTimeout = this.liveness.consumeRunTimeout(opts.runId);
+				const cancellationReason = runTimeout.timedOut
+					? INSTANCE_AI_RUN_TIMEOUT_REASON
+					: getAbortReason(opts.signal);
+				if (cancellationReason === INSTANCE_AI_RUN_TIMEOUT_REASON) {
+					this.liveness.publishRunTimeoutNotice(opts.threadId, opts.runId);
+				}
+				await this.terminalOutcome.evaluateTerminalResponse(
+					opts.threadId,
+					opts.runId,
+					'cancelled',
+					{
+						messageGroupId: opts.messageGroupId,
+					},
+				);
+				const archivedWorkflowIds = await this.temporaryWorkflowService.reapForRun(
+					opts.threadId,
+					opts.user,
+					undefined,
+					this.backgroundTasks.getRunningTasks(opts.threadId).length,
+				);
+				this.publishRunFinish(
+					opts.threadId,
+					opts.runId,
+					'cancelled',
+					cancellationReason,
+					archivedWorkflowIds,
+					opts.user.id,
+				);
+				await this.saveAgentTreeSnapshot(opts.threadId, opts.runId, opts.snapshotStorage);
+				return;
+			}
+
+			const errorMessage = getErrorMessage(error);
+			const userFacingErrorMessage = getUserFacingErrorMessage(error);
+			const userFacingErrorCode = getUserFacingErrorCode(error);
+			const errCtx: InstanceAiObservabilityContext = {
+				threadId: opts.threadId,
+				runId: opts.runId,
+				tracing: undefined,
+				agentId: orchestratorAgentId(opts.runId),
+				userId: opts.user.id,
+				messageGroupId: opts.messageGroupId,
+			};
+			this.logger.error(`Instance AI crash-resumed run error: ${errorMessage}`, {
+				error: errorMessage,
+				...buildInstanceAiObservabilityContext(errCtx),
+			});
+			this.instanceAiErrorReporter.report(error, { component: 'instance-ai-run', ...errCtx });
+			await this.terminalOutcome.evaluateTerminalResponse(opts.threadId, opts.runId, 'errored', {
+				messageGroupId: opts.messageGroupId,
+				errorMessage: userFacingErrorMessage,
+				errorCode: userFacingErrorCode,
+			});
+			const archivedWorkflowIds = await this.temporaryWorkflowService.reapForRun(
+				opts.threadId,
+				opts.user,
+				undefined,
+				this.backgroundTasks.getRunningTasks(opts.threadId).length,
+			);
+			this.publishRunFinish(
+				opts.threadId,
+				opts.runId,
+				'errored',
+				userFacingErrorMessage,
+				archivedWorkflowIds,
+				opts.user.id,
+				{ errorMessage, errorSource: 'exception' },
+			);
+			await this.saveAgentTreeSnapshot(opts.threadId, opts.runId, opts.snapshotStorage);
+		} finally {
+			this.runState.clearActiveRun(opts.threadId);
+			// Post-run planned-task wiring — mirror processResumedStream's finally
+			// (a background task may have settled while the run was crashed).
+			if (!this.runState.hasSuspendedRun(opts.threadId)) {
+				await this.schedulePlannedTasks(opts.user, opts.threadId);
+				await this.drainPendingCheckpointReentries(opts.user, opts.threadId);
+				await this.taskProjector.syncFromWorkflowLoop(opts.threadId, opts.runId);
+				await this.maybeStartWorkflowSetupFollowUp(opts.user, opts.threadId);
+			}
+			this.instanceAiErrorReporter.endRun(opts.runId);
+		}
+	}
+
 	private async processResumedStream(
 		agent: unknown,
 		resumeData: Record<string, unknown>,

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-checkpoint.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-checkpoint.repository.ts
@@ -38,4 +38,21 @@ export class InstanceAiCheckpointRepository extends Repository<InstanceAiCheckpo
 		});
 		return row ?? undefined;
 	}
+
+	/**
+	 * Durable-log RFC (resilience phase): atomic claim before crash-resume.
+	 * Compare-and-swap on `updatedAt` — when two mains sweep the same
+	 * interrupted run concurrently, exactly one wins the claim and re-drives
+	 * it; the loser sees 0 affected rows and leaves the run alone.
+	 */
+	async claimForCrashResume(key: string, seenUpdatedAt: Date): Promise<boolean> {
+		const result = await this.createQueryBuilder()
+			.update()
+			.set({ updatedAt: new Date() })
+			.where('key = :key', { key })
+			.andWhere('expiredAt IS NULL')
+			.andWhere('updatedAt = :seenUpdatedAt', { seenUpdatedAt })
+			.execute();
+		return (result.affected ?? 0) === 1;
+	}
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.reducer.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.reducer.test.ts
@@ -251,6 +251,26 @@ describe('instanceAi.reducer', () => {
 			expect(state.messages[0].agentTree!.status).toBe('error');
 		});
 
+		test('run-resumed re-activates streaming and returns the run as active', () => {
+			const state = stateWithRun('run-1', 'agent-root');
+			// A client that watched the run die (connection error, stale bootstrap)
+			// may hold terminal-looking local state; the crash-resume boundary must
+			// bring the bubble back to live streaming.
+			handleEvent(state, makeRunFinishEvent('run-1', 'agent-root', 'error'));
+			expect(state.messages[0].isStreaming).toBe(false);
+
+			const newActiveRunId = handleEvent(state, {
+				type: 'run-resumed',
+				runId: 'run-1',
+				agentId: 'agent-root',
+				payload: { reason: 'crash_interrupted' },
+			});
+
+			expect(newActiveRunId).toBe('run-1');
+			expect(state.messages[0].isStreaming).toBe(true);
+			expect(state.messages[0].agentTree!.status).toBe('active');
+		});
+
 		test('run-finish for an older run in the group does not clear activeRunId', () => {
 			const state = stateWithRun('run-active', 'agent-root');
 			state.groupIdByRunId.set('run-old', 'run-active');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.reducer.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.reducer.ts
@@ -303,6 +303,20 @@ export function handleEvent(state: InstanceAiReducerState, event: InstanceAiEven
 			return state.activeRunId;
 		}
 
+		case 'run-resumed': {
+			// Crash-resume boundary: the run continues under its original runId
+			// after a server restart — re-activate the group's tree and streaming
+			// state so the resumed stream renders live again.
+			const { msg, runState } = resolveTarget(state, event.runId);
+			if (runState) {
+				reduceRunEvent(runState, event);
+			}
+			if (msg) {
+				msg.isStreaming = true;
+			}
+			return event.runId;
+		}
+
 		case 'error': {
 			const { msg, runState } = resolveTarget(state, event.runId);
 			if (runState) {


### PR DESCRIPTION
## Summary

Third resilience phase of the durable event log: a run that died mid-flight with a `running`-status step checkpoint is now **re-driven from that checkpoint** by the startup sweep, instead of only being terminally marked `run-finish {interrupted}`. Flag-gated behind `N8N_INSTANCE_AI_DURABLE_LOG` end to end (the sweeper is inert flag-off, so this whole path is too).

What lands here (cut from `r00gm/durable-log-qa-section`, adapted to current master):

- **Atomic CAS checkpoint claim** (`InstanceAiCheckpointRepository.claimForCrashResume`): compare-and-swap on `updatedAt`, so two mains sweeping the same interrupted run can never double-drive it. The claim-less accepted race documented on the sweeper now applies only to checkpoint-less runs.
- **Sweeper resume branch**: a swept run whose exact-`hostRunId` checkpoint is `running` gets claimed and handed to the service; claim lost → leave the run alone (the winner owns it); resume declined/failed → fall through to the existing interrupted-mark. In-flight tool calls still become durable `tool-interrupted` facts first.
- **Steering-correction re-queue**: `correct-task` calls present in the log but absent from the checkpoint's message list (queued-but-undrained at crash time) become context notes, with a `correctionsRequeued` counter (metrics struct + `instance-ai-run-swept` payload + new Prometheus counter).
- **Service drive path** (`crashResumeInterruptedRun` + `processCrashResumedStream`): rebuilds env + agent via the same machinery as the suspended-orphan restorer (including registry MCP servers), seeds run state under the **original runId** via the suspendRun/activateSuspendedRun re-seeding trick, and consumes the stream through a faithful port of `processResumedStream`'s current shape: HITL re-suspension (in-memory suspension + persisted pending confirmation + invalid-confirmation guard), abort-vs-error catch split, reap + finalize + per-segment usage claims, and the planned-task finally block. Interrupted tool calls resolve as verify-before-retry context notes, never blind re-execution.
- **Structural `run-resumed` fact** (INS-837 decision): a first-class schema event marking the resume boundary, replacing the prototype's markdown text-block marker (which also sidesteps the id-less-marker responseId issues from the INS-835 review). Persisted + replayed (not in `INSTANCE_AI_EPHEMERAL_EVENT_TYPES`); the shared reducer re-activates the tree, the FE reducer re-activates streaming state. Surfacing the boundary visually stays the FE's call, on this fact.

Deliberate deltas from a literal port, flagged for review:
- qa-section's pre-`hostRunId`-column recency fallback is **not** ported (per the 2026-07-14 no-hybrid decision: the flag only flips together with the INS-851 backfill).
- The crash path carries no tracing context (the trace registry died with the crashed process), so tracing finalization and the `Builder sent message` product-telemetry calls are intentionally absent; run metrics still flow via `finalizeRun`/`emitRunMetrics`.
- `messageGroupId` comes from the durable log's `run-start` fact, not the (empty) tracing registry.

## How to test

- Unit matrix (all green): sweeper 15 (claim won/lost, resume-declined fallthrough, no-userId, correction re-queue vs drained corrections, plus all pre-existing sweep/suspension/liveness cases), service crash-resume 3 (HITL re-suspension registers exactly like the resumed path, completed run finalizes + claims usage, non-`running` checkpoint refused), durable-log classification (run-resumed is a structural, seq-bearing fact), shared reducer 90, FE reducer 58.
- `packages/cli` typecheck clean; biome + file-scoped eslint clean (0 errors).
- The real-Anthropic end-to-end scenario (thinking + tool calls, kill -9, restart, completion under the original runId, zero signature errors) was proven on the prototype branch via `scripts/durable-log-harness/real-crash-resume.mjs` (preserved on `r00gm/durable-log-evaluation-record`); a confirmatory run on this branch is part of the INS-843 verification pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-845

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

