### PR TITLE
fix(core): Allow publishing end-user credentials with Send-and-Wait nodes

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -678,6 +678,17 @@ describe('WorkflowValidationService', () => {
 				trigger: async () => ({ closeFunction: async () => {} }),
 			}) as unknown as INodeType;
 
+		// A "Send and Wait for Response" (HITL) action node — or its AI-tool variant.
+		// It carries a `webhook` method for the approval callback but is NOT a trigger
+		// (group is `transform`/`output`, not `trigger`).
+		const createSendAndWaitNodeType = (): INodeType =>
+			({
+				description: {
+					group: ['transform'],
+				},
+				webhook: async () => ({}),
+			}) as unknown as INodeType;
+
 		const SYSTEM_RESOLVER = 'system-resolver';
 		const CUSTOM_RESOLVER = 'custom-resolver';
 
@@ -887,6 +898,35 @@ describe('WorkflowValidationService', () => {
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === 'n8n-nodes-base.manualTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should not treat a Send-and-Wait action node (webhook method, non-trigger group) as a trigger', async () => {
+			// Regression: an MCP trigger (n8n identity) alongside a Gmail tool node using
+			// "Send and Wait for Response". The tool carries a HITL `webhook`, so the old
+			// method-based check mistook it for an identity-less trigger and blocked publish.
+			const nodes: INode[] = [
+				createNode('MCP Server Trigger', '@n8n/n8n-nodes-langchain.mcpTrigger', {
+					parameters: { authentication: 'n8nOAuth2' },
+				}),
+				createNode('Send a message in Gmail', 'n8n-nodes-base.gmailTool', {
+					credentials: { gmailOAuth2: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'Gmail account' } as any,
+			]);
+			useSystemResolver();
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === '@n8n/n8n-nodes-langchain.mcpTrigger') return createTriggerNodeType();
+				if (type === 'n8n-nodes-base.gmailTool') return createSendAndWaitNodeType();
 				return {} as INodeType;
 			}) as any);
 

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -11,6 +11,7 @@ import {
 	validateNodeCredentials,
 	isNodeConnected,
 	isTriggerLikeNode,
+	isTriggerNode,
 	classifyTriggerIdentity,
 } from 'n8n-workflow';
 import type {
@@ -407,7 +408,12 @@ export class WorkflowValidationService {
 		for (const node of nodes) {
 			if (node.disabled) continue;
 			const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-			if (!nodeType || !isTriggerLikeNode(nodeType)) continue;
+			// Only real workflow entry-points count. `isTriggerLikeNode` keys on a `webhook`/
+			// `poll`/`trigger` method, which also matches "Send and Wait for Response" action
+			// nodes (and their AI-tool variants) — those carry a HITL webhook but are not
+			// triggers, and would wrongly poison the identity check. `isTriggerNode` keys on
+			// the node group, which only true triggers declare.
+			if (!nodeType?.description || !isTriggerNode(nodeType.description)) continue;
 
 			hasTrigger = true;
 			const { providesExternalIdentity, providesN8nIdentity } = classifyTriggerIdentity(


### PR DESCRIPTION
## Summary

Publishing a workflow that mixed an end-user credential with an MCP trigger failed with *"end-user credentials (...) are only supported in workflows triggered manually, via chat, or as a sub-workflow"*, even though the MCP trigger provides the required identity. The publish check (`WorkflowValidationService.classifyTriggerIdentities`) detected triggers via `isTriggerLikeNode` (presence of a `webhook`/`poll`/`trigger` method), which also matches "Send and Wait for Response" action nodes and their AI-tool variants (e.g. the Gmail tool) — those carry a HITL approval webhook but are not triggers, so they were counted as identity-less triggers and poisoned the check. The fix classifies triggers by node group (`isTriggerNode`), which only true triggers declare, aligning the backend with the editor (which already filters trigger nodes by group).

## How to test

Build a workflow with an **MCP Server Trigger** (authentication: *n8n User Auth (OAuth2)*) and a **Gmail** tool node that uses an end-user credential, then publish it — it now succeeds instead of erroring. A regression test covers the case in `workflow-validation.service.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- None linked yet. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

