### PR TITLE
test(editor): Cover managed OAuth availability without node context

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/__tests__/useCredentialForm.test.ts
@@ -52,10 +52,24 @@ const privateOAuth: ICredentialType = {
 	],
 };
 
+// A managed OAuth type opted out of managed creation (skip-list) — the overwrite
+// exists but the managed option must not be offered.
+const skipManagedOAuth: ICredentialType = {
+	name: 'skipOAuth2Api',
+	displayName: 'Skip OAuth2 API',
+	__overwrittenProperties: ['clientId', 'clientSecret'],
+	__skipManagedCreation: true,
+	properties: [
+		{ displayName: 'Client ID', name: 'clientId', type: 'string', default: '' },
+		{ displayName: 'Client Secret', name: 'clientSecret', type: 'string', default: '' },
+	],
+};
+
 const typesByName: Record<string, ICredentialType> = {
 	httpBasicAuth,
 	acmeOAuth2Api: managedOAuth,
 	privateOAuth2Api: privateOAuth,
+	skipOAuth2Api: skipManagedOAuth,
 };
 
 describe('useCredentialForm', () => {
@@ -158,6 +172,29 @@ describe('useCredentialForm', () => {
 			const form = await loadPrivateCred();
 
 			expect(form.getChangedSharedFields({ clientId: 'id', clientSecret: 'secret' })).toEqual([]);
+		});
+	});
+
+	describe('managedOAuthAvailable', () => {
+		// Regression (IAM-853): opening a new credential from the Credentials tab has
+		// no node context, so managed availability must derive from the selected type
+		// directly (via its overwritten client fields), not only from the active node.
+		it('is true for an overwritten OAuth type with no node context', () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'acmeOAuth2Api' });
+
+			expect(form.managedOAuthAvailable.value).toBe(true);
+		});
+
+		it('is false for a type without overwritten client fields', () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'httpBasicAuth' });
+
+			expect(form.managedOAuthAvailable.value).toBe(false);
+		});
+
+		it('is false for a skip-list type even though it is overwritten', () => {
+			const form = useCredentialForm({ mode: 'new', activeId: 'skipOAuth2Api' });
+
+			expect(form.managedOAuthAvailable.value).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

IAM-853 (Managed/Custom OAuth2 selector missing when creating a credential from the Credentials tab) is already fixed on `master` — the fallback landed in #33432 and moved into `useCredentialForm` in #33566 — but that no-node path had no test coverage. This PR adds regression tests for `managedOAuthAvailable`: it must resolve managed OAuth from the selected credential type directly (the Credentials-tab path, which has no active node), stay `false` for non-overwritten types, and stay `false` for skip-list types.

## How to test

Run the composable tests: `cd packages/frontend/editor-ui && pnpm test src/features/credentials/composables/__tests__/useCredentialForm.test.ts`. To confirm the UX, start n8n with `CREDENTIALS_OVERWRITE_DATA='{"microsoftOAuth2Api":{"clientId":"x","clientSecret":"y"}}'`, then Credentials tab → Add credential → Microsoft Outlook OAuth2 API → the "Managed OAuth2 (recommended) / Custom OAuth2" selector should render.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-853

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34430">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

