### PR TITLE
fix(Gmail): Split multiple Reply-To addresses correctly

### DIFF
--- a/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/test/utils/replyToEmail.test.ts
@@ -629,4 +629,101 @@ describe('replyToEmail', () => {
 			}),
 		);
 	});
+
+	test('should split multiple comma-separated Reply-To addresses', async () => {
+		const messageWithMultipleReplyTo = {
+			...mockMessageMetadata,
+			payload: {
+				...mockMessageMetadata.payload,
+				headers: [
+					{ name: 'Subject', value: 'Original Subject' },
+					{ name: 'Message-ID', value: '<original@example.com>' },
+					{ name: 'From', value: 'John Doe <john@example.com>' },
+					{ name: 'To', value: 'recipient1@example.com' },
+					{ name: 'Reply-To', value: 'jacob@example.com, charles@example.com' },
+				],
+			},
+		};
+
+		mockedGoogleApiRequest
+			.mockResolvedValueOnce(messageWithMultipleReplyTo)
+			.mockResolvedValueOnce(mockUserProfile)
+			.mockResolvedValueOnce(mockSentMessage);
+
+		const options: IDataObject = {};
+
+		await replyToEmail.call(mockExecuteFunctions, 'message123', options, 0, 2.2);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('<jacob@example.com>'),
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				cc: expect.any(String),
+			}),
+		);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('<charles@example.com>'),
+			}),
+		);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('<recipient1@example.com>'),
+			}),
+		);
+	});
+
+	test('should split multiple Reply-To addresses with angle brackets', async () => {
+		const messageWithBracketedReplyTo = {
+			...mockMessageMetadata,
+			payload: {
+				...mockMessageMetadata.payload,
+				headers: [
+					{ name: 'Subject', value: 'Original Subject' },
+					{ name: 'Message-ID', value: '<original@example.com>' },
+					{ name: 'From', value: 'John Doe <john@example.com>' },
+					{ name: 'To', value: 'recipient1@example.com' },
+					{
+						name: 'Reply-To',
+						value: 'Jacob Smith <jacob@example.com>, Charles Brown <charles@example.com>',
+					},
+				],
+			},
+		};
+
+		mockedGoogleApiRequest
+			.mockResolvedValueOnce(messageWithBracketedReplyTo)
+			.mockResolvedValueOnce(mockUserProfile)
+			.mockResolvedValueOnce(mockSentMessage);
+
+		const options: IDataObject = {};
+
+		await replyToEmail.call(mockExecuteFunctions, 'message123', options, 0, 2.2);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('Jacob Smith <jacob@example.com>'),
+			}),
+		);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('Charles Brown <charles@example.com>'),
+			}),
+		);
+
+		expect(mockedEncodeEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				to: expect.stringContaining('<recipient1@example.com>'),
+			}),
+		);
+	});
 });

--- a/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/utils/replyToEmail.ts
@@ -106,12 +106,15 @@ export async function replyToEmail(
 	for (const header of payload.headers) {
 		const headerName = (header.name || '').toLowerCase();
 		if (headerName === replyToHeaderName && !replyToRecipientsOnly) {
-			const replyToEmail = header.value;
-			if (replyToEmail.includes('<') && replyToEmail.includes('>')) {
-				to.push(replyToEmail);
-			} else {
-				to.push(`<${replyToEmail}>`);
-			}
+			const replyToEmails = header.value;
+			replyToEmails.split(',').forEach((email: string) => {
+				const trimmedEmail = email.trim();
+				if (trimmedEmail.includes('<') && trimmedEmail.includes('>')) {
+					to.push(trimmedEmail);
+				} else {
+					to.push(`<${trimmedEmail}>`);
+				}
+			});
 		}
 
 		if (headerName === 'to' && !replyToSenderOnly) {


### PR DESCRIPTION
## Summary

Fixes Gmail Reply failing when the original email has multiple comma-separated `Reply-To` addresses.

Previously, the `Reply-To` header was passed as a single string without splitting by commas, resulting in a malformed address like `"jacob@example.com, charles@example.com"` being treated as one address. Now it correctly splits and processes each address separately, matching the existing behavior for `To` addresses.

Closes #34221

## How to test

1. Create a Gmail node configured to "Reply to" an email
2. Use an email that has multiple comma-separated `Reply-To` addresses (e.g., `jacob@example.com, charles@example.com`)
3. Execute the workflow — previously it failed, now it sends the reply successfully to all addresses

## Review / Merge checklist

- [x] Tests included — 2 new tests added for multiple comma-separated Reply-To addresses (plain and with angle brackets)
- [x] PR title follows [conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34424">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

