### PR TITLE
feat(editor): Rename Message an Agent node to AI Agent, deprecate old node (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
@@ -46,7 +46,7 @@ const { t } = useI18n();
 		<div>
 			<div :class="$style.details">
 				<span :class="$style.name" data-test-id="node-creator-item-name" v-text="title" />
-				<PreviewTag v-if="tag?.preview" size="small" />
+				<PreviewTag v-if="tag?.preview" size="small" :text="tag.text" />
 				<N8nActionPill v-else-if="tag?.pill" size="small" :text="tag.text" />
 				<ElTag
 					v-else-if="tag"

--- a/packages/frontend/@n8n/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nNodeCreatorNode/NodeCreatorNode.vue
@@ -46,7 +46,7 @@ const { t } = useI18n();
 		<div>
 			<div :class="$style.details">
 				<span :class="$style.name" data-test-id="node-creator-item-name" v-text="title" />
-				<PreviewTag v-if="tag?.preview" size="small" :text="tag.text" />
+				<PreviewTag v-if="tag?.preview" size="small" :class="$style.previewTag" :text="tag.text" />
 				<N8nActionPill v-else-if="tag?.pill" size="small" :text="tag.text" />
 				<ElTag
 					v-else-if="tag"
@@ -97,6 +97,9 @@ const { t } = useI18n();
 }
 .creatorNode:hover .panelIcon {
 	color: var(--action--arrow--color--hover, var(--color--text--tint-1));
+}
+.previewTag {
+	margin-left: var(--spacing--2xs);
 }
 :root .tag {
 	margin-left: var(--spacing--2xs);

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.test.ts
@@ -12,4 +12,9 @@ describe('PreviewTag', () => {
 		const { container } = render(PreviewTag, { props: { size: 'medium' } });
 		expect(container).toMatchSnapshot();
 	});
+
+	it('renders custom text instead of the default label', () => {
+		const { getByText } = render(PreviewTag, { props: { text: 'Early preview' } });
+		expect(getByText('Early preview')).toBeInTheDocument();
+	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
@@ -28,7 +28,7 @@ const { t } = useI18n();
 
 .small {
 	font-size: var(--font-size--3xs);
-	padding: var(--spacing--5xs) var(--spacing--2xs);
+	padding: var(--spacing--5xs) var(--spacing--4xs);
 }
 
 .medium {

--- a/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
+++ b/packages/frontend/@n8n/design-system/src/components/PreviewTag/PreviewTag.vue
@@ -4,15 +4,16 @@ import { useI18n } from '../../composables/useI18n';
 withDefaults(
 	defineProps<{
 		size?: 'small' | 'medium';
+		text?: string;
 	}>(),
-	{ size: 'small' },
+	{ size: 'small', text: undefined },
 );
 
 const { t } = useI18n();
 </script>
 
 <template>
-	<div :class="[$style.preview, $style[size]]">{{ t('previewTag.preview') }}</div>
+	<div :class="[$style.preview, $style[size]]">{{ text ?? t('previewTag.preview') }}</div>
 </template>
 
 <style lang="scss" module>
@@ -27,7 +28,7 @@ const { t } = useI18n();
 
 .small {
 	font-size: var(--font-size--3xs);
-	padding: var(--spacing--5xs) var(--spacing--4xs);
+	padding: var(--spacing--5xs) var(--spacing--2xs);
 }
 
 .medium {

--- a/packages/frontend/@n8n/design-system/src/types/node-creator-node.ts
+++ b/packages/frontend/@n8n/design-system/src/types/node-creator-node.ts
@@ -5,6 +5,6 @@ export type NodeCreatorTag = {
 	type?: (typeof ElTag)['type'];
 	/** When true, renders as N8nActionPill instead of ElTag. */
 	pill?: boolean;
-	/** When true, renders as PreviewTag instead of ElTag. */
+	/** When true, renders as PreviewTag instead of ElTag; `text` overrides the tag's default "Preview" label. */
 	preview?: boolean;
 };

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2165,6 +2165,8 @@
 	"nodeCreator.nodeItem.triggerIconTitle": "Trigger Node",
 	"nodeCreator.nodeItem.aiIconTitle": "LangChain AI Node",
 	"nodeCreator.nodeItem.deprecated": "Deprecated",
+	"nodeCreator.nodeItem.deprecatingSoon": "Deprecating soon",
+	"nodeCreator.nodeItem.earlyPreview": "Early preview",
 	"nodeCreator.nodeItem.beta": "Beta",
 	"nodeCredentials.createNew": "Create new credential",
 	"nodeCredentials.createNew.permissionDenied": "Your current role does not allow you to create credentials",

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/ItemTypes/NodeItem.test.ts
@@ -50,7 +50,7 @@ describe('NodeItem', () => {
 			props: {
 				nodeType: mockSimplifiedNodeType({
 					name: MESSAGE_AN_AGENT_NODE_TYPE,
-					displayName: 'Message an n8n Agent',
+					displayName: 'AI Agent',
 					group: ['transform'],
 				}),
 			},

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/AgentsMode.test.ts
@@ -61,7 +61,7 @@ const render = createComponentRenderer(AgentsMode);
 
 function pushAgentsViewStack() {
 	useViewStacks().pushViewStack({
-		title: 'Message an n8n Agent',
+		title: 'AI Agent',
 		hasSearch: true,
 		mode: 'agents',
 		items: [],

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/NodesMode.test.ts
@@ -42,7 +42,7 @@ function messageAnAgentElement(): NodeCreateElement {
 		subcategory: '*',
 		properties: mockSimplifiedNodeType({
 			name: MESSAGE_AN_AGENT_NODE_TYPE,
-			displayName: 'Message an n8n Agent',
+			displayName: 'AI Agent',
 			group: ['transform'],
 		}),
 	};
@@ -69,13 +69,13 @@ describe('NodesMode', () => {
 		const { emitted } = render({ pinia });
 		await nextTick();
 
-		await userEvent.click(screen.getByText('Message an n8n Agent'));
+		await userEvent.click(screen.getByText('AI Agent'));
 
 		expect(emitted('nodeTypeSelected')).toBeUndefined();
 
 		const activeStack = useViewStacks().activeViewStack;
 		expect(activeStack.mode).toBe('agents');
-		expect(activeStack.title).toBe('Message an n8n Agent');
+		expect(activeStack.title).toBe('AI Agent');
 		expect(activeStack.hasSearch).toBe(true);
 		expect(activeStack.rootView).toBe(REGULAR_NODE_CREATOR_VIEW);
 	});

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -930,7 +930,7 @@ describe('NodeCreator - utils', () => {
 			const [result] = finalizeItems([
 				makeAgentNode(MESSAGE_AN_AGENT_NODE_TYPE),
 			]) as NodeCreateElement[];
-			expect(result.properties.tag).toEqual({ type: 'info', text: 'Early preview' });
+			expect(result.properties.tag).toEqual({ preview: true, text: 'Early preview' });
 		});
 
 		it('should keep a pre-set tag', () => {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.test.ts
@@ -36,8 +36,12 @@ import { createTestingPinia } from '@pinia/testing';
 import { mock } from 'vitest-mock-extended';
 import type { ViewStack } from './composables/useViewStacks';
 import { NodeConnectionTypes, SEND_AND_WAIT_OPERATION } from 'n8n-workflow';
+import type { NodeCreatorTag } from '@n8n/design-system';
 import {
+	AGENT_NODE_TYPE,
+	AGENT_TOOL_NODE_TYPE,
 	DISCORD_NODE_TYPE,
+	MESSAGE_AN_AGENT_NODE_TYPE,
 	MICROSOFT_TEAMS_NODE_TYPE,
 	AI_CATEGORY_OTHER_TOOLS,
 	AI_CATEGORY_VECTOR_STORES,
@@ -893,6 +897,52 @@ describe('NodeCreator - utils', () => {
 		});
 	});
 
+	describe('finalizeItems - agent transition badges', () => {
+		const makeAgentNode = (name: string, tag?: NodeCreatorTag) =>
+			mockNodeCreateElement(undefined, { name, ...(tag ? { tag } : {}) });
+
+		const mockSettingsStore = (agentsModuleActive: boolean) => {
+			vi.mocked(useSettingsStore).mockReturnValue({
+				isModuleActive: vi.fn((name: string) => agentsModuleActive && name === 'agents'),
+			} as unknown as ReturnType<typeof useSettingsStore>);
+		};
+
+		it.each([AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE])(
+			'should show Deprecating soon badge on %s when the agents module is active',
+			(nodeType) => {
+				mockSettingsStore(true);
+				const [result] = finalizeItems([makeAgentNode(nodeType)]) as NodeCreateElement[];
+				expect(result.properties.tag).toEqual({ type: 'info', text: 'Deprecating soon' });
+			},
+		);
+
+		it.each([AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE])(
+			'should not show Deprecating soon badge on %s when the agents module is inactive',
+			(nodeType) => {
+				mockSettingsStore(false);
+				const [result] = finalizeItems([makeAgentNode(nodeType)]) as NodeCreateElement[];
+				expect(result.properties.tag).toBeUndefined();
+			},
+		);
+
+		it('should show Early preview badge on the Message an Agent node', () => {
+			mockSettingsStore(true);
+			const [result] = finalizeItems([
+				makeAgentNode(MESSAGE_AN_AGENT_NODE_TYPE),
+			]) as NodeCreateElement[];
+			expect(result.properties.tag).toEqual({ type: 'info', text: 'Early preview' });
+		});
+
+		it('should keep a pre-set tag', () => {
+			mockSettingsStore(true);
+			const presetTag = { text: 'Custom' };
+			const [result] = finalizeItems([
+				makeAgentNode(AGENT_NODE_TYPE, presetTag),
+			]) as NodeCreateElement[];
+			expect(result.properties.tag).toEqual(presetTag);
+		});
+	});
+
 	describe('showsAiGatewaySection', () => {
 		it.each<[string, ViewStack, boolean]>([
 			['Language Models list', { connectionType: NodeConnectionTypes.AiLanguageModel }, true],
@@ -1155,6 +1205,48 @@ describe('NodeCreator - utils', () => {
 
 			const keys = searchNodes('serp', [plain, action]).map((item) => item.key);
 			expect(keys[0]).toBe('plainNode');
+		});
+	});
+
+	describe('searchNodes - Message an Agent boost', () => {
+		const makeNode = (name: string, displayName: string, alias: string[] = []) =>
+			mockNodeCreateElement(
+				{ key: name },
+				{ name, displayName, codex: { categories: [], subcategories: {}, alias } },
+			);
+
+		beforeEach(() => {
+			vi.mocked(useSettingsStore).mockReturnValue({
+				isAskAiEnabled: true,
+				isAiGatewayEnabled: false,
+			} as unknown as ReturnType<typeof useSettingsStore>);
+		});
+
+		// Both nodes display as "AI Agent"; the legacy agent carries the popularity
+		// factor, so the successor ranking first proves the boost outweighs it.
+		const legacyAgent = makeNode(AGENT_NODE_TYPE, 'AI Agent', ['agent']);
+		const messageAnAgent = makeNode(MESSAGE_AN_AGENT_NODE_TYPE, 'AI Agent', [
+			'agent',
+			'ai',
+			'sdk',
+			'Message an Agent',
+		]);
+		const popularity = { [AGENT_NODE_TYPE]: 98.2 };
+
+		it('should rank the Message an Agent node above the legacy agent despite its popularity', () => {
+			const result = searchNodes('AI Agent', [legacyAgent, messageAnAgent], { popularity });
+			expect(result.map((item) => item.key)).toEqual([MESSAGE_AN_AGENT_NODE_TYPE, AGENT_NODE_TYPE]);
+		});
+
+		it('should keep the legacy agent first without the boosted node in the result set', () => {
+			const result = searchNodes('AI Agent', [legacyAgent], { popularity });
+			expect(result.map((item) => item.key)).toEqual([AGENT_NODE_TYPE]);
+		});
+
+		it('should not hijack an exact match on another node', () => {
+			const sheets = makeNode('googleSheets', 'Google Sheets');
+			const result = searchNodes('Google Sheets', [messageAnAgent, sheets], { popularity });
+			expect(result[0].key).toBe('googleSheets');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
@@ -463,7 +463,7 @@ function applyNodeTags(element: INodeCreateElement): INodeCreateElement {
 		};
 	} else if (element.properties.name === MESSAGE_AN_AGENT_NODE_TYPE) {
 		element.properties.tag = {
-			type: 'info',
+			preview: true,
 			text: i18n.baseText('nodeCreator.nodeItem.earlyPreview'),
 		};
 	} else if (RECOMMENDED_NODES.includes(element.properties.name)) {

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.utils.ts
@@ -12,6 +12,8 @@ import type {
 	SubcategoryCreateElement,
 } from '@/Interface';
 import {
+	AGENT_NODE_TYPE,
+	AGENT_TOOL_NODE_TYPE,
 	AI_CATEGORY_AGENTS,
 	AI_CATEGORY_HUMAN_IN_THE_LOOP,
 	AI_CATEGORY_MCP_NODES,
@@ -26,6 +28,7 @@ import {
 	DISCORD_NODE_TYPE,
 	HITL_SUBCATEGORY,
 	HUMAN_IN_THE_LOOP_CATEGORY,
+	MESSAGE_AN_AGENT_NODE_TYPE,
 	MICROSOFT_TEAMS_NODE_TYPE,
 	RECOMMENDED_NODES,
 	REGULAR_NODE_CREATOR_VIEW,
@@ -42,6 +45,7 @@ import type { NodeViewItemSection } from './views/viewsData';
 import { stripToolSuffix, useAiGatewayStore } from '@/app/stores/aiGateway.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { AGENTS_MODULE_NAME } from '@/features/agents/constants';
 import type { NodeIconSource } from '@/app/utils/nodeIcon';
 import { SampleTemplates } from '@/features/workflows/templates/utils/workflowSamples';
 import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
@@ -133,6 +137,10 @@ export function removeTrailingTrigger(searchFilter: string) {
 // Modest on purpose: high-confidence matches on other nodes should still win.
 const AI_GATEWAY_SEARCH_BOOST = 75;
 const AI_GATEWAY_BOOST_MIN_QUERY_LENGTH = 3;
+
+// Must exceed the legacy AI Agent's popularity boost (~98, see node-popularity.json)
+// so the successor node ranks first when both match a query equally.
+const MESSAGE_AN_AGENT_SEARCH_BOOST = 150;
 
 /**
  * 1. exact alias match (any query length): `scrape` → `scrape`
@@ -241,6 +249,7 @@ export function searchNodes(
 	const reRankedResults = reRankSearchResults(searchResults, {
 		...additionalFactors,
 		aiGatewayBoost,
+		messageAnAgentBoost: { [MESSAGE_AN_AGENT_NODE_TYPE]: MESSAGE_AN_AGENT_SEARCH_BOOST },
 	});
 
 	return reRankedResults.map(({ item }) => item);
@@ -444,7 +453,20 @@ function applyNodeTags(element: INodeCreateElement): INodeCreateElement {
 
 	if (element.properties.tag) return element;
 
-	if (RECOMMENDED_NODES.includes(element.properties.name)) {
+	if (
+		[AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE].includes(element.properties.name) &&
+		useSettingsStore().isModuleActive(AGENTS_MODULE_NAME)
+	) {
+		element.properties.tag = {
+			type: 'info',
+			text: i18n.baseText('nodeCreator.nodeItem.deprecatingSoon'),
+		};
+	} else if (element.properties.name === MESSAGE_AN_AGENT_NODE_TYPE) {
+		element.properties.tag = {
+			type: 'info',
+			text: i18n.baseText('nodeCreator.nodeItem.earlyPreview'),
+		};
+	} else if (RECOMMENDED_NODES.includes(element.properties.name)) {
 		element.properties.tag = {
 			type: 'info',
 			text: i18n.baseText('generic.recommended'),

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.test.ts
@@ -19,7 +19,7 @@ const getNodeType = vi.fn();
 const aiTransformNode = mockNodeTypeDescription({ name: AI_TRANSFORM_NODE_TYPE });
 const messageAnAgentNode = mockNodeTypeDescription({
 	name: MESSAGE_AN_AGENT_NODE_TYPE,
-	displayName: 'Message an Agent',
+	displayName: 'AI Agent',
 	hidden: true,
 });
 
@@ -114,7 +114,7 @@ describe('viewsData', () => {
 			expect(AIView([])).toMatchSnapshot();
 		});
 
-		test('should include Message an Agent node with preview tag when agents module is active', () => {
+		test('should include Message an Agent node before the agent node when agents module is active', () => {
 			const settingsStore = useSettingsStore();
 			vi.spyOn(settingsStore, 'isAskAiEnabled', 'get').mockReturnValue(false);
 			vi.spyOn(settingsStore, 'isModuleActive').mockImplementation(
@@ -125,9 +125,6 @@ describe('viewsData', () => {
 			const messageAgentItem = result.items.find((item) => item.key === MESSAGE_AN_AGENT_NODE_TYPE);
 
 			expect(messageAgentItem).toBeDefined();
-			expect(messageAgentItem?.properties.tag).toEqual({
-				preview: true,
-			});
 
 			const agentItem = result.items.find((item) => item.key === 'agent');
 			const messageIdx = result.items.indexOf(messageAgentItem!);

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/viewsData.ts
@@ -180,18 +180,8 @@ function getMessageAnAgentNode(
 	const node = nodeTypesStore.getNodeType(MESSAGE_AN_AGENT_NODE_TYPE);
 	if (!node) return [];
 
-	const view = getNodeView(node);
-	return [
-		{
-			...view,
-			properties: {
-				...view.properties,
-				tag: {
-					preview: true,
-				},
-			},
-		},
-	];
+	// The early-preview tag is attached centrally in `applyNodeTags`.
+	return [getNodeView(node)];
 }
 
 export function AIView(_nodes: SimplifiedNodeType[]): NodeView {

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.json
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.json
@@ -6,7 +6,7 @@
 	"resources": {
 		"primaryDocumentation": []
 	},
-	"alias": ["agent", "ai", "sdk"],
+	"alias": ["agent", "ai", "sdk", "Message an Agent"],
 	"subcategories": {
 		"AI": ["Agents", "Root Nodes"]
 	}

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -9,7 +9,7 @@ import { MessageAnAgentV2 } from './v2/MessageAnAgentV2.node';
  * the `agentId` property, and (v1 only) the `listAgents` search method.
  */
 export const baseDescription: INodeTypeBaseDescription = {
-	displayName: 'Message an n8n Agent',
+	displayName: 'AI Agent',
 	name: 'messageAnAgent',
 	icon: 'node:ai-agent',
 	group: ['transform'],

--- a/packages/nodes-base/nodes/MessageAnAgent/shared.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/shared.ts
@@ -18,7 +18,7 @@ export const sharedVersionDescription: Pick<
 > = {
 	hidden: true,
 	defaults: {
-		name: 'Message an Agent',
+		name: 'AI Agent',
 	},
 	codex: {
 		categories: ['AI'],


### PR DESCRIPTION
## Summary

<img width="394" height="133" alt="image" src="https://github.com/user-attachments/assets/ca91eed4-9e39-4eef-9df2-8db401c9685a" />

When the `agents` module is enabled, the node creator now presents the Message an Agent node as the successor of the legacy AI Agent node:

- **Message an Agent node** is renamed to **"AI Agent"** (creator display name and canvas default name) and gets an **"Early preview"** badge in the node creator. The old name is kept as a search alias.
- **Legacy AI Agent and AI Agent Tool nodes** get a **"Deprecating soon"** badge, shown only when the `agents` module is active.
- **Search ranking**: the new node gets a re-rank boost so it appears above the legacy AI Agent (which otherwise wins via its telemetry popularity score) when both match a query.

Badges reuse the existing node-creator tag mechanism and are applied centrally in `applyNodeTags`. The "Early preview" badge uses the design-system `PreviewTag`, which now accepts a text override. Nothing changes when the `agents` module is disabled — the new node stays hidden and no badges are shown.

## How to test

1. Start n8n with `N8N_ENABLED_MODULES=agents`.
2. Open the node creator and search for "AI Agent" (or just "ai"/"agent").
3. Verify two "AI Agent" entries appear: the new node (Early preview badge) ranked above the legacy one (Deprecating soon badge). The AI Agent Tool node also shows the Deprecating soon badge in tool lists.
4. Add the new node — the canvas node is named "AI Agent". Searching "Message an Agent" still finds it via alias.
5. Restart without the module: the legacy AI Agent shows no badge and the new node is absent.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

