### PR TITLE
fix: handle string values in fixedCollection with multipleValues

### DIFF
--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -838,10 +838,13 @@ export function getNodeParameters(
 					if (typeof propertyValues !== 'object' || Array.isArray(propertyValues)) {
 						continue;
 					}
+					const collectionItems = (propertyValues as INodeParameters)[itemName];
+					// Skip if collection items is not an array (e.g. string from expression)
+					if (!Array.isArray(collectionItems)) {
+						continue;
+					}
 					// Iterate over all items as it contains multiple ones
-					for (const nodeValue of (propertyValues as INodeParameters)[
-						itemName
-					] as INodeParameters[]) {
+					for (const nodeValue of collectionItems as INodeParameters[]) {
 						nodePropertyOptions = nodeProperties.options!.find(
 							(nodePropertyOptions) => nodePropertyOptions.name === itemName,
 						) as INodePropertyCollection;

--- a/packages/workflow/test/node-helpers.test.ts
+++ b/packages/workflow/test/node-helpers.test.ts
@@ -3514,6 +3514,55 @@ describe('NodeHelpers', () => {
 					},
 				},
 			},
+			{
+				description:
+					'fixedCollection with multipleValues: true - skip when collection item value is a string instead of array',
+				input: {
+					nodePropertiesArray: [
+						{
+							displayName: 'Values',
+							name: 'values',
+							type: 'fixedCollection',
+							typeOptions: {
+								multipleValues: true,
+							},
+							default: {},
+							options: [
+								{
+									name: 'option1',
+									displayName: 'Option 1',
+									values: [
+										{
+											displayName: 'String',
+											name: 'string1',
+											type: 'string',
+											default: 'default string',
+										},
+									],
+								},
+							],
+						},
+					],
+					nodeValues: {
+						// Simulates expression result where item value is a string instead of array
+						values: { option1: 'some expression string' } as any,
+					},
+				},
+				output: {
+					noneDisplayedFalse: {
+						defaultsFalse: {},
+						defaultsTrue: {
+							values: {},
+						},
+					},
+					noneDisplayedTrue: {
+						defaultsFalse: {},
+						defaultsTrue: {
+							values: {},
+						},
+					},
+				},
+			},
 		];
 
 		for (const testData of tests) {


### PR DESCRIPTION
## Summary

This PR fixes a bug where `fixedCollection` parameters with `multipleValues: true` iterate over string characters when the parameter value is an expression that resolves to a string.

## Problem

In `packages/workflow/src/node-helpers.ts`, the `getNodeParameters` function uses a `for...of` loop to iterate over collection items. When a `fixedCollection` with `multipleValues: true` receives a string value (e.g. from an expression like `={{ $json.someField }}`), the `for...of` loop treats the string as an iterable and iterates over each character instead of treating it as a single value.

## Fix

Added an `Array.isArray` check before the `for...of` loop to skip non-array collection items. When the collection item value is not an array (e.g. a string from an expression), it is now safely skipped instead of being iterated character-by-character.

## Changes

- **`packages/workflow/src/node-helpers.ts`**: Added `Array.isArray` guard before iterating over collection items in the `multipleValues` branch
- **`packages/workflow/test/node-helpers.test.ts`**: Added test case for string values in fixedCollection with multipleValues

## Testing

All existing tests pass (129 tests in `node-helpers.test.ts`, 31 tests in `node-helpers.conditions.test.ts`). New test case added covering the specific scenario from the bug report.

Closes #29619

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34537">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

