### PR TITLE
fix: Do not lose scenario results on a budget/timeout abort

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/fixtures/eval-results.partial-abort.json
@@ -1,0 +1,72 @@
+{
+	"totalRuns": 1,
+	"summary": {
+		"testCases": 2,
+		"built": 1,
+		"scenariosTotal": 2,
+		"passAtK": 0.5,
+		"passHatK": 0.5,
+		"passRatePerIter": "50%"
+	},
+	"comparisonStatus": "not_attempted",
+	"testCases": [
+		{
+			"name": "build me something",
+			"buildSuccessCount": 1,
+			"totalRuns": 1,
+			"workflowChecksPerRun": [null],
+			"buildExpectationResultsPerRun": [null],
+			"buildExpectations": [],
+			"threadIds": [null],
+			"scenarios": [
+				{
+					"name": "happy path",
+					"passCount": 1,
+					"evaluatedCount": 1,
+					"totalRuns": 1,
+					"passAtK": 1,
+					"passHatK": 1,
+					"runs": [
+						{
+							"workflowId": "Wa",
+							"passed": true,
+							"score": 1,
+							"reasoning": "passed",
+							"execErrors": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "build me something",
+			"buildSuccessCount": 0,
+			"totalRuns": 1,
+			"workflowChecksPerRun": [null],
+			"buildExpectationResultsPerRun": [null],
+			"buildExpectations": [],
+			"threadIds": [null],
+			"scenarios": [
+				{
+					"name": "edge case",
+					"passCount": 0,
+					"evaluatedCount": 1,
+					"totalRuns": 1,
+					"passAtK": 0,
+					"passHatK": 0,
+					"runs": [
+						{
+							"workflowId": null,
+							"passed": false,
+							"score": 0,
+							"reasoning": "Scenario execution error: TimeoutError: The operation was aborted due to timeout",
+							"failureCategory": "framework_issue",
+							"rootCause": "Scenario execution exceeded its per-iteration time budget and was aborted before a verdict: TimeoutError: The operation was aborted due to timeout",
+							"execErrors": []
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/packages/@n8n/instance-ai/evaluations/__tests__/partial-results-abort.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/partial-results-abort.test.ts
@@ -1,0 +1,124 @@
+import { aggregateResults } from '../cli/aggregator';
+import { abortedWorkflowTestCaseResult } from '../harness/runner';
+import { classifyScenarioExecutionError } from '../harness/transient-error';
+import type { ExecutionScenario, WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+
+// ---------------------------------------------------------------------------
+// TRUST-310: a per-iteration budget / timeout abort must never lose the
+// scenarios that already completed, and the offending scenario must be stamped
+// with the pinned cross-repo contract so the lang-tracer side can route it to
+// an infra bucket instead of counting it against product quality.
+//
+//   - `failureCategory: "framework_issue"` (verbatim — do NOT invent a new one)
+//   - a `rootCause` string that mentions the timeout/budget
+// ---------------------------------------------------------------------------
+
+describe('classifyScenarioExecutionError', () => {
+	it('stamps a budget/timeout abort as framework_issue with a timeout rootCause', () => {
+		// undici's AbortSignal.timeout surfaces as this message via the n8n client.
+		const message = 'TimeoutError: The operation was aborted due to timeout';
+
+		const classified = classifyScenarioExecutionError(message);
+
+		expect(classified.failureCategory).toBe('framework_issue');
+		expect(classified.rootCause).toBeDefined();
+		expect(classified.rootCause?.toLowerCase()).toMatch(/timeout|budget/);
+		expect(classified.rootCause).toContain(message);
+		expect(classified.reasoning).toContain(message);
+	});
+
+	it('stamps a non-timeout framework error without a timeout rootCause', () => {
+		const message = 'fetch failed: ECONNRESET';
+
+		const classified = classifyScenarioExecutionError(message);
+
+		// Still framework_issue (any error escaping executeScenario is infra), but
+		// no timeout-flavoured rootCause — only budget aborts carry that.
+		expect(classified.failureCategory).toBe('framework_issue');
+		expect(classified.rootCause).toBeUndefined();
+		expect(classified.reasoning).toContain(message);
+	});
+});
+
+function makeTestCase(scenarios: ExecutionScenario[]): WorkflowTestCase {
+	return {
+		conversation: [{ role: 'user', text: 'build me something' }],
+		complexity: 'complex',
+		tags: ['test'],
+		executionScenarios: scenarios,
+	};
+}
+
+const scenarioA: ExecutionScenario = {
+	name: 'happy path',
+	description: 'a',
+	dataSetup: 'setup a',
+	successCriteria: 'criteria a',
+};
+const scenarioB: ExecutionScenario = {
+	name: 'edge case',
+	description: 'b',
+	dataSetup: 'setup b',
+	successCriteria: 'criteria b',
+};
+
+describe('abortedWorkflowTestCaseResult', () => {
+	it('produces a build-failed result with one framework_issue row per scenario', () => {
+		const testCase = makeTestCase([scenarioA, scenarioB]);
+		const message = 'TimeoutError: The operation was aborted due to timeout';
+
+		const result = abortedWorkflowTestCaseResult(testCase, 'http://localhost:5678', message);
+
+		expect(result.workflowBuildSuccess).toBe(false);
+		expect(result.buildError).toContain(message);
+		expect(result.n8nBaseUrl).toBe('http://localhost:5678');
+		// One result per declared scenario keeps the aggregator's positional index
+		// aligned so the case is counted rather than the whole batch being lost.
+		expect(result.executionScenarioResults).toHaveLength(2);
+		for (const sr of result.executionScenarioResults) {
+			expect(sr.success).toBe(false);
+			expect(sr.score).toBe(0);
+			expect(sr.failureCategory).toBe('framework_issue');
+			expect(sr.rootCause?.toLowerCase()).toMatch(/timeout|budget/);
+		}
+	});
+});
+
+describe('aggregateResults with a mid-run abort', () => {
+	it('keeps the completed case alongside an aborted case', () => {
+		// Case A completed before the abort: built + its scenario passed.
+		const caseA = makeTestCase([scenarioA]);
+		const completed: WorkflowTestCaseResult = {
+			testCase: caseA,
+			workflowBuildSuccess: true,
+			workflowId: 'Wa',
+			executionScenarioResults: [
+				{ scenario: scenarioA, success: true, score: 1, reasoning: 'passed' },
+			],
+		};
+
+		// Case B threw on a budget/timeout abort — captured instead of lost.
+		const caseB = makeTestCase([scenarioB]);
+		const aborted = abortedWorkflowTestCaseResult(
+			caseB,
+			'http://localhost:5678',
+			'TimeoutError: The operation was aborted due to timeout',
+		);
+
+		const evaluation = aggregateResults([[completed, aborted]], 1);
+
+		expect(evaluation.testCases).toHaveLength(2);
+
+		// The passing scenario survives the abort and is counted.
+		const aggA = evaluation.testCases[0];
+		expect(aggA.executionScenarios[0].passCount).toBe(1);
+		expect(aggA.executionScenarios[0].evaluatedCount).toBe(1);
+
+		// The aborted scenario is present and carries the pinned contract.
+		const aggB = evaluation.testCases[1];
+		const abortedRun = aggB.executionScenarios[0].runs[0];
+		expect(abortedRun.success).toBe(false);
+		expect(abortedRun.failureCategory).toBe('framework_issue');
+		expect(abortedRun.rootCause?.toLowerCase()).toMatch(/timeout|budget/);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/write-partial-results.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/write-partial-results.test.ts
@@ -1,3 +1,4 @@
+import { jsonParse } from 'n8n-workflow';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,6 +16,29 @@ import type { ExecutionScenario, WorkflowTestCase, WorkflowTestCaseResult } from
 // --output-dir and pins the JSON shape the dispatcher parses against a golden
 // fixture (the cross-repo contract anchor).
 // ---------------------------------------------------------------------------
+
+/** Minimal shape of the emitted eval-results.json — only the fields these tests read. */
+interface ParsedEvalResults {
+	timestamp?: string;
+	duration?: number;
+	testCases: Array<{
+		buildSuccessCount: number;
+		totalRuns: number;
+		scenarios: Array<{
+			passCount: number;
+			evaluatedCount: number;
+			totalRuns: number;
+			passAtK: number;
+			runs: Array<{
+				passed: boolean;
+				score: number;
+				failureCategory?: string;
+				rootCause?: string;
+			}>;
+		}>;
+	}>;
+	[key: string]: unknown;
+}
 
 const silentLogger: EvalLogger = {
 	info: () => {},
@@ -81,6 +105,7 @@ describe('runEvalAndPersist write-on-abort', () => {
 		// exact shape of a budget abort after some scenarios already passed.
 		const runEval = async (partialResults: WorkflowTestCaseResult[][]) => {
 			partialResults.push(partialIteration());
+			await Promise.resolve();
 			throw new Error('operation aborted due to timeout');
 		};
 
@@ -102,7 +127,7 @@ describe('runEvalAndPersist write-on-abort', () => {
 
 		const file = join(outputDir, 'eval-results.json');
 		expect(existsSync(file)).toBe(true);
-		const parsed = JSON.parse(readFileSync(file, 'utf8'));
+		const parsed = jsonParse<ParsedEvalResults>(readFileSync(file, 'utf8'));
 
 		// (a) the passing scenario that completed before the abort survives. The
 		// emitted per-scenario key is `scenarios`, and pass state is carried as
@@ -131,6 +156,7 @@ describe('runEvalAndPersist write-on-abort', () => {
 	it('matches the cross-repo golden fixture (minus the volatile timestamp/duration)', async () => {
 		const runEval = async (partialResults: WorkflowTestCaseResult[][]) => {
 			partialResults.push(partialIteration());
+			await Promise.resolve();
 			throw new Error('operation aborted due to timeout');
 		};
 
@@ -150,13 +176,15 @@ describe('runEvalAndPersist write-on-abort', () => {
 			),
 		).rejects.toThrow(/aborted/);
 
-		const parsed = JSON.parse(readFileSync(join(outputDir, 'eval-results.json'), 'utf8'));
+		const parsed = jsonParse<ParsedEvalResults>(
+			readFileSync(join(outputDir, 'eval-results.json'), 'utf8'),
+		);
 		// timestamp + duration are wall-clock and can't be pinned; the rest is the
 		// contract the dispatcher parses.
 		delete parsed.timestamp;
 		delete parsed.duration;
 
-		const golden = JSON.parse(
+		const golden = jsonParse<ParsedEvalResults>(
 			readFileSync(join(__dirname, 'fixtures', 'eval-results.partial-abort.json'), 'utf8'),
 		);
 		expect(parsed).toEqual(golden);

--- a/packages/@n8n/instance-ai/evaluations/__tests__/write-partial-results.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/write-partial-results.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runEvalAndPersist } from '../cli/index';
+import type { EvalLogger } from '../harness/logger';
+import { abortedWorkflowTestCaseResult } from '../harness/runner';
+import type { ExecutionScenario, WorkflowTestCase, WorkflowTestCaseResult } from '../types';
+
+// ---------------------------------------------------------------------------
+// TRUST-310: the CLI must WRITE a partial eval-results.json when the run throws
+// mid-flight (a per-iteration budget / timeout abort). Without a file the
+// lang-tracer dispatcher discards the whole run — including scenarios that had
+// already passed. This drives the actual write-on-abort seam to a real temp
+// --output-dir and pins the JSON shape the dispatcher parses against a golden
+// fixture (the cross-repo contract anchor).
+// ---------------------------------------------------------------------------
+
+const silentLogger: EvalLogger = {
+	info: () => {},
+	verbose: () => {},
+	success: () => {},
+	warn: () => {},
+	error: () => {},
+	isVerbose: false,
+};
+
+const scenarioA: ExecutionScenario = {
+	name: 'happy path',
+	description: 'a',
+	dataSetup: 'setup a',
+	successCriteria: 'criteria a',
+};
+const scenarioB: ExecutionScenario = {
+	name: 'edge case',
+	description: 'b',
+	dataSetup: 'setup b',
+	successCriteria: 'criteria b',
+};
+
+function makeTestCase(scenarios: ExecutionScenario[]): WorkflowTestCase {
+	return {
+		conversation: [{ role: 'user', text: 'build me something' }],
+		complexity: 'complex',
+		tags: ['test'],
+		executionScenarios: scenarios,
+	};
+}
+
+/** One iteration's results: case A completed + passed before the abort, case B
+ *  was aborted by the budget/timeout. */
+function partialIteration(): WorkflowTestCaseResult[] {
+	const completed: WorkflowTestCaseResult = {
+		testCase: makeTestCase([scenarioA]),
+		workflowBuildSuccess: true,
+		workflowId: 'Wa',
+		executionScenarioResults: [
+			{ scenario: scenarioA, success: true, score: 1, reasoning: 'passed' },
+		],
+	};
+	const aborted = abortedWorkflowTestCaseResult(
+		makeTestCase([scenarioB]),
+		'http://localhost:5678',
+		'TimeoutError: The operation was aborted due to timeout',
+	);
+	return [completed, aborted];
+}
+
+describe('runEvalAndPersist write-on-abort', () => {
+	let outputDir: string;
+
+	beforeEach(() => {
+		outputDir = mkdtempSync(join(tmpdir(), 'eval-310-'));
+	});
+	afterEach(() => {
+		rmSync(outputDir, { recursive: true, force: true });
+	});
+
+	it('writes eval-results.json with completed + aborted scenarios when the run throws', async () => {
+		// The run captures one completed iteration into the sink, then throws — the
+		// exact shape of a budget abort after some scenarios already passed.
+		const runEval = async (partialResults: WorkflowTestCaseResult[][]) => {
+			partialResults.push(partialIteration());
+			throw new Error('operation aborted due to timeout');
+		};
+
+		await expect(
+			runEvalAndPersist(
+				{
+					logger: silentLogger,
+					outputDir,
+					startTime: Date.now(),
+					iterations: 1,
+					tier: undefined,
+					commitSha: undefined,
+					rerun: undefined,
+					mcpBuildSpend: [],
+				},
+				runEval,
+			),
+		).rejects.toThrow(/aborted/);
+
+		const file = join(outputDir, 'eval-results.json');
+		expect(existsSync(file)).toBe(true);
+		const parsed = JSON.parse(readFileSync(file, 'utf8'));
+
+		// (a) the passing scenario that completed before the abort survives. The
+		// emitted per-scenario key is `scenarios`, and pass state is carried as
+		// passCount/evaluatedCount + passAtK/passHatK (NOT a `passRate` field).
+		const completedCase = parsed.testCases[0];
+		expect(completedCase.buildSuccessCount).toBe(1);
+		expect(completedCase.totalRuns).toBe(1);
+		expect(completedCase.scenarios[0].passCount).toBe(1);
+		expect(completedCase.scenarios[0].evaluatedCount).toBe(1);
+		expect(completedCase.scenarios[0].totalRuns).toBe(1);
+		expect(completedCase.scenarios[0].passAtK).toBe(1);
+		expect(completedCase.scenarios[0].runs[0].passed).toBe(true);
+
+		// (b) the aborted scenario carries the pinned cross-repo contract.
+		const abortedCase = parsed.testCases[1];
+		expect(abortedCase.buildSuccessCount).toBe(0);
+		expect(abortedCase.scenarios[0].passCount).toBe(0);
+		expect(abortedCase.scenarios[0].evaluatedCount).toBe(1);
+		const abortedRun = abortedCase.scenarios[0].runs[0];
+		expect(abortedRun.passed).toBe(false);
+		expect(abortedRun.score).toBe(0);
+		expect(abortedRun.failureCategory).toBe('framework_issue');
+		expect(abortedRun.rootCause).toContain('time budget');
+	});
+
+	it('matches the cross-repo golden fixture (minus the volatile timestamp/duration)', async () => {
+		const runEval = async (partialResults: WorkflowTestCaseResult[][]) => {
+			partialResults.push(partialIteration());
+			throw new Error('operation aborted due to timeout');
+		};
+
+		await expect(
+			runEvalAndPersist(
+				{
+					logger: silentLogger,
+					outputDir,
+					startTime: Date.now(),
+					iterations: 1,
+					tier: undefined,
+					commitSha: undefined,
+					rerun: undefined,
+					mcpBuildSpend: [],
+				},
+				runEval,
+			),
+		).rejects.toThrow(/aborted/);
+
+		const parsed = JSON.parse(readFileSync(join(outputDir, 'eval-results.json'), 'utf8'));
+		// timestamp + duration are wall-clock and can't be pinned; the rest is the
+		// contract the dispatcher parses.
+		delete parsed.timestamp;
+		delete parsed.duration;
+
+		const golden = JSON.parse(
+			readFileSync(join(__dirname, 'fixtures', 'eval-results.partial-abort.json'), 'utf8'),
+		);
+		expect(parsed).toEqual(golden);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -187,6 +187,10 @@ interface RunConfig {
 	 *  LangSmith experiment metadata and eval-results.json — the run's only spend
 	 *  record beyond raw session logs, for a suite that's manual-only due to cost. */
 	mcpBuildSpend: McpBuildSpend[];
+	/** Optional sink the direct loop pushes each completed iteration's results into
+	 *  as they finish, so an abort that rejects the run still leaves the caller
+	 *  (runEvalAndPersist) with the scenarios that already completed. */
+	partialResults?: WorkflowTestCaseResult[][];
 }
 
 /** Map eval CLI args to the shared MCP builder's settings. */
@@ -424,73 +428,67 @@ async function main(): Promise<void> {
 	const cleanupBuiltWorkflows =
 		args.deletePrebuiltWorkflows || (args.buildViaMcp && !args.keepWorkflows);
 
-	// Hoisted out of the try so the finally can guarantee an eval-results.json is
-	// written even if the run throws (a budget/timeout abort, a lane meltdown, an
-	// OOM). Without a file the dispatcher discards the whole run — including every
-	// scenario that already passed — so a partial file is strictly better.
-	let evaluation: MultiRunEvaluation | undefined;
-	let slugByTestCase: Map<WorkflowTestCase, string> | undefined;
 	const mcpBuildSpend: McpBuildSpend[] = [];
-	let resultsWritten = false;
+	const commitSha = process.env.LANGSMITH_REVISION_ID ?? process.env.GITHUB_SHA;
 
 	try {
 		const hasLangSmith = Boolean(process.env.LANGSMITH_API_KEY);
 
-		let experimentName: string | undefined;
-		let experimentUrl: string | undefined;
-		let outcome: ComparisonOutcome | undefined;
+		// runEvalAndPersist owns the always-write guarantee: it writes
+		// eval-results.json even if the run below throws (a budget/timeout abort, a
+		// lane meltdown, an OOM), aggregating whatever completed scenarios were
+		// pushed into `partialResults` so the dispatcher never finds no file.
+		const { evaluation, slugByTestCase, outcome, gate, jsonPath, prCommentPath } =
+			await runEvalAndPersist(
+				{
+					logger,
+					outputDir: args.outputDir,
+					startTime,
+					iterations: args.iterations,
+					tier: args.tier,
+					commitSha,
+					rerun: ciRerunHint(),
+					mcpBuildSpend,
+				},
+				async (partialResults) => {
+					if (hasLangSmith) {
+						logger.info('LangSmith API key detected, using evaluate() with experiment tracking');
+						const langsmithRun = await runWithLangSmith({
+							args,
+							lanes,
+							logger,
+							testCasesWithFiles,
+							prebuiltManifest,
+							cleanupBuiltWorkflows,
+							mcpBuildLogDir,
+							mcpBuildSpend,
+						});
+						return {
+							evaluation: langsmithRun.evaluation,
+							experimentName: langsmithRun.experimentName,
+							experimentUrl: langsmithRun.experimentUrl,
+							outcome: langsmithRun.outcome,
+							slugByTestCase: langsmithRun.slugByTestCase,
+						};
+					}
+					logger.info(
+						'No LANGSMITH_API_KEY, running direct loop (results in eval-results.json only)',
+					);
+					const directRun = await runDirectLoop({
+						args,
+						lanes,
+						logger,
+						testCasesWithFiles,
+						prebuiltManifest,
+						cleanupBuiltWorkflows,
+						mcpBuildLogDir,
+						mcpBuildSpend,
+						partialResults,
+					});
+					return { evaluation: directRun.evaluation, slugByTestCase: directRun.slugByTestCase };
+				},
+			);
 
-		if (hasLangSmith) {
-			logger.info('LangSmith API key detected, using evaluate() with experiment tracking');
-			const langsmithRun = await runWithLangSmith({
-				args,
-				lanes,
-				logger,
-				testCasesWithFiles,
-				prebuiltManifest,
-				cleanupBuiltWorkflows,
-				mcpBuildLogDir,
-				mcpBuildSpend,
-			});
-			evaluation = langsmithRun.evaluation;
-			experimentName = langsmithRun.experimentName;
-			experimentUrl = langsmithRun.experimentUrl;
-			outcome = langsmithRun.outcome;
-			slugByTestCase = langsmithRun.slugByTestCase;
-		} else {
-			logger.info('No LANGSMITH_API_KEY, running direct loop (results in eval-results.json only)');
-			const directRun = await runDirectLoop({
-				args,
-				lanes,
-				logger,
-				testCasesWithFiles,
-				prebuiltManifest,
-				cleanupBuiltWorkflows,
-				mcpBuildLogDir,
-				mcpBuildSpend,
-			});
-			evaluation = directRun.evaluation;
-			slugByTestCase = directRun.slugByTestCase;
-		}
-
-		const totalDuration = Date.now() - startTime;
-		const commitSha = process.env.LANGSMITH_REVISION_ID ?? process.env.GITHUB_SHA;
-		// Gated tiers report an absolute green verdict in place of the baseline comparison.
-		const gate = isGatedTier(args.tier) ? evaluateGate(evaluation, { slugByTestCase }) : undefined;
-		const { jsonPath, prCommentPath } = writeEvalResults(
-			evaluation,
-			totalDuration,
-			args.outputDir,
-			experimentName,
-			outcome,
-			commitSha,
-			slugByTestCase,
-			ciRerunHint(),
-			gate,
-			mcpBuildSpend,
-			experimentUrl,
-		);
-		resultsWritten = true;
 		console.log(`Results:    ${jsonPath}`);
 		console.log(`PR comment: ${prCommentPath}`);
 		const reportResults = flattenRunsForReport(evaluation);
@@ -524,33 +522,6 @@ async function main(): Promise<void> {
 			}
 		}
 	} finally {
-		// Never let the dispatcher find no results file. If the run threw before the
-		// happy-path write (a budget/timeout abort propagating past the per-case
-		// guard, an OOM, a lane meltdown), emit whatever aggregation we captured —
-		// aggregation already tolerates missing/incomplete entries, so partial input
-		// is safe and the already-passed scenarios survive. An empty evaluation is
-		// still better than nothing (the dispatcher distinguishes it from a crash).
-		if (!resultsWritten) {
-			try {
-				const { jsonPath } = writeEvalResults(
-					evaluation ?? { totalRuns: args.iterations, testCases: [] },
-					Date.now() - startTime,
-					args.outputDir,
-					undefined,
-					undefined,
-					process.env.LANGSMITH_REVISION_ID ?? process.env.GITHUB_SHA,
-					slugByTestCase,
-					ciRerunHint(),
-					undefined,
-					mcpBuildSpend,
-					undefined,
-				);
-				logger.error(`Eval run did not finish cleanly — wrote partial results to ${jsonPath}`);
-			} catch (writeError: unknown) {
-				logger.error(`Failed to write partial eval results: ${extractErrorMessage(writeError)}`);
-			}
-		}
-
 		// Per-lane cleanup: each lane only holds the workflows built/fetched on it,
 		// so delete them via that lane's own client (multi-lane MCP builds spread
 		// workflows across lanes; a single-lane cleanup would 404 on the rest).
@@ -1661,7 +1632,12 @@ async function runDirectLoop(config: RunConfig): Promise<{
 			);
 			const flat = laneResults.flat();
 			flat.sort((a, b) => a.origIdx - b.origIdx);
-			return flat.map((x) => x.result);
+			const iterationResults = flat.map((x) => x.result);
+			// Capture each iteration as it completes (source-ordered, full-length) so
+			// an abort in a LATER iteration still leaves runEvalAndPersist the ones
+			// that finished — every captured array is a complete, index-aligned row.
+			config.partialResults?.push(iterationResults);
+			return iterationResults;
 		}),
 	);
 
@@ -1792,7 +1768,104 @@ function ciRerunHint(): RerunHint | undefined {
 	};
 }
 
-function writeEvalResults(
+/** What `runEval` produces on success — the aggregation plus the LangSmith-only
+ *  comparison metadata (undefined in direct-loop mode). */
+export interface EvalRunOutput {
+	evaluation: MultiRunEvaluation;
+	experimentName?: string;
+	experimentUrl?: string;
+	outcome?: ComparisonOutcome;
+	slugByTestCase?: Map<WorkflowTestCase, string>;
+}
+
+export interface PersistEvalConfig {
+	logger: EvalLogger;
+	outputDir: string | undefined;
+	startTime: number;
+	iterations: number;
+	tier: CliArgs['tier'];
+	commitSha: string | undefined;
+	rerun: RerunHint | undefined;
+	mcpBuildSpend: McpBuildSpend[];
+}
+
+export interface PersistedEval extends EvalRunOutput {
+	gate: GateResult | undefined;
+	jsonPath: string;
+	prCommentPath: string;
+}
+
+/**
+ * Run the eval via `runEval` and ALWAYS persist eval-results.json +
+ * eval-pr-comment.md. On success returns the aggregation + write metadata so the
+ * caller can render the HTML report / terminal summary.
+ *
+ * If `runEval` throws — a per-iteration budget/timeout abort, a lane meltdown, an
+ * OOM — whatever it pushed into `partialResults` before throwing is aggregated
+ * and written before the error is re-thrown. Aggregation already tolerates
+ * missing/incomplete entries, so the scenarios that already completed survive
+ * instead of the dispatcher finding no file and discarding the entire run.
+ */
+export async function runEvalAndPersist(
+	config: PersistEvalConfig,
+	runEval: (partialResults: WorkflowTestCaseResult[][]) => Promise<EvalRunOutput>,
+): Promise<PersistedEval> {
+	const partialResults: WorkflowTestCaseResult[][] = [];
+	let persisted = false;
+	try {
+		const out = await runEval(partialResults);
+		// Gated tiers report an absolute green verdict in place of the baseline comparison.
+		const gate = isGatedTier(config.tier)
+			? evaluateGate(out.evaluation, { slugByTestCase: out.slugByTestCase })
+			: undefined;
+		const { jsonPath, prCommentPath } = writeEvalResults(
+			out.evaluation,
+			Date.now() - config.startTime,
+			config.outputDir,
+			out.experimentName,
+			out.outcome,
+			config.commitSha,
+			out.slugByTestCase,
+			config.rerun,
+			gate,
+			config.mcpBuildSpend,
+			out.experimentUrl,
+		);
+		persisted = true;
+		return { ...out, gate, jsonPath, prCommentPath };
+	} finally {
+		if (!persisted) {
+			try {
+				const evaluation: MultiRunEvaluation =
+					partialResults.length > 0
+						? aggregateResults(partialResults, partialResults.length)
+						: { totalRuns: config.iterations, testCases: [] };
+				const { jsonPath } = writeEvalResults(
+					evaluation,
+					Date.now() - config.startTime,
+					config.outputDir,
+					undefined,
+					undefined,
+					config.commitSha,
+					undefined,
+					config.rerun,
+					undefined,
+					config.mcpBuildSpend,
+					undefined,
+				);
+				config.logger.error(
+					`Eval run did not finish cleanly — wrote partial results (${String(partialResults.length)} iteration(s)) to ${jsonPath}`,
+				);
+			} catch (writeError: unknown) {
+				config.logger.error(
+					`Failed to write partial eval results: ${extractErrorMessage(writeError)}`,
+				);
+			}
+		}
+	}
+}
+
+export function writeEvalResults(
 	evaluation: MultiRunEvaluation,
 	duration: number,
 	outputDir: string | undefined,
@@ -1981,7 +2054,12 @@ async function tryRunComparison(config: {
 	}
 }
 
-main().catch((error) => {
-	console.error('Fatal error:', error);
-	process.exit(1);
-});
+// Only auto-run as the CLI entry point. Importing this module (e.g. from a unit
+// test that exercises the exported runEvalAndPersist / writeEvalResults seams)
+// must not kick off a real eval run against process.argv.
+if (!process.env.VITEST) {
+	main().catch((error) => {
+		console.error('Fatal error:', error);
+		process.exit(1);
+	});
+}

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -68,6 +68,7 @@ import {
 	type PrebuiltManifest,
 } from '../harness/prebuilt-workflows';
 import {
+	abortedWorkflowTestCaseResult,
 	buildWorkflow,
 	executeScenario,
 	cleanupBuild,
@@ -79,6 +80,7 @@ import {
 	type BuildResult,
 } from '../harness/runner';
 import {
+	classifyScenarioExecutionError,
 	extractErrorMessage,
 	isTransientNetworkError,
 	MAX_EXEC_ATTEMPTS,
@@ -422,15 +424,21 @@ async function main(): Promise<void> {
 	const cleanupBuiltWorkflows =
 		args.deletePrebuiltWorkflows || (args.buildViaMcp && !args.keepWorkflows);
 
+	// Hoisted out of the try so the finally can guarantee an eval-results.json is
+	// written even if the run throws (a budget/timeout abort, a lane meltdown, an
+	// OOM). Without a file the dispatcher discards the whole run — including every
+	// scenario that already passed — so a partial file is strictly better.
+	let evaluation: MultiRunEvaluation | undefined;
+	let slugByTestCase: Map<WorkflowTestCase, string> | undefined;
+	const mcpBuildSpend: McpBuildSpend[] = [];
+	let resultsWritten = false;
+
 	try {
 		const hasLangSmith = Boolean(process.env.LANGSMITH_API_KEY);
 
-		let evaluation: MultiRunEvaluation;
 		let experimentName: string | undefined;
 		let experimentUrl: string | undefined;
 		let outcome: ComparisonOutcome | undefined;
-		let slugByTestCase: Map<WorkflowTestCase, string> | undefined;
-		const mcpBuildSpend: McpBuildSpend[] = [];
 
 		if (hasLangSmith) {
 			logger.info('LangSmith API key detected, using evaluate() with experiment tracking');
@@ -482,6 +490,7 @@ async function main(): Promise<void> {
 			mcpBuildSpend,
 			experimentUrl,
 		);
+		resultsWritten = true;
 		console.log(`Results:    ${jsonPath}`);
 		console.log(`PR comment: ${prCommentPath}`);
 		const reportResults = flattenRunsForReport(evaluation);
@@ -515,6 +524,33 @@ async function main(): Promise<void> {
 			}
 		}
 	} finally {
+		// Never let the dispatcher find no results file. If the run threw before the
+		// happy-path write (a budget/timeout abort propagating past the per-case
+		// guard, an OOM, a lane meltdown), emit whatever aggregation we captured —
+		// aggregation already tolerates missing/incomplete entries, so partial input
+		// is safe and the already-passed scenarios survive. An empty evaluation is
+		// still better than nothing (the dispatcher distinguishes it from a crash).
+		if (!resultsWritten) {
+			try {
+				const { jsonPath } = writeEvalResults(
+					evaluation ?? { totalRuns: args.iterations, testCases: [] },
+					Date.now() - startTime,
+					args.outputDir,
+					undefined,
+					undefined,
+					process.env.LANGSMITH_REVISION_ID ?? process.env.GITHUB_SHA,
+					slugByTestCase,
+					ciRerunHint(),
+					undefined,
+					mcpBuildSpend,
+					undefined,
+				);
+				logger.error(`Eval run did not finish cleanly — wrote partial results to ${jsonPath}`);
+			} catch (writeError: unknown) {
+				logger.error(`Failed to write partial eval results: ${extractErrorMessage(writeError)}`);
+			}
+		}
+
 		// Per-lane cleanup: each lane only holds the workflows built/fetched on it,
 		// so delete them via that lane's own client (multi-lane MCP builds spread
 		// workflows across lanes; a single-lane cleanup would 404 on the rest).
@@ -987,6 +1023,27 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		const iteration = inputs._iteration ?? 0;
 		try {
 			return await targetRow(inputs, iteration);
+		} catch (error: unknown) {
+			// targetRow guards scenario execution internally, but a build-phase throw
+			// (getOrBuild) or a budget abort must not reject up to evaluate() and
+			// abort the whole experiment — that would discard every OTHER row's
+			// completed results. Record this row as an aborted (framework_issue)
+			// output instead so evaluate() finalizes and writeEvalResults still runs.
+			const message = extractErrorMessage(error);
+			logger.error(`    ERROR [${inputs.scenarioName}] (${inputs.testCaseFile}): ${message}`);
+			const classified = classifyScenarioExecutionError(message);
+			return {
+				buildSuccess: false,
+				passed: false,
+				score: 0,
+				reasoning: classified.reasoning,
+				failureCategory: classified.failureCategory,
+				rootCause: classified.rootCause,
+				execErrors: [message],
+				buildDurationMs: 0,
+				execDurationMs: 0,
+				nodeCount: 0,
+			};
 		} finally {
 			await releaseCaseRow(iteration, inputs.testCaseFile);
 		}
@@ -1091,18 +1148,22 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
 					continue;
 				}
-				// Mirror direct mode's per-scenario guard — without this, n8n API errors
-				// or verifier timeouts from executeWithLlmMock / verifyChecklist would
-				// escape to LangSmith, come back as a Run with null outputs, and be
-				// misclassified as builder regressions by the feedback extractor.
+				// Mirror direct mode's per-scenario guard — without this, n8n API errors,
+				// verifier timeouts, or a per-iteration budget abort from
+				// executeWithLlmMock / verifyChecklist would escape to LangSmith, come
+				// back as a Run with null outputs, and be misclassified as builder
+				// regressions by the feedback extractor. classifyScenarioExecutionError
+				// stamps framework_issue + a timeout-flavoured rootCause for budget aborts.
 				logger.error(`    ERROR [${scenario.name}]: ${errorMessage}`);
+				const classified = classifyScenarioExecutionError(errorMessage);
 				return await attachExpectations({
 					buildSuccess: true,
 					workflowId: build.workflowId,
 					passed: false,
 					score: 0,
-					reasoning: `Scenario execution error: ${errorMessage}`,
-					failureCategory: 'framework_issue',
+					reasoning: classified.reasoning,
+					failureCategory: classified.failureCategory,
+					rootCause: classified.rootCause,
 					execErrors: [errorMessage],
 					buildDurationMs,
 					execDurationMs: Date.now() - execStart,
@@ -1558,29 +1619,40 @@ async function runDirectLoop(config: RunConfig): Promise<{
 								tc.fileSlug,
 								iter,
 							);
-							const result = await runWorkflowTestCase({
-								client: lane.client,
-								baseUrl: lane.baseUrl,
-								testCase: tc.testCase,
-								timeoutMs: args.timeoutMs,
-								createdCredentialIds: lane.createdCredentialIds,
-								preRunWorkflowIds: lane.preRunWorkflowIds,
-								claimedWorkflowIds: lane.claimedWorkflowIds,
-								logger,
-								keepWorkflows: args.keepWorkflows,
-								laneTag,
-								prebuiltWorkflowId,
-								pinAiRoots: args.pinAiRoots,
-							});
-							if (
-								prebuiltWorkflowId !== undefined &&
-								cleanupBuiltWorkflows &&
-								result.workflowBuildSuccess &&
-								result.workflowId
-							) {
-								lane.workflowIdsToDelete.add(result.workflowId);
+							try {
+								const result = await runWorkflowTestCase({
+									client: lane.client,
+									baseUrl: lane.baseUrl,
+									testCase: tc.testCase,
+									timeoutMs: args.timeoutMs,
+									createdCredentialIds: lane.createdCredentialIds,
+									preRunWorkflowIds: lane.preRunWorkflowIds,
+									claimedWorkflowIds: lane.claimedWorkflowIds,
+									logger,
+									keepWorkflows: args.keepWorkflows,
+									laneTag,
+									prebuiltWorkflowId,
+									pinAiRoots: args.pinAiRoots,
+								});
+								if (
+									prebuiltWorkflowId !== undefined &&
+									cleanupBuiltWorkflows &&
+									result.workflowBuildSuccess &&
+									result.workflowId
+								) {
+									lane.workflowIdsToDelete.add(result.workflowId);
+								}
+								return result;
+							} catch (error: unknown) {
+								// runWorkflowTestCase guards its own scenario loop, but a throw
+								// from the build phase (or a per-iteration budget abort) would
+								// otherwise reject runWithConcurrency and take every OTHER case's
+								// completed results down with it. Record this one case as an
+								// aborted (framework_issue) result and keep the batch alive.
+								const message = extractErrorMessage(error);
+								logger.error(`  ERROR running ${tc.fileSlug}${laneTag}: ${message}`);
+								return abortedWorkflowTestCaseResult(tc.testCase, lane.baseUrl, message);
 							}
-							return result;
 						},
 						MAX_CONCURRENT_BUILDS,
 					);

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -34,6 +34,7 @@ import { reconstructSeedFromThread, type SeedThreadRef } from './langsmith-seed'
 import { type EvalLogger } from './logger';
 import { fetchPrebuiltBuild } from './prebuilt-workflows';
 import {
+	classifyScenarioExecutionError,
 	extractErrorMessage,
 	isTransientExecutionAbort,
 	MAX_EXEC_ATTEMPTS,
@@ -265,6 +266,35 @@ interface WorkflowTestCaseConfig {
 }
 
 /**
+ * Synthetic result for a test case whose run threw before it could produce one
+ * (a budget/timeout abort, a lane meltdown, an OOM). Recording it — instead of
+ * letting the throw reject the batch — keeps every OTHER case's already-completed
+ * results, and keeps this case index-aligned so the aggregator counts it rather
+ * than losing the whole run. One `framework_issue` row per declared scenario
+ * carries the pinned cross-repo contract (timeout-flavoured rootCause for budget
+ * aborts) so the lang-tracer side buckets it as infra, not product quality.
+ */
+export function abortedWorkflowTestCaseResult(
+	testCase: WorkflowTestCase,
+	baseUrl: string,
+	errorMessage: string,
+): WorkflowTestCaseResult {
+	const classified = classifyScenarioExecutionError(errorMessage);
+	return {
+		testCase,
+		workflowBuildSuccess: false,
+		buildError: errorMessage,
+		n8nBaseUrl: baseUrl,
+		executionScenarioResults: (testCase.executionScenarios ?? []).map((scenario) => ({
+			scenario,
+			success: false,
+			score: 0,
+			...classified,
+		})),
+	};
+}
+
+/**
  * All-in-one test case runner: build workflow + run all scenarios + cleanup.
  * Used by the CLI. The split API (buildWorkflow + executeScenario + cleanupBuild)
  * is available for custom orchestration (e.g. LangSmith evaluate).
@@ -442,16 +472,18 @@ export async function runWorkflowTestCase(
 					}
 					// executeScenario categorizes builder/mock/verification failures
 					// internally; an error escaping it is an infra/framework problem
-					// (network drop, n8n API error, verifier timeout). Tag it
-					// framework_issue so the report and baseline keep it out of builder
-					// regressions instead of scoring it as an uncategorized failure.
+					// (network drop, n8n API error, verifier timeout, per-iteration
+					// budget abort). Tag it framework_issue — with a timeout-flavoured
+					// rootCause when it's a budget abort — so the report and baseline
+					// keep it out of builder regressions instead of scoring it as an
+					// uncategorized failure, and this one timed-out scenario doesn't
+					// take the whole case's already-completed scenarios down with it.
 					logger.error(`    ERROR [${scenario.name}]: ${errorMessage}`);
 					return {
 						scenario,
 						success: false,
 						score: 0,
-						reasoning: `Scenario execution error: ${errorMessage}`,
-						failureCategory: 'framework_issue',
+						...classifyScenarioExecutionError(errorMessage),
 					} satisfies ExecutionScenarioResult;
 				}
 			}

--- a/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/transient-error.ts
@@ -61,6 +61,37 @@ export function shouldRetryScenarioExecution(message: string, attempt: number): 
 }
 
 /**
+ * Marker prefix for the rootCause stamped on a scenario whose execution was
+ * aborted by the per-iteration budget/timeout. The lang-tracer side keys its
+ * `infra_incomplete` attribution off `failureCategory: "framework_issue"` plus
+ * a timeout-flavoured rootCause — keep the wording stable across both repos.
+ */
+export const BUDGET_TIMEOUT_ROOT_CAUSE =
+	'Scenario execution exceeded its per-iteration time budget and was aborted before a verdict';
+
+/**
+ * Classify an error thrown out of scenario execution into the report fields.
+ *
+ * Any error that escapes `executeScenario` (after its own retries) is an
+ * infra/framework problem, never an agent verdict, so it is always
+ * `framework_issue`. A budget/timeout abort additionally carries a
+ * timeout-flavoured `rootCause` so partial-result consumers can route it to an
+ * infra/incomplete bucket instead of counting it against product quality.
+ */
+export function classifyScenarioExecutionError(errorMessage: string): {
+	failureCategory: 'framework_issue';
+	rootCause: string | undefined;
+	reasoning: string;
+} {
+	const timedOut = isExecutionTimeout(errorMessage);
+	return {
+		failureCategory: 'framework_issue',
+		rootCause: timedOut ? `${BUDGET_TIMEOUT_ROOT_CAUSE}: ${errorMessage}` : undefined,
+		reasoning: `Scenario execution error: ${errorMessage}`,
+	};
+}
+
+/**
  * Eval-DB races abort an execution before any node runs. Two known shapes:
  * `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` and `Workflow <id> not
  * found or not accessible` (lookup misses that outlast the server's own 1.7s


### PR DESCRIPTION
## TRUST-310 (n8n) — never lose scenario results on a budget/timeout abort

Fixes [TRUST-310](https://linear.app/n8n/issue/TRUST-310) (n8n side). Long/complex cases blew the per-iteration budget (`effectiveTimeoutMs`, 1350s for complex) or hit an operation timeout, the CLI exited 1 **without writing** `eval-results.json`, and every scenario result was discarded — including ones that had already passed.

### What changed (all under `packages/@n8n/instance-ai/evaluations/`)
- **`harness/transient-error.ts`** — new `classifyScenarioExecutionError()` + exported `BUDGET_TIMEOUT_ROOT_CAUSE`.
- **`harness/runner.ts`** — new `abortedWorkflowTestCaseResult()`; direct-loop scenario catch uses the classifier.
- **`cli/index.ts`** — `main()` `finally` write backstop; LangSmith `target()` / `targetRow` catches; `runDirectLoop` per-case guard.

Behaviour:
1. **Per-scenario isolation** — a timeout/abort becomes one `framework_issue` scenario result instead of rejecting; siblings survive.
2. **Never-lose-the-batch** — a build-phase throw becomes an index-aligned aborted result per scenario instead of dropping the whole case/experiment.
3. **Always-write** — `writeEvalResults` runs in a `finally`; aggregation already tolerates partial/incomplete entries.

### Contract for the lang-tracer side
Budget/timeout aborts are stamped `failureCategory: "framework_issue"` with `rootCause` beginning `"Scenario execution exceeded its per-iteration time budget and was aborted before a verdict:"`. The lang-tracer PR keys `infra_incomplete` off that prefix. Paired with `n8n-io/lang-tracer#trust-310-runner-incomplete-state`.

### Test plan
- New `__tests__/partial-results-abort.test.ts` (4) — a completed passing case aggregates alongside an aborted case (passCount preserved); the aborted scenario carries `framework_issue` + timeout rootCause. Typecheck clean.

Observed on n8n 2.31.1; CI sweeps #29/#30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34419">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

