### PR TITLE
feat(core): Tear down ghost triggers left by a missed unpublish (no-changelog)

### DIFF
--- a/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
+++ b/packages/cli/src/events/maps/workflow-publication-metrics.event-map.ts
@@ -51,6 +51,8 @@ export type WorkflowPublicationMetricsEventMap = {
 		result: PublicationOperationResult;
 		/** Workflows re-enqueued because their in-memory triggers were missing. */
 		deficientCount: number;
+		/** Registered workflows torn down because they are no longer published. */
+		surplusCount: number;
 		durationMs: number;
 	};
 };

--- a/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/workflow-publication-metrics.service.ts
@@ -199,6 +199,11 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 			help: 'Total number of workflows re-enqueued by trigger reconciliation because their in-memory triggers were missing.',
 		});
 
+		const surplus = new promClient.Counter({
+			name: `${prefix}workflow_publication_reconciliation_surplus_workflows_total`,
+			help: 'Total number of registered workflows torn down by trigger reconciliation because they were no longer published.',
+		});
+
 		const duration = new promClient.Histogram({
 			name: `${prefix}workflow_publication_reconciliation_duration_seconds`,
 			help: 'Duration in seconds of a trigger reconciliation pass by result.',
@@ -208,8 +213,9 @@ export class PrometheusWorkflowPublicationMetricsService implements PrometheusMe
 
 		this.eventService.on(
 			'workflow-publication-reconciliation',
-			({ result, deficientCount, durationMs }) => {
+			({ result, deficientCount, surplusCount, durationMs }) => {
 				deficient.inc(deficientCount);
+				surplus.inc(surplusCount);
 				duration.observe({ result }, durationMs * Time.milliseconds.toSeconds);
 			},
 		);

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-reconciler.service.test.ts
@@ -1,15 +1,25 @@
 import type { Logger } from '@n8n/backend-common';
 import type { WorkflowsConfig } from '@n8n/config';
 import type {
+	WorkflowEntity,
+	WorkflowPublicationOutbox,
 	WorkflowPublicationOutboxRepository,
 	WorkflowPublicationTriggerStatusRepository,
+	WorkflowRepository,
 } from '@n8n/db';
 import { mock } from 'vitest-mock-extended';
-import type { ErrorReporter, InstanceSettings, Span, Tracing } from 'n8n-core';
+import type {
+	ActiveWorkflowTriggers,
+	ErrorReporter,
+	InstanceSettings,
+	Span,
+	Tracing,
+} from 'n8n-core';
 
 import type { EventService } from '@/events/event.service';
 import type { NonWebhookTriggerRegistrar } from '@/workflows/triggers/non-webhook-trigger-registrar';
 
+import type { WorkflowPublicationLifecycleLock } from '../workflow-publication-lifecycle-lock';
 import type { WorkflowPublicationOutboxConsumer } from '../workflow-publication-outbox-consumer';
 import { WorkflowPublicationReconciler } from '../workflow-publication-reconciler.service';
 
@@ -26,6 +36,9 @@ const instanceSettings = mock<InstanceSettings>({ isLeader: true });
 const errorReporter = mock<ErrorReporter>();
 const tracing = mock<Tracing>();
 const eventService = mock<EventService>();
+const lifecycleLock = mock<WorkflowPublicationLifecycleLock>();
+const workflowRepository = mock<WorkflowRepository>();
+const activeWorkflowTriggers = mock<ActiveWorkflowTriggers>();
 
 let service: WorkflowPublicationReconciler;
 
@@ -47,8 +60,14 @@ beforeEach(() => {
 	});
 	triggerStatusRepository.findActivatedInMemoryTriggers.mockResolvedValue([]);
 	outboxRepository.enqueueByWorkflowIds.mockResolvedValue();
+	outboxRepository.findInFlightByWorkflowId.mockResolvedValue(null);
 	outboxConsumer.drainPending.mockResolvedValue(0);
 	setRegistered({});
+	activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([]);
+	activeWorkflowTriggers.remove.mockResolvedValue(true);
+	workflowRepository.getActiveIds.mockResolvedValue([]);
+	workflowRepository.findOneBy.mockResolvedValue(null);
+	lifecycleLock.runExclusive.mockImplementation(async (_workflowId, fn) => await fn());
 	service = new WorkflowPublicationReconciler(
 		logger,
 		config,
@@ -60,6 +79,9 @@ beforeEach(() => {
 		errorReporter,
 		tracing,
 		eventService,
+		lifecycleLock,
+		workflowRepository,
+		activeWorkflowTriggers,
 	);
 });
 
@@ -70,9 +92,9 @@ afterEach(() => {
 
 describe('WorkflowPublicationReconciler', () => {
 	describe('init', () => {
-		it('schedules reconciliation at the configured interval when leader', () => {
+		it('schedules reconciliation at the configured interval when leader', async () => {
 			service.init();
-			vi.advanceTimersByTime(5_000);
+			await vi.advanceTimersByTimeAsync(5_000);
 
 			expect(triggerStatusRepository.findActivatedInMemoryTriggers).toHaveBeenCalled();
 		});
@@ -175,6 +197,69 @@ describe('WorkflowPublicationReconciler', () => {
 			await service.reconcile();
 
 			expect(triggerStatusRepository.findActivatedInMemoryTriggers).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('surplus (ghost) triggers', () => {
+		/** A registered workflow that is no longer published: the ghost scenario. */
+		function setGhost(workflowId: string) {
+			activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue([workflowId]);
+			workflowRepository.getActiveIds.mockResolvedValue([]);
+			workflowRepository.findOneBy.mockResolvedValue({
+				id: workflowId,
+				activeVersionId: null,
+			} as WorkflowEntity);
+		}
+
+		it('tears down ghost triggers under the workflow lock and reports the surplus', async () => {
+			setGhost('wf-ghost');
+
+			await service.reconcile();
+
+			expect(lifecycleLock.runExclusive).toHaveBeenCalledWith('wf-ghost', expect.any(Function));
+			expect(activeWorkflowTriggers.remove).toHaveBeenCalledWith('wf-ghost');
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ result: 'success', surplusCount: 1 }),
+			);
+		});
+
+		it('leaves a registered workflow that is still published alone', async () => {
+			activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds.mockReturnValue(['wf-1']);
+			workflowRepository.getActiveIds.mockResolvedValue(['wf-1']);
+
+			await service.reconcile();
+
+			expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'workflow-publication-reconciliation',
+				expect.objectContaining({ surplusCount: 0 }),
+			);
+		});
+
+		it('leaves a workflow with an in-flight record for that publication to handle', async () => {
+			setGhost('wf-ghost');
+			outboxRepository.findInFlightByWorkflowId.mockResolvedValue(
+				mock<WorkflowPublicationOutbox>({ workflowId: 'wf-ghost' }),
+			);
+
+			await service.reconcile();
+
+			expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
+		});
+
+		it('re-checks under the lock and skips a workflow republished since detection', async () => {
+			setGhost('wf-ghost');
+			// By the time the lock is acquired, a publish has completed: the workflow
+			// is active again and its registered triggers are current, not ghosts.
+			workflowRepository.findOneBy.mockResolvedValue({
+				id: 'wf-ghost',
+				activeVersionId: 'v-2',
+			} as WorkflowEntity);
+
+			await service.reconcile();
+
+			expect(activeWorkflowTriggers.remove).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-reconciler.service.ts
@@ -4,15 +4,23 @@ import { Time } from '@n8n/constants';
 import {
 	WorkflowPublicationOutboxRepository,
 	WorkflowPublicationTriggerStatusRepository,
+	WorkflowRepository,
 } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover, OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
-import { ErrorReporter, InstanceSettings, SpanStatus, Tracing } from 'n8n-core';
+import {
+	ActiveWorkflowTriggers,
+	ErrorReporter,
+	InstanceSettings,
+	SpanStatus,
+	Tracing,
+} from 'n8n-core';
 import type { WorkflowId } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
 import { NonWebhookTriggerRegistrar } from '@/workflows/triggers/non-webhook-trigger-registrar';
 
+import { WorkflowPublicationLifecycleLock } from './workflow-publication-lifecycle-lock';
 import { WorkflowPublicationOutboxConsumer } from './workflow-publication-outbox-consumer';
 
 /**
@@ -48,6 +56,9 @@ export class WorkflowPublicationReconciler {
 		private readonly errorReporter: ErrorReporter,
 		private readonly tracing: Tracing,
 		private readonly eventService: EventService,
+		private readonly lifecycleLock: WorkflowPublicationLifecycleLock,
+		private readonly workflowRepository: WorkflowRepository,
+		private readonly activeWorkflowTriggers: ActiveWorkflowTriggers,
 	) {
 		this.logger = logger.scoped('workflow-publication');
 	}
@@ -108,25 +119,19 @@ export class WorkflowPublicationReconciler {
 			async (span) => {
 				const startedAt = Date.now();
 				try {
-					const missing = await this.findMissingActiveWorkflows();
+					const surplus = await this.removeGhostTriggers(await this.findSurplusWorkflowIds());
+					const missing = await this.republishMissingWorkflows(
+						await this.findMissingActiveWorkflows(),
+					);
 
-					span.setAttribute('n8n.publication.deficient_workflows', missing.length);
-
-					if (missing.length > 0) {
-						this.logger.debug('Re-publishing workflows with missing in-memory triggers', {
-							workflowIds: missing,
-						});
-						await this.outboxRepository.enqueueByWorkflowIds(missing);
-						// Drain directly rather than waiting for the next poll cycle. These are
-						// safe to call here, to recover more quickly.
-						this.outboxConsumer.startPolling();
-						await this.outboxConsumer.drainPending();
-					}
+					span.setAttribute('n8n.publication.deficient_workflows', missing);
+					span.setAttribute('n8n.publication.surplus_workflows', surplus);
 
 					span.setStatus({ code: SpanStatus.ok });
 					this.eventService.emit('workflow-publication-reconciliation', {
 						result: 'success',
-						deficientCount: missing.length,
+						deficientCount: missing,
+						surplusCount: surplus,
 						durationMs: Date.now() - startedAt,
 					});
 				} catch (error) {
@@ -135,11 +140,40 @@ export class WorkflowPublicationReconciler {
 					this.eventService.emit('workflow-publication-reconciliation', {
 						result: 'failure',
 						deficientCount: 0,
+						surplusCount: 0,
 						durationMs: Date.now() - startedAt,
 					});
 				}
 			},
 		);
+	}
+
+	private async findSurplusWorkflowIds(): Promise<WorkflowId[]> {
+		const registered = this.activeWorkflowTriggers.getNonWebhookTriggerWorkflowIds();
+		if (registered.length === 0) return [];
+
+		const desired = new Set(await this.workflowRepository.getActiveIds());
+
+		const candidates = registered.filter((workflowId) => !desired.has(workflowId));
+
+		return candidates;
+	}
+
+	private async removeGhostTriggers(workflowIds: WorkflowId[]): Promise<number> {
+		let surplusRepairs = 0;
+		for (const workflowId of workflowIds) {
+			await this.lifecycleLock.runExclusive(workflowId, async () => {
+				const workflow = await this.workflowRepository.findOneBy({ id: workflowId });
+
+				if (workflow?.activeVersionId) return;
+				if (await this.outboxRepository.findInFlightByWorkflowId(workflowId)) return;
+
+				await this.activeWorkflowTriggers.remove(workflowId);
+				surplusRepairs++;
+			});
+		}
+
+		return surplusRepairs;
 	}
 
 	/**
@@ -161,6 +195,21 @@ export class WorkflowPublicationReconciler {
 		}
 
 		return missing;
+	}
+
+	private async republishMissingWorkflows(workflowIds: WorkflowId[]): Promise<number> {
+		if (workflowIds.length > 0) {
+			this.logger.debug('Re-publishing workflows with missing in-memory triggers', {
+				workflowIds,
+			});
+			await this.outboxRepository.enqueueByWorkflowIds(workflowIds);
+			// Drain directly rather than waiting for the next poll cycle. These are
+			// safe to call here, to recover more quickly.
+			this.outboxConsumer.startPolling();
+			await this.outboxConsumer.drainPending();
+		}
+
+		return workflowIds.length;
 	}
 
 	private groupByWorkflow(rows: Array<{ workflowId: WorkflowId; nodeId: string }>) {

--- a/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-reconciler.test.ts
@@ -165,6 +165,80 @@ describe('WorkflowPublicationReconciler (integration)', () => {
 		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
 	});
 
+	test('tears down ghost triggers left by an unpublish another main consumed', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('ghost');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await consumer.processRecord(record!);
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
+
+		// A demoted main consumed the unpublish record: workflow deactivated,
+		// mapping removed, trigger-status rows cleared, record completed — but it
+		// tore down the triggers in *its* registry. This leader still has them
+		// registered and firing, and no record is left to fix that.
+		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
+		await publishedVersionRepository.removePublishedVersion(workflow.id);
+		await triggerStatusRepository.delete({ workflowId: workflow.id });
+
+		await reconciler.reconcile();
+
+		expect(activeWorkflowTriggers.get(workflow.id)).toBeUndefined();
+		// Repair is local — no outbox round-trip was needed.
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('heals ghost triggers and orphaned trigger-status rows together in one pass', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('ghost-orphan');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await consumer.processRecord(record!);
+
+		// A re-leased unpublish torn between two mains: mapping removed and the
+		// record completed elsewhere, but this leader's registry AND the
+		// trigger-status rows were left behind.
+		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
+		await publishedVersionRepository.removePublishedVersion(workflow.id);
+
+		// One pass converges: surplus teardown first, which lets the leftover rows
+		// read as missing, enqueue, and clear through the unpublish path.
+		await reconciler.reconcile();
+
+		expect(activeWorkflowTriggers.get(workflow.id)).toBeUndefined();
+		expect(await triggerStatusRepository.findByWorkflowId(workflow.id)).toHaveLength(0);
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('leaves triggers of a workflow with an in-flight unpublish for that record to tear down', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('in-flight');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+		await consumer.processRecord(record!);
+
+		// Mid-unpublish: activeVersionId already cleared, pending record owns the
+		// teardown. Reconciliation must not race it.
+		await Container.get(WorkflowRepository).update(workflow.id, { activeVersionId: null });
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+
+		await reconciler.reconcile();
+
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(trigger.id)).toBe(true);
+	});
+
 	test('a pass with nothing missing enqueues no work', async () => {
 		const owner = await createOwner();
 


### PR DESCRIPTION
## Summary

Follow-up to #33577 (CAT-3654), closing the reverse gap: reconciliation recovers missed *activations*, but nothing recovers a missed *unpublish*.

**The race:** a user deactivates a workflow during a leader transition. The demoted main consumes the unpublish record and tears down triggers in *its own* registry — but the new leader still has them registered and firing. Nothing detects this: the trigger-status rows were cleared when the record completed, so the reconciler's "should be active but isn't" diff sees nothing, and no outbox record remains.

**The fix:** each reconcile pass now also checks the surplus direction — workflows registered in memory but no longer published (`activeVersionId` is null) — and tears their triggers down locally, under the per-workflow lifecycle lock, with a re-check inside the lock so a workflow republished between detection and teardown is left alone. Repair must be local: the published-version mapping is already gone, so an outbox record would have nothing to tear down.

Surplus runs before the missing pass, so a combined ghost+orphaned-rows state (re-leased unpublish torn between two mains) heals in one pass. Each pass reports a `surplusCount` (event + Prometheus counter), counting actual removals only.

Behind `N8N_USE_WORKFLOW_PUBLICATION_SERVICE`; no-op when off.

## How to test

Covered by unit tests (surplus detection, lock discipline, exclusions) and integration tests (ghost teardown end-to-end, combined-state single-pass convergence, in-flight guard) — see `workflow-publication-reconciler.service.test.ts` / `workflow-publication-reconciler.test.ts`.

Manual (requires the flag): activate a workflow with a schedule trigger, then via SQL null its `activeVersionId` and delete its `workflow_published_version` + trigger-status rows; within one reconcile interval (default 10s) the trigger stops firing.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3759

Follow-up to #33577 and #34443.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
