### PR TITLE
refactor(editor): Centralize Vue Flow imports and correct canvas mount props (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.test.ts
@@ -12,7 +12,7 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import { reactive, computed, shallowRef } from 'vue';

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -43,7 +43,7 @@ import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionSt
 import ExperimentalNodeDetailsDrawer from '@/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.vue';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import ExperimentalFocusPanelHeader from '@/features/workflows/canvas/experimental/components/ExperimentalFocusPanelHeader.vue';
 import { type ContextMenuAction } from '@/features/shared/contextMenu/composables/useContextMenuItems';
 import { type CanvasNode, CanvasNodeRenderType } from '@/features/workflows/canvas/canvas.types';

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -16,7 +16,7 @@ import {
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
 import { createTestingPinia } from '@pinia/testing';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import { reactive, computed, ref, shallowRef } from 'vue';

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -9,7 +9,7 @@ import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
 import { computed, onMounted, watch, useTemplateRef, onBeforeUnmount } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { useActiveElement, useThrottleFn } from '@vueuse/core';
 import { type CanvasNode, CanvasNodeRenderType } from '@/features/workflows/canvas/canvas.types';
 import { type ContextMenuAction } from '@/features/shared/contextMenu/composables/useContextMenuItems';

--- a/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 
 import { replaceCanvasConnection } from './canvasConnectionReplacement.utils';
 import type { INodeUi } from '@/Interface';

--- a/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.ts
+++ b/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import uniq from 'lodash/uniq';
 import type { IConnection, NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -63,7 +63,7 @@ import {
 	WEBHOOK_NODE_TYPE,
 } from '@/app/constants';
 import { STORES } from '@n8n/stores';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import { useClipboard } from '@vueuse/core';
 import { createCanvasConnectionHandleString } from '@/features/workflows/canvas/canvas.utils';
 import { isVNode, nextTick, reactive, ref } from 'vue';

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -100,7 +100,7 @@ import {
 	doRectsOverlap,
 } from '@/app/utils/nodeViewUtils';
 import { isAgentNodeV2 } from '@/features/agents/utils/agentNode';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import type {
 	IConnection,
 	IConnections,

--- a/packages/frontend/editor-ui/src/app/composables/useNodeConnections.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeConnections.ts
@@ -6,7 +6,7 @@ import { CanvasConnectionMode } from '@/features/workflows/canvas/canvas.types';
 import type { MaybeRef } from 'vue';
 import { computed, unref } from 'vue';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import { parseCanvasConnectionHandleString } from '@/features/workflows/canvas/canvas.utils';
 
 export function useNodeConnections({

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -98,7 +98,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { applyThemeToBody, getThemeOverride, isValidTheme } from './ui.utils';
 import { computed, ref } from 'vue';
 import type { IMenuItem } from '@n8n/design-system';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import { useLocalStorage, useMediaQuery } from '@vueuse/core';
 import type { EventBus } from '@n8n/utils/event-bus';
 import type { ProjectSharingData } from '@/features/collaboration/projects/projects.types';

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentViewport.ts
@@ -1,6 +1,6 @@
 import { ref, readonly } from 'vue';
 import { createEventHook } from '@vueuse/core';
-import type { ViewportTransform } from '@vue-flow/core';
+import type { ViewportTransform } from '@/features/workflows/canvas/vueFlow.adapter';
 import { CHANGE_ACTION } from './types';
 import type { ChangeAction, ChangeEvent } from './types';
 

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mock, type MockProxy } from 'vitest-mock-extended';
 import { SET_NODE_TYPE, STICKY_NODE_TYPE } from '@/app/constants';
 import { createTestNode } from '@/__tests__/mocks';
-import type { GraphNode } from '@vue-flow/core';
+import type { GraphNode } from '@/features/workflows/canvas/vueFlow.adapter';
 import { v4 as uuid } from 'uuid';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';

--- a/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeViewUtils.ts
@@ -26,7 +26,7 @@ import {
 	type GraphNode,
 	type Rect,
 	type ViewportTransform,
-} from '@vue-flow/core';
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import * as workflowUtils from 'n8n-workflow/common';
 
 /*

--- a/packages/frontend/editor-ui/src/app/utils/typeGuards.ts
+++ b/packages/frontend/editor-ui/src/app/utils/typeGuards.ts
@@ -17,7 +17,7 @@ import type {
 } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import type { ICredentialsResponse } from '@/features/credentials/credentials.types';
-import type { Connection as VueFlowConnection } from '@vue-flow/core';
+import type { Connection as VueFlowConnection } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { RouteLocationRaw } from 'vue-router';
 import type { CanvasConnectionMode } from '@/features/workflows/canvas/canvas.types';
 import { canvasConnectionModes } from '@/features/workflows/canvas/canvas.types';

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -40,7 +40,7 @@ import type {
 	Dimensions,
 	ViewportTransform,
 	XYPosition as VueFlowXYPosition,
-} from '@vue-flow/core';
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import type {
 	CanvasNode,
 	CanvasNodeMoveEvent,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -35,7 +35,7 @@ import {
 	createCanvasConnectionHandleString,
 	parseCanvasConnectionHandleString,
 } from '@/features/workflows/canvas/canvas.utils';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import get from 'lodash/get';
 import type { IDataObject, NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes, isCommunityPackageName } from 'n8n-workflow';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
@@ -25,7 +25,11 @@ import {
 } from '@/features/workflows/canvas/stores/canvasNodeGroups.constants';
 import type { NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
-import type { GraphEdge, GraphNode, ViewportTransform } from '@vue-flow/core';
+import type {
+	GraphEdge,
+	GraphNode,
+	ViewportTransform,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -14,7 +14,7 @@ import type {
 	Position,
 	OnConnectStartParams,
 	ViewportTransform,
-} from '@vue-flow/core';
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import type { AgentCapabilitySummary } from '@n8n/api-types';
 import type { INodeUi } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.test.ts
@@ -15,7 +15,7 @@ import { NodeConnectionTypes } from 'n8n-workflow';
 import type { CanvasConnection } from './canvas.types';
 import { CanvasConnectionMode } from './canvas.types';
 import type { INodeUi } from '@/Interface';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import { createTestNode } from '@/__tests__/mocks';
 import { NODE_MIN_INPUT_ITEMS_COUNT } from '@/app/constants';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
@@ -15,7 +15,7 @@ import type {
 	CanvasNodeDefaultRenderLabelSize,
 } from './canvas.types';
 import { CanvasConnectionMode } from './canvas.types';
-import type { Connection } from '@vue-flow/core';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import { isValidCanvasConnectionMode, isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { NODE_MIN_INPUT_ITEMS_COUNT } from '@/app/constants';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@/app/stores/workflowDocument.store';
 
 import type { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { SIMULATE_NODE_TYPE } from '@/app/constants';
 import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { createEventBus } from '@n8n/utils/event-bus';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -48,9 +48,16 @@ import type {
 	NodeMouseEvent,
 	ViewportTransform,
 	XYPosition,
-} from '@vue-flow/core';
-import { getRectOfNodes, MarkerType, PanelPosition, useVueFlow, VueFlow } from '@vue-flow/core';
-import { MiniMap } from '@vue-flow/minimap';
+} from '@/features/workflows/canvas/vueFlow.adapter';
+import {
+	ConnectionMode,
+	getRectOfNodes,
+	MarkerType,
+	MiniMap,
+	PanelPosition,
+	useVueFlow,
+	VueFlow,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { onKeyDown, onKeyUp, useThrottleFn } from '@vueuse/core';
 import { NodeConnectionTypes, type IConnections, type IWorkflowGroup } from 'n8n-workflow';
 import type { CanvasRenderData } from '../canvas.utils';
@@ -1545,13 +1552,19 @@ defineExpose({
 </script>
 
 <template>
+	<!--
+		Controlled flow: `:nodes`/`:edges` are one-way bindings off read-only computeds; the
+		workflowDocument store is the source of truth and applies changes itself (no auto-apply prop
+		needed). `connection-mode` is set explicitly because Vue Flow 1.x defaults to `loose` but 2.0
+		defaults to `strict`, which would silently stop forming n8n's connections.
+	-->
 	<VueFlow
 		:id="id"
 		:nodes="vueFlowNodes"
 		:edges="connections"
 		:class="classes"
 		:style="selectionBoxStyle"
-		:apply-changes="false"
+		:connection-mode="ConnectionMode.Loose"
 		:connection-line-options="{ markerEnd: MarkerType.ArrowClosed }"
 		:connection-radius="60"
 		:pan-on-drag="panningMouseButton"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -3,8 +3,8 @@ import type { ContextMenuAction } from '@/features/shared/contextMenu/composable
 import type { IWorkflowDb } from '@/Interface';
 import type { EventBus } from '@n8n/utils/event-bus';
 import { createEventBus } from '@n8n/utils/event-bus';
-import type { ViewportTransform } from '@vue-flow/core';
-import { getRectOfNodes, useVueFlow } from '@vue-flow/core';
+import type { ViewportTransform } from '@/features/workflows/canvas/vueFlow.adapter';
+import { getRectOfNodes, useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { throttledRef } from '@vueuse/core';
 import {
 	computed,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/background/CanvasBackground.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/background/CanvasBackground.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { GRID_SIZE } from '@/app/utils/nodeViewUtils';
 import CanvasBackgroundStripedPattern from './CanvasBackgroundStripedPattern.vue';
-import { Background } from '@vue-flow/background';
-import type { ViewportTransform } from '@vue-flow/core';
+import { Background } from '@/features/workflows/canvas/vueFlow.adapter';
+import type { ViewportTransform } from '@/features/workflows/canvas/vueFlow.adapter';
 
 defineProps<{
 	striped: boolean;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/buttons/CanvasControlButtons.vue
@@ -2,7 +2,7 @@
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import TidyUpIcon from '@/app/components/TidyUpIcon.vue';
 import { useI18n } from '@n8n/i18n';
-import { Controls } from '@vue-flow/controls';
+import { Controls } from '@/features/workflows/canvas/vueFlow.adapter';
 import { computed } from 'vue';
 import { useExperimentalNdvStore } from '../../../experimental/experimentalNdv.store';
 import { N8nButton, N8nIconButton, N8nTooltip } from '@n8n/design-system';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasConnectionLine.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasConnectionLine.test.ts
@@ -2,8 +2,8 @@ import CanvasConnectionLine from './CanvasConnectionLine.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
-import type { ConnectionLineProps } from '@vue-flow/core';
-import { Position } from '@vue-flow/core';
+import type { ConnectionLineProps } from '@/features/workflows/canvas/vueFlow.adapter';
+import { Position } from '@/features/workflows/canvas/vueFlow.adapter';
 import { createCanvasProvide } from '@/features/workflows/canvas/__tests__/utils';
 import { waitFor } from '@testing-library/vue';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasConnectionLine.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasConnectionLine.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 /* eslint-disable vue/no-multiple-template-root */
-import type { ConnectionLineProps } from '@vue-flow/core';
-import { BaseEdge } from '@vue-flow/core';
+import type { ConnectionLineProps } from '@/features/workflows/canvas/vueFlow.adapter';
+import { BaseEdge } from '@/features/workflows/canvas/vueFlow.adapter';
 import { computed, onMounted, ref, useCssModule } from 'vue';
 import { getEdgeRenderData } from './utils';
 import { useCanvas } from '../../../composables/useCanvas';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.test.ts
@@ -1,7 +1,7 @@
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
-import { Position } from '@vue-flow/core';
+import { Position } from '@/features/workflows/canvas/vueFlow.adapter';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import CanvasEdge, { type CanvasEdgeProps } from './CanvasEdge.vue';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdge.vue
@@ -2,8 +2,8 @@
 /* eslint-disable vue/no-multiple-template-root */
 import type { CanvasConnectionData } from '../../../canvas.types';
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
-import type { Connection, EdgeProps } from '@vue-flow/core';
-import { BaseEdge, EdgeLabelRenderer } from '@vue-flow/core';
+import type { Connection, EdgeProps } from '@/features/workflows/canvas/vueFlow.adapter';
+import { BaseEdge, EdgeLabelRenderer } from '@/features/workflows/canvas/vueFlow.adapter';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { computed, ref, toRef, useCssModule, watch } from 'vue';
 import CanvasEdgeToolbar from './CanvasEdgeToolbar.vue';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/CanvasEdgeToolbar.vue
@@ -5,7 +5,7 @@ import type { NodeConnectionType } from 'n8n-workflow';
 import { isHitlToolType, NodeConnectionTypes } from 'n8n-workflow';
 
 import { N8nIconButton } from '@n8n/design-system';
-import type { GraphNode } from '@vue-flow/core';
+import type { GraphNode } from '@/features/workflows/canvas/vueFlow.adapter';
 import { AGENT_NODE_TYPE, AGENT_TOOL_NODE_TYPE } from '@/app/constants';
 import CanvasEdgeTooltip from './CanvasEdgeTooltip.vue';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/utils/getEdgeRenderData.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/edges/utils/getEdgeRenderData.ts
@@ -1,5 +1,9 @@
-import type { EdgeProps } from '@vue-flow/core';
-import { getBezierPath, getSmoothStepPath, Position } from '@vue-flow/core';
+import type { EdgeProps } from '@/features/workflows/canvas/vueFlow.adapter';
+import {
+	getBezierPath,
+	getSmoothStepPath,
+	Position,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { NodeConnectionType } from 'n8n-workflow';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onMounted, ref, useCssModule, useTemplateRef, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nIcon, N8nIconButton, N8nInlineTextEdit, N8nTooltip } from '@n8n/design-system';
-import { Handle, Position, useVueFlow } from '@vue-flow/core';
+import { Handle, Position, useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import CanvasNodeStatusMark from '../nodes/render-types/parts/CanvasNodeStatusMark.vue';
 import { useZoomAdjustedValues } from '../../../composables/useZoomAdjustedValues';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
@@ -8,7 +8,7 @@ import {
 	type CanvasConnectionPort,
 	type CanvasElementPortWithRenderData,
 } from '../../../canvas.types';
-import { Position } from '@vue-flow/core';
+import { Position } from '@/features/workflows/canvas/vueFlow.adapter';
 import {
 	createCanvasNodeProvide,
 	createCanvasProvide,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.vue
@@ -2,8 +2,8 @@
 import { computed, h, provide, toRef, useCssModule } from 'vue';
 import type { CanvasConnectionPort, CanvasElementPortWithRenderData } from '../../../canvas.types';
 import { CanvasConnectionMode } from '../../../canvas.types';
-import type { ValidConnectionFunc } from '@vue-flow/core';
-import { Handle } from '@vue-flow/core';
+import type { ValidConnectionFunc } from '@/features/workflows/canvas/vueFlow.adapter';
+import { Handle } from '@/features/workflows/canvas/vueFlow.adapter';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import CanvasHandleMainInput from './render-types/CanvasHandleMainInput.vue';
 import CanvasHandleMainOutput from './render-types/CanvasHandleMainOutput.vue';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.vue
@@ -24,8 +24,8 @@ import { useNodeConnections } from '@/app/composables/useNodeConnections';
 import { CanvasNodeKey } from '@/app/constants';
 import { injectCanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
 import { useContextMenu } from '@/features/shared/contextMenu/composables/useContextMenu';
-import type { NodeProps, XYPosition } from '@vue-flow/core';
-import { Position } from '@vue-flow/core';
+import type { NodeProps, XYPosition } from '@/features/workflows/canvas/vueFlow.adapter';
+import { Position } from '@/features/workflows/canvas/vueFlow.adapter';
 import { useCanvas } from '../../../composables/useCanvas';
 import {
 	createCanvasConnectionHandleString,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.vue
@@ -3,9 +3,8 @@
 import { useCanvasNode } from '../../../../composables/useCanvasNode';
 import type { CanvasNodeStickyNoteRender } from '../../../../canvas.types';
 import { ref, computed, useCssModule, onMounted, onBeforeUnmount } from 'vue';
-import { NodeResizer } from '@vue-flow/node-resizer';
-import type { OnResize } from '@vue-flow/node-resizer';
-import type { XYPosition } from '@vue-flow/core';
+import { NodeResizer } from '@/features/workflows/canvas/vueFlow.adapter';
+import type { OnResize, XYPosition } from '@/features/workflows/canvas/vueFlow.adapter';
 
 import { N8nSticky } from '@n8n/design-system';
 defineOptions({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/selection/CanvasSelectionToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/selection/CanvasSelectionToolbar.test.ts
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/vue';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { computed } from 'vue';
-import type { GraphNode } from '@vue-flow/core';
+import type { GraphNode } from '@/features/workflows/canvas/vueFlow.adapter';
 
 import CanvasSelectionToolbar from './CanvasSelectionToolbar.vue';
 import {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/selection/CanvasSelectionToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/selection/CanvasSelectionToolbar.vue
@@ -3,8 +3,8 @@ import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vu
 import { computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nIconButton } from '@n8n/design-system';
-import { getRectOfNodes } from '@vue-flow/core';
-import type { GraphNode } from '@vue-flow/core';
+import { getRectOfNodes } from '@/features/workflows/canvas/vueFlow.adapter';
+import type { GraphNode } from '@/features/workflows/canvas/vueFlow.adapter';
 
 import { useVueFlowTransformPaneTeleport } from '../../../composables/useVueFlowTransformPaneTeleport';
 import { useCanvasNodeGroupActions } from '../../../composables/useCanvasNodeGroupActions';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -1,4 +1,8 @@
-import { useVueFlow, type GraphNode, type VueFlowStore } from '@vue-flow/core';
+import {
+	useVueFlow,
+	type GraphNode,
+	type VueFlowStore,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { computed, ref, shallowRef } from 'vue';
 import {
 	createEmptyCanvasRenderData,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
@@ -1,6 +1,11 @@
 import dagre from '@dagrejs/dagre';
 
-import { useVueFlow, type GraphEdge, type GraphNode, type XYPosition } from '@vue-flow/core';
+import {
+	useVueFlow,
+	type GraphEdge,
+	type GraphNode,
+	type XYPosition,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { STICKY_NODE_TYPE } from '@/app/constants';
 import {
 	CanvasNodeRenderType,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -22,7 +22,7 @@ import type { CanvasNodeGroupView } from './useCanvasNodeGroupView';
 import { createTestNode } from '@/__tests__/mocks';
 import type { INodeUi } from '@/Interface';
 import { CanvasNodeRenderType, type CanvasNodeData } from '../canvas.types';
-import { MarkerType } from '@vue-flow/core';
+import { MarkerType } from '@/features/workflows/canvas/vueFlow.adapter';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
 	...(await importOriginal()),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -29,8 +29,8 @@ import {
 import type { IConnections, ITaskData, IWorkflowGroup } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
-import { MarkerType } from '@vue-flow/core';
-import type { Connection } from '@vue-flow/core';
+import { MarkerType } from '@/features/workflows/canvas/vueFlow.adapter';
+import type { Connection } from '@/features/workflows/canvas/vueFlow.adapter';
 import * as workflowUtils from 'n8n-workflow/common';
 
 // Highest priority first — single source of precedence for connection status.

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupActions.ts
@@ -1,4 +1,4 @@
-import type { GraphNode } from '@vue-flow/core';
+import type { GraphNode } from '@/features/workflows/canvas/vueFlow.adapter';
 import { useI18n } from '@n8n/i18n';
 import type { IWorkflowGroup } from 'n8n-workflow';
 import type { MaybeRefOrGetter } from 'vue';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { GraphNode, NodeDragEvent } from '@vue-flow/core';
+import type { GraphNode, NodeDragEvent } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { INodeUi } from '@/Interface';
 import { useCanvasNodeGroupDrag } from './useCanvasNodeGroupDrag';
 import { CANVAS_NODE_GROUP_TYPE } from '../canvas.types';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupDrag.ts
@@ -1,5 +1,5 @@
-import type { GraphNode, NodeDragEvent } from '@vue-flow/core';
-import { useVueFlow } from '@vue-flow/core';
+import type { GraphNode, NodeDragEvent } from '@/features/workflows/canvas/vueFlow.adapter';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { INodeUi } from '@/Interface';
 import type { CanvasGroupNodeData, CanvasNodeMoveEvent } from '../canvas.types';
 import {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupSelection.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupSelection.ts
@@ -1,5 +1,5 @@
 import { computed, toValue, watch, type MaybeRefOrGetter } from 'vue';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import type { IWorkflowGroup } from 'n8n-workflow';
 import { isPresent } from '@/app/utils/typesUtils';
 import {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeHover.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeHover.test.ts
@@ -2,7 +2,7 @@
 import { renderComponent } from '@/__tests__/render';
 import { type CanvasNode } from '../canvas.types';
 import { fireEvent } from '@testing-library/dom';
-import { type Rect, useVueFlow, VueFlow } from '@vue-flow/core';
+import { type Rect, useVueFlow, VueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { describe, expect, it } from 'vitest';
 import { computed, defineComponent, h } from 'vue';
 import { useCanvasNodeHover } from './useCanvasNodeHover';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeHover.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeHover.ts
@@ -1,5 +1,9 @@
 import { type CanvasNode } from '../canvas.types';
-import { getRectOfNodes, type Rect, type VueFlowStore } from '@vue-flow/core';
+import {
+	getRectOfNodes,
+	type Rect,
+	type VueFlowStore,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { useThrottleFn } from '@vueuse/core';
 import { type ComputedRef, onMounted, onUnmounted, ref } from 'vue';
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasTraversal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasTraversal.test.ts
@@ -1,6 +1,6 @@
 import { useCanvasTraversal } from '@/features/workflows/canvas/composables/useCanvasTraversal';
 import type { CanvasNode } from '../canvas.types';
-import type { VueFlowStore } from '@vue-flow/core';
+import type { VueFlowStore } from '@/features/workflows/canvas/vueFlow.adapter';
 import { mock } from 'vitest-mock-extended';
 
 describe('useCanvasTraversal', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasTraversal.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasTraversal.ts
@@ -1,5 +1,5 @@
 import type { CanvasNode } from '../canvas.types';
-import type { VueFlowStore } from '@vue-flow/core';
+import type { VueFlowStore } from '@/features/workflows/canvas/vueFlow.adapter';
 
 export function useCanvasTraversal({ getIncomers, getOutgoers }: VueFlowStore) {
 	function sortNodesByVerticalPosition(nodes: CanvasNode[]) {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useViewportAutoAdjust.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useViewportAutoAdjust.ts
@@ -1,4 +1,8 @@
-import type { Rect, SetViewport, ViewportTransform } from '@vue-flow/core';
+import type {
+	Rect,
+	SetViewport,
+	ViewportTransform,
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { type Ref, ref, watch } from 'vue';
 
 /**

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useVueFlowTransformPaneTeleport.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useVueFlowTransformPaneTeleport.ts
@@ -1,5 +1,5 @@
 import { nextTick, ref, watch } from 'vue';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 
 // Vue-flow's transform pane has no public API; the class name is part of its
 // DOM contract. Overlays teleported here inherit the same pan/zoom transforms

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.ts
@@ -1,5 +1,5 @@
 import { computed, ref, type Ref } from 'vue';
-import type { ViewportTransform } from '@vue-flow/core';
+import type { ViewportTransform } from '@/features/workflows/canvas/vueFlow.adapter';
 
 /**
  * Composable for calculating zoom-adjusted visual values (lightness, opacity, etc.)

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
@@ -2,7 +2,7 @@
 import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { watchOnce } from '@vueuse/core';
 import { computed, provide, ref } from 'vue';
 import { useExperimentalNdvStore } from '../experimentalNdv.store';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/experimentalNdv.store.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/experimentalNdv.store.ts
@@ -8,7 +8,7 @@ import {
 	type SetViewport,
 	type ViewportTransform,
 	type ZoomTo,
-} from '@vue-flow/core';
+} from '@/features/workflows/canvas/vueFlow.adapter';
 import { CanvasNodeRenderType, type CanvasNodeData } from '../canvas.types';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { CANVAS_ZOOMED_VIEW_EXPERIMENT, NDV_IN_FOCUS_PANEL_EXPERIMENT } from '@/app/constants';

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/vueFlow.adapter.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/vueFlow.adapter.ts
@@ -1,0 +1,17 @@
+/**
+ * Single entry point for everything the editor imports from Vue Flow.
+ *
+ * All app code imports Vue Flow values and types from this module instead of
+ * from `@vue-flow/*` directly. Vue Flow 2.0 (`@xyflow/vue`) ships every built-in
+ * from one package — `Background`, `Controls`, `MiniMap`, `NodeResizer` all move
+ * out of their standalone packages into core — so routing the imports through
+ * here keeps the eventual package swap confined to this file rather than spread
+ * across the whole feature.
+ */
+export * from '@vue-flow/core';
+
+export { Background } from '@vue-flow/background';
+export { Controls } from '@vue-flow/controls';
+export { MiniMap } from '@vue-flow/minimap';
+export { NodeResizer } from '@vue-flow/node-resizer';
+export type { OnResize } from '@vue-flow/node-resizer';

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/HighlightedEdge.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/HighlightedEdge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { createComponentRenderer } from '@/__tests__/render';
 import HighlightedEdge from '@/features/workflows/workflowDiff/HighlightedEdge.vue';
 import type { CanvasEdgeProps } from '@/features/workflows/canvas/components/elements/edges/CanvasEdge.vue';
-import { Position } from '@vue-flow/core';
+import { Position } from '@/features/workflows/canvas/vueFlow.adapter';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 // Mock the Edge component

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/HighlightedEdge.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/HighlightedEdge.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { CanvasEdgeProps } from '@/features/workflows/canvas/components/elements/edges/CanvasEdge.vue';
 import Edge from '@/features/workflows/canvas/components/elements/edges/CanvasEdge.vue';
-import { BaseEdge } from '@vue-flow/core';
+import { BaseEdge } from '@/features/workflows/canvas/vueFlow.adapter';
 
 const props = defineProps<CanvasEdgeProps>();
 </script>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.vue
@@ -8,7 +8,7 @@ import type {
 } from '@/features/workflows/canvas/canvas.types';
 import type { CanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
 import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/useCanvasLayout';
-import { useVueFlow } from '@vue-flow/core';
+import { useVueFlow } from '@/features/workflows/canvas/vueFlow.adapter';
 import { watch } from 'vue';
 import Canvas from '@/features/workflows/canvas/components/Canvas.vue';
 import { createEventBus } from '@n8n/utils/event-bus';


### PR DESCRIPTION
## Summary

Version-agnostic preparation for the Vue Flow 2.0 (`@xyflow/vue`) migration. Every change here is valid on the **current Vue Flow 1.48** and is independently mergeable — the goal is to shrink the eventual 2.0 diff, not to migrate.

- **Adapter module.** Adds `packages/frontend/editor-ui/src/features/workflows/canvas/vueFlow.adapter.ts`, a thin barrel that re-exports `@vue-flow/*`, and routes all 58 editor-ui consumers (source + tests) through it. Vue Flow 2.0 ships every built-in from one package (`Background`, `Controls`, `MiniMap`, `NodeResizer` fold into core), so the eventual package consolidation becomes a one-file change instead of a repo-wide edit.
- **Remove the inert `:apply-changes="false"` prop** on the `<VueFlow>` mount. It is not a real Vue Flow prop (the real name is `apply-default` / `autoApplyChanges`), so it is a no-op today. Controlled flow already comes from the one-way `:nodes` binding, with the `workflowDocument` store as the source of truth — no auto-apply prop is needed.
- **Set `connection-mode` explicitly to `Loose`.** This is the Vue Flow 1.x default (a no-op today), but 2.0 defaults to `strict`, which would silently stop forming n8n's connections. Setting it now is safe on 1.48 and pre-empts the silent breakage. Note: on 1.48 the prop is typed as the `ConnectionMode` enum, so it is bound as `:connection-mode="ConnectionMode.Loose"` (the bare `"loose"` string in the migration guide does not typecheck on 1.x).

No behavioral or visual change on 1.48 — this is import routing plus a prop cleanup.

## How to test

No UI behavior changes on the current 1.48. Verified locally in `packages/frontend/editor-ui`:

- `pnpm typecheck` — 0 errors
- `pnpm lint` — 0 errors
- `pnpm test src/features/workflows/canvas` and the app/diff consumers — 946 tests passing

Manual smoke test: open the workflow canvas, confirm nodes render and connections (including AI/non-main handles) still form and drag normally, and the minimap/controls/background/sticky-note resizer still render.

## Related Linear tickets, Github issues, and Community forum posts

Multica issue N8N-48 (Phase 1 of the Vue Flow 2.0 migration, parent N8N-41). No corresponding Linear ticket or GitHub issue.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- No new behavior; existing canvas suites (946 tests) exercise the adapter and mount and pass. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34451">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

