### PR TITLE
fix(editor): Restore previous route when closing session trace

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionTimelineView.vue
@@ -340,6 +340,19 @@ function formatDate(fullDate: string): string {
 }
 
 function closeTimeline() {
+	/**
+	 * Get the last visited route from Vue router so we return to the correct starting point (e.g Preview)
+	 * If no state is available, it's most likey because the link was visited directly.
+	 * Here we fallback to default Agents view.
+	 */
+	const previousRoute = router.options.history.state.back;
+	const resolvedPreviousRoute =
+		typeof previousRoute === 'string' ? router.resolve(previousRoute) : null;
+
+	if (resolvedPreviousRoute?.matched.length) {
+		router.back();
+		return;
+	}
 	void router.push(agentExecutionsRoute.value);
 }
 


### PR DESCRIPTION
## Summary

Restore navigation to the previously visited route when closing the agent session trace view. If the session trace was opened directly or the previous route cannot be resolved, return to the default agent executions view.

## How to test

1. Open an agent session trace from the agent preview.
2. Close the session trace.
3. Confirm that the agent preview is restored.
4. Open a session trace directly in a new tab.
5. Close it and confirm that the agent executions view opens as the fallback.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-388

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->