### PR TITLE
chore: Prepare for Node 26 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
       "undici@5": "catalog:undici-v6",
       "undici@6": "catalog:undici-v6",
       "undici@7": "catalog:undici-v7",
+      "node-gyp>undici": "catalog:undici-v7",
       "@babel/traverse": "^7.23.2"
     },
     "patchedDependencies": {

--- a/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/evaluations/evaluators/binary-checks/llm-checks/create-llm-check.ts
@@ -1,7 +1,7 @@
+import { binaryJudgeResultSchema } from './schemas';
 import { runWithOptionalLimiter, withTimeout } from '../../../harness/evaluation-helpers';
 import { createEvaluatorChain, invokeEvaluatorChain } from '../../llm-judge/evaluators/base';
 import type { BinaryCheck, BinaryCheckContext, SimpleWorkflow } from '../types';
-import { binaryJudgeResultSchema } from './schemas';
 
 const REASONING_FIRST_SUFFIX = `
 

--- a/packages/@n8n/crdt/src/transports/integration.test.ts
+++ b/packages/@n8n/crdt/src/transports/integration.test.ts
@@ -1,10 +1,10 @@
 import WebSocketMock from 'vitest-websocket-mock';
 
 import { CRDTEngine, createCRDTProvider } from '../index';
-import { createSyncProvider } from '../sync/base-sync-provider';
-import type { CRDTDoc, CRDTMap } from '../types';
 import { MessagePortTransport } from './message-port';
 import { WebSocketTransport } from './websocket';
+import { createSyncProvider } from '../sync/base-sync-provider';
+import type { CRDTDoc, CRDTMap } from '../types';
 
 /**
  * Test: Does onUpdate fire for applied remote updates?

--- a/packages/@n8n/node-cli/src/commands/dev/index.ts
+++ b/packages/@n8n/node-cli/src/commands/dev/index.ts
@@ -3,11 +3,6 @@ import os from 'node:os';
 import path from 'node:path';
 import picocolors from 'picocolors';
 
-import { createSymlink, ensureFolder } from '../../utils/filesystem';
-import { detectPackageManager } from '../../utils/package-manager';
-import { getCommandHeader, onCancel } from '../../utils/prompts';
-import { validateNodeName } from '../../utils/validation';
-import { copyStaticFiles } from '../build';
 import {
 	buildHelpText,
 	type CommandConfig,
@@ -16,6 +11,11 @@ import {
 	readPackageName,
 	runCommands,
 } from './utils';
+import { createSymlink, ensureFolder } from '../../utils/filesystem';
+import { detectPackageManager } from '../../utils/package-manager';
+import { getCommandHeader, onCancel } from '../../utils/prompts';
+import { validateNodeName } from '../../utils/validation';
+import { copyStaticFiles } from '../build';
 
 export default class Dev extends Command {
 	static override description = 'Run n8n with the node and rebuild on changes for live preview';

--- a/packages/core/src/execution-engine/__tests__/requests-response.test.ts
+++ b/packages/core/src/execution-engine/__tests__/requests-response.test.ts
@@ -2,9 +2,9 @@ import type { IExecuteData, IRunData, EngineRequest, INodeExecutionData } from '
 import { mock } from 'vitest-mock-extended';
 
 import { DirectedGraph } from '../partial-execution-utils';
+import { nodeTypes, types } from './mock-node-types';
 import { createNodeData } from '../partial-execution-utils/__tests__/helpers';
 import { handleRequest } from '../requests-response';
-import { nodeTypes, types } from './mock-node-types';
 
 describe('handleRequests', () => {
 	test('throws if an action mentions a node that does not exist in the workflow', () => {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -25,8 +25,6 @@ vi.mock('node:fs', async (importActual) => ({
 }));
 
 import { DirectedGraph } from '../partial-execution-utils';
-import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
-import { WorkflowExecute } from '../workflow-execute';
 import {
 	types,
 	nodeTypes,
@@ -34,6 +32,8 @@ import {
 	nodeTypeArguments,
 	modifyNode,
 } from './mock-node-types';
+import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
+import { WorkflowExecute } from '../workflow-execute';
 
 describe('processRunExecutionData', () => {
 	const runHook = vi.fn().mockResolvedValue(undefined);

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
@@ -8,10 +8,10 @@ import {
 } from 'reka-ui';
 import { computed, ref, useAttrs, watch } from 'vue';
 
+import type { N8nTooltipProps } from './Tooltip.types';
 import { useInjectTooltipAppendTo } from '../../composables/useTooltipAppendTo';
 import { n8nHtml as vN8nHtml } from '../../directives';
 import N8nButton from '../N8nButton';
-import type { N8nTooltipProps } from './Tooltip.types';
 
 defineOptions({
 	name: 'N8nTooltip',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,7 @@ overrides:
   undici@5: ^6.27.0
   undici@6: ^6.27.0
   undici@7: ^7.28.0
+  node-gyp>undici: ^7.28.0
   '@babel/traverse': ^7.23.2
 
 patchedDependencies:
@@ -36911,7 +36912,7 @@ snapshots:
       semver: 7.7.3
       tar: 7.5.17
       tinyglobby: 0.2.15
-      undici: 6.27.0
+      undici: 7.28.0
       which: 6.0.1
 
   node-gyp@8.4.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,7 +94,7 @@ catalog:
   '@types/lodash-es': ^4.17.12
   '@types/luxon': 3.2.0
   '@types/markdown-it': ^13.0.2
-  '@types/markdown-it-link-attributes': "^3.0.5"
+  '@types/markdown-it-link-attributes': '^3.0.5'
   '@types/mime-types': 3.0.1
   '@types/ms': 2.1.0
   '@types/node': 24.10.1


### PR DESCRIPTION
## Summary

Splits the Node-26-compatible changes out of #34032 so they can land today, leaving the eventual Node 26 switch as a minimal diff (Node version pins in CI plus the `isolated-vm` v7 bump, which hard-requires Node >=26).

- **Import-order fixes** (6 files): the order required by `import-x/order` when linting on Node 26. Both the old and new orders pass lint on Node 22/24 (relative-path segments of different depth are ties in import-x 4.15.2), so landing the Node 26 order now is a no-op for current CI.
- **`node-gyp>undici` override to undici v7**: node-gyp 12 (via `@electron/rebuild`) pins undici ^6, which fails to download Node headers on Node 26. undici 7 only requires Node >=20.18.1, and this path is not exercised on Node 24, so the override is inert today.
- **`pnpm-workspace.yaml` quote normalization**: matches what pnpm writes when it next rewrites the catalog, keeping that noise out of the flip PR.

## How to test

CI covers it: lint and unit tests exercise all touched files. Verified locally on top of this branch:

- `pnpm install` and full `pnpm build` pass
- eslint passes on all six reordered files
- Touched test files pass: crdt `integration.test.ts` (8/8), core execution-engine tests (26/26), design-system `N8nTooltip` (37/37)

## Related Linear tickets, Github issues, and Community forum posts

Related: #34032 (Node 26 CI switch, kept as canary until Node 26 LTS in October 2026)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34340">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

