### PR TITLE
fix(editor): Fix focus parameter button breaking selection in credential dialog

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.test.ts
@@ -1,8 +1,73 @@
-import { render } from '@testing-library/vue';
+import { fireEvent, render } from '@testing-library/vue';
 
 import InputLabel from './InputLabel.vue';
 
 describe('component', () => {
+	describe('Label click behavior', () => {
+		it('does not activate a button in the options slot when the label is clicked', async () => {
+			const { getByText, getByTestId } = render(InputLabel, {
+				props: {
+					label: 'a label',
+				},
+				slots: {
+					options: '<button data-test-id="focus-button">focus</button>',
+				},
+			});
+
+			const onButtonClick = vi.fn();
+			getByTestId('focus-button').addEventListener('click', onButtonClick);
+
+			await fireEvent.click(getByText('a label'));
+
+			// clicking a label without `for` must not forward the click
+			// to the first labelable element (the options slot button)
+			expect(onButtonClick).not.toHaveBeenCalled();
+		});
+
+		it('activates the associated input when the label has a `for` target', async () => {
+			const { getByText, getByTestId } = render(InputLabel, {
+				props: {
+					label: 'a label',
+					inputName: 'my-input',
+				},
+				slots: {
+					options: '<button data-test-id="focus-button">focus</button>',
+					default: '<input id="my-input" data-test-id="the-input" />',
+				},
+			});
+
+			const onInputClick = vi.fn();
+			const onButtonClick = vi.fn();
+			getByTestId('the-input').addEventListener('click', onInputClick);
+			getByTestId('focus-button').addEventListener('click', onButtonClick);
+
+			await fireEvent.click(getByText('a label'));
+
+			// with a `for` target the label activation stays intact and never
+			// leaks to the options slot
+			expect(onInputClick).toHaveBeenCalledTimes(1);
+			expect(onButtonClick).not.toHaveBeenCalled();
+		});
+
+		it('activates a button in the options slot when the button itself is clicked', async () => {
+			const { getByTestId } = render(InputLabel, {
+				props: {
+					label: 'a label',
+				},
+				slots: {
+					options: '<button data-test-id="focus-button">focus</button>',
+				},
+			});
+
+			const onButtonClick = vi.fn();
+			getByTestId('focus-button').addEventListener('click', onButtonClick);
+
+			await fireEvent.click(getByTestId('focus-button'));
+
+			expect(onButtonClick).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe('Text overflow behavior', () => {
 		it('displays full text without options', () => {
 			const { container } = render(InputLabel, {

--- a/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nInputLabel/InputLabel.vue
@@ -22,7 +22,7 @@ interface InputLabelProps {
 }
 
 defineOptions({ name: 'N8nInputLabel' });
-withDefaults(defineProps<InputLabelProps>(), {
+const props = withDefaults(defineProps<InputLabelProps>(), {
 	compact: false,
 	bold: true,
 	size: 'medium',
@@ -30,6 +30,12 @@ withDefaults(defineProps<InputLabelProps>(), {
 
 const addTargetBlank = (html: string) =>
 	html && html.includes('href=') ? html.replace(/href=/g, 'target="_blank" href=') : html;
+
+const onLabelClick = (event: MouseEvent) => {
+	// Per the HTML spec, clicking a label without a `for` target activates its
+	// first labelable descendant, unintentionally triggering slotted controls
+	if (!props.inputName) event.preventDefault();
+};
 </script>
 
 <template>
@@ -53,6 +59,7 @@ const addTargetBlank = (html: string) =>
 					[$style[size]]: true,
 					[$style.overflow]: !!$slots.options,
 				}"
+				@click="onLabelClick"
 			>
 				<div :class="$style['main-content']">
 					<div v-if="label" :class="$style.title">

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.test.ts
@@ -2,11 +2,15 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { STORES } from '@n8n/stores';
 import { SETTINGS_STORE_DEFAULT_STATE } from '@/__tests__/utils';
-import { createTestNodeProperties } from '@/__tests__/mocks';
+import { createTestNode, createTestNodeProperties } from '@/__tests__/mocks';
 import ParameterInputExpanded from './ParameterInputExpanded.vue';
+import type { NDVStore } from '@/features/ndv/shared/ndv.store';
 import type { INodePropertyCollection } from 'n8n-workflow';
 import userEvent from '@testing-library/user-event';
+import { mock } from 'vitest-mock-extended';
 import { nextTick } from 'vue';
+
+const ndvStoreMock = vi.hoisted(() => ({ current: null as unknown }));
 
 // Instantiates a store that derives the workflow id from the route. These tests run
 // without a router, so resolve the id directly.
@@ -15,6 +19,14 @@ vi.mock('@/app/composables/useWorkflowId', async () => {
 	return {
 		useWorkflowId: () => computed(() => ''),
 		useRouteWorkflowId: () => computed(() => ''),
+	};
+});
+
+vi.mock('@/features/ndv/shared/ndv.store', async (importOriginal) => {
+	const { computed } = await import('vue');
+	return {
+		...(await importOriginal<typeof import('@/features/ndv/shared/ndv.store')>()),
+		injectNDVStoreIfProvided: () => computed(() => ndvStoreMock.current),
 	};
 });
 
@@ -74,6 +86,26 @@ describe('ParameterInputExpanded.vue', () => {
 
 	const renderComponent = createComponentRenderer(ParameterInputExpanded, {
 		pinia: mockPinia,
+	});
+
+	afterEach(() => {
+		ndvStoreMock.current = null;
+	});
+
+	it('does not render the focus parameter button, even with an active NDV node', async () => {
+		ndvStoreMock.current = mock<NDVStore>({ activeNode: createTestNode() });
+
+		const { getByTestId, queryByTestId } = renderComponent({
+			props: {
+				parameter: createTestNodeProperties({ name: 'apiKey', type: 'string' }),
+				value: '',
+			},
+		});
+		await vi.dynamicImportSettled();
+
+		expect(getByTestId('parameter-options-container')).toBeInTheDocument();
+		// the focus panel cannot host credential fields, so the button must stay hidden
+		expect(queryByTestId('parameter-focus-button')).not.toBeInTheDocument();
 	});
 
 	describe('FixedCollectionParameter', () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.vue
@@ -188,6 +188,7 @@ defineExpose({
 					:is-read-only="false"
 					:show-options="!isFixedCollectionType"
 					:show-expression-selector="!isFixedCollectionType"
+					:show-focus-panel="false"
 					:is-value-expression="isValueExpression"
 					@update:model-value="optionSelected"
 					@menu-expanded="onMenuExpanded"


### PR DESCRIPTION
## Summary

The "Focus parameter" button leaked into the credential dialog through the shared `ParameterOptions` component. The focus panel can only host node parameters, so clicking the button closed the NDV behind the dialog and broke the UI. Credential fields no longer render the button; NDV parameters are unaffected.

Clicking the field label also no longer triggers buttons from the options slot: a `<label>` without a `for` target forwards clicks to its first labelable descendant (the focus button, now the actions toggle).

### Screenshots

<img width="295" height="219" alt="image" src="https://github.com/user-attachments/assets/964be215-3aa2-49cb-8ca9-0f91de4f6821" />


## How to test

1. Open a node with credentials → *Set up credential*.
2. Hover a credential field label: only the actions toggle and Fixed/Expression appear — no focus button.
3. Click the label or the empty area next to the controls: nothing is triggered; close the dialog — the NDV behind it is intact.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-643

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)