### PR TITLE
fix(core): Stop reporting quota-exhausted Instance AI runs to Sentry and isolate report request context

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-error-reporter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-error-reporter.service.test.ts
@@ -6,11 +6,12 @@ describe('InstanceAiErrorReporterService', () => {
 	function createService(): {
 		service: InstanceAiErrorReporterService;
 		errorReporter: { error: Mock };
-		logger: { error: Mock };
+		logger: { error: Mock; info: Mock };
 	} {
 		const errorReporter = { error: vi.fn() };
-		const logger: { error: Mock; scoped: Mock } = {
+		const logger: { error: Mock; info: Mock; scoped: Mock } = {
 			error: vi.fn(),
+			info: vi.fn(),
 			scoped: vi.fn(),
 		};
 		logger.scoped.mockReturnValue(logger);
@@ -78,7 +79,44 @@ describe('InstanceAiErrorReporterService', () => {
 				userId: 'user-1',
 				projectId: 'project-1',
 			},
+			shouldIsolate: true,
 		});
+	});
+
+	it('logs at info level instead of reporting for quota-exhausted errors', () => {
+		const { service, errorReporter, logger } = createService();
+		const error = Object.assign(new Error('Have reached end of quota'), {
+			errorCode: 'quota_exhausted',
+		});
+
+		service.beginRun('r');
+		service.report(error, {
+			component: 'instance-ai-run',
+			threadId: 't',
+			runId: 'r',
+		});
+
+		expect(errorReporter.error).not.toHaveBeenCalled();
+		expect(logger.error).not.toHaveBeenCalled();
+		expect(logger.info).toHaveBeenCalledWith(
+			'Instance AI quota exhausted in instance-ai-run',
+			expect.objectContaining({ threadId: 't', runId: 'r' }),
+		);
+	});
+
+	it('withBoundary rethrows quota-exhausted errors without reporting to Sentry', async () => {
+		const { service, errorReporter } = createService();
+		const error = Object.assign(new Error('Have reached end of quota'), {
+			errorCode: 'quota_exhausted',
+		});
+
+		await expect(
+			service.withBoundary('instance-ai-sandbox-setup', { threadId: 't', runId: 'r' }, async () => {
+				throw error;
+			}),
+		).rejects.toBe(error);
+
+		expect(errorReporter.error).not.toHaveBeenCalled();
 	});
 
 	it('drops per-run dedup state after endRun', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai-error-reporter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-error-reporter.service.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
+import { isQuotaExhaustedError } from '@n8n/instance-ai';
 import { ErrorReporter } from 'n8n-core';
 
 import {
@@ -39,6 +40,16 @@ export class InstanceAiErrorReporterService {
 
 		const observability = buildInstanceAiObservabilityContext(context);
 
+		if (isQuotaExhaustedError(error)) {
+			// Expected condition: the user ran out of AI credits and the run already
+			// surfaces it as `quota_exhausted`. Not worth a Sentry event.
+			this.logger.info(`Instance AI quota exhausted in ${context.component}`, {
+				component: context.component,
+				...observability,
+			});
+			return;
+		}
+
 		this.logger.error(`Instance AI error in ${context.component}`, {
 			error,
 			component: context.component,
@@ -48,6 +59,9 @@ export class InstanceAiErrorReporterService {
 		this.errorReporter.error(error, {
 			tags: { component: context.component, ...observability },
 			extra: observability,
+			// Reports fire from the background run loop, where the ambient Sentry
+			// scope can hold an unrelated HTTP request (e.g. a health check).
+			shouldIsolate: true,
 		});
 	}
 

--- a/packages/core/src/errors/__tests__/error-reporter.test.ts
+++ b/packages/core/src/errors/__tests__/error-reporter.test.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import { QueryFailedError } from '@n8n/typeorm';
 import type { ErrorEvent } from '@sentry/core';
+import { captureException, withIsolationScope } from '@sentry/node';
 import { AxiosError } from 'axios';
 import { ApplicationError, BaseError, ExpressionError, NodeOperationError } from 'n8n-workflow';
 import type { INode } from 'n8n-workflow';
@@ -9,11 +10,29 @@ import { mock } from 'vitest-mock-extended';
 
 import { ErrorReporter, normalizeFrameFilename } from '../error-reporter';
 
+const { isolationScopeMock } = vi.hoisted(() => ({
+	isolationScopeMock: {
+		clearBreadcrumbs: vi.fn(),
+		setSDKProcessingMetadata: vi.fn(),
+	},
+}));
+
 vi.mock('@sentry/node', () => ({
 	init: vi.fn(),
 	setTag: vi.fn(),
+	setUser: vi.fn(),
 	captureException: vi.fn(),
+	withIsolationScope: vi.fn((fn: (scope: unknown) => unknown) => fn(isolationScopeMock)),
+	requestDataIntegration: vi.fn(),
+	rewriteFramesIntegration: vi.fn(),
+	httpIntegration: vi.fn(),
 	Integrations: {},
+}));
+
+// `init()` bails in the test env; flip the flag so the Sentry wiring can be exercised.
+vi.mock('@n8n/backend-common', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@n8n/backend-common')>()),
+	inTest: false,
 }));
 
 const eventLoopBlockIntegrationMock = vi.fn((opts: unknown) => ({
@@ -369,6 +388,53 @@ describe('ErrorReporter', () => {
 			expect(logger.error).toHaveBeenCalledTimes(2);
 			expect(logger.error).toHaveBeenNthCalledWith(1, `outer\n${outer.stack}\n`, undefined);
 			expect(logger.error).toHaveBeenNthCalledWith(2, `root cause\n${cause.stack}\n`, undefined);
+		});
+	});
+
+	describe('error with Sentry initialized', () => {
+		const sentryErrorReporter = new ErrorReporter(mock(), mock());
+
+		beforeAll(async () => {
+			await sentryErrorReporter.init({
+				serverType: 'main',
+				dsn: 'https://fake@sentry.example.com/1',
+				release: '1.0.0',
+				environment: 'test',
+				serverName: 'test-server',
+				withEventLoopBlockDetection: false,
+				tracesSampleRate: 0,
+				profilesSampleRate: 0,
+			});
+		});
+
+		beforeEach(() => {
+			vi.mocked(captureException).mockClear();
+			vi.mocked(withIsolationScope).mockClear();
+			isolationScopeMock.clearBreadcrumbs.mockClear();
+			isolationScopeMock.setSDKProcessingMetadata.mockClear();
+		});
+
+		it('captures on the ambient scope by default', () => {
+			const error = new Error('boom');
+
+			sentryErrorReporter.error(error);
+
+			expect(captureException).toHaveBeenCalledWith(error, undefined);
+			expect(withIsolationScope).not.toHaveBeenCalled();
+		});
+
+		it('captures in a forked isolation scope without request metadata when shouldIsolate is set', () => {
+			const error = new Error('boom');
+
+			sentryErrorReporter.error(error, { shouldIsolate: true });
+
+			expect(withIsolationScope).toHaveBeenCalledTimes(1);
+			expect(isolationScopeMock.clearBreadcrumbs).toHaveBeenCalledTimes(1);
+			expect(isolationScopeMock.setSDKProcessingMetadata).toHaveBeenCalledWith({
+				normalizedRequest: undefined,
+				ipAddress: undefined,
+			});
+			expect(captureException).toHaveBeenCalledWith(error, { shouldIsolate: true });
 		});
 	});
 });

--- a/packages/core/src/errors/error-reporter.ts
+++ b/packages/core/src/errors/error-reporter.ts
@@ -83,6 +83,15 @@ const SENTRY_MAX_VALUE_LENGTH = 500;
 const PNPM_NESTED_FRAME_RE = /.*\/node_modules\/\.pnpm\/[^/]+\/node_modules\//;
 const N8N_CLI_INSTALL_PREFIX = '/usr/local/lib/node_modules/n8n/';
 
+type ErrorReportingOptions = ReportingOptions & {
+	/**
+	 * Capture in a forked Sentry isolation scope, dropping any ambient HTTP
+	 * request context. Use for errors reported from background work, which would
+	 * otherwise inherit whatever unrelated request is active at capture time.
+	 */
+	shouldIsolate?: boolean;
+};
+
 /**
  * Normalises a Sentry stack-frame filename so that pnpm-nested dependency
  * paths and the n8n CLI install prefix become stable `app:///` roots. This
@@ -102,7 +111,7 @@ export class ErrorReporter {
 	/** Hashes of error stack traces, to deduplicate error reports. */
 	private seenErrors = new Set<string>();
 
-	private report: (error: Error | string, options?: ReportingOptions) => void;
+	private report: (error: Error | string, options?: ErrorReportingOptions) => void;
 
 	private beforeSendFilter?: (event: ErrorEvent, hint: EventHint) => boolean;
 
@@ -207,6 +216,7 @@ export class ErrorReporter {
 			requestDataIntegration,
 			rewriteFramesIntegration,
 			httpIntegration,
+			withIsolationScope,
 		} = sentry;
 
 		// Most of the integrations are listed here:
@@ -311,7 +321,22 @@ export class ErrorReporter {
 			setUser({ id: serverName });
 		}
 
-		this.report = (error, options) => captureException(error, options);
+		this.report = (error, options) => {
+			if (options?.shouldIsolate) {
+				// The fork is a clone of the ambient isolation scope, so instance-level
+				// tags and user identity survive while request metadata is dropped.
+				withIsolationScope((isolationScope) => {
+					isolationScope.clearBreadcrumbs();
+					isolationScope.setSDKProcessingMetadata({
+						normalizedRequest: undefined,
+						ipAddress: undefined,
+					});
+					captureException(error, options);
+				});
+				return;
+			}
+			captureException(error, options);
+		};
 		this.beforeSendFilter = beforeSendFilter;
 	}
 
@@ -368,7 +393,7 @@ export class ErrorReporter {
 		return event;
 	}
 
-	error(e: unknown, options?: ReportingOptions) {
+	error(e: unknown, options?: ErrorReportingOptions) {
 		if (e instanceof ExecutionCancelledError) return;
 		const toReport = this.wrap(e);
 		if (toReport) this.report(toReport, options);


### PR DESCRIPTION
## Summary

Two changes to Instance AI error reporting, both in service of Sentry signal quality:

**1. Skip Sentry for quota-exhausted runs.** [INSTANCE-BACKEND-26GB](https://n8nio.sentry.io/issues/7589177627/) has accumulated ~4,500 events across ~4,000 users (~250/day, 91% trial plan). Every one is the expected "user ran out of AI credits" condition, already surfaced correctly in the UI as `quota_exhausted`. `InstanceAiErrorReporterService.report()` now logs these at info level and skips the Sentry report. The guard sits in the one service all component call sites (including `withBoundary`) go through.

**2. Detach Instance AI reports from the ambient request context.** Instance AI errors are captured from the background run loop, so the Sentry event inherits whatever unrelated HTTP request is active on the isolation scope (`GET /healthz`, random webhook POSTs). This misled the Sentry-to-Linear triage bot into blaming Task Runners health checks for an unrelated escalating issue. `ErrorReporter` now supports a `shouldIsolate` reporting option: it captures inside `Sentry.withIsolationScope` and clears `normalizedRequest`/`ipAddress` metadata and breadcrumbs from the forked scope. The fork is a clone of the ambient scope, so instance-level identity (`server_type` tag, server-name user, which drives per-instance user counts) is preserved. Instance AI reports always set this flag.

User-facing behavior is unchanged: runs still end with `errorCode: quota_exhausted` and the credits message.

## How to test

- `pnpm test src/errors/__tests__/error-reporter.test.ts` in `packages/core`: covers default capture vs `shouldIsolate` capture (forked scope, scrubbed request metadata, preserved options).
- `pnpm test src/modules/instance-ai/__tests__/instance-ai-error-reporter.service.test.ts` in `packages/cli`: covers quota-exhausted errors logging at info without a Sentry report (direct and via `withBoundary`), and non-quota errors reporting with `shouldIsolate: true`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-937

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/34549">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/34549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

