### PR TITLE
fix(HTTP Request Tool Node): Pass error response bodies to the model

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -359,4 +359,198 @@ describe('ToolHttpRequest', () => {
 			);
 		});
 	});
+
+	describe('Error responses', () => {
+		beforeEach(() => {
+			executeFunctions.getNodeParameter.mockImplementation(
+				(paramName: string, _: any, fallback: any) => {
+					switch (paramName) {
+						case 'method':
+							return 'GET';
+						case 'url':
+							return 'https://httpbin.org/status';
+						case 'options':
+							return {};
+						case 'placeholderDefinitions.values':
+							return [];
+						default:
+							return fallback;
+					}
+				},
+			);
+		});
+
+		const invokeTool = async () => {
+			const { response } = await httpTool.supplyData.call(executeFunctions, 0);
+			return await (response as N8nTool).invoke({});
+		};
+
+		it('should include the response body when the request fails with a 4xx', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Request failed with status code 403'), {
+					response: {
+						status: 403,
+						data: { error: 'insufficient_scope', required: 'read:users' },
+					},
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 403');
+			expect(res).toContain('insufficient_scope');
+			expect(res).toContain('read:users');
+		});
+
+		it('should include the response body when the request fails with a 5xx', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Request failed with status code 503'), {
+					response: { status: 503, data: 'Upstream database is unavailable' },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 503');
+			expect(res).toContain('Upstream database is unavailable');
+		});
+
+		it('should read the response body from the cause when the error is wrapped', async () => {
+			const cause = Object.assign(new Error('Request failed with status code 422'), {
+				response: { status: 422, data: { message: 'The "email" field is required' } },
+			});
+
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Unprocessable Entity'), { httpCode: '422', cause }),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 422');
+			expect(res).toContain('email');
+			expect(res).toContain('field is required');
+		});
+
+		it('should report the error alone when the request failed without a response', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), { code: 'ECONNREFUSED' }),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('There was an error');
+			expect(res).toContain('ECONNREFUSED');
+			expect(res).not.toContain('Response body');
+		});
+
+		it('should not add a response body section when the error response is empty', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Request failed with status code 404'), {
+					response: { status: 404, data: '' },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 404');
+			expect(res).not.toContain('Response body');
+		});
+
+		it('should read the response body reported by the legacy request helper', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Forbidden'), {
+					statusCode: 403,
+					error: { error: 'insufficient_scope' },
+					response: { status: 403, headers: {}, statusText: 'Forbidden' },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 403');
+			expect(res).toContain('insufficient_scope');
+		});
+
+		it('should derive the status code from the wrapped error when the wrapper has none', async () => {
+			const cause = Object.assign(new Error('Request failed with status code 429'), {
+				response: { status: 429, data: 'Rate limit exceeded' },
+			});
+
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Too Many Requests'), { httpCode: null, cause }),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 429');
+			expect(res).toContain('Rate limit exceeded');
+		});
+
+		it('should truncate an oversized error body', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Internal Server Error'), {
+					response: { status: 500, data: 'x'.repeat(5000) },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('[truncated]');
+			expect(res.length).toBeLessThan(3000);
+		});
+
+		it('should skip a binary error body', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Internal Server Error'), {
+					response: { status: 500, data: Buffer.from([0x89, 0x50, 0x4e, 0x47]) },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 500');
+			expect(res).not.toContain('Response body');
+		});
+
+		it('should not throw when the error body cannot be serialized', async () => {
+			const circular: Record<string, unknown> = { message: 'Bad Request' };
+			circular.self = circular;
+
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Bad Request'), {
+					response: { status: 400, data: circular },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 400');
+			expect(res).not.toContain('Response body');
+		});
+
+		it('should not repeat the body when it is already part of the error message', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('403 - forbidden by policy'), {
+					response: { status: 403, data: 'forbidden by policy' },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('forbidden by policy');
+			expect(res).not.toContain('Response body');
+		});
+
+		it('should leave successful responses untouched', async () => {
+			helpers.httpRequest.mockResolvedValue({
+				body: 'Hello World',
+				statusCode: 200,
+				headers: { 'content-type': 'text/plain' },
+			});
+
+			const res = await invokeTool();
+
+			expect(res).toEqual('Hello World');
+		});
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -541,6 +541,30 @@ describe('ToolHttpRequest', () => {
 			expect(res).not.toContain('Response body');
 		});
 
+		it('should redact credential values echoed back in the error body', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Unauthorized'), {
+					response: {
+						status: 401,
+						data: {
+							message: 'Rejected request',
+							api_key: 'sk-live-abcdef123456',
+							authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9',
+						},
+					},
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 401');
+			// The key stays so the model still learns which credential was rejected.
+			expect(res).toContain('api_key');
+			expect(res).toContain('Rejected request');
+			expect(res).not.toContain('sk-live-abcdef123456');
+			expect(res).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+		});
+
 		it('should leave successful responses untouched', async () => {
 			helpers.httpRequest.mockResolvedValue({
 				body: 'Hello World',

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -1,5 +1,5 @@
-import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
-import { jsonParse } from 'n8n-workflow';
+import type { INode, ISupplyDataFunctions, JsonObject } from 'n8n-workflow';
+import { NodeApiError, jsonParse } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { N8nTool } from '@utils/N8nTool';
@@ -563,6 +563,51 @@ describe('ToolHttpRequest', () => {
 			expect(res).toContain('Rejected request');
 			expect(res).not.toContain('sk-live-abcdef123456');
 			expect(res).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+		});
+
+		it('should include the response body when a predefined credential wraps the failure', async () => {
+			// A tool authenticated with a stored credential goes through
+			// `httpRequestWithAuthentication`, which rejects with a real `NodeApiError` rather than
+			// the client's own error. That wrapper keeps the payload somewhere else entirely.
+			executeFunctions.getNodeParameter.mockImplementation(
+				(paramName: string, _: any, fallback: any) => {
+					switch (paramName) {
+						case 'method':
+							return 'GET';
+						case 'url':
+							return 'https://httpbin.org/status';
+						case 'authentication':
+							return 'predefinedCredentialType';
+						case 'nodeCredentialType':
+							return 'slackApi';
+						case 'options':
+							return {};
+						case 'placeholderDefinitions.values':
+							return [];
+						default:
+							return fallback;
+					}
+				},
+			);
+
+			helpers.httpRequestWithAuthentication.mockRejectedValue(
+				new NodeApiError(
+					executeFunctions.getNode(),
+					Object.assign(new Error('Request failed with status code 403'), {
+						isAxiosError: true,
+						response: {
+							status: 403,
+							data: { error: 'insufficient_scope', required: 'read:users' },
+						},
+					}) as unknown as JsonObject,
+				),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 403');
+			expect(res).toContain('insufficient_scope');
+			expect(res).toContain('read:users');
 		});
 
 		it('should leave successful responses untouched', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -565,6 +565,47 @@ describe('ToolHttpRequest', () => {
 			expect(res).not.toContain('eyJhbGciOiJIUzI1NiJ9');
 		});
 
+		it('should redact compound credential keys and unprefixed authorization values', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('Unauthorized'), {
+					response: {
+						status: 401,
+						data: {
+							message: 'Token exchange failed',
+							client_secret: 'cs-live-abcdef',
+							Authorization: 'abcdef-bare-key',
+							token_type: 'Bearer',
+						},
+					},
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('Token exchange failed');
+			expect(res).toContain('client_secret');
+			expect(res).not.toContain('cs-live-abcdef');
+			expect(res).not.toContain('abcdef-bare-key');
+			// Keys that merely read like credentials keep their value.
+			expect(res).toContain('"token_type": "Bearer"');
+		});
+
+		it('should redact a credential the client folded into the error message', async () => {
+			helpers.httpRequest.mockRejectedValue(
+				Object.assign(new Error('401 - {"client_secret":"cs-live-abcdef"}'), {
+					response: { status: 401, data: '{"client_secret":"cs-live-abcdef"}' },
+				}),
+			);
+
+			const res = await invokeTool();
+
+			expect(res).toContain('HTTP 401');
+			expect(res).toContain('client_secret');
+			expect(res).not.toContain('cs-live-abcdef');
+			// Both sides are redacted, so the body is still recognised as a repeat of the message.
+			expect(res).not.toContain('Response body');
+		});
+
 		it('should include the response body when a predefined credential wraps the failure', async () => {
 			// A tool authenticated with a stored credential goes through
 			// `httpRequestWithAuthentication`, which rejects with a real `NodeApiError` rather than
@@ -590,16 +631,21 @@ describe('ToolHttpRequest', () => {
 				},
 			);
 
+			// `NodeApiError` recognises an axios rejection by `constructor.name`, so the fixture
+			// carries that name to take the same branch production does.
+			class AxiosError extends Error {
+				isAxiosError = true;
+
+				response = {
+					status: 403,
+					data: { error: 'insufficient_scope', required: 'read:users' },
+				};
+			}
+
 			helpers.httpRequestWithAuthentication.mockRejectedValue(
 				new NodeApiError(
 					executeFunctions.getNode(),
-					Object.assign(new Error('Request failed with status code 403'), {
-						isAxiosError: true,
-						response: {
-							status: 403,
-							data: { error: 'insufficient_scope', required: 'read:users' },
-						},
-					}) as unknown as JsonObject,
+					new AxiosError('Request failed with status code 403') as unknown as JsonObject,
 				),
 			);
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -145,6 +145,53 @@ const defaultOptimizer = <T>(response: T) => {
 	return String(response);
 };
 
+/** Error payloads are appended to the tool output, so they must not flood the model's context. */
+const MAX_ERROR_BODY_LENGTH = 2000;
+
+type FailedRequest = {
+	error?: unknown;
+	response?: { status?: number; data?: unknown };
+};
+
+/**
+ * Reads the status and payload a failed request came back with. The error is either the one the
+ * HTTP client rejected with, or a `NodeApiError` wrapping it, which keeps the original as its
+ * cause. The current client reports the payload as `response.data`, the legacy one as `error`.
+ */
+const getFailedRequest = (error: unknown): { status?: number; body?: unknown } => {
+	for (const candidate of [error, (error as { cause?: unknown })?.cause]) {
+		const failed = candidate as FailedRequest | undefined;
+		const body = failed?.response?.data ?? failed?.error;
+		const status = failed?.response?.status;
+
+		if (body !== undefined || status !== undefined) {
+			return { status, body };
+		}
+	}
+
+	return {};
+};
+
+/**
+ * Turns an error payload into something safe to hand to the model: skips empty and binary bodies,
+ * and never throws, since this runs while we are already handling a failed request.
+ */
+const serializeErrorBody = (body: unknown): string | undefined => {
+	if (body === undefined || body === null || body === '' || isBinary(body)) {
+		return undefined;
+	}
+
+	let serialized: string;
+
+	try {
+		serialized = defaultOptimizer(body);
+	} catch {
+		return undefined;
+	}
+
+	return serialized.trim() ? serialized : undefined;
+};
+
 function isBinary(data: unknown) {
 	// Check if data is a Buffer
 	if (Buffer.isBuffer(data)) {
@@ -755,8 +802,18 @@ export const configureToolFunction = (
 			try {
 				fullResponse = await httpRequest(options);
 			} catch (error) {
-				const httpCode = (error as NodeApiError).httpCode;
+				const { status, body } = getFailedRequest(error);
+				const httpCode = (error as NodeApiError).httpCode ?? status;
 				response = `${httpCode ? `HTTP ${httpCode} ` : ''}There was an error: "${error.message}"`;
+
+				// The API's own error payload is what tells the model why the call was rejected. Without
+				// it the model only sees a status code and tends to invent a reason for the failure.
+				const errorBody = serializeErrorBody(body);
+				if (errorBody !== undefined && !error.message.includes(errorBody)) {
+					response += `\nResponse body: ${errorBody.slice(0, MAX_ERROR_BODY_LENGTH)}${
+						errorBody.length > MAX_ERROR_BODY_LENGTH ? '... [truncated]' : ''
+					}`;
+				}
 			}
 
 			if (!response) {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -148,6 +148,24 @@ const defaultOptimizer = <T>(response: T) => {
 /** Error payloads are appended to the tool output, so they must not flood the model's context. */
 const MAX_ERROR_BODY_LENGTH = 2000;
 
+const SECRET_REDACTION = '[redacted]';
+
+/**
+ * Masks credential-shaped values that an API echoed back in its error payload, so they do not
+ * reach the model or the stored execution data. The key is kept, so `invalid api_key: <secret>`
+ * still tells the model which credential the API rejected.
+ */
+const redactSecrets = (content: string): string =>
+	content
+		.replace(
+			/\b(authorization)(["']?\s*[:=]\s*["']?\s*(?:bearer|basic)\s+)[^\s"',;]+/gi,
+			`$1$2${SECRET_REDACTION}`,
+		)
+		.replace(
+			/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret|credential)(["']?\s*[:=]\s*)(["']?)[^\s"',;}]+\3/gi,
+			`$1$2$3${SECRET_REDACTION}$3`,
+		);
+
 type FailedRequest = {
 	error?: unknown;
 	response?: { status?: number; data?: unknown };
@@ -189,7 +207,7 @@ const serializeErrorBody = (body: unknown): string | undefined => {
 		return undefined;
 	}
 
-	return serialized.trim() ? serialized : undefined;
+	return serialized.trim() ? redactSecrets(serialized) : undefined;
 };
 
 function isBinary(data: unknown) {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -154,15 +154,23 @@ const SECRET_REDACTION = '[redacted]';
  * Masks credential-shaped values that an API echoed back in its error payload, so they do not
  * reach the model or the stored execution data. The key is kept, so `invalid api_key: <secret>`
  * still tells the model which credential the API rejected.
+ *
+ * A sibling of the redaction applied to skill tool output in
+ * `packages/@n8n/agents/src/skills/tools.ts`; kept separate because `@n8n/agents` is not a
+ * dependency here. Keep the two in mind when changing either.
+ *
+ * The leading `[\w-]*` matters: `\b` alone never fires inside a compound key such as
+ * `client_secret`, where every character before `secret` is a word character. The auth scheme is
+ * optional so an `Authorization` header holding a bare key is masked too.
  */
 const redactSecrets = (content: string): string =>
 	content
 		.replace(
-			/\b(authorization)(["']?\s*[:=]\s*["']?\s*(?:bearer|basic)\s+)[^\s"',;]+/gi,
+			/\b(authorization)(["']?\s*[:=]\s*["']?\s*(?:(?:bearer|basic)\s+)?)[^\s"',;}]+/gi,
 			`$1$2${SECRET_REDACTION}`,
 		)
 		.replace(
-			/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret|credential)(["']?\s*[:=]\s*)(["']?)[^\s"',;}]+\3/gi,
+			/([\w-]*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|password|passwd|secret|credential|private[_-]?key))(["']?\s*[:=]\s*)(["']?)[^\s"',;}]+\3/gi,
 			`$1$2$3${SECRET_REDACTION}$3`,
 		);
 
@@ -826,12 +834,15 @@ export const configureToolFunction = (
 			} catch (error) {
 				const { status, body } = getFailedRequest(error);
 				const httpCode = (error as NodeApiError).httpCode ?? status;
-				response = `${httpCode ? `HTTP ${httpCode} ` : ''}There was an error: "${error.message}"`;
+				// Some clients fold the response body into the message, so it needs the same masking
+				// as the body itself — and the dedupe check below only holds if both sides are redacted.
+				const message = redactSecrets(error.message);
+				response = `${httpCode ? `HTTP ${httpCode} ` : ''}There was an error: "${message}"`;
 
 				// The API's own error payload is what tells the model why the call was rejected. Without
 				// it the model only sees a status code and tends to invent a reason for the failure.
 				const errorBody = serializeErrorBody(body);
-				if (errorBody !== undefined && !error.message.includes(errorBody)) {
+				if (errorBody !== undefined && !message.includes(errorBody)) {
 					response += `\nResponse body: ${errorBody.slice(0, MAX_ERROR_BODY_LENGTH)}${
 						errorBody.length > MAX_ERROR_BODY_LENGTH ? '... [truncated]' : ''
 					}`;

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -169,17 +169,21 @@ const redactSecrets = (content: string): string =>
 type FailedRequest = {
 	error?: unknown;
 	response?: { status?: number; data?: unknown };
+	// A tool using a predefined credential goes through `httpRequestWithAuthentication`, which
+	// rejects with a `NodeApiError`. That has no `response`, and its `cause` is not retained, but
+	// it copies an object payload onto `context.data`.
+	context?: { data?: unknown };
 };
 
 /**
  * Reads the status and payload a failed request came back with. The error is either the one the
- * HTTP client rejected with, or a `NodeApiError` wrapping it, which keeps the original as its
- * cause. The current client reports the payload as `response.data`, the legacy one as `error`.
+ * HTTP client rejected with, or a `NodeApiError` wrapping it. The current client reports the
+ * payload as `response.data`, the legacy one as `error`.
  */
 const getFailedRequest = (error: unknown): { status?: number; body?: unknown } => {
 	for (const candidate of [error, (error as { cause?: unknown })?.cause]) {
 		const failed = candidate as FailedRequest | undefined;
-		const body = failed?.response?.data ?? failed?.error;
+		const body = failed?.response?.data ?? failed?.error ?? failed?.context?.data;
 		const status = failed?.response?.status;
 
 		if (body !== undefined || status !== undefined) {


### PR DESCRIPTION
## Summary

When a request made by the HTTP Request Tool failed, the tool handed the model only the status code and a generic message:

```
HTTP 403 There was an error: "Forbidden - perhaps check your credentials?"
```

The API's own explanation was dropped, so the agent had nothing to act on. In practice it either invents a reason for the failure or reports it inaccurately to the user, which is what #29528 describes.

The response body is what makes an error actionable — `insufficient_scope`, `the "email" field is required`, `rate limit exceeded, retry in 30s` — and it is available on the rejected error. This PR appends it to the tool output:

```
HTTP 403 There was an error: "Forbidden - perhaps check your credentials?"
Response body: {
  "error": "insufficient_scope",
  "required": "read:users"
}
```

Notes on the implementation:

- **Nothing about the request changes.** Non-2xx responses still reject exactly as before, so OAuth2 token refresh (including credentials that set a custom `tokenExpiredStatusCode`), retries and redirect handling are untouched. An earlier attempt relaxed `ignoreHttpStatusErrors` instead and would have silently broken token refresh for APIs that signal expiry with something other than 401.
- **All three error shapes the tool can see are handled.** The current HTTP client reports the payload as `response.data` and the legacy one as `error`. A tool using a predefined credential requests through `httpRequestWithAuthentication`, which rejects with a `NodeApiError` instead — that wrapper exposes neither `response` nor a usable `cause` (`ExecutionBaseError` declares `cause` as a class field, so it is reset to `undefined` after `super()` runs), but it copies an object payload onto `context.data`. The payload is read from whichever is present. Thanks to @DeveloperTheExplorer for catching that the predefined-credential path was silently doing nothing.
- **Only the body is read**, never the headers, so nothing from `set-cookie` or `www-authenticate` reaches the model.
- **The body is capped at 2000 characters** with an explicit `... [truncated]` marker. Servers are often far more verbose on errors than on success, and this output goes straight into the model's context.
- Binary and non-serializable payloads are skipped, and the body is not appended when the error message already contains it.

- **Credential values echoed back in an error payload are masked.** APIs sometimes include the rejected credential in their error body, and that text would otherwise reach the model and the stored execution data. The patterns mirror the redaction already applied to skill tool output in `packages/@n8n/agents/src/skills/tools.ts`. Only the value is masked, so `"api_key": "[redacted]"` still tells the model which credential was rejected.

Three limitations worth stating explicitly rather than leaving implicit: pattern-based redaction is best-effort and cannot catch a bare secret returned with no surrounding key name; the success path is untouched here, so a 200 body containing a token still reaches the model as it always has (making redaction a general rule for this node would be a separate change); and on the predefined-credential path a **plain-text** error body is still lost, because `NodeApiError` only retains non-array object payloads and discards a string one entirely. Recovering that means making `ExecutionBaseError.cause` survive construction — shared platform code whose `toJSON()` would then start carrying the raw `AxiosError`, request config included, so it belongs in its own PR rather than here.

## How to test

1. Add an AI Agent with an HTTP Request Tool pointing at an endpoint that returns a 4xx or 5xx with a JSON body — `https://httpbin.org/status/403` for a bare status, or any real API called without the required scope for a body with detail.
2. Ask the agent to call the tool.
3. Before this change the tool output is only `HTTP 403 There was an error: "..."`. After it, the response body follows on the next line and the agent can explain or correct the failure.

Successful responses are unaffected — they still go through the configured response optimizer untouched.

Automated coverage is in `packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts` (`Error responses`), which had no coverage of the error path before. It covers a real `NodeApiError` arriving from the predefined-credential path, 4xx and 5xx bodies, the legacy client shape, reading through a wrapping error's cause, deriving the status from the cause, truncation, binary and non-serializable bodies, connection failures with no response, and successful responses staying unchanged.

```bash
cd packages/@n8n/nodes-langchain && pnpm vitest run nodes/tools/ToolHttpRequest
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #29528

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

