### PR TITLE
ci(ai-builder): Point eval workflows at the consolidated LangTracer baseline suite (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -198,7 +198,7 @@ The current trigger fires once per `opened` / `reopened` / `ready_for_review`
 on a non-fork PR touching the eval surface, and runs the `pr` test-case dataset
 (a small set of high-reliability, capability-diverse cases) instead of the full
 suite. Test cases are pulled at run time from the LangTracer suite
-`n8n-workflows` — the source of truth; CI has no disk fallback (local runs
+`baseline` — the source of truth; CI has no disk fallback (local runs
 keep `--source disk` for authoring). To
 re-run after pushing a fix, dispatch `ci-instance-ai-evals.yml` with the PR
 number (optionally `tier: full` for broader coverage) — results post back to

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -500,3 +500,18 @@ jobs:
             packages/@n8n/instance-ai/.data/workflow-eval-report.html
             eval-diag/
           retention-days: 14
+
+      # The eval step runs with continue-on-error so the logs/artifacts above
+      # always land — but a run that never wrote eval-results.json (bad secret,
+      # unresolvable LangTracer suite, CLI crash before any results) must still
+      # fail the job rather than end green with zero evals. Per-case build
+      # failures DO write results and stay green by design. Mirrors the same
+      # guard in test-evals-mcp.yml.
+      - name: Fail when no results were produced
+        if: ${{ always() }}
+        working-directory: packages/@n8n/instance-ai
+        run: |
+          if [ ! -f eval-results.json ]; then
+            echo "::error::Eval run produced no eval-results.json — it failed before writing any results. Check the 'Run Instance AI Evals' step logs and the uploaded artifacts."
+            exit 1
+          fi

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -22,7 +22,7 @@ on:
         description: 'LangTracer suite slug or id to pull test cases from.'
         required: false
         type: string
-        default: 'n8n-workflows'
+        default: 'baseline'
       sandbox-provider:
         description: 'Sandbox provider (n8n-sandbox or daytona)'
         required: false
@@ -80,7 +80,7 @@ on:
       suite:
         description: 'LangTracer suite slug or id to pull test cases from.'
         required: false
-        default: 'n8n-workflows'
+        default: 'baseline'
       sandbox-provider:
         description: 'Sandbox provider (n8n-sandbox or daytona)'
         required: false
@@ -371,7 +371,7 @@ jobs:
           BASE_URLS=$(IFS=,; printf '%s' "${URLS[*]}")
           ARGS=(--base-url "$BASE_URLS" --concurrency 32 --verbose --iterations "${ITERATIONS:-3}")
           # LangTracer is the only CI case source (no disk fallback by design).
-          ARGS+=(--source langtracer --suite "${SUITE:-n8n-workflows}")
+          ARGS+=(--source langtracer --suite "${SUITE:-baseline}")
           # Pin the LangSmith cohort: langtracer mode otherwise derives a
           # suite-scoped dataset/baseline prefix, which would fork the KPI
           # history and orphan the baseline comparison.

--- a/.github/workflows/test-evals-mcp.yml
+++ b/.github/workflows/test-evals-mcp.yml
@@ -29,7 +29,7 @@ on:
         description: 'LangTracer suite slug or id to pull test cases from.'
         required: false
         type: string
-        default: 'n8n-workflows'
+        default: 'baseline'
       filter:
         description: 'Only build + eval test cases whose slug matches (comma-separated; empty = whole tier)'
         required: false
@@ -94,7 +94,7 @@ on:
       suite:
         description: 'LangTracer suite slug or id to pull test cases from.'
         required: false
-        default: 'n8n-workflows'
+        default: 'baseline'
       filter:
         description: 'Only build + eval test cases whose slug matches (comma-separated; empty = whole tier)'
         required: false
@@ -302,7 +302,7 @@ jobs:
             --verbose
           )
           # LangTracer is the only CI case source (no disk fallback by design).
-          ARGS+=(--source langtracer --suite "${SUITE:-n8n-workflows}")
+          ARGS+=(--source langtracer --suite "${SUITE:-baseline}")
           [ -n "$FILTER" ] && ARGS+=(--filter "$FILTER")
           [ -n "$EXPERIMENT_NAME" ] && ARGS+=(--experiment-name "$EXPERIMENT_NAME")
           pnpm eval:instance-ai "${ARGS[@]}"

--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -177,7 +177,7 @@ A case can belong to multiple groupings — e.g. PR-tier cases declare `"dataset
 
 ### Sourcing test cases from LangTracer
 
-**LangTracer is the source of truth for the workflow-eval corpus** — the `n8n-workflows` suite holds the cases, and CI pulls it on every run (see `.github/workflows/test-evals-instance-ai.yml`). The two `--source` modes split the work:
+**LangTracer is the source of truth for the workflow-eval corpus** — the `baseline` suite holds the cases, and CI pulls it on every run (see `.github/workflows/test-evals-instance-ai.yml`). The two `--source` modes split the work:
 
 - **`disk` (the default) — the preferred mode for local development.** Reads `data/workflows/` and `data/agents/`. Use it while authoring and calibrating a case: drop the JSON in, `--filter` it, iterate. It is also the only home of the `agents` tier and the seeded carve-out cases. Since the corpus migration the directory holds only those, so disk mode is about the case in front of you, not the full suite.
 - **`langtracer` — for bigger runs, already-pushed cases, and CI.** Pulls a suite from [LangTracer](https://github.com/n8n-io/lang-tracer)'s REST API (`GET /api/v1/suites/:id/export`), validated through the same `EvalTestCaseSchema`. Reach for it locally when you want the real corpus (a full or tier run) or to re-run a specific case that already lives in the suite; CI always runs this way.
@@ -191,7 +191,7 @@ Set these in `.env.local`:
 
 ```
 dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai \
-  --source langtracer --suite n8n-workflows --base-url http://localhost:5678
+  --source langtracer --suite baseline --base-url http://localhost:5678
 ```
 
 In langtracer mode, `--dataset` / `--baseline-prefix` default to a suite-scoped, eval-tagged name (`instance-ai-langtracer-<suite>`) so runs don't touch the shared `instance-ai-workflow-evals` cohort and re-runs of a suite upsert one stable dataset. `--filter` / `--exclude` / `--tier` still narrow within the suite. The MCP manifest builder (`eval:build-mcp-manifest`) accepts the same `--source langtracer --suite` flags.
@@ -336,7 +336,7 @@ There is no auto-refresh — refresh explicitly when you want a new reference po
 # The --dataset/--baseline-prefix pins mirror CI: langtracer mode otherwise
 # derives suite-scoped names, and later runs would never find this baseline.
 LANGSMITH_API_KEY=... dotenvx run -f ../../../.env.local -- \
-  pnpm eval:instance-ai --source langtracer --suite n8n-workflows \
+  pnpm eval:instance-ai --source langtracer --suite baseline \
   --dataset instance-ai-workflow-evals --baseline-prefix instance-ai-baseline- \
   --experiment-name instance-ai-baseline --iterations 10
 ```
@@ -661,7 +661,7 @@ To record an isolated cohort without touching the shared dataset or baseline —
 
 ## Adding test cases
 
-The corpus lives in **LangTracer** — suite `n8n-workflows` is what CI runs. Author a case as a local JSON file in `evaluations/data/workflows/` (disk mode picks it up, no registration step), calibrate it against a real build, then push it to the suite with `pnpm eval:langtracer-push --suite n8n-workflows <slug>` and delete the local file rather than committing it. Seeded cases (`priorConversation`/`seedFile`) are the exception — the case-write API can't represent them yet, so they stay as committed JSON. Every case is validated against `harness/schema.ts`.
+The corpus lives in **LangTracer** — suite `baseline` is what CI runs. Author a case as a local JSON file in `evaluations/data/workflows/` (disk mode picks it up, no registration step), calibrate it against a real build, then push it to the suite with `pnpm eval:langtracer-push --suite baseline <slug>` and delete the local file rather than committing it. Seeded cases (`priorConversation`/`seedFile`) are the exception — the case-write API can't represent them yet, so they stay as committed JSON. Every case is validated against `harness/schema.ts`.
 
 > The essentials are below. For the full authoring guide — picking a case archetype, sizing assertions so a wrong build fails, multi-turn director scripts, seeding vs synthetic, and calibrating against a real build — follow the [`create-instance-ai-eval` skill](../../../../.agents/skills/create-instance-ai-eval/SKILL.md) (with [`case-shapes.md`](../../../../.agents/skills/create-instance-ai-eval/case-shapes.md) and [`running-evals.md`](../../../../.agents/skills/create-instance-ai-eval/running-evals.md)).
 
@@ -835,7 +835,7 @@ Suite pass rates typically sit between 40–65%; most failures are `builder_issu
 
 ## CI
 
-Evals run automatically on PRs that change Instance AI code (path-filtered). The workflow boots a set of n8n lane containers, pulls the test-case suite from LangTracer (`--source langtracer --suite n8n-workflows`), and runs the CLI against the lanes. See `.github/workflows/test-evals-instance-ai.yml`.
+Evals run automatically on PRs that change Instance AI code (path-filtered). The workflow boots a set of n8n lane containers, pulls the test-case suite from LangTracer (`--source langtracer --suite baseline`), and runs the CLI against the lanes. See `.github/workflows/test-evals-instance-ai.yml`.
 
 The job is **non-blocking**. Results are posted as a PR comment and uploaded as artifacts. When `LANGSMITH_API_KEY` is set via the `EVALS_LANGSMITH_API_KEY` secret, runs also land as LangSmith experiments tagged with commit SHA + branch, so you can compare against master side-by-side.
 

--- a/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/langtracer-push.ts
@@ -3,8 +3,8 @@
 // leave unchanged, skip unsupported. The inverse of `--source langtracer` (which
 // pulls a suite down). Env: LANGTRACER_URL + LANGTRACER_API_KEY (repo-root .env.local).
 //
-//   dotenvx run -f ../../../.env.local -- pnpm eval:langtracer-push --suite n8n-workflows --changed
-//   dotenvx run -f ../../../.env.local -- pnpm eval:langtracer-push --suite n8n-workflows my-new-case ...
+//   dotenvx run -f ../../../.env.local -- pnpm eval:langtracer-push --suite baseline --changed
+//   dotenvx run -f ../../../.env.local -- pnpm eval:langtracer-push --suite baseline my-new-case ...
 //   ... --dry-run   # plan only, no writes
 
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
## Summary

The LangTracer suites were consolidated into a single suite — slug `baseline` (id 8, https://lang-tracer.n8n-maintenance.workers.dev/suites/8). The previous `n8n-workflows` slug no longer resolves, and since LangTracer is the only CI case source (no disk fallback by design), every run relying on the default suite fails at case export — including PR-gate runs, which never pass an explicit suite.

**Two changes:**

1. **Default suite slug → `baseline`** in:
   - `test-evals-instance-ai.yml` (both dispatch and `workflow_call` input defaults + the `${SUITE:-…}` fallback)
   - `test-evals-mcp.yml` (same three spots)
   - docs (`WORKFLOWS.md`, evaluations `README.md`) and the `eval:langtracer-push` usage examples

2. **Fail the instance-ai eval job when no results are produced.** Run [29564135331](https://github.com/n8n-io/n8n/actions/runs/29564135331) demonstrated the gap: the eval CLI crashed at case export (`lang-tracer suite "n8n-workflows" not found`) yet the job concluded **green** — the eval step is `continue-on-error` and nothing downstream checked for `eval-results.json`. This mirrors the "Fail when no results were produced" guard `test-evals-mcp.yml` already has. Per-case build failures still write results and stay green by design.

Safety notes:
- **Tier filtering is unaffected**: `--tier` matches on each case's `datasets` tags, which live on the case (not the suite), so `pr`/`mcp` tiers select the same subsets from the consolidated suite.
- **LangSmith cohorts are unaffected**: both workflows pin `--dataset`/`--baseline-prefix` explicitly, so the suite rename can't fork the KPI history or orphan baseline comparisons.

## How to test

Dispatch "Instance AI Evals: Experiments" from this branch with defaults — the case export resolves the `baseline` suite instead of failing on `n8n-workflows`. For the guard: a run with defaults on current master crashes at case export and now fails instead of ending green.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)