### PR TITLE
fix(Split Out Node): honor dot notation in Destination Field Name (#34053)

### DIFF
--- a/packages/nodes-base/nodes/Transform/SplitOut/SplitOut.node.ts
+++ b/packages/nodes-base/nodes/Transform/SplitOut/SplitOut.node.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import set from 'lodash/set';
 import unset from 'lodash/unset';
 import { NodeOperationError, deepCopy, NodeConnectionTypes } from 'n8n-workflow';
 import type {
@@ -157,6 +158,17 @@ export class SplitOut implements INodeType {
 
 			const multiSplit = fieldsToSplitOut.length > 1;
 
+			// Assign a value under the destination field name, honoring dot notation
+			// (e.g. "data.foo" creates a nested { data: { foo: ... } }) unless dot
+			// notation has been disabled, in which case the key is treated literally.
+			const assignToDestination = (target: IDataObject, fieldName: string, value: IDataObject) => {
+				if (!disableDotNotation && fieldName.includes('.')) {
+					set(target, fieldName, value);
+				} else {
+					target[fieldName] = value;
+				}
+			};
+
 			const item = { ...items[i].json };
 			const splited: INodeExecutionData[] = [];
 			for (const [entryIndex, fieldToSplitOut] of fieldsToSplitOut.entries()) {
@@ -219,10 +231,10 @@ export class SplitOut implements INodeType {
 								pairedItem: { item: i },
 							};
 						} else {
-							splited[elementIndex].json[fieldName] = element;
+							assignToDestination(splited[elementIndex].json, fieldName, element);
 						}
 					} else {
-						splited[elementIndex].json[fieldName] = element;
+						assignToDestination(splited[elementIndex].json, fieldName, element);
 					}
 				}
 			}

--- a/packages/nodes-base/nodes/Transform/SplitOut/test/SplitOut.test.ts
+++ b/packages/nodes-base/nodes/Transform/SplitOut/test/SplitOut.test.ts
@@ -65,3 +65,57 @@ describe('SplitOut', () => {
 		);
 	});
 });
+
+describe('SplitOut - Destination Field Name dot notation (issue #34053)', () => {
+	const executeWithOptions = async (
+		fieldToSplitOut: string,
+		options: Record<string, unknown>,
+		include: string = 'noOtherFields',
+	) => {
+		const executeFunctions = mock<IExecuteFunctions>();
+		executeFunctions.getInputData.mockReturnValue([
+			{
+				json: {
+					myarraydata: [{ id: 1 }, { id: 2 }],
+				},
+			},
+		]);
+		executeFunctions.getNodeParameter.mockImplementation(((
+			parameterName: string,
+			_itemIndex?: number,
+			fallback?: unknown,
+		) => {
+			if (parameterName === 'fieldToSplitOut') return fieldToSplitOut;
+			if (parameterName === 'options') return options;
+			if (parameterName === 'include') return include;
+			return fallback;
+		}) as IExecuteFunctions['getNodeParameter']);
+
+		return await new SplitOut().execute.call(executeFunctions);
+	};
+
+	it('should place split contents under a nested path when destination uses dot notation', async () => {
+		await expect(
+			executeWithOptions('myarraydata', { destinationFieldName: 'data.foo' }),
+		).resolves.toEqual([
+			[
+				{ json: { data: { foo: { id: 1 } } }, pairedItem: { item: 0 } },
+				{ json: { data: { foo: { id: 2 } } }, pairedItem: { item: 0 } },
+			],
+		]);
+	});
+
+	it('should treat destination dots literally when dot notation is disabled', async () => {
+		await expect(
+			executeWithOptions('myarraydata', {
+				destinationFieldName: 'data.foo',
+				disableDotNotation: true,
+			}),
+		).resolves.toEqual([
+			[
+				{ json: { 'data.foo': { id: 1 } }, pairedItem: { item: 0 } },
+				{ json: { 'data.foo': { id: 2 } }, pairedItem: { item: 0 } },
+			],
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the Split Out node so that **Destination Field Name** honors dot notation when dot notation is enabled (the default).

Closes #34053
Source issue: https://github.com/n8n-io/n8n/issues/34053

## The bug

When the Split Out node was configured with:

- Fields To Split Out = `myarraydata`
- Destination Field Name = `data.foo`
- Disable Dot Notation = off (default)

each split element was written under a **literal top-level key** `"data.foo"` instead of being nested under `{ data: { foo: ... } }`.

This was inconsistent with the *source* side of the node, which already resolves `Fields To Split Out` using dot notation (via `lodash/get`).

## The fix

`packages/nodes-base/nodes/Transform/SplitOut/SplitOut.node.ts`

- Introduced a small `assignToDestination(target, fieldName, value)` helper.
- When dot notation is **enabled** and the destination field name contains a `.`, the value is written with `lodash/set`, producing the expected nested structure.
- When **Disable Dot Notation** is on, the field name is treated literally (existing behavior preserved), so keys that legitimately contain dots keep working.
- Replaced the two direct `splited[elementIndex].json[fieldName] = element` assignments with the helper.

## Testing notes

`packages/nodes-base/nodes/Transform/SplitOut/test/SplitOut.test.ts`

Added a regression suite `SplitOut - Destination Field Name dot notation (issue #34053)` with two cases:

1. Destination `data.foo` with dot notation enabled → output nested as `{ data: { foo: {...} } }`.
2. Destination `data.foo` with **Disable Dot Notation** on → output keeps the literal key `{ "data.foo": {...} }`.

Ran the narrowest relevant tests:

```
cd packages/nodes-base
node_modules/.bin/vitest run nodes/Transform/SplitOut/test/SplitOut.test.ts
```

Result: 5 passed (3 existing + 2 new). Typecheck of the changed files is clean (`tsc --noEmit`). Biome pre-commit formatting applied.

(The `Test Split Out Node` JSON-harness suite reports "No test found in suite" — this is pre-existing on a clean `master` checkout and unrelated to this change.)

---

Submitted via **openjobs.bot** — job `71b37411-0f38-4baf-af1d-dcf0110a53c7`
https://openjobs.bot/jobs/71b37411-0f38-4baf-af1d-dcf0110a53c7


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

