### PR TITLE
feat: Handle both string and JSON chat WebSocket frames (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
@@ -155,4 +155,66 @@ describe('ChatInput', () => {
 
 		expect(wrapper.vm.isSubmitting).toBe(false);
 	});
+
+	describe('WebSocket frame handling (backward compatible)', () => {
+		// The shared vi.fn WebSocket mock doesn't return its object from `new`, so
+		// use a class that returns a captured instance we can drive directly.
+		let ws: { send: ReturnType<typeof vi.fn>; onmessage: ((e: { data: string }) => void) | null };
+		const emit = (data: string) => ws.onmessage?.({ data });
+
+		beforeEach(() => {
+			ws = { send: vi.fn(), onmessage: null };
+			class FakeWebSocket {
+				constructor() {
+					return ws;
+				}
+			}
+			// @ts-expect-error - mock WebSocket
+			global.WebSocket = FakeWebSocket;
+			wrapper = mount(Input);
+			wrapper.vm.setupWebsocketConnection('exec-123');
+		});
+
+		it('acks a legacy string heartbeat with the legacy ack', () => {
+			emit('n8n|heartbeat');
+
+			expect(ws.send).toHaveBeenCalledWith('n8n|heartbeat-ack');
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
+		});
+
+		it('acks a JSON heartbeat frame with a JSON ack', () => {
+			emit(JSON.stringify({ type: 'heartbeat' }));
+
+			expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat-ack' }));
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
+		});
+
+		it('treats both legacy and JSON continue frames as control, not messages', () => {
+			emit('n8n|continue');
+			emit(JSON.stringify({ type: 'continue' }));
+
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
+			expect(wrapper.vm.chatStore.waitingForResponse.value).toBe(true);
+		});
+
+		it('renders a JSON message frame as bot text', () => {
+			emit(JSON.stringify({ type: 'message', text: 'Hello' }));
+
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(1);
+			expect(wrapper.vm.chatStore.messages.value[0]).toMatchObject({
+				sender: 'bot',
+				text: 'Hello',
+			});
+		});
+
+		it('renders a legacy raw-string message as bot text', () => {
+			emit('Just some text');
+
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(1);
+			expect(wrapper.vm.chatStore.messages.value[0]).toMatchObject({
+				sender: 'bot',
+				text: 'Just some text',
+			});
+		});
+	});
 });

--- a/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
@@ -189,12 +189,39 @@ describe('ChatInput', () => {
 			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
 		});
 
-		it('treats both legacy and JSON continue frames as control, not messages', () => {
+		it('treats a legacy continue frame as control, not a message', () => {
+			emit('n8n|heartbeat'); // locks legacy mode
 			emit('n8n|continue');
+
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
+			expect(wrapper.vm.chatStore.waitingForResponse.value).toBe(true);
+		});
+
+		it('treats a JSON continue frame as control once JSON mode is established', () => {
+			emit(JSON.stringify({ type: 'heartbeat' })); // locks JSON mode
 			emit(JSON.stringify({ type: 'continue' }));
 
 			expect(wrapper.vm.chatStore.messages.value).toHaveLength(0);
 			expect(wrapper.vm.chatStore.waitingForResponse.value).toBe(true);
+		});
+
+		it('renders JSON that looks like a control frame as a message when the server is legacy', () => {
+			emit('n8n|heartbeat'); // locks legacy mode (single legacy ack)
+			emit(JSON.stringify({ type: 'continue' }));
+			emit(JSON.stringify({ type: 'heartbeat' }));
+
+			// Both are rendered as text, not swallowed or acked as control frames
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(2);
+			expect(wrapper.vm.chatStore.messages.value[0]).toMatchObject({
+				sender: 'bot',
+				text: JSON.stringify({ type: 'continue' }),
+			});
+			expect(wrapper.vm.chatStore.messages.value[1]).toMatchObject({
+				sender: 'bot',
+				text: JSON.stringify({ type: 'heartbeat' }),
+			});
+			expect(ws.send).toHaveBeenCalledTimes(1);
+			expect(ws.send).toHaveBeenCalledWith('n8n|heartbeat-ack');
 		});
 
 		it('renders a JSON message frame as bot text', () => {

--- a/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/Input.spec.ts
@@ -224,6 +224,23 @@ describe('ChatInput', () => {
 			expect(ws.send).toHaveBeenCalledWith('n8n|heartbeat-ack');
 		});
 
+		it('keeps JSON mode when a stray legacy heartbeat arrives later', () => {
+			emit(JSON.stringify({ type: 'heartbeat' })); // locks JSON mode
+			emit('n8n|heartbeat'); // stray legacy frame — must NOT flip the mode
+			emit(JSON.stringify({ type: 'continue' }));
+
+			// the stray legacy heartbeat renders as a message; JSON control still works
+			expect(wrapper.vm.chatStore.messages.value).toHaveLength(1);
+			expect(wrapper.vm.chatStore.messages.value[0]).toMatchObject({
+				sender: 'bot',
+				text: 'n8n|heartbeat',
+			});
+			expect(wrapper.vm.chatStore.waitingForResponse.value).toBe(true);
+			// only the JSON ack from the real heartbeat — no legacy ack for the stray
+			expect(ws.send).toHaveBeenCalledTimes(1);
+			expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'heartbeat-ack' }));
+		});
+
 		it('renders a JSON message frame as bot text', () => {
 			emit(JSON.stringify({ type: 'message', text: 'Hello' }));
 

--- a/packages/frontend/@n8n/chat/src/__tests__/utils/utils.spec.ts
+++ b/packages/frontend/@n8n/chat/src/__tests__/utils/utils.spec.ts
@@ -12,6 +12,34 @@ describe('utils', () => {
 			});
 		});
 
+		it('should render a message frame as plain text', () => {
+			const message = parseBotChatMessageContent(JSON.stringify({ type: 'message', text: 'hi' }));
+			expect(message).toEqual({
+				id: expect.any(String),
+				sender: 'bot',
+				text: 'hi',
+			});
+		});
+
+		it('should render a message frame text verbatim even when it is JSON', () => {
+			const messageText = JSON.stringify({
+				type: 'with-buttons',
+				text: 'Click',
+				blockUserInput: false,
+				buttons: [{ text: 'Go', link: 'https://example.com/action', type: 'primary' }],
+			});
+
+			const message = parseBotChatMessageContent(
+				JSON.stringify({ type: 'message', text: messageText }),
+			);
+
+			expect(message).toEqual({
+				id: expect.any(String),
+				sender: 'bot',
+				text: messageText,
+			});
+		});
+
 		it('should parse a message with buttons', () => {
 			const jsonMessage = {
 				type: 'with-buttons',

--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -168,18 +168,37 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 			);
 			chatStore.ws = new WebSocket(wsUrl);
 			chatStore.ws.onmessage = (e) => {
-				if (e.data === 'n8n|heartbeat') {
-					chatStore.ws?.send('n8n|heartbeat-ack');
+				const data = e.data as string;
+
+				// Backward compatible with both protocols: legacy string sentinels
+				// (n8n < v3) and JSON frames (n8n v3+). Normalize to a frame type,
+				// remembering the legacy case so heartbeats are acked in kind.
+				const isLegacy = data === 'n8n|heartbeat' || data === 'n8n|continue';
+				let frameType: string | undefined;
+				if (isLegacy) {
+					frameType = data === 'n8n|heartbeat' ? 'heartbeat' : 'continue';
+				} else {
+					try {
+						frameType = (JSON.parse(data) as { type?: string }).type;
+					} catch {
+						frameType = undefined;
+					}
+				}
+
+				if (frameType === 'heartbeat') {
+					chatStore.ws?.send(
+						isLegacy ? 'n8n|heartbeat-ack' : JSON.stringify({ type: 'heartbeat-ack' }),
+					);
 					return;
 				}
 
-				if (e.data === 'n8n|continue') {
+				if (frameType === 'continue') {
 					waitingForChatResponse.value = false;
 					chatStore.waitingForResponse.value = true;
 					return;
 				}
 
-				const newMessage = parseBotChatMessageContent(e.data as string);
+				const newMessage = parseBotChatMessageContent(data);
 				chatStore.messages.value.push(newMessage);
 				waitingForChatResponse.value = true;
 				chatStore.waitingForResponse.value = false;

--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -189,9 +189,12 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 					}
 				}
 
-				// A JSON heartbeat is only honored until legacy mode is locked; a legacy
-				// string heartbeat always is. Either one locks the mode for this socket.
-				if (frameType === 'heartbeat' && (isLegacy || jsonProtocol !== false)) {
+				// A control frame only counts if it matches the mode locked by the first
+				// heartbeat; either protocol is accepted until that lock happens. This
+				// keeps a stray cross-protocol frame from flipping the mode.
+				const matchesProtocol = isLegacy ? jsonProtocol !== true : jsonProtocol !== false;
+
+				if (frameType === 'heartbeat' && matchesProtocol) {
 					jsonProtocol = !isLegacy;
 					chatStore.ws?.send(
 						isLegacy ? 'n8n|heartbeat-ack' : JSON.stringify({ type: 'heartbeat-ack' }),
@@ -199,9 +202,7 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 					return;
 				}
 
-				// JSON control frames only count once JSON mode is established; legacy
-				// string sentinels always count.
-				if (frameType === 'continue' && (isLegacy || jsonProtocol === true)) {
+				if (frameType === 'continue' && matchesProtocol) {
 					waitingForChatResponse.value = false;
 					chatStore.waitingForResponse.value = true;
 					return;

--- a/packages/frontend/@n8n/chat/src/components/Input.vue
+++ b/packages/frontend/@n8n/chat/src/components/Input.vue
@@ -167,6 +167,10 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 				resumeToken,
 			);
 			chatStore.ws = new WebSocket(wsUrl);
+			// The first heartbeat locks the protocol: a pre-v3 server sends the string
+			// `n8n|heartbeat`, a v3 server sends `{type:'heartbeat'}`. Once legacy mode is
+			// locked, JSON that merely looks like a control frame is a chat message.
+			let jsonProtocol: boolean | undefined;
 			chatStore.ws.onmessage = (e) => {
 				const data = e.data as string;
 
@@ -185,14 +189,19 @@ function setupWebsocketConnection(executionId: string, resumeToken?: string) {
 					}
 				}
 
-				if (frameType === 'heartbeat') {
+				// A JSON heartbeat is only honored until legacy mode is locked; a legacy
+				// string heartbeat always is. Either one locks the mode for this socket.
+				if (frameType === 'heartbeat' && (isLegacy || jsonProtocol !== false)) {
+					jsonProtocol = !isLegacy;
 					chatStore.ws?.send(
 						isLegacy ? 'n8n|heartbeat-ack' : JSON.stringify({ type: 'heartbeat-ack' }),
 					);
 					return;
 				}
 
-				if (frameType === 'continue') {
+				// JSON control frames only count once JSON mode is established; legacy
+				// string sentinels always count.
+				if (frameType === 'continue' && (isLegacy || jsonProtocol === true)) {
 					waitingForChatResponse.value = false;
 					chatStore.waitingForResponse.value = true;
 					return;

--- a/packages/frontend/@n8n/chat/src/utils/utils.ts
+++ b/packages/frontend/@n8n/chat/src/utils/utils.ts
@@ -3,7 +3,9 @@ import { v4 as uuid } from 'uuid';
 import { MessageComponentKey } from '../constants';
 import type { ChatMessage } from '../types';
 
+const CHAT_NODE_MESSAGE_TYPE = 'message';
 const CHAT_NODE_MESSAGE_WITH_BUTTONS_TYPE = 'with-buttons';
+const CHAT_NODE_ERROR_TYPE = 'error';
 
 interface ChatNodeMessageWithButtons {
 	type: typeof CHAT_NODE_MESSAGE_WITH_BUTTONS_TYPE;
@@ -15,6 +17,18 @@ interface ChatNodeMessageWithButtons {
 		type: string;
 	}>;
 }
+
+interface ChatNodeMessageRegular {
+	type: typeof CHAT_NODE_MESSAGE_TYPE;
+	text: string;
+}
+
+interface ChatNodeError {
+	type: typeof CHAT_NODE_ERROR_TYPE;
+	message: string;
+}
+
+type ChatNodeFrame = ChatNodeMessageWithButtons | ChatNodeMessageRegular | ChatNodeError;
 
 export function constructChatWebsocketUrl(
 	url: string,
@@ -40,7 +54,7 @@ export function parseBotChatMessageContent(message: string): ChatMessage {
 		text: message,
 	};
 	try {
-		const parsed = JSON.parse(message) as ChatNodeMessageWithButtons;
+		const parsed = JSON.parse(message) as ChatNodeFrame;
 		if (parsed.type === CHAT_NODE_MESSAGE_WITH_BUTTONS_TYPE) {
 			chatMessage = {
 				id,
@@ -53,6 +67,10 @@ export function parseBotChatMessageContent(message: string): ChatMessage {
 					blockUserInput: parsed.blockUserInput,
 				},
 			};
+		} else if (parsed.type === CHAT_NODE_MESSAGE_TYPE) {
+			chatMessage = { id, sender: 'bot', text: parsed.text };
+		} else if (parsed.type === CHAT_NODE_ERROR_TYPE) {
+			chatMessage = { id, sender: 'bot', text: parsed.message };
 		}
 	} catch {
 		// ignore error as the message might be just a string


### PR DESCRIPTION
## Summary

Makes the `@n8n/chat` widget understand **both** chat WebSocket protocols:
- legacy string sentinels (`n8n|heartbeat`, `n8n|continue`) — what servers send today, and
- JSON frames (`{ "type": "heartbeat" | "continue" | "error" | "message" | "with-buttons" }`).

The widget acks heartbeats in whatever format it received, so a single widget build works against both current servers and servers that send JSON frames. Behavior against a current server is unchanged (the JSON branches stay dormant).

This is **forward-compatible preparation** for the v3 change that makes the chat WebSocket backend JSON-only (companion PR against `3.x`: #34247). Landing the tolerant reader now means already-deployed and embedded chat widgets keep working when a server later switches to the JSON-only protocol.

Changes are confined to `@n8n/chat`:
- `utils.ts` `parseBotChatMessageContent` switches on `type` (`message` → text, `with-buttons` → buttons, `error` → text) with a raw-string fallback.
- `Input.vue` `onmessage` handles both legacy sentinels and JSON control frames.

## How to test

1. In the workflow editor, run a Chat Trigger workflow and use the chat panel — everything behaves exactly as before against a current server.
2. Unit tests: `cd packages/frontend/@n8n/chat && pnpm test` (see the added cases in `utils.spec.ts` and `Input.spec.ts` covering both protocols).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4436

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34348">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

