### PR TITLE
feat(core): Add structured output to MCP node search

### DIFF
--- a/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search.test.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search.test.ts
@@ -1,0 +1,247 @@
+import { NodeTypeParser } from '../node-type-parser';
+import { createStructuredNodeSearchItem, searchCodeBuilderNodes } from '../search';
+import { createNodeType } from './helpers';
+
+describe('searchCodeBuilderNodes structured results', () => {
+	test('returns primary node metadata without changing the legacy Markdown', () => {
+		const parser = new NodeTypeParser([
+			createNodeType({
+				name: 'n8n-nodes-base.telegram',
+				displayName: 'Telegram',
+				description: 'Sends Telegram messages',
+				version: [1, 1.1, 1.2],
+				group: ['transform'],
+			}),
+		]);
+
+		const result = searchCodeBuilderNodes(parser, ['telegram']);
+
+		expect(result.results).toBe(
+			'## "telegram"\nFound 1 nodes:\n\n- n8n-nodes-base.telegram\n  Display Name: Telegram\n  Version: 1.2\n  Description: Sends Telegram messages\n  Discriminators: none (use node directly without resource/operation/mode)',
+		);
+		expect(result.items).toEqual([
+			{
+				queryIndex: 0,
+				query: 'telegram',
+				nodeType: 'n8n-nodes-base.telegram',
+				displayName: 'Telegram',
+				description: 'Sends Telegram messages',
+				package: 'n8n-nodes-base',
+				versions: [1, 1.1, 1.2],
+				groups: ['transform'],
+				isTrigger: false,
+				relation: 'primary',
+			},
+		]);
+		expect(result.queriesWithNoResults).toEqual([]);
+	});
+
+	test('preserves query order, duplicate queries, and query indexes', () => {
+		const parser = new NodeTypeParser([
+			createNodeType({
+				name: 'n8n-nodes-base.telegram',
+				displayName: 'Telegram',
+				description: 'Telegram integration',
+			}),
+		]);
+
+		const result = searchCodeBuilderNodes(parser, ['telegram', 'missing', 'telegram']);
+
+		expect(
+			result.items.map(({ queryIndex, query, nodeType }) => ({ queryIndex, query, nodeType })),
+		).toEqual([
+			{ queryIndex: 0, query: 'telegram', nodeType: 'n8n-nodes-base.telegram' },
+			{ queryIndex: 2, query: 'telegram', nodeType: 'n8n-nodes-base.telegram' },
+		]);
+		expect(result.queriesWithNoResults).toEqual(['missing']);
+	});
+
+	test('returns an empty items array for zero results and scales to many queries', () => {
+		const parser = new NodeTypeParser([]);
+		const queries = Array.from({ length: 250 }, (_, index) => `missing-${index}`);
+
+		const result = searchCodeBuilderNodes(parser, queries);
+
+		expect(result.items).toEqual([]);
+		expect(result.queriesWithNoResults).toEqual(queries);
+		expect(result.results.match(/No nodes found/g)).toHaveLength(250);
+	});
+
+	test('adds directly related nodes after their primary result without changing Markdown expansion', () => {
+		const parser = new NodeTypeParser([
+			createNodeType({
+				name: 'n8n-nodes-base.telegram',
+				displayName: 'Telegram Sender',
+				description: 'Sends a chat message',
+				builderHint: {
+					relatedNodes: [
+						{
+							nodeType: 'n8n-nodes-base.telegramTrigger',
+							relationHint: 'Use to receive Telegram updates',
+						},
+					],
+				},
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.telegramTrigger',
+				displayName: 'Telegram Trigger',
+				description: 'Receives Telegram updates',
+				version: 1.2,
+				group: ['trigger'],
+			}),
+		]);
+
+		const result = searchCodeBuilderNodes(parser, ['sender']);
+
+		expect(result.results).toContain('  @relatedNodes');
+		expect(result.results).not.toContain('[RELATED]');
+		expect(result.items.map(({ nodeType, relation }) => ({ nodeType, relation }))).toEqual([
+			{ nodeType: 'n8n-nodes-base.telegram', relation: 'primary' },
+			{ nodeType: 'n8n-nodes-base.telegramTrigger', relation: 'related' },
+		]);
+		expect(result.items[1]).toMatchObject({
+			versions: [1.2],
+			groups: ['trigger'],
+			isTrigger: true,
+		});
+	});
+
+	test('preserves related-node duplicate behavior across separate primary results', () => {
+		const sharedRelated = {
+			nodeType: 'n8n-nodes-base.sharedHelper',
+			relationHint: 'Shared helper',
+		};
+		const parser = new NodeTypeParser([
+			createNodeType({
+				name: 'community.alpha',
+				displayName: 'Shared Alpha',
+				description: 'Shared capability alpha',
+				builderHint: { relatedNodes: [sharedRelated] },
+			}),
+			createNodeType({
+				name: 'community.beta',
+				displayName: 'Shared Beta',
+				description: 'Shared capability beta',
+				builderHint: { relatedNodes: [sharedRelated] },
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.sharedHelper',
+				displayName: 'Shared Helper',
+				description: 'Related helper only',
+			}),
+		]);
+
+		const result = searchCodeBuilderNodes(parser, ['shared capability']);
+		const related = result.items.filter(({ relation }) => relation === 'related');
+
+		expect(related).toHaveLength(2);
+		expect(related.map(({ nodeType }) => nodeType)).toEqual([
+			'n8n-nodes-base.sharedHelper',
+			'n8n-nodes-base.sharedHelper',
+		]);
+	});
+
+	test('omits unavailable optional metadata and preserves explicit false', () => {
+		const item = createStructuredNodeSearchItem({
+			queryIndex: 3,
+			query: 'minimal',
+			nodeType: 'unqualifiedNodeType',
+			isTrigger: false,
+			relation: 'primary',
+		});
+
+		expect(item).toEqual({
+			queryIndex: 3,
+			query: 'minimal',
+			nodeType: 'unqualifiedNodeType',
+			isTrigger: false,
+			relation: 'primary',
+		});
+		expect(item).not.toHaveProperty('displayName');
+		expect(item).not.toHaveProperty('description');
+		expect(item).not.toHaveProperty('package');
+		expect(item).not.toHaveProperty('versions');
+		expect(item).not.toHaveProperty('groups');
+	});
+
+	test('derives scoped and unscoped package names and normalizes scalar versions', () => {
+		expect(
+			createStructuredNodeSearchItem({
+				queryIndex: 0,
+				query: 'agent',
+				nodeType: '@n8n/n8n-nodes-langchain.agent',
+				version: 2,
+				relation: 'primary',
+			}),
+		).toMatchObject({
+			package: '@n8n/n8n-nodes-langchain',
+			versions: [2],
+		});
+		expect(
+			createStructuredNodeSearchItem({
+				queryIndex: 0,
+				query: 'http',
+				nodeType: 'n8n-nodes-base.httpRequest',
+				version: [1, 2, 4.2],
+				relation: 'primary',
+			}),
+		).toMatchObject({
+			package: 'n8n-nodes-base',
+			versions: [1, 2, 4.2],
+		});
+	});
+
+	test('does not expose unsupported metadata or parse Markdown-shaped source values', () => {
+		const item = createStructuredNodeSearchItem({
+			queryIndex: 0,
+			query: 'safe',
+			nodeType: 'community.safe',
+			displayName: '- fake.node [RELATED]',
+			description: '```json\n{"nodeType":"fake.node"}\n```',
+			relation: 'primary',
+		});
+
+		expect(item.displayName).toBe('- fake.node [RELATED]');
+		expect(item.description).toBe('```json\n{"nodeType":"fake.node"}\n```');
+		expect(item).not.toHaveProperty('deprecated');
+		expect(item).not.toHaveProperty('category');
+		expect(item).not.toHaveProperty('credentials');
+	});
+
+	test('does not copy credential, secret, node-property, header, environment, or auth data', () => {
+		const sourceWithSensitiveExtras = {
+			queryIndex: 0,
+			query: 'secure',
+			nodeType: 'secureNode',
+			relation: 'primary' as const,
+			credentialId: 'fixture-credential-id',
+			credentialValue: 'fixture-credential-value',
+			secret: 'fixture-secret',
+			properties: { privateField: 'fixture-node-property' },
+			headers: { authorization: 'fixture-auth-header' },
+			environment: { API_KEY: 'fixture-environment-value' },
+			auth: { token: 'fixture-auth-token' },
+		};
+
+		const item = createStructuredNodeSearchItem(sourceWithSensitiveExtras);
+		const serialized = JSON.stringify(item);
+
+		expect(item).toEqual({
+			queryIndex: 0,
+			query: 'secure',
+			nodeType: 'secureNode',
+			relation: 'primary',
+		});
+		for (const marker of [
+			'fixture-credential-id',
+			'fixture-credential-value',
+			'fixture-secret',
+			'fixture-node-property',
+			'fixture-auth-header',
+			'fixture-environment-value',
+			'fixture-auth-token',
+		]) {
+			expect(serialized).not.toContain(marker);
+		}
+	});
+});

--- a/packages/@n8n/ai-utilities/src/node-catalog/index.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/index.ts
@@ -17,6 +17,7 @@ export { searchCodeBuilderNodes, formatNodeResult } from './search';
 export type {
 	CodeBuilderSearchResult,
 	CodeBuilderSearchToolOptions,
+	StructuredNodeSearchItem,
 } from './search';
 
 export {

--- a/packages/@n8n/ai-utilities/src/node-catalog/search.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/search.ts
@@ -414,14 +414,66 @@ export interface CodeBuilderSearchToolOptions {
 	nodeFilter?: (nodeId: string) => boolean;
 }
 
+export interface StructuredNodeSearchItem {
+	queryIndex: number;
+	query: string;
+	nodeType: string;
+	displayName?: string;
+	description?: string;
+	package?: string;
+	versions?: number[];
+	groups?: string[];
+	isTrigger?: boolean;
+	relation: 'primary' | 'related';
+}
+
+interface StructuredNodeSearchItemSource {
+	queryIndex: number;
+	query: string;
+	nodeType: string;
+	displayName?: string;
+	description?: string;
+	version?: number | number[];
+	groups?: string[];
+	isTrigger?: boolean;
+	relation: StructuredNodeSearchItem['relation'];
+}
+
+function deriveNodePackage(nodeType: string): string | undefined {
+	const separatorIndex = nodeType.lastIndexOf('.');
+	return separatorIndex > 0 ? nodeType.slice(0, separatorIndex) : undefined;
+}
+
+export function createStructuredNodeSearchItem(
+	source: StructuredNodeSearchItemSource,
+): StructuredNodeSearchItem {
+	const packageName = deriveNodePackage(source.nodeType);
+	return {
+		queryIndex: source.queryIndex,
+		query: source.query,
+		nodeType: source.nodeType,
+		...(source.displayName !== undefined ? { displayName: source.displayName } : {}),
+		...(source.description !== undefined ? { description: source.description } : {}),
+		...(packageName !== undefined ? { package: packageName } : {}),
+		...(source.version !== undefined
+			? { versions: Array.isArray(source.version) ? [...source.version] : [source.version] }
+			: {}),
+		...(source.groups !== undefined ? { groups: [...source.groups] } : {}),
+		...(source.isTrigger !== undefined ? { isTrigger: source.isTrigger } : {}),
+		relation: source.relation,
+	};
+}
+
 export interface CodeBuilderSearchResult {
 	results: string;
+	items: StructuredNodeSearchItem[];
 	queriesWithNoResults: string[];
 }
 
 interface SearchForQueryResult {
 	result: string;
 	hasResults: boolean;
+	items: StructuredNodeSearchItem[];
 }
 
 /**
@@ -431,6 +483,7 @@ interface SearchForQueryResult {
 function searchForQuery(
 	nodeTypeParser: NodeTypeParser,
 	query: string,
+	queryIndex: number,
 	nodeFilter?: (nodeId: string) => boolean,
 ): SearchForQueryResult {
 	const results = nodeTypeParser.searchNodeTypes(query, 5, nodeFilter);
@@ -439,6 +492,7 @@ function searchForQuery(
 		return {
 			result: `## "${query}"\nNo nodes found. Try a different search term.`,
 			hasResults: false,
+			items: [],
 		};
 	}
 
@@ -446,9 +500,25 @@ function searchForQuery(
 	const shownNodeIds = new Set<string>(results.map((node: ParsedNodeType) => node.id));
 
 	const allNodeLines: string[] = [];
+	const items: StructuredNodeSearchItem[] = [];
 	let totalRelatedCount = 0;
 
 	for (const node of results) {
+		const leanNodeType = nodeTypeParser.getLeanNodeType(node.id, node.version);
+		items.push(
+			createStructuredNodeSearchItem({
+				queryIndex,
+				query,
+				nodeType: node.id,
+				displayName: node.displayName,
+				description: node.description,
+				version: leanNodeType?.version ?? node.version,
+				groups: leanNodeType?.group,
+				isTrigger: node.isTrigger,
+				relation: 'primary',
+			}),
+		);
+
 		// Format the search result node
 		const triggerTag = node.isTrigger ? ' [TRIGGER]' : '';
 		const basicInfo = `- ${node.id}${triggerTag}\n  Display Name: ${node.displayName}\n  Version: ${node.version}\n  Description: ${node.description}`;
@@ -473,6 +543,25 @@ function searchForQuery(
 
 		// If using new format with hints, display @relatedNodes section instead of expanding
 		if (relatedNodesWithHints && relatedNodesWithHints.length > 0) {
+			for (const relatedNode of relatedNodesWithHints) {
+				const relatedNodeType = nodeTypeParser.getLeanNodeType(relatedNode.nodeType);
+				items.push(
+					createStructuredNodeSearchItem({
+						queryIndex,
+						query,
+						nodeType: relatedNode.nodeType,
+						displayName: relatedNodeType?.displayName,
+						description: relatedNodeType?.description,
+						version: relatedNodeType?.version,
+						groups: relatedNodeType?.group,
+						isTrigger: relatedNodeType
+							? relatedNodeType.group.includes('trigger') || isTriggerNodeType(relatedNode.nodeType)
+							: undefined,
+						relation: 'related',
+					}),
+				);
+			}
+
 			const relatedNodesStr = formatRelatedNodesWithHints(relatedNodesWithHints);
 			if (relatedNodesStr) parts.push(relatedNodesStr);
 		} else {
@@ -492,6 +581,20 @@ function searchForQuery(
 
 				const nodeType = nodeTypeParser.getLeanNodeType(relatedId);
 				if (nodeType) {
+					items.push(
+						createStructuredNodeSearchItem({
+							queryIndex,
+							query,
+							nodeType: relatedId,
+							displayName: nodeType.displayName,
+							description: nodeType.description,
+							version: nodeType.version,
+							groups: nodeType.group,
+							isTrigger: nodeType.group.includes('trigger') || isTriggerNodeType(relatedId),
+							relation: 'related',
+						}),
+					);
+
 					const version = Array.isArray(nodeType.version)
 						? nodeType.version[nodeType.version.length - 1]
 						: nodeType.version;
@@ -527,6 +630,7 @@ function searchForQuery(
 	return {
 		result: `## "${query}"\nFound ${results.length} nodes${countSuffix}:\n\n${allNodeLines.join('\n\n')}`,
 		hasResults: true,
+		items,
 	};
 }
 
@@ -536,13 +640,14 @@ export function searchCodeBuilderNodes(
 	options?: CodeBuilderSearchToolOptions,
 ): CodeBuilderSearchResult {
 	const { nodeFilter } = options ?? {};
-	const searchResults = queries.map((query) => ({
+	const searchResults = queries.map((query, queryIndex) => ({
 		query,
-		...searchForQuery(nodeTypeParser, query, nodeFilter),
+		...searchForQuery(nodeTypeParser, query, queryIndex, nodeFilter),
 	}));
 
 	return {
 		results: searchResults.map(({ result }) => result).join('\n\n---\n\n'),
+		items: searchResults.flatMap(({ items }) => items),
 		queriesWithNoResults: searchResults
 			.filter(({ hasResults }) => !hasResults)
 			.map(({ query }) => query),

--- a/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
@@ -23,6 +23,7 @@ function makeService() {
 	const nodeCatalogService = mock<NodeCatalogService>();
 	nodeCatalogService.searchNodes.mockResolvedValue({
 		results: 'search-result',
+		items: [],
 		queriesWithNoResults: [],
 	});
 	nodeCatalogService.getNodeTypes.mockResolvedValue('node-types-string');
@@ -139,6 +140,7 @@ describe('AgentsToolsService', () => {
 			});
 			expect(result).toEqual({
 				results: 'search-result',
+				items: [],
 				queriesWithNoResults: [],
 			});
 		});

--- a/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/__tests__/resolve-integration.tool.test.ts
@@ -43,19 +43,27 @@ describe('buildResolveIntegrationTool', () => {
 		const agentsToolsService = mock<AgentsToolsService>();
 		mcpRegistryService.search.mockResolvedValue([]);
 		agentsToolsService.searchAgentToolNodes.mockResolvedValue({
-			results: 'slack node results',
-			queriesWithNoResults: ['unknown'],
+			results: 'http request node results',
+			items: [
+				{
+					queryIndex: 0,
+					query: 'http request',
+					nodeType: 'n8n-nodes-base.httpRequestTool',
+					relation: 'primary',
+				},
+			],
+			queriesWithNoResults: [],
 		});
 
 		const tool = buildResolveIntegrationTool({ mcpRegistryService, agentsToolsService });
-		const result = await tool.handler!({ queries: ['slack'] }, ctx);
+		const result = await tool.handler!({ queries: ['http request'] }, ctx);
 
-		expect(mcpRegistryService.search).toHaveBeenCalledWith(['slack']);
-		expect(agentsToolsService.searchAgentToolNodes).toHaveBeenCalledWith(['slack']);
+		expect(mcpRegistryService.search).toHaveBeenCalledWith(['http request']);
+		expect(agentsToolsService.searchAgentToolNodes).toHaveBeenCalledWith(['http request']);
 		expect(result).toEqual({
 			kind: 'node',
-			results: 'slack node results',
-			queriesWithNoResults: ['unknown'],
+			results: 'http request node results',
+			queriesWithNoResults: [],
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/search-workflow-nodes.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflow-nodes.tool.test.ts
@@ -1,5 +1,6 @@
 import type { AiGatewayConfigDto } from '@n8n/api-types';
 import { User } from '@n8n/db';
+import z from 'zod';
 import type { Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -41,6 +42,19 @@ describe('search-workflow-nodes MCP tool', () => {
 		aiGatewayService.isAvailable.mockResolvedValue({ available: false });
 		nodeCatalogService.searchNodes.mockResolvedValue({
 			results: 'search-result',
+			items: [
+				{
+					queryIndex: 0,
+					query: 'gmail',
+					nodeType: 'n8n-nodes-base.gmail',
+					displayName: 'Gmail',
+					package: 'n8n-nodes-base',
+					versions: [2, 2.1],
+					groups: ['communication'],
+					isTrigger: false,
+					relation: 'primary',
+				},
+			],
 			queriesWithNoResults: [],
 		});
 	});
@@ -48,9 +62,24 @@ describe('search-workflow-nodes MCP tool', () => {
 	const createTool = () =>
 		createSearchWorkflowNodesTool(user, nodeCatalogService, telemetry, aiGatewayService);
 
+	test('preserves the existing tool name and input schema', () => {
+		const tool = createTool();
+
+		expect(tool.name).toBe('search_workflow_nodes');
+		expect(Object.keys(tool.config.inputSchema ?? {})).toEqual(['queries']);
+	});
+
 	test('returns search results and tracks queries with no results', async () => {
 		nodeCatalogService.searchNodes.mockResolvedValueOnce({
 			results: 'search-result',
+			items: [
+				{
+					queryIndex: 0,
+					query: 'gmail',
+					nodeType: 'n8n-nodes-base.gmail',
+					relation: 'primary',
+				},
+			],
 			queriesWithNoResults: ['missing-node'],
 		});
 
@@ -59,7 +88,21 @@ describe('search-workflow-nodes MCP tool', () => {
 
 		expect(nodeCatalogService.searchNodes).toHaveBeenCalledWith(['gmail', 'missing-node']);
 		expect(result.content).toEqual([{ type: 'text', text: 'search-result' }]);
-		expect(result.structuredContent).toEqual({ results: 'search-result' });
+		expect(result.structuredContent).toEqual({
+			schemaVersion: '1.0',
+			queries: ['gmail', 'missing-node'],
+			count: 1,
+			items: [
+				{
+					queryIndex: 0,
+					query: 'gmail',
+					nodeType: 'n8n-nodes-base.gmail',
+					relation: 'primary',
+				},
+			],
+			queriesWithNoResults: ['missing-node'],
+			results: 'search-result',
+		});
 		expect(telemetry.track).toHaveBeenCalledWith(
 			USER_CALLED_MCP_TOOL_EVENT,
 			expect.objectContaining({
@@ -76,6 +119,48 @@ describe('search-workflow-nodes MCP tool', () => {
 				},
 			}),
 		);
+	});
+
+	test('declares and returns a strict structured output contract', async () => {
+		const tool = createTool();
+		const result = await tool.handler({ queries: ['gmail'] }, {} as never);
+		const strictSchema = z.object(tool.config.outputSchema as z.ZodRawShape).strict();
+
+		expect(() => strictSchema.parse(result.structuredContent)).not.toThrow();
+		expect(result.structuredContent).toMatchObject({
+			schemaVersion: '1.0',
+			queries: ['gmail'],
+			count: 1,
+			queriesWithNoResults: [],
+			results: 'search-result',
+		});
+	});
+
+	test('preserves legacy content and legacy structured fields byte-for-byte', async () => {
+		const tool = createTool();
+		const result = await tool.handler({ queries: ['gmail'] }, {} as never);
+
+		expect(result.content).toEqual([{ type: 'text', text: 'search-result' }]);
+		expect(result.structuredContent?.results).toBe('search-result');
+		expect(result.structuredContent?.n8nConnect).toBeUndefined();
+	});
+
+	test('preserves duplicate query order and reports an empty result set exactly', async () => {
+		nodeCatalogService.searchNodes.mockResolvedValueOnce({
+			results: 'no-results',
+			items: [],
+			queriesWithNoResults: ['missing', 'missing'],
+		});
+		const tool = createTool();
+
+		const result = await tool.handler({ queries: ['missing', 'missing'] }, {} as never);
+
+		expect(result.structuredContent).toMatchObject({
+			queries: ['missing', 'missing'],
+			count: 0,
+			items: [],
+			queriesWithNoResults: ['missing', 'missing'],
+		});
 	});
 
 	test('tracks empty no-result metadata when every query has results', async () => {
@@ -120,6 +205,18 @@ describe('search-workflow-nodes MCP tool', () => {
 
 	describe('n8nConnect block', () => {
 		test('includes n8nConnect block when gateway is available', async () => {
+			nodeCatalogService.searchNodes.mockResolvedValueOnce({
+				results: 'search-result',
+				items: [
+					{
+						queryIndex: 0,
+						query: 'openai',
+						nodeType: '@n8n/n8n-nodes-langchain.openAi',
+						relation: 'primary',
+					},
+				],
+				queriesWithNoResults: [],
+			});
 			aiGatewayService.isAvailable.mockResolvedValue({
 				available: true,
 				config: {
@@ -133,6 +230,18 @@ describe('search-workflow-nodes MCP tool', () => {
 			const result = await tool.handler({ queries: ['openai'] }, {} as never);
 
 			expect(result.structuredContent).toEqual({
+				schemaVersion: '1.0',
+				queries: ['openai'],
+				count: 1,
+				items: [
+					{
+						queryIndex: 0,
+						query: 'openai',
+						nodeType: '@n8n/n8n-nodes-langchain.openAi',
+						relation: 'primary',
+					},
+				],
+				queriesWithNoResults: [],
 				results: 'search-result',
 				n8nConnect: {
 					credentialTypes: ['openAiApi'],
@@ -147,8 +256,15 @@ describe('search-workflow-nodes MCP tool', () => {
 
 		test('omits n8nConnect block when unavailable', async () => {
 			const tool = createTool();
-			const result = await tool.handler({ queries: ['openai'] }, {} as never);
-			expect(result.structuredContent).toEqual({ results: 'search-result' });
+			const result = await tool.handler({ queries: ['gmail'] }, {} as never);
+			expect(result.structuredContent).toMatchObject({
+				schemaVersion: '1.0',
+				queries: ['gmail'],
+				count: 1,
+				queriesWithNoResults: [],
+				results: 'search-result',
+			});
+			expect(result.structuredContent).not.toHaveProperty('n8nConnect');
 			expect((result.content[0] as { text: string }).text).toBe('search-result');
 		});
 	});

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
@@ -27,6 +27,28 @@ const inputSchema = {
 } satisfies z.ZodRawShape;
 
 const outputSchema = {
+	schemaVersion: z.literal('1.0').describe('Version of the structured node-search result schema.'),
+	queries: z.array(z.string()).describe('Search queries in their original input order.'),
+	count: z.number().int().nonnegative().describe('Number of structured node result items.'),
+	items: z
+		.array(
+			z.object({
+				queryIndex: z.number().int().nonnegative(),
+				query: z.string(),
+				nodeType: z.string(),
+				displayName: z.string().optional(),
+				description: z.string().optional(),
+				package: z.string().optional(),
+				versions: z.array(z.number()).optional(),
+				groups: z.array(z.string()).optional(),
+				isTrigger: z.boolean().optional(),
+				relation: z.enum(['primary', 'related']),
+			}),
+		)
+		.describe('Structured node matches in source order.'),
+	queriesWithNoResults: z
+		.array(z.string())
+		.describe('Queries with no matching nodes, preserving input order and duplicates.'),
 	results: z
 		.string()
 		.describe('Search results with matching node IDs, discriminators, and related nodes'),
@@ -77,7 +99,7 @@ export const createSearchWorkflowNodesTool = (
 		};
 
 		try {
-			const [{ results, queriesWithNoResults }, availability] = await Promise.all([
+			const [{ results, items, queriesWithNoResults }, availability] = await Promise.all([
 				nodeCatalogService.searchNodes(queries),
 				aiGatewayService.isAvailable(),
 			]);
@@ -92,13 +114,23 @@ export const createSearchWorkflowNodesTool = (
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
+			const coverage = toN8nConnectCoverage(availability);
 			const structured: {
+				schemaVersion: '1.0';
+				queries: string[];
+				count: number;
+				items: typeof items;
+				queriesWithNoResults: string[];
 				results: string;
 				n8nConnect?: N8nConnectCoverage;
 			} = {
+				schemaVersion: '1.0',
+				queries,
+				count: items.length,
+				items,
+				queriesWithNoResults,
 				results,
 			};
-			const coverage = toN8nConnectCoverage(availability);
 			if (coverage) structured.n8nConnect = coverage;
 
 			const text = coverage ? `${results}\n\nn8nConnect: ${JSON.stringify(coverage)}` : results;

--- a/packages/cli/src/node-catalog/__tests__/node-catalog.service.test.ts
+++ b/packages/cli/src/node-catalog/__tests__/node-catalog.service.test.ts
@@ -47,6 +47,7 @@ describe('NodeCatalogService', () => {
 		vi.clearAllMocks();
 		mockSearchCodeBuilderNodes.mockReturnValue({
 			results: 'search-result',
+			items: [],
 			queriesWithNoResults: [],
 		});
 		mockGetNodeTypes.mockReturnValue('get-result');
@@ -180,6 +181,7 @@ describe('NodeCatalogService', () => {
 		test('returns queriesWithNoResults metadata', async () => {
 			mockSearchCodeBuilderNodes.mockReturnValueOnce({
 				results: 'search-result',
+				items: [],
 				queriesWithNoResults: ['missing-node'],
 			});
 			await service.initialize();
@@ -188,17 +190,26 @@ describe('NodeCatalogService', () => {
 
 			expect(result).toEqual({
 				results: 'search-result',
+				items: [],
 				queriesWithNoResults: ['missing-node'],
 			});
 		});
 
-		test('returns cached result regardless of query order', async () => {
+		test('uses separate cache entries when query order differs', async () => {
 			await service.initialize();
 
 			await service.searchNodes(['gmail', 'slack']);
 			await service.searchNodes(['slack', 'gmail']);
 
-			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(1);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(2);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenNthCalledWith(1, expect.anything(), [
+				'gmail',
+				'slack',
+			]);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenNthCalledWith(2, expect.anything(), [
+				'slack',
+				'gmail',
+			]);
 		});
 
 		test('calls search for different queries', async () => {

--- a/packages/cli/src/node-catalog/node-catalog.service.ts
+++ b/packages/cli/src/node-catalog/node-catalog.service.ts
@@ -185,7 +185,7 @@ export class NodeCatalogService {
 			this.searchStates.set(stateKey, state);
 		}
 
-		const cacheKey = JSON.stringify([...queries].sort());
+		const cacheKey = JSON.stringify(queries);
 		const cached = state.cache.get(cacheKey);
 		if (cached) return cached;
 


### PR DESCRIPTION
﻿### Summary

The `search_nodes` MCP tool currently exposes node-search metadata primarily through human-readable Markdown. This change adds an additive structured representation while preserving the existing text response.

### Why

Deterministic MCP consumers need machine-readable node types, query association, relations, versions, groups, and trigger metadata without parsing human-facing Markdown.

### Compatibility

- The legacy text response is unchanged.
- `results: string` is unchanged.
- `n8nConnect` is preserved.
- The input schema is unchanged.
- Tool annotations, telemetry, and error behavior are unchanged.
- The structured fields are additive.
- Existing internal consumers continue to project the legacy fields they already use.

### Cache key

Structured results preserve the original query order and expose `queryIndex`. Cache keys must therefore distinguish `["gmail", "slack"]` from `["slack", "gmail"]`; otherwise a cached result could expose incorrect query ordering and associations.

### Test plan

- Structured node-search tests: 9 passed.
- MCP contract tests: 9 passed.
- Node-catalog and cache tests: 34 passed.
- Agents tools tests: 15 passed.
- Resolve-integration tests: 3 passed.
- Full `@n8n/ai-utilities` suite: 683 passed.
- Affected package typechecks passed.
- Targeted ESLint passed.
- Biome formatting checks passed.
- `git diff --check` passed.

The full repository test suite was not run.

### Security

The structured representation excludes credential identifiers and values, node properties, authentication data, headers, environment values, and secrets. No network or filesystem operations were added.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34524">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

