### PR TITLE
feat(Microsoft SharePoint Node): Add v2 list columns as fillable form fields (no-changelog)

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
@@ -1,0 +1,544 @@
+/* eslint-disable n8n-nodes-base/node-param-default-missing */
+import type { IDataObject, ILoadOptionsFunctions, INode } from 'n8n-workflow';
+import type { Mock } from 'vitest';
+import type { DeepMockProxy } from 'vitest-mock-extended';
+import { mock, mockDeep } from 'vitest-mock-extended';
+
+import { versionDescription } from '../../../v2/actions/versionDescription';
+import { getMappingColumns, itemColumns } from '../../../v2/list/columns';
+import type { SharePointListColumn } from '../../../v2/list/columns';
+import { MicrosoftSharePointV2 } from '../../../v2/MicrosoftSharePointV2.node';
+import * as transport from '../../../v2/transport';
+import type * as _importType0 from '../../../v2/transport';
+
+vi.mock('../../../v2/transport', async () => {
+	const originalModule = await vi.importActual<typeof _importType0>('../../../v2/transport');
+	return {
+		...originalModule,
+		microsoftApiRequest: vi.fn(),
+	};
+});
+
+const SITE_ID = 'contoso.sharepoint.com,g1,g2';
+const ENCODED_SITE_ID = encodeURIComponent(SITE_ID);
+const LIST_ID = '58a279af-1f06-4392-a5ed-2b37fa1d6c1d';
+
+const contentTypesReply = (columns: SharePointListColumn[]): IDataObject => ({
+	value: [{ id: '0x0100', name: 'Item', columns }],
+});
+
+// v1's captured contentTypes reply (test/methods/resourceMapping.test.ts),
+// trimmed to one column per distinct mapping outcome.
+const V1_CONTENT_TYPES_REPLY: IDataObject = {
+	value: [
+		{
+			id: '0x0100362657F7588C5C438072A77E0EF184F4000272C0D1046D984B8097B3C00D199EDE',
+			description: 'Create a new list item.',
+			hidden: false,
+			name: 'Item',
+			readOnly: false,
+			columns: [
+				{
+					displayName: 'Title',
+					description: 'Description Title',
+					enforceUniqueValues: true,
+					hidden: false,
+					indexed: true,
+					name: 'Title',
+					readOnly: false,
+					required: true,
+					type: 'text',
+					text: { allowMultipleLines: false, maxLength: 255 },
+				},
+				{
+					displayName: 'Othertitle',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'LinkTitle',
+					readOnly: true,
+					type: 'unknownFutureValue',
+				},
+				{
+					displayName: 'Choice',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'choice',
+					readOnly: false,
+					type: 'choice',
+					choice: {
+						allowTextEntry: false,
+						choices: ['Choice 1', 'Choice 2', 'Choice 3'],
+						displayAs: 'dropDownMenu',
+					},
+				},
+				{
+					displayName: 'Datetime',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'datetime',
+					readOnly: false,
+					type: 'dateTime',
+					dateTime: { displayAs: 'standard', format: 'dateOnly' },
+				},
+				{
+					displayName: 'Person',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'person',
+					readOnly: false,
+					type: 'user',
+					personOrGroup: { allowMultipleSelection: false, format: 'peopleOnly' },
+				},
+				{
+					displayName: 'Number',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'number',
+					readOnly: false,
+					type: 'number',
+					number: { decimalPlaces: 'automatic', displayAs: 'number' },
+				},
+				{
+					displayName: 'Bool',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'bool',
+					readOnly: false,
+					type: 'boolean',
+					boolean: {},
+				},
+				{
+					displayName: 'Hyperlink',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'hyperlink',
+					readOnly: false,
+					type: 'url',
+					hyperlinkOrPicture: { isPicture: false },
+				},
+				{
+					displayName: 'Currency',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'currency',
+					readOnly: false,
+					type: 'currency',
+					currency: { locale: 'en-US' },
+				},
+				{
+					displayName: 'Location',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'location',
+					readOnly: false,
+					type: 'location',
+					location: {},
+				},
+				{
+					displayName: 'location: Country/Region',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'CountryOrRegion',
+					readOnly: true,
+					type: 'text',
+					text: { allowMultipleLines: false, maxLength: 255 },
+				},
+				{
+					displayName: 'location: Coordinates',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'GeoLoc',
+					readOnly: true,
+					type: 'geolocation',
+					geolocation: {},
+				},
+				{
+					displayName: 'location: Name',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'DispName',
+					readOnly: true,
+					type: 'text',
+					text: { allowMultipleLines: false, maxLength: 255 },
+				},
+				{
+					displayName: 'Image',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'image',
+					readOnly: false,
+					type: 'thumbnail',
+					thumbnail: {},
+				},
+				{
+					displayName: 'Metadata',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'metadata',
+					readOnly: false,
+					type: 'term',
+					term: { allowMultipleValues: false },
+				},
+				{
+					displayName: 'Lookup',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'lookup',
+					readOnly: false,
+					type: 'lookup',
+					lookup: { allowMultipleValues: false, columnName: 'Title', listId: LIST_ID },
+				},
+				{
+					displayName: 'Rating (0-5)',
+					description: 'Average value of all the ratings that have been submitted',
+					enforceUniqueValues: false,
+					hidden: false,
+					name: 'AverageRating',
+					readOnly: false,
+					type: 'unknownFutureValue',
+				},
+			],
+		},
+	],
+};
+
+// v1's pinned expectations (test/methods/resourceMapping.test.ts) with the
+// deliberate v2 deltas: no disabled placeholders, omitted booleans become false.
+const sharedFieldShape = {
+	canBeUsedToMatch: false,
+	defaultMatch: false,
+	display: true,
+	readOnly: false,
+	required: false,
+};
+const EXPECTED_CREATE_FIELDS = [
+	{
+		...sharedFieldShape,
+		id: 'Title',
+		displayName: 'Title',
+		canBeUsedToMatch: true,
+		required: true,
+		type: 'string',
+	},
+	{
+		...sharedFieldShape,
+		id: 'choice',
+		displayName: 'Choice',
+		type: 'options',
+		options: [
+			{ name: 'Choice 1', value: 'Choice 1' },
+			{ name: 'Choice 2', value: 'Choice 2' },
+			{ name: 'Choice 3', value: 'Choice 3' },
+		],
+	},
+	{ ...sharedFieldShape, id: 'datetime', displayName: 'Datetime', type: 'dateTime' },
+	{ ...sharedFieldShape, id: 'person', displayName: 'Person', type: 'string' },
+	{ ...sharedFieldShape, id: 'number', displayName: 'Number', type: 'number' },
+	{ ...sharedFieldShape, id: 'bool', displayName: 'Bool', type: 'boolean' },
+	{ ...sharedFieldShape, id: 'hyperlink.Url', displayName: 'Hyperlink (URL)', type: 'url' },
+	{
+		...sharedFieldShape,
+		id: 'hyperlink.Description',
+		displayName: 'Hyperlink (Description)',
+		type: 'string',
+	},
+	{ ...sharedFieldShape, id: 'currency', displayName: 'Currency', type: 'number' },
+	{ ...sharedFieldShape, id: 'image', displayName: 'Image', type: 'object' },
+	{ ...sharedFieldShape, id: 'lookup', displayName: 'Lookup', type: 'string' },
+	{ ...sharedFieldShape, id: 'AverageRating', displayName: 'Rating (0-5)', type: 'number' },
+];
+
+const SYNTHETIC_ID_FIELD = {
+	id: 'id',
+	displayName: 'ID',
+	canBeUsedToMatch: true,
+	defaultMatch: false,
+	display: true,
+	readOnly: true,
+	required: true,
+	type: 'string',
+};
+
+describe('Microsoft SharePoint v2 — list columns as form fields', () => {
+	let ctx: DeepMockProxy<ILoadOptionsFunctions>;
+	const apiRequest = transport.microsoftApiRequest as Mock;
+
+	const setParams = (params: Record<string, unknown>) => {
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, fallback?: unknown) => (name in params ? params[name] : fallback) as never,
+		);
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		ctx = mockDeep<ILoadOptionsFunctions>();
+		ctx.getNode.mockReturnValue(mock<INode>({ typeVersion: 2 }));
+		setParams({ site: { mode: 'id', value: SITE_ID }, list: LIST_ID, operation: 'create' });
+	});
+
+	it('maps a full contentTypes reply to the v1 baseline fields plus the documented v2 deltas', async () => {
+		apiRequest.mockResolvedValue({ ...V1_CONTENT_TYPES_REPLY });
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			`/v1.0/sites/${ENCODED_SITE_ID}/lists/${LIST_ID}/contentTypes`,
+			{},
+			{ expand: 'columns' },
+		);
+		expect(result).toEqual({ fields: EXPECTED_CREATE_FIELDS });
+	});
+
+	it('produces fields for neither hidden nor read-only columns', async () => {
+		apiRequest.mockResolvedValue(
+			contentTypesReply([
+				{ displayName: 'Visible', name: 'Visible', hidden: false, readOnly: false, type: 'text' },
+				{ displayName: 'Hidden', name: 'Hidden', hidden: true, readOnly: false, type: 'text' },
+				{ displayName: 'Locked', name: 'Locked', hidden: false, readOnly: true, type: 'text' },
+			]),
+		);
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields.map((field) => field.id)).toEqual(['Visible']);
+	});
+
+	it('omits location, geolocation, and metadata columns entirely', async () => {
+		apiRequest.mockResolvedValue(
+			contentTypesReply([
+				{ displayName: 'Where', name: 'Where', hidden: false, readOnly: false, type: 'location' },
+				{
+					displayName: 'Coords',
+					name: 'Coords',
+					hidden: false,
+					readOnly: false,
+					type: 'geolocation',
+				},
+				{ displayName: 'Tags', name: 'Tags', hidden: false, readOnly: false, type: 'term' },
+				{
+					displayName: 'MultiTags',
+					name: 'MultiTags',
+					hidden: false,
+					readOnly: false,
+					type: 'multiterm',
+				},
+				{ displayName: 'Kept', name: 'Kept', hidden: false, readOnly: false, type: 'text' },
+			]),
+		);
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields.map((field) => field.id)).toEqual(['Kept']);
+	});
+
+	it('returns false for the match and required flags on columns where Graph omits them', async () => {
+		apiRequest.mockResolvedValue(contentTypesReply([{ displayName: 'Bare', name: 'Bare' }]));
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields).toEqual([
+			{
+				id: 'Bare',
+				displayName: 'Bare',
+				canBeUsedToMatch: false,
+				defaultMatch: false,
+				display: true,
+				readOnly: false,
+				required: false,
+				type: 'string',
+			},
+		]);
+	});
+
+	it('presents a choice column without listed choices as an empty options field', async () => {
+		apiRequest.mockResolvedValue(
+			contentTypesReply([
+				{ displayName: 'Pick', name: 'Pick', hidden: false, readOnly: false, type: 'choice' },
+			]),
+		);
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields[0].type).toBe('options');
+		expect(result.fields[0].options).toEqual([]);
+	});
+
+	it('presents a hyperlink column as a URL input and a description input', async () => {
+		apiRequest.mockResolvedValue(
+			contentTypesReply([
+				{
+					displayName: 'My Link',
+					name: 'mylink',
+					hidden: false,
+					readOnly: false,
+					required: true,
+					type: 'url',
+				},
+			]),
+		);
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields).toEqual([
+			{
+				id: 'mylink.Url',
+				displayName: 'My Link (URL)',
+				canBeUsedToMatch: false,
+				defaultMatch: false,
+				display: true,
+				readOnly: false,
+				required: true,
+				type: 'url',
+			},
+			{
+				id: 'mylink.Description',
+				displayName: 'My Link (Description)',
+				canBeUsedToMatch: false,
+				defaultMatch: false,
+				display: true,
+				readOnly: false,
+				required: false,
+				type: 'string',
+			},
+		]);
+	});
+
+	it('loads the fields with both sign-in methods', async () => {
+		// Real transport here (not the stub): the reply is fed to the credential-
+		// specific request helper each auth mode routes through.
+		const { microsoftApiRequest: realMicrosoftApiRequest } =
+			await vi.importActual<typeof _importType0>('../../../v2/transport');
+		apiRequest
+			.mockImplementationOnce(realMicrosoftApiRequest)
+			.mockImplementationOnce(realMicrosoftApiRequest);
+		ctx.getCredentials.mockResolvedValue({});
+		ctx.helpers.requestOAuth2.mockResolvedValue({ ...V1_CONTENT_TYPES_REPLY });
+		ctx.helpers.requestWithAuthentication.mockResolvedValue({ ...V1_CONTENT_TYPES_REPLY });
+
+		setParams({
+			site: { mode: 'id', value: SITE_ID },
+			list: LIST_ID,
+			operation: 'create',
+			authentication: 'microsoftOAuth2Api',
+		});
+		const delegated = await getMappingColumns.call(ctx);
+
+		setParams({
+			site: { mode: 'id', value: SITE_ID },
+			list: LIST_ID,
+			operation: 'create',
+			authentication: transport.SERVICE_PRINCIPAL_AUTH,
+		});
+		const appOnly = await getMappingColumns.call(ctx);
+
+		expect(ctx.helpers.requestOAuth2).toHaveBeenCalledTimes(1);
+		expect(ctx.helpers.requestWithAuthentication).toHaveBeenCalledTimes(1);
+		expect(delegated).toEqual({ fields: EXPECTED_CREATE_FIELDS });
+		expect(appOnly).toEqual(delegated);
+	});
+
+	it('appends the ID matching field after the mapped columns for update, matching v1', async () => {
+		setParams({ site: { mode: 'id', value: SITE_ID }, list: LIST_ID, operation: 'update' });
+		apiRequest.mockResolvedValue(
+			contentTypesReply([
+				{ displayName: 'Title', name: 'Title', hidden: false, readOnly: false, type: 'text' },
+			]),
+		);
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields.map((field) => field.id)).toEqual(['Title', 'id']);
+		expect(result.fields[1]).toEqual(SYNTHETIC_ID_FIELD);
+	});
+
+	it('does not append the ID field for upsert — it matches on a real column', async () => {
+		setParams({ site: { mode: 'id', value: SITE_ID }, list: LIST_ID, operation: 'upsert' });
+		apiRequest.mockResolvedValue(contentTypesReply([]));
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result).toEqual({ fields: [] });
+	});
+
+	it('reads columns from the first content type only', async () => {
+		apiRequest.mockResolvedValue({
+			value: [
+				{
+					columns: [
+						{ displayName: 'First', name: 'First', hidden: false, readOnly: false, type: 'text' },
+					],
+				},
+				{
+					columns: [
+						{ displayName: 'Second', name: 'Second', hidden: false, readOnly: false, type: 'text' },
+					],
+				},
+			],
+		});
+
+		const result = await getMappingColumns.call(ctx);
+
+		expect(result.fields.map((field) => field.id)).toEqual(['First']);
+	});
+
+	it('returns no fields when the list has no content types', async () => {
+		apiRequest.mockResolvedValue({ value: [] });
+
+		await expect(getMappingColumns.call(ctx)).resolves.toEqual({ fields: [] });
+	});
+
+	it('accepts a list title and encodes it in the request path', async () => {
+		setParams({ site: { mode: 'id', value: SITE_ID }, list: 'My List 1', operation: 'create' });
+		apiRequest.mockResolvedValue(contentTypesReply([]));
+
+		await getMappingColumns.call(ctx);
+
+		expect(apiRequest).toHaveBeenCalledWith(
+			'GET',
+			`/v1.0/sites/${ENCODED_SITE_ID}/lists/My%20List%201/contentTypes`,
+			{},
+			{ expand: 'columns' },
+		);
+	});
+
+	it('rejects an empty List value before requesting', async () => {
+		setParams({ site: { mode: 'id', value: SITE_ID }, list: '', operation: 'create' });
+
+		await expect(getMappingColumns.call(ctx)).rejects.toThrow("The 'List' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects an empty Site value before requesting', async () => {
+		setParams({ site: { mode: 'id', value: '' }, list: LIST_ID, operation: 'create' });
+
+		await expect(getMappingColumns.call(ctx)).rejects.toThrow("The 'Site' parameter is empty");
+		expect(apiRequest).not.toHaveBeenCalled();
+	});
+
+	it('is wired into the node as a resource-mapping method', () => {
+		const node = new MicrosoftSharePointV2(versionDescription);
+
+		expect(node.methods?.resourceMapping?.getMappingColumns).toBe(getMappingColumns);
+	});
+
+	it.each(['add', 'update', 'upsert'] as const)(
+		'builds the shared columns property for the %s mode',
+		(mode) => {
+			const property = itemColumns(mode);
+
+			expect(property.name).toBe('columns');
+			expect(property.type).toBe('resourceMapper');
+			expect(property.default).toEqual({ mappingMode: 'defineBelow', value: null });
+			expect(property.displayOptions?.hide).toEqual({ site: [''], list: [''] });
+			expect(property.typeOptions?.loadOptionsDependsOn).toEqual(['site.value', 'list.value']);
+			expect(property.typeOptions?.resourceMapper).toEqual({
+				resourceMapperMethod: 'getMappingColumns',
+				mode,
+				fieldWords: { singular: 'column', plural: 'columns' },
+				addAllFields: true,
+				multiKeyMatch: false,
+			});
+		},
+	);
+});

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/MicrosoftSharePointV2.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/MicrosoftSharePointV2.node.ts
@@ -7,7 +7,7 @@ import type {
 
 import { router } from './actions/router';
 import { versionDescription } from './actions/versionDescription';
-import { listSearch } from './methods';
+import { listSearch, resourceMapping } from './methods';
 
 // Graph-based v2 rebuild in progress. Not registered yet — uncomment the
 // registration in MicrosoftSharePoint.node.ts to test locally.
@@ -23,6 +23,7 @@ export class MicrosoftSharePointV2 implements INodeType {
 
 	methods = {
 		listSearch,
+		resourceMapping,
 	};
 
 	async execute(this: IExecuteFunctions) {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/columns.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/columns.ts
@@ -1,0 +1,169 @@
+import type {
+	FieldType,
+	ILoadOptionsFunctions,
+	INodeProperties,
+	ResourceMapperField,
+	ResourceMapperFields,
+} from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { resolveSiteId } from '../site';
+import { microsoftApiRequest } from '../transport';
+import { untilListSelected, untilSiteSelected } from './index';
+
+export interface SharePointListColumn {
+	name: string;
+	displayName: string;
+	type?: string;
+	hidden?: boolean;
+	readOnly?: boolean;
+	required?: boolean;
+	enforceUniqueValues?: boolean;
+	choice?: { choices?: string[] };
+}
+
+type ContentTypesReply = { value?: Array<{ columns?: SharePointListColumn[] }> };
+
+// No n8n field kind can hold these; omitted rather than shown as v1's disabled placeholders.
+const UNSUPPORTED_COLUMN_TYPES = new Set(['location', 'geolocation', 'term', 'multiterm']);
+
+const FIELD_TYPE_BY_COLUMN_TYPE: Record<string, FieldType> = {
+	text: 'string',
+	user: 'string',
+	lookup: 'string',
+	number: 'number',
+	currency: 'number',
+	// Rating columns report unknownFutureValue
+	unknownFutureValue: 'number',
+	boolean: 'boolean',
+	dateTime: 'dateTime',
+	thumbnail: 'object',
+	choice: 'options',
+};
+
+function toMapperFields(column: SharePointListColumn): ResourceMapperField[] {
+	const columnType = column.type ?? '';
+	if (UNSUPPORTED_COLUMN_TYPES.has(columnType)) {
+		return [];
+	}
+
+	const base = {
+		defaultMatch: false,
+		display: true,
+		readOnly: false,
+		required: column.required === true,
+	};
+
+	// A hyperlink column becomes two fields; the item operations fold
+	// `{name}.Url`/`{name}.Description` back into SharePoint's two-part shape,
+	// and their fields write must send `Prefer: apiversion=2.1` or Graph rejects it.
+	if (columnType === 'url') {
+		return [
+			{
+				...base,
+				id: `${column.name}.Url`,
+				displayName: `${column.displayName} (URL)`,
+				canBeUsedToMatch: false,
+				type: 'url',
+			},
+			{
+				...base,
+				required: false,
+				id: `${column.name}.Description`,
+				displayName: `${column.displayName} (Description)`,
+				canBeUsedToMatch: false,
+				type: 'string',
+			},
+		];
+	}
+
+	const field: ResourceMapperField = {
+		...base,
+		id: column.name,
+		displayName: column.displayName,
+		canBeUsedToMatch: Boolean(column.enforceUniqueValues && column.required),
+		type: FIELD_TYPE_BY_COLUMN_TYPE[columnType] ?? 'string',
+	};
+	if (field.type === 'options') {
+		field.options = (column.choice?.choices ?? []).map((choice) => ({
+			name: choice,
+			value: choice,
+		}));
+	}
+	return [field];
+}
+
+export async function getMappingColumns(
+	this: ILoadOptionsFunctions,
+): Promise<ResourceMapperFields> {
+	const siteId = await resolveSiteId.call(this, 0);
+	const listIdOrTitle = (
+		this.getNodeParameter('list', '', { extractValue: true }) as string
+	).trim();
+	if (listIdOrTitle === '') {
+		throw new NodeOperationError(this.getNode(), "The 'List' parameter is empty", {
+			description: 'Set the list ID or title and try again.',
+		});
+	}
+
+	// Only the contentTypes columns reply carries the `type` discriminator
+	// https://learn.microsoft.com/en-us/graph/api/resources/columndefinition
+	const response = (await microsoftApiRequest.call(
+		this,
+		'GET',
+		`/v1.0/sites/${encodeURIComponent(siteId)}/lists/${encodeURIComponent(listIdOrTitle)}/contentTypes`,
+		{},
+		{ expand: 'columns' },
+	)) as ContentTypesReply;
+
+	// The list's default content type comes first.
+	const columns = response.value?.[0]?.columns ?? [];
+	const fields = columns
+		.filter((column) => !column.hidden && !column.readOnly)
+		.flatMap(toMapperFields);
+
+	if (this.getNodeParameter('operation', '') === 'update') {
+		fields.push({
+			id: 'id',
+			displayName: 'ID',
+			defaultMatch: false,
+			display: true,
+			readOnly: true,
+			required: true,
+			canBeUsedToMatch: true,
+			type: 'string',
+		});
+	}
+
+	return { fields };
+}
+
+export function itemColumns(mode: 'add' | 'update' | 'upsert'): INodeProperties {
+	return {
+		displayName: 'Columns',
+		name: 'columns',
+		type: 'resourceMapper',
+		default: { mappingMode: 'defineBelow', value: null },
+		noDataExpression: true,
+		required: true,
+		displayOptions: {
+			hide: {
+				...untilSiteSelected,
+				...untilListSelected,
+			},
+		},
+		typeOptions: {
+			loadOptionsDependsOn: ['site.value', 'list.value'],
+			resourceMapper: {
+				resourceMapperMethod: 'getMappingColumns',
+				mode,
+				fieldWords: {
+					singular: 'column',
+					plural: 'columns',
+				},
+				addAllFields: true,
+				multiKeyMatch: false,
+			},
+		},
+	};
+}

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/list/index.ts
@@ -7,6 +7,8 @@ import { microsoftApiRequest } from '../transport';
 /** Hide gate copied from v1: the list field stays hidden until a site is chosen. */
 export const untilSiteSelected = { site: [''] };
 
+export const untilListSelected = { list: [''] };
+
 // Colocated with getLists/resolveSiteId, mirroring how siteRLC lives next to
 // getSites/resolveSiteId in v2/site/index.ts, rather than a separate registry.
 export const listRLC: INodeProperties = {

--- a/packages/nodes-base/nodes/Microsoft/SharePoint/v2/methods/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/SharePoint/v2/methods/index.ts
@@ -1,7 +1,12 @@
 import { getLists } from '../list';
+import { getMappingColumns } from '../list/columns';
 import { getSites } from '../site';
 
 export const listSearch = {
 	getSites,
 	getLists,
+};
+
+export const resourceMapping = {
+	getMappingColumns,
 };


### PR DESCRIPTION
## Summary

Part of the SharePoint v2 rebuild ([ENT-170](https://linear.app/n8n/issue/ENT-170)). Adds the machinery that shows a chosen list's columns as fillable form fields, which the upcoming item Create / Update / Create-or-Update actions all rely on.

> **Stacked on #34329** (List — Get Many + list dropdown) — the list picker and the load-options widening of `resolveSiteId` live there. Do not merge before it; once #34329 merges, this PR gets rebased and retargeted onto `master`.

What's in here:

- **`getMappingColumns` resource-mapping method** (`v2/list/columns.ts`): fetches the list's columns via `GET /v1.0/sites/{site}/lists/{list}/contentTypes?expand=columns` through the shared v2 transport, reads the default (first) content type, filters out hidden and read-only columns, and maps each column type to the matching field kind using v1's mapping as the reference.
- **`itemColumns(mode)` property factory**: the shared `Columns` resource-mapper parameter the item operation tickets (ENT-174 / ENT-171 / ENT-186) will drop in with their mode (`add` / `update` / `upsert`).
- Deliberate deltas from v1, each pinned by a test:
  - Unsupported column types (location, geolocation, managed metadata) are **omitted** instead of rendered as disabled placeholder fields.
  - Hyperlink columns become **two real fields** (`{name}.Url` typed `url`, `{name}.Description` typed `string`) instead of v1's disabled untyped field.
  - Booleans Graph omits are normalised to `false` (v1 leaked `undefined` into the mapper schema).
  - v1's `geoLocation` casing bug is not carried over (Graph sends lowercase `geolocation`).
  - An empty `contentTypes` reply returns no fields instead of crashing.
- v1 is untouched; v2 stays unregistered (dormant) per the epic's rollout plan.

## How to test

Automated tests are the proof mechanism for this epic (v2 is dormant, and no item operation consumes these fields until ENT-174):

```bash
cd packages/nodes-base
pnpm test nodes/Microsoft/SharePoint/test/v2/list/columns.test.ts
```

17 tests cover the ticket's acceptance criteria against faked Graph replies: v1-parity of the produced fields (ported v1 fixture), hidden + read-only filtering, unsupported-type omission, the hyperlink two-part input, both sign-in methods (delegated OAuth2 and Service Principal, through the real transport), the update-mode synthetic ID field, first-content-type reading, encoding, and error paths.

To poke at it in the editor once ENT-174 lands: uncomment the v2 registration in `MicrosoftSharePoint.node.ts` (marked with a comment) and paste a workflow with `"typeVersion": 2` — re-comment before committing.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/ENT-185

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34542">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

