### PR TITLE
fix(core): Show a single error toast when a manual execution fails pre-flight validation

### DIFF
--- a/packages/cli/src/__tests__/workflow-runner.test.ts
+++ b/packages/cli/src/__tests__/workflow-runner.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@n8n/db';
 import { Container, Service } from '@n8n/di';
 import type { Response } from 'express';
-import { DirectedGraph, WorkflowExecute } from 'n8n-core';
+import { DirectedGraph, WorkflowExecute, WorkflowHasIssuesError } from 'n8n-core';
 import * as core from 'n8n-core';
 import {
 	type IExecuteData,
@@ -355,6 +355,59 @@ describe('run', () => {
 			// Not setting data.configureAdditionalData
 
 			await expect(runner.run(data)).resolves.toBe('1');
+		});
+	});
+
+	describe('workflow issues pre-flight failure', () => {
+		function arrangeFailingRunDeps(error: Error) {
+			const activeExecutions = Container.get(ActiveExecutions);
+			vi.spyOn(activeExecutions, 'add').mockResolvedValue('1');
+			vi.spyOn(Container.get(CredentialsPermissionChecker), 'check').mockResolvedValueOnce();
+			vi.spyOn(WorkflowExecute.prototype, 'processRunExecutionData').mockImplementationOnce(() => {
+				throw error;
+			});
+			vi.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue(
+				mock<IWorkflowExecuteAdditionalData>(),
+			);
+
+			const data = mock<IWorkflowExecutionDataProcess>({
+				workflowData: { nodes: [], id: 'workflow-id', settings: undefined, staticData: {} },
+				executionData: createRunExecutionData({}),
+				triggerToStartFrom: undefined,
+				startNodes: undefined,
+				destinationNode: undefined,
+				userId: 'mock-user-id',
+			});
+			return { data };
+		}
+
+		it('surfaces a WorkflowHasIssuesError as a failed run instead of rejecting', async () => {
+			const error = new WorkflowHasIssuesError(
+				{ node1: { parameters: { field: ['is missing'] } } },
+				{},
+			);
+			const { data } = arrangeFailingRunDeps(error);
+			// @ts-expect-error Private method
+			const failExecution = vi.spyOn(runner, 'failExecution').mockResolvedValueOnce();
+			const processError = vi.spyOn(runner, 'processError').mockResolvedValueOnce();
+
+			await expect(runner.run(data)).resolves.toBe('1');
+
+			expect(failExecution).toHaveBeenCalledWith(data, '1', error);
+			expect(processError).not.toHaveBeenCalled();
+		});
+
+		it('still rejects on other startup errors', async () => {
+			const error = new Error('boom');
+			const { data } = arrangeFailingRunDeps(error);
+			// @ts-expect-error Private method
+			const failExecution = vi.spyOn(runner, 'failExecution').mockResolvedValueOnce();
+			const processError = vi.spyOn(runner, 'processError').mockResolvedValueOnce();
+
+			await expect(runner.run(data)).rejects.toThrowError(error);
+
+			expect(processError).toHaveBeenCalled();
+			expect(failExecution).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -12,6 +12,7 @@ import {
 	InstanceSettings,
 	StorageConfig,
 	WorkflowExecute,
+	WorkflowHasIssuesError,
 } from 'n8n-core';
 import type {
 	ExecutionError,
@@ -479,6 +480,11 @@ export class WorkflowRunner {
 						),
 				);
 		} catch (error) {
+			if (error instanceof WorkflowHasIssuesError) {
+				await this.failExecution(data, executionId, error);
+				return;
+			}
+
 			await this.processError(
 				error,
 				new Date(),


### PR DESCRIPTION
## Summary

Manually executing a workflow that has a node with unresolved issues (e.g. a required parameter left empty) showed **two** error toasts for the same failure: "Problem running workflow" and "Workflow execution cannot start".

Both toasts came from the same backend `WorkflowHasIssuesError`: the synchronous pre-flight check in `WorkflowExecute.processRunExecutionData` threw into `runMainProcess`'s catch, which pushed the failed run to the editor (toast 2) **and** rethrew, rejecting the POST `/run` request (toast 1).

This PR routes `WorkflowHasIssuesError` through the existing pre-flight failure path (`failExecution`) — the same one used for credential-permission and context-establishment failures — so the request resolves normally and the failure surfaces once, as a normal failed run with the more specific "Workflow execution cannot start" toast.

## How to test

1. Create a workflow, e.g. Manual Trigger → Edit Fields → any node with a required parameter, and leave that required parameter empty.
2. Click "Execute workflow".
3. Before: two error toasts appear ("Problem running workflow" + "Workflow execution cannot start"). After: only "Workflow execution cannot start", listing the node issues.
4. Regression tests: `packages/cli/src/__tests__/workflow-runner.test.ts` covers both the new pre-flight routing and that other startup errors still reject the request.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3790

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

