### PR TITLE
fix(editor): Reconcile stale Instance AI run state on reload and stop

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -6,7 +6,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { mockedStore } from '@/__tests__/utils';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { fetchThreadMessages, fetchThreadStatus } from '../instanceAi.memory.api';
-import { ensureThread, postMessage, postConfirmation } from '../instanceAi.api';
+import { ensureThread, postMessage, postCancel, postConfirmation } from '../instanceAi.api';
 import { createThreadRuntime, type ThreadRuntime } from '../instanceAi.threadRuntime';
 
 // ---------------------------------------------------------------------------
@@ -218,6 +218,7 @@ const mockFetchThreadMessages = vi.mocked(fetchThreadMessages);
 const mockFetchThreadStatus = vi.mocked(fetchThreadStatus);
 const mockEnsureThread = vi.mocked(ensureThread);
 const mockPostMessage = vi.mocked(postMessage);
+const mockPostCancel = vi.mocked(postCancel);
 const mockPostConfirmation = vi.mocked(postConfirmation);
 
 beforeAll(() => {
@@ -1299,6 +1300,176 @@ describe('createThreadRuntime - loadThreadStatus and HITL reconnect', () => {
 		await runtime.confirmAction('req-deny', { kind: 'approval', approved: false });
 
 		expect(runtime.activeRunId).toBeNull();
+	});
+
+	test('cancelRun posts thread cancellation without an activeRunId', async () => {
+		const runtime = activeRuntime(registry);
+		expect(runtime.activeRunId).toBeNull();
+		mockPostCancel.mockResolvedValueOnce(undefined);
+		mockFetchThreadStatus.mockResolvedValue({
+			hasActiveRun: false,
+			isSuspended: false,
+			backgroundTasks: [],
+		});
+
+		await runtime.cancelRun();
+
+		expect(mockPostCancel).toHaveBeenCalledWith(
+			expect.objectContaining({ baseUrl: 'http://localhost:5678/api' }),
+			activeThreadId,
+		);
+		expect(mockFetchThreadStatus).toHaveBeenCalledOnce();
+	});
+
+	test('loadThreadStatus settles stale hydrated agent trees when the backend is idle', async () => {
+		const runtime = activeRuntime(registry);
+		runtime.messages = [
+			{
+				id: 'msg-1',
+				role: 'assistant',
+				runId: 'run-stale',
+				content: '',
+				reasoning: '',
+				isStreaming: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				agentTree: {
+					agentId: 'agent-root',
+					role: 'orchestrator',
+					status: 'active',
+					textContent: '',
+					reasoning: '',
+					toolCalls: [{ toolCallId: 'tc-root', toolName: 'workflows', args: {}, isLoading: true }],
+					children: [
+						{
+							agentId: 'agent-child',
+							role: 'agent-builder',
+							status: 'active',
+							textContent: '',
+							reasoning: '',
+							toolCalls: [
+								{ toolCallId: 'tc-child', toolName: 'build-workflow', args: {}, isLoading: true },
+							],
+							children: [],
+							timeline: [],
+						},
+					],
+					timeline: [],
+				},
+			},
+		];
+		mockFetchThreadStatus.mockResolvedValue({
+			hasActiveRun: false,
+			isSuspended: false,
+			backgroundTasks: [],
+		});
+
+		await runtime.loadThreadStatus();
+
+		expect(runtime.activeRunId).toBeNull();
+		const [message] = runtime.messages;
+		expect(message.isStreaming).toBe(false);
+		expect(message.agentTree?.status).toBe('cancelled');
+		expect(message.agentTree?.toolCalls[0].isLoading).toBe(false);
+		const [child] = message.agentTree?.children ?? [];
+		expect(child.status).toBe('cancelled');
+		expect(child.toolCalls[0].isLoading).toBe(false);
+	});
+
+	test('loadThreadStatus preserves active trees and restores activeRunId for a live run', async () => {
+		const runtime = activeRuntime(registry);
+		runtime.messages = [
+			{
+				id: 'msg-1',
+				role: 'assistant',
+				runId: 'run-live',
+				content: '',
+				reasoning: '',
+				isStreaming: false,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				agentTree: {
+					agentId: 'agent-root',
+					role: 'orchestrator',
+					status: 'active',
+					textContent: '',
+					reasoning: '',
+					toolCalls: [{ toolCallId: 'tc-root', toolName: 'workflows', args: {}, isLoading: true }],
+					children: [],
+					timeline: [],
+				},
+			},
+		];
+		mockFetchThreadStatus.mockResolvedValue({
+			hasActiveRun: true,
+			isSuspended: false,
+			runId: 'run-live',
+			backgroundTasks: [],
+		});
+
+		await runtime.loadThreadStatus();
+
+		expect(runtime.activeRunId).toBe('run-live');
+		const [message] = runtime.messages;
+		expect(message.isStreaming).toBe(true);
+		expect(message.agentTree?.status).toBe('active');
+		expect(message.agentTree?.toolCalls[0].isLoading).toBe(true);
+	});
+
+	test('loadThreadStatus ignores an idle response after a newer run starts', async () => {
+		const runtime = activeRuntime(registry);
+		runtime.messages = [
+			{
+				id: 'msg-1',
+				role: 'assistant',
+				runId: 'run-old',
+				content: '',
+				reasoning: '',
+				isStreaming: true,
+				createdAt: '2026-01-01T00:00:00.000Z',
+				agentTree: {
+					agentId: 'agent-root',
+					role: 'orchestrator',
+					status: 'active',
+					textContent: '',
+					reasoning: '',
+					toolCalls: [{ toolCallId: 'tc-root', toolName: 'workflows', args: {}, isLoading: true }],
+					children: [],
+					timeline: [],
+				},
+			},
+		];
+		let resolveStatus: ((value: Awaited<ReturnType<typeof fetchThreadStatus>>) => void) | undefined;
+		mockFetchThreadStatus.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveStatus = resolve;
+			}),
+		);
+
+		const statusPromise = runtime.loadThreadStatus();
+
+		mockPostMessage.mockResolvedValueOnce({ runId: 'run-new' });
+		await runtime.sendMessage('new request');
+		expect(runtime.activeRunId).toBe('run-new');
+
+		resolveStatus?.({ hasActiveRun: false, isSuspended: false, backgroundTasks: [] });
+		await statusPromise;
+
+		expect(runtime.activeRunId).toBe('run-new');
+		const [message] = runtime.messages;
+		expect(message.agentTree?.status).toBe('active');
+		expect(message.agentTree?.toolCalls[0].isLoading).toBe(true);
+	});
+
+	test('cancelRun shows an actionable error when cancellation fails', async () => {
+		const runtime = activeRuntime(registry);
+		mockPostCancel.mockRejectedValueOnce(new Error('network'));
+
+		await runtime.cancelRun();
+
+		expect(mockShowError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: 'Failed to cancel. Try again.' }),
+			'Cancel failed',
+		);
+		expect(mockFetchThreadStatus).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -165,6 +165,21 @@ function hasUnresolvedConfirmation(
 	return node.children.some((child) => hasUnresolvedConfirmation(child, resolved));
 }
 
+/** Settle persisted activity only after thread status confirms there is no live work. */
+function settleStaleAgentTree(node: InstanceAiAgentNode): void {
+	if (node.status === 'active') {
+		node.status = 'cancelled';
+	}
+	for (const tc of node.toolCalls) {
+		if (tc.isLoading) {
+			tc.isLoading = false;
+		}
+	}
+	for (const child of node.children) {
+		settleStaleAgentTree(child);
+	}
+}
+
 function findLatestTasksFromMessages(messages: InstanceAiMessage[]): TaskList | null {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const tasks = messages[i].agentTree?.tasks;
@@ -944,20 +959,37 @@ export function createThreadRuntime(
 	}
 
 	async function loadThreadStatus(): Promise<void> {
+		const runIdAtRequest = activeRunId.value;
 		try {
 			const status = await fetchThreadStatusApi(rootStore.restApiContext, threadId);
 
-			const hasActivity = isOrchestratorLive(status) || status.backgroundTasks.length > 0;
-			if (!hasActivity) return;
-
-			const runId = syncLiveRunFromStatus(status, messages.value);
-			if (runId) {
-				activeRunId.value = runId;
-				triggerRef(messages);
+			// A newer local run started while this request was in flight — this
+			// response is stale and must not clobber it.
+			if (activeRunId.value !== runIdAtRequest && activeRunId.value !== (status.runId ?? null)) {
+				return;
 			}
 
-			// Background task visibility is handled by the run-sync control frame
-			// that is sent on SSE connect. No need to inject children directly here.
+			if (isOrchestratorLive(status)) {
+				const runId = syncLiveRunFromStatus(status, messages.value);
+				if (runId) {
+					activeRunId.value = runId;
+					triggerRef(messages);
+				}
+				return;
+			}
+
+			activeRunId.value = null;
+
+			// Background work is still visible via SSE run-sync on reconnect —
+			// settling trees here would race with that authoritative snapshot.
+			if (status.backgroundTasks.length > 0) return;
+
+			for (const message of messages.value) {
+				if (message.role !== 'assistant') continue;
+				message.isStreaming = false;
+				if (message.agentTree) settleStaleAgentTree(message.agentTree);
+			}
+			triggerRef(messages);
 		} catch {
 			// Silently ignore
 		}
@@ -1072,13 +1104,15 @@ export function createThreadRuntime(
 	}
 
 	async function cancelRun(): Promise<void> {
-		if (!activeRunId.value) return;
 		try {
 			await postCancel(rootStore.restApiContext, threadId);
-			// Don't clear activeRunId here — wait for the run-finish event via SSE
 		} catch {
 			toast.showError(new Error('Failed to cancel. Try again.'), 'Cancel failed');
+			return;
 		}
+		// Cancel is idempotent, so an already-dead run emits no run-finish SSE —
+		// re-check authoritative status to settle stale local state either way.
+		await loadThreadStatus();
 	}
 
 	/** Cancel a specific background task. */


### PR DESCRIPTION
## Summary

Instance AI's Stop button and reload/reconnect flow can leave an agent build looking stuck even when the backend run is already gone:

- `cancelRun()` silently did nothing when the frontend had lost its local run id (e.g. after a reload), so Stop sent no request at all.
- After hydration, `loadThreadStatus()` only ever restored a live run — when the backend reported the thread fully idle, hydrated agent trees left `active`/loading from a previous session were never settled.

This PR makes cancellation thread-scoped from the frontend's perspective and makes status reconciliation bidirectional:

- `cancelRun()` always calls the existing idempotent `POST /chat/:threadId/cancel` endpoint, then re-checks authoritative status to reconcile local state (an already-dead run emits no `run-finish` SSE to react to).
- `loadThreadStatus()` now: restores `activeRunId` and streaming state when the backend reports a live run (unchanged), clears `activeRunId` when idle, and — only when there are no background tasks either — recursively settles any stale `active` nodes/loading tool calls left over in hydrated messages.
- A stale status response race (started before a newer message/run began) is detected and ignored so it can't clobber a newer run.
- Live/suspended runs are left untouched — the UI only ever settles state once the backend has confirmed there's no live work.

Backend cancellation/status APIs were already correct (thread-scoped, idempotent, multi-main aware); no backend changes were needed.

## How to test

Automated:

```bash
cd packages/frontend/editor-ui
pnpm test src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts -t "cancelRun posts thread cancellation without an activeRunId|loadThreadStatus settles stale hydrated agent trees when the backend is idle|loadThreadStatus preserves active trees and restores activeRunId for a live run|loadThreadStatus ignores an idle response after a newer run starts|cancelRun shows an actionable error when cancellation fails"
```

Manual:

1. Start n8n with the `agents` and `instance-ai` modules enabled and required model configuration.
2. Ask Instance AI to build an agent and let it reach a long-running step.
3. Reload the page mid-build, then reload again once the backend run has actually finished/died.
4. Verify Stop reliably stops an in-progress build, and that stale activity indicators clear on reload once the backend confirms the thread is idle — instead of staying stuck.

Also verified package lint and typecheck.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-424

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

