### PR TITLE
fix: Gate agent knowledge base table on AI Assistant proxy availability

### DIFF
--- a/packages/@n8n/api-types/src/frontend-settings.ts
+++ b/packages/@n8n/api-types/src/frontend-settings.ts
@@ -359,9 +359,10 @@ export type FrontendModuleSettings = {
 		 */
 		modules: string[];
 		/**
-		 * Whether the agent knowledge base is enabled. Requires
-		 * `N8N_AGENTS_AI_SANDBOX_ENABLED=true` and
-		 * `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona` on the backend.
+		 * Whether the agent knowledge base is enabled. True when the backend's
+		 * Daytona sandbox env vars (`N8N_AGENTS_AI_SANDBOX_ENABLED=true` +
+		 * `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona`) are set, OR the AI Assistant
+		 * proxy is available.
 		 */
 		knowledgeBaseEnabled: boolean;
 	};

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-gate.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-gate.test.ts
@@ -1,0 +1,33 @@
+import { isAgentKnowledgeBaseEnabled } from '../agent-knowledge-gate';
+
+describe('isAgentKnowledgeBaseEnabled', () => {
+	it('is enabled when direct Daytona sandbox config is complete, even without proxy', () => {
+		expect(
+			isAgentKnowledgeBaseEnabled({ sandboxEnabled: true, sandboxProvider: 'daytona' }, false),
+		).toBe(true);
+	});
+
+	it('is enabled when the AI Assistant proxy is available, even without sandbox env vars', () => {
+		expect(isAgentKnowledgeBaseEnabled({ sandboxEnabled: false, sandboxProvider: '' }, true)).toBe(
+			true,
+		);
+	});
+
+	it('is enabled when the proxy is available even if the sandbox provider is not daytona', () => {
+		expect(
+			isAgentKnowledgeBaseEnabled({ sandboxEnabled: true, sandboxProvider: 'n8n-sandbox' }, true),
+		).toBe(true);
+	});
+
+	it('is disabled when neither the sandbox config nor the proxy is available', () => {
+		expect(isAgentKnowledgeBaseEnabled({ sandboxEnabled: false, sandboxProvider: '' }, false)).toBe(
+			false,
+		);
+	});
+
+	it('is disabled when sandboxEnabled is true but the provider is not daytona and the proxy is unavailable', () => {
+		expect(
+			isAgentKnowledgeBaseEnabled({ sandboxEnabled: true, sandboxProvider: 'n8n-sandbox' }, false),
+		).toBe(false);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge-sandbox.service.test.ts
@@ -331,7 +331,7 @@ describe('AgentKnowledgeSandboxService', () => {
 		expect(params.snapshot).toBeUndefined();
 	});
 
-	it('requests a proxy token scoped to the project id when the proxy is enabled', async () => {
+	it('requests a proxy token scoped to the project id when the proxy is enabled, even without sandbox env vars', async () => {
 		const client = mock<AiAssistantClient>();
 		client.getSandboxProxyConfig.mockResolvedValue({ image: 'proxy-image' });
 		client.getBuilderApiProxyToken.mockResolvedValue({
@@ -343,7 +343,11 @@ describe('AgentKnowledgeSandboxService', () => {
 			isProxyEnabled: vi.fn().mockReturnValue(true),
 			getClient: vi.fn().mockResolvedValue(client),
 		});
-		const service = makeService({}, mock<Logger>(), aiService);
+		const service = makeService(
+			{ sandboxEnabled: false, sandboxProvider: '' },
+			mock<Logger>(),
+			aiService,
+		);
 
 		await service.warmSandbox(projectId, agentId);
 

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge.controller.test.ts
@@ -5,6 +5,7 @@ import multer from 'multer';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { AiService } from '@/services/ai.service';
 
 import { AgentKnowledgeController } from '../agent-knowledge.controller';
 import type { AgentKnowledgeService } from '../agent-knowledge.service';
@@ -21,19 +22,23 @@ function makeController({
 		sandboxProvider: 'daytona',
 	} as AgentsConfig,
 	runtimeCacheService = mock<AgentRuntimeCacheService>(),
+	aiService = mock<AiService>({ isProxyEnabled: () => false }),
 }: {
 	agentKnowledgeService?: Mocked<AgentKnowledgeService>;
 	agentsConfig?: AgentsConfig;
 	runtimeCacheService?: Mocked<AgentRuntimeCacheService>;
+	aiService?: Mocked<AiService>;
 } = {}) {
 	return {
 		controller: new AgentKnowledgeController(
 			agentKnowledgeService,
 			agentsConfig,
 			runtimeCacheService,
+			aiService,
 		),
 		agentKnowledgeService,
 		runtimeCacheService,
+		aiService,
 	};
 }
 

--- a/packages/cli/src/modules/agents/__tests__/agent-sandbox.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-sandbox.controller.test.ts
@@ -4,16 +4,23 @@ import type { AuthenticatedRequest } from '@n8n/db';
 import type { Response } from 'express';
 import { mock } from 'vitest-mock-extended';
 
+import type { AiService } from '@/services/ai.service';
+
 import type { AgentKnowledgeService } from '../agent-knowledge.service';
 import { AgentSandboxController } from '../agent-sandbox.controller';
 
 describe('AgentSandboxController', () => {
 	it('accepts knowledge sandbox warmup before files exist', async () => {
 		const agentKnowledgeService = mock<AgentKnowledgeService>();
-		const controller = new AgentSandboxController(agentKnowledgeService, mock<Logger>(), {
-			sandboxEnabled: true,
-			sandboxProvider: 'daytona',
-		} as AgentsConfig);
+		const controller = new AgentSandboxController(
+			agentKnowledgeService,
+			mock<Logger>(),
+			{
+				sandboxEnabled: true,
+				sandboxProvider: 'daytona',
+			} as AgentsConfig,
+			mock<AiService>({ isProxyEnabled: () => false }),
+		);
 		const req = { user: { id: 'user-1' } } as AuthenticatedRequest<{ projectId: string }>;
 		const res = mock<Response>();
 

--- a/packages/cli/src/modules/agents/__tests__/agents.module.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.module.test.ts
@@ -1,0 +1,66 @@
+import { AgentsConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import { mock } from 'vitest-mock-extended';
+
+import { AiService } from '@/services/ai.service';
+
+import { AgentsModule } from '../agents.module';
+
+describe('AgentsModule', () => {
+	let module: AgentsModule;
+
+	beforeEach(() => {
+		Container.reset();
+		module = new AgentsModule();
+	});
+
+	describe('settings()', () => {
+		it('exposes knowledgeBaseEnabled when the direct Daytona sandbox config is complete', async () => {
+			Container.set(
+				AgentsConfig,
+				mock<AgentsConfig>({
+					modules: [],
+					sandboxEnabled: true,
+					sandboxProvider: 'daytona',
+				}),
+			);
+			Container.set(AiService, mock<AiService>({ isProxyEnabled: () => false }));
+
+			const settings = await module.settings();
+
+			expect(settings.knowledgeBaseEnabled).toBe(true);
+		});
+
+		it('exposes knowledgeBaseEnabled when the AI Assistant proxy is available without sandbox env vars', async () => {
+			Container.set(
+				AgentsConfig,
+				mock<AgentsConfig>({
+					modules: [],
+					sandboxEnabled: false,
+					sandboxProvider: '',
+				}),
+			);
+			Container.set(AiService, mock<AiService>({ isProxyEnabled: () => true }));
+
+			const settings = await module.settings();
+
+			expect(settings.knowledgeBaseEnabled).toBe(true);
+		});
+
+		it('disables knowledgeBaseEnabled when neither the sandbox config nor the proxy is available', async () => {
+			Container.set(
+				AgentsConfig,
+				mock<AgentsConfig>({
+					modules: [],
+					sandboxEnabled: false,
+					sandboxProvider: '',
+				}),
+			);
+			Container.set(AiService, mock<AiService>({ isProxyEnabled: () => false }));
+
+			const settings = await module.settings();
+
+			expect(settings.knowledgeBaseEnabled).toBe(false);
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/agent-knowledge-gate.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-gate.ts
@@ -2,6 +2,7 @@ import type { AgentsConfig } from '@n8n/config';
 
 export function isAgentKnowledgeBaseEnabled(
 	config: Pick<AgentsConfig, 'sandboxEnabled' | 'sandboxProvider'>,
+	aiAssistantAvailable: boolean,
 ): boolean {
-	return config.sandboxEnabled && config.sandboxProvider === 'daytona';
+	return aiAssistantAvailable || (config.sandboxEnabled && config.sandboxProvider === 'daytona');
 }

--- a/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge-sandbox.service.ts
@@ -229,7 +229,7 @@ export class AgentKnowledgeSandboxService {
 	 * callers must not have cleanup failures block the parent delete operation.
 	 */
 	async destroySandbox(projectId: string, agentId: string): Promise<void> {
-		if (!isAgentKnowledgeBaseEnabled(this.agentsConfig)) return;
+		if (!this.isKnowledgeBaseEnabled()) return;
 
 		try {
 			const { Daytona } = loadDaytona();
@@ -885,8 +885,12 @@ export class AgentKnowledgeSandboxService {
 		}
 	}
 
+	private isKnowledgeBaseEnabled(): boolean {
+		return isAgentKnowledgeBaseEnabled(this.agentsConfig, this.aiService.isProxyEnabled());
+	}
+
 	private assertKnowledgeBaseEnabled(): void {
-		if (isAgentKnowledgeBaseEnabled(this.agentsConfig)) {
+		if (this.isKnowledgeBaseEnabled()) {
 			return;
 		}
 

--- a/packages/cli/src/modules/agents/agent-knowledge.controller.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.controller.ts
@@ -7,6 +7,7 @@ import multer from 'multer';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { AiService } from '@/services/ai.service';
 
 import { isAgentKnowledgeBaseEnabled } from './agent-knowledge-gate';
 import { AgentKnowledgeService } from './agent-knowledge.service';
@@ -25,11 +26,12 @@ export class AgentKnowledgeController {
 		private readonly agentKnowledgeService: AgentKnowledgeService,
 		private readonly agentsConfig: AgentsConfig,
 		private readonly runtimeCacheService: AgentRuntimeCacheService,
+		private readonly aiService: AiService,
 	) {}
 
-	/** Knowledge base endpoints are gated behind Daytona sandbox env vars. */
+	/** Knowledge base endpoints are gated behind Daytona sandbox env vars or AI Assistant proxy availability. */
 	private assertKnowledgeBaseEnabled() {
-		if (!isAgentKnowledgeBaseEnabled(this.agentsConfig)) {
+		if (!isAgentKnowledgeBaseEnabled(this.agentsConfig, this.aiService.isProxyEnabled())) {
 			throw new NotFoundError('Agent knowledge base is not enabled');
 		}
 	}

--- a/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
+++ b/packages/cli/src/modules/agents/agent-runtime-reconstruction.service.ts
@@ -520,7 +520,7 @@ export class AgentRuntimeReconstructionService {
 
 		if (
 			runtimeProfile !== 'inline' &&
-			isAgentKnowledgeBaseEnabled(this.agentsConfig) &&
+			isAgentKnowledgeBaseEnabled(this.agentsConfig, this.aiService.isProxyEnabled()) &&
 			(await this.agentFileRepository.hasFilesForAgent(agentId))
 		) {
 			const { createKnowledgeRetrievalTools } = await import(

--- a/packages/cli/src/modules/agents/agent-sandbox.controller.ts
+++ b/packages/cli/src/modules/agents/agent-sandbox.controller.ts
@@ -5,6 +5,7 @@ import { Param, Post, ProjectScope, RestController } from '@n8n/decorators';
 import type { Response } from 'express';
 
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import { AiService } from '@/services/ai.service';
 
 import { isAgentKnowledgeBaseEnabled } from './agent-knowledge-gate';
 import { AgentKnowledgeService } from './agent-knowledge.service';
@@ -15,6 +16,7 @@ export class AgentSandboxController {
 		private readonly agentKnowledgeService: AgentKnowledgeService,
 		private readonly logger: Logger,
 		private readonly agentsConfig: AgentsConfig,
+		private readonly aiService: AiService,
 	) {}
 
 	@Post('/:agentId/sandbox/knowledge/warmup')
@@ -34,8 +36,12 @@ export class AgentSandboxController {
 		return { accepted: true };
 	}
 
+	private isKnowledgeBaseEnabled(): boolean {
+		return isAgentKnowledgeBaseEnabled(this.agentsConfig, this.aiService.isProxyEnabled());
+	}
+
 	private assertKnowledgeBaseEnabled() {
-		if (!isAgentKnowledgeBaseEnabled(this.agentsConfig)) {
+		if (!this.isKnowledgeBaseEnabled()) {
 			throw new NotFoundError('Agent knowledge base is not enabled');
 		}
 	}
@@ -45,7 +51,7 @@ export class AgentSandboxController {
 		agentId: string,
 	): Promise<void> {
 		try {
-			if (!isAgentKnowledgeBaseEnabled(this.agentsConfig)) return;
+			if (!this.isKnowledgeBaseEnabled()) return;
 			await this.agentKnowledgeService.warmSandbox(agentId, projectId);
 		} catch (error) {
 			this.logger.warn('Failed to warm agent knowledge sandbox', {

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -96,10 +96,12 @@ export class AgentsModule implements ModuleInterface {
 	async settings() {
 		const config = Container.get(AgentsConfig);
 		const { isAgentKnowledgeBaseEnabled } = await import('./agent-knowledge-gate.js');
+		const { AiService } = await import('@/services/ai.service.js');
+		const aiService = Container.get(AiService);
 		return {
 			enabled: true,
 			modules: [...config.modules],
-			knowledgeBaseEnabled: isAgentKnowledgeBaseEnabled(config),
+			knowledgeBaseEnabled: isAgentKnowledgeBaseEnabled(config, aiService.isProxyEnabled()),
 		};
 	}
 

--- a/packages/frontend/editor-ui/src/app/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/settings.store.ts
@@ -183,8 +183,9 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		return isOtelCustomSpanAttributesLicensed && isOtelModuleActive;
 	});
 
-	// Opt-in flag: requires `N8N_AGENTS_AI_SANDBOX_ENABLED=true` and
-	// `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona` on the backend.
+	// Opt-in flag: enabled when the backend's Daytona sandbox env vars
+	// (`N8N_AGENTS_AI_SANDBOX_ENABLED=true` + `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona`)
+	// are set, OR the AI Assistant proxy is available.
 	const isAgentsKnowledgeBaseFeatureEnabled = computed(
 		() =>
 			isModuleActive('agents') === true &&

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderEditorColumn.spec.ts
@@ -257,6 +257,14 @@ describe('AgentBuilderEditorColumn', () => {
 		expect(knowledgeWrapper.findComponent({ name: 'AgentFilesPanel' }).exists()).toBe(true);
 	});
 
+	it('renders the Knowledge tab with vector stores but without the files table when the knowledge base is disabled', async () => {
+		const wrapper = await mountColumn({ activeMainTab: 'knowledge', knowledgeBaseEnabled: false });
+
+		expect(wrapper.find('[data-testid="agent-knowledge-tab-content"]').exists()).toBe(true);
+		expect(wrapper.findComponent({ name: 'AgentFilesPanel' }).exists()).toBe(false);
+		expect(wrapper.find('[data-testid="agent-vector-stores-card"]').exists()).toBe(true);
+	});
+
 	it('renders tabs inside the constrained rule container that aligns with content cards', async () => {
 		const wrapper = await mountColumn();
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -662,16 +662,32 @@ describe('AgentBuilderView — preview routing', () => {
 		expect(uploadAgentFilesMock).not.toHaveBeenCalled();
 	});
 
-	it('adds the Knowledge tab only when the knowledge base is enabled', async () => {
+	it('always includes the Knowledge tab and keeps it selectable regardless of the knowledge base flag', async () => {
+		routeQuery.section = 'knowledge';
 		const withoutKnowledge = await renderView();
 		expect(
 			withoutKnowledge.findComponent({ name: 'AgentBuilderEditorColumn' }).props('mainTabOptions'),
-		).not.toContainEqual(expect.objectContaining({ value: 'knowledge' }));
+		).toContainEqual(expect.objectContaining({ value: 'knowledge' }));
+		expect(
+			withoutKnowledge.findComponent({ name: 'AgentBuilderEditorColumn' }).props('activeMainTab'),
+		).toBe('knowledge');
+		expect(
+			withoutKnowledge
+				.findComponent({ name: 'AgentBuilderEditorColumn' })
+				.props('knowledgeBaseEnabled'),
+		).toBe(false);
 
 		const withKnowledge = await renderView({ knowledgeBaseEnabled: true });
 		expect(
 			withKnowledge.findComponent({ name: 'AgentBuilderEditorColumn' }).props('mainTabOptions'),
 		).toContainEqual(expect.objectContaining({ value: 'knowledge' }));
+	});
+
+	it('does not fetch knowledge files when the knowledge base is disabled', async () => {
+		routeQuery.section = 'knowledge';
+		await renderView();
+
+		expect(listAgentFilesMock).not.toHaveBeenCalled();
 	});
 
 	it('marks the knowledge files panel unpublished for an unpublished agent', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderEditorColumn.vue
@@ -143,10 +143,11 @@ const i18n = useI18n();
 				</AgentBuilderTabPanel>
 
 				<AgentBuilderTabPanel
-					v-else-if="activeMainTab === 'knowledge' && knowledgeBaseEnabled"
+					v-else-if="activeMainTab === 'knowledge'"
 					data-testid="agent-knowledge-tab-content"
 				>
 					<AgentFilesPanel
+						v-if="knowledgeBaseEnabled"
 						:files="agentFiles"
 						:disabled="childrenDisabled"
 						:loading="agentFilesLoading"

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderMainTabs.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentBuilderMainTabs.ts
@@ -31,11 +31,9 @@ function getSectionFromTab(tab: AgentBuilderMainTab): AgentBuilderSection {
 
 export function useAgentBuilderMainTabs({
 	executionsCount,
-	knowledgeBaseEnabled,
 	routeBacked = computed(() => true),
 }: {
 	executionsCount: ComputedRef<number>;
-	knowledgeBaseEnabled: ComputedRef<boolean>;
 	routeBacked?: ComputedRef<boolean>;
 }) {
 	const route = useRoute();
@@ -53,7 +51,7 @@ export function useAgentBuilderMainTabs({
 
 	const activeMainTab = computed<AgentBuilderMainTab>({
 		get() {
-			if (selectedSection.value === 'knowledge' && knowledgeBaseEnabled.value) return 'knowledge';
+			if (selectedSection.value === 'knowledge') return 'knowledge';
 			if (selectedSection.value === EXECUTIONS_SECTION_KEY) return 'sessions';
 			if (selectedSection.value === 'settings') return 'settings';
 			return 'agent';
@@ -63,31 +61,18 @@ export function useAgentBuilderMainTabs({
 		},
 	});
 
-	const mainTabOptions = computed(() => {
-		const options: Array<{ label: string; value: AgentBuilderMainTab }> = [
-			{ label: i18n.baseText('agents.builder.header.tab.agent'), value: 'agent' },
-		];
-
-		if (knowledgeBaseEnabled.value) {
-			options.push({
-				label: i18n.baseText('agents.builder.header.tab.knowledge' as BaseTextKey),
-				value: 'knowledge',
-			});
-		}
-
-		options.push(
-			{
-				label: i18n.baseText('agents.builder.header.tab.executions'),
-				value: 'sessions',
-			},
-			{
-				label: i18n.baseText('agents.builder.header.tab.settings' as BaseTextKey),
-				value: 'settings',
-			},
-		);
-
-		return options;
-	});
+	const mainTabOptions = computed<Array<{ label: string; value: AgentBuilderMainTab }>>(() => [
+		{ label: i18n.baseText('agents.builder.header.tab.agent'), value: 'agent' },
+		{
+			label: i18n.baseText('agents.builder.header.tab.knowledge' as BaseTextKey),
+			value: 'knowledge',
+		},
+		{ label: i18n.baseText('agents.builder.header.tab.executions'), value: 'sessions' },
+		{
+			label: i18n.baseText('agents.builder.header.tab.settings' as BaseTextKey),
+			value: 'settings',
+		},
+	]);
 
 	const executionsDescription = computed(() =>
 		i18n.baseText('agents.builder.executions.count', {

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -102,8 +102,10 @@ const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const favoritesStore = useFavoritesStore();
 
-// Gates the entire knowledge base feature (files panel + fetching) behind the
-// Daytona sandbox env vars on the backend (N8N_AGENTS_AI_SANDBOX_ENABLED + PROVIDER=daytona).
+// Gates the Knowledge Base files table (upload, list, sandbox fetch/warmup) on
+// the backend: Daytona sandbox env vars (N8N_AGENTS_AI_SANDBOX_ENABLED +
+// PROVIDER=daytona) OR AI Assistant proxy availability. The Knowledge tab and
+// vector store management are always available regardless of this flag.
 const isKnowledgeBaseEnabled = computed(() => settingsStore.isAgentsKnowledgeBaseFeatureEnabled);
 const documentTitle = useDocumentTitle();
 const { showError, showMessage } = useToast();
@@ -175,7 +177,6 @@ const versionHistoryPanel = useTemplateRef<{ refresh: () => Promise<void> }>('ve
 const executionsCount = computed(() => sessionsStore.threads.length);
 const { activeMainTab, mainTabOptions, executionsDescription } = useAgentBuilderMainTabs({
 	executionsCount,
-	knowledgeBaseEnabled: isKnowledgeBaseEnabled,
 	routeBacked: computed(() => !isArtifactMode.value),
 });
 


### PR DESCRIPTION
## Summary

The Knowledge tab in the Agent Builder had two gating bugs:

1. The whole Knowledge tab was hidden unless the Daytona sandbox env vars (`N8N_AGENTS_AI_SANDBOX_ENABLED` + `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona`) were set. The tab also hosts vector store management (`AgentVectorStoresPanel`), which has nothing to do with the sandboxed knowledge-base files table and shouldn't depend on it.
2. The knowledge-base files table gate ignored AI Assistant proxy availability. `AgentKnowledgeSandboxService.resolveDaytonaConnection` already has a working proxy path via `AiService.isProxyEnabled()` that routes sandbox creation through the AI Assistant SDK instead of direct Daytona API credentials, but that path was unreachable unless the env vars were *also* set.

This PR:
- Makes the Knowledge tab (and vector store management inside it) always visible, regardless of sandbox config.
- Changes the knowledge-base files table gate (`isAgentKnowledgeBaseEnabled`) to `(N8N_AGENTS_AI_SANDBOX_ENABLED=true AND N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona) OR AiService.isProxyEnabled()`, and updates every backend call site (both controllers, the sandbox service, runtime reconstruction, and the module's `settings()`).
- Fixes two doc comments (`settings.store.ts`, `frontend-settings.ts`) that still described the flag as requiring only the sandbox env vars.
- Small follow-up cleanup: extracts a private `isKnowledgeBaseEnabled()` helper in `AgentKnowledgeSandboxService` and `AgentSandboxController` to avoid repeating the OR'd gate expression.

## How to test

This is gated behind either of two configs, so there are 4 permutations worth checking on a locally running instance (backend needs a restart after changing env vars):

1. **Direct only**: `N8N_AGENTS_AI_SANDBOX_ENABLED=true`, `N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona`, no `N8N_AI_ASSISTANT_BASE_URL` → enabled via direct Daytona.
2. **Proxy only**: `N8N_AI_ASSISTANT_BASE_URL` set (and a license with the AI Assistant feature), sandbox env vars unset → enabled via proxy (this is the case that used to be broken).
3. **Both**: both configs set → enabled; sandbox creation routes through the proxy (checked first in `resolveDaytonaConnection`).
4. **Neither**: both unset → disabled. Knowledge tab still shows with vector stores, but the files table (`AgentFilesPanel`) is hidden and `GET/POST/DELETE .../files` plus the warmup endpoint 404.

Check `moduleSettings.agents.knowledgeBaseEnabled` in the `/rest/settings` response, and confirm the Knowledge tab is always selectable in the Agent Builder UI regardless of the flag.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-384

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34366">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

