### PR TITLE
fix(core): Self-heal orphaned trigger status rows on unpublish (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -51,6 +51,7 @@ import { WorkflowDependency } from './workflow-dependency-entity';
 import { WorkflowEntity } from './workflow-entity';
 import { WorkflowHistory } from './workflow-history';
 import {
+	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus,
 } from './workflow-publication-outbox';
@@ -110,6 +111,7 @@ export {
 	WorkflowHistory,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus,
+	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationTriggerStatus,
 	type WorkflowPublicationTriggerStatusType,
 	type WorkflowPublicationTriggerKind,

--- a/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
+++ b/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
@@ -2,6 +2,14 @@ import { Column, Entity, Index, PrimaryGeneratedColumn } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
 
+/**
+ * `publishedVersionId` value for records enqueued to unpublish a workflow that
+ * no longer has an `activeVersionId` to carry (the column is NOT NULL). Inert:
+ * the applier dispatches an unpublish on the workflow's null `activeVersionId`
+ * and never reads the record's version.
+ */
+export const UNPUBLISH_VERSION_SENTINEL = '__unpublish__';
+
 export const WorkflowPublicationOutboxStatus = {
 	Pending: 'pending',
 	InProgress: 'in_progress',

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -161,12 +161,13 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 	}
 
 	/**
-	 * Enqueue a pending publication record for each given workflow that is active
-	 * and non-archived, at its current active version, in a single statement.
-	 * Workflows that are inactive, archived, or absent are skipped. Idempotent via
-	 * the same partial-unique-index upsert as {@link enqueue}, so the enqueued
-	 * version is always the canonical `activeVersionId`. Used by reconciliation to
-	 * re-publish workflows whose triggers went missing in memory.
+	 * Enqueue a pending publication record for each given workflow that still
+	 * exists, in a single statement. Used by reconciliation, which must be able to
+	 * enqueue whatever its detection returns — refusing a workflow here would
+	 * re-detect it on every pass forever. Published workflows are enqueued at
+	 * their canonical `activeVersionId`; unpublished (including archived) ones get
+	 * an unpublish record that clears their stale trigger-status rows. Idempotent
+	 * via the same partial-unique-index upsert as {@link enqueue}.
 	 */
 	async enqueueByWorkflowIds(workflowIds: string[]): Promise<void> {
 		if (workflowIds.length === 0) return;
@@ -183,11 +184,15 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const outboxTableName = this.getTableName('workflow_publication_outbox');
 		const workflowTableName = this.getTableName('workflow_entity');
 
+		// COALESCE: an unpublished workflow has no `activeVersionId`, but the column
+		// is NOT NULL. The fallback is inert — the applier dispatches an unpublish
+		// on the workflow's null `activeVersionId` and never reads the record's
+		// version. (Mirrored in the sqlite variant below.)
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", w."activeVersionId", '${Status.Pending}'
+			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'
 			 FROM ${workflowTableName} w
-			 WHERE w."id" = ANY($1) AND w."activeVersionId" IS NOT NULL AND w."isArchived" = false
+			 WHERE w."id" = ANY($1)
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
 			 DO UPDATE SET "publishedVersionId" = EXCLUDED."publishedVersionId", "updatedAt" = CURRENT_TIMESTAMP(3)`,
 			[workflowIds],
@@ -201,9 +206,9 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", w."activeVersionId", '${Status.Pending}'
+			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'
 			 FROM ${workflowTableName} w
-			 WHERE w."id" IN (${placeholders}) AND w."activeVersionId" IS NOT NULL AND w."isArchived" = 0
+			 WHERE w."id" IN (${placeholders})
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
 			 DO UPDATE SET "publishedVersionId" = excluded."publishedVersionId", "updatedAt" = STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')`,
 			workflowIds,

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -189,10 +189,11 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		// on the workflow's null `activeVersionId` and never reads the record's
 		// version. (Mirrored in the sqlite variant below.)
 		//
-		// DO NOTHING, unlike `enqueue`: reconciliation only targets workflows with
-		// no in-flight record at detection time, so a conflicting pending record
-		// can only come from a concurrent publish/unpublish — it is at least as
-		// fresh as this statement's snapshot and must not be overwritten.
+		// DO NOTHING, unlike `enqueue`: reconciliation's detection and this enqueue
+		// are two separate statements, so a publish/unpublish can commit a pending
+		// record in the gap between them (detection's in-flight exclusion saw an
+		// earlier snapshot). Such a record is at least as fresh as this statement's
+		// snapshot — overwriting it could roll the workflow back to a stale version.
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
 			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -5,6 +5,7 @@ import type { EntityManager } from '@n8n/typeorm';
 import { UnexpectedError } from 'n8n-workflow';
 
 import {
+	UNPUBLISH_VERSION_SENTINEL,
 	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxStatus as Status,
 } from '../entities/workflow-publication-outbox';
@@ -185,9 +186,10 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		const workflowTableName = this.getTableName('workflow_entity');
 
 		// COALESCE: an unpublished workflow has no `activeVersionId`, but the column
-		// is NOT NULL. The fallback is inert — the applier dispatches an unpublish
-		// on the workflow's null `activeVersionId` and never reads the record's
-		// version. (Mirrored in the sqlite variant below.)
+		// is NOT NULL, so those records carry the unpublish sentinel. It is inert —
+		// the applier dispatches an unpublish on the workflow's null
+		// `activeVersionId` and never reads the record's version. (Mirrored in the
+		// sqlite variant below.)
 		//
 		// DO NOTHING, unlike `enqueue`: reconciliation's detection and this enqueue
 		// are two separate statements, so a publish/unpublish can commit a pending
@@ -196,7 +198,7 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		// snapshot — overwriting it could roll the workflow back to a stale version.
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'
+			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" = ANY($1)
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
@@ -212,7 +214,7 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
-			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'
+			 SELECT w."id", COALESCE(w."activeVersionId", '${UNPUBLISH_VERSION_SENTINEL}'), '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" IN (${placeholders})
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')

--- a/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-outbox.repository.ts
@@ -188,13 +188,18 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 		// is NOT NULL. The fallback is inert — the applier dispatches an unpublish
 		// on the workflow's null `activeVersionId` and never reads the record's
 		// version. (Mirrored in the sqlite variant below.)
+		//
+		// DO NOTHING, unlike `enqueue`: reconciliation only targets workflows with
+		// no in-flight record at detection time, so a conflicting pending record
+		// can only come from a concurrent publish/unpublish — it is at least as
+		// fresh as this statement's snapshot and must not be overwritten.
 		await this.query(
 			`INSERT INTO ${outboxTableName} ("workflowId", "publishedVersionId", "status")
 			 SELECT w."id", COALESCE(w."activeVersionId", w."versionId"), '${Status.Pending}'
 			 FROM ${workflowTableName} w
 			 WHERE w."id" = ANY($1)
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = EXCLUDED."publishedVersionId", "updatedAt" = CURRENT_TIMESTAMP(3)`,
+			 DO NOTHING`,
 			[workflowIds],
 		);
 	}
@@ -210,7 +215,7 @@ export class WorkflowPublicationOutboxRepository extends Repository<WorkflowPubl
 			 FROM ${workflowTableName} w
 			 WHERE w."id" IN (${placeholders})
 			 ON CONFLICT ("workflowId", "status") WHERE "status" IN ('${Status.Pending}', '${Status.InProgress}')
-			 DO UPDATE SET "publishedVersionId" = excluded."publishedVersionId", "updatedAt" = STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')`,
+			 DO NOTHING`,
 			workflowIds,
 		);
 	}

--- a/packages/@n8n/db/src/repositories/workflow-publication-trigger-status.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-publication-trigger-status.repository.ts
@@ -49,16 +49,15 @@ export class WorkflowPublicationTriggerStatusRepository extends Repository<Workf
 	}
 
 	/**
-	 * Returns every trigger that should currently be registered in memory: the
-	 * activated, in-memory triggers of active workflows. The join on
-	 * `activeVersionId` drops stale rows left by an interrupted unpublish, which
-	 * would otherwise read as missing forever. Workflows with an in-flight
-	 * (pending/in-progress) publication record are excluded: that publication is
-	 * about to reconcile them anyway.
+	 * Returns every trigger status row that claims an in-memory registration
+	 * (`activated`, in-memory) — deliberately including rows of unpublished
+	 * workflows: stale rows left by an interrupted unpublish then surface as a
+	 * deficit, and reconciliation heals them by re-running the unpublish.
+	 * Workflows with an in-flight (pending/in-progress) publication record are
+	 * excluded: that publication is about to reconcile them anyway.
 	 */
 	async findActivatedInMemoryTriggers(): Promise<InMemoryTriggerRef[]> {
 		return await this.createQueryBuilder('ts')
-			.innerJoin('ts.workflow', 'workflow', 'workflow.activeVersionId IS NOT NULL')
 			.select(['ts.workflowId AS "workflowId"', 'ts.nodeId AS "nodeId"'])
 			.where('ts.status = :status', { status: 'activated' })
 			.andWhere('ts.triggerKind = :kind', { kind: 'in-memory' })

--- a/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
@@ -14,11 +14,7 @@ export type PublicationOutcomeResult =
 	| 'failed';
 
 /** Why a record was skipped (or `none` for any non-skipped outcome). */
-export type PublicationOutcomeReason =
-	| 'none'
-	| 'workflow_not_found'
-	| 'workflow_inactive'
-	| 'version_missing';
+export type PublicationOutcomeReason = 'none' | 'workflow_not_found' | 'version_missing';
 
 /** A trigger operation performed during publication. */
 export type PublicationTriggerOperation = 'activate' | 'deactivate';

--- a/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/publication-status-reporter.test.ts
@@ -134,18 +134,15 @@ describe('PublicationStatusReporter', () => {
 		});
 	});
 
-	test.each([['workflow-not-found'], ['workflow-inactive']] as const)(
-		'skipped (%s) marks the record completed and clears activation errors',
-		async (reason) => {
-			await reporter.report(makeRecord(), { type: 'skipped', reason });
+	test('skipped (workflow-not-found) marks the record completed and clears activation errors', async () => {
+		await reporter.report(makeRecord(), { type: 'skipped', reason: 'workflow-not-found' });
 
-			expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1, entityManager);
-			expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
-			expect(outboxRepository.markFailed).not.toHaveBeenCalled();
-			expect(push.broadcast).not.toHaveBeenCalled();
-			expect(publisher.publishCommand).not.toHaveBeenCalled();
-		},
-	);
+		expect(outboxRepository.markCompleted).toHaveBeenCalledWith(1, entityManager);
+		expect(activationErrorsService.deregister).toHaveBeenCalledWith('wf-1');
+		expect(outboxRepository.markFailed).not.toHaveBeenCalled();
+		expect(push.broadcast).not.toHaveBeenCalled();
+		expect(publisher.publishCommand).not.toHaveBeenCalled();
+	});
 
 	test('version-missing marks the record failed without reporting an error', async () => {
 		await reporter.report(makeRecord(), { type: 'version-missing' });

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -177,14 +177,20 @@ describe('WorkflowPublicationApplier', () => {
 			);
 		});
 
-		test('skips with workflow-inactive when there is no published-version mapping', async () => {
+		test('completes as unpublished when there is no published-version mapping, so stale trigger-status rows are cleared', async () => {
+			// A retried/reconciled unpublish whose mapping is already gone must still
+			// end in `unpublished` (not a skip): the reporter clears the workflow's
+			// trigger-status rows only on that result, and an interrupted unpublish
+			// can leave rows behind after the mapping was removed.
 			workflowPublishedVersionRepository.findOne.mockResolvedValue(makePublishedVersion(null));
 
 			const result = await applier.apply(makeRecord());
 
-			expect(result).toEqual({ type: 'skipped', reason: 'workflow-inactive' });
+			expect(result).toEqual({ type: 'unpublished' });
 			expect(workflowTriggerActivator.deactivate).not.toHaveBeenCalled();
-			expect(workflowPublishedVersionRepository.removePublishedVersion).not.toHaveBeenCalled();
+			expect(workflowPublishedVersionRepository.removePublishedVersion).toHaveBeenCalledWith(
+				'wf-1',
+			);
 			expect(workflowPublishedVersionRepository.setPublishedVersion).not.toHaveBeenCalled();
 		});
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-outbox-consumer.test.ts
@@ -346,7 +346,6 @@ describe('WorkflowPublicationOutboxConsumer', () => {
 			[{ type: 'completed', triggerStatuses: [] }, 'published', 'none'],
 			[{ type: 'unpublished' }, 'unpublished', 'none'],
 			[{ type: 'skipped', reason: 'workflow-not-found' }, 'skipped', 'workflow_not_found'],
-			[{ type: 'skipped', reason: 'workflow-inactive' }, 'skipped', 'workflow_inactive'],
 			[{ type: 'version-missing' }, 'failed', 'version_missing'],
 			[{ type: 'partial', triggerStatuses: [] }, 'partial_success', 'none'],
 			[{ type: 'failed', error: new Error('boom') }, 'failed', 'none'],

--- a/packages/cli/src/workflows/publication/publication-result.ts
+++ b/packages/cli/src/workflows/publication/publication-result.ts
@@ -5,9 +5,7 @@
  */
 export type PublicationSkipReason =
 	/** The workflow row no longer exists. */
-	| 'workflow-not-found'
-	/** The workflow is no longer active, so there are no triggers to reconcile. */
-	| 'workflow-inactive';
+	'workflow-not-found';
 
 import type { WorkflowPublicationTriggerKind } from '@n8n/db';
 

--- a/packages/cli/src/workflows/publication/publication-status-reporter.ts
+++ b/packages/cli/src/workflows/publication/publication-status-reporter.ts
@@ -16,7 +16,6 @@ import { Publisher } from '@/scaling/pubsub/publisher.service';
 import type {
 	FailedTriggerPublicationStatus,
 	PublicationResult,
-	PublicationSkipReason,
 	TriggerPublicationStatus,
 } from '@/workflows/publication/publication-result';
 
@@ -61,7 +60,7 @@ export class PublicationStatusReporter {
 			}
 
 			case 'skipped': {
-				this.logSkip(record, result.reason);
+				this.logSkip(record);
 				await this.complete(record);
 				return;
 			}
@@ -219,14 +218,9 @@ export class PublicationStatusReporter {
 		await this.activationErrorsService.deregister(record.workflowId);
 	}
 
-	private logSkip(record: WorkflowPublicationOutbox, reason: PublicationSkipReason): void {
+	private logSkip(record: WorkflowPublicationOutbox): void {
 		const context = { workflowId: record.workflowId, outboxId: record.id };
 
-		if (reason === 'workflow-not-found') {
-			this.logger.warn('Workflow not found, marking outbox record as completed', context);
-			return;
-		}
-
-		this.logger.debug('Workflow is no longer active, marking outbox record as completed', context);
+		this.logger.warn('Workflow not found, marking outbox record as completed', context);
 	}
 }

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -177,11 +177,12 @@ export class WorkflowPublicationApplier {
 	 * published version and removing the `workflow_published_version` mapping. The
 	 * version to deactivate comes from the mapping (`oldVersion`), since the
 	 * workflow's `activeVersionId` has already been cleared by the service that
-	 * enqueued this record. A missing mapping means nothing was published on this
-	 * leader, so there is nothing to tear down — but the record still completes as
-	 * `unpublished`, so the reporter clears any trigger-status rows left behind by
-	 * an unpublish that was interrupted between removing the mapping and clearing
-	 * the rows. Every step here is idempotent for exactly that retry.
+	 * enqueued this record.
+	 *
+	 * A missing mapping means nothing was published on this leader, so there is
+	 * nothing to tear down. In that case the record still completes as a
+	 * successful `unpublished` to support idempotent retries — the reporter then
+	 * clears any trigger-status rows left behind by an interrupted unpublish.
 	 *
 	 * A teardown failure bubbles up (the consumer turns it into a `failed` result)
 	 * so the mapping is only removed once teardown has succeeded.

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -178,7 +178,10 @@ export class WorkflowPublicationApplier {
 	 * version to deactivate comes from the mapping (`oldVersion`), since the
 	 * workflow's `activeVersionId` has already been cleared by the service that
 	 * enqueued this record. A missing mapping means nothing was published on this
-	 * leader, so there is nothing to tear down.
+	 * leader, so there is nothing to tear down — but the record still completes as
+	 * `unpublished`, so the reporter clears any trigger-status rows left behind by
+	 * an unpublish that was interrupted between removing the mapping and clearing
+	 * the rows. Every step here is idempotent for exactly that retry.
 	 *
 	 * A teardown failure bubbles up (the consumer turns it into a `failed` result)
 	 * so the mapping is only removed once teardown has succeeded.
@@ -188,13 +191,11 @@ export class WorkflowPublicationApplier {
 		oldVersion: WorkflowHistory | null,
 		record: WorkflowPublicationOutbox,
 	): Promise<PublicationResult> {
-		if (!oldVersion) return { type: 'skipped', reason: 'workflow-inactive' };
-
 		const toRemove = new Set(
 			this.workflowTriggerActivator.getEnabledTriggerNodes(oldVersion).map((node) => node.id),
 		);
 
-		if (toRemove.size > 0) {
+		if (oldVersion && toRemove.size > 0) {
 			await this.workflowTriggerActivator.deactivate(workflow, oldVersion, toRemove);
 		}
 

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -192,6 +192,9 @@ export class WorkflowPublicationApplier {
 		oldVersion: WorkflowHistory | null,
 		record: WorkflowPublicationOutbox,
 	): Promise<PublicationResult> {
+		// If there is no oldVersion we may be retrying an unpublish that was
+		// interrupted after removing the mapping: nothing to tear down, but we
+		// still complete as `unpublished`.
 		const toRemove = new Set(
 			this.workflowTriggerActivator.getEnabledTriggerNodes(oldVersion).map((node) => node.id),
 		);

--- a/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-outbox-consumer.ts
@@ -298,8 +298,7 @@ export class WorkflowPublicationOutboxConsumer {
 			case 'skipped':
 				return {
 					result: 'skipped',
-					reason:
-						result.reason === 'workflow-not-found' ? 'workflow_not_found' : 'workflow_inactive',
+					reason: 'workflow_not_found',
 				};
 			case 'version-missing':
 				return { result: 'failed', reason: 'version_missing' };

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -1,5 +1,6 @@
 import { createActiveWorkflow, createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { WorkflowsConfig } from '@n8n/config';
+import { UNPUBLISH_VERSION_SENTINEL } from '@n8n/db';
 import type { WorkflowPublicationTriggerKind } from '@n8n/db';
 import {
 	WorkflowPublicationOutboxRepository,
@@ -404,11 +405,11 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			expect(pending.map((record) => record.workflowId)).not.toContain(wf2.id);
 		});
 
-		it('enqueues unpublished and archived workflows at their draft version so stale trigger-status rows can be healed', async () => {
+		it('enqueues unpublished and archived workflows with the unpublish sentinel so stale trigger-status rows can be healed', async () => {
 			// The reconciler enqueues whatever its detection query returns; refusing
-			// any of it here would re-detect the same workflow forever. The version id
-			// is inert for these records — the applier dispatches an unpublish on the
-			// workflow's null `activeVersionId` and never reads it.
+			// any of it here would re-detect the same workflow forever. The sentinel
+			// is inert — the applier dispatches an unpublish on the workflow's null
+			// `activeVersionId` and never reads the record's version.
 			const unpublished = await createWorkflow(); // no activeVersionId
 			const archived = await createWorkflow();
 			await Container.get(WorkflowRepository).update(archived.id, { isArchived: true });
@@ -420,11 +421,11 @@ describe('WorkflowPublicationOutboxRepository', () => {
 				expect.arrayContaining([
 					expect.objectContaining({
 						workflowId: unpublished.id,
-						publishedVersionId: unpublished.versionId,
+						publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
 					}),
 					expect.objectContaining({
 						workflowId: archived.id,
-						publishedVersionId: archived.versionId,
+						publishedVersionId: UNPUBLISH_VERSION_SENTINEL,
 					}),
 				]),
 			);

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -404,17 +404,31 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			expect(pending.map((record) => record.workflowId)).not.toContain(wf2.id);
 		});
 
-		it('skips inactive and archived workflows even when listed', async () => {
-			const active = await createActiveWorkflow();
-			const inactive = await createWorkflow(); // no activeVersionId
-			const archived = await createActiveWorkflow();
+		it('enqueues unpublished and archived workflows at their draft version so stale trigger-status rows can be healed', async () => {
+			// The reconciler enqueues whatever its detection query returns; refusing
+			// any of it here would re-detect the same workflow forever. The version id
+			// is inert for these records — the applier dispatches an unpublish on the
+			// workflow's null `activeVersionId` and never reads it.
+			const unpublished = await createWorkflow(); // no activeVersionId
+			const archived = await createWorkflow();
 			await Container.get(WorkflowRepository).update(archived.id, { isArchived: true });
 
-			await repository.enqueueByWorkflowIds([active.id, inactive.id, archived.id]);
+			await repository.enqueueByWorkflowIds([unpublished.id, archived.id]);
 
 			const pending = await repository.find({ where: { status: 'pending' } });
-			expect(pending).toHaveLength(1);
-			expect(pending[0].workflowId).toBe(active.id);
+			expect(pending).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						workflowId: unpublished.id,
+						publishedVersionId: unpublished.versionId,
+					}),
+					expect.objectContaining({
+						workflowId: archived.id,
+						publishedVersionId: archived.versionId,
+					}),
+				]),
+			);
+			expect(pending).toHaveLength(2);
 		});
 
 		it('is idempotent: re-running does not create duplicate pending records', async () => {

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -445,10 +445,10 @@ describe('WorkflowPublicationOutboxRepository', () => {
 		});
 
 		it('does not overwrite an existing pending record', async () => {
-			// Reconciliation only enqueues workflows that had no in-flight record at
-			// detection time, so a conflicting pending record can only have been
-			// enqueued concurrently (e.g. a publish committing mid-statement) — it is
-			// at least as fresh as reconciliation's snapshot and must win.
+			// Reconciliation's detection and its enqueue are two separate statements:
+			// a publish can commit a pending record in the gap between them. That
+			// record is at least as fresh as reconciliation's snapshot and must win —
+			// overwriting it could roll the workflow back to a stale version.
 			const workflow = await createActiveWorkflow();
 			await repository.enqueue(workflow.id, 'v-concurrent');
 

--- a/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts
@@ -444,6 +444,23 @@ describe('WorkflowPublicationOutboxRepository', () => {
 			expect(pending[0].publishedVersionId).toBe(workflow.activeVersionId);
 		});
 
+		it('does not overwrite an existing pending record', async () => {
+			// Reconciliation only enqueues workflows that had no in-flight record at
+			// detection time, so a conflicting pending record can only have been
+			// enqueued concurrently (e.g. a publish committing mid-statement) — it is
+			// at least as fresh as reconciliation's snapshot and must win.
+			const workflow = await createActiveWorkflow();
+			await repository.enqueue(workflow.id, 'v-concurrent');
+
+			await repository.enqueueByWorkflowIds([workflow.id]);
+
+			const pending = await repository.find({
+				where: { workflowId: workflow.id, status: 'pending' },
+			});
+			expect(pending).toHaveLength(1);
+			expect(pending[0].publishedVersionId).toBe('v-concurrent');
+		});
+
 		it('is a no-op for an empty list', async () => {
 			await createActiveWorkflow();
 

--- a/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
+++ b/packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts
@@ -260,9 +260,10 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 			expect(rows).toHaveLength(2);
 		});
 
-		it('excludes stale rows of workflows without an active version', async () => {
-			// Simulates rows orphaned by an interrupted unpublish: the workflow is no
-			// longer active but its `activated` rows were never cleared.
+		it('includes stale rows of workflows without an active version so reconciliation can heal them', async () => {
+			// Rows orphaned by an interrupted unpublish: the workflow is no longer
+			// active but its `activated` rows were never cleared. They must surface as
+			// a deficit so the reconciler re-enqueues the unpublish that clears them.
 			const unpublishedWorkflow = await createWorkflow();
 			await seedVersions(unpublishedWorkflow, ['v-stale']);
 			await repo.replaceForWorkflow(unpublishedWorkflow.id, [
@@ -275,7 +276,9 @@ describe('WorkflowPublicationTriggerStatusRepository', () => {
 				},
 			]);
 
-			expect(await repo.findActivatedInMemoryTriggers()).toEqual([]);
+			expect(await repo.findActivatedInMemoryTriggers()).toEqual([
+				{ workflowId: unpublishedWorkflow.id, nodeId: 'poll-stale' },
+			]);
 		});
 
 		it('excludes workflows with an in-flight publication record', async () => {

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -5,7 +5,12 @@ import {
 	testDb,
 } from '@n8n/backend-test-utils';
 import { WorkflowsConfig } from '@n8n/config';
-import { WorkflowPublicationOutboxRepository, WorkflowPublishedVersionRepository } from '@n8n/db';
+import {
+	WorkflowPublicationOutboxRepository,
+	WorkflowPublicationTriggerStatusRepository,
+	WorkflowPublishedVersionRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import { ActiveWorkflowTriggers, ExternalSecretsProxy, InstanceSettings } from 'n8n-core';
 import { ScheduleTrigger } from 'n8n-nodes-base/nodes/Schedule/ScheduleTrigger.node';
@@ -40,6 +45,7 @@ let consumer: WorkflowPublicationOutboxConsumer;
 let activeWorkflowTriggers: ActiveWorkflowTriggers;
 let outboxRepository: WorkflowPublicationOutboxRepository;
 let publishedVersionRepository: WorkflowPublishedVersionRepository;
+let triggerStatusRepository: WorkflowPublicationTriggerStatusRepository;
 let originalUseWorkflowPublicationService: boolean;
 
 const scheduleNode = (suffix: string): INode => ({
@@ -69,6 +75,7 @@ beforeAll(async () => {
 	activeWorkflowTriggers = Container.get(ActiveWorkflowTriggers);
 	outboxRepository = Container.get(WorkflowPublicationOutboxRepository);
 	publishedVersionRepository = Container.get(WorkflowPublishedVersionRepository);
+	triggerStatusRepository = Container.get(WorkflowPublicationTriggerStatusRepository);
 });
 
 afterEach(async () => {
@@ -123,6 +130,38 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 			workflow.id,
 		);
 		expect(published?.publishedVersionId).toBe(workflow.versionId);
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('clears orphaned trigger-status rows of an unpublished workflow by re-running the unpublish', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('orphaned');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		// Publish through the real pipeline so the reporter persists the
+		// `activated` trigger-status rows.
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await consumer.processRecord(record!);
+
+		// An unpublish interrupted after removing the published-version mapping
+		// but before the reporter cleared the trigger-status rows, with its outbox
+		// record already terminal: triggers down, mapping gone, workflow
+		// unpublished — only the `activated` rows remain, claiming a trigger that
+		// no longer exists.
+		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
+		await activeWorkflowTriggers.remove(workflow.id);
+		await publishedVersionRepository.removePublishedVersion(workflow.id);
+		expect(await triggerStatusRepository.findByWorkflowId(workflow.id)).toHaveLength(1);
+
+		// One reconcile pass surfaces the orphaned rows as a deficit, enqueues the
+		// workflow, and the drained unpublish clears the rows and completes.
+		await reconciler.reconcile();
+
+		expect(await triggerStatusRepository.findByWorkflowId(workflow.id)).toHaveLength(0);
+		expect(activeWorkflowTriggers.get(workflow.id)).toBeUndefined();
 		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
 	});
 


### PR DESCRIPTION
## Summary

First of two follow-ups to #33577 (CAT-3654), covering the unpublish direction. Fixes the **orphaned trigger-status rows** gap: an unpublish interrupted between removing the `workflow_published_version` mapping and clearing the workflow's `workflow_publication_trigger_status` rows left those rows permanently claiming `activated` for an unpublished workflow. The retried record hit the no-mapping `skipped/workflow-inactive` path without touching them, and reconciliation both hid them (the `activeVersionId` join in `findActivatedInMemoryTriggers`) and refused to enqueue their workflow (`enqueueByWorkflowIds` filtered unpublished workflows).

Per the [review discussion on #33577](https://github.com/n8n-io/n8n/pull/33577#discussion_r3577180243), the rows now self-heal through the normal unpublish path instead of being filtered out of detection:

- **Applier**: an unpublish with no published-version mapping completes as `unpublished` instead of skipping, so the reporter clears the workflow's trigger-status rows in the same transaction that completes the record. Every step on this path is idempotent, so a crash anywhere just retries.
- **Outbox**: `enqueueByWorkflowIds` accepts unpublished and archived workflows. Detection and enqueue must agree on what they cover, or the same workflow re-detects on every pass forever. `publishedVersionId` falls back to the draft `versionId` (`COALESCE`) to satisfy the NOT NULL column — the value is inert, the applier never reads it on unpublish.
- **Detection**: the `activeVersionId` join is dropped, so orphaned rows surface as a deficit and heal within one reconcile pass (rows cleared → they drop out of detection → loop stops).
- The now-unreachable `workflow-inactive` skip reason is removed end to end (result type, reporter, consumer, `workflow_inactive` metric label).

The **ghost triggers** gap (surplus in-memory triggers after a missed unpublish) is the second follow-up and comes in a separate PR.

Everything sits behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` and is a no-op when it is off.

## How to test

Requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE=true`.

Covered by tests at each layer:
- `packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts` — end to end: seeds the interrupted-unpublish state (orphaned `activated` rows, no mapping, workflow unpublished), one reconcile pass clears the rows and completes the record.
- `packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts` — no-mapping unpublish returns `unpublished` and still removes the mapping.
- `packages/cli/test/integration/database/repositories/workflow-publication-outbox.repository.test.ts` — unpublished/archived workflows are enqueued with a non-null version.
- `packages/cli/test/integration/workflow-publication-trigger-status.repository.test.ts` — stale rows of unpublished workflows are included in detection.

Manual: activate a workflow with a schedule trigger, deactivate it, then (with the DB paused mid-unpublish or via SQL) delete its `workflow_published_version` row while keeping the `workflow_publication_trigger_status` rows; within one reconcile interval (default 10s) the rows are cleared.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3759

Follow-up to #33577.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

