### PR TITLE
feat: Adding agents tracing environment variable

### DIFF
--- a/packages/@n8n/config/src/configs/agents.config.ts
+++ b/packages/@n8n/config/src/configs/agents.config.ts
@@ -39,6 +39,15 @@ export class AgentsConfig {
 	checkpointTtlSeconds: number = 96 * Time.hours.toSeconds;
 
 	/**
+	 * Whether agent runs emit OpenTelemetry spans. Rides along with the OTel
+	 * module (endpoint, headers, sampling and transport are inherited from
+	 * `N8N_OTEL_*`), so it has no effect when no OTel provider is registered.
+	 * Lets operators run workflow OTel without agent spans.
+	 */
+	@Env('N8N_AGENTS_TRACING_ENABLED')
+	tracingEnabled: boolean = true;
+
+	/**
 	 * Comma-separated list of agent sub-feature modules to enable. Each entry
 	 * gates a specific frontend/runtime capability inside the agents module.
 	 * Add supported module tokens to `AGENTS_MODULE_NAMES`.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -650,6 +650,7 @@ describe('GlobalConfig', () => {
 		},
 		agents: {
 			checkpointTtlSeconds: 345600,
+			tracingEnabled: true,
 			modules: [],
 			sandboxEnabled: false,
 			sandboxProvider: '',
@@ -670,6 +671,15 @@ describe('GlobalConfig', () => {
 		expect(defaultConfig).toMatchObject(config);
 		expect(config).toMatchObject(defaultConfig);
 		expect(readFileSyncMock).not.toHaveBeenCalled();
+	});
+
+	it('should parse N8N_AGENTS_TRACING_ENABLED from env variables', () => {
+		process.env = {
+			N8N_AGENTS_TRACING_ENABLED: 'false',
+		};
+		const config = Container.get(GlobalConfig);
+
+		expect(config.agents.tracingEnabled).toBe(false);
 	});
 
 	it('should parse N8N_AGENTS_AI_SANDBOX_EPHEMERAL from env variables', () => {


### PR DESCRIPTION
## Summary

Adding N8N_AGENTS_TRACING_ENABLED config to enable agents tracing with Otel

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/TRUST-277/add-agent-tracing-config-enable-toggle-record-io


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34401">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->