### PR TITLE
fix(HTTP Request): Stop re-decoding valid UTF-8 responses with Latin-1 characters

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
@@ -3,7 +3,6 @@ import type { Readable } from 'stream';
 
 const CHINESE_ENCODINGS = ['gb18030', 'gbk', 'gb2312'] as const;
 const REPLACEMENT_CHAR = '�';
-const HIGH_ASCII_PATTERN = /[\x80-\xFF]{3,}/;
 const DEFAULT_ENCODING = 'utf-8';
 
 /**
@@ -54,7 +53,7 @@ export async function binaryToStringWithEncodingDetection(
 
 	const decodedString = await helpers.binaryToString(bufferedData);
 
-	if (decodedString.includes(REPLACEMENT_CHAR) || HIGH_ASCII_PATTERN.test(decodedString)) {
+	if (decodedString.includes(REPLACEMENT_CHAR)) {
 		const detected = helpers.detectBinaryEncoding(bufferedData).toLowerCase() as BufferEncoding;
 		if (detected && detected !== DEFAULT_ENCODING) {
 			return await helpers.binaryToString(bufferedData, detected);

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
@@ -141,23 +141,80 @@ describe('buffer-decoding utils', () => {
 				expect(result).toBe('test content with proper chars');
 			});
 
-			it('should detect high ASCII pattern and try chardet for Buffer', async () => {
-				const buffer = Buffer.from([0x80, 0x81, 0x82, 0x83]); // High ASCII bytes
+			it('should not re-encode valid UTF-8 with consecutive Latin-1 characters', async () => {
+				const turkishText = 'Küçük Köpek Künyesi';
+				const buffer = Buffer.from(turkishText, 'utf8');
 				const contentType = 'text/html';
-				const highAsciiString = String.fromCharCode(0x80, 0x81, 0x82, 0x83);
 
-				mockBinaryToString
-					.mockResolvedValueOnce(highAsciiString) // First UTF-8 attempt
-					.mockResolvedValueOnce('proper decoded content'); // Second attempt with detected encoding
-
-				mockDetectBinaryEncoding.mockReturnValue('windows-1252');
+				mockBinaryToString.mockResolvedValue(turkishText);
 
 				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
 
-				expect(mockDetectBinaryEncoding).toHaveBeenCalledWith(buffer);
-				expect(mockBinaryToString).toHaveBeenCalledTimes(2);
-				expect(mockBinaryToString).toHaveBeenNthCalledWith(2, buffer, 'windows-1252');
-				expect(result).toBe('proper decoded content');
+				expect(result).toBe(turkishText);
+				expect(mockBinaryToString).toHaveBeenCalledTimes(1);
+				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
+			});
+
+			it('should not re-encode valid UTF-8 with French accented characters', async () => {
+				const frenchText = 'François résumé naïve café';
+				const buffer = Buffer.from(frenchText, 'utf8');
+				const contentType = 'text/html';
+
+				mockBinaryToString.mockResolvedValue(frenchText);
+
+				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
+
+				expect(result).toBe(frenchText);
+				expect(mockBinaryToString).toHaveBeenCalledTimes(1);
+				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
+			});
+
+			it('should not re-encode valid UTF-8 with German umlauts', async () => {
+				const germanText = 'Straße Grüße für München';
+				const buffer = Buffer.from(germanText, 'utf8');
+				const contentType = 'text/html';
+
+				mockBinaryToString.mockResolvedValue(germanText);
+
+				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
+
+				expect(result).toBe(germanText);
+				expect(mockBinaryToString).toHaveBeenCalledTimes(1);
+				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
+			});
+
+			it('should not re-encode valid UTF-8 with Spanish characters', async () => {
+				const spanishText = 'Señor año niñomü';
+				const buffer = Buffer.from(spanishText, 'utf8');
+				const contentType = 'text/html';
+
+				mockBinaryToString.mockResolvedValue(spanishText);
+
+				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
+
+				expect(result).toBe(spanishText);
+				expect(mockBinaryToString).toHaveBeenCalledTimes(1);
+				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
+			});
+
+			it('should still re-encode content with actual replacement characters (broken UTF-8)', async () => {
+				const brokenUtf8 = Buffer.from([0xc3, 0x28]); // Invalid UTF-8 sequence
+				const contentType = 'text/html';
+
+				mockBinaryToString
+					.mockResolvedValueOnce('test � content') // UTF-8 decode produces replacement char
+					.mockResolvedValueOnce('test ( content'); // Re-decode with detected encoding
+
+				mockDetectBinaryEncoding.mockReturnValue('iso-8859-1');
+
+				const result = await binaryToStringWithEncodingDetection(
+					brokenUtf8,
+					contentType,
+					mockHelpers,
+				);
+
+				expect(mockDetectBinaryEncoding).toHaveBeenCalledWith(brokenUtf8);
+				expect(result).toBe('test ( content');
 			});
 
 			it('should try Chinese encodings for Readable streams with replacement chars', async () => {
@@ -372,36 +429,20 @@ describe('buffer-decoding utils', () => {
 				expect(result).toBe('content with �'); // Should return original
 			});
 
-			it('should handle very short high ASCII sequences (less than 3 chars)', async () => {
-				const buffer = Buffer.from([0x80, 0x81]); // Only 2 high ASCII bytes
-				const contentType = 'text/html';
-				const shortHighAsciiString = String.fromCharCode(0x80, 0x81);
-
-				mockBinaryToString.mockResolvedValue(shortHighAsciiString);
-
-				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
-
-				expect(result).toBe(shortHighAsciiString);
-				expect(mockBinaryToString).toHaveBeenCalledTimes(1); // Should not trigger re-encoding
-				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
-			});
-
-			it('should handle mixed content with both replacement chars and high ASCII', async () => {
-				const buffer = Buffer.from(
-					'test � content ' + String.fromCharCode(0x80, 0x81, 0x82),
-					'utf8',
-				);
+			it('should handle mixed content with replacement chars and Latin-1 characters', async () => {
+				const buffer = Buffer.from('test content with Küçük and café', 'utf8');
 				const contentType = 'text/html';
 
+				// Simulate: UTF-8 decode succeeds for Latin-1 but fails for broken bytes
 				mockBinaryToString
-					.mockResolvedValueOnce('test � content ' + String.fromCharCode(0x80, 0x81, 0x82))
-					.mockResolvedValueOnce('test proper content decoded');
+					.mockResolvedValueOnce('test content with replacement � and Küçük')
+					.mockResolvedValueOnce('test content with proper and Küçük');
 
 				mockDetectBinaryEncoding.mockReturnValue('windows-1252');
 
 				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
 
-				expect(result).toBe('test proper content decoded');
+				expect(result).toBe('test content with proper and Küçük');
 				expect(mockDetectBinaryEncoding).toHaveBeenCalledWith(buffer);
 			});
 		});


### PR DESCRIPTION
## Summary

The HTTP Request node incorrectly re-decoded UTF-8 responses as GBK/GB18030 when the decoded text contained 3+ consecutive characters in the U+0080-U+00FF range (e.g. Turkish, French, German text). This caused accented Latin text to be silently corrupted as Chinese characters.

**Root cause**: The `HIGH_ASCII_PATTERN` regex (`/[\x80-\xFF]{3,}/`) matched valid UTF-8 decoded strings, triggering the Chinese encoding fallback which always succeeded with GB18030.

**Fix**: Remove the `HIGH_ASCII_PATTERN` check and rely solely on the replacement character (U+FFFD) to detect encoding mismatches. A clean UTF-8 decode without replacement characters is strong evidence the bytes are UTF-8.

## How to test

1. Create a workflow with an HTTP Request node
2. Point it to an endpoint returning UTF-8 text with consecutive Latin-1 characters (e.g. Turkish `Küçük Köpek Künyesi`, French `François résumé naïve café`)
3. **Before fix**: Response is corrupted as Chinese characters (e.g. `K眉莽眉k K枚pek K眉nyesi`)
4. **After fix**: Response is returned correctly as UTF-8

## Related Linear tickets, Github issues, and Community forum posts

Fixes #34372

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

