### PR TITLE
fix(core): Exclude in-flight Instance AI groups from history reads on non-driving mains

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -607,6 +607,159 @@ describe('InstanceAiMemoryService.getRichMessages — durable-log fold-on-read',
 		expect(result.messages[0].role).toBe('user');
 	});
 
+	it('excludes an in-flight group when the caller passes no exclusions (multi-main sibling read)', async () => {
+		// On a main that is not driving the run the controller's per-process run
+		// state is empty, so no excludeRunIds arrive. The log alone must identify
+		// the in-flight group: its run has a run-start but no terminal run-finish.
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_done',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1' },
+				},
+				at,
+			),
+			...toolCallRows('run_done', 1),
+			eventRow(
+				{
+					type: 'run-finish',
+					runId: 'run_done',
+					agentId: 'agent-001',
+					payload: { status: 'completed' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_live',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-2', messageGroupId: 'mg-2' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'text-block',
+					runId: 'run_live',
+					agentId: 'agent-001',
+					payload: { text: 'partial segment driven by another main' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		// Only run_done's entry is derived, exactly as the driving main would.
+		expect(mockDurableLogMetrics.recordFoldRead).toHaveBeenCalledWith(expect.any(Number), 1);
+		expect(result.messages[1].agentTree?.toolCalls).toHaveLength(1);
+		expect(mockDbSnapshotStorage.getAll).not.toHaveBeenCalled();
+	});
+
+	it('renders nothing when the only group is in flight on another main instead of falling back', async () => {
+		mockListMessages.mockResolvedValue({ messages: [userMessage] });
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_live',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'text-block',
+					runId: 'run_live',
+					agentId: 'agent-001',
+					payload: { text: 'partial segment driven by another main' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(mockDbSnapshotStorage.getAll).not.toHaveBeenCalled();
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0].role).toBe('user');
+	});
+
+	it('keeps folding a HITL-suspended run without a run-finish', async () => {
+		// A suspended run legitimately never wrote its run-finish, but its turn
+		// must keep rendering: the fold entry pairs with the checkpoint-surfaced
+		// assistant message. The suspension is recognized by the run's own
+		// checkpoint — the same predicate that spares it from the interrupted-run
+		// sweep.
+		mockListMessages.mockResolvedValue({ messages: [userMessage] });
+		mockCheckpointRepository.findActiveByThreadId.mockResolvedValueOnce([
+			{
+				key: 'cp-1',
+				runId: 'sdk-run-1',
+				hostRunId: 'run_susp',
+				threadId: 'thread-1',
+				expiredAt: null,
+				state: {
+					status: 'suspended',
+					messageList: {
+						messages: [
+							{
+								id: 'cp-assistant-1',
+								role: 'assistant',
+								content: [{ type: 'text', text: 'Confirm before I continue' }],
+								createdAt: '2026-01-01T00:00:01.000Z',
+							},
+						],
+					},
+				},
+				createdAt: new Date('2026-01-01T00:00:01.000Z'),
+				updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+			},
+		]);
+		mockEventLogRepository.getForThread.mockResolvedValue([
+			eventRow(
+				{
+					type: 'run-start',
+					runId: 'run_susp',
+					agentId: 'agent-001',
+					payload: { messageId: 'm-1', messageGroupId: 'mg-1' },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'tool-call',
+					runId: 'run_susp',
+					agentId: 'agent-001',
+					payload: { toolCallId: 'tc-1', toolName: 'execute_workflow', args: {} },
+				},
+				at,
+			),
+			eventRow(
+				{
+					type: 'confirmation-request',
+					runId: 'run_susp',
+					agentId: 'agent-001',
+					payload: { toolCallId: 'tc-1', requestId: 'req-1', message: 'Run it?' },
+				},
+				at,
+			),
+		]);
+
+		const service = createService({ durableLog: true });
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages).toHaveLength(2);
+		const assistant = result.messages[1];
+		expect(assistant.agentTree?.toolCalls[0]?.confirmation?.requestId).toBe('req-1');
+	});
+
 	it('anchors a group at its parent run so late background completions do not shift pairing', async () => {
 		// Turn 1's group has a background run that finishes AFTER turn 2. A
 		// stored snapshot's createdAt is stamped at parent-run end and never

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -25,6 +25,7 @@ import { DbSnapshotStorage } from './storage/db-snapshot-storage';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
+import type { InstanceAiCheckpoint } from './entities/instance-ai-checkpoint.entity';
 import { DurableLogMetrics } from './event-bus/durable-log-metrics';
 import {
 	collectConfirmationRequestIds,
@@ -82,12 +83,54 @@ function messageCreatedAtMs(message: AgentDbMessage): number {
 	return Number.isNaN(parsed) ? 0 : parsed;
 }
 
+function collectInFlightCheckpointMessages(checkpoints: InstanceAiCheckpoint[]): AgentDbMessage[] {
+	const merged: AgentDbMessage[] = [];
+	const seen = new Set<string>();
+	for (const checkpoint of checkpoints) {
+		const stateMessages = checkpoint.state?.messageList?.messages ?? [];
+		for (const candidate of stateMessages) {
+			if (!isAgentMessageLike(candidate) || seen.has(candidate.id)) continue;
+			seen.add(candidate.id);
+			merged.push({
+				...candidate,
+				createdAt:
+					candidate.createdAt instanceof Date ? candidate.createdAt : new Date(candidate.createdAt),
+			});
+		}
+	}
+	return merged;
+}
+
 function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): AgentDbMessage[] {
 	if (extras.length === 0) return stored;
 	const byId = new Map<string, AgentDbMessage>();
 	for (const message of stored) byId.set(message.id, message);
 	for (const message of extras) if (!byId.has(message.id)) byId.set(message.id, message);
 	return [...byId.values()].sort((a, b) => messageCreatedAtMs(a) - messageCreatedAtMs(b));
+}
+
+/** Runs with a `run-start` fact but no terminal `run-finish` in the log. */
+function collectUnfinishedRunIds(rows: Array<{ runId: string; event: InstanceAiEvent }>) {
+	const unfinished = new Set<string>();
+	for (const row of rows) {
+		if (row.event.type === 'run-start') unfinished.add(row.runId);
+		else if (row.event.type === 'run-finish') unfinished.delete(row.runId);
+	}
+	return unfinished;
+}
+
+/** Host run ids whose own checkpoint is HITL-suspended — the same predicate the
+ *  interrupted-run sweeper uses to spare a run, so "keeps folding" and "won't
+ *  be swept" stay one definition. Sub-agent and legacy rows carry a null
+ *  hostRunId and never match. */
+function collectSuspendedHostRunIds(checkpoints: InstanceAiCheckpoint[]): Set<string> {
+	const suspended = new Set<string>();
+	for (const checkpoint of checkpoints) {
+		if (checkpoint.state?.status === 'suspended' && checkpoint.hostRunId) {
+			suspended.add(checkpoint.hostRunId);
+		}
+	}
+	return suspended;
 }
 
 /** Snapshot-shaped entries derived from the log, grouped the way the snapshot
@@ -349,6 +392,10 @@ export class InstanceAiMemoryService {
 			return snapshots;
 		};
 
+		// Loaded once, shared by the fold's suspension carve-out and the
+		// in-flight message merge below.
+		const activeCheckpoints = await this.loadActiveCheckpoints(threadId);
+
 		// Durable-log flag (fold-on-read): history trees derive from the event
 		// log; the stored snapshots (the flag-off and rollback path) are only
 		// loaded when the fold needs its pre-log/failure fallback, keeping the
@@ -357,6 +404,7 @@ export class InstanceAiMemoryService {
 			? await this.foldSnapshotsFromLog(
 					threadId,
 					loadStoredSnapshots,
+					collectSuspendedHostRunIds(activeCheckpoints),
 					options?.excludeRunIds,
 					options?.excludeMessageGroupIds,
 				)
@@ -369,7 +417,7 @@ export class InstanceAiMemoryService {
 		// only inside the checkpoint blob. Without merging them in, a thread
 		// waiting on a confirmation renders without those in-flight artifacts
 		// after a page reload.
-		const checkpointMessages = await this.loadInFlightCheckpointMessages(threadId);
+		const checkpointMessages = collectInFlightCheckpointMessages(activeCheckpoints);
 		const storedMessages = mergeMessagesById(result.messages, checkpointMessages);
 
 		const fallbacksBefore = messageParserStats.fallbackActivations;
@@ -393,6 +441,7 @@ export class InstanceAiMemoryService {
 	private async foldSnapshotsFromLog(
 		threadId: string,
 		loadStoredSnapshots: () => Promise<AgentTreeSnapshot[]>,
+		suspendedRunIds: ReadonlySet<string>,
 		excludeRunIds?: string[],
 		excludeMessageGroupIds?: string[],
 	): Promise<AgentTreeSnapshot[]> {
@@ -412,9 +461,23 @@ export class InstanceAiMemoryService {
 		// (INS-851), so this branch is a dev-instance safety, not a design.
 		if (rows.length === 0) return await loadStoredSnapshots();
 
+		// Multi-main backstop (INS-913): the caller's exclusions come from
+		// per-process run state, which is empty on a main that is not driving
+		// the run — the log knows main-agnostically that a run without a
+		// terminal run-finish is in flight, and its group must stay out of
+		// history (SSE renders it live). HITL-suspended runs are the exception:
+		// they legitimately lack a run-finish and their turn folds, paired with
+		// the checkpoint-surfaced messages. A crashed run stays hidden until the
+		// startup sweep terminalizes it — hidden beats a forever-spinning
+		// partial tree.
+		const skipRunIds = new Set(excludeRunIds ?? []);
+		for (const runId of collectUnfinishedRunIds(rows)) {
+			if (!suspendedRunIds.has(runId)) skipRunIds.add(runId);
+		}
+
 		const { entries, skippedInFlight } = buildLogDerivedSnapshots(
 			rows,
-			new Set(excludeRunIds ?? []),
+			skipRunIds,
 			new Set(excludeMessageGroupIds ?? []),
 		);
 		if (entries.length === 0) {
@@ -452,35 +515,18 @@ export class InstanceAiMemoryService {
 		}
 	}
 
-	private async loadInFlightCheckpointMessages(threadId: string): Promise<AgentDbMessage[]> {
-		let checkpoints;
+	/** Live checkpoints for the thread; [] on failure — the consumers (suspension
+	 *  carve-out, in-flight message merge) degrade rather than fail the read. */
+	private async loadActiveCheckpoints(threadId: string): Promise<InstanceAiCheckpoint[]> {
 		try {
-			checkpoints = await this.checkpointRepository.findActiveByThreadId(threadId);
+			return await this.checkpointRepository.findActiveByThreadId(threadId);
 		} catch (error) {
-			this.logger.warn('Failed to load in-flight checkpoint messages', {
+			this.logger.warn('Failed to load in-flight checkpoints', {
 				threadId,
 				error: error instanceof Error ? error.message : String(error),
 			});
 			return [];
 		}
-
-		const merged: AgentDbMessage[] = [];
-		const seen = new Set<string>();
-		for (const checkpoint of checkpoints) {
-			const stateMessages = checkpoint.state?.messageList?.messages ?? [];
-			for (const candidate of stateMessages) {
-				if (!isAgentMessageLike(candidate) || seen.has(candidate.id)) continue;
-				seen.add(candidate.id);
-				merged.push({
-					...candidate,
-					createdAt:
-						candidate.createdAt instanceof Date
-							? candidate.createdAt
-							: new Date(candidate.createdAt),
-				});
-			}
-		}
-		return merged;
 	}
 
 	async getLatestRunSnapshot(


### PR DESCRIPTION
## Summary

Under the durable-log flag, `getThreadMessages` computes its `excludeRunIds`/`excludeMessageGroupIds` from per-process run state. Multi-main routing is a supported topology for this module, and on a main that is not driving the run those exclusions are empty — so a mid-run history read on a sibling main folded the in-flight group's partial tree into history: positional misalignment against a turn that has no assistant message yet, plus duplication of what SSE renders live.

This PR keeps the in-memory exclusions (authoritative locally, and they cover the drain-queue window where the active run's rows are not persisted yet) and adds a **log-derived in-flight backstop** to the fold:

- A run with a `run-start` but no terminal `run-finish` is in flight, main-agnostically. Its message group stays out of history — the in-flight turn renders via the SSE relay instead.
- **HITL-suspended runs keep folding.** They legitimately never wrote a `run-finish`; they are recognized by their own checkpoint (`state.status === 'suspended'`, matched by `hostRunId`) — the same predicate the interrupted-run sweeper uses to spare them, so "keeps folding" and "won't be swept" stay one definition. The active-checkpoint query already ran in this read path for the in-flight message merge; it is now loaded once and shared.
- **Pre-sweep crashed runs are hidden, not rendered broken.** Until the startup sweep (INS-842) terminalizes a crashed run, its group is suppressed from history — better than a permanently-spinning partial tree.

Flag-off is unaffected (snapshots are only written at run end/suspension, so this path never had the exposure).

## How to test

Unit tests cover the contract at the layer that owns it (`InstanceAiMemoryService.getRichMessages`):

- a read with **no exclusions** (sibling-main run state) excludes the in-flight group exactly as the driving main would;
- a thread whose only group is in flight renders nothing instead of falling back to stored snapshots;
- a HITL-suspended run (no `run-finish`, suspended checkpoint) keeps rendering its fold entry with the confirmation card.

```bash
cd packages/cli && pnpm test src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
```

A mid-run reload on the non-driving main in the multi-main Playwright harness is covered by https://linear.app/n8n/issue/INS-843.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-913

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34345">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

