### PR TITLE
feat(core): Prefer MCP servers over node tools when available

### DIFF
--- a/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
+++ b/packages/@n8n/api-types/src/agents/agent-json-config.schema.ts
@@ -258,7 +258,7 @@ export const McpServerConfigSchema = z
 			})
 			.optional()
 			.describe(
-				'Server-generated metadata. Do not set this manually, only copy from search_mcp_servers result if present',
+				'Server-generated metadata. Do not set this manually; only copy it from an MCP discovery result when present',
 			),
 		toolFilter: z
 			.discriminatedUnion('mode', [

--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -242,6 +242,7 @@ describe('AgentsBuilderToolsService', () => {
 			const toolNames = tools.map((tool) => tool.name);
 			expect(toolNames).toContain(BUILDER_TOOLS.VERIFY_MCP_SERVER);
 			expect(toolNames).toContain(BUILDER_TOOLS.SEARCH_MCP_SERVERS);
+			expect(toolNames).toContain(BUILDER_TOOLS.RESOLVE_INTEGRATION);
 		});
 
 		it('registers publish and unpublish tools in the builder toolset', () => {

--- a/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
@@ -127,6 +127,23 @@ describe('AgentsToolsService', () => {
 		});
 	});
 
+	describe('searchAgentToolNodes()', () => {
+		it('initializes and searches the catalog with the agent tool-node filter', async () => {
+			const { service, nodeCatalogService } = makeService();
+
+			const result = await service.searchAgentToolNodes(['gmail', 'slack']);
+
+			expect(nodeCatalogService.initialize).toHaveBeenCalled();
+			expect(nodeCatalogService.searchNodes).toHaveBeenCalledWith(['gmail', 'slack'], {
+				nodeFilter: isAgentToolNodeType,
+			});
+			expect(result).toEqual({
+				results: 'search-result',
+				queriesWithNoResults: [],
+			});
+		});
+	});
+
 	describe('isExecutableNodeType', () => {
 		it('rejects trigger nodes only', () => {
 			expect(isExecutableNodeType('n8n-nodes-base.scheduleTrigger')).toBe(false);

--- a/packages/cli/src/modules/agents/agents-tools.service.ts
+++ b/packages/cli/src/modules/agents/agents-tools.service.ts
@@ -1,5 +1,6 @@
 import type { BuiltTool, CredentialProvider } from '@n8n/agents';
 import { Tool } from '@n8n/agents/tool';
+import type { CodeBuilderSearchResult } from '@n8n/ai-utilities/node-catalog';
 import {
 	AGENT_BUILDER_AVAILABLE_AI_UTILITY_TOOL_NODE_TYPES,
 	AGENT_BUILDER_HIDDEN_AVAILABLE_TOOL_NODE_TYPES,
@@ -70,7 +71,11 @@ const searchNodesInputSchema = z.object({
 	queries: z.array(z.string()).min(1).describe('Search queries (e.g., ["gmail", "slack", "http"])'),
 });
 
-const nodeVersionSchema = z.number().describe('Tool node type version from search_nodes');
+const nodeVersionSchema = z
+	.number()
+	.describe(
+		'Tool node type version from node discovery results (search_nodes or resolve_integration kind: "node")',
+	);
 
 const getNodeTypesInputSchema = z.object({
 	nodeIds: z
@@ -87,7 +92,9 @@ const getNodeTypesInputSchema = z.object({
 			]),
 		)
 		.min(1)
-		.describe('Tool node IDs from search_nodes (e.g., ["n8n-nodes-base.gmailTool"])'),
+		.describe(
+			'Tool node IDs from node discovery results (search_nodes or resolve_integration kind: "node"; e.g., ["n8n-nodes-base.gmailTool"])',
+		),
 });
 
 const listCredentialsInputSchema = z.object({
@@ -120,6 +127,13 @@ export class AgentsToolsService {
 		];
 	}
 
+	async searchAgentToolNodes(queries: string[]): Promise<CodeBuilderSearchResult> {
+		await this.nodeCatalogService.initialize();
+		return await this.nodeCatalogService.searchNodes(queries, {
+			nodeFilter: isAgentToolNodeType,
+		});
+	}
+
 	private buildSearchNodesTool(): BuiltTool {
 		return new Tool('search_nodes')
 			.description(
@@ -129,10 +143,7 @@ export class AgentsToolsService {
 			)
 			.input(searchNodesInputSchema)
 			.handler(async ({ queries }: { queries: string[] }) => {
-				await this.nodeCatalogService.initialize();
-				const { results } = await this.nodeCatalogService.searchNodes(queries, {
-					nodeFilter: isAgentToolNodeType,
-				});
+				const { results } = await this.searchAgentToolNodes(queries);
 				return { results };
 			})
 			.build();
@@ -141,10 +152,11 @@ export class AgentsToolsService {
 	private buildGetNodeTypesTool(): BuiltTool {
 		return new Tool('get_node_types')
 			.description(
-				'Get detailed parameter schema for specific n8n nodes. Use the node IDs returned ' +
-					'by search_nodes. Returns parameter definitions needed to configure a node for execution. ' +
-					'Use the tool node IDs from search_nodes. ' +
-					'You can optionally filter by resource/operation/mode.',
+				'Get detailed parameter schema for specific n8n nodes. Use the node IDs from node ' +
+					'discovery results (search_nodes or resolve_integration kind: "node"). Returns ' +
+					'parameter definitions needed to configure a node for execution. Use the tool node ' +
+					'IDs from discovery, usually ending in Tool. You can optionally filter by ' +
+					'resource/operation/mode.',
 			)
 			.input(getNodeTypesInputSchema)
 			.handler(async ({ nodeIds }: { nodeIds: NodeRequest[] }) => {

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder-model-recommendations.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder-model-recommendations.test.ts
@@ -233,9 +233,11 @@ describe('builder model recommendations', () => {
 		expect(skillsById.has('agent-builder-research')).toBe(false);
 
 		const integrations = skillsById.get('agent-builder-integrations');
-		expect(integrations?.description).toContain('chat integration/trigger versus a node tool');
-		expect(integrations?.instructions).toContain('Integration vs Node Tool Decision');
-		expect(integrations?.instructions).toContain('Linear node tools');
+		expect(integrations?.description).toContain(
+			'chat integration/trigger versus an MCP, node, or workflow tool',
+		);
+		expect(integrations?.instructions).toContain('Integration vs Callable Tool Decision');
+		expect(integrations?.instructions).toContain('Linear callable tools');
 
 		const resourceLocators = skillsById.get('agent-builder-resource-locators');
 		expect(resourceLocators?.description).toContain('stable dynamic selector fields');

--- a/packages/cli/src/modules/agents/builder/__tests__/agents-builder-prompts.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/agents-builder-prompts.test.ts
@@ -1,13 +1,20 @@
 import { SUB_AGENT_MAX_CHILDREN_MAX, SUB_AGENT_MAX_CHILDREN_MIN } from '@n8n/api-types';
 
 import {
+	FEW_SHOT_FLOWS_SECTION,
 	INTERACTIVE_TOOLS_SECTION,
 	READ_CONFIG_FRESHNESS_SECTION,
 	WORKFLOW_SECTION,
 	buildBuilderPrompt,
 } from '../agents-builder-prompts';
 import { getConfigMutationPrompt } from '../prompts/config-mutation.prompt';
+import { getLlmSelectionPrompt } from '../prompts/llm-selection.prompt';
+import { TOOLS_PROMPT } from '../prompts/tools.prompt';
 import { getBuilderRuntimeSkills } from '../skills';
+
+function normalizeWhitespace(value: string | undefined): string {
+	return value?.replace(/\s+/g, ' ').trim() ?? '';
+}
 
 describe('builder prompt stability', () => {
 	it('omits stale agent state while retaining config freshness guidance', () => {
@@ -146,6 +153,12 @@ describe('agents builder integrations prompt', () => {
 describe('chat-channel credential guidance', () => {
 	it('mandates configure_channel and forbids ask_credential for chat-channel credentials', () => {
 		expect(INTERACTIVE_TOOLS_SECTION).toContain(
+			'`ask_credential` for node-tool, MCP-server, and fallback web-search credentials',
+		);
+		expect(normalizeWhitespace(INTERACTIVE_TOOLS_SECTION)).toContain(
+			"anything that isn't a node-tool credential, MCP-server credential, fallback web-search credential, or channel choice",
+		);
+		expect(INTERACTIVE_TOOLS_SECTION).toContain(
 			'NEVER use it for a chat-channel\n  credential — use `configure_channel` instead.',
 		);
 		expect(INTERACTIVE_TOOLS_SECTION).toContain(
@@ -157,6 +170,14 @@ describe('chat-channel credential guidance', () => {
 		);
 		expect(integrationsSkill?.instructions).toContain(
 			'ALWAYS use `configure_channel` for chat-channel\n  credentials — never `ask_credential`',
+		);
+
+		const llmSelectionPrompt = getLlmSelectionPrompt(null);
+		expect(llmSelectionPrompt).toContain(
+			'Use `ask_credential` for node tools, MCP servers, and fallback web-search credentials.',
+		);
+		expect(llmSelectionPrompt).not.toContain(
+			'Use `ask_credential` for node tools and integrations.',
 		);
 	});
 
@@ -186,6 +207,72 @@ describe('chat-channel credential guidance', () => {
 		expect(getConfigMutationPrompt()).toContain(
 			'Omitting `integrations` preserves existing channels.',
 		);
+	});
+});
+
+describe('external integration routing guidance', () => {
+	it('routes chat and trigger surfaces before resolving callable services', () => {
+		const toolsPrompt = normalizeWhitespace(TOOLS_PROMPT);
+
+		expect(toolsPrompt).toContain(
+			"first decide whether it is the target agent's chat or trigger surface",
+		);
+		expect(toolsPrompt).toContain(
+			'Do not call `resolve_integration` for chat/trigger integrations.',
+		);
+		expect(toolsPrompt).toContain(
+			'For each requested non-chat callable service, call `resolve_integration` separately',
+		);
+
+		const slackFlow = normalizeWhitespace(
+			FEW_SHOT_FLOWS_SECTION.split('### New agent: "Use Anthropic via OpenRouter"')[0],
+		);
+		expect(slackFlow).toContain('`list_integration_types()`');
+		expect(slackFlow).toContain('`configure_channel({ integrationType: "slack" })`');
+		expect(slackFlow).not.toContain('`resolve_integration`');
+	});
+
+	it('selects an MCP candidate before credential and verification', () => {
+		const mcpSkill = getBuilderRuntimeSkills().find((skill) => skill.id === 'agent-builder-mcp');
+		const mcpInstructions = normalizeWhitespace(mcpSkill?.instructions);
+
+		expect(mcpInstructions).toContain(
+			'`resolve_integration` returns `{ kind: "mcp", results: [...] }`',
+		);
+		expect(mcpInstructions).toContain('Never read server fields from the wrapper');
+		expect(mcpInstructions).toContain('never choose by array order');
+		expect(mcpInstructions).toContain('call `ask_questions` with the candidate');
+		expect(mcpInstructions).toContain('`selectedResult.credentialType`');
+		expect(mcpInstructions).toContain('returned `credentialId` as `credential`');
+		expect(mcpInstructions).toContain(
+			'If `ask_questions` returns `{ answered: false }`, stop MCP setup',
+		);
+		expect(mcpSkill?.recommendedTools).toContain('ask_questions');
+
+		const notionFlow = normalizeWhitespace(
+			FEW_SHOT_FLOWS_SECTION.split('### Add MCP integration:')[1]?.split(
+				'### Ambiguous request:',
+			)[0],
+		);
+		expect(notionFlow).toContain('select one entry from `results[]`');
+		expect(notionFlow).toContain('`selectedResult.credentialType`');
+		expect(notionFlow).toContain('`credentialId` as `credential`');
+	});
+
+	it('stops after channel setup and mutates config only for the non-chat branch', () => {
+		const ambiguousFlow = normalizeWhitespace(
+			FEW_SHOT_FLOWS_SECTION.split('### Ambiguous request:')[1]?.split(
+				'### Publish after build:',
+			)[0],
+		);
+
+		expect(ambiguousFlow).toContain('After `configure_channel` returns, stop this flow');
+		expect(ambiguousFlow).toContain('In this non-chat branch only, `read_config()`');
+
+		const chatBranch = ambiguousFlow.split('If it is a chat integration')[1]?.split('Otherwise')[0];
+		expect(chatBranch).not.toContain('`read_config`');
+		expect(chatBranch).not.toContain('`patch_config`');
+		expect(chatBranch).not.toContain('`write_config`');
 	});
 });
 

--- a/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
@@ -1,0 +1,74 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { McpRegistrySearchResult } from '@/modules/mcp-registry/registry/mcp-registry-search';
+import type { McpRegistryService } from '@/modules/mcp-registry/registry/mcp-registry.service';
+
+import type { AgentsToolsService } from '../../agents-tools.service';
+import { buildResolveIntegrationTool } from '../resolve-integration.tool';
+
+const ctx = {
+	resumeData: undefined,
+	suspend: vi.fn().mockResolvedValue(undefined as never),
+	parentTelemetry: undefined,
+};
+
+const notionResult: McpRegistrySearchResult = {
+	name: 'notion',
+	title: 'Notion',
+	description: 'Connect to the Notion MCP Server',
+	url: 'https://mcp.notion.com/mcp',
+	transport: 'streamableHttp',
+	authentication: 'notionMcpOAuth2Api',
+	credentialType: 'notionMcpOAuth2Api',
+	tools: [],
+	metadata: { nodeTypeName: '@n8n/mcp-registry.notion' },
+};
+
+describe('buildResolveIntegrationTool', () => {
+	it('returns kind: "mcp" when the registry has matches and does not search nodes', async () => {
+		const mcpRegistryService = mock<McpRegistryService>();
+		const agentsToolsService = mock<AgentsToolsService>();
+		mcpRegistryService.search.mockResolvedValue([notionResult]);
+
+		const tool = buildResolveIntegrationTool({ mcpRegistryService, agentsToolsService });
+		const result = await tool.handler!({ queries: ['notion'] }, ctx);
+
+		expect(mcpRegistryService.search).toHaveBeenCalledWith(['notion']);
+		expect(agentsToolsService.searchAgentToolNodes).not.toHaveBeenCalled();
+		expect(result).toEqual({ kind: 'mcp', results: [notionResult] });
+	});
+
+	it('returns kind: "node" with node search results when the registry has no matches', async () => {
+		const mcpRegistryService = mock<McpRegistryService>();
+		const agentsToolsService = mock<AgentsToolsService>();
+		mcpRegistryService.search.mockResolvedValue([]);
+		agentsToolsService.searchAgentToolNodes.mockResolvedValue({
+			results: 'slack node results',
+			queriesWithNoResults: ['unknown'],
+		});
+
+		const tool = buildResolveIntegrationTool({ mcpRegistryService, agentsToolsService });
+		const result = await tool.handler!({ queries: ['slack'] }, ctx);
+
+		expect(mcpRegistryService.search).toHaveBeenCalledWith(['slack']);
+		expect(agentsToolsService.searchAgentToolNodes).toHaveBeenCalledWith(['slack']);
+		expect(result).toEqual({
+			kind: 'node',
+			results: 'slack node results',
+			queriesWithNoResults: ['unknown'],
+		});
+	});
+
+	it('propagates registry search errors instead of falling back to nodes', async () => {
+		const mcpRegistryService = mock<McpRegistryService>();
+		const agentsToolsService = mock<AgentsToolsService>();
+		mcpRegistryService.search.mockRejectedValue(new Error('registry unavailable'));
+
+		const tool = buildResolveIntegrationTool({ mcpRegistryService, agentsToolsService });
+
+		await expect(tool.handler!({ queries: ['slack'] }, ctx)).rejects.toThrow(
+			'registry unavailable',
+		);
+		expect(agentsToolsService.searchAgentToolNodes).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -124,10 +124,15 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 ### New agent: "Build me a Slack triage agent"
 1. \`ask_questions({ ... })\` for the model choice, then
    \`resolve_llm({ provider, model })\` -> resolved provider, model, and credential.
-2. \`search_nodes({ query: "slack" })\`, then \`get_node_types(...)\`.
-3. \`ask_credential(...)\` for the Slack credential slot.
+2. \`resolve_integration({ queries: ["slack"] })\`.
+3. Follow the returned kind:
+   - \`kind: "mcp"\`: load \`agent-builder-mcp\`, ask for the returned credential
+     type, and verify the server.
+   - \`kind: "node"\`: load \`agent-builder-node-tools\`, inspect the returned node
+     results with \`get_node_types\`, and ask for every required credential.
 4. \`read_config()\`.
-5. \`write_config(...)\` with model, credential, instructions, and Slack tool.
+5. \`write_config(...)\` with the model, credential, instructions, and resolved
+   Slack capability.
 
 ### New agent: "Use Anthropic via OpenRouter"
 1. \`resolve_llm({ provider: "openrouter" })\`.
@@ -141,32 +146,46 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 2. \`read_config()\`.
 3. \`patch_config(...)\` replacing \`/model\` and \`/credential\`.
 
-### Add a node tool to an existing agent
-1. Search and inspect the node type.
+### Add an explicitly requested n8n node tool to an existing agent
+1. Load \`agent-builder-node-tools\`, then call \`search_nodes\` and
+   \`get_node_types\`; the explicit n8n-node request does not need
+   \`resolve_integration\`.
 2. \`ask_credential\` for every required slot.
 3. \`read_config()\`.
 4. \`patch_config(...)\` adding the node tool to \`/tools/-\`.
 
-### Add a node tool when credential setup is skipped
-1. Search and inspect the node type.
+### Add an explicitly requested n8n node tool when credential setup is skipped
+1. Load \`agent-builder-node-tools\`, then call \`search_nodes\` and
+   \`get_node_types\`.
 2. \`ask_credential(...)\` -> \`{ skipped: true }\`.
 3. \`read_config()\`.
 4. \`patch_config(...)\` adding the tool and omitting only the skipped
    credential slot. Do not abort the tool addition.
 
 ### Add MCP integration: "Connect Notion MCP"
-1. \`load_skill({ "skillId": "agent-builder-mcp" })\`.
-2. \`search_mcp_servers({ queries: ["notion"] })\`.
+1. \`resolve_integration({ queries: ["notion"] })\`.
+2. When it returns \`kind: "mcp"\`, load
+   \`agent-builder-mcp\`.
 3. \`ask_credential({ credentialType: "<result.credentialType>" })\`.
 4. \`verify_mcp_server({ name, url, transport, authentication, credential })\`.
-5. \`read_config()\`.
-6. \`patch_config(...)\` adding a new \`/mcpServers/-\` entry (including
-   \`metadata.nodeTypeName\` when returned by \`search_mcp_servers\`).
+5. Confirm the verified tools cover the requested capability.
+6. \`read_config()\`.
+7. \`patch_config(...)\` adding a new \`/mcpServers/-\` entry (including
+   \`metadata.nodeTypeName\` when returned by \`resolve_integration\`).
 
 ### Ambiguous request: "Make it post somewhere"
 1. \`ask_questions(...)\` with the known destination choices.
-2. Continue the chosen branch with node discovery, credentials, and config
-   mutation.
+2. Load \`agent-builder-integrations\` to decide whether the destination is the
+   agent's chat/trigger surface.
+3. If it is a chat integration, call \`configure_channel\` with the returned
+   \`integrationType\`.
+4. Otherwise call \`resolve_integration({ queries: ["<selected service>"] })\`
+   and follow the returned kind:
+   - \`kind: "mcp"\`: load \`agent-builder-mcp\`, verify, and wire the MCP server.
+   - \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
+     results with \`get_node_types\`, and ask for every required credential.
+5. \`read_config()\`, then \`patch_config(...)\` or \`write_config(...)\` with
+   the resolved capability.
 
 ### Publish after build: "Publish it" / "Make it live"
 1. Finish any pending config mutations.

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -39,23 +39,27 @@ must be persisted exactly as returned.
 
 Once you are building, ask for any specific decision, choice, value, or
 clarification through one of these tools rather than in plain prose. Use
-\`ask_credential\` for node-tool credentials, \`configure_channel\` for
-chat-channel connections, and \`ask_questions\` for everything else, including
-the model/credential choice — resolve the answer with \`resolve_llm\`.
+\`ask_credential\` for node-tool, MCP-server, and fallback web-search credentials,
+\`configure_channel\` for chat-channel connections, and \`ask_questions\` for
+everything else, including the model/credential choice — resolve the answer with
+\`resolve_llm\`.
 Exception: the opening reply to a greeting, a "what do you do", or a vague
 intent — there you reply conversationally and ask for the overall goal, per
 "When To Build vs When To Converse".
 
-- \`ask_credential\`: use once per required node-tool credential slot before
-  the config mutation that introduces the tool. NEVER use it for a chat-channel
+- \`ask_credential\`: use once per required node-tool, MCP-server, or fallback
+  web-search credential slot. For node tools and fallback web search, call it
+  before the related config mutation; for MCP servers, call it before
+  verification. NEVER use it for a chat-channel
   credential — use \`configure_channel\` instead.
 - \`configure_channel\`: ALWAYS use this to connect a chat platform (Slack,
   Telegram, ...) as an agent channel, with a type from \`list_integration_types\`.
   The setup UI creates and persists the credential itself.
 - \`ask_questions\`: the default way to ask the user anything that isn't a
-  node-tool credential or channel choice, including when the user must choose,
-  confirm, configure, or change the target agent's main provider, model, or
-  LLM credential — resolve the answer with \`resolve_llm\`. Batch every
+  node-tool credential, MCP-server credential, fallback web-search credential,
+  or channel choice, including when the user must choose, confirm, configure, or
+  change the target agent's main provider, model, or LLM credential — resolve
+  the answer with \`resolve_llm\`. Batch every
   question you currently need into a single call instead of asking one at a
   time. Each question is single-select, multi-select, or free-text; pass
   discrete \`options\` for a known small set of choices, or \`type: "text"\` for
@@ -121,18 +125,15 @@ export const WORKFLOW_SECTION = `\
 export const FEW_SHOT_FLOWS_SECTION = `\
 ## Example flows
 
-### New agent: "Build me a Slack triage agent"
+### New agent: "Build me an agent teammates can @mention in Slack to triage messages"
 1. \`ask_questions({ ... })\` for the model choice, then
    \`resolve_llm({ provider, model })\` -> resolved provider, model, and credential.
-2. \`resolve_integration({ queries: ["slack"] })\`.
-3. Follow the returned kind:
-   - \`kind: "mcp"\`: load \`agent-builder-mcp\`, ask for the returned credential
-     type, and verify the server.
-   - \`kind: "node"\`: load \`agent-builder-node-tools\`, inspect the returned node
-     results with \`get_node_types\`, and ask for every required credential.
-4. \`read_config()\`.
-5. \`write_config(...)\` with the model, credential, instructions, and resolved
-   Slack capability.
+2. \`read_config()\`.
+3. \`write_config(...)\` with the model, credential, and instructions.
+4. Load \`agent-builder-integrations\`, call \`list_integration_types()\`, and
+   select the returned Slack type.
+5. \`configure_channel({ integrationType: "slack" })\`. The setup UI persists or
+   skips the channel; do not follow it with a config read or mutation.
 
 ### New agent: "Use Anthropic via OpenRouter"
 1. \`resolve_llm({ provider: "openrouter" })\`.
@@ -164,28 +165,36 @@ export const FEW_SHOT_FLOWS_SECTION = `\
 
 ### Add MCP integration: "Connect Notion MCP"
 1. \`resolve_integration({ queries: ["notion"] })\`.
-2. When it returns \`kind: "mcp"\`, load
-   \`agent-builder-mcp\`.
-3. \`ask_credential({ credentialType: "<result.credentialType>" })\`.
-4. \`verify_mcp_server({ name, url, transport, authentication, credential })\`.
-5. Confirm the verified tools cover the requested capability.
-6. \`read_config()\`.
-7. \`patch_config(...)\` adding a new \`/mcpServers/-\` entry (including
-   \`metadata.nodeTypeName\` when returned by \`resolve_integration\`).
+2. When it returns \`kind: "mcp"\`, load \`agent-builder-mcp\`.
+3. For MCP candidates, select one entry from \`results[]\`. If
+   multiple candidates remain, use \`ask_questions\` with their titles and
+   descriptions; never choose by array order. If the user dismisses the
+   question, stop without selecting or configuring a server. Otherwise treat
+   the chosen entry as \`selectedResult\`.
+4. Use \`selectedResult.credentialType\` in
+   \`ask_credential({ purpose: "Connect Notion MCP", credentialType: "<selectedResult.credentialType>" })\`.
+5. Call \`verify_mcp_server\` with the connection fields from \`selectedResult\`
+   and the returned \`credentialId\` as \`credential\`.
+6. Confirm the verified tools cover the requested capability.
+7. \`read_config()\`.
+8. \`patch_config(...)\` adding a new \`/mcpServers/-\` entry, including
+   \`selectedResult.metadata.nodeTypeName\` when present.
 
 ### Ambiguous request: "Make it post somewhere"
 1. \`ask_questions(...)\` with the known destination choices.
 2. Load \`agent-builder-integrations\` to decide whether the destination is the
    agent's chat/trigger surface.
 3. If it is a chat integration, call \`configure_channel\` with the returned
-   \`integrationType\`.
+   \`integrationType\`. After \`configure_channel\` returns, stop this flow; the
+   setup UI already persisted or skipped the channel, so do not read or mutate
+   the config.
 4. Otherwise call \`resolve_integration({ queries: ["<selected service>"] })\`
    and follow the returned kind:
    - \`kind: "mcp"\`: load \`agent-builder-mcp\`, verify, and wire the MCP server.
    - \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
      results with \`get_node_types\`, and ask for every required credential.
-5. \`read_config()\`, then \`patch_config(...)\` or \`write_config(...)\` with
-   the resolved capability.
+5. In this non-chat branch only, \`read_config()\`, then \`patch_config(...)\` or
+   \`write_config(...)\` with the resolved capability.
 
 ### Publish after build: "Publish it" / "Make it live"
 1. Finish any pending config mutations.

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -58,6 +58,7 @@ import {
 	buildResolveLlmTool,
 } from './interactive';
 import type { ModelLookup } from './interactive/resolve-llm.tool';
+import { buildResolveIntegrationTool } from './resolve-integration.tool';
 import { buildSearchMcpServersTool } from './search-mcp-servers.tool';
 import { SKILL_BODY_GUIDANCE, SKILL_DESCRIPTION_RULE } from './skill-body-template';
 import { TASK_OBJECTIVE_GUIDANCE } from './task-objective-template';
@@ -593,6 +594,10 @@ export class AgentsBuilderToolsService {
 				),
 			}),
 			buildSearchMcpServersTool({ mcpRegistryService: this.mcpRegistryService }),
+			buildResolveIntegrationTool({
+				mcpRegistryService: this.mcpRegistryService,
+				agentsToolsService: this.agentsToolsService,
+			}),
 		];
 
 		return tools;

--- a/packages/cli/src/modules/agents/builder/builder-tool-names.ts
+++ b/packages/cli/src/modules/agents/builder/builder-tool-names.ts
@@ -22,6 +22,7 @@ export const BUILDER_TOOLS = {
 	LIST_SUB_AGENTS: 'list_sub_agents',
 	PUBLISH_AGENT: 'publish_agent',
 	UNPUBLISH_AGENT: 'unpublish_agent',
+	RESOLVE_INTEGRATION: 'resolve_integration',
 	RESOLVE_LLM: 'resolve_llm',
 	SEARCH_MCP_SERVERS: 'search_mcp_servers',
 	VERIFY_MCP_SERVER: 'verify_mcp_server',

--- a/packages/cli/src/modules/agents/builder/prompts/llm-selection.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/llm-selection.prompt.ts
@@ -42,8 +42,9 @@ Use this to resolve the target agent's main \`model\` and \`credential\`.
 ### Gotchas
 
 - Use \`resolve_llm\` only for the target agent's main model credential.
-- Use \`ask_credential\` for node tools and integrations. For Episodic Memory,
-  load \`agent-builder-memory\` and use \`ask_embedding_credential\` instead.
+- Use \`ask_credential\` for node tools, MCP servers, and fallback web-search credentials.
+  Never use it for chat-channel credentials. For Episodic Memory, load
+  \`agent-builder-memory\` and use \`ask_embedding_credential\` instead.
 - For OpenRouter, \`provider\` is \`"openrouter"\`; the model can be a routed id such as \`anthropic/...\`.
 - Do not recommend current, best, latest, or fallback model IDs from memory when the recommendation catalog is unavailable.
 

--- a/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
@@ -12,20 +12,29 @@ Use this guidance before calling \`resolve_integration\`, \`search_nodes\`,
 \`search_mcp_servers\`, \`get_node_types\`, \`build_custom_tool\`, or adding,
 changing, or removing entries in \`tools[]\` / \`mcpServers\` / \`providerTools\`.
 
-For every real-world external service, call \`resolve_integration\` before
-loading MCP or node-tool skills. Do not infer MCP availability from memory.
+For an external product, first decide whether it is the target agent's chat or
+trigger surface. Load \`agent-builder-integrations\` whenever the request could
+mean that the product is where people invoke or converse with the agent.
 
-- \`kind: "mcp"\`: load \`agent-builder-mcp\` and follow the MCP credential,
-  verification, and config workflow.
-- \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
-  results, and continue with \`get_node_types\`.
+- Chat/trigger integration: call \`list_integration_types\`, then
+  \`configure_channel\` with a returned type. Do not call \`resolve_integration\`
+  for chat/trigger integrations.
+- Callable external service: the conversation or trigger happens elsewhere and
+  the agent only operates on the product. For each requested non-chat callable
+  service, call \`resolve_integration\` separately, using \`queries\` as
+  alternative search terms for that one service. Do not infer MCP availability
+  from memory.
+  - \`kind: "mcp"\`: load \`agent-builder-mcp\` and follow the MCP credential,
+    verification, and config workflow.
+  - \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
+    results, and continue with \`get_node_types\`.
 
 Use \`search_nodes\` directly only when the user explicitly asks for an n8n node,
 when refining node results, or when a verified MCP server lacks the requested
 capability. Use \`search_mcp_servers\` directly only when refining MCP results or
 when the user explicitly asks to browse the MCP registry.
 
-Preference order for real-world integrations:
+Preference order for non-chat callable services:
 1. MCP servers selected by \`resolve_integration\`
 2. Node tools returned by \`resolve_integration\`
 3. Workflow tools (\`list_workflows\`)
@@ -33,9 +42,6 @@ Preference order for real-world integrations:
 
 Custom tools are for pure computation, validation, formatting, or planning logic;
 they cannot perform live network, filesystem, process, timer, or host I/O.
-
-Load \`agent-builder-integrations\` when deciding whether a product belongs in
-\`integrations\` or should be exposed as an MCP, node, or workflow tool.
 
 #### Workflow Tools
 
@@ -71,6 +77,10 @@ Custom tools are last resort and only for pure computation. Load
 
 ### Verify
 
-- External services were resolved through \`resolve_integration\` unless the user explicitly requested an n8n node or custom MCP server.
+- Chat/trigger integrations bypassed \`resolve_integration\` and were set up
+  through \`configure_channel\`.
+- Each non-chat callable service was resolved separately through
+  \`resolve_integration\` unless the user explicitly requested an n8n node or
+  custom MCP server.
 - Workflow tools reference discovered workflow names.
 - Provider tool keys match the configured model provider and the valid key list.`;

--- a/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
+++ b/packages/cli/src/modules/agents/builder/prompts/tools.prompt.ts
@@ -3,17 +3,31 @@ export const TOOLS_PROMPT = `\
 
 ### Purpose
 
-Use this to give the target agent callable capabilities through workflows,
-nodes, custom code tools, or provider tools.
+Use this to give the target agent callable capabilities through MCP servers,
+workflows, nodes, custom code tools, or provider tools.
 
 ### Workflow
 
-Use this guidance before calling \`search_nodes\`, \`get_node_types\`, \`build_custom_tool\`,
-or adding, changing, or removing entries in \`tools[]\` / \`providerTools\`.
+Use this guidance before calling \`resolve_integration\`, \`search_nodes\`,
+\`search_mcp_servers\`, \`get_node_types\`, \`build_custom_tool\`, or adding,
+changing, or removing entries in \`tools[]\` / \`mcpServers\` / \`providerTools\`.
+
+For every real-world external service, call \`resolve_integration\` before
+loading MCP or node-tool skills. Do not infer MCP availability from memory.
+
+- \`kind: "mcp"\`: load \`agent-builder-mcp\` and follow the MCP credential,
+  verification, and config workflow.
+- \`kind: "node"\`: load \`agent-builder-node-tools\`, use the returned node
+  results, and continue with \`get_node_types\`.
+
+Use \`search_nodes\` directly only when the user explicitly asks for an n8n node,
+when refining node results, or when a verified MCP server lacks the requested
+capability. Use \`search_mcp_servers\` directly only when refining MCP results or
+when the user explicitly asks to browse the MCP registry.
 
 Preference order for real-world integrations:
-1. MCP servers (\`search_mcp_servers\`)
-2. Node tools (\`search_nodes\`)
+1. MCP servers selected by \`resolve_integration\`
+2. Node tools returned by \`resolve_integration\`
 3. Workflow tools (\`list_workflows\`)
 4. Custom tools (\`build_custom_tool\`) — last resort
 
@@ -21,7 +35,7 @@ Custom tools are for pure computation, validation, formatting, or planning logic
 they cannot perform live network, filesystem, process, timer, or host I/O.
 
 Load \`agent-builder-integrations\` when deciding whether a product belongs in
-\`integrations\` or should be exposed as a node/workflow tool.
+\`integrations\` or should be exposed as an MCP, node, or workflow tool.
 
 #### Workflow Tools
 
@@ -29,8 +43,15 @@ Load \`agent-builder-integrations\` when deciding whether a product belongs in
 
 #### Node Tools
 
-Load \`agent-builder-node-tools\` before adding, changing, or removing
-node-backed tools, \`nodeParameters\`, \`$fromAI\` usage, or n8n expressions.
+Load \`agent-builder-node-tools\` after \`resolve_integration\` returns
+\`kind: "node"\`, or when the user explicitly requests an n8n node. Follow it
+before adding, changing, or removing node-backed tools, \`nodeParameters\`,
+\`$fromAI\` usage, or n8n expressions.
+
+#### MCP Servers
+
+Load \`agent-builder-mcp\` after \`resolve_integration\` returns \`kind: "mcp"\`, or
+when the user explicitly requests a custom MCP server.
 
 #### Custom Tools
 
@@ -45,10 +66,11 @@ Custom tools are last resort and only for pure computation. Load
 
 ### Gotchas
 
-- Live crawling, fetching, and API integrations need workflow or node tools, not custom tools.
-- Do not invent node type names, workflow names, credential ids, or provider tool keys.
+- Live crawling, fetching, and API integrations need MCP, workflow, or node tools, not custom tools.
+- Do not invent MCP servers, node type names, workflow names, credential ids, or provider tool keys.
 
 ### Verify
 
+- External services were resolved through \`resolve_integration\` unless the user explicitly requested an n8n node or custom MCP server.
 - Workflow tools reference discovered workflow names.
 - Provider tool keys match the configured model provider and the valid key list.`;

--- a/packages/cli/src/modules/agents/builder/resolve-integration.tool.ts
+++ b/packages/cli/src/modules/agents/builder/resolve-integration.tool.ts
@@ -1,0 +1,42 @@
+import type { BuiltTool } from '@n8n/agents';
+import { Tool } from '@n8n/agents/tool';
+import { z } from 'zod';
+
+import type { McpRegistryService } from '@/modules/mcp-registry/registry/mcp-registry.service';
+
+import type { AgentsToolsService } from '../agents-tools.service';
+import { BUILDER_TOOLS } from './builder-tool-names';
+
+export interface ResolveIntegrationDeps {
+	mcpRegistryService: McpRegistryService;
+	agentsToolsService: AgentsToolsService;
+}
+
+const resolveIntegrationInputSchema = z.object({
+	queries: z
+		.array(z.string())
+		.min(1)
+		.describe('External services to resolve (e.g. ["github"], ["slack"])'),
+});
+
+export function buildResolveIntegrationTool(deps: ResolveIntegrationDeps): BuiltTool {
+	return new Tool(BUILDER_TOOLS.RESOLVE_INTEGRATION)
+		.description(
+			'Resolve external services to MCP servers or n8n node tools. Searches the MCP registry first and returns kind: "mcp" when a match exists; only searches agent-eligible n8n node tools and returns kind: "node" when no MCP server matches. For kind: "mcp", load agent-builder-mcp. For kind: "node", load agent-builder-node-tools and use the returned node results.',
+		)
+		.input(resolveIntegrationInputSchema)
+		.handler(async ({ queries }: { queries: string[] }) => {
+			const mcpResults = await deps.mcpRegistryService.search(queries);
+			if (mcpResults.length > 0) {
+				return { kind: 'mcp' as const, results: mcpResults };
+			}
+
+			const nodeResults = await deps.agentsToolsService.searchAgentToolNodes(queries);
+			return {
+				kind: 'node' as const,
+				results: nodeResults.results,
+				queriesWithNoResults: nodeResults.queriesWithNoResults,
+			};
+		})
+		.build();
+}

--- a/packages/cli/src/modules/agents/builder/skills/integrations.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/integrations.skill.ts
@@ -5,8 +5,9 @@ export function integrationsSkill(): RuntimeSkill {
 		id: 'agent-builder-integrations',
 		name: 'Agent Builder Integrations',
 		description:
-			'Use when deciding whether Slack, Linear, Telegram, or another external platform should be a target-agent chat integration/trigger versus a node tool, and when adding, changing, or removing chat integrations; not for built-in Build chat or Preview chat behavior.',
+			'Use when deciding whether Slack, Linear, Telegram, or another external platform should be a target-agent chat integration/trigger versus an MCP, node, or workflow tool, and when adding, changing, or removing chat integrations; not for built-in Build chat or Preview chat behavior.',
 		recommendedTools: [
+			'resolve_integration',
 			'list_integration_types',
 			'configure_channel',
 			'ask_questions',
@@ -14,18 +15,20 @@ export function integrationsSkill(): RuntimeSkill {
 			'patch_config',
 		],
 		allowedTools: [
+			'resolve_integration',
 			'list_integration_types',
 			'configure_channel',
 			'ask_questions',
 			'read_config',
 			'patch_config',
 			'write_config',
+			'load_skill',
 		],
 		instructions: `\
 ## Purpose
 
 Use this to decide whether the target agent needs an entry in \`integrations\`
-or a normal node/workflow tool for an external product, then configure
+or an MCP, node, or workflow tool for an external product, then configure
 \`integrations\` only when the integration is the right surface.
 
 ## Use when
@@ -35,14 +38,14 @@ or a normal node/workflow tool for an external product, then configure
 - The user asks to connect the target agent to an external chat platform with
   credentials.
 
-## Integration vs Node Tool Decision
+## Integration vs Callable Tool Decision
 
 Use an integration when the product is the agent's conversation or trigger
 surface: humans will mention, message, comment to, or resume the agent there,
 or the agent needs to respond in that same platform conversation context.
 
-Use a node/workflow tool when the product is only something the agent operates
-on: searching records, creating tickets, updating objects, or sending a
+Use an MCP, node, or workflow tool when the product is only something the agent
+operates on: searching records, creating tickets, updating objects, or sending a
 business-process notification while the conversation happens elsewhere.
 
 Examples:
@@ -53,8 +56,9 @@ Examples:
 - Linear integration: the agent should be triggered from Linear issues/comments,
   understand the current Linear subject, or reply in the same Linear
   conversation.
-- Linear node tools: the agent is triggered from Slack, Preview, a task, or a
-  workflow and only needs to search/create/update Linear tickets.
+- Linear callable tools: the agent is triggered from Slack, Preview, a task, or a
+  workflow and only needs to search/create/update Linear tickets via MCP or node
+  tools.
 
 ## Workflow
 
@@ -82,11 +86,26 @@ The \`integrations\` array controls how the target agent is triggered.
 - Removing a chat integration means deleting its entry from
   \`integrations[]\`. Do not call \`configure_channel\` to remove a channel.
 
+### Callable External Services
+
+When the product is not a chat/trigger integration, call \`resolve_integration\`
+with queries matching the requested service before loading MCP or node-tool
+skills.
+
+- If it returns \`kind: "mcp"\`, load \`agent-builder-mcp\` and follow the MCP
+  credential, verification, and config workflow.
+- If it returns \`kind: "node"\`, load \`agent-builder-node-tools\`, use the
+  returned node results with \`get_node_types\`, and ask for every required
+  credential.
+- Use workflow tools when the capability should come from an existing workflow
+  instead of a direct MCP or node tool.
+
 ## Gotchas
 
 - Chat integration types must come from \`list_integration_types\`.
-- Do not add a Linear integration just because the agent needs Linear issue
-  CRUD. Use Linear node tools unless Linear itself is the chat/trigger context.
+- Do not add a chat integration just because the agent needs CRUD or notifications
+  for that product. Resolve the callable capability through \`resolve_integration\`
+  unless the product itself is the chat/trigger context.
 - For recurring or scheduled runs, create a task (\`create_tasks\`), not an
   integration.
 - Omitting \`integrations\` from a config write preserves the current channels.
@@ -97,8 +116,11 @@ The \`integrations\` array controls how the target agent is triggered.
 
 - Connected chat integrations were set up through \`configure_channel\`, not
   \`ask_credential\` or a manual config write.
-- The chosen integration matches \`useIntegrationWhen\`; otherwise use node or
+- The chosen integration matches \`useIntegrationWhen\`; otherwise resolve the
+  callable capability through \`resolve_integration\` and use MCP, node, or
   workflow tools.
+- Generic non-chat external services were routed through \`resolve_integration\`
+  before MCP or node setup.
 - The final \`integrations\` array keeps unrelated integrations intact and
   removes only the requested channel entries.`,
 	};

--- a/packages/cli/src/modules/agents/builder/skills/mcp.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/mcp.skill.ts
@@ -17,6 +17,7 @@ export function mcpSkill(): RuntimeSkill {
 			'Use when adding, removing, or updating MCP (Model Context Protocol) servers on the target agent.',
 		recommendedTools: [
 			'resolve_integration',
+			'ask_questions',
 			'ask_credential',
 			'verify_mcp_server',
 			'read_config',
@@ -56,7 +57,8 @@ connected MCP server.
 For a generic external-service request, \`resolve_integration\` must select the
 integration type before this skill is loaded. If no resolver result is
 available yet, call \`resolve_integration\` with queries matching the requested
-service.
+service. Resolve one requested service per call; use \`queries\` only for
+alternative search terms for that service.
 
 - If it returns \`kind: "node"\` for a generic service request, load
   \`agent-builder-node-tools\` and continue with the returned node results. Stop
@@ -65,15 +67,27 @@ service.
   do not silently substitute a node tool. Continue with manual MCP setup by
   asking for the URL and transport/authentication decision through
   \`${ASK_QUESTIONS_TOOL_NAME}\`.
-- If it returns \`kind: "mcp"\`, use the returned \`name\`, \`url\`, \`transport\`,
-  \`authentication\`, \`credentialType\`, \`tools\`, and optional \`metadata\`.
+- \`resolve_integration\` returns \`{ kind: "mcp", results: [...] }\` for MCP
+  matches. Never read server fields from the wrapper; select a result first:
+  - If \`results[]\` contains one entry, use it as \`selectedResult\`.
+  - If the request uniquely identifies one entry by \`name\` or \`title\`, use
+    that entry as \`selectedResult\`.
+  - If multiple candidates remain, call \`ask_questions\` with the candidate
+    titles and descriptions; never choose by array order. Use the chosen entry
+    as \`selectedResult\`. If \`ask_questions\` returns \`{ answered: false }\`,
+    stop MCP setup without selecting a server, asking for credentials, verifying
+    a connection, or mutating config. Do not re-present the question.
+- Use \`name\`, \`url\`, \`transport\`, \`authentication\`, \`credentialType\`,
+  \`tools\`, and optional \`metadata\` only from \`selectedResult\`.
 
-Follow these steps for an MCP result:
+Follow these steps for the selected MCP result:
 
-1. Credential: call \`ask_credential\` with the returned \`credentialType\`. Never
-   invent credential IDs.
-2. Verify: call \`verify_mcp_server\` with \`name\`, \`url\`, \`transport\`,
-   \`authentication\`, and (if applicable) \`credential\`.
+1. Credential: call \`ask_credential\` with a short \`purpose\`, using
+   \`selectedResult.credentialType\` as \`credentialType\`. Never invent
+   credential IDs.
+2. Verify: call \`verify_mcp_server\` with the selected result's \`name\`, \`url\`,
+   \`transport\`, and \`authentication\`, plus the returned \`credentialId\` as
+   \`credential\` when authentication is required.
 3. Capability check: confirm the verified tool names and descriptions cover the
    capability the user requested.
 4. Write config: call \`read_config\`, then \`patch_config\` to add the entry to
@@ -130,7 +144,7 @@ setup later:
 ### Selecting credentials
 
 When using a registry-backed server, always use the \`credentialType\` returned
-by the MCP discovery result.
+by \`selectedResult\`.
 
 For custom MCP servers, if credential type is unknown, ask the user which
 credential type to use (OAuth2, Bearer Token, Header Auth, Multiple Headers
@@ -153,9 +167,9 @@ Auth, or None) via \`${ASK_QUESTIONS_TOOL_NAME}\`. Then map to:
 
 - Server \`name\` must be unique across \`mcpServers\` within an agent.
 - Never fabricate \`metadata.nodeTypeName\`.
-- When the MCP discovery result includes \`metadata.nodeTypeName\`, include
-  \`metadata: { nodeTypeName: <result.nodeTypeName> }\` in the entry so the UI
-  can render the correct server form.
+- When \`selectedResult\` includes \`metadata.nodeTypeName\`, include
+  \`metadata: { nodeTypeName: <selectedResult.metadata.nodeTypeName> }\` in the
+  entry so the UI can render the correct server form.
 - A registry match proves server availability, not support for the requested
   capability; use the verified live tool list for that decision.`,
 	};

--- a/packages/cli/src/modules/agents/builder/skills/mcp.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/mcp.skill.ts
@@ -16,20 +16,24 @@ export function mcpSkill(): RuntimeSkill {
 		description:
 			'Use when adding, removing, or updating MCP (Model Context Protocol) servers on the target agent.',
 		recommendedTools: [
-			'search_mcp_servers',
+			'resolve_integration',
 			'ask_credential',
 			'verify_mcp_server',
 			'read_config',
 			'patch_config',
 		],
 		allowedTools: [
+			'resolve_integration',
 			'search_mcp_servers',
+			'search_nodes',
+			'get_node_types',
 			'ask_credential',
 			'verify_mcp_server',
 			'ask_questions',
 			'read_config',
 			'patch_config',
 			'write_config',
+			'load_skill',
 		],
 		instructions: `\
 ## Purpose
@@ -41,30 +45,44 @@ connected MCP server.
 
 ## Use when:
 
-- The user asks for an external integration and you need to discover/connect an MCP server for it.
-- The user asks to edit the target agent's MCP servers.
-- The users wants to add a custom MCP server.
+- \`resolve_integration\` returned \`kind: "mcp"\`.
+- The user explicitly asks to add or edit an MCP server.
+- The user provides or asks to configure a custom MCP server.
 
 ## Workflow
 
 ### Discovery and setup
 
-Follow these steps in order when adding an MCP server:
+For a generic external-service request, \`resolve_integration\` must select the
+integration type before this skill is loaded. If no resolver result is
+available yet, call \`resolve_integration\` with queries matching the requested
+service.
 
-1. Search: call \`search_mcp_servers\` with queries matching the requested
-   integration (for example \`["github"]\`, \`["slack"]\`).
-   The result includes \`name\`, \`url\`, \`transport\`, \`authentication\`,
-   \`credentialType\`, \`tools\`, and optional \`metadata\`.
-2. Credential: for registry results, call \`ask_credential\` with the returned
-   \`credentialType\`. Never invent credential IDs.
-3. Verify: call \`verify_mcp_server\` with \`name\`, \`url\`, \`transport\`,
+- If it returns \`kind: "node"\` for a generic service request, load
+  \`agent-builder-node-tools\` and continue with the returned node results. Stop
+  this MCP workflow.
+- If it returns \`kind: "node"\` but the user explicitly requested an MCP server,
+  do not silently substitute a node tool. Continue with manual MCP setup by
+  asking for the URL and transport/authentication decision through
+  \`${ASK_QUESTIONS_TOOL_NAME}\`.
+- If it returns \`kind: "mcp"\`, use the returned \`name\`, \`url\`, \`transport\`,
+  \`authentication\`, \`credentialType\`, \`tools\`, and optional \`metadata\`.
+
+Follow these steps for an MCP result:
+
+1. Credential: call \`ask_credential\` with the returned \`credentialType\`. Never
+   invent credential IDs.
+2. Verify: call \`verify_mcp_server\` with \`name\`, \`url\`, \`transport\`,
    \`authentication\`, and (if applicable) \`credential\`.
-4. Write config: call \`read_config\`, then \`patch_config\` to add the entry
-   to \`mcpServers[]\` using the patch pattern below.
+3. Capability check: confirm the verified tool names and descriptions cover the
+   capability the user requested.
+4. Write config: call \`read_config\`, then \`patch_config\` to add the entry to
+   \`mcpServers[]\` using the patch pattern below.
 
-If \`search_mcp_servers\` returns no matches, continue with manual server
-setup: ask for the URL and transport/authentication decision through
-\`${ASK_QUESTIONS_TOOL_NAME}\`.
+If verification succeeds but the tools do not cover the requested capability
+for a generic service request, load \`agent-builder-node-tools\`, call
+\`search_nodes\` with the same service queries, and continue with node setup. Do
+not add the MCP server merely because its registry entry matched.
 
 Full schema reference:
 
@@ -112,7 +130,7 @@ setup later:
 ### Selecting credentials
 
 When using a registry-backed server, always use the \`credentialType\` returned
-by \`search_mcp_servers\`.
+by the MCP discovery result.
 
 For custom MCP servers, if credential type is unknown, ask the user which
 credential type to use (OAuth2, Bearer Token, Header Auth, Multiple Headers
@@ -135,8 +153,10 @@ Auth, or None) via \`${ASK_QUESTIONS_TOOL_NAME}\`. Then map to:
 
 - Server \`name\` must be unique across \`mcpServers\` within an agent.
 - Never fabricate \`metadata.nodeTypeName\`.
-- When \`search_mcp_servers\` returns \`metadata.nodeTypeName\`, include
+- When the MCP discovery result includes \`metadata.nodeTypeName\`, include
   \`metadata: { nodeTypeName: <result.nodeTypeName> }\` in the entry so the UI
-  can render the correct server form.`,
+  can render the correct server form.
+- A registry match proves server availability, not support for the requested
+  capability; use the verified live tool list for that decision.`,
 	};
 }

--- a/packages/cli/src/modules/agents/builder/skills/node-tools.skill.ts
+++ b/packages/cli/src/modules/agents/builder/skills/node-tools.skill.ts
@@ -5,8 +5,9 @@ export function nodeToolsSkill(): RuntimeSkill {
 		id: 'agent-builder-node-tools',
 		name: 'Agent Builder Node Tools',
 		description:
-			'Use when adding, changing, or removing node-backed tools: search_nodes/get_node_types discovery, nodeParameters, node credential slots, $fromAI usage, or other n8n expressions.',
+			'Use when resolve_integration returns kind: "node" or the user explicitly requests an n8n node-backed tool: search_nodes/get_node_types discovery, nodeParameters, node credential slots, $fromAI usage, or other n8n expressions.',
 		recommendedTools: [
+			'resolve_integration',
 			'search_nodes',
 			'get_node_types',
 			'ask_credential',
@@ -14,6 +15,7 @@ export function nodeToolsSkill(): RuntimeSkill {
 			'patch_config',
 		],
 		allowedTools: [
+			'resolve_integration',
 			'search_nodes',
 			'get_node_types',
 			'ask_credential',
@@ -32,7 +34,16 @@ Use this to discover, configure, and wire node tools into the target agent's
 
 ## Workflow
 
-- Use \`search_nodes\`, then \`get_node_types\`; never guess node type names.
+- For a generic external-service request, call \`resolve_integration\` before
+  node discovery unless a resolver result is already available.
+- If it returns \`kind: "mcp"\`, load \`agent-builder-mcp\` and stop this node-tool
+  workflow.
+- If it returns \`kind: "node"\`, use its returned node results and call
+  \`get_node_types\`; do not repeat the same search with \`search_nodes\`.
+- Call \`search_nodes\` directly only when the user explicitly requests an n8n
+  node, when refining node results, or when a verified MCP server lacks the
+  requested capability.
+- Never guess node type names.
 - Use the tool node id from discovery, usually ending in \`Tool\`.
 - Put fixed values in \`nodeParameters\`; use complete n8n expressions for values the agent should decide at runtime:
   \`={{ $fromAI('url', 'The URL to inspect', 'string') }}\`.


### PR DESCRIPTION
## Summary

Adds a `resolve_integration({ queries })` builder tool that makes external-service discovery in the agent builder deterministic:

- Checks the current locally cached MCP registry first (`McpRegistryService.search()`).
- Falls back to agent-eligible n8n node-tool discovery only when the registry has no match, via a newly extracted `AgentsToolsService.searchAgentToolNodes()`.
- Returns `{ kind: 'mcp', results }` or `{ kind: 'node', results, queriesWithNoResults }`; registry/search errors propagate instead of silently defaulting to nodes.
- The registry is **not** loaded into the system prompt, so prompt caching stays stable.

Builder prompts, few-shot examples, and the `agent-builder-mcp`, `agent-builder-node-tools`, and `agent-builder-integrations` skills are updated so every generic external-service request is routed through `resolve_integration` before loading MCP or node-tool guidance. Explicit n8n-node requests, explicit custom-MCP setup, and chat/trigger integrations (`configure_channel`) keep their existing direct paths. `search_mcp_servers`, `search_nodes`, and `get_node_types` retain their existing public contracts and remain available for explicit/refinement flows.

## How to test

1. In the agent builder, ask to add an integration that exists in the MCP registry (e.g. "Connect Notion") and confirm the builder calls `resolve_integration`, gets `kind: "mcp"`, and proceeds through `agent-builder-mcp` (credential -> `verify_mcp_server` -> `patch_config`).
2. Ask for an integration with no MCP registry match (e.g. "Add a Slack node tool") and confirm `resolve_integration` returns `kind: "node"` and the builder proceeds through `agent-builder-node-tools`.
3. Ask explicitly for an n8n node (e.g. "search for the HTTP Request node") and confirm the builder can call `search_nodes` directly without going through the resolver first.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-400

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34458">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

