### PR TITLE
fix(core): Add a per-attempt timeout to AI assistant service calls

### DIFF
--- a/packages/cli/src/services/__tests__/ai.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai.service.test.ts
@@ -272,6 +272,22 @@ describe('AiService', () => {
 			expect(client.generateAiCreditsCredentials).toHaveBeenCalledWith(user);
 		});
 
+		it('should not retry timed-out credential generation', async () => {
+			vi.useFakeTimers();
+			client.generateAiCreditsCredentials.mockImplementation(
+				async () => await new Promise<never>(() => {}),
+			);
+
+			const promise = aiService.createFreeAiCredits(user);
+			const assertion = expect(promise).rejects.toThrow(
+				'The AI assistant service is temporarily unavailable',
+			);
+			await vi.runAllTimersAsync();
+
+			await assertion;
+			expect(client.generateAiCreditsCredentials).toHaveBeenCalledTimes(1);
+		});
+
 		it('should not retry definite client errors', async () => {
 			const alreadyClaimed = Object.assign(new Error('Already claimed'), { statusCode: 400 });
 			client.generateAiCreditsCredentials.mockRejectedValue(alreadyClaimed);

--- a/packages/cli/src/services/ai.service.ts
+++ b/packages/cli/src/services/ai.service.ts
@@ -90,12 +90,12 @@ export class AiService {
 
 	async createFreeAiCredits(user: IUser) {
 		const client = await this.getClient();
-		// Retrying the claim is no worse than the user clicking again; already-claimed is a definite 4xx.
 		return await callAiServiceWithRetry(
 			'AI credits credential generation',
 			async () => await client.generateAiCreditsCredentials(user),
 			this.logger,
 			this.errorReporter,
+			{ retryOnTimeout: false },
 		);
 	}
 }

--- a/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
+++ b/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
@@ -47,6 +47,24 @@ describe('callAiServiceWithRetry', () => {
 		expect(errorReporter.warn).toHaveBeenCalledTimes(1);
 	});
 
+	it('does not retry timed-out calls when timeout retries are disabled', async () => {
+		vi.useFakeTimers();
+		const errorReporter = { warn: vi.fn() };
+		const call = vi.fn(async () => await new Promise<never>(() => {}));
+
+		const promise = callAiServiceWithRetry('Test call', call, undefined, errorReporter, {
+			retryOnTimeout: false,
+		});
+		const assertion = expect(promise).rejects.toThrow(
+			'The AI assistant service is temporarily unavailable',
+		);
+		await vi.runAllTimersAsync();
+
+		await assertion;
+		expect(call).toHaveBeenCalledTimes(1);
+		expect(errorReporter.warn).toHaveBeenCalledTimes(1);
+	});
+
 	it('does not retry definite client errors', async () => {
 		const unauthorized = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
 		const call = vi.fn(async () => await Promise.reject(unauthorized));

--- a/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
+++ b/packages/cli/src/utils/__tests__/ai-service-retry.test.ts
@@ -1,0 +1,79 @@
+import { callAiServiceWithRetry } from '../ai-service-retry';
+
+describe('callAiServiceWithRetry', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('resolves fast calls without interference', async () => {
+		const call = vi.fn(async () => await Promise.resolve('ok'));
+
+		await expect(callAiServiceWithRetry('Test call', call)).resolves.toBe('ok');
+		expect(call).toHaveBeenCalledTimes(1);
+	});
+
+	it('times out a hung call and retries', async () => {
+		vi.useFakeTimers();
+		const logger = { warn: vi.fn() };
+		const call = vi
+			.fn()
+			.mockImplementationOnce(async () => await new Promise<never>(() => {}))
+			.mockResolvedValue('ok');
+
+		const promise = callAiServiceWithRetry('Test call', call, logger);
+		await vi.runAllTimersAsync();
+
+		await expect(promise).resolves.toBe('ok');
+		expect(call).toHaveBeenCalledTimes(2);
+		expect(logger.warn).toHaveBeenCalledWith(
+			'Test call hit a transient AI assistant service error; retrying',
+			expect.objectContaining({ error: expect.stringContaining('timed out after') }),
+		);
+	});
+
+	it('surfaces an OperationalError when every attempt hangs', async () => {
+		vi.useFakeTimers();
+		const errorReporter = { warn: vi.fn() };
+		const call = vi.fn(async () => await new Promise<never>(() => {}));
+
+		const promise = callAiServiceWithRetry('Test call', call, undefined, errorReporter);
+		const assertion = expect(promise).rejects.toThrow(
+			'The AI assistant service is temporarily unavailable',
+		);
+		await vi.runAllTimersAsync();
+
+		await assertion;
+		expect(call).toHaveBeenCalledTimes(3);
+		expect(errorReporter.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not retry definite client errors', async () => {
+		const unauthorized = Object.assign(new Error('Unauthorized'), { statusCode: 401 });
+		const call = vi.fn(async () => await Promise.reject(unauthorized));
+
+		await expect(callAiServiceWithRetry('Test call', call)).rejects.toBe(unauthorized);
+		expect(call).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps a late rejection from a timed-out call handled', async () => {
+		vi.useFakeTimers();
+		let rejectLate: ((error: Error) => void) | undefined;
+		const call = vi
+			.fn()
+			.mockImplementationOnce(
+				async () =>
+					await new Promise<never>((_, reject) => {
+						rejectLate = reject;
+					}),
+			)
+			.mockResolvedValue('ok');
+
+		const promise = callAiServiceWithRetry('Test call', call);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toBe('ok');
+
+		// The first attempt rejects after already losing the race; must not crash the process.
+		rejectLate?.(new Error('late failure'));
+		await vi.runAllTimersAsync();
+	});
+});

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -3,6 +3,7 @@ import { OperationalError } from 'n8n-workflow';
 const AI_SERVICE_MAX_ATTEMPTS = 3;
 const AI_SERVICE_RETRY_BACKOFF_BASE_MS = 1_000;
 const AI_SERVICE_RETRY_BACKOFF_CAP_MS = 5_000;
+const AI_SERVICE_CALL_TIMEOUT_MS = 30_000;
 const AI_SERVICE_UNAVAILABLE_MESSAGE =
 	'The AI assistant service is temporarily unavailable. Please try again in a few minutes.';
 
@@ -16,6 +17,29 @@ type RetryErrorReporter = {
 
 async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The SDK's fetch calls carry no timeout, so a stalled connection would hang the caller
+// forever and never reach the retry loop; the race unblocks the caller (the underlying
+// request cannot be aborted without SDK AbortSignal support).
+async function callWithTimeout<T>(call: () => Promise<T>, label: string): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	const pending = call();
+	// Keep a handler attached so a late rejection after losing the race stays handled.
+	pending.catch(() => {});
+	try {
+		return await Promise.race([
+			pending,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`${label} timed out after ${AI_SERVICE_CALL_TIMEOUT_MS}ms`)),
+					AI_SERVICE_CALL_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
 }
 
 // The AI assistant service SDK carries upstream HTTP status as numeric statusCode;
@@ -35,7 +59,7 @@ export async function callAiServiceWithRetry<T>(
 ): Promise<T> {
 	for (let attempt = 1; ; attempt++) {
 		try {
-			return await call();
+			return await callWithTimeout(call, label);
 		} catch (error) {
 			if (!isTransientAiServiceError(error)) throw error;
 			if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -3,6 +3,7 @@ import { OperationalError } from 'n8n-workflow';
 const AI_SERVICE_MAX_ATTEMPTS = 3;
 const AI_SERVICE_RETRY_BACKOFF_BASE_MS = 1_000;
 const AI_SERVICE_RETRY_BACKOFF_CAP_MS = 5_000;
+// Small control-plane JSON calls only; 3 attempts + backoff stays inside Cloudflare's ~100s budget.
 const AI_SERVICE_CALL_TIMEOUT_MS = 30_000;
 const AI_SERVICE_UNAVAILABLE_MESSAGE =
 	'The AI assistant service is temporarily unavailable. Please try again in a few minutes.';

--- a/packages/cli/src/utils/ai-service-retry.ts
+++ b/packages/cli/src/utils/ai-service-retry.ts
@@ -16,6 +16,12 @@ type RetryErrorReporter = {
 	warn: (error: Error | string) => void;
 };
 
+type RetryOptions = {
+	retryOnTimeout?: boolean;
+};
+
+class AiServiceCallTimeoutError extends Error {}
+
 async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -33,7 +39,12 @@ async function callWithTimeout<T>(call: () => Promise<T>, label: string): Promis
 			pending,
 			new Promise<never>((_, reject) => {
 				timer = setTimeout(
-					() => reject(new Error(`${label} timed out after ${AI_SERVICE_CALL_TIMEOUT_MS}ms`)),
+					() =>
+						reject(
+							new AiServiceCallTimeoutError(
+								`${label} timed out after ${AI_SERVICE_CALL_TIMEOUT_MS}ms`,
+							),
+						),
 					AI_SERVICE_CALL_TIMEOUT_MS,
 				);
 			}),
@@ -57,11 +68,20 @@ export async function callAiServiceWithRetry<T>(
 	call: () => Promise<T>,
 	logger?: RetryLogger,
 	errorReporter?: RetryErrorReporter,
+	options: RetryOptions = {},
 ): Promise<T> {
 	for (let attempt = 1; ; attempt++) {
 		try {
 			return await callWithTimeout(call, label);
 		} catch (error) {
+			if (error instanceof AiServiceCallTimeoutError && options.retryOnTimeout === false) {
+				errorReporter?.warn(
+					new Error(`${label} failed after ${attempt} ${attempt === 1 ? 'attempt' : 'attempts'}`, {
+						cause: error,
+					}),
+				);
+				throw new OperationalError(AI_SERVICE_UNAVAILABLE_MESSAGE, { cause: error });
+			}
 			if (!isTransientAiServiceError(error)) throw error;
 			if (attempt >= AI_SERVICE_MAX_ATTEMPTS) {
 				// Warning-level Sentry trail for user-visible exhaustion, without error-level paging.


### PR DESCRIPTION
## Summary

Follow-up to #34324. The retry helper handles AI assistant service calls that *fail*, but not calls that *hang*: the SDK's `fetch` calls carry no timeout or `AbortSignal`, so a stalled connection blocked environment setup indefinitely and the retry loop never fired.

Every attempt through `callAiServiceWithRetry` is now bounded at 30s. A timed-out attempt rejects with no status code, which the existing classifier already treats as transient — so timeouts flow through the same retry, backoff, user-facing `OperationalError`, and warning-level Sentry event with no additional wiring. Worst case per call is now ~93s (3 × 30s + backoff) instead of unbounded.

### Why 30s

- Only four small control-plane JSON calls go through this helper (proxy config fetch, token minting, credits lookup, free-credits claim). The slow-by-nature calls (`chat`, `askAi`, streaming) are not wrapped.
- Across the whole Sentry incident cluster these endpoints never failed as "slow success" — always gateway 502/503 or Cloudflare 524, and the 524 fires at ~100s, so the infrastructure already enforces that budget. Our worst case (3 x 30s + backoff = ~93s) sits deliberately just inside it.
- If a legitimate call ever exceeds 30s, the failure mode is graceful: retry on a fresh connection, then the retryable "temporarily unavailable" message — and for the claim call a timeout-retry has the same semantics as the user clicking again.
- If a genuinely slower call site joins the helper later, the constant becomes a per-call option then.

Caveat: the losing request cannot be aborted (the SDK's `fetch` accepts no signal), so the socket may linger until the server closes it — the caller is unblocked either way. Proper cancellation needs `AbortSignal` support in `@n8n_io/ai-assistant-sdk`.

Note: stacked on #34324 — the diff collapses to a single commit once that merges.

## How to test

- `pushd packages/cli && pnpm vitest run src/utils/__tests__/ai-service-retry.test.ts`
- Covers: hung call times out and retries, all-attempts-hang surfaces the OperationalError + Sentry warning, fast calls unaffected, definite 4xx untouched, and a late rejection from a timed-out call stays handled.

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to https://linear.app/n8n/issue/INS-894

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

