### PR TITLE
fix(editor): Stop write-lock polling on fetch failure to prevent 401 storm

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.test.ts
@@ -6,6 +6,7 @@ import { useCollaborationStore } from './collaboration.store';
 const mockFetchWorkflow = vi.fn();
 const mockShowMessage = vi.fn();
 const mockUiStore = reactive({ stateIsDirty: false });
+const mockGetWorkflowWriteLock = vi.fn().mockResolvedValue(null);
 
 const mockPushStore = {
 	send: vi.fn(),
@@ -76,7 +77,7 @@ vi.mock('@/features/ai/assistant/builder.store', () => ({
 }));
 
 vi.mock('@/app/api/workflows', () => ({
-	getWorkflowWriteLock: vi.fn().mockResolvedValue(null),
+	getWorkflowWriteLock: (...args: unknown[]) => mockGetWorkflowWriteLock(...args),
 }));
 
 vi.mock('vue-router', () => ({
@@ -95,13 +96,16 @@ describe('useCollaborationStore', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 		vi.clearAllMocks();
+		vi.useFakeTimers();
 		mockWorkflowId.value = 'workflow-1';
 		mockIsWorkflowSaved.value = { 'workflow-1': true, 'workflow-2': true };
 		mockUiStore.stateIsDirty = false;
 		mockShowMessage.mockImplementation(() => ({ close: vi.fn() }));
+		mockGetWorkflowWriteLock.mockResolvedValue(null);
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.clearAllMocks();
 	});
 
@@ -177,6 +181,111 @@ describe('useCollaborationStore', () => {
 			await nextTick();
 
 			expect(close).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('write-lock state polling', () => {
+		test('should stop polling when fetchWriteLockState returns null due to error (e.g. session expired)', async () => {
+			mockGetWorkflowWriteLock.mockResolvedValue({
+				clientId: 'other-client',
+				userId: 'other-user',
+			});
+			const store = useCollaborationStore();
+
+			await store.initialize('workflow-1');
+			const handler = mockPushStore.addEventListener.mock.calls[0][0] as (event: {
+				type: string;
+				data: { workflowId: string; clientId: string; userId: string };
+			}) => void;
+
+			handler({
+				type: 'writeAccessAcquired',
+				data: { workflowId: 'workflow-1', clientId: 'other-client', userId: 'other-user' },
+			});
+
+			expect(store.isAnyoneWriting).toBe(true);
+
+			// Simulate session expiry: fetch returns null (401 error caught internally)
+			mockGetWorkflowWriteLock.mockResolvedValue(null);
+
+			// Advance timer to trigger the first poll
+			await vi.advanceTimersByTimeAsync(20_000);
+
+			// Verify the lock was cleared
+			expect(store.isAnyoneWriting).toBe(false);
+
+			// Record the call count after the first poll stopped it
+			const callsAfterStop = mockGetWorkflowWriteLock.mock.calls.length;
+
+			// Advance another full interval — no more polls should fire
+			await vi.advanceTimersByTimeAsync(20_000);
+
+			expect(mockGetWorkflowWriteLock).toHaveBeenCalledTimes(callsAfterStop);
+		});
+
+		test('should stop polling when writer leaves collaborators list', async () => {
+			mockGetWorkflowWriteLock.mockResolvedValue({
+				clientId: 'other-client',
+				userId: 'other-user',
+			});
+			const store = useCollaborationStore();
+
+			await store.initialize('workflow-1');
+			const handler = mockPushStore.addEventListener.mock.calls[0][0] as (event: {
+				type: string;
+				data: {
+					workflowId: string;
+					clientId: string;
+					userId: string;
+					collaborators: unknown[];
+				};
+			}) => void;
+
+			handler({
+				type: 'writeAccessAcquired',
+				data: { workflowId: 'workflow-1', clientId: 'other-client', userId: 'other-user' },
+			});
+
+			expect(store.isAnyoneWriting).toBe(true);
+
+			// Simulate the writer leaving (collaborators list no longer includes them)
+			handler({
+				type: 'collaboratorsChanged',
+				data: {
+					workflowId: 'workflow-1',
+					collaborators: [{ user: { id: 'user-1' } }],
+				},
+			});
+
+			expect(store.isAnyoneWriting).toBe(false);
+		});
+
+		test('should not continue polling after terminate is called', async () => {
+			mockGetWorkflowWriteLock.mockResolvedValue({
+				clientId: 'other-client',
+				userId: 'other-user',
+			});
+			const store = useCollaborationStore();
+
+			await store.initialize('workflow-1');
+			const handler = mockPushStore.addEventListener.mock.calls[0][0] as (event: {
+				type: string;
+				data: { workflowId: string; clientId: string; userId: string };
+			}) => void;
+
+			handler({
+				type: 'writeAccessAcquired',
+				data: { workflowId: 'workflow-1', clientId: 'other-client', userId: 'other-user' },
+			});
+
+			store.terminate();
+
+			mockGetWorkflowWriteLock.mockClear();
+
+			// Advance timer - should NOT trigger any more polls
+			await vi.advanceTimersByTimeAsync(40_000);
+
+			expect(mockGetWorkflowWriteLock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -177,8 +177,9 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 
 		const writeLock = await fetchWriteLockState(workflowId);
 
-		// If lock is gone on backend but still exists in frontend, clear it
-		if (!writeLock && currentWriterLock.value) {
+		// If lock is gone on backend (or fetch failed, e.g. session expired),
+		// clear frontend lock state and stop polling
+		if (!writeLock) {
 			currentWriterLock.value = null;
 			stopLockStatePolling();
 		}
@@ -361,6 +362,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 
 		if (!writerStillPresent) {
 			currentWriterLock.value = null;
+			stopLockStatePolling();
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix sustained 401 storm caused by orphaned lock-state polling timers in the collaboration store.

When `fetchWriteLockState` returns null (e.g. session expired / 401 error), `pollLockState` now always clears the lock and stops polling — instead of only stopping when `currentWriterLock.value` is set. Additionally, `handleWriteLockHolderLeft` now calls `stopLockStatePolling()` when clearing the lock, preventing orphaned intervals from continuing to fire.

## How to test

1. Open a workflow where another user holds the write lock
2. Verify that the lock-state polling starts (check Network tab for periodic `GET /workflows/:id/collaboration/write-lock` requests every 20s)
3. Expire the session (e.g. clear cookies / wait for token expiry)
4. Verify that polling stops after the next poll returns 401 — no further requests should be made
5. Run the unit tests: `pnpm vitest run packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

Fixes #34488

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

