### PR TITLE
fix(core): Preserve agent builder question answers

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-agent.tool.test.ts
@@ -1,4 +1,8 @@
-import { BUILDER_CHECKPOINT_UNAVAILABLE_CODE, type InstanceAiEvent } from '@n8n/api-types';
+import {
+	BUILDER_CHECKPOINT_UNAVAILABLE_CODE,
+	type InstanceAiEvent,
+	type QuestionAnswer,
+} from '@n8n/api-types';
 import { UserError } from 'n8n-workflow';
 import type { Mock } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -41,6 +45,7 @@ interface BuildAgentOutput {
 	error?: string;
 	agentId?: string;
 	agentName?: string;
+	answers?: QuestionAnswer[];
 }
 
 function fakeStream(chunks: unknown[], text: string): BuilderTurnStream {
@@ -1010,6 +1015,40 @@ describe('build-agent tool', () => {
 			expect(result).toEqual({
 				ok: true,
 				builderReply: 'Using Slack.',
+				configUpdated: false,
+				agentId: 'agent-1',
+				answers: [{ questionId: 'q1', selectedOptions: ['slack'] }],
+			});
+		});
+
+		it('does not attach answers when resuming a credential suspension', async () => {
+			const { context, delegate } = makeContext();
+			context.domainContext!.agentBuilderTarget = { agentId: 'agent-1', projectId: 'proj-1' };
+			vi.mocked(delegate.findOpenSuspensions).mockResolvedValue([
+				{ runId: 'builder-run-1', toolCallId: 'builder-call-1' },
+			]);
+			vi.mocked(delegate.resumeBuild).mockResolvedValue(fakeStream([], 'Connected Slack.'));
+
+			const result = await runToolWithCtx(
+				context,
+				{ message: 'Build it', name: 'New Agent' },
+				{
+					resumeData: { credentials: { slack: 'cred-1' } },
+					suspendPayload: {
+						...askCredentialSuspendPayload(),
+						requestId: 'orch-req-1',
+						builderCheckpoint: {
+							runId: 'builder-run-1',
+							toolCallId: 'builder-call-1',
+							configUpdated: false,
+						},
+					},
+				},
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				builderReply: 'Connected Slack.',
 				configUpdated: false,
 				agentId: 'agent-1',
 			});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-agent.tool.ts
@@ -30,6 +30,8 @@ import {
 	CONFIG_MUTATION_TOOL_NAMES,
 	channelSuspendPayloadSchema,
 	credentialSuspendPayloadSchema,
+	questionAnswerSchema,
+	questionsResumeSchema,
 	questionsSuspendPayloadSchema,
 } from '@n8n/api-types';
 import { isRecord } from '@n8n/utils/is-record';
@@ -184,6 +186,10 @@ const buildAgentOutputSchema = z.object({
 			'Id of the agent this turn targeted. Record it and pass it as `agentId` when switching back to this agent later.',
 		),
 	agentName: z.string().optional().describe('Display name of the targeted agent, when known.'),
+	answers: z
+		.array(questionAnswerSchema)
+		.optional()
+		.describe('Answers submitted when resuming a cascaded questions request.'),
 });
 
 type BuildAgentOutput = z.infer<typeof buildAgentOutputSchema>;
@@ -476,6 +482,19 @@ async function runBuilderConsumeLoop(params: {
 	});
 }
 
+/** Discriminate via the suspend payload because questionsResumeSchema accepts unrelated objects. */
+function getResumedQuestionAnswers(
+	ctx: BuildAgentToolContext,
+): Array<z.infer<typeof questionAnswerSchema>> | undefined {
+	const isQuestionsSuspension = questionsSuspendPayloadSchema.safeParse(ctx.suspendPayload);
+	if (!isQuestionsSuspension.success) return undefined;
+
+	const resume = questionsResumeSchema.safeParse(ctx.resumeData);
+	if (!resume.success || !resume.data.answers) return undefined;
+
+	return resume.data.answers;
+}
+
 /**
  * Resume leg: re-derive the target agent and the builder's open suspension
  * from persistence, verify they match the `builderCheckpoint` ref carried in
@@ -670,7 +689,9 @@ export function createBuildAgentTool(context: OrchestrationContext) {
 			}
 
 			if (ctx.resumeData !== undefined && ctx.resumeData !== null) {
-				return await handleResume(context, domainContext, delegate, ctx);
+				const output = await handleResume(context, domainContext, delegate, ctx);
+				const answers = getResumedQuestionAnswers(ctx);
+				return answers ? { ...output, answers } : output;
 			}
 
 			const existingTarget = await resolveAgentBuilderTarget(domainContext);


### PR DESCRIPTION
## Summary

Preserve answers submitted to cascaded Agent Builder questions in the outer `build-agent` tool result. This lets Instance AI render the selected LLM correctly after the builder resumes and when the conversation is hydrated from history.

The resume path first verifies that the suspended interaction is a questions request, so credential and channel resumes remain unchanged.

## How to test

Automated:

```bash
cd packages/@n8n/instance-ai
pnpm test src/tools/orchestration/__tests__/build-agent.tool.test.ts -t "resumes the builder via delegate.resumeBuild|does not attach answers when resuming a credential suspension"
```

Manual:

1. Start n8n with the `agents` and `instance-ai` modules enabled and their required model configuration.
2. Ask Instance AI to build an agent.
3. Select an LLM when the Agent Builder asks.
4. Verify the resolved question displays the selected LLM instead of "Skipped" and remains correct after the build completes or the conversation is reloaded.

Also verified package lint and typecheck.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-414

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

