### PR TITLE
fix(postgres): close non-SSH pool on eviction to prevent memory leak

### DIFF
--- a/packages/nodes-base/nodes/Postgres/transport/index.ts
+++ b/packages/nodes-base/nodes/Postgres/transport/index.ts
@@ -147,6 +147,22 @@ export async function configurePostgres(
 		if (!credentials.sshTunnel) {
 			const db = pgp(dbConfig);
 
+			// Register an abort listener so that when ConnectionPoolManager evicts this
+			// pool after the idle TTL, the underlying pg-promise Database object is
+			// properly ended and removed from pg-promise's process-global registry.
+			// Without this, evicted pools accumulate indefinitely, each retaining
+			// memory proportional to the last execution's payload (fixes #32724).
+			abortController.signal.addEventListener('abort', async () => {
+				this.logger.debug('configurePostgres: Got abort signal, closing pg connection.');
+				try {
+					if (!db.$pool.ended) await db.$pool.end();
+				} catch (error) {
+					this.logger.error('configurePostgres: Encountered error while closing the pool.', {
+						error,
+					});
+				}
+			});
+
 			return { db, pgp };
 		} else {
 			if (credentials.sshAuthenticateWith === 'privateKey' && credentials.privateKey) {


### PR DESCRIPTION
## Summary

Fixes #32724

## Problem

The Postgres node leaks `pg-promise` `Database` objects every time the **non-SSH** connection path evicts a pool.

`ConnectionPoolManager` evicts pools idle longer than the 5-minute TTL by calling `abortController.abort()`. The **SSH branch** correctly handles this — it has an abort listener that calls `db.$pool.end()`. The **non-SSH branch** had no such listener, so `abort()` was fired but nobody called `end()`. The `Database` object was then permanently stuck in pg-promise's process-global registry:

```
global[Symbol.for('pgPromiseDatabasePool')].dbs[]
```

This registry is never pruned, so leaked pools accumulate indefinitely. Because `createReceiveHandler()` captures a closure, each leaked pool also retained the full execution context (all upstream `inputData`). The retained size per leaked pool was proportional to the upstream payload — **~10 MB per eviction cycle** in the reporter's repro.

The reporter confirmed this via Chrome DevTools heap snapshots:
- `Database` objects grow +1 per workflow execution, never GC'd
- Retainer path: `pgPromiseDatabasePool.dbs[] → Database.$config.options.receive → captured execution context`

> **Note:** `createReceiveHandler()` was already moved to module scope in a prior fix to break the closure capture on `this`. The remaining issue was purely the missing abort listener.

## Fix

Add an `abort` event listener to the non-SSH branch that mirrors the existing SSH branch:

```typescript
// Non-SSH: NEW abort listener (mirrors SSH branch)
abortController.signal.addEventListener('abort', async () => {
    this.logger.debug('configurePostgres: Got abort signal, closing pg connection.');
    try {
        if (!db.$pool.ended) await db.$pool.end();
    } catch (error) {
        this.logger.error('configurePostgres: Encountered error while closing the pool.', { error });
    }
});
```

When `ConnectionPoolManager` evicts the pool, `db.$pool.end()` now correctly drains active connections, ends the pool, and allows pg-promise to remove the `Database` from its global registry so it can be GC'd.

## Impact

- **Before:** Every Postgres pool eviction (every ~5 min of idle time) permanently leaks one `Database` object + retained execution context. Long-running instances accumulate unbounded memory.
- **After:** Evicted pools are properly cleaned up. Memory footprint stays flat over time.

## Related

- Closes #32724
- Companion to SSH fix already in `transport/index.ts` (lines 174–188)
- `createReceiveHandler()` module-scope refactor was a prerequisite (already merged)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34508">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

