### PR TITLE
fix(agents): strip itemId from OpenAI reasoning providerOptions for multi-step replay

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime-conversion.test.ts
@@ -149,9 +149,60 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 		).content[0];
 
 		expect(reasoningPart.type).toBe('reasoning');
+		// itemId is intentionally stripped so the @ai-sdk/openai provider sends
+		// full reasoning items with encrypted_content instead of item_reference
+		// on multi-step turns (see QUIRK comment in toAiContent).
 		expect(reasoningPart.providerOptions).toEqual({
-			openai: { itemId: 'rs_123', reasoningEncryptedContent: 'encrypted' },
+			openai: { reasoningEncryptedContent: 'encrypted' },
 		});
+	});
+
+	it('strips itemId from OpenAI reasoning providerOptions to force full reasoning items on multi-step turns', () => {
+		const providerMetadata = {
+			openai: { itemId: 'rs_456', reasoningEncryptedContent: 'encrypted-content-abc' },
+		};
+		const input: Message[] = [
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'reasoning',
+						text: 'Let me think about this...',
+						providerMetadata,
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'call_1',
+						toolName: 'build_workflow',
+						input: {},
+						state: 'pending',
+					},
+				],
+			},
+		];
+
+		const aiMessages = toAiMessages(input);
+		const assistantMsg = aiMessages[0] as {
+			role: string;
+			content: Array<{
+				type: string;
+				providerOptions?: Record<string, Record<string, unknown>>;
+			}>;
+		};
+		const reasoningPart = assistantMsg.content.find((p) => p.type === 'reasoning');
+
+		expect(reasoningPart).toBeDefined();
+		// itemId must be stripped so @ai-sdk/openai sends a full reasoning item
+		// (with encrypted_content) instead of an item_reference that the API
+		// cannot resolve on multi-step turns without previous_response_id.
+		expect(reasoningPart!.providerOptions?.openai).not.toHaveProperty('itemId');
+		// reasoningEncryptedContent must be preserved so the provider can build
+		// the full reasoning item body.
+		expect(reasoningPart!.providerOptions?.openai).toEqual({
+			reasoningEncryptedContent: 'encrypted-content-abc',
+		});
+		// providerMetadata is preserved untouched for downstream use.
+		expect((reasoningPart as any).providerMetadata).toEqual(providerMetadata);
 	});
 
 	it.each([

--- a/packages/@n8n/agents/src/runtime/model/messages.ts
+++ b/packages/@n8n/agents/src/runtime/model/messages.ts
@@ -184,11 +184,28 @@ function toAiContent(block: MessageContent): AiContentPart | undefined {
 		// Provider metadata can be required for replay. Gemini attaches
 		// `google.thoughtSignature` to function-call parts, and the next request
 		// is rejected if that signature is dropped from conversation history.
-		const providerOptions = isReasoning(block)
+		let providerOptions = isReasoning(block)
 			? toReasoningProviderOptions(block)
 			: block.providerOptions;
-		if (isReasoning(block) && !hasReplayableReasoningProviderOptions(providerOptions)) {
-			return undefined;
+
+		if (isReasoning(block)) {
+			// QUIRK: the OpenAI Responses API rejects requests where a
+			// function_call item references a reasoning item by ID
+			// (item_reference) that the server cannot resolve.  When replaying
+			// conversation history (multi-step turns) without
+			// `previous_response_id`, the reasoning must be sent as a full
+			// reasoning item with `encrypted_content` — not as an
+			// item_reference.  Strip `itemId` so the @ai-sdk/openai provider
+			// falls through to the full-item path.  Keep `reasoningEncryptedContent`
+			// so the provider can build the full reasoning item.
+			if (providerOptions?.openai) {
+				const { itemId: _itemId, ...rest } = providerOptions.openai as Record<string, unknown>;
+				providerOptions = { ...providerOptions, openai: rest as JSONObject };
+			}
+
+			if (!hasReplayableReasoningProviderOptions(providerOptions)) {
+				return undefined;
+			}
 		}
 
 		return {


### PR DESCRIPTION
## Summary

The OpenAI Responses API rejects requests where a `function_call` item references a reasoning item by ID (`item_reference`) that the server cannot resolve. When replaying conversation history on multi-step turns without `previous_response_id`, reasoning must be sent as a full reasoning item with `encrypted_content` — not as an `item_reference`.

This PR strips `itemId` from `providerOptions.openai` on reasoning parts during the `toAiContent()` conversion, so the `@ai-sdk/openai` provider sends full reasoning items with `encrypted_content` instead of `item_reference`.

**Root cause**: `@ai-sdk/openai` v3.0.68 sends reasoning items as `item_reference` when `store: true` (default). On multi-step turns, the OpenAI Responses API cannot resolve these references without `previous_response_id`, causing:
> "Item `msg_…` of type `message` was provided without its required `reasoning` item: `rs_…`"

**Fix**: Strip `itemId` from `providerOptions.openai` in `toAiContent()` so the provider sends full reasoning items with `encrypted_content`. The `reasoningEncryptedContent` is preserved so the provider can build the full reasoning item body.

## How to test

1. Set up an n8n instance with Instance AI enabled and an OpenAI reasoning model (e.g. `o4-mini`, `o3`, `gpt-5`) configured via `N8N_INSTANCE_AI_MODEL`
2. Create a workflow with an AI Agent that uses tools (e.g. HTTP Request, Code tool)
3. Run the agent on a prompt that requires multiple steps (e.g. "Look up the current weather in Tokyo and create a workflow to fetch it")
4. **Before fix**: The agent fails with `"Item msg_… of type message was provided without its required reasoning item: rs_…"` on the second tool-call step
5. **After fix**: The agent completes all steps successfully

## Related Linear tickets, Github issues, and Community forum posts

Fixes #33974

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)