### PR TITLE
fix(core): Resolve @n8n/expression-runtime to its CJS build under Node

### DIFF
--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
+      "node": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },


### PR DESCRIPTION
## Summary

Starting n8n with `N8N_EXPRESSION_ENGINE=vm` (the default on cloud) crashes on current master:

```
Error: Cannot find module '.../expression-runtime/dist/esm/evaluator/expression-evaluator'
imported from .../expression-runtime/dist/esm/index.js
```

**Root cause:** the TypeScript 7 migration (#34338) switched CJS builds from `module: umd` to `module: NodeNext`. UMD downleveled dynamic `import()` to `require()`; NodeNext preserves it as a real ESM import. The lazy `await import('@n8n/expression-runtime')` in `packages/workflow/src/expression.ts` therefore started resolving the package's `"import"` export condition → `dist/esm/index.js`, whose relative imports are extensionless (built with `moduleResolution: bundler`) — legal for bundlers, rejected by Node's ESM loader.

**Fix:** add a `"node"` export condition pointing at the CJS build, so Node (both `require()` and `import()`) always loads it, while bundlers keep the ESM build. One line, no rebuild required — exports are resolved at runtime.

A sweep of all built dists for other preserved `import()` calls of workspace packages found no other affected package (all others ship CJS-only or identical files for both conditions).

## How to test

1. On master: `N8N_EXPRESSION_ENGINE=vm pnpm start` → crashes at startup with the module error above.
2. On this branch: same command → boots cleanly; expressions evaluate through the isolate (e.g. a Set node with `{{ 1 + 2 }}`).

## Related Linear tickets, Github issues, and Community forum posts

Regression introduced by #34338.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34463">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

