### PR TITLE
fix(OpenAi Node): Honor configured AI timeout for outbound requests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/index.ts
@@ -1,9 +1,16 @@
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import type {
 	IDataObject,
 	IExecuteFunctions,
 	IHttpRequestMethods,
 	ILoadOptionsFunctions,
 } from 'n8n-workflow';
+
+// Fallback used only when the AiConfig cannot be resolved from the DI container
+// (e.g. in unit tests). At runtime the configured value is authoritative.
+const DEFAULT_AI_TIMEOUT_MS = 60 * 60 * 1000;
+
 type RequestParameters = {
 	headers?: IDataObject;
 	body?: IDataObject | string;
@@ -40,6 +47,11 @@ export async function apiRequest(
 		};
 	}
 
+	// Honor the configured AI timeout (N8N_AI_TIMEOUT_MAX) so long-running requests
+	// aren't capped at the process-global axios default (300000 ms). Read from the
+	// central AiConfig, matching how sibling AI nodes consume this setting.
+	const timeout = Container.get(AiConfig)?.timeout ?? DEFAULT_AI_TIMEOUT_MS;
+
 	const options = {
 		headers,
 		method,
@@ -47,6 +59,7 @@ export async function apiRequest(
 		qs,
 		uri,
 		json: true,
+		timeout,
 	};
 
 	if (option && Object.keys(option).length !== 0) {

--- a/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/OpenAi/transport/test/transport.test.ts
@@ -1,3 +1,5 @@
+import type { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
 import { apiRequest } from '../index';
@@ -12,6 +14,12 @@ const mockedExecutionContext = {
 describe('apiRequest', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		// Default: AiConfig resolves with the built-in one hour timeout.
+		vi.spyOn(Container, 'get').mockReturnValue({ timeout: 3600000 } as AiConfig);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it('should call requestWithAuthentication with credentials URL if one is provided', async () => {
@@ -34,6 +42,7 @@ describe('apiRequest', () => {
 				method: 'GET',
 				uri: 'http://www.test/url/v1/test',
 				json: true,
+				timeout: 3600000,
 			},
 		);
 	});
@@ -56,7 +65,51 @@ describe('apiRequest', () => {
 				method: 'GET',
 				uri: 'https://api.openai.com/v1/test',
 				json: true,
+				timeout: 3600000,
 			},
+		);
+	});
+
+	it('should use the configured AI timeout for the request', async () => {
+		vi.spyOn(Container, 'get').mockReturnValue({ timeout: 7200000 } as AiConfig);
+		mockedExecutionContext.getCredentials.mockResolvedValue({});
+
+		// Act
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test');
+
+		// Assert
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.objectContaining({ timeout: 7200000 }),
+		);
+	});
+
+	it('should fall back to a one hour timeout when AiConfig cannot be resolved', async () => {
+		vi.spyOn(Container, 'get').mockReturnValue(undefined as unknown as AiConfig);
+		mockedExecutionContext.getCredentials.mockResolvedValue({});
+
+		// Act
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test');
+
+		// Assert
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.objectContaining({ timeout: 3600000 }),
+		);
+	});
+
+	it('should let an explicit option.timeout override the configured timeout', async () => {
+		mockedExecutionContext.getCredentials.mockResolvedValue({});
+
+		// Act
+		await apiRequest.call(mockedExecutionContext as unknown as IExecuteFunctions, 'GET', '/test', {
+			option: { timeout: 1000 },
+		});
+
+		// Assert
+		expect(mockedExecutionContext.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+			'openAiApi',
+			expect.objectContaining({ timeout: 1000 }),
 		);
 	});
 


### PR DESCRIPTION
## Summary

The OpenAI node (`@n8n/n8n-nodes-langchain.openAi`) aborted every outbound request after exactly 300000 ms (`timeout of 300000ms exceeded`), regardless of the configured `N8N_AI_TIMEOUT_MAX`. Long-running requests (reasoning models, background/response polling, large batches) therefore failed even when an administrator had raised the AI timeout.

The node's shared transport (`apiRequest`) never set a `timeout` on its request options, so the request fell back to the process-global axios default (`axios.defaults.timeout = 300000`). `N8N_AI_TIMEOUT_MAX` was only wired into the SDK/undici path (the `LmChat*` sub-nodes via `getProxyAgent`), never into the axios path this node uses.

This change makes `apiRequest` read the timeout from the central `AiConfig` (`Container.get(AiConfig)?.timeout`) — the same way sibling AI nodes (Tools Agent, `LmChat*`, embeddings) consume this setting — instead of parsing `process.env` inline. That picks up `AiConfig`'s typed default (1 hour, aligned with `EXECUTIONS_TIMEOUT_MAX`) and avoids a raw-parse `NaN` edge case. A one-hour constant is kept only as a fallback for when the DI container cannot resolve the config (e.g. unit tests). The default is applied before merging per-call options, so an explicit `option.timeout` still takes precedence, and fast requests are unaffected since the change only raises the ceiling.

## How to test

Automated: `pnpm --filter @n8n/n8n-nodes-langchain test nodes/vendors/OpenAi/transport/test/transport.test.ts`

The transport tests assert that:
- the outbound request uses the configured `AiConfig.timeout`,
- it falls back to a one-hour timeout when the config cannot be resolved,
- an explicit `option.timeout` overrides the configured value.

Manual: set `N8N_AI_TIMEOUT_MAX` above 300000 (e.g. `7200000`) and run an OpenAI node request that takes longer than 5 minutes; it now completes instead of aborting at 300000 ms.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #34403

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported).
