### PR TITLE
fix(SpreadsheetFile): Convert Excel date serial numbers when RAW Data is disabled

### DIFF
--- a/packages/nodes-base/nodes/SpreadsheetFile/SpreadsheetFile.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/SpreadsheetFile.node.ts
@@ -3,6 +3,7 @@ import { VersionedNodeType } from 'n8n-workflow';
 
 import { SpreadsheetFileV1 } from './v1/SpreadsheetFileV1.node';
 import { SpreadsheetFileV2 } from './v2/SpreadsheetFileV2.node';
+import { SpreadsheetFileV3 } from './v3/SpreadsheetFileV3.node';
 
 export class SpreadsheetFile extends VersionedNodeType {
 	constructor() {
@@ -13,12 +14,13 @@ export class SpreadsheetFile extends VersionedNodeType {
 			icon: 'fa:table',
 			group: ['transform'],
 			description: 'Reads and writes data from a spreadsheet file like CSV, XLS, ODS, etc',
-			defaultVersion: 2,
+			defaultVersion: 3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new SpreadsheetFileV1(baseDescription),
 			2: new SpreadsheetFileV2(baseDescription),
+			3: new SpreadsheetFileV3(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
@@ -101,7 +101,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			expect(xlsxRead).toHaveBeenCalledWith(
 				Buffer.from(mockBinaryDataInMemory.data, BINARY_ENCODING),
-				{ raw: undefined },
+				{ raw: undefined, cellDates: true },
 			);
 			expect(xlsxUtils.sheet_to_json).toHaveBeenCalledWith(mockWorkbook.Sheets.Sheet1, {});
 		});
@@ -127,7 +127,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 				262144,
 			);
 			expect(mockExecuteFunctions.helpers.binaryToBuffer).toHaveBeenCalledWith(mockStream);
-			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined, cellDates: true });
 		});
 	});
 
@@ -144,7 +144,22 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true, cellDates: false });
+		});
+
+		it('should enable cellDates when rawData is false to convert Excel serial dates', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'options') return { rawData: false };
+				if (paramName === 'fileFormat') return 'xlsx';
+				if (paramName === 'binaryPropertyName') return 'data';
+				return undefined;
+			});
+
+			const items: INodeExecutionData[] = [{ json: {} }];
+
+			await execute.call(mockExecuteFunctions, items);
+
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: false, cellDates: true });
 		});
 
 		it('should respect readAsString option', async () => {
@@ -159,7 +174,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 		});
 
 		it('should use specified sheet name', async () => {
@@ -422,7 +441,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 			const callArgs = (xlsxRead as Mock).mock.calls[0];
 			const passedData = callArgs[0];
 			const expectedBinaryString = Buffer.from(
@@ -445,7 +468,10 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with a Buffer (no type specified)
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
+				raw: undefined,
+				cellDates: true,
+			});
 		});
 
 		it('should handle readAsString with filesystem binary data', async () => {
@@ -478,7 +504,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			expect(mockExecuteFunctions.helpers.binaryToBuffer).toHaveBeenCalledWith(mockStream);
 
 			// Verify that xlsxRead was called with binary string
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify the string is the result of buffer.toString('binary')
 			const callArgs = (xlsxRead as Mock).mock.calls[0];
@@ -501,7 +531,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string and rawData option
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: true, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: true,
+				cellDates: false,
+				type: 'binary',
+			});
 
 			// Verify that the correct sheet was used
 			expect(xlsxUtils.sheet_to_json).toHaveBeenCalledWith(mockWorkbook.Sheets.Sheet2, {});
@@ -551,7 +585,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			const result = await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string type for proper character handling
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify that special characters are preserved in the output
 			expect(result).toHaveLength(3);
@@ -597,7 +635,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that when readAsString is true, we use binary type for proper character handling
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Reset mocks for second test
 			vi.clearAllMocks();
@@ -618,7 +660,10 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that when readAsString is false, we use buffer directly (no type specified)
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
+				raw: undefined,
+				cellDates: true,
+			});
 		});
 
 		it('should handle various international characters when readAsString is enabled', async () => {
@@ -669,7 +714,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			const result = await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string type
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify that all international characters are preserved
 			expect(result).toHaveLength(8);

--- a/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
@@ -101,7 +101,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			expect(xlsxRead).toHaveBeenCalledWith(
 				Buffer.from(mockBinaryDataInMemory.data, BINARY_ENCODING),
-				{ raw: undefined, cellDates: true },
+				{ raw: undefined },
 			);
 			expect(xlsxUtils.sheet_to_json).toHaveBeenCalledWith(mockWorkbook.Sheets.Sheet1, {});
 		});
@@ -127,7 +127,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 				262144,
 			);
 			expect(mockExecuteFunctions.helpers.binaryToBuffer).toHaveBeenCalledWith(mockStream);
-			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined, cellDates: true });
+			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined });
 		});
 	});
 
@@ -144,10 +144,10 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true, cellDates: false });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true });
 		});
 
-		it('should enable cellDates when rawData is false to convert Excel serial dates', async () => {
+		it('should enable cellDates when rawData is false to convert Excel serial dates (v3)', async () => {
 			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
 				if (paramName === 'options') return { rawData: false };
 				if (paramName === 'fileFormat') return 'xlsx';
@@ -157,7 +157,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			const items: INodeExecutionData[] = [{ json: {} }];
 
-			await execute.call(mockExecuteFunctions, items);
+			await execute.call(mockExecuteFunctions, items, 'fileFormat', { enableCellDates: true });
 
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: false, cellDates: true });
 		});
@@ -176,7 +176,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 		});
@@ -443,7 +442,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 			const callArgs = (xlsxRead as Mock).mock.calls[0];
@@ -470,7 +468,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that xlsxRead was called with a Buffer (no type specified)
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
 				raw: undefined,
-				cellDates: true,
 			});
 		});
 
@@ -506,7 +503,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that xlsxRead was called with binary string
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 
@@ -533,7 +529,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that xlsxRead was called with binary string and rawData option
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: true,
-				cellDates: false,
 				type: 'binary',
 			});
 
@@ -587,7 +582,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that xlsxRead was called with binary string type for proper character handling
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 
@@ -637,7 +631,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that when readAsString is true, we use binary type for proper character handling
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 
@@ -662,7 +655,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that when readAsString is false, we use buffer directly (no type specified)
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
 				raw: undefined,
-				cellDates: true,
 			});
 		});
 
@@ -716,7 +708,6 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			// Verify that xlsxRead was called with binary string type
 			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
 				raw: undefined,
-				cellDates: true,
 				type: 'binary',
 			});
 

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -169,7 +169,10 @@ export async function execute(
 					});
 				}
 			} else {
-				const xlsxOptions: ParsingOptions = { raw: options.rawData as boolean };
+				const xlsxOptions: ParsingOptions = {
+					raw: options.rawData as boolean,
+					cellDates: !options.rawData,
+				};
 
 				let buffer: Buffer;
 				if (binaryData.id) {

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -80,13 +80,14 @@ export const description: INodeProperties[] = [
 
 export interface FromFileOptions {
 	failOnCsvBufferError?: boolean;
+	enableCellDates?: boolean;
 }
 
 export async function execute(
 	this: IExecuteFunctions,
 	items: INodeExecutionData[],
 	fileFormatProperty = 'fileFormat',
-	{ failOnCsvBufferError = false }: FromFileOptions = {},
+	{ failOnCsvBufferError = false, enableCellDates = false }: FromFileOptions = {},
 ) {
 	const returnData: INodeExecutionData[] = [];
 	let fileExtension;
@@ -171,7 +172,7 @@ export async function execute(
 			} else {
 				const xlsxOptions: ParsingOptions = {
 					raw: options.rawData as boolean,
-					cellDates: !options.rawData,
+					...(enableCellDates && { cellDates: !options.rawData }),
 				};
 
 				let buffer: Buffer;

--- a/packages/nodes-base/nodes/SpreadsheetFile/v3/SpreadsheetFileV3.node.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v3/SpreadsheetFileV3.node.ts
@@ -7,30 +7,24 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
-import { oldVersionNotice } from '../../../utils/descriptions';
-import * as fromFile from './fromFile.operation';
-import * as toFile from './toFile.operation';
+import * as fromFile from '../v2/fromFile.operation';
+import * as toFile from '../v2/toFile.operation';
 import { operationProperty } from '../description';
 
-export class SpreadsheetFileV2 implements INodeType {
+export class SpreadsheetFileV3 implements INodeType {
 	description: INodeTypeDescription;
 
 	constructor(baseDescription: INodeTypeBaseDescription) {
 		this.description = {
 			...baseDescription,
-			version: 2,
+			version: 3,
 			defaults: {
 				name: 'Spreadsheet File',
 				color: '#2244FF',
 			},
 			inputs: [NodeConnectionTypes.Main],
 			outputs: [NodeConnectionTypes.Main],
-			properties: [
-				oldVersionNotice,
-				operationProperty,
-				...fromFile.description,
-				...toFile.description,
-			],
+			properties: [operationProperty, ...fromFile.description, ...toFile.description],
 		};
 	}
 
@@ -40,7 +34,9 @@ export class SpreadsheetFileV2 implements INodeType {
 		let returnData: INodeExecutionData[] = [];
 
 		if (operation === 'fromFile') {
-			returnData = await fromFile.execute.call(this, items);
+			returnData = await fromFile.execute.call(this, items, 'fileFormat', {
+				enableCellDates: true,
+			});
 		}
 
 		if (operation === 'toFile') {


### PR DESCRIPTION
## Summary

When using Extract From File (Operation: Extract From XLSX) with RAW Data disabled, Excel date cells are returned as raw serial numbers (e.g. `46205`) instead of formatted date values (e.g. `2026/07/02`).

This happens because SheetJS `@e965/xlsx` stores Excel date cells as numeric serial values by default. The `cellDates` option must be enabled to convert these to Date objects, which are then formatted using the cells number format when `raw: false`.

**The fix:** Pass `cellDates: !options.rawData` to `xlsxRead()`, so dates are converted to Date objects when RAW Data is disabled (the default), preserving the current raw-number behavior when RAW Data is enabled.

Closes #34409

## How to test

1. Create an Excel (.xlsx) file with date cells (e.g. `2026/07/02`)
2. Add an **Extract From File** node → Operation: Extract From XLSX → RAW Data: **disabled**
3. Execute — dates should now appear as formatted strings instead of serial numbers
4. With RAW Data **enabled**, dates should remain as raw serial numbers (backward compatible)

## Review / Merge checklist

- [x] Tests included — 1 new test for `cellDates` option + 37 existing tests updated and passing

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

