### PR TITLE
test: Align MCP trigger credential gate e2e test with owner-bound authorize link

### DIFF
--- a/packages/testing/playwright/services/dynamic-credential-api-helper.ts
+++ b/packages/testing/playwright/services/dynamic-credential-api-helper.ts
@@ -222,5 +222,28 @@ export class DynamicCredentialApiHelper {
 		}
 	}
 
+	/**
+	 * Resolves the provider authorization URL from a gate-issued n8n authorize link
+	 * (`/rest/credentials/:id/authorize?token=…`).
+	 *
+	 * The link is bound to an n8n user, so it must be opened with that user's session:
+	 * we GET its path+query via the authenticated api.request context, which resolves the
+	 * intent and 302-redirects to the provider. `maxRedirects: 0` captures that redirect so
+	 * the caller can drive the provider flow directly.
+	 */
+	async resolveProviderUrlFromAuthorizeLink(authorizeUrl: string): Promise<string> {
+		const parsed = new URL(authorizeUrl);
+		const response = await this.api.request.get(parsed.pathname + parsed.search, {
+			maxRedirects: 0,
+		});
+		const location = response.headers().location;
+		if (!location) {
+			throw new TestError(
+				`Expected authorize link to redirect to the provider, got ${response.status()}: ${await response.text()}`,
+			);
+		}
+		return location;
+	}
+
 	// ===== Revoke =====
 }

--- a/packages/testing/playwright/tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts
+++ b/packages/testing/playwright/tests/e2e/dynamic-credentials/mcp-trigger-credential-gate.spec.ts
@@ -195,10 +195,8 @@ test.describe(
 			);
 
 			try {
-				// First call hits the gate and returns the Keycloak authorization URL.
-				// (The gate emits the provider URL directly — its CSRF state already
-				// carries the caller identity + resolver — so no separate n8n authorize
-				// step is needed before completing the Keycloak flow.)
+				// First call hits the gate and returns an n8n authorize link
+				// (`/rest/credentials/:id/authorize?token=…`), bound to the owner.
 				const gateResult = await mainApi.mcp.callTool(
 					session,
 					mcpPath,
@@ -211,12 +209,15 @@ test.describe(
 				const authorizationUrl = gateText.split('\n').find((line) => line.startsWith('http'));
 				expect(authorizationUrl).toBeTruthy();
 
-				// Complete the Keycloak authorization code flow, then GET the n8n callback
-				// (on the same main) so n8n exchanges the code and stores the caller's
-				// token for the resolver-keyed private credential.
-				const n8nCallbackUrl = await services.keycloak.completeAuthorizationCodeFlow(
+				// The authorize link is owner-bound, so open it with the owner's authenticated
+				// context: n8n resolves the intent and redirects to the Keycloak authorization
+				// URL. Then complete the Keycloak flow and GET the n8n callback (on the same
+				// main) so n8n exchanges the code and stores the caller's token for the
+				// resolver-keyed private credential.
+				const providerUrl = await mainApi.dynamicCredentials.resolveProviderUrlFromAuthorizeLink(
 					authorizationUrl!,
 				);
+				const n8nCallbackUrl = await services.keycloak.completeAuthorizationCodeFlow(providerUrl);
 				await mainApi.dynamicCredentials.completeAuthorizationCallback(n8nCallbackUrl);
 
 				// Retry with the same caller token: the credential is now connected, the


### PR DESCRIPTION
## Summary

The dynamic-credentials/mcp-trigger-credential-gate e2e test broke after the credential gate
changed what it hands back to the caller. The gate now returns an n8n authorize link
(/rest/credentials/:id/authorize?token=…) rather than the provider (Keycloak) authorization URL
directly. The old test assumed the gate emitted the provider URL and fed it straight into the
Keycloak flow, so it no longer completed the connect step.

This PR updates the test to follow the new flow:

Adds resolveProviderUrlFromAuthorizeLink() to DynamicCredentialApiHelper. The authorize link
is bound to an n8n user, so the helper GETs its path+query through the owner’s authenticated
api.request context with maxRedirects: 0, and returns the Location header — the provider
authorization URL that n8n resolves the intent to.
Rewrites the “should execute the tool after the caller connects the private credential” test to
resolve the provider URL from the owner-bound authorize link first, then complete the Keycloak
authorization code flow and hit the n8n callback as before.

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

