### PR TITLE
feat(API): Add @PublicApiController pattern with reference tags endpoint (no-changelog)

### DIFF
--- a/.agents/skills/public-api/SKILL.md
+++ b/.agents/skills/public-api/SKILL.md
@@ -3,16 +3,68 @@ name: n8n:public-api
 description: >-
   Adds or updates n8n Public API v1 endpoints, OpenAPI specs, and handler wiring.
   Use when creating public API handlers, registering paths in openapi.yml, or
-  adding OpenAPI tags.
+  adding OpenAPI tags. Prefer @PublicApiController for new endpoints (API-37+).
 ---
 
 # Public API v1
 
-Public API lives under `packages/cli/src/public-api/v1/`. Handlers are
-`express-openapi-validator` route modules; OpenAPI path specs are YAML under
-each handler's `spec/` directory.
+Public API lives under `packages/cli/src/public-api/v1/`.
 
-## Adding an endpoint
+**Preferred for new endpoints (API-37+):** `@PublicApiController` +
+`PublicApiControllerRegistry` — same decorator style as internal
+`@RestController`, mounted at `/api/v1` with API-key auth and public errors.
+
+**Legacy (existing endpoints):** `express-openapi-validator` handlers under
+`handlers/`; OpenAPI path specs are YAML under each handler's `spec/` directory.
+Migrate to the controller pattern when touching an endpoint; do not mix data
+access styles within a new feature.
+
+## Architecture
+
+Convergence is at the **service layer**, not HTTP. Public and internal stay as
+two sibling routes over one shared service — neither calls the other:
+
+```
+GET /rest/tags    → TagsController         ┐  JWT auth, internal shape
+                                            ├─→ TagService
+GET /api/v1/tags  → TagsPublicController   ┘  API-key auth, public DTO
+```
+
+## Adding an endpoint (controller pattern)
+
+Reference: `v1/controllers/tags.public.controller.ts` (`GET /tags`).
+
+1. **Public DTOs** in `@n8n/api-types` — input query/body + output resource DTO
+   (distinct from internal shapes when they diverge). Use `Z.class` so the
+   registry can validate/parse.
+2. **Controller** — `v1/controllers/<feature>.public.controller.ts`
+   ```ts
+   @PublicApiController('/tags')
+   export class TagsPublicController {
+     constructor(private readonly tagService: TagService) {}
+
+     @Get('/')
+     @ApiKeyScope('tag:list')
+     @ApiResponse(TagListPublicDto)
+     async getTags(_req, _res, @Query q: ListTagsQueryDto) { /* call service */ }
+   }
+   ```
+   - Reuse `@Get/@Post/@Body/@Query/@Param/@GlobalScope/@ProjectScope` as-is.
+   - `@ApiKeyScope` — string, or `{ anyOf }` / `{ allOf }` (no bare arrays).
+   - `@ApiResponse(Dto)` — registry `.parse()`s the return value (strips
+     undeclared fields). Shape is provisional until API-39 (doc-gen).
+   - Delegate to the same service as the internal REST controller.
+3. **Side-effect import** the controller from `packages/cli/src/public-api/index.ts`
+   so metadata is registered before `PublicApiControllerRegistry.activate`.
+4. **OpenAPI path spec** — still required for docs + `scope-parity.test.ts`
+   (`handlers/<feature>/spec/paths/…`, `$ref` in `openapi.yml`,
+   `x-required-scope` matching `@ApiKeyScope`). Until scope-parity reads
+   decorator metadata, keep a scope-tagged stub in the eov handler (see
+   `getTags` in `tags.handler.ts`).
+5. **Coverage manifest** — add every new OpenAPI endpoint to
+   `packages/nodes-base/nodes/N8n/n8n-api-coverage.json`.
+
+## Adding an endpoint (legacy eov handler)
 
 1. **Handler** — `handlers/<feature>/<feature>.handler.ts`
    - Export middleware arrays keyed by `x-eov-operation-id`.
@@ -53,10 +105,12 @@ tags:
 `scope-parity.test.ts` asserts this ordering — CI fails if tags drift out of
 sort order.
 
-## Reference handlers
+## Reference
 
-- Simple GET via service: `handlers/insights/`
-- CRUD via service/controller: `handlers/variables/`, `handlers/folders/`,
+- **Controller pattern:** `v1/controllers/tags.public.controller.ts`
+- **Registry:** `packages/cli/src/public-api/public-api-controller.registry.ts`
+- Simple GET via eov + service: `handlers/insights/`
+- CRUD via eov + service/controller: `handlers/variables/`, `handlers/folders/`,
   `handlers/projects/`, `handlers/data-tables/`
 - Multipart: `handlers/n8n-packages/` (see also
   `packages/cli/src/modules/n8n-packages/CLAUDE.md`)

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -128,6 +128,8 @@ export { GetResourceDependenciesDto } from './workflows/get-resource-dependencie
 
 export { CreateOrUpdateTagRequestDto } from './tag/create-or-update-tag-request.dto';
 export { RetrieveTagQueryDto } from './tag/retrieve-tag-query.dto';
+export { ListTagsQueryDto } from './tag/list-tags-query.dto';
+export { TagPublicDto, TagListPublicDto, tagPublicSchema } from './tag/tag-public.dto';
 
 export { UpdateApiKeyRequestDto } from './api-keys/update-api-key-request.dto';
 export { CreateApiKeyRequestDto } from './api-keys/create-api-key-request.dto';

--- a/packages/@n8n/api-types/src/dto/tag/list-tags-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/list-tags-query.dto.ts
@@ -3,10 +3,6 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 import { publicApiPaginationSchema } from '../pagination/pagination.dto';
 
-/**
- * Query for `GET /api/v1/tags`. Clients send `limit` + optional `cursor`;
- * the controller decodes the cursor into an offset.
- */
 export class ListTagsQueryDto extends Z.class({
 	limit: publicApiPaginationSchema.limit,
 	cursor: z.string().optional(),

--- a/packages/@n8n/api-types/src/dto/tag/list-tags-query.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/list-tags-query.dto.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+import { publicApiPaginationSchema } from '../pagination/pagination.dto';
+
+/**
+ * Query for `GET /api/v1/tags`. Clients send `limit` + optional `cursor`;
+ * the controller decodes the cursor into an offset.
+ */
+export class ListTagsQueryDto extends Z.class({
+	limit: publicApiPaginationSchema.limit,
+	cursor: z.string().optional(),
+}) {}

--- a/packages/@n8n/api-types/src/dto/tag/tag-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/tag-public.dto.ts
@@ -2,10 +2,6 @@ import { z } from 'zod';
 
 import { Z } from '../../zod-class';
 
-/**
- * Public API tag resource shape — strips internal fields at the registry boundary.
- * Matches `handlers/tags/spec/schemas/tag.yml`.
- */
 export const tagPublicSchema = z.object({
 	id: z.string(),
 	name: z.string(),

--- a/packages/@n8n/api-types/src/dto/tag/tag-public.dto.ts
+++ b/packages/@n8n/api-types/src/dto/tag/tag-public.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/**
+ * Public API tag resource shape — strips internal fields at the registry boundary.
+ * Matches `handlers/tags/spec/schemas/tag.yml`.
+ */
+export const tagPublicSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+});
+
+export class TagPublicDto extends Z.class({
+	id: z.string(),
+	name: z.string(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+}) {}
+
+export class TagListPublicDto extends Z.class({
+	data: z.array(tagPublicSchema),
+	nextCursor: z.string().nullable(),
+}) {}

--- a/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
@@ -51,18 +51,6 @@ describe('@ApiKeyScope Decorator', () => {
 		).toEqual({ allOf: ['tag:list', 'tag:create'] });
 	});
 
-	it('should reject bare arrays', () => {
-		expect(() => {
-			class TestController {
-				@Get('/')
-				// @ts-expect-error — bare arrays are intentionally unsupported
-				@ApiKeyScope(['tag:list', 'tag:read'])
-				async handler() {}
-			}
-			void TestController;
-		}).toThrow(/bare array/);
-	});
-
 	it('should reject objects that declare both anyOf and allOf', () => {
 		const ambiguous = {
 			anyOf: ['tag:list' as const],

--- a/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
@@ -62,4 +62,20 @@ describe('@ApiKeyScope Decorator', () => {
 			void TestController;
 		}).toThrow(/bare array/);
 	});
+
+	it('should reject objects that declare both anyOf and allOf', () => {
+		const ambiguous = {
+			anyOf: ['tag:list' as const],
+			allOf: ['tag:create' as const],
+		};
+
+		expect(() => {
+			class TestController {
+				@Get('/')
+				@ApiKeyScope(ambiguous as never)
+				async handler() {}
+			}
+			void TestController;
+		}).toThrow(/both anyOf and allOf/);
+	});
 });

--- a/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/api-key-scope.test.ts
@@ -1,0 +1,65 @@
+import { Container } from '@n8n/di';
+
+import { ApiKeyScope } from '../api-key-scope';
+import { ControllerRegistryMetadata } from '../controller-registry-metadata';
+import { Get } from '../route';
+import type { Controller } from '../types';
+
+describe('@ApiKeyScope Decorator', () => {
+	let controllerRegistryMetadata: ControllerRegistryMetadata;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		Container.reset();
+
+		controllerRegistryMetadata = new ControllerRegistryMetadata();
+		Container.set(ControllerRegistryMetadata, controllerRegistryMetadata);
+	});
+
+	it('should store a single scope string', () => {
+		class TestController {
+			@Get('/')
+			@ApiKeyScope('tag:list')
+			async handler() {}
+		}
+
+		const route = controllerRegistryMetadata.getRouteMetadata(
+			TestController as Controller,
+			'handler',
+		);
+		expect(route.apiKeyScope).toBe('tag:list');
+	});
+
+	it('should store anyOf and allOf requirements', () => {
+		class TestController {
+			@Get('/any')
+			@ApiKeyScope({ anyOf: ['tag:list', 'tag:read'] })
+			async anyOfHandler() {}
+
+			@Get('/all')
+			@ApiKeyScope({ allOf: ['tag:list', 'tag:create'] })
+			async allOfHandler() {}
+		}
+
+		expect(
+			controllerRegistryMetadata.getRouteMetadata(TestController as Controller, 'anyOfHandler')
+				.apiKeyScope,
+		).toEqual({ anyOf: ['tag:list', 'tag:read'] });
+		expect(
+			controllerRegistryMetadata.getRouteMetadata(TestController as Controller, 'allOfHandler')
+				.apiKeyScope,
+		).toEqual({ allOf: ['tag:list', 'tag:create'] });
+	});
+
+	it('should reject bare arrays', () => {
+		expect(() => {
+			class TestController {
+				@Get('/')
+				// @ts-expect-error — bare arrays are intentionally unsupported
+				@ApiKeyScope(['tag:list', 'tag:read'])
+				async handler() {}
+			}
+			void TestController;
+		}).toThrow(/bare array/);
+	});
+});

--- a/packages/@n8n/decorators/src/controller/__tests__/api-response.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/api-response.test.ts
@@ -1,0 +1,39 @@
+import { Z } from '@n8n/api-types';
+import { Container } from '@n8n/di';
+import { z } from 'zod';
+
+import { ApiResponse } from '../api-response';
+import { ControllerRegistryMetadata } from '../controller-registry-metadata';
+import { Get } from '../route';
+import type { Controller } from '../types';
+
+const ExampleDto = Z.class({
+	id: z.string(),
+	name: z.string(),
+});
+
+describe('@ApiResponse Decorator', () => {
+	let controllerRegistryMetadata: ControllerRegistryMetadata;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		Container.reset();
+
+		controllerRegistryMetadata = new ControllerRegistryMetadata();
+		Container.set(ControllerRegistryMetadata, controllerRegistryMetadata);
+	});
+
+	it('should store the response DTO on the route', () => {
+		class TestController {
+			@Get('/')
+			@ApiResponse(ExampleDto)
+			async handler() {}
+		}
+
+		const route = controllerRegistryMetadata.getRouteMetadata(
+			TestController as Controller,
+			'handler',
+		);
+		expect(route.responseDto).toBe(ExampleDto);
+	});
+});

--- a/packages/@n8n/decorators/src/controller/__tests__/public-api-controller.test.ts
+++ b/packages/@n8n/decorators/src/controller/__tests__/public-api-controller.test.ts
@@ -1,0 +1,41 @@
+import { Container } from '@n8n/di';
+
+import { ControllerRegistryMetadata } from '../controller-registry-metadata';
+import { PublicApiController } from '../public-api-controller';
+import type { Controller } from '../types';
+
+describe('@PublicApiController Decorator', () => {
+	let controllerRegistryMetadata: ControllerRegistryMetadata;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		Container.reset();
+
+		controllerRegistryMetadata = new ControllerRegistryMetadata();
+		Container.set(ControllerRegistryMetadata, controllerRegistryMetadata);
+	});
+
+	it('should set base path and mark as public API', () => {
+		@PublicApiController('/tags')
+		class TagsPublicController {}
+
+		const metadata = controllerRegistryMetadata.getControllerMetadata(
+			TagsPublicController as Controller,
+		);
+		expect(metadata.basePath).toBe('/tags');
+		expect(metadata.isPublicApi).toBe(true);
+		expect(metadata.registerOnRootPath).toBe(false);
+		expect(Container.has(TagsPublicController)).toBe(true);
+	});
+
+	it('should default base path to /', () => {
+		@PublicApiController()
+		class DefaultPublicController {}
+
+		const metadata = controllerRegistryMetadata.getControllerMetadata(
+			DefaultPublicController as Controller,
+		);
+		expect(metadata.basePath).toBe('/');
+		expect(metadata.isPublicApi).toBe(true);
+	});
+});

--- a/packages/@n8n/decorators/src/controller/api-key-scope.ts
+++ b/packages/@n8n/decorators/src/controller/api-key-scope.ts
@@ -1,0 +1,49 @@
+import { Container } from '@n8n/di';
+
+import { ControllerRegistryMetadata } from './controller-registry-metadata';
+import type { ApiKeyScopeRequirement, Controller } from './types';
+
+function isBareArray(value: unknown): value is unknown[] {
+	return Array.isArray(value);
+}
+
+/**
+ * Declares the API-key scope(s) required for a public API route.
+ *
+ * Accepts a single scope string, or `{ anyOf }` / `{ allOf }` for multiples.
+ * Bare arrays are rejected (ambiguous between any-of and all-of).
+ *
+ * The PublicApiControllerRegistry enforces the check against
+ * `req.tokenGrant.apiKeyScopes`.
+ *
+ * @example
+ * ```ts
+ * @ApiKeyScope('tag:list')
+ * @ApiKeyScope({ anyOf: ['workflow:read', 'workflow:list'] })
+ * @ApiKeyScope({ allOf: ['project:read', 'project:update'] })
+ * ```
+ */
+export const ApiKeyScope =
+	(requirement: ApiKeyScopeRequirement): MethodDecorator =>
+	(target, handlerName) => {
+		if (isBareArray(requirement)) {
+			throw new Error(
+				'@ApiKeyScope does not accept a bare array — use { anyOf: [...] } or { allOf: [...] }',
+			);
+		}
+
+		if (typeof requirement === 'object') {
+			if ('anyOf' in requirement && requirement.anyOf.length === 0) {
+				throw new Error('@ApiKeyScope({ anyOf }) requires at least one scope');
+			}
+			if ('allOf' in requirement && requirement.allOf.length === 0) {
+				throw new Error('@ApiKeyScope({ allOf }) requires at least one scope');
+			}
+		}
+
+		const routeMetadata = Container.get(ControllerRegistryMetadata).getRouteMetadata(
+			target.constructor as Controller,
+			String(handlerName),
+		);
+		routeMetadata.apiKeyScope = requirement;
+	};

--- a/packages/@n8n/decorators/src/controller/api-key-scope.ts
+++ b/packages/@n8n/decorators/src/controller/api-key-scope.ts
@@ -33,10 +33,17 @@ export const ApiKeyScope =
 		}
 
 		if (typeof requirement === 'object') {
-			if ('anyOf' in requirement && requirement.anyOf.length === 0) {
+			const hasAnyOf = 'anyOf' in requirement;
+			const hasAllOf = 'allOf' in requirement;
+			if (hasAnyOf && hasAllOf) {
+				throw new Error(
+					'@ApiKeyScope does not accept both anyOf and allOf — pick one authorization rule',
+				);
+			}
+			if (hasAnyOf && requirement.anyOf.length === 0) {
 				throw new Error('@ApiKeyScope({ anyOf }) requires at least one scope');
 			}
-			if ('allOf' in requirement && requirement.allOf.length === 0) {
+			if (hasAllOf && requirement.allOf.length === 0) {
 				throw new Error('@ApiKeyScope({ allOf }) requires at least one scope');
 			}
 		}

--- a/packages/@n8n/decorators/src/controller/api-key-scope.ts
+++ b/packages/@n8n/decorators/src/controller/api-key-scope.ts
@@ -3,15 +3,10 @@ import { Container } from '@n8n/di';
 import { ControllerRegistryMetadata } from './controller-registry-metadata';
 import type { ApiKeyScopeRequirement, Controller } from './types';
 
-function isBareArray(value: unknown): value is unknown[] {
-	return Array.isArray(value);
-}
-
 /**
  * Declares the API-key scope(s) required for a public API route.
  *
- * Accepts a single scope string, or `{ anyOf }` / `{ allOf }` for multiples.
- * Bare arrays are rejected (ambiguous between any-of and all-of).
+ * Accepts a single scope string, or `{ anyOf }` / `{ allOf }` for multiples
  *
  * The PublicApiControllerRegistry enforces the check against
  * `req.tokenGrant.apiKeyScopes`.
@@ -26,12 +21,6 @@ function isBareArray(value: unknown): value is unknown[] {
 export const ApiKeyScope =
 	(requirement: ApiKeyScopeRequirement): MethodDecorator =>
 	(target, handlerName) => {
-		if (isBareArray(requirement)) {
-			throw new Error(
-				'@ApiKeyScope does not accept a bare array — use { anyOf: [...] } or { allOf: [...] }',
-			);
-		}
-
 		if (typeof requirement === 'object') {
 			const hasAnyOf = 'anyOf' in requirement;
 			const hasAllOf = 'allOf' in requirement;

--- a/packages/@n8n/decorators/src/controller/api-response.ts
+++ b/packages/@n8n/decorators/src/controller/api-response.ts
@@ -1,0 +1,28 @@
+import { Container } from '@n8n/di';
+
+import { ControllerRegistryMetadata } from './controller-registry-metadata';
+import type { Controller, ResponseDtoClass } from './types';
+
+/**
+ * Declares the public output DTO for a route.
+ *
+ * PublicApiControllerRegistry `.parse()`s the handler return value through this
+ * schema before sending, stripping undeclared/internal fields. The same schema
+ * will feed OpenAPI response generation once API-39 lands (shape is provisional).
+ *
+ * @example
+ * ```ts
+ * @Get('/')
+ * @ApiResponse(TagListPublicDto)
+ * async getTags() { ... }
+ * ```
+ */
+export const ApiResponse =
+	(dto: ResponseDtoClass): MethodDecorator =>
+	(target, handlerName) => {
+		const routeMetadata = Container.get(ControllerRegistryMetadata).getRouteMetadata(
+			target.constructor as Controller,
+			String(handlerName),
+		);
+		routeMetadata.responseDto = dto;
+	};

--- a/packages/@n8n/decorators/src/controller/index.ts
+++ b/packages/@n8n/decorators/src/controller/index.ts
@@ -1,6 +1,9 @@
 export { Body, Query, Param } from './args';
 export { RestController } from './rest-controller';
 export { RootLevelController } from './root-level-controller';
+export { PublicApiController } from './public-api-controller';
+export { ApiKeyScope } from './api-key-scope';
+export { ApiResponse } from './api-response';
 export { Get, Post, Put, Patch, Delete, Head, Options } from './route';
 export { Middleware } from './middleware';
 export { ControllerRegistryMetadata } from './controller-registry-metadata';
@@ -8,9 +11,11 @@ export { Licensed } from './licensed';
 export { GlobalScope, ProjectScope } from './scoped';
 export type {
 	AccessScope,
+	ApiKeyScopeRequirement,
 	Controller,
 	CorsOptions,
 	Method,
+	ResponseDtoClass,
 	StaticRouterMetadata,
 } from './types';
 export {

--- a/packages/@n8n/decorators/src/controller/public-api-controller.ts
+++ b/packages/@n8n/decorators/src/controller/public-api-controller.ts
@@ -1,0 +1,34 @@
+import { Container, Service } from '@n8n/di';
+
+import { ControllerRegistryMetadata } from './controller-registry-metadata';
+import type { Controller } from './types';
+
+/**
+ * Marks a controller for the public API surface (`/api/v1`).
+ *
+ * Reuses the same route/arg/RBAC decorators as `@RestController`, but registers
+ * into a public collection so `ControllerRegistry` does not mount it under `/rest`.
+ * Auth, errors, and mounting are handled by `PublicApiControllerRegistry`.
+ *
+ * @example
+ * ```ts
+ * @PublicApiController('/tags')
+ * export class TagsPublicController {
+ *   @Get('/')
+ *   @ApiKeyScope('tag:list')
+ *   async getTags() { ... }
+ * }
+ * ```
+ */
+export const PublicApiController =
+	(basePath: `/${string}` = '/'): ClassDecorator =>
+	(target) => {
+		const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+			target as unknown as Controller,
+		);
+		metadata.basePath = basePath;
+		metadata.isPublicApi = true;
+		metadata.registerOnRootPath = false;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return Service()(target);
+	};

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -1,9 +1,23 @@
+import type { ZodClass } from '@n8n/api-types';
 import type { BooleanLicenseFeature } from '@n8n/constants';
 import type { Constructable } from '@n8n/di';
-import type { Scope } from '@n8n/permissions';
+import type { ApiKeyScope, Scope } from '@n8n/permissions';
 import type { RequestHandler, Router } from 'express';
 
 import type { KeyedRateLimiterConfig, RateLimiterLimits } from './rate-limit';
+
+/**
+ * API-key scope requirement for public API routes.
+ * Use a string for a single scope, or `{ anyOf }` / `{ allOf }` for multiples
+ * (bare arrays are rejected as ambiguous).
+ */
+export type ApiKeyScopeRequirement =
+	| ApiKeyScope
+	| { anyOf: readonly ApiKeyScope[] }
+	| { allOf: readonly ApiKeyScope[] };
+
+/** Minimal shape for `@ApiResponse` output DTOs (Z.class / Zod parse). */
+export type ResponseDtoClass = Pick<ZodClass, 'parse'>;
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options';
 
@@ -43,6 +57,13 @@ export interface RouteMetadata {
 	keyedRateLimit?: KeyedRateLimiterConfig;
 	licenseFeature?: BooleanLicenseFeature;
 	accessScope?: AccessScope;
+	/** API-key scope(s) required for public API routes (`@ApiKeyScope`). */
+	apiKeyScope?: ApiKeyScopeRequirement;
+	/**
+	 * Output DTO used by PublicApiControllerRegistry to strip undeclared fields
+	 * before responding. Provisional until API-39 picks a doc-gen library.
+	 */
+	responseDto?: ResponseDtoClass;
 	args: Arg[];
 	router?: Router;
 }
@@ -72,6 +93,11 @@ export interface ControllerMetadata {
 	basePath: `/${string}`;
 	// If true, the controller will be registered on the root path without the any prefix
 	registerOnRootPath?: boolean;
+	/**
+	 * If true, the controller is mounted by PublicApiControllerRegistry at `/api/v1`
+	 * instead of by ControllerRegistry under `/rest`.
+	 */
+	isPublicApi?: boolean;
 	middlewares: HandlerName[];
 	routes: Map<HandlerName, RouteMetadata>;
 }

--- a/packages/@n8n/decorators/src/controller/types.ts
+++ b/packages/@n8n/decorators/src/controller/types.ts
@@ -6,17 +6,11 @@ import type { RequestHandler, Router } from 'express';
 
 import type { KeyedRateLimiterConfig, RateLimiterLimits } from './rate-limit';
 
-/**
- * API-key scope requirement for public API routes.
- * Use a string for a single scope, or `{ anyOf }` / `{ allOf }` for multiples
- * (bare arrays are rejected as ambiguous).
- */
 export type ApiKeyScopeRequirement =
 	| ApiKeyScope
 	| { anyOf: readonly ApiKeyScope[] }
 	| { allOf: readonly ApiKeyScope[] };
 
-/** Minimal shape for `@ApiResponse` output DTOs (Z.class / Zod parse). */
 export type ResponseDtoClass = Pick<ZodClass, 'parse'>;
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options';
@@ -57,12 +51,7 @@ export interface RouteMetadata {
 	keyedRateLimit?: KeyedRateLimiterConfig;
 	licenseFeature?: BooleanLicenseFeature;
 	accessScope?: AccessScope;
-	/** API-key scope(s) required for public API routes (`@ApiKeyScope`). */
 	apiKeyScope?: ApiKeyScopeRequirement;
-	/**
-	 * Output DTO used by PublicApiControllerRegistry to strip undeclared fields
-	 * before responding. Provisional until API-39 picks a doc-gen library.
-	 */
 	responseDto?: ResponseDtoClass;
 	args: Arg[];
 	router?: Router;
@@ -93,10 +82,6 @@ export interface ControllerMetadata {
 	basePath: `/${string}`;
 	// If true, the controller will be registered on the root path without the any prefix
 	registerOnRootPath?: boolean;
-	/**
-	 * If true, the controller is mounted by PublicApiControllerRegistry at `/api/v1`
-	 * instead of by ControllerRegistry under `/rest`.
-	 */
 	isPublicApi?: boolean;
 	middlewares: HandlerName[];
 	routes: Map<HandlerName, RouteMetadata>;

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -46,7 +46,6 @@ export class ControllerRegistry {
 	activate(app: Application) {
 		for (const controllerClass of this.metadata.controllerClasses) {
 			const metadata = this.metadata.getControllerMetadata(controllerClass);
-			// Public API controllers are mounted by PublicApiControllerRegistry.
 			if (metadata.isPublicApi) continue;
 			this.activateController(app, controllerClass);
 		}

--- a/packages/cli/src/controller.registry.ts
+++ b/packages/cli/src/controller.registry.ts
@@ -45,6 +45,9 @@ export class ControllerRegistry {
 
 	activate(app: Application) {
 		for (const controllerClass of this.metadata.controllerClasses) {
+			const metadata = this.metadata.getControllerMetadata(controllerClass);
+			// Public API controllers are mounted by PublicApiControllerRegistry.
+			if (metadata.isPublicApi) continue;
 			this.activateController(app, controllerClass);
 		}
 	}

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -20,7 +20,6 @@ import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
 import { LastActiveAtService } from '@/services/last-active-at.service';
 import { UrlService } from '@/services/url.service';
 
-// Side-effect: register @PublicApiController classes into ControllerRegistryMetadata.
 import './v1/controllers/tags.public.controller';
 
 // Renders `x-required-scope` as a badge on each operation. swagger-ui-express
@@ -332,8 +331,6 @@ function createApiRouter(
 		`/${publicApiEndpoint}/${version}`,
 		express.json({ limit: payloadLimit }),
 		jsonParseErrorHandler,
-		// Decorator-based public controllers (API-37+) mount before eov so they
-		// own matching routes; remaining OpenAPI paths stay on eov handlers.
 		createPublicControllerMiddleware(version),
 		createLazyValidatorMiddleware(openApiSpecPath, handlersDirectory, version),
 	);

--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -10,6 +10,9 @@ import path from 'path';
 import type { JsonObject } from 'swagger-ui-express';
 import validator from 'validator';
 
+import { PublicApiControllerRegistry } from './public-api-controller.registry';
+import { sendPublicApiErrorResponse } from './v1/public-api-error-response';
+
 import { EventService } from '@/events/event.service';
 import { License } from '@/license';
 import { createN8nPackageMulterOptions } from '@/modules/n8n-packages/utils/import-package-upload';
@@ -17,7 +20,8 @@ import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
 import { LastActiveAtService } from '@/services/last-active-at.service';
 import { UrlService } from '@/services/url.service';
 
-import { sendPublicApiErrorResponse } from './v1/public-api-error-response';
+// Side-effect: register @PublicApiController classes into ControllerRegistryMetadata.
+import './v1/controllers/tags.public.controller';
 
 // Renders `x-required-scope` as a badge on each operation. swagger-ui-express
 // serializes this function's source into the page, so it must be self-contained:
@@ -186,6 +190,12 @@ async function importOperationHandlerResolver(
 	return handler;
 }
 
+function createPublicControllerMiddleware(version: string): RequestHandler {
+	const router = express.Router({ mergeParams: true });
+	Container.get(PublicApiControllerRegistry).activate(router, version);
+	return router;
+}
+
 function createLazyValidatorMiddleware(
 	openApiSpecPath: string,
 	handlersDirectory: string,
@@ -322,6 +332,9 @@ function createApiRouter(
 		`/${publicApiEndpoint}/${version}`,
 		express.json({ limit: payloadLimit }),
 		jsonParseErrorHandler,
+		// Decorator-based public controllers (API-37+) mount before eov so they
+		// own matching routes; remaining OpenAPI paths stay on eov handlers.
+		createPublicControllerMiddleware(version),
 		createLazyValidatorMiddleware(openApiSpecPath, handlersDirectory, version),
 	);
 

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -31,13 +31,6 @@ function apiKeyScopesSatisfy(
 	return requirement.allOf.every((scope) => granted.includes(scope));
 }
 
-/**
- * Mounts `@PublicApiController` classes onto a router under `/api/v1`.
- *
- * Sibling to `ControllerRegistry`: reuses route/arg metadata, but uses API-key
- * auth via `AuthStrategyRegistry`, public error serialization, and optional
- * `@ApiResponse` output parsing — no JWT `/rest` coupling.
- */
 @Service()
 export class PublicApiControllerRegistry {
 	constructor(
@@ -47,10 +40,6 @@ export class PublicApiControllerRegistry {
 		private readonly eventService: EventService,
 	) {}
 
-	/**
-	 * Register all public API controllers on `router`. The caller must mount
-	 * that router at `/{publicApi.path}/{version}` (e.g. `/api/v1`).
-	 */
 	activate(router: Router, apiVersion: string) {
 		for (const controllerClass of this.metadata.controllerClasses) {
 			const metadata = this.metadata.getControllerMetadata(controllerClass);
@@ -159,9 +148,7 @@ export class PublicApiControllerRegistry {
 
 			const userId = (req as AuthenticatedRequest).user?.id;
 			if (userId) {
-				this.lastActiveAtService.updateLastActiveIfStale(userId).catch(() => {
-					/* best-effort */
-				});
+				this.lastActiveAtService.updateLastActiveIfStale(userId).catch(() => undefined);
 				this.eventService.emit('public-api-invoked', {
 					userId,
 					path: req.path,

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -1,0 +1,222 @@
+import type { ZodClass } from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import type { AccessScope, ApiKeyScopeRequirement, Controller } from '@n8n/decorators';
+import { Container, Service } from '@n8n/di';
+import type { Request, RequestHandler, Response, Router } from 'express';
+import { Router as createRouter } from 'express';
+import { UnexpectedError } from 'n8n-workflow';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { EventService } from '@/events/event.service';
+import { userHasScopes } from '@/permissions.ee/check-access';
+import { sendPublicApiErrorResponse } from '@/public-api/v1/public-api-error-response';
+import { AuthStrategyRegistry } from '@/services/auth-strategy.registry';
+import { LastActiveAtService } from '@/services/last-active-at.service';
+
+function apiKeyScopesSatisfy(
+	granted: readonly string[] | undefined,
+	requirement: ApiKeyScopeRequirement,
+): boolean {
+	if (!granted) return false;
+
+	if (typeof requirement === 'string') {
+		return granted.includes(requirement);
+	}
+
+	if ('anyOf' in requirement) {
+		return requirement.anyOf.some((scope) => granted.includes(scope));
+	}
+
+	return requirement.allOf.every((scope) => granted.includes(scope));
+}
+
+/**
+ * Mounts `@PublicApiController` classes onto a router under `/api/v1`.
+ *
+ * Sibling to `ControllerRegistry`: reuses route/arg metadata, but uses API-key
+ * auth via `AuthStrategyRegistry`, public error serialization, and optional
+ * `@ApiResponse` output parsing — no JWT `/rest` coupling.
+ */
+@Service()
+export class PublicApiControllerRegistry {
+	constructor(
+		private readonly metadata: ControllerRegistryMetadata,
+		private readonly authStrategyRegistry: AuthStrategyRegistry,
+		private readonly lastActiveAtService: LastActiveAtService,
+		private readonly eventService: EventService,
+	) {}
+
+	/**
+	 * Register all public API controllers on `router`. The caller must mount
+	 * that router at `/{publicApi.path}/{version}` (e.g. `/api/v1`).
+	 */
+	activate(router: Router, apiVersion: string) {
+		for (const controllerClass of this.metadata.controllerClasses) {
+			const metadata = this.metadata.getControllerMetadata(controllerClass);
+			if (!metadata.isPublicApi) continue;
+			this.activateController(router, controllerClass, apiVersion);
+		}
+	}
+
+	private activateController(parent: Router, controllerClass: Controller, apiVersion: string) {
+		const metadata = this.metadata.getControllerMetadata(controllerClass);
+		const controllerRouter = createRouter({ mergeParams: true });
+		const prefix = metadata.basePath.replace(/\/+/g, '/').replace(/\/$/, '') || '/';
+		parent.use(prefix === '' ? '/' : prefix, controllerRouter);
+
+		const controller = Container.get(controllerClass) as Controller;
+		const controllerMiddlewares = metadata.middlewares.map(
+			(handlerName) => controller[handlerName].bind(controller) as RequestHandler,
+		);
+
+		for (const [handlerName, route] of metadata.routes) {
+			const argTypes = Reflect.getMetadata(
+				'design:paramtypes',
+				controller,
+				handlerName,
+			) as unknown[];
+
+			const handler = async (req: Request, res: Response) => {
+				const args: unknown[] = [req, res];
+				for (let index = 0; index < route.args.length; index++) {
+					const arg = route.args[index];
+					if (!arg) continue;
+					if (arg.type === 'param') {
+						args.push(req.params[arg.key]);
+					} else if (arg.type === 'body' || arg.type === 'query') {
+						const paramType = argTypes[index] as ZodClass | undefined;
+						if (paramType && 'safeParse' in paramType) {
+							const output = paramType.safeParse(req[arg.type]);
+							if (output.success) {
+								args.push(output.data);
+							} else {
+								throw new BadRequestError(output.error.errors[0]?.message ?? 'Invalid request');
+							}
+						} else {
+							throw new UnexpectedError(
+								`Public API route ${controllerClass.name}.${handlerName} is missing a Zod DTO for @${arg.type}`,
+							);
+						}
+					} else {
+						throw new UnexpectedError(`Unknown arg type: ${String(arg.type)}`);
+					}
+				}
+
+				const result = await controller[handlerName](...args);
+
+				if (res.headersSent) return;
+
+				if (route.responseDto) {
+					res.json(route.responseDto.parse(result));
+					return;
+				}
+
+				res.json(result);
+			};
+
+			const middlewares: RequestHandler[] = [
+				this.createAuthMiddleware(apiVersion),
+				...controllerMiddlewares,
+				...(route.middlewares ?? []),
+			];
+
+			if (route.apiKeyScope) {
+				middlewares.push(this.createApiKeyScopeMiddleware(route.apiKeyScope));
+			}
+
+			if (route.accessScope) {
+				middlewares.push(this.createAccessScopeMiddleware(route.accessScope));
+			}
+
+			const finalHandler: RequestHandler = async (req, res, next) => {
+				try {
+					await handler(req, res);
+				} catch (error) {
+					if (res.headersSent) {
+						next(error);
+						return;
+					}
+					sendPublicApiErrorResponse(
+						res,
+						error instanceof Error ? error : new Error(String(error)),
+					);
+				}
+			};
+
+			controllerRouter[route.method](route.path, ...middlewares, finalHandler);
+		}
+	}
+
+	private createAuthMiddleware(apiVersion: string): RequestHandler {
+		return async (req, res, next) => {
+			const authenticated = await this.authStrategyRegistry.authenticate(
+				req as AuthenticatedRequest,
+			);
+
+			if (!authenticated) {
+				res.status(401).json({ message: 'Unauthorized' });
+				return;
+			}
+
+			const userId = (req as AuthenticatedRequest).user?.id;
+			if (userId) {
+				this.lastActiveAtService.updateLastActiveIfStale(userId).catch(() => {
+					/* best-effort */
+				});
+				this.eventService.emit('public-api-invoked', {
+					userId,
+					path: req.path,
+					method: req.method,
+					apiVersion,
+					userAgent: req.headers['user-agent'],
+				});
+			}
+
+			next();
+		};
+	}
+
+	private createApiKeyScopeMiddleware(requirement: ApiKeyScopeRequirement): RequestHandler {
+		return (req, res, next) => {
+			const { tokenGrant } = req as AuthenticatedRequest;
+
+			if (!tokenGrant || !apiKeyScopesSatisfy(tokenGrant.apiKeyScopes, requirement)) {
+				res.status(403).json({ message: 'Forbidden' });
+				return;
+			}
+
+			next();
+		};
+	}
+
+	private createAccessScopeMiddleware(accessScope: AccessScope): RequestHandler {
+		return async (req, res, next) => {
+			const authReq = req as AuthenticatedRequest;
+
+			if (!authReq.user) {
+				res.status(401).json({ message: 'Unauthorized' });
+				return;
+			}
+
+			try {
+				if (
+					!(await userHasScopes(
+						authReq.user,
+						[accessScope.scope],
+						accessScope.globalOnly,
+						req.params,
+					))
+				) {
+					res.status(403).json({ message: 'Forbidden' });
+					return;
+				}
+			} catch (error) {
+				sendPublicApiErrorResponse(res, error instanceof Error ? error : new Error(String(error)));
+				return;
+			}
+
+			next();
+		};
+	}
+}

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -117,8 +117,6 @@ export class PublicApiControllerRegistry {
 
 			const middlewares: RequestHandler[] = [this.createAuthMiddleware(apiVersion)];
 
-			// Authorize immediately after auth so controller/route middleware
-			// cannot run side effects for an under-scoped key.
 			if (route.apiKeyScope) {
 				middlewares.push(this.createApiKeyScopeMiddleware(route.apiKeyScope));
 			}

--- a/packages/cli/src/public-api/public-api-controller.registry.ts
+++ b/packages/cli/src/public-api/public-api-controller.registry.ts
@@ -115,12 +115,10 @@ export class PublicApiControllerRegistry {
 				res.json(result);
 			};
 
-			const middlewares: RequestHandler[] = [
-				this.createAuthMiddleware(apiVersion),
-				...controllerMiddlewares,
-				...(route.middlewares ?? []),
-			];
+			const middlewares: RequestHandler[] = [this.createAuthMiddleware(apiVersion)];
 
+			// Authorize immediately after auth so controller/route middleware
+			// cannot run side effects for an under-scoped key.
 			if (route.apiKeyScope) {
 				middlewares.push(this.createApiKeyScopeMiddleware(route.apiKeyScope));
 			}
@@ -128,6 +126,8 @@ export class PublicApiControllerRegistry {
 			if (route.accessScope) {
 				middlewares.push(this.createAccessScopeMiddleware(route.accessScope));
 			}
+
+			middlewares.push(...controllerMiddlewares, ...(route.middlewares ?? []));
 
 			const finalHandler: RequestHandler = async (req, res, next) => {
 				try {

--- a/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
@@ -7,12 +7,6 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
 import { TagService } from '@/services/tag.service';
 
-/**
- * Reference public API controller (API-37).
- *
- * Copy-me example for the `@PublicApiController` pattern: thin adapter over
- * `TagService`, public output DTO, API-key scope — no direct repository access.
- */
 @PublicApiController('/tags')
 export class TagsPublicController {
 	constructor(private readonly tagService: TagService) {}

--- a/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
@@ -20,7 +20,11 @@ export class TagsPublicController {
 	@Get('/')
 	@ApiKeyScope('tag:list')
 	@ApiResponse(TagListPublicDto)
-	async getTags(_req: AuthenticatedRequest, _res: Response, @Query query: ListTagsQueryDto) {
+	async getTags(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Query query: ListTagsQueryDto,
+	): Promise<TagListPublicDto> {
 		let offset = 0;
 		let { limit } = query;
 

--- a/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
+++ b/packages/cli/src/public-api/v1/controllers/tags.public.controller.ts
@@ -1,0 +1,52 @@
+import { ListTagsQueryDto, TagListPublicDto } from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { ApiKeyScope, ApiResponse, Get, PublicApiController, Query } from '@n8n/decorators';
+import type { Response } from 'express';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { decodeCursor, encodeNextCursor } from '@/public-api/v1/shared/services/pagination.service';
+import { TagService } from '@/services/tag.service';
+
+/**
+ * Reference public API controller (API-37).
+ *
+ * Copy-me example for the `@PublicApiController` pattern: thin adapter over
+ * `TagService`, public output DTO, API-key scope — no direct repository access.
+ */
+@PublicApiController('/tags')
+export class TagsPublicController {
+	constructor(private readonly tagService: TagService) {}
+
+	@Get('/')
+	@ApiKeyScope('tag:list')
+	@ApiResponse(TagListPublicDto)
+	async getTags(_req: AuthenticatedRequest, _res: Response, @Query query: ListTagsQueryDto) {
+		let offset = 0;
+		let { limit } = query;
+
+		if (query.cursor) {
+			try {
+				const decoded = decodeCursor(query.cursor);
+				if (!('offset' in decoded)) {
+					throw new BadRequestError('An invalid cursor was provided');
+				}
+				offset = decoded.offset;
+				limit = decoded.limit;
+			} catch (error) {
+				if (error instanceof BadRequestError) throw error;
+				throw new BadRequestError('An invalid cursor was provided');
+			}
+		}
+
+		const { data, count } = await this.tagService.getPaginated({ offset, limit });
+
+		return {
+			data,
+			nextCursor: encodeNextCursor({
+				offset,
+				limit,
+				numberOfTotalRecords: count,
+			}),
+		};
+	}
+}

--- a/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/tags/tags.handler.ts
@@ -1,21 +1,12 @@
-import type { TagEntity } from '@n8n/db';
-import { TagRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 
-// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import type { FindManyOptions } from '@n8n/typeorm';
+import type { TagRequest } from '../../../types';
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import { apiKeyHasScopeWithGlobalScopeFallback } from '../../shared/middlewares/global.middleware';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { TagService } from '@/services/tag.service';
-
-import type { TagRequest } from '../../../types';
-import type { PublicAPIEndpoint } from '../../shared/handler.types';
-import {
-	apiKeyHasScopeWithGlobalScopeFallback,
-	validCursor,
-} from '../../shared/middlewares/global.middleware';
-import { encodeNextCursor } from '../../shared/services/pagination.service';
 
 type TagHandlers = {
 	createTag: PublicAPIEndpoint<TagRequest.Create>;
@@ -79,26 +70,19 @@ const tagHandlers: TagHandlers = {
 			return res.json(tag);
 		},
 	],
+	/**
+	 * Not the reference implementation — that is TagsPublicController
+	 * (PublicApiControllerRegistry mounts before eov and owns runtime GET /tags).
+	 *
+	 * Kept only so scope-parity.test.ts can match openapi.yml `x-required-scope`
+	 * against a handler middleware tagged with `__apiKeyScope`. Once that test
+	 * also reads `@ApiKeyScope` from public controllers, this stub can go.
+	 */
 	getTags: [
 		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'tag:list' }),
-		validCursor,
-		async (req, res) => {
-			const { offset = 0, limit = 100 } = req.query;
-
-			const query: FindManyOptions<TagEntity> = {
-				skip: offset,
-				take: limit,
-			};
-
-			const [tags, count] = await Container.get(TagRepository).findAndCount(query);
-
-			return res.json({
-				data: tags,
-				nextCursor: encodeNextCursor({
-					offset,
-					limit,
-					numberOfTotalRecords: count,
-				}),
+		async (_req, res) => {
+			return res.status(500).json({
+				message: 'Unexpected: GET /tags should be handled by TagsPublicController',
 			});
 		},
 	],

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -113,6 +113,7 @@ export class TagService {
 			skip: offset,
 			take: limit,
 			select: ['id', 'name', 'createdAt', 'updatedAt'],
+			order: { createdAt: 'ASC', id: 'ASC' },
 		});
 		return { data, count };
 	}

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -102,6 +102,21 @@ export class TagService {
 		}) as Promise<GetAllResult<T>>);
 	}
 
+	/**
+	 * Offset/limit page of tags plus total count (for public API cursor pagination).
+	 */
+	async getPaginated({ offset, limit }: { offset: number; limit: number }): Promise<{
+		data: TagEntity[];
+		count: number;
+	}> {
+		const [data, count] = await this.tagRepository.findAndCount({
+			skip: offset,
+			take: limit,
+			select: ['id', 'name', 'createdAt', 'updatedAt'],
+		});
+		return { data, count };
+	}
+
 	async getById(id: string) {
 		return await this.tagRepository.findOneOrFail({
 			where: { id },

--- a/packages/cli/src/services/tag.service.ts
+++ b/packages/cli/src/services/tag.service.ts
@@ -102,9 +102,6 @@ export class TagService {
 		}) as Promise<GetAllResult<T>>);
 	}
 
-	/**
-	 * Offset/limit page of tags plus total count (for public API cursor pagination).
-	 */
 	async getPaginated({ offset, limit }: { offset: number; limit: number }): Promise<{
 		data: TagEntity[];
 		count: number;


### PR DESCRIPTION
## Summary

Introduces a decorator-based **`@PublicApiController`** pattern for the Public API (`/api/v1`), as an alternative to the existing `express-openapi-validator` (eov) handler modules, plus a reference endpoint (`GET /api/v1/tags`) built with it.

The goal (API-37) is to let public endpoints be authored with the same ergonomics as internal `@RestController` routes, while keeping the two surfaces converged at the **service layer** rather than at HTTP.

**What's included:**

- **New decorators** (`@n8n/decorators`): `@PublicApiController`, `@ApiKeyScope` (single scope, or `{ anyOf }` / `{ allOf }`), and `@ApiResponse(Dto)` (strips undeclared fields from the response). Reuses the existing `@Get/@Post/@Body/@Query/@Param/@GlobalScope/@ProjectScope` decorators and route/arg metadata.
- **`PublicApiControllerRegistry`** (`packages/cli`): sibling to `ControllerRegistry`. Mounts `@PublicApiController` classes under `/api/v1` with API-key auth (via `AuthStrategyRegistry`), public error serialization, and optional `@ApiResponse` output parsing. `ControllerRegistry` now skips `isPublicApi` controllers so the two registries don't double-mount.
- **Mounting** (`public-api/index.ts`): decorator controllers mount **before** eov so they own matching routes; remaining OpenAPI paths stay on eov handlers.
- **Reference endpoint**: `TagsPublicController` (`GET /tags`) — a thin adapter over `TagService` (new `getPaginated()` method), a public `TagListPublicDto`, and `@ApiKeyScope('tag:list')`. No direct repository access.
- **eov `getTags` stub** kept only so `scope-parity.test.ts` can still match `openapi.yml`'s `x-required-scope`; the controller owns the runtime route.
- **Docs**: `.agents/skills/public-api/SKILL.md` updated to prefer the controller pattern for new endpoints and document the wiring steps.

This is infrastructure + a migrated endpoint; `GET /api/v1/tags` behaves the same for consumers, hence `(no-changelog)`.

## How to test

Public API is enabled by default. Create an API key in **Settings → API**, then:

```bash
# Returns the paginated tag list (public DTO shape: id, name, createdAt, updatedAt)
curl -s http://localhost:5678/api/v1/tags \
  -H "X-N8N-API-KEY: <your-api-key>"

# Pagination
curl -s "http://localhost:5678/api/v1/tags?limit=1" -H "X-N8N-API-KEY: <key>"
# → use the returned nextCursor for the next page

# Auth / scope
curl -s http://localhost:5678/api/v1/tags                     # → 401 (no key)
curl -s http://localhost:5678/api/v1/tags -H "X-N8N-API-KEY: bad"  # → 401
# A key without the tag:list scope (scopes feature enabled) → 403
```

Automated: `cd packages/cli && pnpm test public-api/tags` and the new decorator unit tests under `packages/@n8n/decorators/src/controller/__tests__/`.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/API-37
- Follow-up / open question surfaced during review: https://linear.app/n8n/issue/API-67 — cursor-supplied `limit`/`offset` bypass the pagination cap (pre-existing behavior carried over from the eov handler; pending a decision on whether to tighten it).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34511">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

