### PR TITLE
chore: Clean up dangling Jest artifacts

### DIFF
--- a/packages/@n8n/computer-use/vite.config.ts
+++ b/packages/@n8n/computer-use/vite.config.ts
@@ -6,8 +6,7 @@ export default mergeConfig(createVitestConfig({}), {
 	resolve: {
 		alias: [
 			// @inquirer/prompts and its sub-packages are ESM-only. Tests redirect
-			// any @inquirer/* import to this mock (mirrors the former Jest
-			// moduleNameMapper).
+			// any @inquirer/* import to this mock.
 			{
 				find: /^@inquirer\/.*$/,
 				replacement: path.resolve(__dirname, './src/__mocks__/@inquirer/prompts.ts'),

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -145,10 +145,8 @@ interface EovApiDoc {
  *
  * Why it's needed in tests: eov's default resolver `require()`s each handler module, but under
  * Vitest only the `.ts` handler sources exist on disk (no `.js`) and they're served by Vite, not
- * Node's `require` — so `require()` throws and every route 500s. (Under Jest this worked via
- * ts-jest's require hook, which Vitest has no equivalent of.) `import()` is intercepted by Vite and
- * resolves the `.ts`. Mirrors eov's `defaultResolver` lookup (`mod[id]` / `mod.default[id]` / `mod.default`).
- */
+ * Node's `require` — so `require()` throws and every route 500s.
+ * */
 async function importOperationHandlerResolver(
 	handlersPath: string,
 	// Typed as `unknown` (then narrowed) so the signature stays assignable to eov's

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -418,8 +418,6 @@ describe('WorkflowExecutionService', () => {
 				dirtyNodeNames: [],
 			} as WorkflowRequest.ManualRunPayload;
 
-			// Not jest.spyOn/vi.spyOn: the mock proxy exposes mock methods
-			// directly, keeping this test agnostic of the test runner
 			nodeTypes.getByNameAndVersion.mockReturnValueOnce(
 				mock<INodeType>({ description: { group: [] } }),
 			);

--- a/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
@@ -6,8 +6,6 @@ import {
 	validateJSON,
 } from '../GenericFunctions';
 
-const jest = vi;
-
 type RequestOptions = {
 	method?: string;
 	uri?: string;
@@ -19,7 +17,7 @@ type RequestOptions = {
 
 describe('RocketChat > GenericFunctions', () => {
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	describe('validateJSON', () => {
@@ -46,10 +44,10 @@ describe('RocketChat > GenericFunctions', () => {
 
 	describe('rocketchatApiRequest', () => {
 		function createContext() {
-			const requestWithAuthentication = jest.fn();
+			const requestWithAuthentication = vi.fn();
 
 			const context = {
-				getCredentials: jest.fn().mockResolvedValue({
+				getCredentials: vi.fn().mockResolvedValue({
 					domain: 'https://chat.example.com',
 				}),
 				helpers: {
@@ -127,10 +125,10 @@ describe('RocketChat > GenericFunctions', () => {
 
 	describe('rocketchatApiRequestAllItems', () => {
 		function createContext() {
-			const requestWithAuthentication = jest.fn();
+			const requestWithAuthentication = vi.fn();
 
 			const context = {
-				getCredentials: jest.fn().mockResolvedValue({
+				getCredentials: vi.fn().mockResolvedValue({
 					domain: 'https://chat.example.com',
 				}),
 				helpers: {


### PR DESCRIPTION
## Summary

Some unnecessary Jest references still live in the monorepo. This PR removes them.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34446">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

