### PR TITLE
fix(core): Acquire expression isolate for MCP Trigger tool calls in queue mode

### DIFF
--- a/packages/cli/src/__tests__/utils.test.ts
+++ b/packages/cli/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { generateNanoId } from '@n8n/utils/generate-nano-id';
-import type { INodeType } from 'n8n-workflow';
+import type { INodeType, Workflow } from 'n8n-workflow';
 
 import {
 	shouldAssignExecuteMethod,
@@ -8,7 +8,49 @@ import {
 	setMicrosoftObservabilityDefaults,
 	containsExpression,
 	stripToolSuffix,
+	withExpressionIsolate,
 } from '../utils';
+
+describe('withExpressionIsolate', () => {
+	const acquireIsolate = vi.fn();
+	const releaseIsolate = vi.fn();
+	const workflow = { expression: { acquireIsolate, releaseIsolate } } as unknown as Workflow;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('should acquire before the callback and release after when newly acquired', async () => {
+		acquireIsolate.mockResolvedValue(true);
+		const fn = vi.fn().mockResolvedValue('result');
+
+		await expect(withExpressionIsolate(workflow, fn)).resolves.toBe('result');
+
+		expect(acquireIsolate.mock.invocationCallOrder[0]).toBeLessThan(fn.mock.invocationCallOrder[0]);
+		expect(releaseIsolate.mock.invocationCallOrder[0]).toBeGreaterThan(
+			fn.mock.invocationCallOrder[0],
+		);
+	});
+
+	it('should release when the callback throws', async () => {
+		acquireIsolate.mockResolvedValue(true);
+		const error = new Error('boom');
+
+		await expect(
+			withExpressionIsolate(workflow, async () => await Promise.reject(error)),
+		).rejects.toThrow(error);
+
+		expect(releaseIsolate).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not release an isolate the caller already held', async () => {
+		acquireIsolate.mockResolvedValue(false);
+
+		await withExpressionIsolate(workflow, async () => await Promise.resolve());
+
+		expect(releaseIsolate).not.toHaveBeenCalled();
+	});
+});
 
 describe('stripToolSuffix', () => {
 	it.each([

--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -19,8 +19,9 @@ import {
 	type IRunExecutionData,
 	type WorkflowExecuteMode,
 	type ExecutionError,
+	WorkflowExpression,
 } from 'n8n-workflow';
-import type { Mock, MockedClass } from 'vitest';
+import type { Mock, MockedClass, MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { CredentialsHelper } from '@/credentials-helper';
@@ -938,6 +939,127 @@ describe('JobProcessor', () => {
 			});
 			// Response should contain the tool's output data
 			expect(lastResponse.response).toEqual([{ result: 'tool response data' }]);
+		});
+
+		describe('expression isolate for tool calls', () => {
+			const toolNode = {
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequestTool',
+				typeVersion: 4.4,
+				parameters: {},
+				position: [0, 0] as [number, number],
+			};
+
+			const setupToolJob = (executeFn: Mock) => {
+				const executionPersistence = mock<ExecutionPersistence>();
+				executionPersistence.findSingleExecution.mockResolvedValueOnce(
+					mock<IExecutionResponse>({
+						mode: 'trigger',
+						workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+						data: mock<IRunExecutionData>({ executionData: undefined }),
+					}),
+				);
+				executionPersistence.findSingleExecution.mockResolvedValueOnce(
+					mock<IExecutionResponse>({
+						status: 'success',
+						workflowData: { id: 'wf-1', nodes: [toolNode], staticData: {} },
+						data: mock<IRunExecutionData>({ resultData: { runData: {} } }),
+					}),
+				);
+
+				const nodeTypes = mock<NodeTypes>();
+				nodeTypes.getByNameAndVersion.mockReturnValue({
+					description: {
+						name: 'httpRequestTool',
+						outputs: [NodeConnectionTypes.AiTool],
+						properties: [],
+					},
+					execute: executeFn,
+				} as never);
+
+				const jobProcessor = new JobProcessor(
+					logger,
+					mock(), // executionRepository
+					executionPersistence,
+					mock(), // workflowRepository
+					nodeTypes,
+					{ hostId: 'worker-host-123' } as unknown as InstanceSettings,
+					createManualExecutionServiceMock(),
+					executionsConfig,
+					mock(), // eventService
+				);
+
+				const job = mock<Job>();
+				job.data = {
+					workflowId: 'wf-1',
+					executionId: 'exec-mcp-isolate',
+					loadStaticData: false,
+					isMcpExecution: true,
+					mcpType: 'trigger',
+					mcpSessionId: 'session-isolate',
+					mcpMessageId: 'msg-isolate',
+					mcpToolCall: {
+						toolName: 'HTTP Request',
+						arguments: { url: 'https://example.com' },
+						sourceNodeName: 'HTTP Request',
+					},
+				};
+
+				return { jobProcessor, job };
+			};
+
+			let acquireSpy: MockInstance;
+			let releaseSpy: MockInstance;
+
+			beforeEach(() => {
+				acquireSpy = vi
+					.spyOn(WorkflowExpression.prototype, 'acquireIsolate')
+					.mockResolvedValue(true);
+				releaseSpy = vi.spyOn(WorkflowExpression.prototype, 'releaseIsolate').mockResolvedValue();
+			});
+
+			afterEach(() => {
+				acquireSpy.mockRestore();
+				releaseSpy.mockRestore();
+			});
+
+			it('should acquire an isolate around the tool invocation and release it after', async () => {
+				const executeFn = vi.fn().mockResolvedValue([[{ json: { ok: true } }]]);
+				const { jobProcessor, job } = setupToolJob(executeFn);
+
+				await jobProcessor.processJob(job);
+
+				expect(acquireSpy).toHaveBeenCalledTimes(1);
+				expect(releaseSpy).toHaveBeenCalledTimes(1);
+				// The tool must run inside the acquire/release window
+				expect(acquireSpy.mock.invocationCallOrder[0]).toBeLessThan(
+					executeFn.mock.invocationCallOrder[0],
+				);
+				expect(releaseSpy.mock.invocationCallOrder[0]).toBeGreaterThan(
+					executeFn.mock.invocationCallOrder[0],
+				);
+			});
+
+			it('should release the isolate when the tool invocation throws', async () => {
+				const executeFn = vi.fn().mockRejectedValue(new Error('tool failed'));
+				const { jobProcessor, job } = setupToolJob(executeFn);
+
+				await jobProcessor.processJob(job);
+
+				expect(acquireSpy).toHaveBeenCalledTimes(1);
+				expect(releaseSpy).toHaveBeenCalledTimes(1);
+			});
+
+			it('should not release an isolate it did not newly acquire', async () => {
+				acquireSpy.mockResolvedValue(false);
+				const executeFn = vi.fn().mockResolvedValue([[{ json: { ok: true } }]]);
+				const { jobProcessor, job } = setupToolJob(executeFn);
+
+				await jobProcessor.processJob(job);
+
+				expect(acquireSpy).toHaveBeenCalledTimes(1);
+				expect(releaseSpy).not.toHaveBeenCalled();
+			});
 		});
 
 		it('should invoke tool via supplyData for nodes with supplyData method', async () => {

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -45,6 +45,7 @@ import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { getWorkflowActiveStatusFromWorkflowData } from '@/executions/execution.utils';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { NodeTypes } from '@/node-types';
+import { withExpressionIsolate } from '@/utils';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 import type {
@@ -356,16 +357,23 @@ export class JobProcessor {
 
 			let toolResult: unknown;
 			try {
-				toolResult = await this.invokeTool(
+				// The execution's isolate window closed when the run finished, but the
+				// tool's parameters may still contain expressions (e.g. $fromAI), so
+				// the tool call needs its own isolate window.
+				toolResult = await withExpressionIsolate(
 					workflow,
-					sourceNodeName,
-					toolArgs,
-					additionalData,
-					run.data,
-					// The execution context (e.g. the OAuth identity for private credentials)
-					// is established on the main and loaded with the execution here; pass it
-					// through so the tool node can resolve dynamic credentials on the worker.
-					execution.data?.executionData?.runtimeData,
+					async () =>
+						await this.invokeTool(
+							workflow,
+							sourceNodeName,
+							toolArgs,
+							additionalData,
+							run.data,
+							// The execution context (e.g. the OAuth identity for private credentials)
+							// is established on the main and loaded with the execution here; pass it
+							// through so the tool node can resolve dynamic credentials on the worker.
+							execution.data?.executionData?.runtimeData,
+						),
 				);
 			} catch (error) {
 				this.logger.error('Tool node execution failed for MCP Trigger', {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -165,10 +165,12 @@ export async function withExpressionIsolate<T>(
 	workflow: Workflow,
 	fn: () => Promise<T>,
 ): Promise<T> {
-	await workflow.expression.acquireIsolate();
+	// Release is not reference-counted: only release if this scope newly acquired
+	// the isolate, otherwise we'd return the outer caller's bridge to the pool mid-use.
+	const acquired = await workflow.expression.acquireIsolate();
 	try {
 		return await fn();
 	} finally {
-		await workflow.expression.releaseIsolate();
+		if (acquired) await workflow.expression.releaseIsolate();
 	}
 }


### PR DESCRIPTION
## Summary

In queue mode, the worker invokes MCP Server Trigger tools (`JobProcessor.invokeTool`) after the execution's expression-isolate window has closed. Under `N8N_EXPRESSION_ENGINE=vm`, the first expression evaluated during the tool call (e.g. a `$fromAI` argument mapping — but any expression in any tool parameter) then failed with:

```
No bridge acquired for this context. Call acquire() first.
```

Direct mode was unaffected because tool invocation happens inside the `LiveWebhooks` acquire/release bracket.

This PR:

- Wraps the worker's MCP tool invocation in its own isolate window via `withExpressionIsolate`, so tool parameters with expressions resolve correctly in queue mode.
- Hardens `withExpressionIsolate` to only release isolates it newly acquired. Release is not reference-counted, so unconditionally releasing inside a nested scope would return the outer caller's bridge to the pool mid-use. Behavior is unchanged for existing call sites in the non-nested case; the `try/finally` still guarantees release on both success and error, so no isolates leak.

## How to test

Unit tests cover the acquire-before/release-after ordering around the tool invocation, release-on-throw, and no-release-when-the-isolate-was-already-held (both at the `JobProcessor` level and for the `withExpressionIsolate` helper).

Manual repro (pre-fix fails, post-fix works):

1. Start n8n in queue mode (`EXECUTIONS_MODE=queue` + Redis + a worker) with `N8N_EXPRESSION_ENGINE=vm`.
2. Create a workflow with an MCP Server Trigger and connect a tool whose input mapping uses an expression (e.g. `$fromAI(...)`; a Custom Workflow tool works well).
3. Activate the workflow and connect an MCP client: `initialize`, `tools/list`, then `tools/call` on the tool.
4. Pre-fix: `tools/call` returns `No bridge acquired for this context. Call acquire() first.` Post-fix: the tool executes and returns its result.
5. Sanity: the same `tools/call` with a static (expressionless) tool input works in both cases, and everything works under the legacy engine (`N8N_EXPRESSION_ENGINE` unset).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3776

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

