### PR TITLE
fix(core): Pass project context to Data Table agent tools (no-changelog)

### DIFF
--- a/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
+++ b/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
@@ -544,6 +544,25 @@ describe('EphemeralNodeExecutor', () => {
 			);
 		});
 
+		it('does not add data table project context for other node types', async () => {
+			const additionalData = {};
+			mockGetBase.mockResolvedValue(additionalData);
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: toolDescription,
+				execute: vi.fn().mockResolvedValue([[{ json: { ok: true } }]]),
+			} as unknown as INodeType);
+
+			await executor.executeInline({
+				nodeType: 'n8n-nodes-base.slack',
+				nodeTypeVersion: 1,
+				nodeParameters: {},
+				inputData: [{ json: {} }],
+				projectId: 'p-1',
+			});
+
+			expect(additionalData).not.toHaveProperty('dataTableProjectId');
+		});
+
 		it('runs nodeType.execute and returns its first output batch on success', async () => {
 			const execute = vi.fn().mockResolvedValue([[{ json: { ok: true, count: 3 } }]]);
 			nodeTypes.getByNameAndVersion.mockReturnValue({

--- a/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
+++ b/packages/cli/src/node-execution/__tests__/ephemeral-node-executor.test.ts
@@ -10,6 +10,7 @@ import {
 import { StructuredToolkit } from 'n8n-core';
 import {
 	NodeConnectionTypes,
+	type IExecuteFunctions,
 	type INodeCredentialsDetails,
 	type INodeType,
 	type INodeTypeDescription,
@@ -512,6 +513,36 @@ describe('EphemeralNodeExecutor', () => {
 		// Use plain objects so `typeof nodeType.supplyData === 'function'`
 		// reliably returns false — vitest-mock-extended auto-proxies every
 		// property as callable, which would route us to the supplyData path.
+
+		it('passes the project ID to data table helpers', async () => {
+			const getDataTableProxy = vi.fn().mockResolvedValue({});
+			mockGetBase.mockResolvedValue({
+				'data-table': { dataTableProxyProvider: { getDataTableProxy } },
+			});
+			const execute = vi.fn(async function (this: IExecuteFunctions) {
+				await this.helpers.getDataTableProxy?.('table-id');
+				return [[{ json: { ok: true } }]];
+			});
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: toolDescription,
+				execute,
+			} as unknown as INodeType);
+
+			await executor.executeInline({
+				nodeType: 'n8n-nodes-base.dataTableTool',
+				nodeTypeVersion: 1.1,
+				nodeParameters: {},
+				inputData: [{ json: {} }],
+				projectId: 'p-1',
+			});
+
+			expect(getDataTableProxy).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				'table-id',
+				'p-1',
+			);
+		});
 
 		it('runs nodeType.execute and returns its first output batch on success', async () => {
 			const execute = vi.fn().mockResolvedValue([[{ json: { ok: true, count: 3 } }]]);

--- a/packages/cli/src/node-execution/ephemeral-node-executor.ts
+++ b/packages/cli/src/node-execution/ephemeral-node-executor.ts
@@ -287,6 +287,7 @@ export class EphemeralNodeExecutor {
 			nodeTypes: this.nodeTypes,
 		});
 		const additionalData = await getBase({ projectId: tool.projectId });
+		additionalData.dataTableProjectId = tool.projectId;
 		const runExecutionData = createEmptyRunExecutionData();
 		const inputData: ITaskDataConnections = { main: [inputItems] };
 		const executeData: IExecuteData = { node, data: inputData, source: null };

--- a/packages/cli/src/node-execution/ephemeral-node-executor.ts
+++ b/packages/cli/src/node-execution/ephemeral-node-executor.ts
@@ -19,6 +19,7 @@ import {
 	UserError,
 	AI_VENDOR_NODE_TYPES,
 	createEmptyRunExecutionData,
+	DATA_TABLE_TOOL_NODE_TYPE,
 	NodeConnectionTypes,
 	SEND_AND_WAIT_OPERATION,
 } from 'n8n-workflow';
@@ -287,7 +288,10 @@ export class EphemeralNodeExecutor {
 			nodeTypes: this.nodeTypes,
 		});
 		const additionalData = await getBase({ projectId: tool.projectId });
-		additionalData.dataTableProjectId = tool.projectId;
+		if (tool.nodeType === DATA_TABLE_TOOL_NODE_TYPE) {
+			// Data Table uses separate project authorization and an ephemeral workflow has no owner fallback.
+			additionalData.dataTableProjectId = tool.projectId;
+		}
 		const runExecutionData = createEmptyRunExecutionData();
 		const inputData: ITaskDataConnections = { main: [inputItems] };
 		const executeData: IExecuteData = { node, data: inputData, source: null };


### PR DESCRIPTION
## Summary

Propagate the agent project ID to ephemeral node executions so Data Table tools resolve tables in the correct project.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-410

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled for backporting if required.