### PR TITLE
fix(editor): Keep dropdown tooltips above menus

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.stories.ts
@@ -4,7 +4,9 @@ import { ref, computed } from 'vue';
 
 import N8nBadge from '@n8n/design-system/components/N8nBadge/Badge.vue';
 import N8nButton from '@n8n/design-system/components/N8nButton/Button.vue';
+import N8nIcon from '@n8n/design-system/components/N8nIcon/Icon.vue';
 import N8nKeyboardShortcut from '@n8n/design-system/components/N8nKeyboardShortcut/N8nKeyboardShortcut.vue';
+import N8nTooltip from '@n8n/design-system/components/N8nTooltip/Tooltip.vue';
 import N8nCheckbox from '@n8n/design-system/v2/components/Checkbox/Checkbox.vue';
 
 import { useDropdownSearch } from './composables/useDropdownSearch';
@@ -431,6 +433,68 @@ export const NestedMenu: Story = {
 			},
 			{ id: 'project', label: 'Project', icon: { type: 'icon', value: 'layers' }, disabled: true },
 		] as Array<DropdownMenuItemProps<string>>,
+	},
+};
+
+export const WithTooltips: Story = {
+	render: (args) => ({
+		components: { DropdownMenu, N8nIcon, N8nTooltip },
+		setup() {
+			const handleSelect = (action: string) => {
+				console.log('Selected:', action);
+			};
+			return { args, handleSelect };
+		},
+		template: `
+		<div style="padding: 40px;">
+			<DropdownMenu :items="args.items" @select="handleSelect">
+				<template #item-label="{ item, ui }">
+					<N8nTooltip
+						v-if="item.id === 'main-menu-item'"
+						:content="item.data.tooltip"
+						placement="right"
+						teleported
+						as-child
+					>
+						<span :class="ui.class">{{ item.label }}</span>
+					</N8nTooltip>
+					<span v-else :class="ui.class">{{ item.label }}</span>
+				</template>
+				<template #item-trailing="{ item, ui }">
+					<N8nTooltip
+						v-if="item.id === 'submenu-item'"
+						:content="item.data.tooltip"
+						placement="right"
+						teleported
+						as-child
+					>
+						<N8nIcon icon="info" size="medium" :class="ui.class" />
+					</N8nTooltip>
+				</template>
+			</DropdownMenu>
+		</div>
+		`,
+	}),
+	args: {
+		items: [
+			{
+				id: 'main-menu-item',
+				label: 'Main menu item',
+				data: { tooltip: 'Tooltip for the main menu item' },
+			},
+			{
+				id: 'submenu',
+				label: 'Open submenu',
+				data: { tooltip: '' },
+				children: [
+					{
+						id: 'submenu-item',
+						label: 'Submenu item',
+						data: { tooltip: 'Tooltip for the submenu item' },
+					},
+				],
+			},
+		] as Array<DropdownMenuItemProps<string, { tooltip: string }>>,
 	},
 };
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.test.ts
@@ -4,6 +4,7 @@ import { ref } from 'vue';
 
 import type { DropdownMenuItemProps, DropdownMenuPlacement } from './DropdownMenu.types';
 import DropdownMenu from './DropdownMenu.vue';
+import Tooltip from '../N8nTooltip/Tooltip.vue';
 
 const createItems = (count: number): DropdownMenuItemProps[] => {
 	return Array.from({ length: count }, (_, i) => ({
@@ -540,6 +541,36 @@ describe('N8nDropdownMenu', () => {
 	});
 
 	describe('teleported prop', () => {
+		it('should render a teleported tooltip outside the dropdown content', async () => {
+			render({
+				components: { DropdownMenu, Tooltip },
+				setup() {
+					return {
+						items: [{ id: 'item', label: 'Item' }],
+					};
+				},
+				template: `
+					<DropdownMenu :items="items" :model-value="true">
+						<template #item-label="{ item }">
+							<Tooltip content="Item details" :visible="true" teleported>
+								<span>{{ item.label }}</span>
+							</Tooltip>
+						</template>
+					</DropdownMenu>
+				`,
+			});
+
+			const { dropdown } = await getDropdownContent();
+			const tooltip = await waitFor(() => {
+				const element = document.querySelector('[data-test-id="tooltip-content"]');
+				expect(element).toBeInTheDocument();
+				return element as HTMLElement;
+			});
+
+			expect(dropdown).not.toContainElement(tooltip);
+			expect(document.body).toContainElement(tooltip);
+		});
+
 		it('should teleport to body by default', async () => {
 			const { container } = render(DropdownMenu, {
 				props: {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenu.vue
@@ -361,6 +361,7 @@ defineExpose({ open, close });
 </template>
 
 <style module lang="scss">
+@use '../../css/common/var';
 @use '../../css/mixins/motion';
 
 .content {
@@ -383,7 +384,7 @@ defineExpose({ open, close });
 	box-shadow: var(--shadow--md), var(--shadow--outline);
 	will-change: transform, opacity;
 	transform-origin: var(--n8n--dropdown--offset--origin-x) var(--n8n--dropdown--offset--origin-y);
-	z-index: 9999;
+	z-index: var.$index-popper;
 	scrollbar-width: none;
 
 	&.searchable {

--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -369,6 +369,8 @@ onBeforeUnmount(() => {
 </template>
 
 <style module lang="scss">
+@use '../../css/common/var';
+
 .wrapper {
 	display: contents;
 }
@@ -452,7 +454,7 @@ onBeforeUnmount(() => {
 	border-radius: var(--radius--xs);
 	box-shadow: var(--shadow--md), var(--shadow--outline);
 	background-color: var(--background--surface);
-	z-index: 999999;
+	z-index: var.$index-popper;
 	width: fit-content;
 	min-width: calc(var(--n8n--dropdown-menu-width) / 4);
 	max-width: var(--n8n--dropdown-menu-width);

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.test.ts
@@ -257,8 +257,8 @@ describe('components/N8nTooltip', () => {
 	});
 
 	describe('teleportation', () => {
-		it('should teleport tooltip to body by default', async () => {
-			render(Tooltip, {
+		it('should teleport tooltip outside its container by default', async () => {
+			const { container } = render(Tooltip, {
 				props: {
 					content: 'Test tooltip',
 					visible: true,
@@ -268,15 +268,13 @@ describe('components/N8nTooltip', () => {
 				},
 			});
 
-			await waitFor(() => {
-				const tooltipContent = document.querySelector('[data-dismissable-layer]');
-				expect(tooltipContent).toBeInTheDocument();
-				// Tooltip should be teleported (rendered via portal)
-			});
+			const tooltipContent = await getTooltip();
+			expect(container).not.toContainElement(tooltipContent);
+			expect(document.body).toContainElement(tooltipContent);
 		});
 
-		it('should not teleport when teleported is false', async () => {
-			render(Tooltip, {
+		it('should render tooltip inside its container when teleported is false', async () => {
+			const { container } = render(Tooltip, {
 				props: {
 					content: 'Test tooltip',
 					teleported: false,
@@ -287,10 +285,8 @@ describe('components/N8nTooltip', () => {
 				},
 			});
 
-			await waitFor(() => {
-				const tooltipContent = document.querySelector('[data-dismissable-layer]');
-				expect(tooltipContent).toBeInTheDocument();
-			});
+			const tooltipContent = await getTooltip();
+			expect(container).toContainElement(tooltipContent);
 		});
 	});
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nTooltip/Tooltip.vue
@@ -147,7 +147,7 @@ const handleOpenChange = (open: boolean) => {
 
 // Global styles for teleported tooltip content
 :global(.n8n-tooltip) {
-	z-index: var.$index-popper;
+	z-index: var.$index-tooltip;
 	max-width: 180px;
 	padding: var(--spacing--4xs) var(--spacing--3xs);
 	min-height: var(--height--sm);

--- a/packages/frontend/@n8n/design-system/src/css/common/var.scss
+++ b/packages/frontend/@n8n/design-system/src/css/common/var.scss
@@ -105,6 +105,7 @@ $font-color-disabled-base: var(--color--text--tint-1);
 $index-normal: 1;
 $index-top: 1000;
 $index-popper: 2000;
+$index-tooltip: 2001;
 
 /* Disable base
 -------------------------- */

--- a/packages/frontend/@n8n/design-system/src/css/tooltip.scss
+++ b/packages/frontend/@n8n/design-system/src/css/tooltip.scss
@@ -13,7 +13,7 @@
 		position: absolute;
 		border-radius: 4px;
 		padding: var.$tooltip-padding;
-		z-index: var.$index-popper;
+		z-index: var.$index-tooltip;
 		font-size: var.$tooltip-font-size;
 		line-height: 1.2;
 		min-width: 10px;

--- a/packages/frontend/editor-ui/src/features/core/folders/components/FolderBreadcrumbs.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/FolderBreadcrumbs.vue
@@ -287,7 +287,7 @@ onBeforeUnmount(() => {
 					:content="item.data.tooltip"
 					placement="left"
 					:show-after="300"
-					:teleported="false"
+					teleported
 				>
 					<N8nText
 						:class="ui.class"

--- a/packages/frontend/editor-ui/src/features/core/folders/components/FolderCard.vue
+++ b/packages/frontend/editor-ui/src/features/core/folders/components/FolderCard.vue
@@ -342,7 +342,7 @@ const onBreadcrumbItemClick = async (item: PathItem) => {
 										:content="item.data.tooltip"
 										placement="left"
 										:show-after="300"
-										:teleported="false"
+										teleported
 									>
 										<N8nText
 											:class="ui.class"


### PR DESCRIPTION
## Summary

Fixes broken teleported menu and `z-index` stacking on `N8nDropdownMenu`

- Coordinate dropdown and tooltip overlay layers so teleported tooltips render above nested menus
- Add a Dropdown Menu story covering tooltips in the main menu and submenu
- Ensure folder action menu tooltips in Editor UI are teleported outside clipping containers
- Add regression tests for tooltip teleportation and dropdown integration

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/8122aaee-695a-4858-bd37-83fa30945973" width="960px" alt="before"> | <img src="https://github.com/user-attachments/assets/65152b27-9b3a-4928-92b2-bf16a1c07ead" width="960px" alt="after"> |

## How to test

1. Open Storybook and navigate to **Core / Dropdown Menu / With Tooltips**.
2. Open the dropdown and its submenu.
3. Hover the main menu tooltip target and the submenu information icon.
4. Confirm both tooltips render above the menu without being clipped.
5. Goto Folder breadcrumb → Manage MCP access → Hover child item and verify tooltip stacks on top of menu without clipping

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-594

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34547">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->