### PR TITLE
fix: Keep generated OpenAI cache keys within provider limit (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/model/__tests__/prompt-cache.test.ts
+++ b/packages/@n8n/agents/src/runtime/model/__tests__/prompt-cache.test.ts
@@ -115,24 +115,37 @@ describe('createOpenAIPromptCacheKey (via buildCallPromptCacheOptions)', () => {
 		instructions: 'You are a helpful assistant with very specific secret instructions.',
 	};
 
-	function generatedKey(instructions: string): string {
+	function generatedKey(overrides: { agentName?: string; instructions?: string } = {}): string {
 		const result = buildCallPromptCacheOptions({ enabled: true }, modelId, {
 			...context,
-			instructions,
+			...overrides,
 		});
 		return (result?.openai as { promptCacheKey: string }).promptCacheKey;
 	}
 
 	it('is deterministic for the same agent, model, and instructions', () => {
-		expect(generatedKey(context.instructions)).toBe(generatedKey(context.instructions));
+		expect(generatedKey()).toBe(generatedKey());
 	});
 
 	it('changes when the instructions change (per-agent-version granularity)', () => {
-		expect(generatedKey(context.instructions)).not.toBe(generatedKey('Different instructions.'));
+		expect(generatedKey()).not.toBe(generatedKey({ instructions: 'Different instructions.' }));
 	});
 
 	it('never embeds the raw instructions text', () => {
-		expect(generatedKey(context.instructions)).not.toContain('secret instructions');
+		expect(generatedKey()).not.toContain('secret instructions');
+	});
+
+	it('changes when only the agent name changes', () => {
+		expect(generatedKey()).not.toBe(generatedKey({ agentName: 'other-assistant' }));
+	});
+
+	it("stays within OpenAI's 64-character limit for a 128-character agent name", () => {
+		const longName = 'a'.repeat(128);
+		const key = generatedKey({ agentName: longName });
+
+		expect(key.length).toBe(64);
+		expect(key.startsWith('agent:')).toBe(true);
+		expect(key).not.toContain(longName);
 	});
 });
 

--- a/packages/@n8n/agents/src/runtime/model/prompt-cache.ts
+++ b/packages/@n8n/agents/src/runtime/model/prompt-cache.ts
@@ -61,10 +61,11 @@ export function getModelProvider(modelId: string): string {
 
 /**
  * Deterministic, non-reversible per-agent-version OpenAI `promptCacheKey`.
- * Combines agent name with a hash of the model id and base instructions so
- * the key stays stable across runs but changes when the "version" (model or
- * instructions) changes. Never embeds raw instructions, user input, thread
- * ids, or tenant/user identifiers.
+ * Hashes the agent name, model id, and base instructions together so the key
+ * stays stable across runs but changes when any of them change. Never embeds
+ * raw agent names, instructions, user input, thread ids, or tenant/user
+ * identifiers. Fixed at 64 characters (OpenAI's max) regardless of agent name
+ * length.
  */
 function createOpenAIPromptCacheKey(input: {
 	agentName: string;
@@ -72,11 +73,11 @@ function createOpenAIPromptCacheKey(input: {
 	instructions: string;
 }): string {
 	const hash = createHash('sha256')
-		.update(`${input.modelId}\n${input.instructions}`)
+		.update(`${input.agentName}\n${input.modelId}\n${input.instructions}`)
 		.digest('hex')
-		.slice(0, 16);
+		.slice(0, 58);
 	// Provider-neutral namespace — this is a generic SDK, not an n8n-only surface.
-	return `agent:${input.agentName}:${hash}`;
+	return `agent:${hash}`;
 }
 
 /** `{ anthropic: { cacheControl: { type: 'ephemeral', ttl } } }` using the configured TTL. */


### PR DESCRIPTION
## Summary

- Hash the agent name together with the model ID and instructions when generating OpenAI prompt cache keys
- Keep generated keys at OpenAI's 64-character limit without exposing raw agent names
- Add regression coverage for maximum-length agent names and per-agent key isolation

## How to test

From `packages/@n8n/agents`:

```bash
pnpm vitest run src/runtime/model/__tests__/prompt-cache.test.ts -t "createOpenAIPromptCacheKey"
```

Also verified with package lint and typecheck.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-421

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34365">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

