### PR TITLE
fix(http-request): remove HIGH_ASCII_PATTERN to prevent silent UTF-8 corruption for Latin-1 languages

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/utils/buffer-decoding.ts
@@ -2,8 +2,7 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
 const CHINESE_ENCODINGS = ['gb18030', 'gbk', 'gb2312'] as const;
-const REPLACEMENT_CHAR = '�';
-const HIGH_ASCII_PATTERN = /[\x80-\xFF]{3,}/;
+const REPLACEMENT_CHAR = '\uFFFD';
 const DEFAULT_ENCODING = 'utf-8';
 
 /**
@@ -54,7 +53,7 @@ export async function binaryToStringWithEncodingDetection(
 
 	const decodedString = await helpers.binaryToString(bufferedData);
 
-	if (decodedString.includes(REPLACEMENT_CHAR) || HIGH_ASCII_PATTERN.test(decodedString)) {
+	if (decodedString.includes(REPLACEMENT_CHAR)) {
 		const detected = helpers.detectBinaryEncoding(bufferedData).toLowerCase() as BufferEncoding;
 		if (detected && detected !== DEFAULT_ENCODING) {
 			return await helpers.binaryToString(bufferedData, detected);


### PR DESCRIPTION
## Summary

Fixes #34372

## Problem

The HTTP Request node **silently corrupts** correctly-encoded UTF-8 responses when the decoded text contains 3+ consecutive characters in the `U+0080–U+00FF` range. This affects any language using Latin-1 supplement characters:

- 🇹🇷 Turkish: `Küçük` → `K眉莽眉k`
- 🇫🇷 French: `résumé`, `façade`
- 🇩🇪 German: `Größe`, `Überblick`
- 🇵🇹 Portuguese: `ação`, `português`
- etc.

The root cause is in `buffer-decoding.ts` (introduced in #20889):

```ts
// BEFORE — broken
if (decodedString.includes(REPLACEMENT_CHAR) || HIGH_ASCII_PATTERN.test(decodedString)) {
```

`HIGH_ASCII_PATTERN = /[\x80-\xFF]{3,}/` is tested against the **already correctly decoded** string. Latin accented characters like `ü` (U+00FC), `ç` (U+00E7) sit in the `U+0080–U+00FF` range, so 3+ adjacent ones trigger the pattern even when UTF-8 decoding was perfect. The Chinese encoding loop (`GB18030`) then "succeeds" on nearly any byte sequence, replacing perfectly valid text with Chinese characters — silently, with no error thrown.

## Fix

Remove the `HIGH_ASCII_PATTERN` condition entirely. Rely only on the presence of Unicode replacement characters (`U+FFFD`) as the signal that UTF-8 decoding failed:

```ts
// AFTER — fixed
if (decodedString.includes(REPLACEMENT_CHAR)) {
```

A clean UTF-8 decode with no replacement characters is strong evidence the bytes **are** valid UTF-8. Genuine non-UTF-8 content (the original target of #20889) still produces replacement characters during UTF-8 decoding and therefore still correctly reaches the re-detection / Chinese encoding path.

## Testing (from the reporter)

The reporter ran their test suite against real `iconv-lite`/`jschardet`:

| | Pass |
|---|---|
| Unpatched | 6/8 (Turkish names + SOAP envelope corrupted) |
| **Patched** | **8/8** ✅ (including real GB18030 Chinese payload — still decoded correctly) |

## Impact

- **Before:** Any UTF-8 API response containing accented Latin text with 3+ consecutive `U+0080–U+00FF` chars silently returns garbled Chinese characters — data corruption with no warning.
- **After:** UTF-8 text is returned as-is. Chinese GB18030 responses still auto-detect correctly via the replacement character path.

## Related

- Closes #34372
- Original fix that introduced the regression: #20889

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

