### PR TITLE
fix(core): Stop workflow-builder from adding sticky notes by default (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -4,6 +4,9 @@ Use these guardrails for workflow builds with multiple external systems,
 multiple requested effects, digests or reports, non-trivial branching, or Code
 nodes. They are a runtime checklist, not extra user-facing output.
 
+Do not add sticky notes unless the user explicitly asks for them. Prefer chat
+explanations over canvas stickies.
+
 ## Preserve Source Data
 
 Normalize trigger or source data before side effects. Nodes that create, update,

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -452,7 +452,6 @@ import {
   workflow,
   node,
   trigger,
-  sticky,
   placeholder,
   newCredential,
   ifElse,
@@ -521,6 +520,12 @@ Follow these rules strictly when generating workflows:
    match time units broadly (day/days, week/weeks…), and give every classifier
    an explicit fallback bucket — a one-phrasing regex silently misroutes every
    other phrasing.
+7. Do not add sticky notes (`sticky(...)` / `n8n-nodes-base.stickyNote`) unless
+   the user explicitly asks for canvas notes. They add visual noise and are
+   often poorly positioned. Put explanations in your chat reply instead. Even
+   when the SDK language reference documents `sticky()`, do not use it by
+   default. When editing a workflow, do not add new stickies and do not
+   reintroduce ones you removed.
 
 ## Tool Naming Rules
 
@@ -682,8 +687,9 @@ For AI Agent workflows:
 ## Additional SDK Functions
 
 - `placeholder('hint')`: marks a parameter value for user input.
-- `sticky('content', nodes?, config?)`: creates a sticky note. It must still be
-  added to the workflow.
+- `sticky('content', nodes?, config?)`: opt-in only when the user explicitly
+  asks for a sticky note on the canvas. Do not import or call it otherwise.
+  When used, it must still be added to the workflow.
 - `.output(n)`: selects a zero-based output index.
 - `.onError(handler)`: connects a node's error output to a handler. Requires
   `onError: 'continueErrorOutput'` in the node config.

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -524,8 +524,8 @@ Follow these rules strictly when generating workflows:
    the user explicitly asks for canvas notes. They add visual noise and are
    often poorly positioned. Put explanations in your chat reply instead. Even
    when the SDK language reference documents `sticky()`, do not use it by
-   default. When editing a workflow, do not add new stickies and do not
-   reintroduce ones you removed.
+   default. When editing a workflow, do not add or reintroduce stickies unless the user
+   explicitly asks for them.
 
 ## Tool Naming Rules
 

--- a/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/runtime-skills.test.ts
@@ -24,6 +24,20 @@ describe('Instance AI runtime skills', () => {
 		expect(skill).toContain('knowledge-base/reference/workflow-sdk-language.md');
 	});
 
+	it('tells the workflow-builder not to add sticky notes by default', () => {
+		const skill = readFileSync(
+			join(INSTANCE_AI_SKILLS_DIR, 'workflow-builder', 'SKILL.md'),
+			'utf-8',
+		);
+		expect(skill).toContain(
+			'Do not add sticky notes (`sticky(...)` / `n8n-nodes-base.stickyNote`) unless',
+		);
+		expect(skill).not.toMatch(/import \{\n(?:[^\n]*\n)*?\s*sticky,/);
+		expect(skill).toMatch(
+			/opt-in only when the user explicitly\s+asks for a sticky note on the canvas/,
+		);
+	});
+
 	it('loads the bundled data-table-manager skill and its linked files', async () => {
 		expect(existsSync(INSTANCE_AI_SKILLS_DIR)).toBe(true);
 


### PR DESCRIPTION
## Summary

Stop Instance AI's workflow-builder from adding sticky notes by default. Stickies were noisy, often poorly positioned, and rarely added useful information.

- Remove `sticky` from the default SDK import example
- Add an explicit workflow rule: only add stickies when the user asks
- Demote sticky docs to opt-in in the skill and guardrails
- Add a regression test that the skill keeps this guidance

## How to test

1. Enable Instance AI and ask it to build a new workflow (e.g. a simple Calendar/HTTP flow that previously attracted a "How it works" sticky).
2. Confirm the saved workflow has no `n8n-nodes-base.stickyNote` nodes on the canvas.
3. Optionally ask explicitly for a sticky note and confirm it can still be added when requested.
4. Unit: `cd packages/@n8n/instance-ai && pnpm test src/skills/__tests__/runtime-skills.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-422

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34410">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

