### PR TITLE
fix(postgres): Replace falsy check with undefined check in Upsert operation

### DIFF
--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -288,7 +288,7 @@ export async function execute(
 				valuesLength = valuesLength + 1;
 				values.push(column);
 			});
-			const onConflict = ` ON CONFLICT (${conflictColumns.join(',')})`;
+			const onConflict = ` ON CONFLICT (${conflictColumns.join(',')})` ;
 
 			const insertQuery = `INSERT INTO $1:name.$2:name($${valuesLength}:name) VALUES($${valuesLength}:csv)${onConflict}`;
 			valuesLength = valuesLength + 1;

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -257,14 +257,14 @@ export async function execute(
 				}
 			}
 
-			if (!item[columnsToMatchOn[0]]) {
+			if (!(columnsToMatchOn[0] in item) || item[columnsToMatchOn[0]] === undefined) {
 				throw new NodeOperationError(
 					this.getNode(),
 					"Column to match on not found in input item. Add a column to match on or set the 'Data Mode' to 'Define Below' to define the value to match on.",
 				);
 			}
 
-			if (item[columnsToMatchOn[0]] && Object.keys(item).length === 1) {
+			if ((columnsToMatchOn[0] in item) && Object.keys(item).length === 1) {
 				throw new NodeOperationError(
 					this.getNode(),
 					"Add values to update or insert to the input item or set the 'Data Mode' to 'Define Below' to define the values to insert or update.",

--- a/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Postgres/v2/actions/database/upsert.operation.ts
@@ -257,14 +257,14 @@ export async function execute(
 				}
 			}
 
-			if (!(columnsToMatchOn[0] in item) || item[columnsToMatchOn[0]] === undefined) {
+			if (item[columnsToMatchOn[0]] === undefined) {
 				throw new NodeOperationError(
 					this.getNode(),
-					"Column to match on not found in input item. Add a column to match on or set the 'Data Mode' to 'Define Below' to define the value to match on.",
+					`Column to match on '${columnsToMatchOn[0]}' not found in input item. Add the column to the input data or set the 'Data Mode' to 'Define Below' to define the value to match on.`,
 				);
 			}
 
-			if ((columnsToMatchOn[0] in item) && Object.keys(item).length === 1) {
+			if (item[columnsToMatchOn[0]] !== undefined && Object.keys(item).length === 1) {
 				throw new NodeOperationError(
 					this.getNode(),
 					"Add values to update or insert to the input item or set the 'Data Mode' to 'Define Below' to define the values to insert or update.",


### PR DESCRIPTION
## Summary

Fixes #34504

The Postgres node's **Upsert** operation used a JavaScript falsy check (`!item[columnsToMatchOn[0]]`) to validate whether the match column exists in the input item. This incorrectly rejects valid falsy values:

| Value | `!value` | Should be blocked? |
|-------|----------|--------------------|
| `undefined` (key absent) | `true` | ✅ Yes |
| `null` | `true` | ❌ No |
| `0` | `true` | ❌ No |
| `false` | `true` | ❌ No |
| `""` | `true` | ❌ No |

This is inconsistent with the **MySQL** node which has no such guard and passes falsy values through to the database layer without error.

## Changes

- **Guard 1** (`!item[column]` → `!(column in item) || item[column] === undefined`): Only throws when the key is genuinely absent from the item, not when it holds a falsy value like `null`, `0`, or `false`.
- **Guard 2** (`item[column] && Object.keys(item).length === 1` → `(column in item) && Object.keys(item).length === 1`): Uses explicit key-presence check so the single-field-only error still fires correctly even when the match column value is falsy.

## How to test

1. Add a **Postgres** node with operation = **Upsert**
2. Set `Column to Match On` to a column, e.g. `external_id`
3. Feed an input item where `external_id` is `null`, `0`, or `false`
4. Execute — node should now pass through to the DB instead of throwing

**Before:** `NodeOperationError: Column to match on not found in input item...`  
**After:** Query executes successfully

## Related

- Closes #34504
- Consistent with MySQL node behavior (`packages/nodes-base/nodes/MySql/v2/actions/database/upsert.operation.ts`)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34506">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

