### PR TITLE
fix(editor): Don't show quick connect for non-main auth fields

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -1061,6 +1061,179 @@ describe('NodeCredentials', () => {
 			expect(screen.getByText('Connect to Dropbox')).toBeInTheDocument();
 		});
 
+		it('should show sibling OAuth quick connect when the auth field is kept in NDV', () => {
+			setupQuickConnectStores();
+
+			const discordOAuth2ApiType: ICredentialType = {
+				...slackOAuth2ApiType,
+				name: 'discordOAuth2Api',
+				displayName: 'Discord OAuth2 API',
+			};
+			const discordNode: INodeUi = {
+				parameters: { authentication: 'botToken' },
+				type: 'n8n-nodes-base.discord',
+				typeVersion: 2,
+				position: [0, 0],
+				id: 'discord-node-id',
+				name: 'Discord',
+				credentials: {},
+			};
+
+			credentialsStore.state.credentialTypes = {
+				...credentialsStore.state.credentialTypes,
+				discordOAuth2Api: discordOAuth2ApiType,
+				discordBotApi: {
+					name: 'discordBotApi',
+					displayName: 'Discord Bot API',
+					properties: [],
+				},
+			};
+			mockedStore(useNodeTypesStore).setNodeTypes([
+				{
+					displayName: 'Discord',
+					name: 'n8n-nodes-base.discord',
+					group: ['output'],
+					version: 2,
+					description: '',
+					defaults: { name: 'Discord' },
+					inputs: [NodeConnectionTypes.Main],
+					outputs: [NodeConnectionTypes.Main],
+					credentials: [
+						{
+							name: 'discordBotApi',
+							required: true,
+							displayOptions: { show: { authentication: ['botToken'] } },
+						},
+						{
+							name: 'discordOAuth2Api',
+							required: true,
+							displayOptions: { show: { authentication: ['oAuth2'] } },
+						},
+					],
+					properties: [
+						{
+							displayName: 'Connection Type',
+							name: 'authentication',
+							type: 'options',
+							options: [
+								{ name: 'Bot Token', value: 'botToken' },
+								{ name: 'OAuth2', value: 'oAuth2' },
+							],
+							default: 'botToken',
+						},
+					],
+				} as unknown as INodeTypeDescription,
+			]);
+			ndvStore.activeNode = discordNode;
+
+			renderComponent(
+				{
+					props: {
+						node: discordNode,
+						overrideCredType: '',
+					},
+				},
+				{ merge: true },
+			);
+
+			expect(screen.queryByTestId('quick-connect-empty-state')).toBeInTheDocument();
+			expect(screen.queryByTestId('node-credentials-empty-state')).not.toBeInTheDocument();
+			expect(screen.getByText('Connect to Discord')).toBeInTheDocument();
+		});
+
+		it('should not show sibling OAuth quick connect for an independent credential field', () => {
+			setupQuickConnectStores();
+
+			const pipedriveOAuth2ApiType: ICredentialType = {
+				...slackOAuth2ApiType,
+				name: 'pipedriveOAuth2Api',
+				displayName: 'Pipedrive OAuth2 API',
+			};
+			const pipedriveNode: INodeUi = {
+				parameters: {
+					authentication: 'apiToken',
+					incomingAuthentication: 'basicAuth',
+				},
+				type: 'n8n-nodes-base.pipedriveTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				id: 'pipedrive-trigger-node-id',
+				name: 'Pipedrive Trigger',
+				credentials: {},
+			};
+
+			credentialsStore.state.credentialTypes = {
+				...credentialsStore.state.credentialTypes,
+				pipedriveOAuth2Api: pipedriveOAuth2ApiType,
+				pipedriveApi: {
+					name: 'pipedriveApi',
+					displayName: 'Pipedrive API',
+					properties: [],
+				},
+				httpBasicAuth: {
+					name: 'httpBasicAuth',
+					displayName: 'Basic Auth',
+					properties: [],
+				},
+			};
+			mockedStore(useNodeTypesStore).setNodeTypes([
+				{
+					displayName: 'Pipedrive Trigger',
+					name: 'n8n-nodes-base.pipedriveTrigger',
+					group: ['trigger'],
+					version: 1,
+					description: '',
+					defaults: { name: 'Pipedrive Trigger' },
+					inputs: [],
+					outputs: [NodeConnectionTypes.Main],
+					credentials: [
+						{
+							name: 'pipedriveApi',
+							required: true,
+							displayOptions: { show: { authentication: ['apiToken'] } },
+						},
+						{
+							name: 'pipedriveOAuth2Api',
+							required: true,
+							displayOptions: { show: { authentication: ['oAuth2'] } },
+						},
+						{
+							name: 'httpBasicAuth',
+							required: true,
+							displayOptions: { show: { incomingAuthentication: ['basicAuth'] } },
+						},
+					],
+					properties: [
+						{
+							displayName: 'Authentication',
+							name: 'authentication',
+							type: 'options',
+							required: true,
+							options: [
+								{ name: 'API Token', value: 'apiToken' },
+								{ name: 'OAuth2', value: 'oAuth2' },
+							],
+							default: 'apiToken',
+						},
+					],
+				} as unknown as INodeTypeDescription,
+			]);
+			ndvStore.activeNode = pipedriveNode;
+
+			renderComponent(
+				{
+					props: {
+						node: pipedriveNode,
+						overrideCredType: '',
+					},
+				},
+				{ merge: true },
+			);
+
+			expect(screen.getAllByTestId('quick-connect-empty-state')).toHaveLength(1);
+			expect(screen.getAllByTestId('node-credentials-empty-state')).toHaveLength(1);
+		});
+
 		it('should show standard dropdown when credential already exists', () => {
 			setupQuickConnectStores();
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -809,19 +809,36 @@ function getServiceName(credentialTypeName: string): string {
 	return getAppNameFromCredType(displayName);
 }
 
-const quickConnectCredentialType = computed(() => {
-	return credentialTypesNodeDescriptions.value.find(
-		(t) =>
-			!!getQuickConnectOption(t.name, props.node.type) || canOAuthCredentialQuickConnect(t.name),
-	)?.name;
-});
+function getRelatedCredentialTypes(type: INodeCredentialDescription): INodeCredentialDescription[] {
+	const authFieldName = mainNodeAuthField.value?.name;
+	// if not the main auth field, return the type itself
+	if (!authFieldName || !type.displayOptions?.show?.[authFieldName]) {
+		return [type];
+	}
+
+	// otherwise, return all credential types that show the main auth field
+	return credentialTypesNodeDescriptions.value.filter(
+		(credentialType) => credentialType.displayOptions?.show?.[authFieldName],
+	);
+}
+
+function canQuickConnect(credentialType: INodeCredentialDescription): boolean {
+	return (
+		!!getQuickConnectOption(credentialType.name, props.node.type) ||
+		canOAuthCredentialQuickConnect(credentialType.name)
+	);
+}
+
+function getQuickConnectCredentialType(type: INodeCredentialDescription): string | undefined {
+	return getRelatedCredentialTypes(type).find(canQuickConnect)?.name;
+}
 
 function showQuickConnectEmptyState(type: INodeCredentialDescription): boolean {
-	return !isCredentialExisting(type) && !!quickConnectCredentialType.value;
+	return !isCredentialExisting(type) && !!getQuickConnectCredentialType(type);
 }
 
 function showStandardEmptyState(type: INodeCredentialDescription): boolean {
-	return !isCredentialExisting(type) && !quickConnectCredentialType.value;
+	return !isCredentialExisting(type) && !getQuickConnectCredentialType(type);
 }
 
 function canManuallySetUpCredential(credentialTypeName: string): boolean {
@@ -915,7 +932,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 					v-else-if="
 						options.length === 0 &&
 						showQuickConnectEmptyState(type) &&
-						quickConnectCredentialType &&
+						getQuickConnectCredentialType(type) &&
 						!isAiGatewayManagedCredentials(type.name)
 					"
 					:class="[$style.quickConnectContainer]"
@@ -924,9 +941,9 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 					<QuickConnectButton
 						size="small"
 						:disabled="quickConnectLoading"
-						:credential-type-name="quickConnectCredentialType"
-						:service-name="getServiceName(quickConnectCredentialType)"
-						@click="onQuickConnectSignIn(quickConnectCredentialType)"
+						:credential-type-name="getQuickConnectCredentialType(type) ?? type.name"
+						:service-name="getServiceName(getQuickConnectCredentialType(type) ?? type.name)"
+						@click="onQuickConnectSignIn(getQuickConnectCredentialType(type) ?? type.name)"
 					/>
 					<span v-if="canManuallySetUpCredential(type.name)" :class="$style.setupManuallyContainer">
 						<N8nText size="small" :class="$style.setupManuallyOr">

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.test.ts
@@ -155,6 +155,63 @@ describe('useNodeCredentialOptions', () => {
 		).toEqual(['token-cred', 'oauth-cred']);
 	});
 
+	it('keeps independent credential types out of the main authentication dropdown', () => {
+		const httpBasicAuth = {
+			name: 'httpBasicAuth',
+			displayName: 'Basic Auth',
+			properties: [],
+		} satisfies ICredentialType;
+		const node = computed(
+			() =>
+				({
+					...slackNode,
+					type: 'n8n-nodes-base.discord',
+					parameters: {
+						...slackNode.parameters,
+						incomingAuthentication: 'basicAuth',
+					},
+				}) as INodeUi,
+		);
+		const nodeType = computed(
+			() =>
+				({
+					...slackNodeType,
+					credentials: [
+						...slackNodeType.credentials,
+						{
+							name: 'httpBasicAuth',
+							required: true,
+							displayOptions: {
+								show: {
+									incomingAuthentication: ['basicAuth'],
+								},
+							},
+						},
+					],
+				}) as INodeTypeDescription,
+		);
+		credentialsStore.state.credentialTypes.httpBasicAuth = httpBasicAuth;
+		credentialsStore.state.credentials['basic-auth-cred'] = createCredential({
+			id: 'basic-auth-cred',
+			name: 'Webhook Basic Auth',
+			type: 'httpBasicAuth',
+		});
+
+		const { credentialTypesNodeDescriptionDisplayed } = useNodeCredentialOptions(
+			node,
+			nodeType,
+			'',
+			true,
+		);
+
+		expect(
+			credentialTypesNodeDescriptionDisplayed.value[0].options.map((option) => option.type),
+		).toEqual(['slackApi', 'slackOAuth2Api']);
+		expect(
+			credentialTypesNodeDescriptionDisplayed.value[1].options.map((option) => option.type),
+		).toEqual(['httpBasicAuth']);
+	});
+
 	it('disables mixed credential behavior when override is set', () => {
 		const slackApiDescription = slackNodeType.credentials[0];
 		const { showMixedCredentials } = setupOptions('slackApi');

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useNodeCredentialOptions.ts
@@ -103,26 +103,40 @@ export function useNodeCredentialOptions(
 		return !KEEP_AUTH_IN_NDV_FOR_NODES.includes(node.value.type) && isRequired;
 	}
 
+	function isMainAuthCredential(credentialType: INodeCredentialDescription): boolean {
+		const authFieldName = mainNodeAuthField.value?.name;
+		return (
+			authFieldName !== undefined &&
+			credentialType.displayOptions?.show?.[authFieldName] !== undefined
+		);
+	}
+
+	function shouldShowRelatedCredentials(credentialType: INodeCredentialDescription): boolean {
+		/**
+		 * Show related credentials if:
+		 * - the credential type is mixed - one selector combines multiple credential types
+		 * - the credential type is the main auth credential - the main auth field is shown in the node UI
+		 * - the display all options is enabled
+		 */
+		return (
+			showMixedCredentials(credentialType) ||
+			(toValue(displayAllOptions) && isMainAuthCredential(credentialType))
+		);
+	}
+
 	function getAllRelatedCredentialTypes(credentialType: INodeCredentialDescription): string[] {
-		if (hasOverride.value) {
+		if (hasOverride.value || !shouldShowRelatedCredentials(credentialType)) {
 			return [credentialType.name];
 		}
 
-		const credentialIsRequired = showMixedCredentials(credentialType);
-		if (credentialIsRequired) {
-			if (mainNodeAuthField.value) {
-				if (toValue(displayAllOptions)) {
-					return nodeType.value?.credentials?.map((cred) => cred.name) ?? [];
-				}
-
-				const credentials = getAllNodeCredentialForAuthType(
-					nodeType.value,
-					mainNodeAuthField.value.name,
-				);
-				return credentials.map((cred) => cred.name);
-			}
+		const authFieldName = mainNodeAuthField.value?.name;
+		// if no main auth field exists, return the credential type itself
+		if (!authFieldName) {
+			return [credentialType.name];
 		}
-		return [credentialType.name];
+
+		// otherwise, return all related credential types
+		return getAllNodeCredentialForAuthType(nodeType.value, authFieldName).map((cred) => cred.name);
 	}
 
 	function isCredentialExisting(credentialType: INodeCredentialDescription): boolean {


### PR DESCRIPTION
## Summary

Fixes a bug that lead to incorrect rendering of auth options in nodes that use multiple auth fields. <br>Also fixes another issue, when "basic auth" credential could've been rendered in "pipedriveApi" selector

Before:

https://github.com/user-attachments/assets/f4563a21-d4da-4930-bcdd-5781b04e5fc9

After:

https://github.com/user-attachments/assets/69d36e80-b053-4bdf-95f6-697ac9e556b6

## How to test

1. Set `CREDENTIALS_OVERWRITE_ENDPOINT=send-credentials`
2. Insert the workflow attached below
3. Check that pipedrive trigger renders two selectors without quick connect option visible
4. Run http node to enable quick connect
5. Check that pipedrive renders auth inputs as expected
6. Create a credential for basic auth, ensure this credentials is not shown in pipedrive auth input

<details><summary>Workflow</summary>

```
{
  "nodes": [
    {
      "parameters": {
        "incomingAuthentication": "basicAuth"
      },
      "type": "n8n-nodes-base.pipedriveTrigger",
      "typeVersion": 1.1,
      "position": [
        16,
        -48
      ],
      "id": "a42ced4b-32d9-4834-9c20-a1a0ef5b2073",
      "name": "Pipedrive Trigger",
      "webhookId": "0d509095-e97f-4a16-8fb2-ca6180573479",
      "credentials": {}
    },
    {
      "parameters": {
        "method": "POST",
        "url": "http://127.0.0.1:5678/send-credentials",
        "sendBody": true,
        "specifyBody": "json",
        "jsonBody": "{\n    \"pipedriveOAuth2Api\": {\n      \"clientId\": \"xx\",\n      \"clientSecret\": \"yy\"\n    },\n    \"discordOAuth2Api\": {\n      \"clientId\": \"xx\",\n      \"clientSecret\": \"yy\"\n    }\n}",
        "options": {}
      },
      "type": "n8n-nodes-base.httpRequest",
      "typeVersion": 4.4,
      "position": [
        16,
        128
      ],
      "id": "a317e611-3445-4999-8642-2f24e527c2db",
      "name": "HTTP Request"
    }
  ],
  "connections": {
    "Pipedrive Trigger": {
      "main": [
        []
      ]
    },
    "HTTP Request": {
      "main": [
        []
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "869de6ef8ff5644147e5589ff5c9f86171de90b2c3bb7db31c1025ea70eaa896"
  }
}
```

</details>

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---

![Open in Stage](https://camo.githubusercontent.com/e3b46e319aace348a9c2eabc45f307a073a3bf5a08d5220b2027eac6649007b5/68747470733a2f2f73746167657265766965772e6170702f6173736574732f67682d6f70656e2d696e2d73746167652d6c696768742e737667)

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)