### PR TITLE
fix(core): A new schedule trigger's first occurrences must be seeded on activation (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
+++ b/packages/@n8n/db/src/repositories/scheduled-job.repository.ts
@@ -110,6 +110,12 @@ export class ScheduledJobRepository extends Repository<ScheduledJob> {
 		return await manager.findBy(ScheduledJob, { workflowId, nodeId });
 	}
 
+	/** The jobs with the given ids, read back within a transaction. */
+	async findManyByIds(manager: EntityManager, ids: number[]): Promise<ScheduledJob[]> {
+		if (ids.length === 0) return [];
+		return await manager.findBy(ScheduledJob, { id: In(ids) });
+	}
+
 	/**
 	 * Insert new job rows and return one id per input job, in the same order as
 	 * `jobs`, so the caller can zip the ids back to the jobs by index.

--- a/packages/@n8n/scheduler/src/core/index.ts
+++ b/packages/@n8n/scheduler/src/core/index.ts
@@ -51,6 +51,7 @@ export type {
 	DispatchReporter,
 	DispatchDecision,
 } from './executor';
+export { DEFAULT_MATERIALIZER_OPTIONS, materialize } from './materializer';
 export type {
 	MaterializerOptions,
 	MaterializerSummary,

--- a/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
+++ b/packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts
@@ -1,3 +1,5 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { GlobalConfig } from '@n8n/config';
 import type {
 	DataSource,
 	ScheduledJob,
@@ -64,8 +66,24 @@ describe('DurableJobProvisioner', () => {
 				await run({ setAttribute() {}, setStatus() {} })) as typeof tracing.startSpan,
 		);
 		jobs.findManyByWorkflowNode.mockResolvedValue([]);
+		jobs.findManyByIds.mockResolvedValue([]);
 		jobs.insertMany.mockResolvedValue([]);
-		provisioner = new DurableJobProvisioner(dataSource, jobs, tasks, tracing);
+		tasks.insertIgnoringDuplicates.mockImplementation(async (_manager, occurrences) => ({
+			recorded: occurrences.length,
+			created: [],
+		}));
+		const globalConfig = mock<GlobalConfig>({
+			scheduler: { materializationWindowSeconds: 60 },
+			generic: { timezone: 'UTC' },
+		});
+		provisioner = new DurableJobProvisioner(
+			mockLogger(),
+			dataSource,
+			jobs,
+			tasks,
+			globalConfig,
+			tracing,
+		);
 	});
 
 	describe('provision', () => {
@@ -166,6 +184,136 @@ describe('DurableJobProvisioner', () => {
 			await provisioner.provision('wf', 'node', 'schedule-trigger', {}, [desiredJob('wf:node:0')]);
 
 			expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('seeding a freshly provisioned job', () => {
+		const SEED_NOW = new Date('2026-01-05T00:00:00.000Z');
+		const at = (seconds: number) => new Date(SEED_NOW.getTime() + seconds * 1000);
+
+		// A plain object, not `mock<ScheduledJob>`: the seed plans the row, and a mock
+		// would proxy its Date fields, which then leak into the recorded occurrences.
+		const intervalRow = (id: number, nextRunAt: Date): ScheduledJob =>
+			({
+				id,
+				name: 'wf:node:0',
+				workflowId: 'wf',
+				nodeId: 'node',
+				kind: 'interval',
+				cronExpression: null,
+				timezone: null,
+				recurrenceUnit: null,
+				recurrenceSize: null,
+				intervalSeconds: 30,
+				fireAt: null,
+				enabled: true,
+				nextRunAt,
+				lastFiredAt: null,
+				taskType: 'schedule-trigger',
+				payload: {},
+				maxAttempts: 1,
+			}) as unknown as ScheduledJob;
+
+		// The first fire (30s out) plus every fire up to the 60s window, each a task
+		// due at its own instant.
+		const firstWindowOf = (jobId: number) => [
+			{
+				jobId,
+				taskType: 'schedule-trigger',
+				payload: {},
+				scheduledFor: at(30),
+				runAt: at(30),
+				maxAttempts: 1,
+			},
+			{
+				jobId,
+				taskType: 'schedule-trigger',
+				payload: {},
+				scheduledFor: at(60),
+				runAt: at(60),
+				maxAttempts: 1,
+			},
+		];
+
+		beforeEach(() => {
+			// The seed sizes its window from DB time, not the instance clock.
+			tasks.readDbTime.mockResolvedValue(SEED_NOW);
+		});
+
+		it('queues the first window of a fresh job ahead of its due time instead of leaving it for a later poll', async () => {
+			const firstRunAt = at(30);
+			// The seed reads the row it just inserted back by id, now carrying its clock.
+			jobs.findManyByIds.mockResolvedValue([intervalRow(100, firstRunAt)]);
+			jobs.insertMany.mockResolvedValue([100]);
+
+			await provisioner.provision('wf', 'node', 'schedule-trigger', {}, [
+				desiredJob('wf:node:0', { kind: 'interval', intervalSeconds: 30 }, firstRunAt),
+			]);
+
+			// The whole first window is recorded now, at provision time. All fires lie
+			// in the future, so the executor fires them on time rather than discovering
+			// the first one only after it has already passed.
+			expect(jobs.findManyByIds).toHaveBeenCalledWith(manager, [100]);
+			expect(tasks.insertIgnoringDuplicates.mock.calls[0]?.[1]).toEqual(firstWindowOf(100));
+			// The first recorded fire is still in the future when it is queued.
+			expect(at(30).getTime()).toBeGreaterThan(SEED_NOW.getTime());
+			// The clock advances past the window, as a materializer pass would leave it.
+			expect(jobs.advanceMany.mock.calls[0]?.[1]).toEqual([
+				{ id: 100, nextRunAt: at(90), lastFiredAt: at(60) },
+			]);
+		});
+
+		it('re-seeds a redefined job, recording its new window only after the stale tasks are withdrawn', async () => {
+			const firstRunAt = at(30);
+			// An existing job with a different definition, so the desired rule redefines it.
+			jobs.findManyByWorkflowNode.mockResolvedValue([
+				mock<ScheduledJob>({
+					id: 10,
+					name: 'wf:node:0',
+					kind: 'cron',
+					cronExpression: '0 0 9 * * *',
+					timezone: 'UTC',
+					recurrenceUnit: null,
+					recurrenceSize: null,
+					intervalSeconds: null,
+					fireAt: null,
+					nextRunAt: at(0),
+				}),
+			]);
+			jobs.findManyByIds.mockResolvedValue([intervalRow(10, firstRunAt)]);
+
+			await provisioner.provision('wf', 'node', 'schedule-trigger', {}, [
+				desiredJob('wf:node:0', { kind: 'interval', intervalSeconds: 30 }, firstRunAt),
+			]);
+
+			// The redefine's stale tasks are withdrawn before the fresh window is seeded,
+			// so the new occurrences are the last word.
+			expect(tasks.deletePendingByJobIds).toHaveBeenCalledWith(manager, [10]);
+			expect(tasks.deletePendingByJobIds.mock.invocationCallOrder[0]).toBeLessThan(
+				tasks.insertIgnoringDuplicates.mock.invocationCallOrder[0],
+			);
+			expect(tasks.insertIgnoringDuplicates.mock.calls[0]?.[1]).toEqual(firstWindowOf(10));
+			expect(jobs.advanceMany.mock.calls[0]?.[1]).toEqual([
+				{ id: 10, nextRunAt: at(90), lastFiredAt: at(60) },
+			]);
+		});
+
+		it('does not seed a clock-dead job (a rule that never fires)', async () => {
+			const deadRow = mock<ScheduledJob>({
+				id: 101,
+				name: 'wf:node:0',
+				enabled: true,
+				nextRunAt: null,
+			});
+			jobs.findManyByIds.mockResolvedValue([deadRow]);
+			jobs.insertMany.mockResolvedValue([101]);
+
+			await provisioner.provision('wf', 'node', 'schedule-trigger', {}, [
+				desiredJob('wf:node:0', cronSchedule, null),
+			]);
+
+			expect(tasks.insertIgnoringDuplicates).not.toHaveBeenCalled();
+			expect(jobs.advanceMany).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/scheduling/durable-job-provisioner.ts
+++ b/packages/cli/src/scheduling/durable-job-provisioner.ts
@@ -1,14 +1,18 @@
+import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
 import type { EntityManager, NewScheduledJob, ScheduledJob } from '@n8n/db';
 import { DataSource, ScheduledJobRepository, ScheduledTaskRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { createJobProvisioner } from '@n8n/scheduler';
+import { createJobProvisioner, DEFAULT_MATERIALIZER_OPTIONS, materialize } from '@n8n/scheduler';
 import type {
 	DesiredJob,
 	ExistingJob,
 	JobProvisioner,
+	MaterializerOptions,
 	ProvisionSummary,
 	RunInDeprovisionTransaction,
 	RunInProvisionTransaction,
+	RunInTransaction,
 	ScheduleDefinition,
 } from '@n8n/scheduler';
 import { Tracing } from 'n8n-core';
@@ -50,7 +54,9 @@ type ScheduleColumns = Pick<
  *
  * The counterpart to `DurableScheduler`'s run side, deliberately a separate
  * service: authoring a node's jobs must not depend on this instance running the
- * scheduler loops, and the two only meet at the `scheduled_job` table.
+ * scheduler loops. It also seeds a new job's first window of tasks itself (see
+ * {@link seedInitialOccurrences}), so the two meet at the `scheduled_task` table
+ * too, not only `scheduled_job`.
  *
  * A `ScheduleDefinition` is a discriminated union (one variant per kind); the
  * flat columns are a persistence detail, so the mapping between the two
@@ -60,17 +66,32 @@ type ScheduleColumns = Pick<
 export class DurableJobProvisioner {
 	private readonly provisioner: JobProvisioner<ProvisionScope, DeprovisionScope>;
 
+	/**
+	 * Options for the provision-time seed materialization. Mirrors what the running
+	 * materializer uses, so an eagerly-seeded job records the same occurrences it
+	 * would on its first poll (see {@link seedInitialOccurrences}).
+	 */
+	private readonly materializerOptions: MaterializerOptions;
+
 	constructor(
+		private readonly logger: Logger,
 		private readonly dataSource: DataSource,
 		private readonly jobs: ScheduledJobRepository,
 		private readonly tasks: ScheduledTaskRepository,
+		globalConfig: GlobalConfig,
 		tracing: Tracing,
 	) {
+		this.logger = this.logger.scoped('scheduler');
 		this.provisioner = createJobProvisioner<ProvisionScope, DeprovisionScope>({
 			provisionTransaction: (scope) => this.provisionTransaction(scope),
 			deprovisionTransaction: (scope) => this.deprovisionTransaction(scope),
 			tracer: createSchedulerTracer(tracing),
 		});
+		this.materializerOptions = {
+			...DEFAULT_MATERIALIZER_OPTIONS,
+			windowSeconds: globalConfig.scheduler.materializationWindowSeconds,
+			defaultTimezone: globalConfig.generic.timezone,
+		};
 	}
 
 	/**
@@ -123,44 +144,115 @@ export class DurableJobProvisioner {
 		payload,
 	}: ProvisionScope): RunInProvisionTransaction {
 		return async (work) =>
-			await this.dataSource.transaction(
-				async (manager) =>
-					await work({
-						findExisting: async () => {
-							const rows = await this.jobs.findManyByWorkflowNode(manager, workflowId, nodeId);
-							return rows.map(
-								(row): ExistingJob => ({
-									id: row.id,
-									name: row.name,
-									schedule: rowSchedule(row),
-									hasClock: row.nextRunAt !== null,
-								}),
-							);
-						},
-						insert: async (desired) => {
-							const rows = desired.map(
-								(job): NewScheduledJob => ({
-									name: job.name,
-									workflowId,
-									nodeId,
-									taskType,
-									payload,
-									...scheduleColumns(job.schedule),
-									nextRunAt: job.firstRunAt,
-								}),
-							);
-							return await this.jobs.insertMany(manager, rows);
-						},
-						redefine: async (jobId, schedule, nextRunAt) =>
-							await this.jobs.updateDefinition(manager, jobId, {
-								...scheduleColumns(schedule),
-								nextRunAt,
+			await this.dataSource.transaction(async (manager) => {
+				// Jobs freshly inserted or redefined this pass; their first window is
+				// seeded before the transaction commits (see `seedInitialOccurrences`).
+				const seededJobIds = new Set<number>();
+				const result = await work({
+					findExisting: async () => {
+						const rows = await this.jobs.findManyByWorkflowNode(manager, workflowId, nodeId);
+						return rows.map(
+							(row): ExistingJob => ({
+								id: row.id,
+								name: row.name,
+								schedule: rowSchedule(row),
+								hasClock: row.nextRunAt !== null,
 							}),
-						withdrawPendingTasks: async (jobIds) =>
-							await this.tasks.deletePendingByJobIds(manager, jobIds),
-						deleteJobs: async (jobIds) => await this.jobs.deleteManyByIds(manager, jobIds),
-					}),
-			);
+						);
+					},
+					insert: async (desired) => {
+						const rows = desired.map(
+							(job): NewScheduledJob => ({
+								name: job.name,
+								workflowId,
+								nodeId,
+								taskType,
+								payload,
+								...scheduleColumns(job.schedule),
+								nextRunAt: job.firstRunAt,
+							}),
+						);
+						const ids = await this.jobs.insertMany(manager, rows);
+						for (const id of ids) seededJobIds.add(id);
+						return ids;
+					},
+					redefine: async (jobId, schedule, nextRunAt) => {
+						await this.jobs.updateDefinition(manager, jobId, {
+							...scheduleColumns(schedule),
+							nextRunAt,
+						});
+						seededJobIds.add(jobId);
+					},
+					withdrawPendingTasks: async (jobIds) =>
+						await this.tasks.deletePendingByJobIds(manager, jobIds),
+					deleteJobs: async (jobIds) => await this.jobs.deleteManyByIds(manager, jobIds),
+				});
+				// After all of provisioning's own writes (including withdrawing a
+				// redefined job's stale tasks) so the seeded occurrences are the last word.
+				await this.seedInitialOccurrences(manager, seededJobIds);
+				return result;
+			});
+	}
+
+	/**
+	 * Record the first window of occurrences for jobs whose clock was just seeded,
+	 * and advance their `nextRunAt`. Without this, a fresh job's first fire is only
+	 * recorded once a materializer poll tick runs; when the first interval is
+	 * shorter than the gap to that tick, the fire is recorded after it is already
+	 * due and dispatched late. Seeding here queues it ahead of time, leaving the
+	 * executor its usual slack to fire on schedule.
+	 *
+	 * Reuses the run-side {@link materialize} pass so activation and every later
+	 * poll share one code path: only the claim differs, returning these specific
+	 * jobs (regardless of due-ness) instead of the poll's due-jobs query. Runs on
+	 * the provision transaction's manager, so the seed commits atomically with the
+	 * job rows; a job with no live clock plans nothing.
+	 */
+	private async seedInitialOccurrences(manager: EntityManager, jobIds: Set<number>): Promise<void> {
+		if (jobIds.size === 0) return;
+
+		// DB time, not this instance's clock, so the seed sizes its window the way a
+		// poll would and every instance agrees on it (see `DueJobs.now`).
+		const now = await this.tasks.readDbTime();
+
+		const seedTransaction: RunInTransaction = async (work) =>
+			await work({
+				// The just-written rows, read back so planning uses the persisted clock
+				// and (for a redefined job) its new definition. Enabled with a live clock
+				// only, mirroring the poll's claim predicate.
+				claimDueJobs: async () => {
+					const claimed = (await this.jobs.findManyByIds(manager, [...jobIds])).filter(
+						(job) => job.enabled && job.nextRunAt !== null,
+					);
+					return claimed.length > 0 ? { now, jobs: claimed } : undefined;
+				},
+				recordOccurrences: async (occurrences) =>
+					await this.tasks.insertIgnoringDuplicates(manager, occurrences),
+				advanceJobs: async (planned) =>
+					await this.jobs.advanceMany(
+						manager,
+						planned.map(({ job, plan }) => ({
+							id: job.id,
+							nextRunAt: plan.nextRunAt,
+							lastFiredAt: plan.lastFiredAt,
+						})),
+					),
+			});
+
+		await materialize(seedTransaction, this.materializerOptions, {
+			// A just-registered job was already validated, so a seed-time plan failure is
+			// unexpected; log it (the pass defers the job, as a poll would) instead of
+			// letting it pass silently, matching the run side's reporting.
+			onPlanError: (job, error) =>
+				this.logger.error('Failed to plan a scheduled job while seeding its first run', {
+					jobId: job.id,
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			onSkippedDuplicates: (context) =>
+				this.logger.debug('Seeding skipped occurrences already recorded for a scheduled job', {
+					...context,
+				}),
+		});
 	}
 
 	private deprovisionTransaction(scope: DeprovisionScope): RunInDeprovisionTransaction {


### PR DESCRIPTION
## Summary

A newly activated Schedule Trigger seeded its first `nextRunAt` on the schedule grid but recorded no tasks, so the first fire was only materialized once a materializer poll tick ran. When the first interval was shorter than the gap to that tick (e.g. a 3s interval right after activation), the fire was recorded after it was already due and dispatched late (observed ~1.77-4.77s late).

This is a follow-up to CAT-3778's claim-ahead change: claim-ahead records a job's window before its fire, but only if a poll tick actually runs in `[firstRunAt - lookahead, firstRunAt]` — which does not happen when `firstRunAt` is sooner than the next tick.

The fix seeds the first window of occurrences at provision time, inside the provision transaction, for freshly inserted **and** redefined jobs, by **reusing the run-side `materialize()` pass** over the just-provisioned jobs. Only the claim differs: it returns these specific jobs (regardless of due-ness, enabled + live clock) instead of the poll's due-jobs query. So activation and every later poll share one code path, and the first fire is queued ahead of time like every subsequent one.

Design notes for reviewers:
- The seed runs on the **provision transaction's manager**, so it commits atomically with the job rows (a deliberate choice; the seed's `scheduled_task` writes therefore share the activation transaction — `scheduled_task` is already in that transaction for a redefine's task withdrawal).
- The seed runs **after** the provisioning writes, so a redefined job's stale tasks are withdrawn before its new window is recorded.
- `now` is read from **DB time** (`readDbTime`), not the instance clock, matching the materializer invariant that every instance agrees on "now".
- Rejected alternative: subtracting a margin from `firstRunAt` would move `nextRunAt` off the schedule grid, firing the first task off-schedule.

## How to test

Requires the durable scheduler enabled: `N8N_SCHEDULER_ENABLED=true` plus the workflow publication service so schedule triggers are diverted to durable jobs.

1. Activate a workflow with a Schedule Trigger on a short interval (e.g. every 3 seconds).
2. Observe the very first execution: it fires at its scheduled instant rather than up to a materializer poll interval late.

Covered by unit tests in `packages/cli/src/scheduling/__tests__/durable-job-provisioner.test.ts` (first window queued ahead of due time; redefine re-seeds after withdrawing stale tasks; clock-dead rule not seeded).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3781

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

