### PR TITLE
feat(editor): Show confirmation modal when updating a custom instance role with assigned users

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2916,6 +2916,8 @@
 	"roles.create.validation.nameMinLength": "Enter a name of at least {min} characters",
 	"roles.instance.action.update.success": "Role updated successfully",
 	"roles.instance.action.update.error": "Error updating role",
+	"roles.instance.action.update.title": "Update permissions for this role?",
+	"roles.instance.action.update.text": "This role is currently assigned to <b>{count} user</b>. Saving will immediately update the permissions this user has. | This role is currently assigned to <b>{count} users</b>. Saving will immediately update the permissions these users have.",
 	"roles.instance.assignments.memberColumn": "Member",
 	"roles.instance.assignments.roleColumn": "Instance role",
 	"roles.instance.assignments.emptyState": "No users have this role yet.",

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.test.ts
@@ -9,6 +9,7 @@ import InstanceRoleView from './InstanceRoleView.vue';
 
 const mockShowError = vi.fn();
 const mockShowMessage = vi.fn();
+const mockConfirm = vi.fn();
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/app/composables/useToast', () => ({
 }));
 
 vi.mock('@/app/composables/useMessage', () => ({
-	useMessage: () => ({ confirm: vi.fn() }),
+	useMessage: () => ({ confirm: mockConfirm }),
 }));
 
 const mockRoute = {
@@ -195,6 +196,106 @@ describe('InstanceRoleView', () => {
 				type: 'success',
 				message: 'Role updated successfully',
 			});
+			expect(mockConfirm).not.toHaveBeenCalled();
+		});
+
+		it('asks for confirmation before updating a role with assigned users', async () => {
+			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 8 });
+			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
+			mockConfirm.mockResolvedValueOnce('confirm');
+
+			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
+
+			await waitFor(() => {
+				const { nameInput } = getFormElements(container);
+				expect(nameInput?.value).toBe('Support');
+			});
+
+			await fillName(container, 'Support 2');
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => {
+				expect(mockConfirm).toHaveBeenCalledWith(
+					expect.stringContaining('<b>8 users</b>'),
+					'Update permissions for this role?',
+					expect.objectContaining({ type: 'warning' }),
+				);
+			});
+			await waitFor(() => {
+				expect(rolesStore.updateRole).toHaveBeenCalledWith('support', {
+					displayName: 'Support 2',
+					description: 'A custom instance role',
+					scopes: ['user:read', 'user:list'],
+				});
+			});
+		});
+
+		it('does not save changes when the confirmation is cancelled', async () => {
+			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 1 });
+			mockConfirm.mockResolvedValueOnce('cancel');
+
+			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
+
+			await waitFor(() => {
+				const { nameInput } = getFormElements(container);
+				expect(nameInput?.value).toBe('Support');
+			});
+
+			await fillName(container, 'Support 2');
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => {
+				expect(mockConfirm).toHaveBeenCalledWith(
+					expect.stringContaining('<b>1 user</b>'),
+					'Update permissions for this role?',
+					expect.objectContaining({ type: 'warning' }),
+				);
+			});
+			expect(rolesStore.updateRole).not.toHaveBeenCalled();
+			expect(mockShowMessage).not.toHaveBeenCalled();
+		});
+
+		it('skips the confirmation when the role has no assigned users', async () => {
+			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 0 });
+			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
+
+			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
+
+			await waitFor(() => {
+				const { nameInput } = getFormElements(container);
+				expect(nameInput?.value).toBe('Support');
+			});
+
+			await fillName(container, 'Support 2');
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+
+			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalled());
+			expect(mockConfirm).not.toHaveBeenCalled();
+		});
+
+		it('asks for confirmation again on a second save, even though the update response has no usage count', async () => {
+			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 8 });
+			rolesStore.updateRole
+				.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' })
+				.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 3' });
+			mockConfirm.mockResolvedValueOnce('confirm').mockResolvedValueOnce('confirm');
+
+			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
+
+			await waitFor(() => {
+				const { nameInput } = getFormElements(container);
+				expect(nameInput?.value).toBe('Support');
+			});
+
+			await fillName(container, 'Support 2');
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalledTimes(1));
+
+			await fillName(container, 'Support 3');
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalledTimes(2));
+
+			expect(mockConfirm).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.test.ts
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.test.ts
@@ -169,7 +169,7 @@ describe('InstanceRoleView', () => {
 
 	describe('Edit', () => {
 		it('updates an existing custom role', async () => {
-			rolesStore.fetchRoleBySlug.mockResolvedValueOnce(mockCustomRole);
+			rolesStore.fetchRoleBySlug.mockResolvedValue(mockCustomRole);
 			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
 
 			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
@@ -200,7 +200,7 @@ describe('InstanceRoleView', () => {
 		});
 
 		it('asks for confirmation before updating a role with assigned users', async () => {
-			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 8 });
+			rolesStore.fetchRoleBySlug.mockResolvedValue({ ...mockCustomRole, usedByUsers: 8 });
 			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
 			mockConfirm.mockResolvedValueOnce('confirm');
 
@@ -231,7 +231,7 @@ describe('InstanceRoleView', () => {
 		});
 
 		it('does not save changes when the confirmation is cancelled', async () => {
-			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 1 });
+			rolesStore.fetchRoleBySlug.mockResolvedValue({ ...mockCustomRole, usedByUsers: 1 });
 			mockConfirm.mockResolvedValueOnce('cancel');
 
 			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
@@ -256,7 +256,7 @@ describe('InstanceRoleView', () => {
 		});
 
 		it('skips the confirmation when the role has no assigned users', async () => {
-			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 0 });
+			rolesStore.fetchRoleBySlug.mockResolvedValue({ ...mockCustomRole, usedByUsers: 0 });
 			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
 
 			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
@@ -273,12 +273,13 @@ describe('InstanceRoleView', () => {
 			expect(mockConfirm).not.toHaveBeenCalled();
 		});
 
-		it('asks for confirmation again on a second save, even though the update response has no usage count', async () => {
-			rolesStore.fetchRoleBySlug.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 8 });
-			rolesStore.updateRole
-				.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' })
-				.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 3' });
-			mockConfirm.mockResolvedValueOnce('confirm').mockResolvedValueOnce('confirm');
+		it('picks up assignments made after the page was loaded', async () => {
+			// The role is unassigned at page load; by save time it has 3 users.
+			rolesStore.fetchRoleBySlug
+				.mockResolvedValueOnce(mockCustomRole)
+				.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 3 });
+			rolesStore.updateRole.mockResolvedValueOnce({ ...mockCustomRole, displayName: 'Support 2' });
+			mockConfirm.mockResolvedValueOnce('confirm');
 
 			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
 
@@ -289,13 +290,41 @@ describe('InstanceRoleView', () => {
 
 			await fillName(container, 'Support 2');
 			await userEvent.click(getByRole('button', { name: 'Save' }));
-			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalledTimes(1));
 
-			await fillName(container, 'Support 3');
+			await waitFor(() => {
+				expect(mockConfirm).toHaveBeenCalledWith(
+					expect.stringContaining('<b>3 users</b>'),
+					'Update permissions for this role?',
+					expect.objectContaining({ type: 'warning' }),
+				);
+			});
+			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalled());
+		});
+
+		it('falls back to the count from page load when the pre-save fetch fails', async () => {
+			rolesStore.fetchRoleBySlug
+				.mockResolvedValueOnce({ ...mockCustomRole, usedByUsers: 8 })
+				.mockRejectedValueOnce(new Error('network error'));
+			mockConfirm.mockResolvedValueOnce('cancel');
+
+			const { container, getByRole } = renderComponent({ props: { roleSlug: 'support' } });
+
+			await waitFor(() => {
+				const { nameInput } = getFormElements(container);
+				expect(nameInput?.value).toBe('Support');
+			});
+
+			await fillName(container, 'Support 2');
 			await userEvent.click(getByRole('button', { name: 'Save' }));
-			await waitFor(() => expect(rolesStore.updateRole).toHaveBeenCalledTimes(2));
 
-			expect(mockConfirm).toHaveBeenCalledTimes(2);
+			await waitFor(() => {
+				expect(mockConfirm).toHaveBeenCalledWith(
+					expect.stringContaining('<b>8 users</b>'),
+					'Update permissions for this role?',
+					expect.objectContaining({ type: 'warning' }),
+				);
+			});
+			expect(rolesStore.updateRole).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
@@ -111,7 +111,14 @@ async function createInstanceRole() {
 	}
 }
 
-async function confirmRoleUpdate(usedByUsers?: number) {
+async function confirmRoleUpdate(slug: string) {
+	// Fetch the usage count at save time so the confirmation also covers
+	// assignments made since the page was loaded.
+	const usedByUsers = await rolesStore
+		.fetchRoleBySlug({ slug })
+		.then((role) => role.usedByUsers)
+		.catch(() => initialState.value?.usedByUsers);
+
 	if (!usedByUsers) return true;
 
 	const confirmed = await message.confirm(
@@ -131,7 +138,7 @@ async function confirmRoleUpdate(usedByUsers?: number) {
 }
 
 async function updateInstanceRole(slug: string) {
-	const proceed = await confirmRoleUpdate(initialState.value?.usedByUsers);
+	const proceed = await confirmRoleUpdate(slug);
 	if (!proceed) return;
 
 	try {
@@ -150,12 +157,7 @@ async function updateInstanceRole(slug: string) {
 			permissions_to: role.scopes,
 		});
 
-		// The update response carries no usage count; keep the fetched one so
-		// subsequent saves in this session still ask for confirmation.
-		initialState.value = structuredClone({
-			...role,
-			usedByUsers: initialState.value?.usedByUsers,
-		});
+		initialState.value = structuredClone(role);
 		showMessage({
 			type: 'success',
 			message: i18n.baseText('roles.instance.action.update.success'),

--- a/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
+++ b/packages/frontend/editor-ui/src/features/roles/instance/InstanceRoleView.vue
@@ -111,7 +111,29 @@ async function createInstanceRole() {
 	}
 }
 
+async function confirmRoleUpdate(usedByUsers?: number) {
+	if (!usedByUsers) return true;
+
+	const confirmed = await message.confirm(
+		i18n.baseText('roles.instance.action.update.text', {
+			interpolate: { count: usedByUsers },
+			adjustToNumber: usedByUsers,
+		}),
+		i18n.baseText('roles.instance.action.update.title'),
+		{
+			type: 'warning',
+			confirmButtonText: i18n.baseText('projectRoles.action.update'),
+			cancelButtonText: i18n.baseText('roles.action.cancel'),
+		},
+	);
+
+	return confirmed === MODAL_CONFIRM;
+}
+
 async function updateInstanceRole(slug: string) {
+	const proceed = await confirmRoleUpdate(initialState.value?.usedByUsers);
+	if (!proceed) return;
+
 	try {
 		const role = await rolesStore.updateRole(slug, {
 			displayName: form.value.displayName,
@@ -128,7 +150,12 @@ async function updateInstanceRole(slug: string) {
 			permissions_to: role.scopes,
 		});
 
-		initialState.value = structuredClone(role);
+		// The update response carries no usage count; keep the fetched one so
+		// subsequent saves in this session still ask for confirmation.
+		initialState.value = structuredClone({
+			...role,
+			usedByUsers: initialState.value?.usedByUsers,
+		});
 		showMessage({
 			type: 'success',
 			message: i18n.baseText('roles.instance.action.update.success'),


### PR DESCRIPTION
## Summary

When saving changes to a custom instance role that is assigned to at least one user, the editor now shows a confirmation modal before applying them:

> **Update permissions for this role?**
> This role is currently assigned to **8 users**. Saving will immediately update the permissions these users have.

- Shown only when the role has ≥ 1 assigned user; otherwise saving works as before.
- Cancelling keeps the form dirty and saves nothing.
- Mirrors the existing confirmation for project roles (`ProjectRoleView.vue`).
- The usage count is preserved across consecutive saves, since the update response doesn't include it.

<img width="798" height="667" alt="image" src="https://github.com/user-attachments/assets/9b7b9a12-5c48-4c39-b7eb-a7471f9ab5bc" />

Sanity check
<img width="1043" height="495" alt="image" src="https://github.com/user-attachments/assets/3db1bed1-eeb7-4497-aaf0-67b75c977ff0" />
No assigned users - no modal
<img width="1032" height="558" alt="image" src="https://github.com/user-attachments/assets/a60d1598-809b-46b5-998a-031fea4974d8" />



## How to test

Requires an enterprise license with custom roles enabled.

1. Go to **Settings → Roles → Instance** and create a custom role.
2. Assign it to one or more users, then edit the role and save — the confirmation modal appears with the user count.
3. Cancel → nothing is saved. Confirm → role is updated; saving again re-shows the modal.
4. A role with no assigned users saves without any modal.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-970

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34544">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

