### PR TITLE
feat(ai-builder): Refresh Instance AI agent artifact UI on channel setup success

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -1094,6 +1094,46 @@ describe('AgentBuilderView — three-column shell', () => {
 		wrapper.unmount();
 	});
 
+	it('replays external agent updates that arrive before initialization completes', async () => {
+		let resolveAgent!: (agent: ReturnType<typeof makeAgentResponse>) => void;
+		getAgentMock.mockReturnValueOnce(new Promise((resolve) => (resolveAgent = resolve)));
+
+		// Unique ids so stale mounted instances from earlier tests ignore the emit.
+		const wrapper = await renderView({
+			waitForAsyncSetup: false,
+			props: {
+				artifactMode: true,
+				artifactProjectId: 'p-bus-init',
+				artifactAgentId: 'a-bus-init',
+				artifactRefreshKey: 0,
+			},
+		});
+		await vi.waitFor(() => {
+			expect(getAgentMock).toHaveBeenCalledTimes(1);
+			expect(fetchConfigMock).toHaveBeenCalledTimes(1);
+		});
+
+		agentsEventBus.emit('agentUpdated', { agentId: 'a-bus-init', source: 'channel-setup-card' });
+		await nextTick();
+		expect(getAgentMock).toHaveBeenCalledTimes(1);
+		expect(fetchConfigMock).toHaveBeenCalledTimes(1);
+
+		resolveAgent(makeAgentResponse());
+		await flushPromises();
+		await flushPromises();
+
+		expect(getAgentMock).toHaveBeenCalledTimes(2);
+		expect(fetchConfigMock).toHaveBeenCalledTimes(2);
+		expect(getAgentMock).toHaveBeenLastCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p-bus-init',
+			'a-bus-init',
+		);
+		expect(fetchConfigMock).toHaveBeenLastCalledWith('p-bus-init', 'a-bus-init');
+
+		wrapper.unmount();
+	});
+
 	it('replays artifact refresh key changes that arrive before initialization completes', async () => {
 		let resolveAgent!: (agent: ReturnType<typeof makeAgentResponse>) => void;
 		getAgentMock.mockReturnValueOnce(new Promise((resolve) => (resolveAgent = resolve)));

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -11,6 +11,7 @@ import type {
 	CustomToolEntry,
 } from '../types';
 import { getRandomAgentPersonalisationGradient } from '../utils/agentPersonalisation';
+import { agentsEventBus } from '../agents.eventBus';
 
 const routerPush = vi.fn();
 const routerReplace = vi.fn();
@@ -1054,6 +1055,43 @@ describe('AgentBuilderView — three-column shell', () => {
 
 		expect(getAgentMock).toHaveBeenCalledWith({ baseUrl: 'http://localhost:5678' }, 'p2', 'a2');
 		expect(fetchConfigMock).toHaveBeenCalledWith('p2', 'a2');
+	});
+
+	it('refreshes the shell when another surface reports an update to this agent', async () => {
+		// Unique ids: earlier tests leave mounted instances (and their bus
+		// listeners) behind, so shared ids would inflate the mock call counts.
+		const wrapper = await renderView({
+			props: {
+				artifactMode: true,
+				artifactProjectId: 'p-bus',
+				artifactAgentId: 'a-bus',
+				artifactRefreshKey: 0,
+			},
+		});
+		getAgentMock.mockClear();
+		fetchConfigMock.mockClear();
+
+		agentsEventBus.emit('agentUpdated', { agentId: 'a-bus', source: 'channel-setup-card' });
+		await flushPromises();
+
+		expect(getAgentMock).toHaveBeenCalledWith(
+			{ baseUrl: 'http://localhost:5678' },
+			'p-bus',
+			'a-bus',
+		);
+		expect(fetchConfigMock).toHaveBeenCalledWith('p-bus', 'a-bus');
+
+		// Other agents' updates and the builder's own writes are ignored.
+		getAgentMock.mockClear();
+		fetchConfigMock.mockClear();
+		agentsEventBus.emit('agentUpdated', { agentId: 'a-other', source: 'channel-setup-card' });
+		agentsEventBus.emit('agentUpdated', { agentId: 'a-bus', source: 'agent-builder' });
+		await flushPromises();
+
+		expect(getAgentMock).not.toHaveBeenCalled();
+		expect(fetchConfigMock).not.toHaveBeenCalled();
+
+		wrapper.unmount();
 	});
 
 	it('replays artifact refresh key changes that arrive before initialization completes', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -134,6 +134,8 @@ const { canUpdate: canEditAgent, canDelete: canDeleteAgent } = useAgentPermissio
 const isVersionHistoryOpen = ref(false);
 const initialized = ref(false);
 const pendingArtifactRefreshKey = ref<number>();
+/** Queues `agentUpdated` bus events that land mid-initialize for replay (see `onExternalAgentUpdated`). */
+const pendingExternalRefresh = ref(false);
 const agentName = ref('');
 const agent = ref<AgentResource | null>(null);
 const agentFiles = ref<AgentFileDto[]>([]);
@@ -799,17 +801,23 @@ watch(
 	},
 );
 
-// Cross-surface: another surface (e.g. the Instance AI channel-setup card)
-// wrote this agent outside the builder's own save funnels — refetch so the
-// shell (config, Channels chips) doesn't sit stale until the build run ends.
-// Own writes are filtered by source to avoid re-entrancy (`onConfigUpdated`
-// itself emits `agentUpdated`).
 function onExternalAgentUpdated(event?: AgentUpdatedEvent) {
 	if (event?.source === 'agent-builder') return;
 	if (!event?.agentId || event.agentId !== agentId.value) return;
-	// While initializing, the in-flight initial fetch already returns fresh data.
-	if (!initialized.value) return;
+	// Mid-initialize the write may have landed after initialize()'s own config
+	// fetch already resolved, so queue a replay instead of dropping the event.
+	// Unlike `replayPendingArtifactRefresh` this isn't gated on artifact mode.
+	if (!initialized.value) {
+		pendingExternalRefresh.value = true;
+		return;
+	}
 	void refreshArtifactShell().catch(handleArtifactRefreshError);
+}
+
+async function replayPendingExternalRefresh() {
+	if (!pendingExternalRefresh.value) return;
+	pendingExternalRefresh.value = false;
+	await refreshArtifactShell();
 }
 
 agentsEventBus.on('agentUpdated', onExternalAgentUpdated);
@@ -966,6 +974,10 @@ async function onHeaderAction(action: string) {
 
 async function initialize() {
 	initialized.value = false;
+	// A refresh queued before this (re)initialize is obsolete: it targeted the
+	// agent that was current when the event fired, and the fetches below return
+	// fresh data anyway. Only events arriving during this init need replaying.
+	pendingExternalRefresh.value = false;
 	try {
 		// Flush any pending/in-flight save for the previous agent before we tear
 		// down its state — without this, an autosave scheduled by edits in the
@@ -1032,6 +1044,7 @@ async function initialize() {
 	} finally {
 		initialized.value = true;
 		void replayPendingArtifactRefresh().catch(handleArtifactRefreshError);
+		void replayPendingExternalRefresh().catch(handleArtifactRefreshError);
 		warmAgentKnowledgeSandboxForPage();
 	}
 }

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -64,7 +64,7 @@ import {
 	CONTINUE_SESSION_ID_PARAM,
 	PROJECT_AGENTS,
 } from '../constants';
-import { agentsEventBus } from '../agents.eventBus';
+import { agentsEventBus, type AgentUpdatedEvent } from '../agents.eventBus';
 import AgentBuilderHeader from '../components/AgentBuilderHeader.vue';
 import AgentBuilderPreviewHeader from '../components/AgentBuilderPreviewHeader.vue';
 import AgentBuilderEditorColumn from '../components/AgentBuilderEditorColumn.vue';
@@ -798,6 +798,22 @@ watch(
 		}
 	},
 );
+
+// Cross-surface: another surface (e.g. the Instance AI channel-setup card)
+// wrote this agent outside the builder's own save funnels — refetch so the
+// shell (config, Channels chips) doesn't sit stale until the build run ends.
+// Own writes are filtered by source to avoid re-entrancy (`onConfigUpdated`
+// itself emits `agentUpdated`).
+function onExternalAgentUpdated(event?: AgentUpdatedEvent) {
+	if (event?.source === 'agent-builder') return;
+	if (!event?.agentId || event.agentId !== agentId.value) return;
+	// While initializing, the in-flight initial fetch already returns fresh data.
+	if (!initialized.value) return;
+	void refreshArtifactShell().catch(handleArtifactRefreshError);
+}
+
+agentsEventBus.on('agentUpdated', onExternalAgentUpdated);
+onBeforeUnmount(() => agentsEventBus.off('agentUpdated', onExternalAgentUpdated));
 
 const headerActions = computed(() => {
 	const actions: Array<ActionDropdownItem<string>> = [

--- a/packages/frontend/editor-ui/src/features/ai/shared/components/ChannelSetupCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/shared/components/ChannelSetupCard.test.ts
@@ -102,6 +102,8 @@ vi.mock('@/features/agents/components/AgentChannelSlackSetup.vue', () => ({
 	},
 }));
 
+import { agentsEventBus } from '@/features/agents/agents.eventBus';
+
 import ChannelSetupCard from './ChannelSetupCard.vue';
 
 const defaultProps = {
@@ -156,6 +158,43 @@ describe('ChannelSetupCard', () => {
 
 		expect(mocks.connect).toHaveBeenCalledWith('slack', 'cred-1', undefined);
 		expect(wrapper.emitted('resolve')).toEqual([[{ approved: true }]]);
+	});
+
+	it('notifies agent surfaces on the event bus after a successful connect', async () => {
+		const onAgentUpdated = vi.fn();
+		agentsEventBus.on('agentUpdated', onAgentUpdated);
+		try {
+			const wrapper = mountCard();
+			await flushPromises();
+
+			await wrapper.find('[data-testid="mock-slack-connect"]').trigger('click');
+			await flushPromises();
+
+			expect(onAgentUpdated).toHaveBeenCalledWith({
+				agentId: 'agent-1',
+				source: 'channel-setup-card',
+			});
+		} finally {
+			agentsEventBus.off('agentUpdated', onAgentUpdated);
+		}
+	});
+
+	it('does not notify agent surfaces when the connect fails or setup is skipped', async () => {
+		mocks.connect.mockRejectedValueOnce(new Error('connect failed'));
+		const onAgentUpdated = vi.fn();
+		agentsEventBus.on('agentUpdated', onAgentUpdated);
+		try {
+			const wrapper = mountCard();
+			await flushPromises();
+
+			await wrapper.find('[data-testid="mock-slack-connect"]').trigger('click');
+			await flushPromises();
+			await wrapper.find('[data-testid="channel-setup-card-skip"]').trigger('click');
+
+			expect(onAgentUpdated).not.toHaveBeenCalled();
+		} finally {
+			agentsEventBus.off('agentUpdated', onAgentUpdated);
+		}
 	});
 
 	it('emits resolve({ approved: false }) when the user skips setup', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/shared/components/ChannelSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/shared/components/ChannelSetupCard.vue
@@ -15,6 +15,7 @@ import type { ChatIntegrationDescriptor } from '@n8n/api-types';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { computed, ref, watch } from 'vue';
 
+import { agentsEventBus } from '@/features/agents/agents.eventBus';
 import { getAgent } from '@/features/agents/composables/useAgentApi';
 import { useAgentChannelSetup } from '@/features/agents/composables/useAgentChannelSetup';
 import { useAgentIntegrationStatus } from '@/features/agents/composables/useAgentIntegrationStatus';
@@ -132,6 +133,16 @@ function finish(approved: boolean) {
 	emit('resolve', { approved });
 }
 
+/**
+ * The connect above persists the integration via REST immediately, but the
+ * builder's own `configUpdated` refresh only fires for config-mutation tools
+ * at end of turn — notify other surfaces (e.g. the agent artifact panel's
+ * Channels section) now so they don't stay stale until the run finishes.
+ */
+function notifyAgentUpdated() {
+	agentsEventBus.emit('agentUpdated', { agentId: props.agentId, source: 'channel-setup-card' });
+}
+
 function skipSetup() {
 	if (connectionInFlight.value) return;
 	finish(false);
@@ -145,6 +156,7 @@ async function saveChannelConfig() {
 	connectionInFlight.value = true;
 	try {
 		await connect(props.integrationType, credentialId, channelSetupRef.value?.currentSettings);
+		notifyAgentUpdated();
 		finish(true);
 	} catch {
 		// useAgentIntegrationStatus exposes the connection error to the setup component.
@@ -157,7 +169,10 @@ async function setupSlackApp(appConfigurationToken: string): Promise<boolean> {
 	if (isBlocked() || connectionInFlight.value) return false;
 	connectionInFlight.value = true;
 	try {
-		return await runSlackAppSetup(appConfigurationToken, () => finish(true));
+		return await runSlackAppSetup(appConfigurationToken, () => {
+			notifyAgentUpdated();
+			finish(true);
+		});
 	} finally {
 		connectionInFlight.value = false;
 	}


### PR DESCRIPTION
## Summary

Refresh the agent artifact panel as soon as channel setup succeeds, instead of waiting for the whole build run to finish.

Also replays that refresh if the update arrives while `AgentBuilderView` is still initializing, so the panel does not miss the change during load or agent switches.

## How to test

1. Start building or editing an agent in Instance AI.
2. Set up a channel integration like Telegram or Slack.
3. Confirm the channel appears in the agent panel right after setup succeeds.
4. Repeat while the agent view is still loading / switching agents to confirm the refresh is not missed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-387/bug-telegram-integration-missing-from-agent-panel-after-setup

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

