### PR TITLE
test: Fix flaky Instance AI remediation guard skill narration assertion (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts
@@ -253,10 +253,15 @@ test.describe(
 						'When the build result reports that setup is required before verification, open the workflow setup card with workflows(action="setup") and stop editing.',
 				);
 
-				await expect(n8n.instanceAi.workflowSetup.getCard()).toBeVisible({ timeout: 540_000 });
+				// The skill-opening narration is surfaced transiently in the thinking
+				// trace while the orchestrator loads the workflow-builder skill, then
+				// collapses once the build completes. Assert it while the run is still
+				// in progress — before awaiting the terminal setup card.
 				await expect(
 					n8n.instanceAi.getAssistantMessageText('Opening skill: workflow-builder'),
-				).toBeVisible();
+				).toBeVisible({ timeout: 540_000 });
+
+				await expect(n8n.instanceAi.workflowSetup.getCard()).toBeVisible({ timeout: 540_000 });
 				await expect(n8n.instanceAi.getAssistantMessageText(TERMINAL_FALLBACK_TEXT)).toHaveCount(0);
 
 				const events = getLatestRecordingEvents(await getTraceEvents(api, testInfo));


### PR DESCRIPTION
## Summary

Fixes a flaky E2E test — `instance-ai-remediation-guard.spec.ts` › _"should preserve a submitted workflow when mocked credential verification needs setup"_ — that failed all 3 attempts on an unrelated PR ([run](https://github.com/n8n-io/n8n/actions/runs/29572644162/job/87861430136)).

### Root cause

The `"Opening skill: workflow-builder"` narration is produced by the orchestrator's `load_skill` tool call, but it renders **only transiently** in the `ThinkingBlock` subline — the subline shows the *tail* tool call's label, and only while the block is actively streaming (`v-if="props.active"`). Once the build completes, the thinking trace auto-collapses (`ThinkingBlock.vue`, `AgentSection.vue`) and the narration is no longer in the visible DOM.

The test asserted in this order:

1. Wait for the workflow-setup card (timeout 540s) — this only resolves **after** the build finishes and the trace has collapsed.
2. *Then* assert the narration is visible.

So by step 2 the narration was structurally guaranteed to be gone. It only ever passed when local timing happened to leave the block expanded — hence the intermittent behaviour.

### Fix

Assert the narration **while the run is still in progress** (before awaiting the terminal setup card), giving Playwright the full window to catch it while the thinking block is streaming the `load_skill` step. Intent is preserved — the FE still surfaces the skill-opening narration, and all downstream trace-summary assertions are unchanged.

## How to test

CI: `@capability:proxy` E2E on Shard 8 (`tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts`).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. (test-only fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

