### PR TITLE
feat(EmailSend): Add From Name option for sender display name

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/memoryManagement.ts
@@ -185,6 +185,24 @@ function cleanupOrphanedMessages(chatHistory: BaseMessage[]): BaseMessage[] {
 				changed = true;
 			}
 		}
+
+		// Remove trailing orphaned ToolMessages
+		while (chatHistory.length > 0 && chatHistory[chatHistory.length - 1] instanceof ToolMessage) {
+			chatHistory.pop();
+			changed = true;
+		}
+
+		// Remove trailing AIMessage with tool_calls if not followed by ToolMessage
+		if (chatHistory.length > 0) {
+			const lastMessage = chatHistory[chatHistory.length - 1];
+			const hasOrphanedTrailingAI =
+				lastMessage instanceof AIMessage && (lastMessage.tool_calls?.length ?? 0) > 0;
+
+			if (hasOrphanedTrailingAI) {
+				chatHistory.pop();
+				changed = true;
+			}
+		}
 	}
 
 	return chatHistory;

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/memoryManagement.test.ts
@@ -166,6 +166,58 @@ describe('memoryManagement', () => {
 			expect(result).toHaveLength(0);
 		});
 
+		it('should remove orphaned ToolMessage at end of chat history', async () => {
+			// Simulates memory trimming that removed messages after ToolMessage, leaving it trailing
+			const chatHistory = [
+				new HumanMessage('Question'),
+				new AIMessage('Answer'),
+				new ToolMessage({ content: 'Result', tool_call_id: 'orphaned-id', name: 'tool' }),
+			];
+			mockMemory.loadMemoryVariables.mockResolvedValue({ chat_history: chatHistory });
+
+			const result = await loadMemory(mockMemory);
+
+			expect(result).toHaveLength(2);
+			expect(result?.[0]).toBeInstanceOf(HumanMessage);
+			expect(result?.[1]).toBeInstanceOf(AIMessage);
+		});
+
+		it('should remove trailing AIMessage with tool_calls not followed by ToolMessage', async () => {
+			// Simulates memory trimming that kept AIMessage with tool_calls but removed the ToolMessage
+			const orphanedAI = new AIMessage({
+				content: 'Calling tool',
+				tool_calls: [{ id: 'call-123', name: 'tool', args: {}, type: 'tool_call' }],
+			});
+			const chatHistory = [new HumanMessage('Question'), new AIMessage('Answer'), orphanedAI];
+			mockMemory.loadMemoryVariables.mockResolvedValue({ chat_history: chatHistory });
+
+			const result = await loadMemory(mockMemory);
+
+			expect(result).toHaveLength(2);
+			expect(result?.[0]).toBeInstanceOf(HumanMessage);
+			expect(result?.[1]).toBeInstanceOf(AIMessage);
+		});
+
+		it('should remove chain of AIMessage(tool_calls) -> ToolMessage at end via recursive cleanup', async () => {
+			// After removing trailing ToolMessage, an orphaned AIMessage with tool_calls is revealed
+			const chatHistory = [
+				new HumanMessage('Question'),
+				new AIMessage('Answer'),
+				new AIMessage({
+					content: 'Calling tool',
+					tool_calls: [{ id: 'call-1', name: 'tool1', args: {}, type: 'tool_call' as const }],
+				}),
+				new ToolMessage({ content: 'Result', tool_call_id: 'id-1', name: 'tool1' }),
+			];
+			mockMemory.loadMemoryVariables.mockResolvedValue({ chat_history: chatHistory });
+
+			const result = await loadMemory(mockMemory);
+
+			expect(result).toHaveLength(2);
+			expect(result?.[0]).toBeInstanceOf(HumanMessage);
+			expect(result?.[1]).toBeInstanceOf(AIMessage);
+		});
+
 		it('should trim messages when maxTokens is provided', async () => {
 			const chatHistory = [
 				new SystemMessage('System prompt'),

--- a/packages/nodes-base/nodes/EmailSend/test/v2/send.operation.test.ts
+++ b/packages/nodes-base/nodes/EmailSend/test/v2/send.operation.test.ts
@@ -571,6 +571,68 @@ describe('Test EmailSendV2, send operation', () => {
 		});
 	});
 
+	describe('fromName option', () => {
+		it('should use {name, address} format when fromName is set', async () => {
+			const items = [{ json: { data: 'test' } }];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.1 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('nate@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('html')
+				.mockReturnValueOnce({ fromName: 'Nathan Doe', appendAttribution: false })
+				.mockReturnValueOnce('<p>Test HTML</p>');
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			expect(transporter.sendMail).toHaveBeenCalledWith(
+				expect.objectContaining({
+					from: { name: 'Nathan Doe', address: 'nate@example.com' },
+				}),
+			);
+		});
+
+		it('should use plain email string when fromName is not set', async () => {
+			const items = [{ json: { data: 'test' } }];
+
+			mockExecuteFunctions.getInputData.mockReturnValue(items);
+			mockExecuteFunctions.getNode.mockReturnValue({ typeVersion: 2.1 } as any);
+			mockExecuteFunctions.getInstanceId.mockReturnValue('instanceId');
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				host: 'smtp.example.com',
+				port: 587,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('nate@example.com')
+				.mockReturnValueOnce('to@example.com')
+				.mockReturnValueOnce('Test Subject')
+				.mockReturnValueOnce('html')
+				.mockReturnValueOnce({ appendAttribution: false })
+				.mockReturnValueOnce('<p>Test HTML</p>');
+
+			transporter.sendMail.mockResolvedValue({ messageId: 'test-id' });
+
+			await sendOperation.execute.call(mockExecuteFunctions);
+
+			expect(transporter.sendMail).toHaveBeenCalledWith(
+				expect.objectContaining({
+					from: 'nate@example.com',
+				}),
+			);
+		});
+	});
+
 	describe('emails without attachments', () => {
 		it('should send email when no attachments specified', async () => {
 			const items = [{ json: { data: 'test' } }];

--- a/packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts
+++ b/packages/nodes-base/nodes/EmailSend/v1/EmailSendV1.node.ts
@@ -31,7 +31,6 @@ const versionDescription: INodeTypeDescription = {
 		},
 	],
 	properties: [
-		// TODO: Add choice for text as text or html  (maybe also from name)
 		{
 			displayName: 'From Email',
 			name: 'fromEmail',
@@ -39,7 +38,7 @@ const versionDescription: INodeTypeDescription = {
 			default: '',
 			required: true,
 			placeholder: 'admin@example.com',
-			description: 'Email address of the sender optional with name',
+			description: 'Email address of the sender',
 		},
 		{
 			displayName: 'To Email',
@@ -124,6 +123,15 @@ const versionDescription: INodeTypeDescription = {
 					placeholder: 'info@example.com',
 					description: 'The email address to send the reply to',
 				},
+				{
+					displayName: 'From Name',
+					name: 'fromName',
+					type: 'string',
+					default: '',
+					placeholder: 'e.g. Nathan Doe',
+					description:
+						"Name of the sender. If not set, only the email address is shown in the recipient's inbox.",
+				},
 			],
 		},
 	],
@@ -185,7 +193,9 @@ export class EmailSendV1 implements INodeType {
 
 				// setup email data with unicode symbols
 				const mailOptions: IDataObject = {
-					from: fromEmail,
+					from: options.fromName
+						? { name: options.fromName as string, address: fromEmail }
+						: fromEmail,
 					to: toEmail,
 					cc: ccEmail,
 					bcc: bccEmail,

--- a/packages/nodes-base/nodes/EmailSend/v2/descriptions.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/descriptions.ts
@@ -7,8 +7,7 @@ export const fromEmailProperty: INodeProperties = {
 	default: '',
 	required: true,
 	placeholder: 'admin@example.com',
-	description:
-		'Email address of the sender. You can also specify a name: Nathan Doe &lt;nate@n8n.io&gt;.',
+	description: 'Email address of the sender. Use the "From Name" option to set a display name.',
 };
 
 export const toEmailProperty: INodeProperties = {

--- a/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/send.operation.ts
@@ -15,7 +15,6 @@ import { appendAttributionOption } from '../../../utils/descriptions';
 import { prepareBinariesDataList } from '../../../utils/binary';
 
 const properties: INodeProperties[] = [
-	// TODO: Add choice for text as text or html  (maybe also from name)
 	fromEmailProperty,
 	toEmailProperty,
 
@@ -169,6 +168,15 @@ const properties: INodeProperties[] = [
 				placeholder: 'info@example.com',
 				description: 'The email address to send the reply to',
 			},
+			{
+				displayName: 'From Name',
+				name: 'fromName',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g. Nathan Doe',
+				description:
+					"Name of the sender. If not set, only the email address is shown in the recipient's inbox.",
+			},
 		],
 	},
 ];
@@ -204,7 +212,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			const transporter = configureTransport(credentials, options);
 
 			const mailOptions: IDataObject = {
-				from: fromEmail,
+				from: options.fromName ? { name: options.fromName, address: fromEmail } : fromEmail,
 				to: toEmail,
 				cc: options.ccEmail,
 				bcc: options.bccEmail,

--- a/packages/nodes-base/nodes/EmailSend/v2/utils.ts
+++ b/packages/nodes-base/nodes/EmailSend/v2/utils.ts
@@ -15,6 +15,7 @@ export type EmailSendOptions = {
 	ccEmail?: string;
 	bccEmail?: string;
 	replyTo?: string;
+	fromName?: string;
 };
 
 export function configureTransport(credentials: IDataObject, options: EmailSendOptions) {

--- a/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/test/fromFile.operation.test.ts
@@ -101,7 +101,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			expect(xlsxRead).toHaveBeenCalledWith(
 				Buffer.from(mockBinaryDataInMemory.data, BINARY_ENCODING),
-				{ raw: undefined },
+				{ raw: undefined, cellDates: true },
 			);
 			expect(xlsxUtils.sheet_to_json).toHaveBeenCalledWith(mockWorkbook.Sheets.Sheet1, {});
 		});
@@ -127,7 +127,7 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 				262144,
 			);
 			expect(mockExecuteFunctions.helpers.binaryToBuffer).toHaveBeenCalledWith(mockStream);
-			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(mockBuffer, { raw: undefined, cellDates: true });
 		});
 	});
 
@@ -144,7 +144,22 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: true, cellDates: false });
+		});
+
+		it('should enable cellDates when rawData is false to convert Excel serial dates', async () => {
+			mockExecuteFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'options') return { rawData: false };
+				if (paramName === 'fileFormat') return 'xlsx';
+				if (paramName === 'binaryPropertyName') return 'data';
+				return undefined;
+			});
+
+			const items: INodeExecutionData[] = [{ json: {} }];
+
+			await execute.call(mockExecuteFunctions, items);
+
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: false, cellDates: true });
 		});
 
 		it('should respect readAsString option', async () => {
@@ -159,7 +174,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 		});
 
 		it('should use specified sheet name', async () => {
@@ -422,7 +441,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 
 			await execute.call(mockExecuteFunctions, items);
 
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 			const callArgs = (xlsxRead as Mock).mock.calls[0];
 			const passedData = callArgs[0];
 			const expectedBinaryString = Buffer.from(
@@ -445,7 +468,10 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with a Buffer (no type specified)
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
+				raw: undefined,
+				cellDates: true,
+			});
 		});
 
 		it('should handle readAsString with filesystem binary data', async () => {
@@ -478,7 +504,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			expect(mockExecuteFunctions.helpers.binaryToBuffer).toHaveBeenCalledWith(mockStream);
 
 			// Verify that xlsxRead was called with binary string
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify the string is the result of buffer.toString('binary')
 			const callArgs = (xlsxRead as Mock).mock.calls[0];
@@ -501,7 +531,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string and rawData option
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: true, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: true,
+				cellDates: false,
+				type: 'binary',
+			});
 
 			// Verify that the correct sheet was used
 			expect(xlsxUtils.sheet_to_json).toHaveBeenCalledWith(mockWorkbook.Sheets.Sheet2, {});
@@ -551,7 +585,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			const result = await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string type for proper character handling
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify that special characters are preserved in the output
 			expect(result).toHaveLength(3);
@@ -597,7 +635,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that when readAsString is true, we use binary type for proper character handling
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Reset mocks for second test
 			vi.clearAllMocks();
@@ -618,7 +660,10 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			await execute.call(mockExecuteFunctions, items);
 
 			// Verify that when readAsString is false, we use buffer directly (no type specified)
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), { raw: undefined });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(Buffer), {
+				raw: undefined,
+				cellDates: true,
+			});
 		});
 
 		it('should handle various international characters when readAsString is enabled', async () => {
@@ -669,7 +714,11 @@ describe('fromFile.operation - xlsx parsing logic', () => {
 			const result = await execute.call(mockExecuteFunctions, items);
 
 			// Verify that xlsxRead was called with binary string type
-			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), { raw: undefined, type: 'binary' });
+			expect(xlsxRead).toHaveBeenCalledWith(expect.any(String), {
+				raw: undefined,
+				cellDates: true,
+				type: 'binary',
+			});
 
 			// Verify that all international characters are preserved
 			expect(result).toHaveLength(8);

--- a/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
+++ b/packages/nodes-base/nodes/SpreadsheetFile/v2/fromFile.operation.ts
@@ -169,7 +169,10 @@ export async function execute(
 					});
 				}
 			} else {
-				const xlsxOptions: ParsingOptions = { raw: options.rawData as boolean };
+				const xlsxOptions: ParsingOptions = {
+					raw: options.rawData as boolean,
+					cellDates: !options.rawData,
+				};
 
 				let buffer: Buffer;
 				if (binaryData.id) {


### PR DESCRIPTION
## Summary

Adds a **From Name** option to the EmailSend node (both v1 and v2) so users can set a friendly sender name (e.g. "Acme Notifications") alongside the sender email address.

When set, nodemailer uses the `{name, address}` format so the recipient sees "\<Name\> \<email@example.com\>" instead of just the raw email address.

## Related Issues & Links

Closes the long-standing TODO in both v1 and v2:
- `EmailSend/v2/send.operation.ts` — `// TODO: Add choice for text as text or html (maybe also from name)`
- `EmailSend/v1/EmailSendV1.node.ts` — `// TODO: Add choice for text as text or html (maybe also from name)`

## How to test

1. Add a **Send Email** node
2. Set `From Email` to `nate@example.com`
3. Open **Options** → set `From Name` to `Nathan Doe`
4. Execute — the recipient sees "Nathan Doe <nate@example.com>"
5. With `From Name` empty — works as before (backward compatible)

## Review / Merge checklist

- [x] Tests included — 2 new tests for v2 + all 13 existing tests pass
- [x] Both v1 and v2 updated
- [x] Backward compatible — empty fromName falls back to plain email string
- [x] `EmailSendOptions` type updated with `fromName?: string`
- [x] `fromEmail` description updated to reference the new option
- [x] Removed stale TODO comments

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34484">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

