### PR TITLE
fix(AI Agent Node): Avoid streaming tool-call preambles

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -18,7 +18,7 @@ import { jsonParse, NodeOperationError, sleep } from 'n8n-workflow';
 import type { IExecuteFunctions, INodeExecutionData, ISupplyDataFunctions } from 'n8n-workflow';
 import assert from 'node:assert';
 
-import { loadMemory } from '@utils/agent-execution';
+import { loadMemory, ModelTextStreamBuffer } from '@utils/agent-execution';
 import { getPromptInputByType } from '@utils/helpers';
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 import {
@@ -143,10 +143,13 @@ async function processEventStream(
 	if (returnIntermediateSteps) {
 		agentResult.intermediateSteps = [];
 	}
+	const textStream = new ModelTextStreamBuffer((chunk) => {
+		ctx.sendChunk('item', itemIndex, chunk);
+		agentResult.output += chunk;
+	});
 
 	ctx.sendChunk('begin', itemIndex);
 	for await (const event of eventStream) {
-		// Stream chat model tokens as they come in
 		switch (event.event) {
 			case 'on_chat_model_stream':
 				const chunk = event.data?.chunk as AIMessageChunk;
@@ -162,19 +165,18 @@ async function processEventStream(
 					} else if (typeof chunkContent === 'string') {
 						chunkText = chunkContent;
 					}
-					ctx.sendChunk('item', itemIndex, chunkText);
-
-					agentResult.output += chunkText;
+					textStream.append(event.run_id, chunkText);
 				}
 				break;
 			case 'on_chat_model_end':
 				// Capture full LLM response with tool calls for intermediate steps
-				if (returnIntermediateSteps && event.data) {
+				if (event.data) {
 					const chatModelData = event.data as any;
 					const output = chatModelData.output;
+					const hasToolCalls = Boolean(output?.tool_calls?.length);
+					textStream.complete(event.run_id, !hasToolCalls);
 
-					// Check if this LLM response contains tool calls
-					if (output?.tool_calls && output.tool_calls.length > 0) {
+					if (returnIntermediateSteps && hasToolCalls) {
 						for (const toolCall of output.tool_calls) {
 							agentResult.intermediateSteps!.push({
 								action: {
@@ -209,6 +211,7 @@ async function processEventStream(
 				break;
 		}
 	}
+	textStream.flushPending();
 	ctx.sendChunk('end', itemIndex);
 
 	return agentResult;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -211,7 +211,6 @@ async function processEventStream(
 				break;
 		}
 	}
-	textStream.flushPending();
 	ctx.sendChunk('end', itemIndex);
 
 	return agentResult;

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -691,9 +691,19 @@ describe('toolsAgentExecute', () => {
 
 			// Mock async generator for streamEvents with tool calls
 			const mockStreamEvents = async function* () {
+				yield {
+					event: 'on_chat_model_stream',
+					run_id: 'tool-turn',
+					data: {
+						chunk: {
+							content: [{ type: 'text', text: 'I need to call a tool' }],
+						},
+					},
+				};
 				// LLM response with tool call (using the fake AIMessage instance)
 				yield {
 					event: 'on_chat_model_end',
+					run_id: 'tool-turn',
 					data: {
 						output: fakeAIMessage,
 					},
@@ -709,10 +719,18 @@ describe('toolsAgentExecute', () => {
 				// Final LLM response
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: 'Final response',
 						},
+					},
+				};
+				yield {
+					event: 'on_chat_model_end',
+					run_id: 'final-turn',
+					data: {
+						output: { content: 'Final response', tool_calls: [] },
 					},
 				};
 			};
@@ -729,6 +747,8 @@ describe('toolsAgentExecute', () => {
 
 			expect(result[0]).toHaveLength(1);
 			expect(result[0][0].json.output).toBe('Final response');
+			expect(mockContext.sendChunk).not.toHaveBeenCalledWith('item', 0, 'I need to call a tool');
+			expect(mockContext.sendChunk).toHaveBeenCalledWith('item', 0, 'Final response');
 
 			// Check intermediate steps
 			expect(result[0][0].json.intermediateSteps).toBeDefined();

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -606,6 +606,7 @@ describe('toolsAgentExecute', () => {
 			const mockStreamEvents = async function* () {
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: 'Hello ',
@@ -614,11 +615,17 @@ describe('toolsAgentExecute', () => {
 				};
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: 'world!',
 						},
 					},
+				};
+				yield {
+					event: 'on_chat_model_end',
+					run_id: 'final-turn',
+					data: { output: { content: 'Hello world!', tool_calls: [] } },
 				};
 			};
 
@@ -885,6 +892,7 @@ describe('toolsAgentExecute', () => {
 				// Message with array content including text and non-text types
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: [
@@ -895,6 +903,11 @@ describe('toolsAgentExecute', () => {
 							],
 						},
 					},
+				};
+				yield {
+					event: 'on_chat_model_end',
+					run_id: 'final-turn',
+					data: { output: { content: 'Hello world!', tool_calls: [] } },
 				};
 			};
 
@@ -924,11 +937,17 @@ describe('toolsAgentExecute', () => {
 			const mockStreamEvents = async function* () {
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: 'Direct string content',
 						},
 					},
+				};
+				yield {
+					event: 'on_chat_model_end',
+					run_id: 'final-turn',
+					data: { output: { content: 'Direct string content', tool_calls: [] } },
 				};
 			};
 
@@ -958,6 +977,7 @@ describe('toolsAgentExecute', () => {
 			const mockStreamEvents = async function* () {
 				yield {
 					event: 'on_chat_model_stream',
+					run_id: 'final-turn',
 					data: {
 						chunk: {
 							content: [
@@ -967,6 +987,11 @@ describe('toolsAgentExecute', () => {
 							],
 						},
 					},
+				};
+				yield {
+					event: 'on_chat_model_end',
+					run_id: 'final-turn',
+					data: { output: { content: [], tool_calls: [] } },
 				};
 			};
 

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
@@ -13,6 +13,7 @@ export { executeEngineAction } from './executeEngineAction';
 export { buildResponseMetadata } from './buildResponseMetadata';
 export { buildSteps } from './buildSteps';
 export { processEventStream } from './processEventStream';
+export { ModelTextStreamBuffer } from './modelTextStreamBuffer';
 export { loadMemory, saveToMemory, buildToolContext } from './memoryManagement';
 export { processHitlResponses, type HitlProcessingResult } from './processHitlResponses';
 export { serializeIntermediateSteps } from './serializeIntermediateSteps';

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/modelTextStreamBuffer.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/modelTextStreamBuffer.ts
@@ -20,11 +20,4 @@ export class ModelTextStreamBuffer {
 			for (const chunk of chunks) this.emit(chunk);
 		}
 	}
-
-	flushPending(): void {
-		for (const chunks of this.chunksByRunId.values()) {
-			for (const chunk of chunks) this.emit(chunk);
-		}
-		this.chunksByRunId.clear();
-	}
 }

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/modelTextStreamBuffer.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/modelTextStreamBuffer.ts
@@ -1,0 +1,30 @@
+type RunId = string | undefined;
+
+/** Buffers text until a model turn ends so tool-call preambles can be discarded. */
+export class ModelTextStreamBuffer {
+	private readonly chunksByRunId = new Map<RunId, string[]>();
+
+	constructor(private readonly emit: (chunk: string) => void) {}
+
+	append(runId: RunId, chunk: string): void {
+		const chunks = this.chunksByRunId.get(runId) ?? [];
+		chunks.push(chunk);
+		this.chunksByRunId.set(runId, chunks);
+	}
+
+	complete(runId: RunId, shouldEmit: boolean): void {
+		const chunks = this.chunksByRunId.get(runId) ?? [];
+		this.chunksByRunId.delete(runId);
+
+		if (shouldEmit) {
+			for (const chunk of chunks) this.emit(chunk);
+		}
+	}
+
+	flushPending(): void {
+		for (const chunks of this.chunksByRunId.values()) {
+			for (const chunk of chunks) this.emit(chunk);
+		}
+		this.chunksByRunId.clear();
+	}
+}

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.test.ts
@@ -108,7 +108,7 @@ describe('processEventStream', () => {
 		expect(result.output).toBe('Final answer');
 	});
 
-	it('flushes text if a stream ends without a model-end event', async () => {
+	it('discards text from a model run that does not complete', async () => {
 		const ctx = mock<IExecuteFunctions>();
 		const events = eventStream([streamEvent('unfinished-turn', 'Partial response')]);
 
@@ -116,9 +116,26 @@ describe('processEventStream', () => {
 
 		expect(ctx.sendChunk.mock.calls).toEqual([
 			['begin', 0],
-			['item', 0, 'Partial response'],
 			['end', 0],
 		]);
-		expect(result.output).toBe('Partial response');
+		expect(result.output).toBe('');
+	});
+
+	it('does not mix an incomplete primary response into a completed fallback response', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const events = eventStream([
+			streamEvent('primary-turn', 'Partial primary response'),
+			streamEvent('fallback-turn', 'Fallback response'),
+			endEvent('fallback-turn', { content: 'Fallback response', tool_calls: [] }),
+		]);
+
+		const result = await processEventStream(ctx, events, 0);
+
+		expect(ctx.sendChunk.mock.calls).toEqual([
+			['begin', 0],
+			['item', 0, 'Fallback response'],
+			['end', 0],
+		]);
+		expect(result.output).toBe('Fallback response');
 	});
 });

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.test.ts
@@ -1,0 +1,124 @@
+import type { StreamEvent } from '@langchain/core/types/stream';
+import type { IterableReadableStream } from '@langchain/core/utils/stream';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import { processEventStream } from './processEventStream';
+
+function eventStream(events: StreamEvent[]): IterableReadableStream<StreamEvent> {
+	return (async function* () {
+		for (const event of events) yield event;
+	})() as IterableReadableStream<StreamEvent>;
+}
+
+function streamEvent(runId: string, content: unknown): StreamEvent {
+	return {
+		event: 'on_chat_model_stream',
+		run_id: runId,
+		data: { chunk: { content } },
+	} as StreamEvent;
+}
+
+function endEvent(runId: string, output: unknown): StreamEvent {
+	return {
+		event: 'on_chat_model_end',
+		run_id: runId,
+		data: { output },
+	} as StreamEvent;
+}
+
+describe('processEventStream', () => {
+	it('emits final response chunks after the model turn completes', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const events = eventStream([
+			streamEvent('final-turn', 'Hello '),
+			streamEvent('final-turn', 'world'),
+			endEvent('final-turn', { content: 'Hello world', tool_calls: [] }),
+		]);
+
+		const result = await processEventStream(ctx, events, 0);
+
+		expect(ctx.sendChunk.mock.calls).toEqual([
+			['begin', 0],
+			['item', 0, 'Hello '],
+			['item', 0, 'world'],
+			['end', 0],
+		]);
+		expect(result).toEqual({ output: 'Hello world' });
+	});
+
+	it('discards text from a model turn that contains tool calls', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const toolCall = {
+			name: 'search',
+			args: { query: 'schedule' },
+			id: 'call-1',
+			type: 'tool_call',
+		};
+		const output = {
+			content: [
+				{ type: 'text', text: 'Calling search' },
+				{ type: 'tool_use', id: 'call-1', name: 'search', input: toolCall.args },
+			],
+			tool_calls: [toolCall],
+		};
+		const events = eventStream([
+			streamEvent('tool-turn', [{ type: 'text', text: 'Calling search' }]),
+			endEvent('tool-turn', output),
+		]);
+
+		const result = await processEventStream(ctx, events, 0);
+
+		expect(ctx.sendChunk.mock.calls).toEqual([
+			['begin', 0],
+			['end', 0],
+		]);
+		expect(result).toEqual({
+			output: '',
+			toolCalls: [
+				{
+					tool: 'search',
+					toolInput: { query: 'schedule' },
+					toolCallId: 'call-1',
+					type: 'tool_call',
+					log: output.content,
+					messageLog: [output],
+					additionalKwargs: undefined,
+				},
+			],
+		});
+	});
+
+	it('keeps concurrent model turn text isolated by run ID', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const events = eventStream([
+			streamEvent('tool-turn', 'Calling tool'),
+			streamEvent('final-turn', 'Final answer'),
+			endEvent('tool-turn', {
+				content: 'Calling tool',
+				tool_calls: [{ name: 'search', args: {}, id: 'call-1', type: 'tool_call' }],
+			}),
+			endEvent('final-turn', { content: 'Final answer', tool_calls: [] }),
+		]);
+
+		const result = await processEventStream(ctx, events, 0);
+
+		expect(ctx.sendChunk).toHaveBeenCalledWith('item', 0, 'Final answer');
+		expect(ctx.sendChunk).not.toHaveBeenCalledWith('item', 0, 'Calling tool');
+		expect(result.output).toBe('Final answer');
+	});
+
+	it('flushes text if a stream ends without a model-end event', async () => {
+		const ctx = mock<IExecuteFunctions>();
+		const events = eventStream([streamEvent('unfinished-turn', 'Partial response')]);
+
+		const result = await processEventStream(ctx, events, 0);
+
+		expect(ctx.sendChunk.mock.calls).toEqual([
+			['begin', 0],
+			['item', 0, 'Partial response'],
+			['end', 0],
+		]);
+		expect(result.output).toBe('Partial response');
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
@@ -4,6 +4,7 @@ import type { IterableReadableStream } from '@langchain/core/utils/stream';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
 import type { AgentResult, ToolCallRequest } from './types';
+import { ModelTextStreamBuffer } from './modelTextStreamBuffer';
 
 /**
  * Processes the event stream from a streaming agent execution.
@@ -27,10 +28,13 @@ export async function processEventStream(
 	};
 
 	const toolCalls: ToolCallRequest[] = [];
+	const textStream = new ModelTextStreamBuffer((chunk) => {
+		ctx.sendChunk('item', itemIndex, chunk);
+		agentResult.output += chunk;
+	});
 
 	ctx.sendChunk('begin', itemIndex);
 	for await (const event of eventStream) {
-		// Stream chat model tokens as they come in
 		switch (event.event) {
 			case 'on_chat_model_stream':
 				const chunk = event.data?.chunk as AIMessageChunk;
@@ -46,9 +50,7 @@ export async function processEventStream(
 					} else if (typeof chunkContent === 'string') {
 						chunkText = chunkContent;
 					}
-					ctx.sendChunk('item', itemIndex, chunkText);
-
-					agentResult.output += chunkText;
+					textStream.append(event.run_id, chunkText);
 				}
 				break;
 			case 'on_chat_model_end':
@@ -57,8 +59,10 @@ export async function processEventStream(
 					const chatModelData = event.data;
 					const output = chatModelData.output;
 
-					// Check if this LLM response contains tool calls
-					if (output?.tool_calls && output.tool_calls.length > 0) {
+					const hasToolCalls = Boolean(output?.tool_calls?.length);
+					textStream.complete(event.run_id, !hasToolCalls);
+
+					if (hasToolCalls) {
 						// Collect tool calls for request building
 						// Note: For Gemini, we pass additional_kwargs to ALL tool calls
 						// so the signature can be applied to each when rebuilding
@@ -83,6 +87,7 @@ export async function processEventStream(
 				break;
 		}
 	}
+	textStream.flushPending();
 	ctx.sendChunk('end', itemIndex);
 
 	// Include collected tool calls in the result

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/processEventStream.ts
@@ -87,7 +87,6 @@ export async function processEventStream(
 				break;
 		}
 	}
-	textStream.flushPending();
 	ctx.sendChunk('end', itemIndex);
 
 	// Include collected tool calls in the result


### PR DESCRIPTION
## Summary

Buffers AI Agent model text until each model turn completes, then:

- emits the buffered chunks for final response turns
- discards the buffered text for turns that contain tool calls
- isolates buffers by LangChain run ID so interleaved model events cannot mix
- discards text from model runs that do not complete, including failed primary runs before fallback
- applies the same behavior to the V2 and V3 Tools Agent execution paths

The chat streaming protocol cannot retract text after it has been emitted and does not currently represent intermediate model announcements separately. Waiting for the model-end event is therefore required to classify the turn before exposing its text. This intentionally trades token-by-token delivery for correct final output while preserving the original chunk boundaries once the turn completes.

## How to test

Run the focused regression tests:

```sh
cd packages/@n8n/nodes-langchain
pnpm test utils/agent-execution/processEventStream.test.ts nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
```

Run the complete package verification:

```sh
pnpm build
pnpm test
pnpm lint
pnpm typecheck
```

The regression tests cover final text responses, mixed text and tool-call turns, interleaved run IDs, failed primary and completed fallback runs, incomplete streams, and the V2 agent execution path.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2242

Related to #26352

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs are not required because this corrects internal streaming behavior without changing configuration or the public API.
- [x] Tests included.
- [ ] PR labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` if an urgent backport is required.

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34480">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

