### PR TITLE
fix(HTTP Request Node): Do not re-decode clean UTF-8 responses as GBK

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
@@ -3,7 +3,6 @@ import type { Readable } from 'stream';
 
 const CHINESE_ENCODINGS = ['gb18030', 'gbk', 'gb2312'] as const;
 const REPLACEMENT_CHAR = '�';
-const HIGH_ASCII_PATTERN = /[\x80-\xFF]{3,}/;
 const DEFAULT_ENCODING = 'utf-8';
 
 /**
@@ -54,7 +53,11 @@ export async function binaryToStringWithEncodingDetection(
 
 	const decodedString = await helpers.binaryToString(bufferedData);
 
-	if (decodedString.includes(REPLACEMENT_CHAR) || HIGH_ASCII_PATTERN.test(decodedString)) {
+	// A clean UTF-8 decode (no replacement characters) is strong evidence the
+	// bytes are UTF-8. Accented Latin-1 supplement text (e.g. Turkish "Küçük")
+	// is not a signal of mis-decoding on its own — only fall back to encoding
+	// detection when the UTF-8 decode actually produced replacement characters.
+	if (decodedString.includes(REPLACEMENT_CHAR)) {
 		const detected = helpers.detectBinaryEncoding(bufferedData).toLowerCase() as BufferEncoding;
 		if (detected && detected !== DEFAULT_ENCODING) {
 			return await helpers.binaryToString(bufferedData, detected);

--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
@@ -141,23 +141,21 @@ describe('buffer-decoding utils', () => {
 				expect(result).toBe('test content with proper chars');
 			});
 
-			it('should detect high ASCII pattern and try chardet for Buffer', async () => {
-				const buffer = Buffer.from([0x80, 0x81, 0x82, 0x83]); // High ASCII bytes
-				const contentType = 'text/html';
-				const highAsciiString = String.fromCharCode(0x80, 0x81, 0x82, 0x83);
+			it('should NOT re-decode a clean UTF-8 string that merely contains 3+ consecutive high-ASCII chars', async () => {
+				// Regression test: a clean UTF-8 decode of accented Latin-1 supplement
+				// text (Turkish "Küçük") used to be misidentified as non-UTF-8 because
+				// it contains 3 consecutive characters in the U+0080-U+00FF range, and
+				// was then silently re-decoded (and corrupted) as GBK/GB18030.
+				const buffer = Buffer.from('Küçük Köpek Künyesi', 'utf8');
+				const contentType = 'text/xml';
 
-				mockBinaryToString
-					.mockResolvedValueOnce(highAsciiString) // First UTF-8 attempt
-					.mockResolvedValueOnce('proper decoded content'); // Second attempt with detected encoding
-
-				mockDetectBinaryEncoding.mockReturnValue('windows-1252');
+				mockBinaryToString.mockResolvedValue('Küçük Köpek Künyesi');
 
 				const result = await binaryToStringWithEncodingDetection(buffer, contentType, mockHelpers);
 
-				expect(mockDetectBinaryEncoding).toHaveBeenCalledWith(buffer);
-				expect(mockBinaryToString).toHaveBeenCalledTimes(2);
-				expect(mockBinaryToString).toHaveBeenNthCalledWith(2, buffer, 'windows-1252');
-				expect(result).toBe('proper decoded content');
+				expect(result).toBe('Küçük Köpek Künyesi');
+				expect(mockBinaryToString).toHaveBeenCalledTimes(1);
+				expect(mockDetectBinaryEncoding).not.toHaveBeenCalled();
 			});
 
 			it('should try Chinese encodings for Readable streams with replacement chars', async () => {


### PR DESCRIPTION
## Summary

`binaryToStringWithEncodingDetection()` (used by the HTTP Request node to
decode response bodies) re-decoded a response as GBK/GB18030 whenever the
already-correct UTF-8 decode happened to contain 3+ consecutive characters
in the U+0080–U+00FF range (`HIGH_ASCII_PATTERN`). Accented Latin-1
supplement text — Turkish, French, German, Spanish, Portuguese, etc. — hits
this pattern easily (e.g. Turkish `Küçük` has three such characters in a
row), so a clean UTF-8 response got silently corrupted into Chinese text,
even when the response correctly declared `charset=utf-8`.

This drops the `HIGH_ASCII_PATTERN` heuristic and relies solely on the
presence of the U+FFFD replacement character, which is what a failed UTF-8
decode actually produces (confirmed against `n8n-nodes-base`'s
`binaryToString` helper, which decodes via `iconv-lite` and substitutes
U+FFFD for invalid byte sequences, same as Node's own `Buffer.toString('utf8')`).
The non-UTF-8 detection/fallback path added in #20889 is untouched — genuinely
mis-encoded content still produces replacement characters and still reaches
the GBK/GB18030 detection loop.

Credit to @Godweed, who filed #34372 with a precise root-cause analysis and
a one-line suggested diff (drop the `HIGH_ASCII_PATTERN` condition, keep
`REPLACEMENT_CHAR`). This PR applies that diff essentially as suggested, and
additionally:
- removes the now-unused `HIGH_ASCII_PATTERN` constant,
- replaces the test that asserted the old (buggy) high-ASCII-triggers-redecode
  behavior with a regression test asserting the opposite — a clean UTF-8
  decode of `Küçük Köpek Künyesi` (the reporter's own example) must NOT be
  re-decoded,
- keeps the existing Chinese-encoding-fallback tests as a regression guard
  that genuinely mis-encoded (replacement-char-producing) content is still
  detected and fixed correctly.

## How to test

An example workflow: HTTP Request node → GET a URL whose response is valid
UTF-8 text containing three or more consecutive Latin-1 supplement
characters (e.g. body `Küçük Köpek Künyesi`) with `Content-Type: text/xml`
or `text/html`. Before this fix, the output is corrupted Chinese-looking
text; after this fix, the output is the original Turkish text.

Unit tests (from `packages/nodes-base`):

```bash
pnpm --filter n8n-nodes-base test nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
```

Result: 24/24 passing. Confirmed revert-proof — reverting only
`buffer-decoding.ts` while keeping the new test causes the new regression
test to fail with the exact reported symptom.

Lint/format:

```bash
pnpm exec biome check packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts packages/nodes-base/nodes/HttpRequest/V3/utils/test/buffer-decoding.test.ts
```

Result: clean, no issues. (Full `pnpm --filter n8n-nodes-base lint` via the
package's ESLint config could not be run in this environment without
building several transitive workspace packages — `@n8n/eslint-config`,
`@n8n/eslint-plugin-community-nodes`, and `n8n-workflow` — the last of which
failed to build from a fresh scoped checkout due to unrelated missing
`@n8n/expression-runtime`/`@n8n/config` type declarations, a pre-existing
build-graph issue unrelated to this change. `biome check` — the project's
primary formatter/linter per `lefthook`'s `pre-commit` hook — passed
cleanly and is what the repo's own pre-commit hook runs.)

## Related Linear tickets, Github issues, and Community forum posts

closes #34372

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. (no user-facing docs affected)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (maintainer call)

---
*Note: reporter @Godweed's report included a synthetic repro script using
`jschardet` for illustration; production `detectBinaryEncoding` actually
uses the `chardet` package (via `packages/core`), not `jschardet`. This
doesn't affect the correctness of the fix — the bug and fix are both in the
`HIGH_ASCII_PATTERN` gating condition, upstream of which chardet library is
used — but is noted here for reviewer accuracy.*


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34498">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

