### PR TITLE
fix(core): Normalize AWS signed request header values to string

### DIFF
--- a/packages/nodes-base/credentials/common/aws/utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.test.ts
@@ -40,7 +40,12 @@ vi.mock('aws4', () => ({
 	sign: vi.fn(),
 }));
 
-import { assertSupportedAwsRegion, assumeRole, awsGetSignInOptionsAndUpdateRequest } from './utils';
+import {
+	assertSupportedAwsRegion,
+	assumeRole,
+	awsGetSignInOptionsAndUpdateRequest,
+	stringifyHeaders,
+} from './utils';
 import * as systemCredentialsUtils from './system-credentials-utils';
 
 type FromTemporaryCredentialsCallArg = {
@@ -664,5 +669,29 @@ describe('awsGetSignInOptionsAndUpdateRequest', () => {
 				region as any,
 			),
 		).toThrow(UserError);
+	});
+});
+
+describe('stringifyHeaders', () => {
+	it('should stringify primitive numbers, booleans, and arrays, while keeping strings unchanged', () => {
+		const headers = {
+			'content-length': 5242880,
+			'x-amz-decoded-content-length': 5242880,
+			'x-custom-boolean': true,
+			'x-custom-string': 'already-string',
+			'x-custom-array': ['value1', 'value2', 123],
+			'x-custom-null': null,
+			'x-custom-undefined': undefined,
+		};
+
+		const result = stringifyHeaders(headers);
+
+		expect(result).toEqual({
+			'content-length': '5242880',
+			'x-amz-decoded-content-length': '5242880',
+			'x-custom-boolean': 'true',
+			'x-custom-string': 'already-string',
+			'x-custom-array': 'value1, value2, 123',
+		});
 	});
 });

--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -390,6 +390,17 @@ export async function assumeRole(
 	}
 }
 
+export function stringifyHeaders(headers: IDataObject): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const key of Object.keys(headers)) {
+		const val = headers[key];
+		if (val !== undefined && val !== null) {
+			result[key] = Array.isArray(val) ? val.map(String).join(', ') : String(val);
+		}
+	}
+	return result;
+}
+
 export function signOptions(
 	requestOptions: IHttpRequestOptions,
 	signOpts: Request,
@@ -397,6 +408,9 @@ export function signOptions(
 	url: string,
 	method?: IHttpRequestMethods,
 ) {
+	if (signOpts.headers) {
+		signOpts.headers = stringifyHeaders(signOpts.headers);
+	}
 	try {
 		sign(signOpts, securityHeaders);
 	} catch (err) {

--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -16,7 +16,7 @@ import { NodeApiError, sanitizeXmlName } from 'n8n-workflow';
 import { URL } from 'url';
 import { parseString } from 'xml2js';
 import { getAwsCredentials } from '../GenericFunctions';
-import { assertSupportedAwsRegion } from '../../../credentials/common/aws/utils';
+import { assertSupportedAwsRegion, stringifyHeaders } from '../../../credentials/common/aws/utils';
 
 function getEndpointForService(
 	service: string,
@@ -170,6 +170,10 @@ export async function validateCredentials(
 			? `${credentials.sessionToken}`.trim()
 			: undefined,
 	};
+
+	if (signOpts.headers) {
+		signOpts.headers = stringifyHeaders(signOpts.headers);
+	}
 
 	sign(signOpts, securityHeaders);
 

--- a/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
@@ -20,7 +20,11 @@ import type {
 	AwsIamCredentialsType,
 	AwsSecurityHeaders,
 } from '../../../credentials/common/aws/types';
-import { assertSupportedAwsRegion, assumeRole } from '../../../credentials/common/aws/utils';
+import {
+	assertSupportedAwsRegion,
+	assumeRole,
+	stringifyHeaders,
+} from '../../../credentials/common/aws/utils';
 import { getAwsCredentials } from '../GenericFunctions';
 
 function getEndpointForService(service: string, credentials: AwsCredentialsTypeBase): string {
@@ -66,6 +70,10 @@ export async function awsApiRequest(
 					? `${iamCredentials.sessionToken}`.trim()
 					: undefined,
 			};
+		}
+
+		if (signOpts.headers) {
+			signOpts.headers = stringifyHeaders(signOpts.headers);
 		}
 
 		sign(signOpts, securityHeaders);

--- a/packages/nodes-base/nodes/S3/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/S3/GenericFunctions.ts
@@ -14,6 +14,7 @@ import type {
 import { NodeApiError, NodeOperationError, sanitizeXmlName } from 'n8n-workflow';
 import { URL } from 'url';
 import { parseString } from 'xml2js';
+import { stringifyHeaders } from '../../credentials/common/aws/utils';
 
 function queryToString(params: IDataObject) {
 	return Object.keys(params)
@@ -71,6 +72,10 @@ export async function s3ApiRequest(
 			? `${credentials.sessionToken}`.trim()
 			: undefined,
 	};
+
+	if (signOpts.headers) {
+		signOpts.headers = stringifyHeaders(signOpts.headers);
+	}
 
 	sign(signOpts, securityHeaders);
 


### PR DESCRIPTION
## Summary
Resolves #34321 (https://github.com/n8n-io/n8n/issues/34321)

This PR resolves a regression where AWS-signed requests (such as S3 uploads or HTTP Request node operations using predefined AWS credentials) fail when n8n is configured to use filesystem binary storage (`N8N_DEFAULT_BINARY_DATA_MODE=filesystem`).

### The Cause
In `filesystem` binary mode, file size metadata is retrieved from disk, resulting in a numeric `Content-Length` (e.g., `5242880` instead of `"5242880"`). During request signing, the `aws4` library attempts to call `.trim()` on all header values. Since numeric header values do not have a `.trim()` method, JavaScript throws a `headers[headerName].trim is not a function` error.

### The Fix
Introduced a helper `stringifyHeaders` in `credentials/common/aws/utils.ts` to convert all non-null, non-undefined header values (including numbers, booleans, and arrays) into string format before passing them to `aws4.sign`. This helper is integrated into all AWS signing locations:
- `signOptions` in `credentials/common/aws/utils.ts`
- S3 `s3ApiRequest` in `nodes/S3/GenericFunctions.ts`
- Transcribe `awsApiRequest` in `nodes/Aws/Transcribe/GenericFunctions.ts`
- Textract `validateCredentials` in `nodes/Aws/Textract/GenericFunctions.ts`

---

## How to test

1. Run unit tests in `packages/nodes-base`:
   ```bash
   pnpm test credentials/common/aws/utils.test.ts
---
## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

