### PR TITLE
fix(cli): register production webhooks on activate API in single-main setups (#34038)

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -105,8 +105,9 @@ describe('ActiveWorkflowManager', () => {
 		});
 
 		describe('if follower', () => {
+			// A follower only exists in a multi-main setup, so multi-main must be enabled.
 			beforeAll(() => {
-				Object.assign(instanceSettings, { isLeader: false, isFollower: true });
+				Object.assign(instanceSettings, { isLeader: false, isFollower: true, isMultiMain: true });
 			});
 
 			test('should return `false` for `update` or `activate`', () => {
@@ -115,6 +116,28 @@ describe('ActiveWorkflowManager', () => {
 					const result = activeWorkflowManager.shouldAddWebhooks(mode);
 					expect(result).toBe(false);
 				}
+			});
+		});
+
+		describe('if single-main (not multi-main) and not leader', () => {
+			// Regression test for https://github.com/n8n-io/n8n/issues/34038
+			// A single-main instance (e.g. queue execution mode without multi-main enabled)
+			// keeps `instanceRole` as `unset`, so `isLeader` is `false`. It must still
+			// register webhooks/triggers on `activate`/`update` because it is the sole owner.
+			beforeAll(() => {
+				Object.assign(instanceSettings, { isLeader: false, isFollower: false, isMultiMain: false });
+			});
+
+			test('should return `true` for `update` or `activate`', () => {
+				const modes = ['update', 'activate'] as WorkflowActivateMode[];
+				for (const mode of modes) {
+					const result = activeWorkflowManager.shouldAddWebhooks(mode);
+					expect(result).toBe(true);
+				}
+			});
+
+			test('should return `true` from `shouldAddNonWebhookTriggers`', () => {
+				expect(activeWorkflowManager.shouldAddNonWebhookTriggers()).toBe(true);
 			});
 		});
 

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -1129,16 +1129,24 @@ export class ActiveWorkflowManager {
 		// causing all webhooks to break
 		if (['init', 'leadershipChange'].includes(activationMode)) return true;
 
-		return this.instanceSettings.isLeader; // 'update' or 'activate'
+		// In a multi-main setup only the leader may register webhooks, so followers must not.
+		// In a single-main setup this instance is the sole owner of its webhooks regardless of
+		// the `isLeader` flag (which is only meaningful once multi-main is enabled), so it must
+		// register them on `activate`/`update` too. Without this, activating a workflow via the
+		// API in a single-main instance whose role was never set to `leader` would persist the
+		// active flag but leave the production webhook unregistered until a restart.
+		return !this.instanceSettings.isMultiMain || this.instanceSettings.isLeader;
 	}
 
 	/**
 	 * Whether this instance may add active, poll, and schedule triggers to memory.
 	 *
-	 * In both single- and multi-main setup, only the leader is allowed to manage
-	 * non-webhook triggers in memory, to ensure they are not duplicated.
+	 * In a multi-main setup only the leader is allowed to manage non-webhook triggers in
+	 * memory, to ensure they are not duplicated. In a single-main setup this instance always
+	 * owns them, so it must register them on `activate`/`update` even when the `isLeader` flag
+	 * is not set (e.g. queue execution mode without multi-main enabled).
 	 */
 	shouldAddNonWebhookTriggers() {
-		return this.instanceSettings.isLeader;
+		return !this.instanceSettings.isMultiMain || this.instanceSettings.isLeader;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/n8n-io/n8n/issues/34038 — in a single-main n8n instance (e.g. queue execution mode without multi-main enabled), activating a workflow via the REST API persisted it as `active: true` but left its production webhook unregistered in the in-memory webhook service until a full restart.

### Root cause

`ActiveWorkflowManager.shouldAddWebhooks()` and `shouldAddNonWebhookTriggers()` returned `this.instanceSettings.isLeader` for the `activate`/`update` modes. In a single-main setup the instance role stays `unset`, so `isLeader` is `false`. The `add()` path therefore skipped registering the production webhook even though the workflow was successfully persisted as active, so `POST /webhook/<path>` returned `404 The requested webhook is not registered`. On a restart the `init` mode forced `shouldAddWebhooks` to `true`, which is why only a restart made the webhook work.

### Fix

Return `true` unless this is a multi-main setup in which this instance is not the leader:

```ts
return !this.instanceSettings.isMultiMain || this.instanceSettings.isLeader;
```

A single-main instance is the sole owner of its webhooks/triggers regardless of the `isLeader` flag (which is only meaningful once multi-main is enabled), so it must register them on `activate`/`update` too. Multi-main behaviour is unchanged: followers (`isMultiMain && !isLeader`) still return `false`.

## Testing

- Added a regression test (`if single-main (not multi-main) and not leader`) asserting `shouldAddWebhooks('activate'|'update')` and `shouldAddNonWebhookTriggers()` return `true`.
- Updated the existing `if follower` block to set `isMultiMain: true` (a follower is inherently multi-main) so it still correctly asserts followers must not register webhooks.
- `vitest run src/__tests__/active-workflow-manager.test.ts` → **38 passed** (verified locally against the current fix branch).
- `tsc --noEmit` on the cli package and `eslint` on the changed files → no new errors.

## OpenJobs

openjobs.bot — this PR resolves OpenJobs listing https://openjobs.bot/jobs/62712c65-845f-4e24-97c7-c56c62b7f4af

Linked issue: https://github.com/n8n-io/n8n/issues/34038


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

